### PR TITLE
[Security Solution] [132894] Add searchable flag to detections response deep link config

### DIFF
--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -139,6 +139,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         defaultMessage: 'Detection & Response',
       }),
     ],
+    searchable: true,
   },
   {
     id: SecurityPageName.detections,


### PR DESCRIPTION
[#132894](https://github.com/elastic/kibana/issues/132894)

## Summary

Allow detections & response page to be available to globabl search without grouped navigation being enabled by adding searchable flag to its deep link configuration 

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/28942857/172200562-7157c57a-6d24-4e3f-9ff5-869b93446178.png">

