### PR TITLE
[Fleet] Disable upgrade callout for single agent upgrade

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -99,7 +99,7 @@ export interface CurrentUpgrade {
   nbAgents: number;
   nbAgentsAck: number;
   version: string;
-  startTime: string;
+  startTime?: string;
 }
 
 // Generated from FleetServer schema.json

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/current_bulk_upgrade_callout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/current_bulk_upgrade_callout.tsx
@@ -41,43 +41,47 @@ export const CurrentBulkUpgradeCallout: React.FunctionComponent<CurrentBulkUpgra
   }, [currentUpgrade, abortUpgrade]);
 
   const isScheduled = useMemo(() => {
+    if (!currentUpgrade.startTime) {
+      return false;
+    }
     const now = Date.now();
     const startDate = new Date(currentUpgrade.startTime).getTime();
 
     return startDate > now;
   }, [currentUpgrade]);
 
-  const calloutTitle = isScheduled ? (
-    <FormattedMessage
-      id="xpack.fleet.currentUpgrade.scheduleCalloutTitle"
-      defaultMessage="{nbAgents} agents scheduled to upgrade to version {version} on {date}"
-      values={{
-        nbAgents: currentUpgrade.nbAgents - currentUpgrade.nbAgentsAck,
-        version: currentUpgrade.version,
-        date: (
-          <>
-            <FormattedDate
-              value={currentUpgrade.startTime}
-              year="numeric"
-              month="short"
-              day="2-digit"
-            />
-            &nbsp;
-            <FormattedTime value={currentUpgrade.startTime} />
-          </>
-        ),
-      }}
-    />
-  ) : (
-    <FormattedMessage
-      id="xpack.fleet.currentUpgrade.calloutTitle"
-      defaultMessage="Upgrading {nbAgents, plural, one {# agent} other {# agents}} to version {version}"
-      values={{
-        nbAgents: currentUpgrade.nbAgents - currentUpgrade.nbAgentsAck,
-        version: currentUpgrade.version,
-      }}
-    />
-  );
+  const calloutTitle =
+    isScheduled && currentUpgrade.startTime ? (
+      <FormattedMessage
+        id="xpack.fleet.currentUpgrade.scheduleCalloutTitle"
+        defaultMessage="{nbAgents} agents scheduled to upgrade to version {version} on {date}"
+        values={{
+          nbAgents: currentUpgrade.nbAgents - currentUpgrade.nbAgentsAck,
+          version: currentUpgrade.version,
+          date: (
+            <>
+              <FormattedDate
+                value={currentUpgrade.startTime}
+                year="numeric"
+                month="short"
+                day="2-digit"
+              />
+              &nbsp;
+              <FormattedTime value={currentUpgrade.startTime} />
+            </>
+          ),
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.fleet.currentUpgrade.calloutTitle"
+        defaultMessage="Upgrading {nbAgents, plural, one {# agent} other {# agents}} to version {version}"
+        values={{
+          nbAgents: currentUpgrade.nbAgents - currentUpgrade.nbAgentsAck,
+          version: currentUpgrade.version,
+        }}
+      />
+    );
   return (
     <EuiCallOut color="primary">
       <EuiFlexGroup

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.ts
@@ -316,11 +316,6 @@ async function _getUpgradeActions(esClient: ElasticsearchClient, now = new Date(
             },
           },
           {
-            exists: {
-              field: 'start_time',
-            },
-          },
-          {
             range: {
               expiration: { gte: now },
             },
@@ -343,7 +338,7 @@ async function _getUpgradeActions(esClient: ElasticsearchClient, now = new Date(
           complete: false,
           nbAgentsAck: 0,
           version: hit._source.data?.version as string,
-          startTime: hit._source.start_time as string,
+          startTime: hit._source?.start_time,
         };
       }
 

--- a/x-pack/test/fleet_api_integration/apis/agents/current_upgrades.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/current_upgrades.ts
@@ -150,13 +150,26 @@ export default function (providerContext: FtrProviderContext) {
             },
           },
         });
+
+        // Action 6 1 agent with not start time
+        await es.index({
+          refresh: 'wait_for',
+          index: AGENT_ACTIONS_INDEX,
+          document: {
+            type: 'UPGRADE',
+            action_id: 'action6',
+            agents: ['agent1'],
+            expiration: moment().add(1, 'day').toISOString(),
+          },
+        });
       });
       it('should respond 200 and the current upgrades', async () => {
         const res = await supertest.get(`/api/fleet/agents/current_upgrades`).expect(200);
         const actionIds = res.body.items.map((item: any) => item.actionId);
-        expect(actionIds).length(2);
+        expect(actionIds).length(3);
         expect(actionIds).contain('action1');
         expect(actionIds).contain('action2');
+        expect(actionIds).contain('action6');
       });
     });
   });


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/133499

Display the upgrade callout in the agent list for single agent upgrade.

## How to test?

Trigger a single agent upgrade, you should see the callout, I added a test that cover that scenario.

## UI Change

<img width="1240" alt="Screen Shot 2022-06-07 at 11 31 20 AM" src="https://user-images.githubusercontent.com/1336873/172348775-d438ac6d-764a-4b71-aa05-74fdcbc57481.png">
