### PR TITLE
[Fleet] Fix EuiComboBox in agent upgrade modal to disallow clear

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -26,6 +26,7 @@ import type { EuiComboBoxOptionOption } from '@elastic/eui';
 
 import semverCoerce from 'semver/functions/coerce';
 import semverGt from 'semver/functions/gt';
+import semverValid from 'semver/functions/valid';
 
 import { getMinVersion } from '../../../../../../../common/services/get_min_max_version';
 import type { Agent } from '../../../../types';
@@ -199,6 +200,10 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
   }
 
   const onCreateOption = (searchValue: string) => {
+    if (!semverValid(searchValue)) {
+      return;
+    }
+
     const agentVersionNumber = semverCoerce(searchValue);
     if (
       agentVersionNumber?.version &&
@@ -297,8 +302,12 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           fullWidth
           singleSelection={{ asPlainText: true }}
           options={versionOptions}
+          isClearable={false}
           selectedOptions={selectedVersion}
           onChange={(selected: Array<EuiComboBoxOptionOption<string>>) => {
+            if (!selected.length) {
+              return;
+            }
             setSelectedVersion(selected);
           }}
           onCreateOption={onCreateOption}
@@ -369,10 +378,14 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           <EuiComboBox
             data-test-subj="agentUpgradeModal.MaintainanceCombobox"
             fullWidth
+            isClearable={false}
             singleSelection={{ asPlainText: true }}
             options={maintainanceOptions}
             selectedOptions={selectedMantainanceWindow}
             onChange={(selected: Array<EuiComboBoxOptionOption<number>>) => {
+              if (!selected.length) {
+                return;
+              }
               setSelectedMantainanceWindow(selected);
             }}
           />

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import moment from 'moment';
+import semverIsValid from 'semver/functions/valid';
 
 import { NewAgentActionSchema } from '../models';
 
@@ -61,13 +62,21 @@ export const PostBulkAgentUnenrollRequestSchema = {
   }),
 };
 
+function validateVersion(s: string) {
+  if (!semverIsValid(s)) {
+    return 'not a valid semver';
+  }
+}
+
 export const PostAgentUpgradeRequestSchema = {
   params: schema.object({
     agentId: schema.string(),
   }),
   body: schema.object({
     source_uri: schema.maybe(schema.string()),
-    version: schema.string(),
+    version: schema.string({
+      validate: validateVersion,
+    }),
     force: schema.maybe(schema.boolean()),
   }),
 };
@@ -76,7 +85,7 @@ export const PostBulkAgentUpgradeRequestSchema = {
   body: schema.object({
     agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
     source_uri: schema.maybe(schema.string()),
-    version: schema.string(),
+    version: schema.string({ validate: validateVersion }),
     force: schema.maybe(schema.boolean()),
     rollout_duration_seconds: schema.maybe(schema.number({ min: 600 })),
     start_time: schema.maybe(


### PR DESCRIPTION
## Summary

Resolve #133390 #133378

Fix the combo boxes in the agent upgrade modal for version and maintenance windows to not allow to clear value (with the cross button or with the the delete key input) and to not allow to create invalid version

Also added some server side validation on the upgrade version


## UI Changes

<img width="881" alt="Screen Shot 2022-06-02 at 7 23 58 PM" src="https://user-images.githubusercontent.com/1336873/171690220-827135c3-0be1-4f9f-b32b-4dd53b8ce3df.png">
