### PR TITLE
[Fleet] improve navigation between integration list and details

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -397,6 +397,7 @@ export interface IntegrationCardItem {
   integration: string;
   id: string;
   categories: string[];
+  fromIntegrations: string | undefined;
 }
 
 export type PackagesGroupedByStatus = Record<ValueOf<InstallationStatus>, PackageList>;

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -397,7 +397,7 @@ export interface IntegrationCardItem {
   integration: string;
   id: string;
   categories: string[];
-  fromIntegrations: string | undefined;
+  fromIntegrations?: string;
 }
 
 export type PackagesGroupedByStatus = Record<ValueOf<InstallationStatus>, PackageList>;

--- a/x-pack/plugins/fleet/cypress/screens/integrations.ts
+++ b/x-pack/plugins/fleet/cypress/screens/integrations.ts
@@ -7,7 +7,7 @@
 
 export const ADD_POLICY_BTN = 'addIntegrationPolicyButton';
 export const CREATE_PACKAGE_POLICY_SAVE_BTN = 'createPackagePolicySaveButton';
-export const INTEGRATIONS_CARD = '.euiCard__titleAnchor';
+export const INTEGRATIONS_CARD = '.euiCard__titleButton';
 
 export const INTEGRATION_NAME_LINK = 'integrationNameLink';
 export const AGENT_POLICY_NAME_LINK = 'agentPolicyNameLink';

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './use_links';
 export * from './use_local_search';
 export * from './use_package_install';
 export * from './use_agent_policy_context';
