### PR TITLE
[8.3] added controlGroupInput to locator, passed control group input into locator when creating pdf or png report (#133425)

### DIFF
--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -7,6 +7,7 @@
  */
 
 import { EmbeddableInput, PanelState } from '@kbn/embeddable-plugin/common/types';
+import { SerializableRecord } from '@kbn/utility-types';
 import { ControlInput, ControlStyle, ControlWidth } from '../types';
 
 export const CONTROL_GROUP_TYPE = 'control_group';
@@ -32,11 +33,24 @@ export interface ControlGroupInput extends EmbeddableInput, ControlInput {
   panels: ControlsPanels;
 }
 
-// only parts of the Control Group Input should be persisted
+/**
+ * Only parts of the Control Group Input should be persisted
+ */
 export type PersistableControlGroupInput = Pick<
   ControlGroupInput,
   'panels' | 'chainingSystem' | 'controlStyle' | 'ignoreParentSettings'
 >;
+
+/**
+ * Some use cases need the Persistable Control Group Input to conform to the SerializableRecord format which requires string index signatures in any objects
+ */
+export type SerializableControlGroupInput = Omit<
+  PersistableControlGroupInput,
+  'panels' | 'ignoreParentSettings'
+> & {
+  panels: ControlsPanels & SerializableRecord;
+  ignoreParentSettings: PersistableControlGroupInput['ignoreParentSettings'] & SerializableRecord;
+};
 
 // panels are json stringified for storage in a saved object.
 export type RawControlGroupAttributes = Omit<
@@ -46,6 +60,7 @@ export type RawControlGroupAttributes = Omit<
   ignoreParentSettingsJSON: string;
   panelsJSON: string;
 };
+
 export interface ControlGroupTelemetry {
   total: number;
   chaining_system: {

--- a/src/plugins/controls/common/index.ts
+++ b/src/plugins/controls/common/index.ts
@@ -11,12 +11,13 @@ export type { ControlWidth } from './types';
 // Control Group exports
 export {
   CONTROL_GROUP_TYPE,
-  type ControlPanelState,
   type ControlsPanels,
   type ControlGroupInput,
+  type ControlPanelState,
   type ControlGroupTelemetry,
   type RawControlGroupAttributes,
   type PersistableControlGroupInput,
+  type SerializableControlGroupInput,
 } from './control_group/types';
 export {
   controlGroupInputToRawControlGroupAttributes,

--- a/src/plugins/controls/common/mocks.tsx
+++ b/src/plugins/controls/common/mocks.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getDefaultControlGroupInput } from '.';
+import { ControlGroupInput } from './control_group/types';
+
+export const mockControlGroupInput = (partial?: Partial<ControlGroupInput>): ControlGroupInput => ({
+  id: 'mocked_control_group',
+  ...getDefaultControlGroupInput(),
+  ...{
+    panels: {
+      control1: {
+        order: 0,
+        width: 'medium',
+        grow: true,
+        type: 'mockedOptionsList',
+        explicitInput: {
+          id: 'control1',
+        },
+      },
+      control2: {
+        order: 1,
+        width: 'large',
+        grow: true,
+        type: 'mockedRangeSlider',
+        explicitInput: {
+          id: 'control2',
+        },
+      },
+      control3: {
+        order: 2,
+        width: 'small',
+        grow: true,
+        type: 'mockedOptionsList',
+        explicitInput: {
+          id: 'control3',
+        },
+      },
+    },
+  },
+  ...(partial ?? {}),
+});

--- a/src/plugins/dashboard/public/application/top_nav/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/show_share_modal.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import React, { ReactElement, useState } from 'react';
 import type { Capabilities } from '@kbn/core/public';
+import { SerializableControlGroupInput } from '@kbn/controls-plugin/common';
 import { DashboardSavedObject } from '../..';
 import { shareModalStrings } from '../../dashboard_strings';
 import { DashboardAppLocatorParams, DASHBOARD_APP_LOCATOR } from '../../locator';
@@ -116,7 +117,7 @@ export function ShowShareModal({
 
   let unsavedStateForLocator: Pick<
     DashboardAppLocatorParams,
-    'options' | 'query' | 'savedQuery' | 'filters' | 'panels'
+    'options' | 'query' | 'savedQuery' | 'filters' | 'panels' | 'controlGroupInput'
   > = {};
   const unsavedDashboardState = dashboardSessionStorage.getState(savedDashboard.id);
   if (unsavedDashboardState) {
@@ -125,6 +126,7 @@ export function ShowShareModal({
       filters: unsavedDashboardState.filters,
       options: unsavedDashboardState.options,
       savedQuery: unsavedDashboardState.savedQuery,
+      controlGroupInput: unsavedDashboardState.controlGroupInput as SerializableControlGroupInput,
       panels: unsavedDashboardState.panels
         ? convertPanelMapToSavedPanels(unsavedDashboardState.panels, kibanaVersion)
         : undefined,

--- a/src/plugins/dashboard/public/locator.test.ts
+++ b/src/plugins/dashboard/public/locator.test.ts
@@ -9,7 +9,9 @@
 import { DashboardAppLocatorDefinition } from './locator';
 import { hashedItemStore } from '@kbn/kibana-utils-plugin/public';
 import { mockStorage } from '@kbn/kibana-utils-plugin/public/storage/hashed_item_store/mock';
+import { mockControlGroupInput } from '@kbn/controls-plugin/common/mocks';
 import { FilterStateStore } from '@kbn/es-query';
+import { SerializableControlGroupInput } from '@kbn/controls-plugin/common';
 
 describe('dashboard locator', () => {
   beforeEach(() => {
@@ -200,6 +202,25 @@ describe('dashboard locator', () => {
       path: `#/create?_g=()`,
       state: {
         panels: [{ fakePanelContent: 'fakePanelContent' }],
+      },
+    });
+  });
+
+  test('Control Group Input', async () => {
+    const definition = new DashboardAppLocatorDefinition({
+      useHashedUrl: false,
+      getDashboardFilterFields: async (dashboardId: string) => [],
+    });
+    const controlGroupInput = mockControlGroupInput() as unknown as SerializableControlGroupInput;
+    const location = await definition.getLocation({
+      controlGroupInput,
+    });
+
+    expect(location).toMatchObject({
+      app: 'dashboards',
+      path: `#/create?_g=()`,
+      state: {
+        controlGroupInput,
       },
     });
   });

--- a/src/plugins/dashboard/public/locator.ts
+++ b/src/plugins/dashboard/public/locator.ts
@@ -16,8 +16,10 @@ import type {
   RefreshInterval,
 } from '@kbn/data-plugin/public';
 import type { LocatorDefinition, LocatorPublic } from '@kbn/share-plugin/public';
+import { SerializableControlGroupInput } from '@kbn/controls-plugin/common';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { ViewMode } from '@kbn/embeddable-plugin/public';
+
 import type { SavedDashboardPanel } from '../common/types';
 import type { RawDashboardState } from './types';
 import { DashboardConstants } from './dashboard_constants';
@@ -105,6 +107,11 @@ export type DashboardAppLocatorParams = {
   savedQuery?: string;
 
   options?: RawDashboardState['options'];
+
+  /**
+   * Control group input
+   */
+  controlGroupInput?: SerializableControlGroupInput;
 };
 
 export type DashboardAppLocator = LocatorPublic<DashboardAppLocatorParams>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [added controlGroupInput to locator, passed control group input into locator when creating pdf or png report (#133425)](https://github.com/elastic/kibana/pull/133425)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)