### PR TITLE
Fix attachment of wrong enrichments for Indicator Match rule

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threat_mapping/enrich_signal_threat_matches.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threat_mapping/enrich_signal_threat_matches.ts
@@ -136,12 +136,14 @@ export const enrichSignalThreatMatches = async (
   ];
   const matchedThreats = await getMatchedThreats(matchedThreatIds);
 
-  const enrichmentsWithoutAtomic = signalMatches.map((signalMatch) =>
-    buildEnrichments({
-      indicatorPath,
-      queries: signalMatch.queries,
-      threats: matchedThreats,
-    })
+  const enrichmentsWithoutAtomic: { [key: string]: ThreatEnrichment[] }  = {};
+  signalMatches.forEach((signalMatch) => {
+    enrichmentsWithoutAtomic[signalMatch.signalId] =  buildEnrichments({
+        indicatorPath,
+        queries: signalMatch.queries,
+        threats: matchedThreats,
+      })
+   }
   );
 
   const enrichedSignals: SignalSourceHit[] = uniqueHits.map((signalHit, i) => {
@@ -155,7 +157,7 @@ export const enrichSignalThreatMatches = async (
     // new issues.
     const existingEnrichmentValue = get(signalHit._source, 'threat.enrichments') ?? [];
     const existingEnrichments = [existingEnrichmentValue].flat(); // ensure enrichments is an array
-    const newEnrichmentsWithoutAtomic = enrichmentsWithoutAtomic[i];
+    const newEnrichmentsWithoutAtomic = enrichmentsWithoutAtomic[signalHit._id] ?? [];
     const newEnrichments = newEnrichmentsWithoutAtomic.map((enrichment) => ({
       ...enrichment,
       matched: {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threat_mapping/enrich_signal_threat_matches.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threat_mapping/enrich_signal_threat_matches.ts
@@ -136,15 +136,14 @@ export const enrichSignalThreatMatches = async (
   ];
   const matchedThreats = await getMatchedThreats(matchedThreatIds);
 
-  const enrichmentsWithoutAtomic: { [key: string]: ThreatEnrichment[] }  = {};
+  const enrichmentsWithoutAtomic: { [key: string]: ThreatEnrichment[] } = {};
   signalMatches.forEach((signalMatch) => {
-    enrichmentsWithoutAtomic[signalMatch.signalId] =  buildEnrichments({
-        indicatorPath,
-        queries: signalMatch.queries,
-        threats: matchedThreats,
-      })
-   }
-  );
+    enrichmentsWithoutAtomic[signalMatch.signalId] = buildEnrichments({
+      indicatorPath,
+      queries: signalMatch.queries,
+      threats: matchedThreats,
+    });
+  });
 
   const enrichedSignals: SignalSourceHit[] = uniqueHits.map((signalHit, i) => {
     const threat = get(signalHit._source, 'threat') ?? {};


### PR DESCRIPTION
## Summary

After changes introduced [in 8.2.0](https://github.com/elastic/kibana/pull/127428/files#diff-23d7709dfeb5dfa27a93e789abe329fef4934d9f3b0c78850045e22e34f1f7fc) there was a bug which can cause a wrong enrichment attached to alert.

In the `enrichSignalThreatMatches` function the `signalMatches` and `uniqueHits` can have events which are sorted differently.

Previously we build enrichments from `signalMatches` and then iterate by `uniqueHits` and attach enrichment by element array index.

If the events have different orders it can cause attaching wrong enrichments to the wrong alert.


## Solution
We will attach enrichments to the event by event id.

TODO:
I will add tests in separate PR