### PR TITLE
[8.3] Hide controls when dashboard is in print mode (#133446)

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
@@ -118,14 +118,16 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
               />
             ) : null}
 
-            <div
-              className={
-                controlGroup && controlGroup.getPanelCount() > 0
-                  ? 'dshDashboardViewport-controls'
-                  : ''
-              }
-              ref={this.controlsRoot}
-            />
+            {container.getInput().viewMode !== ViewMode.PRINT && (
+              <div
+                className={
+                  controlGroup && controlGroup.getPanelCount() > 0
+                    ? 'dshDashboardViewport-controls'
+                    : ''
+                }
+                ref={this.controlsRoot}
+              />
+            )}
           </>
         ) : null}
         <div


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Hide controls when dashboard is in print mode (#133446)](https://github.com/elastic/kibana/pull/133446)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)