### PR TITLE
Add coloring package storybook preview in CI

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.js
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.js
@@ -16,6 +16,7 @@ const STORYBOOKS = [
   'canvas',
   'ci_composite',
   'cloud',
+  'coloring',
   'controls',
   'custom_integrations',
   'dashboard_enhanced',


### PR DESCRIPTION
## Summary
When we added the storybook alias for the `kbn-coloring` package we forgot to add the entry to the `build_and_upload` file to enable the CI preview.

Check on this PR that coloring has been added to the storybook preview https://ci-artifacts.kibana.dev/storybooks/pr-133463/f146ca7e0add7ef1ec80b6b38433b51b6be8750a/coloring/index.html