### PR TITLE
[Stack Monitoring] Relax check on `cgroup` key in test

### DIFF
--- a/x-pack/test/api_integration/apis/monitoring/apm/instances.js
+++ b/x-pack/test/api_integration/apis/monitoring/apm/instances.js
@@ -33,7 +33,7 @@ export default function ({ getService }) {
         .send({ timeRange })
         .expect(200);
 
-      const expected = {
+      const expectedWithoutCgroup = {
         stats: {
           totalEvents: 18,
           apms: {
@@ -67,10 +67,14 @@ export default function ({ getService }) {
             time_of_last_event: '2018-08-31T13:59:21.163Z',
           },
         ],
-        cgroup: false,
       };
 
-      expect(body).to.eql(expected);
+      // Due to the lack of `expect`s expressiveness this is an awkward way to
+      // tolate cgroup being false or true, which depends on the test execution
+      // environment. On cloud it is always true.
+      const { cgroup, ...bodyWithoutCgroup } = body;
+      expect(bodyWithoutCgroup).to.eql(expectedWithoutCgroup);
+      expect(cgroup).to.be.a('boolean');
     });
   });
 }


### PR DESCRIPTION
## :memo: Summary

This relaxes the check on the `cgroup` property of the apm instances api test from `false` to any boolean. The reason is that on cloud that is always set to `true` which it happened to be `false` in the other CI environments. While this reduces the strictness of the test a bit, the alternative would have been to skip the whole test case on cloud, which would remove even more coverage.

closes #102008

## :female_detective: Review notes

- I wish the `expect()` in the function tests was as expressive as in the `jest` tests, but this is the tersest I could come up with.