### PR TITLE
[Fleet] Update bundled versions of elastic_agent and fleet_server integrations

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -19,7 +19,7 @@
   },
   {
     "name": "elastic_agent",
-    "version": "1.3.1"
+    "version": "1.3.3"
   },
   {
     "name": "endpoint",
@@ -27,7 +27,7 @@
   },
   {
     "name": "fleet_server",
-    "version": "1.1.1"
+    "version": "1.2.0"
   },
   {
     "name": "synthetics",


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/issues/133255

Updates `elastic_agent` to `1.3.3` and `fleet_server` to `1.2.0` in `fleet_packages.json`.

