### PR TITLE
[SecuritySolution] Dashboards section title in the old nav

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
+++ b/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
@@ -171,6 +171,10 @@ export const navTabs: SecurityNav = {
 };
 
 export const securityNavGroup: SecurityNavGroup = {
+  [SecurityNavGroupKey.dashboards]: {
+    id: SecurityNavGroupKey.dashboards,
+    name: i18n.DASHBOARDS,
+  },
   [SecurityNavGroupKey.detect]: {
     id: SecurityNavGroupKey.detect,
     name: i18n.DETECT,

--- a/x-pack/plugins/security_solution/public/common/components/navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/types.ts
@@ -26,6 +26,7 @@ export interface NavGroupTab {
   name: string;
 }
 export enum SecurityNavGroupKey {
+  dashboards = 'dashboards',
   detect = 'detect',
   explore = 'explore',
   investigate = 'investigate',

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/__snapshots__/index.test.tsx.snap
@@ -17,6 +17,12 @@ Object {
           "name": "Get started",
           "onClick": [Function],
         },
+      ],
+      "name": "",
+    },
+    Object {
+      "id": "dashboards",
+      "items": Array [
         Object {
           "data-href": "securitySolutionUI/overview?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
           "data-test-subj": "navigation-overview",
@@ -38,7 +44,7 @@ Object {
           "onClick": [Function],
         },
       ],
-      "name": "",
+      "name": "Dashboards",
     },
     Object {
       "id": "detect",

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -118,8 +118,7 @@ describe('useSecuritySolutionNavigation', () => {
       () => useSecuritySolutionNavigation(),
       { wrapper: TestProviders }
     );
-
-    expect(result?.current?.items?.[2].items?.[2].id).toEqual(SecurityPageName.users);
+    expect(result?.current?.items?.[3].items?.[2].id).toEqual(SecurityPageName.users);
   });
 
   // TODO: [kubernetes] remove when no longer experimental
@@ -129,7 +128,7 @@ describe('useSecuritySolutionNavigation', () => {
       () => useSecuritySolutionNavigation(),
       { wrapper: TestProviders }
     );
-    expect(result?.current?.items?.[2].items?.[3].id).toEqual(SecurityPageName.kubernetes);
+    expect(result?.current?.items?.[1].items?.[2].id).toEqual(SecurityPageName.kubernetes);
   });
 
   it('should omit host isolation exceptions if hook reports false', () => {
@@ -163,18 +162,7 @@ describe('useSecuritySolutionNavigation', () => {
         const caseNavItem = (result.current?.items || [])[3].items?.find(
           (item) => item['data-test-subj'] === 'navigation-cases'
         );
-        expect(caseNavItem).toMatchInlineSnapshot(`
-          Object {
-            "data-href": "securitySolutionUI/cases?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
-            "data-test-subj": "navigation-cases",
-            "disabled": false,
-            "href": "securitySolutionUI/cases?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
-            "id": "cases",
-            "isSelected": false,
-            "name": "Cases",
-            "onClick": [Function],
-          }
-        `);
+        expect(caseNavItem).toMatchInlineSnapshot(`undefined`);
       });
 
       it('should not display the cases navigation item when the user does not have read permissions', () => {

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -118,6 +118,7 @@ describe('useSecuritySolutionNavigation', () => {
       () => useSecuritySolutionNavigation(),
       { wrapper: TestProviders }
     );
+
     expect(result?.current?.items?.[3].items?.[2].id).toEqual(SecurityPageName.users);
   });
 
@@ -159,10 +160,21 @@ describe('useSecuritySolutionNavigation', () => {
           { wrapper: TestProviders }
         );
 
-        const caseNavItem = (result.current?.items || [])[3].items?.find(
+        const caseNavItem = (result.current?.items || [])[4].items?.find(
           (item) => item['data-test-subj'] === 'navigation-cases'
         );
-        expect(caseNavItem).toMatchInlineSnapshot(`undefined`);
+        expect(caseNavItem).toMatchInlineSnapshot(`
+          Object {
+            "data-href": "securitySolutionUI/cases?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
+            "data-test-subj": "navigation-cases",
+            "disabled": false,
+            "href": "securitySolutionUI/cases?query=(language:kuery,query:'host.name:%22security-solution-es%22')&sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now-24h,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now)))",
+            "id": "cases",
+            "isSelected": false,
+            "name": "Cases",
+            "onClick": [Function],
+          }
+        `);
       });
 
       it('should not display the cases navigation item when the user does not have read permissions', () => {

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
@@ -76,10 +76,16 @@ function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
             {
               id: 'main',
               name: '',
+              items: [navTabs[SecurityPageName.landing]],
+            },
+            {
+              ...securityNavGroup[SecurityNavGroupKey.dashboards],
               items: [
-                navTabs[SecurityPageName.landing],
                 navTabs[SecurityPageName.overview],
                 navTabs[SecurityPageName.detectionAndResponse],
+                ...(navTabs[SecurityPageName.kubernetes] != null
+                  ? [navTabs[SecurityPageName.kubernetes]]
+                  : []),
               ],
             },
             {
@@ -97,9 +103,6 @@ function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
                 navTabs[SecurityPageName.network],
                 ...(navTabs[SecurityPageName.users] != null
                   ? [navTabs[SecurityPageName.users]]
-                  : []),
-                ...(navTabs[SecurityPageName.kubernetes] != null
-                  ? [navTabs[SecurityPageName.kubernetes]]
                   : []),
               ],
             },


### PR DESCRIPTION
## Summary

New section title added to the old side navigation, grouping the "Dashboards" links.
issue: https://github.com/elastic/kibana/issues/133656

![dashboards](https://user-images.githubusercontent.com/17747913/172346267-4d657584-9807-41f2-9539-b8694316a77c.png)
