### PR TITLE
Adds `match_only_text` to ES_FIELD_TYPES

### DIFF
--- a/packages/kbn-field-types/src/kbn_field_types_factory.ts
+++ b/packages/kbn-field-types/src/kbn_field_types_factory.ts
@@ -21,6 +21,7 @@ export const createKbnFieldTypes = (): KbnFieldType[] => [
     esTypes: [
       ES_FIELD_TYPES.STRING,
       ES_FIELD_TYPES.TEXT,
+      ES_FIELD_TYPES.MATCH_ONLY_TEXT,
       ES_FIELD_TYPES.KEYWORD,
       ES_FIELD_TYPES.VERSION,
       ES_FIELD_TYPES._TYPE,

--- a/packages/kbn-field-types/src/types.ts
+++ b/packages/kbn-field-types/src/types.ts
@@ -23,6 +23,7 @@ export enum ES_FIELD_TYPES {
 
   STRING = 'string',
   TEXT = 'text',
+  MATCH_ONLY_TEXT = 'match_only_text',
   KEYWORD = 'keyword',
   VERSION = 'version',
 


### PR DESCRIPTION
## Summary

A new Security Solution feature (https://github.com/elastic/kibana/pull/131475) was added in `8.3` that displays a field name and icon token using the reusable `FieldIcon` component. In testing an issue was reported (https://github.com/elastic/kibana/issues/133291) that the wrong icon token was being displayed. 

I had [previously updated](https://github.com/elastic/kibana/pull/131475/files#diff-d79a8297783f3177da25dd13fe807425d9136a0e235fe170f7c0a61f2448dacaR23) `FieldIcon` to support `match_only_text` however this new issue was with the `float` type not displaying correctly. After some searching I found the `castEsToKbnFieldTypeName` utility which solved the issue with `float` fields not displaying, but then `match_only_text` field types would not show since it is missing from `ES_FIELD_TYPES` and so would resolve as `unknown`. 

This PR adds the `match_only_text` [ES type](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html#match-only-text-field-type) to `ES_FIELD_TYPES` to resolve this missing icon token issue so that `castEsToKbnFieldTypeName` can be used in conjunction with the resuable `FieldIcon` component. 

I imagine this is fine as it's a sibling type to `text`, but am curious here since `sortable: true,` is set for the KbnFieldType even though it includes `ES_FIELD_TYPES.TEXT` (which is not sortable) as well?


