### PR TITLE
[Fleet] fix policy preselect for non fleet server policy

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../applications/fleet/sections/agents/components';
 import { AgentPolicyCreateInlineForm } from '../../applications/fleet/sections/agent_policy/components';
 import type { AgentPolicy } from '../../types';
-import { incrementPolicyName } from '../../services';
+import { incrementPolicyName, policyHasFleetServer } from '../../services';
 
 import { AgentPolicySelection } from '.';
 
@@ -47,6 +47,18 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
         policy && !policy.is_managed && (!excludeFleetServer || !policy.is_default_fleet_server)
     );
   }, [agentPolicies, excludeFleetServer]);
+
+  useEffect(() => {
+    // Select default value if policy has no fleet server
+    if (
+      regularAgentPolicies.length === 1 &&
+      !selectedPolicyId &&
+      excludeFleetServer !== false &&
+      !policyHasFleetServer(regularAgentPolicies[0])
+    ) {
+      setSelectedPolicyId(regularAgentPolicies[0].id);
+    }
+  }, [regularAgentPolicies, selectedPolicyId, setSelectedPolicyId, excludeFleetServer]);
 
   const onAgentPolicyChange = useCallback(
     async (key?: string, policy?: AgentPolicy) => {


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/131121

To verify:
- test in cloud or on prem:
- create a preconfigured managed fleet server policy
- enroll a fleet server to it
- create a non fleet server policy
- open Add agent flyout
- verify that non fleet server policy is preselected
- policy is not preselected if it has fleet server integration


https://user-images.githubusercontent.com/90178898/172339553-09ee0338-cc5c-46bc-bc71-ff40508fa1f0.mov

