### PR TITLE
[8.3] [Security Solution] Hide empty state for timeline when graph overlay is rendered (#132835)

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.test.tsx
@@ -78,4 +78,13 @@ describe('integrated t_grid', () => {
       euiDarkVars.paddingSizes.xl
     );
   });
+  it(`does not render the empty state when the graph overlay is open`, () => {
+    render(
+      <TestProviders>
+        <TGridIntegrated {...defaultProps} graphOverlay={<div />} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('tGridEmptyState')).toBeNull();
+  });
 });

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -353,7 +353,7 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
                   )}
               </UpdatedFlexGroup>
               <>
-                {!hasAlerts && !loading && <TGridEmpty height="short" />}
+                {!hasAlerts && !loading && !graphOverlay && <TGridEmpty height="short" />}
                 {hasAlerts && (
                   <FullWidthFlexGroup
                     $visible={!graphEventId && graphOverlay == null}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Security Solution] Hide empty state for timeline when graph overlay is rendered (#132835)](https://github.com/elastic/kibana/pull/132835)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)