### PR TITLE
[8.3] [Security Solution] Fixes pinned and notes count display for three digit numbers on timeline (#132848)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_styles.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_styles.ts
@@ -7,6 +7,6 @@
 
 /**
  * The width of an action column, which must be wide enough to render a
- * two digit count without wrapping
+ * three digit count without wrapping
  */
-export const ACTION_COLUMN_WIDTH = '40px';
+export const ACTION_COLUMN_WIDTH = '45px';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Security Solution] Fixes pinned and notes count display for three digit numbers on timeline (#132848)](https://github.com/elastic/kibana/pull/132848)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)