### PR TITLE
Add optional chaining to getFieldByName fields

### DIFF
--- a/src/plugins/data_views/server/utils.ts
+++ b/src/plugins/data_views/server/utils.ts
@@ -16,7 +16,8 @@ export const getFieldByName = (
   fieldName: string,
   indexPattern: SavedObject<DataViewAttributes>
 ): FieldSpec | undefined => {
-  const fields: FieldSpec[] = indexPattern && JSON.parse(indexPattern.attributes.fields);
+  const fields: FieldSpec[] =
+    indexPattern?.attributes?.fields && JSON.parse(indexPattern.attributes.fields);
   const field = fields && fields.find((f) => f.name === fieldName);
 
   return field;


### PR DESCRIPTION
## Summary

`suggestions/values/logs-*` was returning 500s on `Security -> Hosts` page when trying to filter fields by `is`
![image](https://user-images.githubusercontent.com/16872649/171941253-1f891bb3-e13b-46b0-b1a1-edd151a8b313.png)

Spent some time to look into it with @kqualters-elastic since the initial thought was it had to do with something on the Host page (it was working fine on `Security -> Alerts` page). But after looking into it we found that it works after adding the optional chaining to `dataView.getFieldByName`:
![image](https://user-images.githubusercontent.com/16872649/171941426-0932942d-7c01-4e60-94d4-20c125e8cdf7.png)

