### PR TITLE
[TSVB2Lens] Use pick_max instead of clamp for positive only

### DIFF
--- a/src/plugins/vis_types/timeseries/public/trigger_action/get_series.test.ts
+++ b/src/plugins/vis_types/timeseries/public/trigger_action/get_series.test.ts
@@ -104,7 +104,7 @@ describe('getSeries', () => {
         fieldName: 'document',
         isFullReference: true,
         params: {
-          formula: 'clamp(max(day_of_week_i), 0, max(day_of_week_i))',
+          formula: 'pick_max(max(day_of_week_i), 0)',
         },
       },
     ]);

--- a/src/plugins/vis_types/timeseries/public/trigger_action/metrics_helpers.ts
+++ b/src/plugins/vis_types/timeseries/public/trigger_action/metrics_helpers.ts
@@ -220,7 +220,10 @@ export const getSiblingPipelineSeriesFormula = (
   // support nested aggs with formula
   const additionalSubFunction = metrics.find((metric) => metric.id === subMetricField);
   let formula = `${aggregationMap.name}(`;
-  let minMax = '';
+  let minimumValue = '';
+  if (currentMetric.type === 'positive_only') {
+    minimumValue = `, 0`;
+  }
   if (additionalSubFunction) {
     const additionalPipelineAggMap = SUPPORTED_METRICS[additionalSubFunction.type];
     if (!additionalPipelineAggMap) {
@@ -228,14 +231,9 @@ export const getSiblingPipelineSeriesFormula = (
     }
     const additionalSubFunctionField =
       additionalSubFunction.type !== 'count' ? additionalSubFunction.field : '';
-    if (currentMetric.type === 'positive_only') {
-      minMax = `, 0, ${pipelineAggMap.name}(${additionalPipelineAggMap.name}(${
-        additionalSubFunctionField ?? ''
-      }))`;
-    }
     formula += `${pipelineAggMap.name}(${additionalPipelineAggMap.name}(${
       additionalSubFunctionField ?? ''
-    }))${minMax})`;
+    }))${minimumValue})`;
   } else {
     let additionalFunctionArgs;
     // handle percentile and percentile_rank
@@ -246,14 +244,9 @@ export const getSiblingPipelineSeriesFormula = (
     if (pipelineAggMap.name === 'percentile_rank' && nestedMetaValue) {
       additionalFunctionArgs = `, value=${nestedMetaValue}`;
     }
-    if (currentMetric.type === 'positive_only') {
-      minMax = `, 0, ${pipelineAggMap.name}(${subMetricField ?? ''}${
-        additionalFunctionArgs ? `${additionalFunctionArgs}` : ''
-      })`;
-    }
     formula += `${pipelineAggMap.name}(${subMetricField ?? ''}${
       additionalFunctionArgs ? `${additionalFunctionArgs}` : ''
-    })${minMax})`;
+    })${minimumValue})`;
   }
   return formula;
 };

--- a/src/plugins/vis_types/timeseries/public/trigger_action/supported_metrics.ts
+++ b/src/plugins/vis_types/timeseries/public/trigger_action/supported_metrics.ts
@@ -93,7 +93,7 @@ export const SUPPORTED_METRICS: { [key: string]: AggOptions } = {
     isFullReference: true,
   },
   positive_only: {
-    name: 'clamp',
+    name: 'pick_max',
     isFullReference: true,
   },
   static: {


### PR DESCRIPTION
## Summary

For the transition from TSVB `positive_only` function to Lens formula we are using `clamp`. This PR uses `pick_max` instead as I think it is a better choice and makes the code a bit cleaner.

![tsvb2lens](https://user-images.githubusercontent.com/17003240/171802770-3b0f79d3-7e2d-4596-aa4b-df3034d47f1e.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios