### PR TITLE
[Security Solution] Add names to some of user interactions on the rules management page

### DIFF
--- a/x-pack/plugins/security_solution/public/common/lib/apm/__mocks__/use_start_transaction.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/apm/__mocks__/use_start_transaction.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const useStartTransaction = jest.fn(() => ({
+  startTransaction: jest.fn(),
+}));

--- a/x-pack/plugins/security_solution/public/common/lib/apm/use_start_transaction.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/apm/use_start_transaction.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { useKibana } from '../kibana';
+
+const transactionOptions = { managed: true };
+
+interface StartTransactionOptions {
+  name: string;
+  type?: string;
+}
+
+export const useStartTransaction = () => {
+  const {
+    services: { apm },
+  } = useKibana();
+
+  const startTransaction = useCallback(
+    ({ name, type = 'user-interaction' }: StartTransactionOptions) => {
+      return apm.startTransaction(name, type, transactionOptions);
+    },
+    [apm]
+  );
+
+  return { startTransaction };
+};

--- a/x-pack/plugins/security_solution/public/common/lib/apm/user_actions.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/apm/user_actions.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SECURITY_ACTIONS_PREFIX = 'securitySolution';
+
+export const SINGLE_RULE_ACTIONS = {
+  ENABLE: `${SECURITY_ACTIONS_PREFIX} singleRuleActions enable`,
+  DISABLE: `${SECURITY_ACTIONS_PREFIX} singleRuleActions disable`,
+  DUPLICATE: `${SECURITY_ACTIONS_PREFIX} singleRuleActions duplicate`,
+  EXPORT: `${SECURITY_ACTIONS_PREFIX} singleRuleActions export`,
+  DELETE: `${SECURITY_ACTIONS_PREFIX} singleRuleActions delete`,
+  PREVIEW: `${SECURITY_ACTIONS_PREFIX} singleRuleActions preview`,
+  SAVE: `${SECURITY_ACTIONS_PREFIX} singleRuleActions save`,
+};
+
+export const BULK_RULE_ACTIONS = {
+  ENABLE: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions enable`,
+  DISABLE: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions disable`,
+  DUPLICATE: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions duplicate`,
+  EXPORT: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions export`,
+  DELETE: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions delete`,
+  EDIT: `${SECURITY_ACTIONS_PREFIX} bulkRuleActions edit`,
+};
+
+export const RULES_TABLE_ACTIONS = {
+  REFRESH: `${SECURITY_ACTIONS_PREFIX} rulesTable refresh`,
+  FILTER: `${SECURITY_ACTIONS_PREFIX} rulesTable filter`,
+  LOAD_PREBUILT: `${SECURITY_ACTIONS_PREFIX} rulesTable loadPrebuilt`,
+  PREVIEW_ON: `${SECURITY_ACTIONS_PREFIX} rulesTable technicalPreview on`,
+  PREVIEW_OFF: `${SECURITY_ACTIONS_PREFIX} rulesTable technicalPreview off`,
+};

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/kibana_react.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/kibana_react.ts
@@ -13,6 +13,7 @@ import {
   useUiSetting$,
   withKibana,
 } from '@kbn/kibana-react-plugin/public';
+import type { ApmBase } from '@elastic/apm-rum';
 import { StartServices } from '../../../types';
 
 export type KibanaContext = KibanaReactContextValue<StartServices>;
@@ -23,6 +24,7 @@ export interface WithKibanaProps {
 const useTypedKibana = () => useKibana<StartServices>();
 
 export {
+  ApmBase,
   KibanaContextProvider,
   useTypedKibana as useKibana,
   useUiSetting,

--- a/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import styled from 'styled-components';
 
 import * as i18n from './translations';
@@ -32,10 +32,6 @@ const PrePackagedRulesPromptComponent: React.FC<PrePackagedRulesPromptProps> = (
   loading = false,
   userHasPermissions = false,
 }) => {
-  const handlePreBuiltCreation = useCallback(() => {
-    createPrePackagedRules();
-  }, [createPrePackagedRules]);
-
   const [{ isSignalIndexExists, isAuthenticated, hasEncryptionKey, canUserCRUD, hasIndexWrite }] =
     useUserData();
 
@@ -51,11 +47,11 @@ const PrePackagedRulesPromptComponent: React.FC<PrePackagedRulesPromptProps> = (
     () =>
       getLoadPrebuiltRulesAndTemplatesButton({
         isDisabled: !userHasPermissions || loading,
-        onClick: handlePreBuiltCreation,
+        onClick: createPrePackagedRules,
         fill: true,
         'data-test-subj': 'load-prebuilt-rules',
       }),
-    [getLoadPrebuiltRulesAndTemplatesButton, handlePreBuiltCreation, userHasPermissions, loading]
+    [getLoadPrebuiltRulesAndTemplatesButton, createPrePackagedRules, userHasPermissions, loading]
   );
 
   return (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.test.tsx
@@ -15,6 +15,7 @@ import {
 import { RuleActionsOverflow } from '.';
 import { mockRule } from '../../../pages/detection_engine/rules/all/__mocks__/mock';
 
+jest.mock('../../../../common/lib/apm/use_start_transaction');
 jest.mock('../../../../common/hooks/use_app_toasts');
 jest.mock('../../../../common/lib/kibana', () => {
   const actual = jest.requireActual('../../../../common/lib/kibana');

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
@@ -20,6 +20,8 @@ import { BulkAction } from '../../../../../common/detection_engine/schemas/commo
 import { getRulesUrl } from '../../../../common/components/link_to/redirect_to_detection_engine';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useBoolState } from '../../../../common/hooks/use_bool_state';
+import { SINGLE_RULE_ACTIONS } from '../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 import { useKibana } from '../../../../common/lib/kibana';
 import { getToolTipContent } from '../../../../common/utils/privileges';
 import { Rule } from '../../../containers/detection_engine/rules';
@@ -58,6 +60,7 @@ const RuleActionsOverflowComponent = ({
   const [isPopoverOpen, , closePopover, togglePopover] = useBoolState();
   const { navigateToApp } = useKibana().services.application;
   const toasts = useAppToasts();
+  const { startTransaction } = useStartTransaction();
 
   const onRuleDeletedCallback = useCallback(() => {
     navigateToApp(APP_UI_ID, {
@@ -76,6 +79,7 @@ const RuleActionsOverflowComponent = ({
               disabled={!canDuplicateRuleWithActions || !userHasPermissions}
               data-test-subj="rules-details-duplicate-rule"
               onClick={async () => {
+                startTransaction({ name: SINGLE_RULE_ACTIONS.DUPLICATE });
                 closePopover();
                 const result = await executeRulesBulkAction({
                   action: BulkAction.duplicate,
@@ -102,6 +106,7 @@ const RuleActionsOverflowComponent = ({
               disabled={!userHasPermissions || rule.immutable}
               data-test-subj="rules-details-export-rule"
               onClick={async () => {
+                startTransaction({ name: SINGLE_RULE_ACTIONS.EXPORT });
                 closePopover();
                 await executeRulesBulkAction({
                   action: BulkAction.export,
@@ -119,6 +124,7 @@ const RuleActionsOverflowComponent = ({
               disabled={!userHasPermissions}
               data-test-subj="rules-details-delete-rule"
               onClick={async () => {
+                startTransaction({ name: SINGLE_RULE_ACTIONS.DELETE });
                 closePopover();
                 await executeRulesBulkAction({
                   action: BulkAction.delete,
@@ -138,6 +144,7 @@ const RuleActionsOverflowComponent = ({
       navigateToApp,
       onRuleDeletedCallback,
       rule,
+      startTransaction,
       toasts,
       userHasPermissions,
     ]

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Unit } from '@kbn/datemath';
 import { ThreatMapping, Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import styled from 'styled-components';
@@ -29,6 +29,8 @@ import { LoadingHistogram } from './loading_histogram';
 import { FieldValueThreshold } from '../threshold_input';
 import { isJobStarted } from '../../../../../common/machine_learning/helpers';
 import { EqlOptionsSelected } from '../../../../../common/search_strategy';
+import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
+import { SINGLE_RULE_ACTIONS } from '../../../../common/lib/apm/user_actions';
 
 const HelpTextComponent = (
   <EuiFlexGroup direction="column" gutterSize="none">
@@ -123,6 +125,13 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
     setTimeFrame(defaultTimeRange);
   }, [ruleType]);
 
+  const { startTransaction } = useStartTransaction();
+
+  const handlePreviewClick = useCallback(() => {
+    startTransaction({ name: SINGLE_RULE_ACTIONS.PREVIEW });
+    createPreview();
+  }, [createPreview, startTransaction]);
+
   return (
     <>
       <EuiFormRow
@@ -150,7 +159,7 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
               fill
               isLoading={isPreviewRequestInProgress}
               isDisabled={isDisabled || !areRelaventMlJobsRunning}
-              onClick={createPreview}
+              onClick={handlePreviewClick}
               data-test-subj="queryPreviewButton"
             >
               {i18n.QUERY_PREVIEW_BUTTON}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.test.tsx
@@ -21,6 +21,7 @@ import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
 jest.mock('../../../../common/hooks/use_app_toasts');
 jest.mock('../../../containers/detection_engine/rules');
 jest.mock('../../../pages/detection_engine/rules/all/rules_table/rules_table_context');
+jest.mock('../../../../common/lib/apm/use_start_transaction');
 
 const useAppToastsValueMock = useAppToastsMock.create();
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
@@ -17,6 +17,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { BulkAction } from '../../../../../common/detection_engine/schemas/common';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { SINGLE_RULE_ACTIONS } from '../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 import { useUpdateRulesCache } from '../../../containers/detection_engine/rules/use_find_rules_query';
 import { executeRulesBulkAction } from '../../../pages/detection_engine/rules/all/actions';
 import { useRulesTableContextOptional } from '../../../pages/detection_engine/rules/all/rules_table/rules_table_context';
@@ -52,10 +54,14 @@ export const RuleSwitchComponent = ({
   const rulesTableContext = useRulesTableContextOptional();
   const updateRulesCache = useUpdateRulesCache();
   const toasts = useAppToasts();
+  const { startTransaction } = useStartTransaction();
 
   const onRuleStateChange = useCallback(
     async (event: EuiSwitchEvent) => {
       setMyIsLoading(true);
+      startTransaction({
+        name: enabled ? SINGLE_RULE_ACTIONS.DISABLE : SINGLE_RULE_ACTIONS.ENABLE,
+      });
       const bulkActionResponse = await executeRulesBulkAction({
         setLoadingRules: rulesTableContext?.actions.setLoadingRules,
         toasts,
@@ -71,7 +77,7 @@ export const RuleSwitchComponent = ({
       }
       setMyIsLoading(false);
     },
-    [id, onChange, rulesTableContext, toasts, updateRulesCache]
+    [enabled, id, onChange, rulesTableContext, startTransaction, toasts, updateRulesCache]
   );
 
   const showLoader = useMemo((): boolean => {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
@@ -39,6 +39,8 @@ import { convertRulesFilterToKQL } from '../../../../../containers/detection_eng
 
 import type { FilterOptions } from '../../../../../containers/detection_engine/rules/types';
 import { useInvalidateRules } from '../../../../../containers/detection_engine/rules/use_find_rules_query';
+import { BULK_RULE_ACTIONS } from '../../../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../../../common/lib/apm/use_start_transaction';
 
 interface UseBulkActionsArgs {
   filterOptions: FilterOptions;
@@ -65,6 +67,7 @@ export const useBulkActions = ({
   const toasts = useAppToasts();
   const getIsMounted = useIsMounted();
   const filterQuery = convertRulesFilterToKQL(filterOptions);
+  const { startTransaction } = useStartTransaction();
 
   // refetch tags if edit action is related to tags: add_tags/delete_tags/set_tags
   const resolveTagsRefetch = useCallback(
@@ -99,6 +102,7 @@ export const useBulkActions = ({
         selectedRules.some((rule) => !canEditRuleWithActions(rule, hasActionsPrivileges));
 
       const handleEnableAction = async () => {
+        startTransaction({ name: BULK_RULE_ACTIONS.ENABLE });
         closePopover();
         const disabledRules = selectedRules.filter(({ enabled }) => !enabled);
         const disabledRulesNoML = disabledRules.filter(({ type }) => !isMlRule(type));
@@ -123,6 +127,7 @@ export const useBulkActions = ({
       };
 
       const handleDisableActions = async () => {
+        startTransaction({ name: BULK_RULE_ACTIONS.DISABLE });
         closePopover();
         const enabledIds = selectedRules.filter(({ enabled }) => enabled).map(({ id }) => id);
         await executeRulesBulkAction({
@@ -136,6 +141,7 @@ export const useBulkActions = ({
       };
 
       const handleDuplicateAction = async () => {
+        startTransaction({ name: BULK_RULE_ACTIONS.DUPLICATE });
         closePopover();
         await executeRulesBulkAction({
           visibleRuleIds: selectedRuleIds,
@@ -156,6 +162,7 @@ export const useBulkActions = ({
           }
         }
 
+        startTransaction({ name: BULK_RULE_ACTIONS.DELETE });
         await executeRulesBulkAction({
           visibleRuleIds: selectedRuleIds,
           action: BulkAction.delete,
@@ -169,6 +176,7 @@ export const useBulkActions = ({
       const handleExportAction = async () => {
         closePopover();
 
+        startTransaction({ name: BULK_RULE_ACTIONS.EXPORT });
         await executeRulesBulkAction({
           visibleRuleIds: selectedRuleIds,
           action: BulkAction.export,
@@ -201,6 +209,8 @@ export const useBulkActions = ({
           setIsRefreshOn(true);
           return;
         }
+
+        startTransaction({ name: BULK_RULE_ACTIONS.EDIT });
 
         const hideWarningToast = () => {
           if (longTimeWarningToast) {
@@ -415,18 +425,19 @@ export const useBulkActions = ({
       hasActionsPrivileges,
       isAllSelected,
       loadingRuleIds,
+      startTransaction,
       hasMlPermissions,
-      invalidateRules,
       setLoadingRules,
       toasts,
       filterQuery,
+      invalidateRules,
       confirmDeletion,
       setIsRefreshOn,
       confirmBulkEdit,
       completeBulkEditForm,
       queryClient,
-      getIsMounted,
       filterOptions,
+      getIsMounted,
       resolveTagsRefetch,
     ]
   );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
@@ -41,7 +41,6 @@ describe('AllRules', () => {
       <AllRules
         createPrePackagedRules={jest.fn()}
         hasPermissions
-        loading={false}
         loadingCreatePrePackagedRules={false}
         rulesCustomInstalled={0}
         rulesInstalled={0}
@@ -60,7 +59,6 @@ describe('AllRules', () => {
           <AllRules
             createPrePackagedRules={jest.fn()}
             hasPermissions
-            loading={false}
             loadingCreatePrePackagedRules={false}
             rulesCustomInstalled={1}
             rulesInstalled={0}
@@ -83,7 +81,6 @@ describe('AllRules', () => {
         <AllRules
           createPrePackagedRules={jest.fn()}
           hasPermissions
-          loading={false}
           loadingCreatePrePackagedRules={false}
           rulesCustomInstalled={1}
           rulesInstalled={0}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
@@ -15,7 +15,6 @@ import { AllRulesTabs, RulesTableToolbar } from './rules_table_toolbar';
 interface AllRulesProps {
   createPrePackagedRules: CreatePreBuiltRules | null;
   hasPermissions: boolean;
-  loading: boolean;
   loadingCreatePrePackagedRules: boolean;
   rulesCustomInstalled: number | null;
   rulesInstalled: number | null;
@@ -35,7 +34,6 @@ export const AllRules = React.memo<AllRulesProps>(
   ({
     createPrePackagedRules,
     hasPermissions,
-    loading,
     loadingCreatePrePackagedRules,
     rulesCustomInstalled,
     rulesInstalled,
@@ -52,7 +50,6 @@ export const AllRules = React.memo<AllRulesProps>(
         <RulesTables
           createPrePackagedRules={createPrePackagedRules}
           hasPermissions={hasPermissions}
-          loading={loading}
           loadingCreatePrePackagedRules={loadingCreatePrePackagedRules}
           rulesCustomInstalled={rulesCustomInstalled}
           rulesInstalled={rulesInstalled}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_actions.test.tsx
@@ -22,6 +22,7 @@ describe('getRulesTableActions', () => {
   const toasts = useAppToastsMock.create();
   const invalidateRules = jest.fn();
   const setLoadingRules = jest.fn();
+  const startTransaction = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -39,7 +40,8 @@ describe('getRulesTableActions', () => {
       navigateToApp,
       invalidateRules,
       true,
-      setLoadingRules
+      setLoadingRules,
+      startTransaction
     )[1];
     const duplicateRulesActionHandler = duplicateRulesActionObject.onClick;
     expect(duplicateRulesActionHandler).toBeDefined();
@@ -59,7 +61,8 @@ describe('getRulesTableActions', () => {
       navigateToApp,
       invalidateRules,
       true,
-      setLoadingRules
+      setLoadingRules,
+      startTransaction
     )[3];
     const deleteRuleActionHandler = deleteRulesActionObject.onClick;
     expect(deleteRuleActionHandler).toBeDefined();

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_filters/rules_table_filters.tsx
@@ -15,6 +15,8 @@ import {
 import { isEqual } from 'lodash/fp';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
+import { RULES_TABLE_ACTIONS } from '../../../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../../../common/lib/apm/use_start_transaction';
 import * as i18n from '../../translations';
 import { SEARCH_CAPABILITIES_TOUR_ANCHOR } from '../feature_tour/rules_feature_tour';
 import { useRulesTableContext } from '../rules_table/rules_table_context';
@@ -48,6 +50,7 @@ const RulesTableFiltersComponent = ({
   rulesInstalled,
   allTags,
 }: RulesTableFiltersProps) => {
+  const { startTransaction } = useStartTransaction();
   const {
     state: { filterOptions },
     actions: { setFilterOptions },
@@ -56,25 +59,31 @@ const RulesTableFiltersComponent = ({
   const { showCustomRules, showElasticRules, tags: selectedTags } = filterOptions;
 
   const handleOnSearch = useCallback(
-    (filterString) => setFilterOptions({ filter: filterString.trim() }),
-    [setFilterOptions]
+    (filterString) => {
+      startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
+      setFilterOptions({ filter: filterString.trim() });
+    },
+    [setFilterOptions, startTransaction]
   );
 
   const handleElasticRulesClick = useCallback(() => {
+    startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
     setFilterOptions({ showElasticRules: !showElasticRules, showCustomRules: false });
-  }, [setFilterOptions, showElasticRules]);
+  }, [setFilterOptions, showElasticRules, startTransaction]);
 
   const handleCustomRulesClick = useCallback(() => {
+    startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
     setFilterOptions({ showCustomRules: !showCustomRules, showElasticRules: false });
-  }, [setFilterOptions, showCustomRules]);
+  }, [setFilterOptions, showCustomRules, startTransaction]);
 
   const handleSelectedTags = useCallback(
     (newTags: string[]) => {
       if (!isEqual(newTags, selectedTags)) {
+        startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
         setFilterOptions({ tags: newTags });
       }
     },
-    [selectedTags, setFilterOptions]
+    [selectedTags, setFilterOptions, startTransaction]
   );
 
   return (

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_toolbar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_toolbar.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { EuiSwitch, EuiTab, EuiTabs, EuiToolTip } from '@elastic/eui';
-import React from 'react';
+import { EuiSwitch, EuiSwitchEvent, EuiTab, EuiTabs, EuiToolTip } from '@elastic/eui';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { useRulesTableContext } from './rules_table/rules_table_context';
 import * as i18n from '../translations';
+import { RULES_TABLE_ACTIONS } from '../../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../../common/lib/apm/use_start_transaction';
 
 const ToolbarLayout = styled.div`
   display: grid;
@@ -48,6 +50,19 @@ export const RulesTableToolbar = React.memo<RulesTableToolbarProps>(
       state: { isInMemorySorting },
       actions: { setIsInMemorySorting },
     } = useRulesTableContext();
+    const { startTransaction } = useStartTransaction();
+
+    const handleInMemorySwitch = useCallback(
+      (e: EuiSwitchEvent) => {
+        startTransaction({
+          name: isInMemorySorting
+            ? RULES_TABLE_ACTIONS.PREVIEW_OFF
+            : RULES_TABLE_ACTIONS.PREVIEW_ON,
+        });
+        setIsInMemorySorting(e.target.checked);
+      },
+      [isInMemorySorting, setIsInMemorySorting, startTransaction]
+    );
 
     return (
       <ToolbarLayout>
@@ -66,9 +81,14 @@ export const RulesTableToolbar = React.memo<RulesTableToolbarProps>(
         </EuiTabs>
         <EuiToolTip content={i18n.EXPERIMENTAL_DESCRIPTION}>
           <EuiSwitch
+            data-test-subj={
+              isInMemorySorting
+                ? 'allRulesTableTechnicalPreviewOff'
+                : 'allRulesTableTechnicalPreviewOn'
+            }
             label={isInMemorySorting ? i18n.EXPERIMENTAL_ON : i18n.EXPERIMENTAL_OFF}
             checked={isInMemorySorting}
-            onChange={(e) => setIsInMemorySorting(e.target.checked)}
+            onChange={handleInMemorySwitch}
           />
         </EuiToolTip>
       </ToolbarLayout>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/use_columns.tsx
@@ -46,6 +46,7 @@ import {
   RuleExecutionSummary,
 } from '../../../../../../common/detection_engine/schemas/common';
 import { useAppToasts } from '../../../../../common/hooks/use_app_toasts';
+import { useStartTransaction } from '../../../../../common/lib/apm/use_start_transaction';
 
 export type TableColumn = EuiBasicTableColumn<Rule> | EuiTableActionsColumnType<Rule>;
 
@@ -73,7 +74,6 @@ const useEnabledColumn = ({ hasPermissions }: ColumnsProps): TableColumn => {
           content={getToolTipContent(rule, hasMlPermissions, hasActionsPrivileges)}
         >
           <RuleSwitch
-            data-test-subj="enabled"
             id={rule.id}
             enabled={rule.enabled}
             isDisabled={
@@ -178,6 +178,7 @@ const useActionsColumn = (): EuiTableActionsColumnType<Rule> => {
   const hasActionsPrivileges = useHasActionsPrivileges();
   const toasts = useAppToasts();
   const { reFetchRules, setLoadingRules } = useRulesTableContext().actions;
+  const { startTransaction } = useStartTransaction();
 
   return useMemo(
     () => ({
@@ -186,11 +187,12 @@ const useActionsColumn = (): EuiTableActionsColumnType<Rule> => {
         navigateToApp,
         reFetchRules,
         hasActionsPrivileges,
-        setLoadingRules
+        setLoadingRules,
+        startTransaction
       ),
       width: '40px',
     }),
-    [hasActionsPrivileges, navigateToApp, reFetchRules, setLoadingRules, toasts]
+    [hasActionsPrivileges, navigateToApp, reFetchRules, setLoadingRules, startTransaction, toasts]
   );
 };
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/edit/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/edit/index.tsx
@@ -57,6 +57,8 @@ import { ruleStepsOrder } from '../utils';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { APP_UI_ID } from '../../../../../../common/constants';
 import { HeaderPage } from '../../../../../common/components/header_page';
+import { useStartTransaction } from '../../../../../common/lib/apm/use_start_transaction';
+import { SINGLE_RULE_ACTIONS } from '../../../../../common/lib/apm/user_actions';
 
 const formHookNoop = async (): Promise<undefined> => undefined;
 
@@ -227,6 +229,8 @@ const EditRulePageComponent: FC = () => {
     ]
   );
 
+  const { startTransaction } = useStartTransaction();
+
   const onSubmit = useCallback(async () => {
     const activeStepData = await formHooks.current[activeStep]();
     if (activeStepData?.data != null) {
@@ -243,6 +247,7 @@ const EditRulePageComponent: FC = () => {
       stepIsValid(schedule) &&
       stepIsValid(actions)
     ) {
+      startTransaction({ name: SINGLE_RULE_ACTIONS.SAVE });
       setRule({
         ...formatRule<UpdateRulesSchema>(
           define.data,
@@ -265,6 +270,7 @@ const EditRulePageComponent: FC = () => {
     scheduleStep,
     setRule,
     setStepData,
+    startTransaction,
   ]);
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
@@ -37,11 +37,14 @@ import { HeaderPage } from '../../../../common/components/header_page';
 import { RulesTableContextProvider } from './all/rules_table/rules_table_context';
 import { useInvalidateRules } from '../../../containers/detection_engine/rules/use_find_rules_query';
 import { useBoolState } from '../../../../common/hooks/use_bool_state';
+import { RULES_TABLE_ACTIONS } from '../../../../common/lib/apm/user_actions';
+import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 
 const RulesPageComponent: React.FC = () => {
   const [isImportModalVisible, showImportModal, hideImportModal] = useBoolState();
   const [isValueListFlyoutVisible, showValueListFlyout, hideValueListFlyout] = useBoolState();
   const { navigateToApp } = useKibana().services.application;
+  const { startTransaction } = useStartTransaction();
   const invalidateRules = useInvalidateRules();
 
   const [
@@ -62,7 +65,6 @@ const RulesPageComponent: React.FC = () => {
   const loading = userInfoLoading || listsConfigLoading;
   const {
     createPrePackagedRules,
-    loading: prePackagedRuleLoading,
     loadingCreatePrePackagedRules,
     refetchPrePackagedRulesStatus,
     rulesCustomInstalled,
@@ -95,10 +97,11 @@ const RulesPageComponent: React.FC = () => {
 
   const handleCreatePrePackagedRules = useCallback(async () => {
     if (createPrePackagedRules != null) {
+      startTransaction({ name: RULES_TABLE_ACTIONS.LOAD_PREBUILT });
       await createPrePackagedRules();
       invalidateRules();
     }
-  }, [createPrePackagedRules, invalidateRules]);
+  }, [createPrePackagedRules, invalidateRules, startTransaction]);
 
   const handleRefetchPrePackagedRulesStatus = useCallback(() => {
     if (refetchPrePackagedRulesStatus != null) {
@@ -224,7 +227,6 @@ const RulesPageComponent: React.FC = () => {
           <AllRules
             createPrePackagedRules={createPrePackagedRules}
             data-test-subj="all-rules"
-            loading={loading || prePackagedRuleLoading}
             loadingCreatePrePackagedRules={loadingCreatePrePackagedRules}
             hasPermissions={userHasPermissions(canUserCRUD)}
             rulesCustomInstalled={rulesCustomInstalled}

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -124,10 +124,12 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
      */
     const startServices: Promise<StartServices> = (async () => {
       const [coreStart, startPlugins] = await core.getStartServices();
+      const { apm } = await import('@elastic/apm-rum');
 
       const services: StartServices = {
         ...coreStart,
         ...startPlugins,
+        apm,
         storage: this.storage,
         security: plugins.security,
       };

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -33,6 +33,7 @@ import type { LicensingPluginStart, LicensingPluginSetup } from '@kbn/licensing-
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
 import type { IndexPatternFieldEditorStart } from '@kbn/data-view-field-editor-plugin/public';
 import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { ApmBase } from '@elastic/apm-rum';
 import type { ResolverPluginSetup } from './resolver/types';
 import type { Inspect } from '../common/search_strategy';
 import type { Detections } from './detections';
@@ -84,6 +85,7 @@ export type StartServices = CoreStart &
   StartPlugins & {
     security: SecurityPluginSetup;
     storage: Storage;
+    apm: ApmBase;
   };
 
 export interface PluginSetup {


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/129324**

## Summary

This PR adds semantic names to user interactions captured by APM.

Previously all user interactions were named by event target, like div, span, SVG, etc.

<img width="2162" alt="Screenshot 2022-05-11 at 15 14 50" src="https://user-images.githubusercontent.com/1938181/172630348-19fbbf94-33bf-45c6-b11e-62795ae16103.png">

That naming scheme didn't make much sense, as it was virtually impossible to distinguish between different user actions. So in this PR, we add proper semantically meaningful names to user interactions. It covers the following actions:

**Actions performed with a single rule:**

- Enable rule
- Disable rule
- Duplicate rule
- Export rule
- Delete rule
- Preview rule alerts
- Save rule

**Actions performed with multiple rules**

- Enable rules
- Disable rules
- Duplicate rules
- Export rules
- Delete rules
- Bulk edit rules

**Actions performed on the rules management page:**

- Refresh rules table
- Filter rules table
- Load prebuilt rules
- Turn the in-memory table on/off

### How to test this PR

1. Enable APM on your local environment: https://docs.elastic.dev/kibana-dev-docs/tutorials/debugging#enabling-apm-on-a-local-environment
2. Open local Kibana and navigate to Security Solution. Perform some actions with rules, like enable/disable, edit, etc.
3. Go to the APM server `Observability > APM > Services > kibana-frontend > Transactions`. 
4. You should be able to see frontend transactions there:

![apm-8-1 kb europe-west4 gcp elastic-cloud com_9243_app_apm_services_kibana-frontend_transactions_comparisonEnabled=true comparisonType=day environment=ENVIRONMENT_ALL kuery=transaction name_%20securitySolution_ latencyAggregationType=avg ra](https://user-images.githubusercontent.com/1938181/172621302-c5cf6643-5bdc-43a1-a2ba-994707f976a2.png)