### PR TITLE
[8.2] [Fleet] Ensure that Elastic Agent is installed when updating policy with monitoring_enabled (#133530)

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -136,15 +136,18 @@ export const createAgentPolicyHandler: FleetRequestHandler<
   }
 };
 
-export const updateAgentPolicyHandler: RequestHandler<
+export const updateAgentPolicyHandler: FleetRequestHandler<
   TypeOf<typeof UpdateAgentPolicyRequestSchema.params>,
   unknown,
   TypeOf<typeof UpdateAgentPolicyRequestSchema.body>
 > = async (context, request, response) => {
-  const soClient = context.core.savedObjects.client;
-  const esClient = context.core.elasticsearch.client.asInternalUser;
+  const coreContext = await context.core;
+  const fleetContext = await context.fleet;
+  const soClient = coreContext.savedObjects.client;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = await appContextService.getSecurity()?.authc.getCurrentUser(request);
   const { force, ...data } = request.body;
+  const spaceId = fleetContext.spaceId;
   try {
     const agentPolicy = await agentPolicyService.update(
       soClient,
@@ -154,6 +157,7 @@ export const updateAgentPolicyHandler: RequestHandler<
       {
         force,
         user: user || undefined,
+        spaceId,
       }
     );
     const body: UpdateAgentPolicyResponse = { item: agentPolicy };

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -17,6 +17,8 @@ import type {
 } from 'src/core/server';
 
 import type { AuthenticatedUser } from '../../../security/server';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
+
 import {
   AGENT_POLICY_SAVED_OBJECT_TYPE,
   AGENTS_PREFIX,
@@ -39,6 +41,7 @@ import {
   AGENT_POLICY_INDEX,
   UUID_V5_NAMESPACE,
   FLEET_APM_PACKAGE,
+  FLEET_ELASTIC_AGENT_PACKAGE,
 } from '../../common';
 import type {
   DeleteAgentPolicyResponse,
@@ -58,7 +61,7 @@ import {
   elasticAgentManagedManifest,
 } from './elastic_agent_manifest';
 
-import { getPackageInfo } from './epm/packages';
+import { getPackageInfo, bulkInstallPackages } from './epm/packages';
 import { getAgentsByKuery } from './agents';
 import { packagePolicyService } from './package_policy';
 import { incrementPackagePolicyCopyName } from './package_policies';
@@ -349,7 +352,7 @@ class AgentPolicyService {
     esClient: ElasticsearchClient,
     id: string,
     agentPolicy: Partial<AgentPolicy>,
-    options?: { user?: AuthenticatedUser; force?: boolean }
+    options?: { user?: AuthenticatedUser; force?: boolean; spaceId?: string }
   ): Promise<AgentPolicy> {
     if (agentPolicy.name) {
       await this.requireUniqueName(soClient, {
@@ -372,6 +375,19 @@ class AgentPolicyService {
             throw new HostedAgentPolicyRestrictionRelatedError(`Cannot update ${key}`);
           }
         });
+    }
+    const { monitoring_enabled: monitoringEnabled } = agentPolicy;
+    const packagesToInstall = [];
+    if (!existingAgentPolicy.monitoring_enabled && monitoringEnabled?.length) {
+      packagesToInstall.push(FLEET_ELASTIC_AGENT_PACKAGE);
+    }
+    if (packagesToInstall.length > 0) {
+      await bulkInstallPackages({
+        savedObjectsClient: soClient,
+        esClient,
+        packagesToInstall,
+        spaceId: options?.spaceId || DEFAULT_SPACE_ID,
+      });
     }
 
     return this._update(soClient, esClient, id, agentPolicy, options?.user);

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -17,7 +17,8 @@ import type {
 } from 'src/core/server';
 
 import type { AuthenticatedUser } from '../../../security/server';
-import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
+
+import { DEFAULT_SPACE_ID } from '../../../spaces/common/constants';
 
 import {
   AGENT_POLICY_SAVED_OBJECT_TYPE,

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -574,6 +574,76 @@ export default function (providerContext: FtrProviderContext) {
           'Cannot update name in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.'
         );
       });
+
+      it('should return a 200 if updating monitoring_enabled on a policy', async () => {
+        const fetchPackageList = async () => {
+          const response = await supertest
+            .get('/api/fleet/epm/packages')
+            .set('kbn-xsrf', 'xxx')
+            .expect(200);
+          return response.body;
+        };
+
+        const {
+          body: { item: originalPolicy },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Test_policy',
+            description: 'Initial description',
+            namespace: 'default',
+          })
+          .expect(200);
+
+        // uninstall the elastic_agent and verify that is installed after the policy update
+        await supertest
+          .delete(`/api/fleet/epm/packages/elastic_agent/1.3.3`)
+          .set('kbn-xsrf', 'xxxx');
+
+        const listResponse = await fetchPackageList();
+        const installedPackages = listResponse.items.filter(
+          (item: any) => item.status === 'installed'
+        );
+
+        expect(installedPackages.length).to.be(0);
+
+        agentPolicyId = originalPolicy.id;
+        const {
+          body: { item: updatedPolicy },
+        } = await supertest
+          .put(`/api/fleet/agent_policies/${agentPolicyId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Test_policy_with_monitoring',
+            description: 'Updated description',
+            namespace: 'default',
+            monitoring_enabled: ['logs', 'metrics'],
+          })
+          .expect(200);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { id, updated_at, ...newPolicy } = updatedPolicy;
+        createdPolicyIds.push(updatedPolicy.id);
+
+        expect(newPolicy).to.eql({
+          status: 'active',
+          name: 'Test_policy_with_monitoring',
+          description: 'Updated description',
+          namespace: 'default',
+          is_managed: false,
+          revision: 2,
+          updated_by: 'elastic',
+          package_policies: [],
+          monitoring_enabled: ['logs', 'metrics'],
+        });
+
+        const listResponseAfterUpdate = await fetchPackageList();
+
+        const installedPackagesAfterUpdate = listResponseAfterUpdate.items
+          .filter((item: any) => item.status === 'installed')
+          .map((item: any) => item.name);
+        expect(installedPackagesAfterUpdate).to.contain('elastic_agent');
+      });
     });
 
     describe('POST /api/fleet/agent_policies/delete', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Fleet] Ensure that Elastic Agent is installed when updating policy with monitoring_enabled (#133530)](https://github.com/elastic/kibana/pull/133530)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)