### PR TITLE
[Shared UX][No Data] Hide No Data card title

### DIFF
--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/__snapshots__/elastic_agent_card.test.tsx.snap
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/__snapshots__/elastic_agent_card.test.tsx.snap
@@ -231,7 +231,13 @@ exports[`ElasticAgentCard renders 1`] = `
                       />
                     }
                     paddingSize="l"
-                    title="Add Elastic Agent"
+                    title={
+                      <EuiScreenReaderOnly>
+                        <span>
+                          Add Elastic Agent
+                        </span>
+                      </EuiScreenReaderOnly>
+                    }
                   >
                     <EuiPanel
                       css="unknown styles"
@@ -366,7 +372,13 @@ exports[`ElasticAgentCard renders 1`] = `
                                   href="/app/integrations/browse"
                                   rel="noreferrer"
                                 >
-                                  Add Elastic Agent
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      Add Elastic Agent
+                                    </span>
+                                  </EuiScreenReaderOnly>
                                 </a>
                               </span>
                             </EuiTitle>

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/__snapshots__/no_data_card.test.tsx.snap
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/__snapshots__/no_data_card.test.tsx.snap
@@ -11,7 +11,11 @@ exports[`NoDataCard props button 1`] = `
       class="euiTitle euiTitle--small euiCard__title"
       id="generated-idTitle"
     >
-      Card title
+      <span
+        class="euiScreenReaderOnly"
+      >
+        Card title
+      </span>
     </span>
     <div
       class="euiText euiText--small euiCard__description"
@@ -54,7 +58,11 @@ exports[`NoDataCard props extends EuiCardProps 1`] = `
       class="euiTitle euiTitle--small euiCard__title"
       id="generated-idTitle"
     >
-      Card title
+      <span
+        class="euiScreenReaderOnly"
+      >
+        Card title
+      </span>
     </span>
     <div
       class="euiText euiText--small euiCard__description"
@@ -103,7 +111,11 @@ exports[`NoDataCard props href 1`] = `
         href="#"
         rel="noreferrer"
       >
-        Card title
+        <span
+          class="euiScreenReaderOnly"
+        >
+          Card title
+        </span>
       </a>
     </span>
     <div
@@ -152,7 +164,11 @@ exports[`NoDataCard props isDisabled 1`] = `
         class="euiCard__titleButton"
         disabled=""
       >
-        Card title
+        <span
+          class="euiScreenReaderOnly"
+        >
+          Card title
+        </span>
       </button>
     </span>
     <div
@@ -178,7 +194,11 @@ exports[`NoDataCard renders 1`] = `
       class="euiTitle euiTitle--small euiCard__title"
       id="generated-idTitle"
     >
-      Card title
+      <span
+        class="euiScreenReaderOnly"
+      >
+        Card title
+      </span>
     </span>
     <div
       class="euiText euiText--small euiCard__description"

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/no_data_card.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/no_data_card.tsx
@@ -8,7 +8,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React, { FunctionComponent } from 'react';
-import { EuiButton, EuiCard } from '@elastic/eui';
+import { EuiButton, EuiCard, EuiScreenReaderOnly } from '@elastic/eui';
 
 import type { NoDataCardProps } from './types';
 import { NoDataCardStyles } from './no_data_card.styles';
@@ -21,7 +21,7 @@ const defaultDescription = i18n.translate(
 );
 
 export const NoDataCard: FunctionComponent<NoDataCardProps> = ({
-  title,
+  title: titleProp,
   button,
   description,
   isDisabled,
@@ -39,9 +39,17 @@ export const NoDataCard: FunctionComponent<NoDataCardProps> = ({
       return button;
     }
     // Default footer action is a button with the provided or default string
-    return <EuiButton fill>{button || title}</EuiButton>;
+    return <EuiButton fill>{button || titleProp}</EuiButton>;
   };
+
   const cardDescription = description || defaultDescription;
+
+  // Bad hack to fix the need for an a11y title even though the button exists
+  const title = titleProp ? (
+    <EuiScreenReaderOnly>
+      <span>{titleProp}</span>
+    </EuiScreenReaderOnly>
+  ) : null;
 
   return (
     <EuiCard

--- a/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/no_data_card.tsx
+++ b/packages/kbn-shared-ux-components/src/page_template/no_data_page/no_data_card/no_data_card.tsx
@@ -44,7 +44,7 @@ export const NoDataCard: FunctionComponent<NoDataCardProps> = ({
 
   const cardDescription = description || defaultDescription;
 
-  // Bad hack to fix the need for an a11y title even though the button exists
+  // Fix the need for an a11y title even though the button exists by setting to screen reader only
   const title = titleProp ? (
     <EuiScreenReaderOnly>
       <span>{titleProp}</span>


### PR DESCRIPTION
## Summary

As titled.  The `kibana_react` plugin [had logic](https://github.com/elastic/kibana/blob/a4f2a811636232396878f0597f257790c16ca4f7/src/plugins/kibana_react/public/page_template/no_data_page/no_data_card/elastic_agent_card.tsx#L99-L104) to hide the title of the no data card, since the button is visible.  This PR applies the same logic.

## Before
<img width="433" alt="Screen Shot 2022-06-06 at 2 34 02 PM" src="https://user-images.githubusercontent.com/297604/172234144-09d8b958-a66e-4ca5-b1b4-1c26d14e2404.png">

## After
<img width="465" alt="Screen Shot 2022-06-06 at 2 33 31 PM" src="https://user-images.githubusercontent.com/297604/172234161-5a0f13b6-d57e-4713-ad34-eff39cc64a45.png">

