### PR TITLE
[8.3] Warn & Disallow Creating Role with Existing Name (#132218)

### DIFF
--- a/docs/api/role-management/put.asciidoc
+++ b/docs/api/role-management/put.asciidoc
@@ -51,11 +51,20 @@ To use the create or update role API, you must have the `manage_security` cluste
   To grant access to all spaces, set to `["*"]`, or omit the value.
 =====
 
+[[role-management-api-put-query-params]]
+==== Query parameters
+
+`createOnly`::
+  (Optional, boolean) When `true`, will prevent overwriting the role if it already exists.
+
 [[role-management-api-put-response-codes]]
 ==== Response code
 
 `204`::
   Indicates a successful call.
+
+'409'::
+  When `createOnly` is true, indicates a conflict with an existing role.
 
 ==== Examples
 

--- a/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -19,7 +19,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import type { ChangeEvent, FunctionComponent, HTMLProps } from 'react';
+import type { ChangeEvent, FocusEvent, FunctionComponent, HTMLProps } from 'react';
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 
 import type {
@@ -302,6 +302,8 @@ export const EditRolePage: FunctionComponent<Props> = ({
   // eventually enable validation after the first time user tries to save a role.
   const { current: validator } = useRef(new RoleValidator({ shouldValidate: false }));
   const [formError, setFormError] = useState<RoleValidationResult | null>(null);
+  const [creatingRoleAlreadyExists, setCreatingRoleAlreadyExists] = useState<boolean>(false);
+  const [previousName, setPreviousName] = useState<string>('');
   const runAsUsers = useRunAsUsers(userAPIClient, fatalErrors);
   const indexPatternsTitles = useIndexPatternsTitles(dataViews, fatalErrors, notifications);
   const privileges = usePrivileges(privilegesAPIClient, fatalErrors);
@@ -382,6 +384,7 @@ export const EditRolePage: FunctionComponent<Props> = ({
     return (
       <EuiPanel hasShadow={false} hasBorder={true}>
         <EuiFormRow
+          data-test-subj={'roleNameFormRow'}
           label={
             <FormattedMessage
               id="xpack.security.management.editRole.roleNameFormRowTitle"
@@ -397,13 +400,18 @@ export const EditRolePage: FunctionComponent<Props> = ({
             ) : undefined
           }
           {...validator.validateRoleName(role)}
+          {...(creatingRoleAlreadyExists
+            ? { error: 'A role with this name already exists.', isInvalid: true }
+            : {})}
         >
           <EuiFieldText
             name={'name'}
             value={role.name || ''}
             onChange={onNameChange}
+            onBlur={onNameBlur}
             data-test-subj={'roleFormNameInput'}
             readOnly={isRoleReserved || isEditingExistingRole}
+            isInvalid={creatingRoleAlreadyExists}
           />
         </EuiFormRow>
       </EuiPanel>
@@ -415,6 +423,15 @@ export const EditRolePage: FunctionComponent<Props> = ({
       ...role,
       name: e.target.value,
     });
+
+  const onNameBlur = (e: FocusEvent<HTMLInputElement>) => {
+    if (!isEditingExistingRole && previousName !== role.name) {
+      setPreviousName(role.name);
+      doesRoleExist().then((roleExists) => {
+        setCreatingRoleAlreadyExists(roleExists);
+      });
+    }
+  };
 
   const getElasticsearchPrivileges = () => {
     return (
@@ -501,7 +518,7 @@ export const EditRolePage: FunctionComponent<Props> = ({
         data-test-subj={`roleFormSaveButton`}
         fill
         onClick={saveRole}
-        disabled={isRoleReserved}
+        disabled={isRoleReserved || creatingRoleAlreadyExists}
       >
         {saveText}
       </EuiButton>
@@ -529,8 +546,13 @@ export const EditRolePage: FunctionComponent<Props> = ({
       setFormError(null);
 
       try {
-        await rolesAPIClient.saveRole({ role });
+        await rolesAPIClient.saveRole({ role, createOnly: !isEditingExistingRole });
       } catch (error) {
+        if (!isEditingExistingRole && error?.body?.statusCode === 409) {
+          setCreatingRoleAlreadyExists(true);
+          window.scroll({ top: 0, behavior: 'smooth' });
+          return;
+        }
         notifications.toasts.addDanger(
           error?.body?.message ??
             i18n.translate('xpack.security.management.editRole.errorSavingRoleError', {
@@ -548,6 +570,15 @@ export const EditRolePage: FunctionComponent<Props> = ({
       );
 
       backToRoleList();
+    }
+  };
+
+  const doesRoleExist = async (): Promise<boolean> => {
+    try {
+      await rolesAPIClient.getRole(role.name);
+      return true;
+    } catch (error) {
+      return false;
     }
   };
 

--- a/x-pack/plugins/security/public/management/roles/roles_api_client.ts
+++ b/x-pack/plugins/security/public/management/roles/roles_api_client.ts
@@ -25,9 +25,10 @@ export class RolesAPIClient {
     await this.http.delete(`/api/security/role/${encodeURIComponent(roleName)}`);
   }
 
-  public async saveRole({ role }: { role: Role }) {
+  public async saveRole({ role, createOnly = false }: { role: Role; createOnly?: boolean }) {
     await this.http.put(`/api/security/role/${encodeURIComponent(role.name)}`, {
       body: JSON.stringify(this.transformRoleForSave(copyRole(role))),
+      query: { createOnly },
     });
   }
 

--- a/x-pack/plugins/security/server/routes/authorization/roles/put.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/put.ts
@@ -47,6 +47,7 @@ export function definePutRolesRoutes({
       path: '/api/security/role/{name}',
       validate: {
         params: schema.object({ name: schema.string({ minLength: 1, maxLength: 1024 }) }),
+        query: schema.object({ createOnly: schema.boolean({ defaultValue: false }) }),
         body: getPutPayloadSchema(() => {
           const privileges = authz.privileges.get();
           return {
@@ -58,7 +59,7 @@ export function definePutRolesRoutes({
     },
     createLicensedRouteHandler(async (context, request, response) => {
       const { name } = request.params;
-
+      const { createOnly } = request.query;
       try {
         const esClient = (await context.core).elasticsearch.client;
         const [features, rawRoles] = await Promise.all([
@@ -73,6 +74,14 @@ export function definePutRolesRoutes({
               message: `Role cannot be updated due to validation errors: ${JSON.stringify(
                 validationErrors
               )}`,
+            },
+          });
+        }
+
+        if (createOnly && !!rawRoles[name]) {
+          return response.conflict({
+            body: {
+              message: `Role already exists and cannot be created: ${name}`,
             },
           });
         }

--- a/x-pack/test/api_integration/apis/security/roles.ts
+++ b/x-pack/test/api_integration/apis/security/roles.ts
@@ -119,6 +119,38 @@ export default function ({ getService }: FtrProviderContext) {
           })
           .expect(basic ? 403 : 204);
       });
+
+      describe('with the createOnly option enabled', () => {
+        it('should fail when role already exists', async () => {
+          await es.security.putRole({
+            name: 'test_role',
+            body: {
+              cluster: ['monitor'],
+              indices: [
+                {
+                  names: ['beats-*'],
+                  privileges: ['write'],
+                },
+              ],
+              run_as: ['reporting_user'],
+            },
+          });
+
+          await supertest
+            .put('/api/security/role/test_role?createOnly=true')
+            .set('kbn-xsrf', 'xxx')
+            .send({})
+            .expect(409);
+        });
+
+        it('should succeed when role does not exist', async () => {
+          await supertest
+            .put('/api/security/role/new_role?createOnly=true')
+            .set('kbn-xsrf', 'xxx')
+            .send({})
+            .expect(204);
+        });
+      });
     });
 
     describe('Update Role', () => {
@@ -360,6 +392,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
       });
     });
+
     describe('Delete Role', () => {
       it('should delete the roles we created', async () => {
         await supertest.delete('/api/security/role/empty_role').set('kbn-xsrf', 'xxx').expect(204);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Warn & Disallow Creating Role with Existing Name (#132218)](https://github.com/elastic/kibana/pull/132218)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)