### PR TITLE
[8.3] [SecuritySolution] Hide the "Investigate in TL" button for the agent status field (#132829)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -24,6 +24,7 @@ import type { EnrichedFieldInfo, EventSummaryField } from './types';
 
 import * as i18n from './translations';
 import { ColumnHeaderOptions } from '../../../../common/types';
+import { AGENT_STATUS_FIELD_NAME } from '../../../timelines/components/timeline/body/renderers/constants';
 
 /**
  * Defines the behavior of the search input that appears above the table of data
@@ -224,4 +225,19 @@ export function getEnrichedFieldInfo({
     linkValue: linkValue ?? undefined,
     fieldFromBrowserField: browserField,
   };
+}
+
+/**
+ * A lookup table for fields that should not have actions
+ */
+export const FIELDS_WITHOUT_ACTIONS: { [field: string]: boolean } = {
+  [AGENT_STATUS_FIELD_NAME]: true,
+};
+
+/**
+ * Checks whether the given field should have hover or row actions.
+ * The lookup is fast, so it is not necessary to memoize the result.
+ */
+export function hasHoverOrRowActions(field: string): boolean {
+  return !FIELDS_WITHOUT_ACTIONS[field];
 }

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/add_to_timeline_cell.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/add_to_timeline_cell.test.tsx
@@ -15,6 +15,7 @@ import { EventFieldsData } from '../types';
 import { TimelineId } from '../../../../../common/types';
 
 import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../detections/components/alerts_table/translations';
+import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 
 jest.mock('../../../lib/kibana');
 
@@ -43,6 +44,37 @@ const hostIpData: EventFieldsData = {
   isObjectArray: false,
   originalValue: ['127.0.0.1', '::1', '10.1.2.3', '2001:0DB8:AC10:FE01::'],
   values: ['127.0.0.1', '::1', '10.1.2.3', '2001:0DB8:AC10:FE01::'],
+};
+
+const agentStatusFieldFromBrowserField: BrowserField = {
+  aggregatable: true,
+  category: 'agent',
+  description: 'Agent status.',
+  fields: {},
+  format: '',
+  indexes: ['auditbeat-*', 'filebeat-*', 'logs-*', 'winlogbeat-*'],
+  name: AGENT_STATUS_FIELD_NAME,
+  readFromDocValues: false,
+  searchable: true,
+  type: 'string',
+  example: 'status',
+};
+
+const agentStatusData: EventFieldsData = {
+  field: AGENT_STATUS_FIELD_NAME,
+  format: '',
+  type: '',
+  aggregatable: false,
+  description: '',
+  example: '',
+  category: '',
+  fields: {},
+  indexes: [],
+  name: AGENT_STATUS_FIELD_NAME,
+  searchable: false,
+  readFromDocValues: false,
+  isObjectArray: false,
+  values: ['status'],
 };
 
 describe('AddToTimelineCellRenderer', () => {
@@ -75,6 +107,24 @@ describe('AddToTimelineCellRenderer', () => {
             linkValue={undefined}
             timelineId={TimelineId.test}
             values={hostIpData.values}
+          />
+        </TestProviders>
+      );
+      expect(screen.queryByLabelText(ACTION_INVESTIGATE_IN_TIMELINE)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('When the field is the host status field', () => {
+    test('it should not render', () => {
+      render(
+        <TestProviders>
+          <AddToTimelineCellRenderer
+            data={agentStatusData}
+            eventId={eventId}
+            fieldFromBrowserField={agentStatusFieldFromBrowserField}
+            linkValue={undefined}
+            timelineId={TimelineId.test}
+            values={agentStatusData.values}
           />
         </TestProviders>
       );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/add_to_timeline_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/add_to_timeline_cell.tsx
@@ -10,7 +10,7 @@ import { EuiButtonIcon } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { useDispatch } from 'react-redux';
 
-import { AlertSummaryRow } from '../helpers';
+import { AlertSummaryRow, hasHoverOrRowActions } from '../helpers';
 import { inputsActions } from '../../../store/inputs';
 import { updateProviders } from '../../../../timelines/store/timeline/actions';
 import { sourcererActions } from '../../../store/actions';
@@ -66,7 +66,9 @@ const AddToTimelineCell = React.memo<AlertSummaryRow['description']>(
       }
     }, [dispatch, clearTimeline, actionCellConfig]);
 
-    const showButton = values != null && !isEmpty(actionCellConfig?.dataProvider);
+    const fieldHasActionsEnabled = hasHoverOrRowActions(data.field);
+    const showButton =
+      values != null && !isEmpty(actionCellConfig?.dataProvider) && fieldHasActionsEnabled;
 
     if (showButton) {
       return (

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
@@ -9,12 +9,8 @@ import React from 'react';
 
 import { ActionCell } from './action_cell';
 import { FieldValueCell } from './field_value_cell';
-import { AlertSummaryRow } from '../helpers';
+import { AlertSummaryRow, hasHoverOrRowActions } from '../helpers';
 import { TimelineId } from '../../../../../common/types';
-
-import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
-
-const FIELDS_WITHOUT_ACTIONS: { [field: string]: boolean } = { [AGENT_STATUS_FIELD_NAME]: true };
 
 const style = { flexGrow: 0 };
 
@@ -28,7 +24,7 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
   values,
   isReadOnly,
 }) => {
-  const hoverActionsEnabled = !FIELDS_WITHOUT_ACTIONS[data.field];
+  const hoverActionsEnabled = hasHoverOrRowActions(data.field);
 
   return (
     <>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[SecuritySolution] Hide the "Investigate in TL" button for the agent status field (#132829)](https://github.com/elastic/kibana/pull/132829)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)