### PR TITLE
use the correct version of flatten

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/top_hit.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.ts
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { aggTopHitFnName } from './top_hit_fn';
 import { IMetricAggConfig, MetricAggType } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
-import { KBN_FIELD_TYPES } from '../../..';
+import { KBN_FIELD_TYPES, flattenHit } from '../../..';
 import { BaseAggParams } from '../types';
 
 export interface AggParamsTopHit extends BaseAggParams {
@@ -216,7 +216,9 @@ export const getTopHitMetricAgg = () => {
 
       let values = _.flatten(
         hits.map((hit) =>
-          path === '_source' ? hit._source : agg.getIndexPattern().flattenHit(hit, true)[path]
+          path === '_source'
+            ? hit._source
+            : flattenHit(hit, agg.getIndexPattern(), { shallow: false })[path]
         )
       );
 


### PR DESCRIPTION
## Summary

Code comments indicate that the data view flatten method is deprecated. We should stop using it.