### PR TITLE
[Synthetics] Script field,  updated validation and width

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/simple_fields.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/simple_fields.tsx
@@ -105,6 +105,7 @@ export const BrowserSimpleFields = memo<Props>(({ validate, onFieldBlur }) => {
         }
       >
         <SourceField
+          validate={validate}
           onChange={onChangeSourceField}
           onFieldBlur={onFieldBlur}
           defaultConfig={useMemo(

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
@@ -84,31 +84,20 @@ export const SourceField = ({
     getDefaultTab(defaultConfig, isZipUrlSourceEnabled)
   );
   const [config, setConfig] = useState<SourceConfig>(defaultConfig);
-  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
-
-  const isInlineInvalid = validate?.[ConfigKey.SOURCE_INLINE]?.({
-    [ConfigKey.SOURCE_INLINE]: config.inlineScript,
-  });
 
   useEffect(() => {
     onChange(config);
   }, [config, onChange]);
 
-  const onFieldTouched = (field: ConfigKey) => {
-    if (!touchedFields[field]) {
-      setTouchedFields((existing) => ({ ...existing, [field]: true }));
-    }
+  const isSourceInlineInvalid =
+    validate?.[ConfigKey.SOURCE_INLINE]?.({
+      [ConfigKey.SOURCE_INLINE]: config.inlineScript,
+    }) ?? false;
 
-    onFieldBlur(field);
-  };
-
-  const isWithInUptime = window.location.pathname.includes('/app/uptime');
-  const isZipUrlInvalid = isWithInUptime
-    ? touchedFields[ConfigKey.SOURCE_ZIP_URL] && !config.zipUrl
-    : !config.zipUrl;
-  const isScriptInvalid = isWithInUptime
-    ? touchedFields[ConfigKey.SOURCE_INLINE] || isInlineInvalid
-    : !config.inlineScript;
+  const isZipUrlInvalid =
+    validate?.[ConfigKey.SOURCE_ZIP_URL]?.({
+      [ConfigKey.SOURCE_ZIP_URL]: config.zipUrl,
+    }) ?? false;
 
   const zipUrlLabel = (
     <FormattedMessage
@@ -146,7 +135,7 @@ export const SourceField = ({
               onChange={({ target: { value } }) =>
                 setConfig((prevConfig) => ({ ...prevConfig, zipUrl: value }))
               }
-              onBlur={() => onFieldTouched(ConfigKey.SOURCE_ZIP_URL)}
+              onBlur={() => onFieldBlur(ConfigKey.SOURCE_ZIP_URL)}
               value={config.zipUrl}
               data-test-subj="syntheticsBrowserZipUrl"
             />
@@ -295,7 +284,7 @@ export const SourceField = ({
       content: (
         <EuiFormRow
           style={{ minWidth: 600 }}
-          isInvalid={isScriptInvalid}
+          isInvalid={isSourceInlineInvalid}
           error={
             <FormattedMessage
               id="xpack.synthetics.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.browser.inlineScript.error"
@@ -320,7 +309,7 @@ export const SourceField = ({
             languageId={MonacoEditorLangId.JAVASCRIPT}
             onChange={(code) => {
               setConfig((prevConfig) => ({ ...prevConfig, inlineScript: code }));
-              onFieldTouched(ConfigKey.SOURCE_INLINE);
+              onFieldBlur(ConfigKey.SOURCE_INLINE);
             }}
             value={config.inlineScript}
           />

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
@@ -48,7 +48,7 @@ interface Props {
   onChange: (sourceConfig: SourceConfig) => void;
   onFieldBlur: (field: ConfigKey) => void;
   defaultConfig?: SourceConfig;
-  validate: Validation;
+  validate?: Validation;
 }
 
 export const defaultValues = {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/source_field.tsx
@@ -283,7 +283,6 @@ export const SourceField = ({
       'data-test-subj': `syntheticsSourceTab__inline`,
       content: (
         <EuiFormRow
-          style={{ minWidth: 600 }}
           isInvalid={isSourceInlineInvalid}
           error={
             <FormattedMessage


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/pull/132339

Show validation error on submit 

Also increased the script field width to make it more manage-bale 

Before:
![image](https://user-images.githubusercontent.com/3505601/172373327-1ad68712-ebc3-4b69-8a88-5150336d9e5b.png)

After:
<img width="2329" alt="image" src="https://user-images.githubusercontent.com/3505601/172375408-0b34e9c5-cd80-4fe6-bca2-47416d1f16c6.png">

