### PR TITLE
[Cloud Posture] add info callout in rules page

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -11,6 +11,7 @@ import { EuiTextColor, EuiEmptyPrompt, EuiButtonEmpty, EuiFlexGroup } from '@ela
 import * as t from 'io-ts';
 import type { KibanaPageTemplateProps } from '@kbn/kibana-react-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import { RulesContainer, type PageUrlParams } from './rules_container';
 import { allNavigationItems } from '../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
@@ -18,6 +19,7 @@ import { CspNavigationItem } from '../../common/navigation/types';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import { useCspIntegration } from './use_csp_integration';
 import { CspPageTemplate } from '../../components/csp_page_template';
+import { useKibana } from '../../common/hooks/use_kibana';
 
 const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   [allNavigationItems.benchmarks, { ...allNavigationItems.rules, name }].filter(
@@ -25,6 +27,7 @@ const getRulesBreadcrumbs = (name?: string): CspNavigationItem[] =>
   );
 
 export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>) => {
+  const { http } = useKibana().services;
   const integrationInfo = useCspIntegration(params);
   const breadcrumbs = useMemo(
     // TODO: make benchmark breadcrumb navigable
@@ -37,6 +40,19 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
   const pageProps: KibanaPageTemplateProps = useMemo(
     () => ({
       pageHeader: {
+        alignItems: 'bottom',
+        rightSideItems: [
+          <EuiButtonEmpty
+            iconType="gear"
+            size="xs"
+            href={http.basePath.prepend(pagePathGetters.edit_integration(params).join(''))}
+          >
+            <FormattedMessage
+              id="xpack.csp.rules.manageIntegrationButtonLabel"
+              defaultMessage="Manage Integration"
+            />
+          </EuiButtonEmpty>,
+        ],
         pageTitle: (
           <EuiFlexGroup direction="column" gutterSize="none">
             <Link to={generatePath(allNavigationItems.benchmarks.path)}>
@@ -70,7 +86,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
         ),
       },
     }),
-    [integrationInfo.data]
+    [http.basePath, integrationInfo.data, params]
   );
 
   return (

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -5,17 +5,8 @@
  * 2.0.
  */
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButtonEmpty,
-  type EuiBasicTable,
-  EuiPanel,
-  EuiSpacer,
-} from '@elastic/eui';
+import { type EuiBasicTable, EuiPanel, EuiSpacer, EuiCallOut } from '@elastic/eui';
 import { useParams } from 'react-router-dom';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import { cspRuleAssetSavedObjectType } from '../../../common/constants';
 import { extractErrorMessage, isNonNullable } from '../../../common/utils/helpers';
 import { RulesTable } from './rules_table';
@@ -30,7 +21,7 @@ import {
 } from './use_csp_rules';
 import * as TEST_SUBJECTS from './test_subjects';
 import { RuleFlyout } from './rules_flyout';
-import { useKibana } from '../../common/hooks/use_kibana';
+import { DATA_UPDATE_INFO } from './translations';
 
 interface RulesPageData {
   rules_page: RuleSavedObject[];
@@ -178,7 +169,7 @@ export const RulesContainer = () => {
 
   return (
     <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
-      <ManageIntegrationButton {...params} />
+      <EuiCallOut size="m" title={DATA_UPDATE_INFO} iconType="iInCircle" />
       <EuiSpacer />
       <EuiPanel hasBorder hasShadow={false}>
         <RulesTableHeader
@@ -231,32 +222,5 @@ export const RulesContainer = () => {
         />
       )}
     </div>
-  );
-};
-
-const ManageIntegrationButton = ({ policyId, packagePolicyId }: PageUrlParams) => {
-  const { http } = useKibana().services;
-  return (
-    <EuiFlexGroup>
-      <EuiFlexItem grow={1} style={{ alignItems: 'flex-end' }}>
-        <EuiButtonEmpty
-          href={http.basePath.prepend(
-            pagePathGetters
-              .edit_integration({
-                policyId,
-                packagePolicyId,
-              })
-              .join('')
-          )}
-          iconType="gear"
-          size="xs"
-        >
-          <FormattedMessage
-            id="xpack.csp.rules.manageIntegrationButtonLabel"
-            defaultMessage="Manage Integration"
-          />
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -87,5 +87,5 @@ export const REMEDIATION = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.remed
 
 export const DATA_UPDATE_INFO = i18n.translate('xpack.csp.rules.dataUpdateInfoCallout', {
   defaultMessage:
-    'Please note, any changes to your benchmark rules will take effect the next time your resources are evaluated again. This can take up to ~5 hours',
+    'Please note, any changes to your benchmark rules will take effect the next time your resources are evaluated. This can take up to ~5 hours',
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -84,3 +84,8 @@ export const OVERVIEW = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.overview
 export const REMEDIATION = i18n.translate('xpack.csp.rules.ruleFlyout.tabs.remediationTabLabel', {
   defaultMessage: 'Remediation',
 });
+
+export const DATA_UPDATE_INFO = i18n.translate('xpack.csp.rules.dataUpdateInfoCallout', {
+  defaultMessage:
+    'Please note, any changes to your benchmark rules will take effect the next time your resources are evaluated again. This can take up to ~5 hours',
+});


### PR DESCRIPTION
adds an info callout in rules page, below the page header, with a text that informs the user how long it takes changes to reflect in UI. also moved the `manage_integration` button to the page header (as per design spec in issue, which is required with the addition of the callout)

![Screen Shot 2022-06-02 at 12 42 01](https://user-images.githubusercontent.com/20814186/171603104-118ae353-2ea8-40ca-b3f4-127b64490fb4.png)

