### PR TITLE
[Fleet] Add $ProgressPreference to windows install command in flyout

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
@@ -51,7 +51,8 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
+        "$ProgressPreference = 'SilentlyContinue'
+        wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
         Expand-Archive .\\\\elastic-agent--windows-x86_64.zip
         cd elastic-agent--windows-x86_64
         .\\\\elastic-agent.exe install  \`
@@ -165,7 +166,8 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
+        "$ProgressPreference = 'SilentlyContinue'
+        wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
         Expand-Archive .\\\\elastic-agent--windows-x86_64.zip
         cd elastic-agent--windows-x86_64
         .\\\\elastic-agent.exe install  \`
@@ -276,7 +278,8 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
+        "$ProgressPreference = 'SilentlyContinue'
+        wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--windows-x86_64.zip -OutFile elastic-agent--windows-x86_64.zip
         Expand-Archive .\\\\elastic-agent--windows-x86_64.zip
         cd elastic-agent--windows-x86_64
         .\\\\elastic-agent.exe install --url=http://fleetserver:8220 \`

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
@@ -64,6 +64,7 @@ export function getInstallCommandForPlatform(
   const downloadCommand =
     platform === 'windows'
       ? [
+          "$ProgressPreference = 'SilentlyContinue'",
           `wget ${artifact.fullUrl} -OutFile ${artifact.filename}`,
           `Expand-Archive .\\${artifact.filename}`,
           `cd ${artifact.unpackedDir}`,


### PR DESCRIPTION
## Summary

Resolves #133198.

Add missing `$ProgressPreference = 'SilentlyContinue'` line from the start of the windows install command.
