### PR TITLE
[Cloud Posture] change browser title on app navigation

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -9,10 +9,10 @@ import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { useEffect } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { type RouteProps, useRouteMatch, useHistory } from 'react-router-dom';
-import type { CspNavigationItem } from './types';
-import { CLOUD_POSTURE } from './translations';
 import type { EuiBreadcrumb } from '@elastic/eui';
 import { string } from 'io-ts';
+import type { CspNavigationItem } from './types';
+import { CLOUD_POSTURE } from './translations';
 
 const getClickableBreadcrumb = (
   routeMatch: RouteProps['path'],

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -11,6 +11,8 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { type RouteProps, useRouteMatch, useHistory } from 'react-router-dom';
 import type { CspNavigationItem } from './types';
 import { CLOUD_POSTURE } from './translations';
+import type { EuiBreadcrumb } from '@elastic/eui';
+import { string } from 'io-ts';
 
 const getClickableBreadcrumb = (
   routeMatch: RouteProps['path'],
@@ -27,7 +29,7 @@ const getClickableBreadcrumb = (
 export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
   const {
     services: {
-      chrome: { setBreadcrumbs },
+      chrome: { setBreadcrumbs, docTitle },
       application: { getUrlForApp },
     },
   } = useKibana<CoreStart>();
@@ -49,15 +51,21 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
       };
     });
 
-    setBreadcrumbs([
+    const nextBreadcrumbs = [
       {
         text: CLOUD_POSTURE,
-        onClick: (e) => {
+        onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
           e.preventDefault();
           history.push(`/`);
         },
       },
       ...additionalBreadCrumbs,
-    ]);
-  }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs, history]);
+    ];
+
+    setBreadcrumbs(nextBreadcrumbs);
+    docTitle.change(getTextBreadcrumbs(nextBreadcrumbs));
+  }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs, history, docTitle]);
 };
+
+const getTextBreadcrumbs = (breakcrumbs: EuiBreadcrumb[]) =>
+  breakcrumbs.map((breadcrumb) => breadcrumb.text).filter(string.is);

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_csp_breadcrumbs.ts
@@ -67,5 +67,5 @@ export const useCspBreadcrumbs = (breadcrumbs: CspNavigationItem[]) => {
   }, [match.path, getUrlForApp, setBreadcrumbs, breadcrumbs, history, docTitle]);
 };
 
-const getTextBreadcrumbs = (breakcrumbs: EuiBreadcrumb[]) =>
-  breakcrumbs.map((breadcrumb) => breadcrumb.text).filter(string.is);
+const getTextBreadcrumbs = (breadcrumbs: EuiBreadcrumb[]) =>
+  breadcrumbs.map((breadcrumb) => breadcrumb.text).filter(string.is);


### PR DESCRIPTION
this PR makes use of `chrome.docTitle` to change the current browser title to be aligned to the current URL.

we already change the breadcrumbs for the same reason, so this change was added there. 

we basically take the breadcrumbs we already computed, extract only `text` items (for browser title) and then set it. 