### PR TITLE
[Cloud Posture] update benchmark table rows size

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -135,7 +135,7 @@ export const Benchmarks = () => {
   const [query, setQuery] = useState<UseCspBenchmarkIntegrationsProps>({
     name: '',
     page: 1,
-    perPage: 5,
+    perPage: 10,
     sortField: 'package_policy.name',
     sortOrder: 'asc',
   });


### PR DESCRIPTION
update the `rows_per_page` from `5` to `10` in benchmark page

![Screen Shot 2022-06-02 at 12 13 56](https://user-images.githubusercontent.com/20814186/171597500-41ad134f-d883-43d3-ba14-8e7ed630ddb4.png)
