### PR TITLE
[Shared UX][No Data] Enable custom descriptions on Agent cards

### DIFF
--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.component.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.component.tsx
@@ -51,12 +51,13 @@ const elasticAgentCardDescription = i18n.translate(
 export const ElasticAgentCardComponent: FunctionComponent<ElasticAgentCardComponentProps> = ({
   canAccessFleet,
   title = elasticAgentCardTitle,
+  description,
   ...cardRest
 }) => {
   const props = canAccessFleet
     ? {
         title,
-        description: elasticAgentCardDescription,
+        description: description || elasticAgentCardDescription,
       }
     : {
         title: <EuiTextColor color="default">{noPermissionTitle}</EuiTextColor>,

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.stories.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.stories.tsx
@@ -31,6 +31,10 @@ PureComponent.argTypes = {
     control: 'boolean',
     defaultValue: true,
   },
+  description: {
+    control: 'text',
+    defaultValue: '',
+  },
 };
 
 export const ConnectedComponent = () => {

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.test.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.test.tsx
@@ -58,6 +58,17 @@ describe('ElasticAgentCard', () => {
     });
   });
 
+  describe('description', () => {
+    test('renders custom description if provided', () => {
+      const component = mount(
+        <ElasticAgentCard description="Build seamless search experiences faster." />
+      );
+      expect(component.find(ElasticAgentCardComponent).props().description).toBe(
+        'Build seamless search experiences faster.'
+      );
+    });
+  });
+
   describe('canAccessFleet', () => {
     test('passes in the right parameter', () => {
       const component = mount(<ElasticAgentCard />);

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/elastic_agent_card.tsx
@@ -20,7 +20,7 @@ export const ElasticAgentCard = (props: ElasticAgentCardProps) => {
   const { navigateToUrl, currentAppId$ } = useApplication();
   const currentAppId = useObservable(currentAppId$);
 
-  const { href: srcHref, category } = props;
+  const { href: srcHref, category, description } = props;
 
   const href = useMemo(() => {
     if (srcHref) {
@@ -39,7 +39,7 @@ export const ElasticAgentCard = (props: ElasticAgentCardProps) => {
 
   return (
     <RedirectAppLinks {...{ currentAppId, navigateToUrl }}>
-      <ElasticAgentCardComponent {...{ ...props, href, canAccessFleet }} />
+      <ElasticAgentCardComponent {...{ ...props, href, canAccessFleet, description }} />
     </RedirectAppLinks>
   );
 };

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/types.ts
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/types.ts
@@ -9,7 +9,7 @@
 import { CommonProps } from '@elastic/eui';
 import { ElasticAgentCardProps } from './no_data_card';
 
-export type NoDataPageActions = Omit<ElasticAgentCardProps, 'description'>;
+export type NoDataPageActions = ElasticAgentCardProps;
 
 export interface NoDataPageProps extends CommonProps {
   /**


### PR DESCRIPTION
## Summary

> Fixes issue found in #133021 

As titled: enables custom descriptions in Elastic Agent cards, if provided.

<img width="1588" alt="Screen Shot 2022-06-05 at 11 51 41 PM" src="https://user-images.githubusercontent.com/297604/172097246-d28e571f-4046-4c87-9d44-94942c698aa0.png">

## Before
<img width="1588" alt="Screen Shot 2022-06-05 at 11 47 33 PM" src="https://user-images.githubusercontent.com/297604/172097238-21ecef7a-cbdf-4f35-8025-425561bee909.png">

## After
<img width="1588" alt="Screen Shot 2022-06-05 at 11 47 57 PM" src="https://user-images.githubusercontent.com/297604/172097243-8e12040c-2b72-4a74-9b31-d8d09d81d160.png">

