### PR TITLE
[ML] Tests for get groups endpoint

### DIFF
--- a/x-pack/plugins/ml/common/types/groups.ts
+++ b/x-pack/plugins/ml/common/types/groups.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface Group {
+  id: string;
+  jobIds: string[];
+  calendarIds: string[];
+}

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_filter_bar/job_filter_bar.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_filter_bar/job_filter_bar.tsx
@@ -37,7 +37,7 @@ export const JobFilterBar: FC<JobFilterBarProps> = ({ queryText, setFilters }) =
   const loadGroups = useCallback(async () => {
     try {
       const response = await mlApiServices.jobs.groups();
-      return response.map((g: any) => ({
+      return response.map((g) => ({
         value: g.id,
         view: (
           <div className="group-item">

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
@@ -20,6 +20,7 @@ import type {
 import type { JobMessage } from '../../../../common/types/audit_message';
 import type { JobAction } from '../../../../common/constants/job_actions';
 import type { AggFieldNamePair, RuntimeMappings } from '../../../../common/types/fields';
+import type { Group } from '../../../../common/types/groups';
 import type { ExistingJobsAndGroups } from '../job_service';
 import type {
   CategorizationAnalyzer,
@@ -83,7 +84,7 @@ export const jobsApiProvider = (httpService: HttpService) => ({
   },
 
   groups() {
-    return httpService.http<any>({
+    return httpService.http<Group[]>({
       path: `${ML_BASE_PATH}/jobs/groups`,
       method: 'GET',
     });

--- a/x-pack/plugins/ml/server/models/job_service/groups.ts
+++ b/x-pack/plugins/ml/server/models/job_service/groups.ts
@@ -7,13 +7,8 @@
 
 import { CalendarManager } from '../calendar';
 import { GLOBAL_CALENDAR } from '../../../common/constants/calendars';
+import type { Group } from '../../../common/types/groups';
 import type { MlClient } from '../../lib/ml_client';
-
-export interface Group {
-  id: string;
-  jobIds: string[];
-  calendarIds: string[];
-}
 
 export interface Results {
   [id: string]: {

--- a/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
@@ -22,13 +22,18 @@ export default ({ getService }: FtrProviderContext) => {
   const testCalendarsConfigs = [
     {
       calendar_id: `test_get_cal_1`,
-      job_ids: [MULTI_METRIC_JOB_CONFIG.job_id, 'multi-metric'],
+      job_ids: ['multi-metric'],
       description: `Test calendar 1`,
     },
     {
       calendar_id: `test_get_cal_2`,
-      job_ids: ['brand-new-group'],
+      job_ids: [MULTI_METRIC_JOB_CONFIG.job_id, 'multi-metric'],
       description: `Test calendar 2`,
+    },
+    {
+      calendar_id: `test_get_cal_3`,
+      job_ids: ['brand-new-group'],
+      description: `Test calendar 3`,
     },
   ];
 
@@ -51,7 +56,7 @@ export default ({ getService }: FtrProviderContext) => {
     {
       id: 'brand-new-group',
       jobIds: [],
-      calendarIds: ['test_get_cal_2'],
+      calendarIds: ['test_get_cal_3'],
     },
     {
       id: 'farequote',
@@ -61,7 +66,7 @@ export default ({ getService }: FtrProviderContext) => {
     {
       id: 'multi-metric',
       jobIds: [MULTI_METRIC_JOB_CONFIG.job_id],
-      calendarIds: ['test_get_cal_1'],
+      calendarIds: ['test_get_cal_1', 'test_get_cal_2'],
     },
     {
       id: 'single-metric',

--- a/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
@@ -91,7 +91,6 @@ export default ({ getService }: FtrProviderContext) => {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
     });
 
     it('returns expected list of groups', async () => {

--- a/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/get_groups.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { Group } from '@kbn/ml-plugin/common/types/groups';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { MULTI_METRIC_JOB_CONFIG, SINGLE_METRIC_JOB_CONFIG } from './common_jobs';
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  const testSetupJobConfigs = [SINGLE_METRIC_JOB_CONFIG, MULTI_METRIC_JOB_CONFIG];
+
+  const testCalendarsConfigs = [
+    {
+      calendar_id: `test_get_cal_1`,
+      job_ids: [MULTI_METRIC_JOB_CONFIG.job_id, 'multi-metric'],
+      description: `Test calendar 1`,
+    },
+    {
+      calendar_id: `test_get_cal_2`,
+      job_ids: ['brand-new-group'],
+      description: `Test calendar 2`,
+    },
+  ];
+
+  async function runGetGroupsRequest(user: USER, expectedResponsecode: number): Promise<Group[]> {
+    const { body, status } = await supertest
+      .get('/api/ml/jobs/groups')
+      .auth(user, ml.securityCommon.getPasswordForUser(user))
+      .set(COMMON_REQUEST_HEADERS);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
+
+    return body;
+  }
+
+  const expectedGroups = [
+    {
+      id: 'automated',
+      jobIds: [MULTI_METRIC_JOB_CONFIG.job_id, SINGLE_METRIC_JOB_CONFIG.job_id],
+      calendarIds: [],
+    },
+    {
+      id: 'brand-new-group',
+      jobIds: [],
+      calendarIds: ['test_get_cal_2'],
+    },
+    {
+      id: 'farequote',
+      jobIds: [MULTI_METRIC_JOB_CONFIG.job_id, SINGLE_METRIC_JOB_CONFIG.job_id],
+      calendarIds: [],
+    },
+    {
+      id: 'multi-metric',
+      jobIds: [MULTI_METRIC_JOB_CONFIG.job_id],
+      calendarIds: ['test_get_cal_1'],
+    },
+    {
+      id: 'single-metric',
+      jobIds: [SINGLE_METRIC_JOB_CONFIG.job_id],
+      calendarIds: [],
+    },
+  ];
+
+  describe('get groups', function () {
+    before(async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      for (const job of testSetupJobConfigs) {
+        await ml.api.createAnomalyDetectionJob(job);
+      }
+
+      for (const cal of testCalendarsConfigs) {
+        await ml.api.createCalendar(cal.calendar_id, cal);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+    });
+
+    it('returns expected list of groups', async () => {
+      const groups = await runGetGroupsRequest(USER.ML_VIEWER, 200);
+      expect(groups).to.eql(
+        expectedGroups,
+        `response groups list should equal the expected groups ${JSON.stringify(expectedGroups)})`
+      );
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/jobs/index.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/index.ts
@@ -22,5 +22,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./force_start_datafeeds_spaces'));
     loadTestFile(require.resolve('./stop_datafeeds'));
     loadTestFile(require.resolve('./stop_datafeeds_spaces'));
+    loadTestFile(require.resolve('./get_groups'));
   });
 }


### PR DESCRIPTION
Adds API test to retrieve groups using the `GET /api/ml/jobs/groups` endpoint.
Groups exist either by being attached to jobs or to calendars.