+export * from './use_integrations_state';

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_integrations_state.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_integrations_state.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React, { createContext, useContext, useRef, useCallback } from 'react';
+
+import type { IntegrationsAppBrowseRouteState } from '../../../types';
+import { useIntraAppState } from '../../../hooks';
+
+interface IntegrationsStateContextValue {
+  getFromIntegrations(): string | undefined;
+}
+
+const IntegrationsStateContext = createContext<IntegrationsStateContextValue>({
+  getFromIntegrations: () => undefined,
+});
+
+export const IntegrationsStateContextProvider: FunctionComponent = ({ children }) => {
+  const maybeState = useIntraAppState<undefined | IntegrationsAppBrowseRouteState>();
+  const fromIntegrationsRef = useRef<undefined | string>(maybeState?.fromIntegrations);
+
+  const getFromIntegrations = useCallback(() => {
+    return fromIntegrationsRef.current;
+  }, []);
+  return (
+    <IntegrationsStateContext.Provider value={{ getFromIntegrations }}>
+      {children}
+    </IntegrationsStateContext.Provider>
+  );
+};
+
+export const useIntegrationsStateContext = () => {
+  const ctx = useContext(IntegrationsStateContext);
+  if (!ctx) {
+    throw new Error(
+      'useIntegrationsStateContext can only be used inside of IntegrationsStateContextProvider'
+    );
+  }
+  return ctx;
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, act } from '@testing-library/react';
+
+import { createFleetTestRendererMock } from '../../../../../mock';
+
+import { useStartServices } from '../../../hooks';
+
+import type { PackageCardProps } from './package_card';
+import { PackageCard } from './package_card';
+
+jest.mock('../../../hooks', () => {
+  return {
+    ...jest.requireActual('../../../hooks'),
+    useStartServices: jest.fn().mockReturnValue({
+      application: {
+        navigateToApp: jest.fn(),
+        navigateToUrl: jest.fn(),
+      },
+    }),
+  };
+});
+
+function renderPackageCard(props: PackageCardProps) {
+  const renderer = createFleetTestRendererMock();
+
+  const utils = renderer.render(<PackageCard {...props} />);
+
+  return { utils };
+}
+
+describe('package card', () => {
+  let mockNavigateToApp: jest.Mock;
+  let mockNavigateToUrl: jest.Mock;
+
+  beforeEach(() => {
+    mockNavigateToApp = useStartServices().application.navigateToApp as jest.Mock;
+    mockNavigateToUrl = useStartServices().application.navigateToUrl as jest.Mock;
+  });
+
+  it('should navigate with state when integrations card', async () => {
+    const { utils } = renderPackageCard({
+      id: 'card-1',
+      url: '/app/integrations/detail/apache-1.0/overview',
+      fromIntegrations: 'installed',
+      title: 'System',
+      description: 'System',
+    } as PackageCardProps);
+
+    await act(async () => {
+      const el = utils.getByRole('button');
+      fireEvent.click(el!, {});
+    });
+    expect(mockNavigateToApp).toHaveBeenCalledWith('integrations', {
+      path: '/detail/apache-1.0/overview',
+      state: { fromIntegrations: 'installed' },
+    });
+  });
+
+  it('should navigate with url when enterprise search card', async () => {
+    const { utils } = renderPackageCard({
+      id: 'card-1',
+      url: '/app/enterprise_search/workplace_search/setup_guide',
+      fromIntegrations: 'installed',
+      title: 'System',
+      description: 'System',
+    } as PackageCardProps);
+
+    await act(async () => {
+      const el = utils.getByRole('button');
+      fireEvent.click(el!, {});
+    });
+    expect(mockNavigateToUrl).toHaveBeenCalledWith(
+      '/app/enterprise_search/workplace_search/setup_guide'
+    );
+  });
+
+  it('should navigate with window open when external url', async () => {
+    window.open = jest.fn();
+
+    const { utils } = renderPackageCard({
+      id: 'card-1',
+      url: 'https://google.com',
+      fromIntegrations: 'installed',
+      title: 'System',
+      description: 'System',
+    } as PackageCardProps);
+
+    await act(async () => {
+      const el = utils.getByRole('button');
+      fireEvent.click(el!, {});
+    });
+    expect(window.open).toHaveBeenCalledWith('https://google.com', '_blank');
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -56,6 +56,19 @@ export function PackageCard({
 
   const { application } = useStartServices();
 
+  const onCardClick = () => {
+    if (url.startsWith(INTEGRATIONS_BASE_PATH)) {
+      application.navigateToApp(INTEGRATIONS_PLUGIN_ID, {
+        path: url.slice(INTEGRATIONS_BASE_PATH.length),
+        state: { fromIntegrations },
+      });
+    } else if (url.startsWith('http') || url.startsWith('https')) {
+      window.open(url, '_blank');
+    } else {
+      application.navigateToUrl(url);
+    }
+  };
+
   const testid = `integration-card:${id}`;
   return (
     <TrackApplicationView viewId={testid}>
@@ -75,18 +88,7 @@ export function PackageCard({
             size="xl"
           />
         }
-        onClick={() => {
-          if (url.startsWith(INTEGRATIONS_BASE_PATH)) {
-            application.navigateToApp(INTEGRATIONS_PLUGIN_ID, {
-              path: url.slice(INTEGRATIONS_BASE_PATH.length),
-              state: { fromIntegrations },
-            });
-          } else if (url.startsWith('http') || url.startsWith('https')) {
-            window.open(url, '_blank');
-          } else {
-            application.navigateToUrl(url);
-          }
-        }}
+        onClick={onCardClick}
       >
         {releaseBadge}
       </Card>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -14,6 +14,9 @@ import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { CardIcon } from '../../../../../components/package_icon';
 import type { IntegrationCardItem } from '../../../../../../common/types/models/epm';
 
+import { useStartServices } from '../../../hooks';
+import { INTEGRATIONS_BASE_PATH, INTEGRATIONS_PLUGIN_ID } from '../../../constants';
+
 import { RELEASE_BADGE_DESCRIPTION, RELEASE_BADGE_LABEL } from './release_badge';
 
 export type PackageCardProps = IntegrationCardItem;
@@ -34,6 +37,7 @@ export function PackageCard({
   url,
   release,
   id,
+  fromIntegrations,
 }: PackageCardProps) {
   let releaseBadge: React.ReactNode | null = null;
 
@@ -49,6 +53,8 @@ export function PackageCard({
       </EuiFlexItem>
     );
   }
+
+  const { application } = useStartServices();
 
   const testid = `integration-card:${id}`;
   return (
@@ -69,8 +75,18 @@ export function PackageCard({
             size="xl"
           />
         }
-        href={url}
-        target={url.startsWith('http') || url.startsWith('https') ? '_blank' : undefined}
+        onClick={() => {
+          if (url.startsWith(INTEGRATIONS_BASE_PATH)) {
+            application.navigateToApp(INTEGRATIONS_PLUGIN_ID, {
+              path: url.slice(INTEGRATIONS_BASE_PATH.length),
+              state: { fromIntegrations },
+            });
+          } else if (url.startsWith('http') || url.startsWith('https')) {
+            window.open(url, '_blank');
+          } else {
+            application.navigateToUrl(url);
+          }
+        }}
       >
         {releaseBadge}
       </Card>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/index.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import { INTEGRATIONS_ROUTING_PATHS } from '../../constants';
-import { useBreadcrumbs } from '../../hooks';
+import { IntegrationsStateContextProvider, useBreadcrumbs } from '../../hooks';
 
 import { EPMHomePage } from './screens/home';
 import { Detail } from './screens/detail';
@@ -24,7 +24,9 @@ export const EPMApp: React.FunctionComponent = () => {
         <Policy />
       </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details}>
-        <Detail />
+        <IntegrationsStateContextProvider>
+          <Detail />
+        </IntegrationsStateContextProvider>
       </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations}>
         <EPMHomePage />

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -34,6 +34,7 @@ import {
   useStartServices,
   useAuthz,
   usePermissionCheck,
+  useIntegrationsStateContext,
 } from '../../../../hooks';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import { ExperimentalFeaturesService } from '../../../../services';
@@ -94,6 +95,7 @@ function Breadcrumbs({ packageTitle }: { packageTitle: string }) {
 
 export function Detail() {
   const { getId: getAgentPolicyId } = useAgentPolicyContext();
+  const { getFromIntegrations } = useIntegrationsStateContext();
   const { pkgkey, panel } = useParams<DetailParams>();
   const { getHref } = useLink();
   const canInstallPackages = useAuthz().integrations.installPackages;
@@ -195,21 +197,25 @@ export function Detail() {
     [integration, packageInfo]
   );
 
+  const fromIntegrations = getFromIntegrations();
+
+  const href =
+    fromIntegrations === 'updates_available'
+      ? getHref('integrations_installed_updates_available')
+      : fromIntegrations === 'installed'
+      ? getHref('integrations_installed')
+      : getHref('integrations_all');
+
   const headerLeftContent = useMemo(
     () => (
       <EuiFlexGroup direction="column" gutterSize="m">
         <EuiFlexItem>
           {/* Allows button to break out of full width */}
           <div>
-            <EuiButtonEmpty
-              iconType="arrowLeft"
-              size="xs"
-              flush="left"
-              href={getHref('integrations_all')}
-            >
+            <EuiButtonEmpty iconType="arrowLeft" size="xs" flush="left" href={href}>
               <FormattedMessage
                 id="xpack.fleet.epm.browseAllButtonText"
-                defaultMessage="Browse all integrations"
+                defaultMessage="Back to integrations"
               />
             </EuiButtonEmpty>
           </div>
@@ -261,7 +267,7 @@ export function Detail() {
         </EuiFlexItem>
       </EuiFlexGroup>
     ),
-    [getHref, integrationInfo, isLoading, packageInfo]
+    [integrationInfo, isLoading, packageInfo, href]
   );
 
   const handleAddIntegrationPolicyClick = useCallback<ReactEventHandler>(

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -144,6 +144,15 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
   }, []);
 
   const navigateToNewSettingsPage = useCallback(() => {
+    // only navigate if still on old settings page (user has not navigated away)
+    if (
+      !history.location.pathname.match(
+        getPath('integration_details_settings', {
+          pkgkey: `${name}-.*`,
+        })
+      )
+    )
+      return;
     const settingsPath = getPath('integration_details_settings', {
       pkgkey: `${name}-${version}`,
     });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -151,8 +151,9 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           pkgkey: `${name}-.*`,
         })
       )
-    )
+    ) {
       return;
+    }
     const settingsPath = getPath('integration_details_settings', {
       pkgkey: `${name}-${version}`,
     });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -46,7 +46,8 @@ export const categoryExists = (category: string, categories: CategoryFacet[]) =>
 export const mapToCard = (
   getAbsolutePath: (p: string) => string,
   getHref: (page: StaticPage | DynamicPage, values?: DynamicPagePathValues) => string,
-  item: CustomIntegration | PackageListItem
+  item: CustomIntegration | PackageListItem,
+  selectedCategory?: string
 ): IntegrationCardItem => {
   let uiInternalPathUrl;
 
@@ -80,6 +81,7 @@ export const mapToCard = (
     icons: !item.icons || !item.icons.length ? [] : item.icons,
     title: item.title,
     url: uiInternalPathUrl,
+    fromIntegrations: selectedCategory,
     integration: 'integration' in item ? item.integration || '' : '',
     name: 'name' in item ? item.name || '' : '',
     version: 'version' in item ? item.version || '' : '',

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
@@ -143,7 +143,7 @@ export const InstalledPackages: React.FC = memo(() => {
 
   const cards = (
     selectedCategory === 'updates_available' ? updatablePackages : allInstalledPackages
-  ).map((item) => mapToCard(getAbsolutePath, getHref, item));
+  ).map((item) => mapToCard(getAbsolutePath, getHref, item, selectedCategory || 'installed'));
 
   const callout = selectedCategory === 'updates_available' ? null : <Callout />;
 

--- a/x-pack/plugins/fleet/public/constants/page_paths.ts
+++ b/x-pack/plugins/fleet/public/constants/page_paths.ts
@@ -22,6 +22,7 @@ export type StaticPage =
 export type DynamicPage =
   | 'integrations_all'
   | 'integrations_installed'
+  | 'integrations_installed_updates_available'
   | 'integration_details_overview'
   | 'integration_details_policies'
   | 'integration_details_assets'
@@ -76,6 +77,7 @@ export const INTEGRATIONS_ROUTING_PATHS = {
   integrations: '/:tabId',
   integrations_all: '/browse/:category?',
   integrations_installed: '/installed/:category?',
+  integrations_installed_updates_available: '/installed/updates_available/:category?',
   integration_details: '/detail/:pkgkey/:panel?',
   integration_details_overview: '/detail/:pkgkey/overview',
   integration_details_policies: '/detail/:pkgkey/policies',
@@ -103,6 +105,17 @@ export const pagePathGetters: {
     const categoryPath = category ? `/${category}` : ``;
     const queryParams = query ? `?${INTEGRATIONS_SEARCH_QUERYPARAM}=${query}` : ``;
     return [INTEGRATIONS_BASE_PATH, `/installed${categoryPath}${queryParams}`];
+  },
+  integrations_installed_updates_available: ({
+    query,
+    category,
+  }: {
+    query?: string;
+    category?: string;
+  }) => {
+    const categoryPath = category ? `/${category}` : ``;
+    const queryParams = query ? `?${INTEGRATIONS_SEARCH_QUERYPARAM}=${query}` : ``;
+    return [INTEGRATIONS_BASE_PATH, `/installed/updates_available${categoryPath}${queryParams}`];
   },
   integration_details_overview: ({ pkgkey, integration }) => [
     INTEGRATIONS_BASE_PATH,

--- a/x-pack/plugins/fleet/public/types/intra_app_route_state.ts
+++ b/x-pack/plugins/fleet/public/types/intra_app_route_state.ts
@@ -56,6 +56,8 @@ export interface AgentDetailsReassignPolicyAction {
 export interface IntegrationsAppBrowseRouteState {
   /** The agent policy that we are browsing integrations for */
   forAgentPolicyId: string;
+  /** The integration tab the user navigated to details from */
+  fromIntegrations: 'installed' | 'updates_available' | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixing https://github.com/elastic/kibana/issues/131893

- Saving state of `All installed` / `Updates available` packages selected when going back from integration details
  - **To test:** go to `Integrations`, select `Installed` tab, go to `All installed` or `Updates available`. Click on a package card. 
  - From details, navigate back by clicking `Back to integrations` button. 
  - The UI should navigate back to the last visited view in integrations.
- Prevent navigating to integration settings after upgrade if the user has navigated away
  - **To test:** Force install an older system package e.g. 1.11.0. Go to Integrations / Update available / System card.
  - Go to Settings tab, click Upgrade button
  - Quickly navigate back with `Back to integrations` button
  - The UI should not force navigate to System integration Settings tab after upgrade is done.


https://user-images.githubusercontent.com/90178898/171587227-8ad54d86-6ab3-4324-af56-4cc08b5fbd15.mov


https://user-images.githubusercontent.com/90178898/171587650-56e6be96-3088-4624-a8bf-4c5c2fbc3aff.mov




I'll add unit tests next.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
