### PR TITLE
[Fleet] Fix maintenance options for rolling upgrades

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/constants.tsx
@@ -23,4 +23,4 @@ export const FALLBACK_VERSIONS = [
   '7.17.0',
 ];
 
-export const MAINTAINANCE_VALUES = [1, 2, 4, 8, 12, 24, 48];
+export const MAINTAINANCE_VALUES = [0, 1, 2, 4, 8, 12, 24, 48];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import { AgentUpgradeAgentModal } from '.';
+import type { AgentUpgradeAgentModalProps } from '.';
+
+jest.mock('../../../../../../hooks/use_fleet_status', () => ({
+  FleetStatusProvider: (props: any) => {
+    return props.children;
+  },
+  useFleetStatus: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('@elastic/eui', () => {
+  return {
+    ...jest.requireActual('@elastic/eui'),
+    EuiConfirmModal: ({ children }: any) => <>{children}</>,
+  };
+});
+
+function renderAgentUpgradeAgentModal(props: Partial<AgentUpgradeAgentModalProps>) {
+  const renderer = createFleetTestRendererMock();
+
+  const utils = renderer.render(
+    <AgentUpgradeAgentModal agents="" agentCount={12} onClose={() => {}} {...props} />
+  );
+
+  return { utils };
+}
+describe('AgentUpgradeAgentModal', () => {
+  it('should set the default to Immediately if there is less than 10 agents using kuery', async () => {
+    const { utils } = renderAgentUpgradeAgentModal({
+      agents: '*',
+      agentCount: 3,
+    });
+
+    const el = utils.container.querySelector(
+      '[data-test-subj="agentUpgradeModal.MaintainanceCombobox"]'
+    );
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe('Immediately');
+  });
+
+  it('should set the default to Immediately if there is less than 10 agents using selected agents', async () => {
+    const { utils } = renderAgentUpgradeAgentModal({
+      agents: [{ id: 'agent1' }, { id: 'agent2' }] as any,
+      agentCount: 3,
+    });
+
+    const el = utils.container.querySelector(
+      '[data-test-subj="agentUpgradeModal.MaintainanceCombobox"]'
+    );
+    expect(el).not.toBeNull();
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe('Immediately');
+  });
+
+  it('should set the default to 1 hour if there is more than 10 agents', async () => {
+    const { utils } = renderAgentUpgradeAgentModal({
+      agents: '*',
+      agentCount: 13,
+    });
+
+    const el = utils.container.querySelector(
+      '[data-test-subj="agentUpgradeModal.MaintainanceCombobox"]'
+    );
+
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe('1 hour');
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #133113

Fix available maintenance options for rolling upgrade:
* `Immediatly` should be available even for more than 10 agents
* `Immediatly` should be the default for <= 10 agents
* `1 hour` should be the default for > 10 agents

I added some unit test to validate the default value depending on the agent count.

