### PR TITLE
[SecuritySolution] Make sure createThresholdTimeline works when no filters are provided

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
@@ -387,6 +387,10 @@ const buildEqlDataProviderOrFilter = (
   return { filters: [], dataProviders: [] };
 };
 
+interface MightHaveFilters {
+  filters?: Filter[];
+}
+
 const createThresholdTimeline = async (
   ecsData: Ecs,
   createTimeline: ({ from, timeline, to }: CreateTimelineProps) => void,
@@ -416,7 +420,10 @@ const createThresholdTimeline = async (
 
     const alertDoc = formattedAlertData[0];
     const params = getField(alertDoc, ALERT_RULE_PARAMETERS);
-    const filters: Filter[] = params.filters ?? alertDoc.signal?.rule?.filters;
+    const filters: Filter[] =
+      (params as MightHaveFilters).filters ??
+      (alertDoc.signal?.rule as MightHaveFilters)?.filters ??
+      [];
     // https://github.com/elastic/kibana/issues/126574 - if the provided filter has no `meta` field
     // we expect an empty object to be inserted before calling `createTimeline`
     const augmentedFilters = filters.map((filter) => {


### PR DESCRIPTION
## Summary

A [recent support request](https://github.com/elastic/sdh-security-team/issues/385) surfaced a Kibana crash when trying to investigate a timeline from a threshold alert. We were able to get hold of a HAR to reproduce this issue locally and were able to identify the piece of code that crashed.

This PR introduces a narrowed-down type that should give us more type-safety around reading `filters` from an alert.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios