### PR TITLE
remove kibana saved object from the esArchive

### DIFF
--- a/test/functional/fixtures/es_archiver/index_pattern_without_timefield/data.json
+++ b/test/functional/fixtures/es_archiver/index_pattern_without_timefield/data.json
@@ -17,22 +17,6 @@
 {
   "type": "doc",
   "value": {
-    "id": "index-pattern:with-timefield",
-    "index": ".kibana",
-    "source": {
-      "index-pattern": {
-        "fields": "[]",
-        "title": "with-timefield",
-        "timeFieldName": "@timestamp"
-      },
-      "type": "index-pattern"
-    }
-  }
-}
-
-{
-  "type": "doc",
-  "value": {
     "id": "AU_x3-TaGFA8no6QjiSJ",
     "index": "with-timefield",
     "source": {


### PR DESCRIPTION
## Summary

Fixing my mistake on PR https://github.com/elastic/kibana/pull/125870
This just removes an index pattern from the esArchive which had already been added to the kbnArchive.

