### PR TITLE
[Enterprise Search] Apply two-column layout to overview page header

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
@@ -156,30 +156,33 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({
       <SetPageChrome />
       <SendTelemetry action="viewed" metric="overview" />
       <TrialCallout />
-      <EuiText textAlign="center">
-        <KibanaPageTemplateSolutionNavAvatar
-          name="Enterprise Search"
-          iconType="logoEnterpriseSearch"
-          size="xxl"
-        />
-
-        <EuiSpacer />
-
-        <h1>
-          {i18n.translate('xpack.enterpriseSearch.overview.heading', {
-            defaultMessage: 'Welcome to Elastic Enterprise Search',
-          })}
-        </h1>
-        <p>
-          {config.host
-            ? i18n.translate('xpack.enterpriseSearch.overview.subheading', {
-                defaultMessage: 'Add search to your app or organization.',
-              })
-            : i18n.translate('xpack.enterpriseSearch.overview.setupHeading', {
-                defaultMessage: 'Choose a product to set up and get started.',
+      <EuiFlexGroup responsive={false} alignItems="center">
+        <EuiFlexItem grow={false}>
+          <KibanaPageTemplateSolutionNavAvatar
+            name="Enterprise Search"
+            iconType="logoEnterpriseSearch"
+            size="xxl"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText>
+            <h1>
+              {i18n.translate('xpack.enterpriseSearch.overview.heading', {
+                defaultMessage: 'Welcome to Elastic Enterprise Search',
               })}
-        </p>
-      </EuiText>
+            </h1>
+            <p>
+              {config.host
+                ? i18n.translate('xpack.enterpriseSearch.overview.subheading', {
+                    defaultMessage: 'Add search to your app or organization.',
+                  })
+                : i18n.translate('xpack.enterpriseSearch.overview.setupHeading', {
+                    defaultMessage: 'Choose a product to set up and get started.',
+                  })}
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="xxl" />
       {shouldShowEnterpriseSearchCards ? productCards : insufficientAccessMessage}
       <Chat />


### PR DESCRIPTION
## Summary

#### Before

![image](https://user-images.githubusercontent.com/2479295/171743151-af254e8d-53c9-4c0e-8c87-e9cec09ce431.png)

#### After 

![image](https://user-images.githubusercontent.com/2479295/171743167-143b564b-ee7b-4834-b50d-b9175a6623c5.png)


### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
