### PR TITLE
[8.3] [Security Solution] Avoid displaying cases information when the alert details flyout is opened on the preview (#132840)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -175,7 +175,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                 />
                 <EuiSpacer size="l" />
                 <Reason eventId={id} data={data} />
-                <RelatedCases eventId={id} />
+                <RelatedCases eventId={id} isReadOnly={isReadOnly} />
                 <EuiHorizontalRule />
                 <AlertSummaryView
                   {...{

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -15,11 +15,12 @@ import { APP_ID } from '../../../../common/constants';
 
 interface Props {
   eventId: string;
+  isReadOnly?: boolean;
 }
 
 type RelatedCaseList = Array<{ id: string; title: string }>;
 
-export const RelatedCases: React.FC<Props> = React.memo(({ eventId }) => {
+export const RelatedCases: React.FC<Props> = React.memo(({ eventId, isReadOnly }) => {
   const {
     services: { cases },
   } = useKibana();
@@ -56,7 +57,7 @@ export const RelatedCases: React.FC<Props> = React.memo(({ eventId }) => {
     getRelatedCases();
   }, [eventId, getRelatedCases]);
 
-  if (hasError || !hasCasesReadPermissions) return null;
+  if (hasError || !hasCasesReadPermissions || isReadOnly) return null;
 
   return areCasesLoading ? (
     <EuiLoadingContent lines={2} />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Security Solution] Avoid displaying cases information when the alert details flyout is opened on the preview (#132840)](https://github.com/elastic/kibana/pull/132840)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)