### PR TITLE
[8.3] Fix API test script (#133308)

### DIFF
--- a/x-pack/plugins/apm/scripts/test/api.js
+++ b/x-pack/plugins/apm/scripts/test/api.js
@@ -71,9 +71,14 @@ if (server) {
   ftrScript = 'functional_test_runner';
 }
 
-const inspectArg = inspect ? '--inspect-brk' : '';
-const grepArg = grep ? `--grep "${grep}"` : '';
-const cmd = `node ${inspectArg} ../../../../scripts/${ftrScript} ${grepArg} --config ../../../../test/apm_api_integration/${license}/config.ts`;
+const cmd = [
+  'node',
+  ...(inspect ? ['--inspect-brk'] : []),
+  `../../../../../scripts/${ftrScript}`,
+  ...(grep ? [`--grep "${grep}"`] : []),
+  ...(updateSnapshots ? [`--updateSnapshots`] : []),
+  `--config ../../../../test/apm_api_integration/${license}/config.ts`,
+].join(' ');
 
 console.log(`Running ${cmd}`);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Fix API test script (#133308)](https://github.com/elastic/kibana/pull/133308)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)