### PR TITLE
[Cases] fix edit tags list displaying old values after edit

### DIFF
--- a/x-pack/plugins/cases/public/components/tag_list/index.tsx
+++ b/x-pack/plugins/cases/public/components/tag_list/index.tsx
@@ -70,9 +70,10 @@ export const TagList = React.memo(
       const { isValid, data: newData } = await submit();
       if (isValid && newData.tags) {
         onSubmit(newData.tags);
+        form.reset({ defaultValue: newData });
         setIsEditTags(false);
       }
-    }, [onSubmit, submit]);
+    }, [form, onSubmit, submit]);
 
     const { tags: tagOptions } = useGetTags();
     const [options, setOptions] = useState(

--- a/x-pack/plugins/cases/public/components/tag_list/index.tsx
+++ b/x-pack/plugins/cases/public/components/tag_list/index.tsx
@@ -73,7 +73,8 @@ export const TagList = React.memo(
         form.reset({ defaultValue: newData });
         setIsEditTags(false);
       }
-    }, [form, onSubmit, submit]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [onSubmit, submit]);
 
     const { tags: tagOptions } = useGetTags();
     const [options, setOptions] = useState(


### PR DESCRIPTION
## Summary

After https://github.com/elastic/kibana/pull/130544 was merged the tag list form started showing this behaviour due to the way the form was implemented.

Fixes https://github.com/elastic/kibana/issues/133464

