### PR TITLE
[Cloud Posture] remove outsideClickCloses prop in rule flyout

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
@@ -45,7 +45,6 @@ export const RuleFlyout = ({ onClose, rule, toggleRule }: RuleFlyoutProps) => {
     <EuiFlyout
       ownFocus={false}
       onClose={onClose}
-      outsideClickCloses
       data-test-subj={TEST_SUBJECTS.CSP_RULES_FLYOUT_CONTAINER}
     >
       <EuiFlyoutHeader>


### PR DESCRIPTION
this PR makes it so that clicking outside the rule flyout won't close it

which makes for easier navigation between rules and prevents the flyout from closing when clicking on search bar 