### PR TITLE
[Fleet] Display agent count in bulk actions

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -257,8 +257,8 @@ describe('View agents', () => {
       cy.getBySel('checkboxSelectAll').click();
       // Trigger a bulk upgrade
       cy.getBySel('agentBulkActionsButton').click();
-      cy.get('button').contains('Upgrade agents').click();
       cy.get('button').contains('Upgrade 15 agents').click();
+      cy.get('.euiModalFooter button').contains('Upgrade 15 agents').click();
       // Cancel upgrade
       cy.getBySel('abortUpgradeBtn').click();
       cy.get('button').contains('Confirm').click();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -62,6 +62,9 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
     selectionMode === 'manual'
       ? !!selectedAgents.find((agent) => agent.active)
       : totalAgents > totalInactiveAgents;
+  const totalActiveAgents = totalAgents - totalInactiveAgents;
+  const agentCount = selectionMode === 'manual' ? selectedAgents.length : totalActiveAgents;
+  const agents = selectionMode === 'manual' ? selectedAgents : currentQuery;
 
   const panels = [
     {
@@ -87,7 +90,10 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
             <FormattedMessage
               id="xpack.fleet.agentBulkActions.unenrollAgents"
               data-test-subj="agentBulkActionsUnenroll"
-              defaultMessage="Unenroll agents"
+              defaultMessage="Unenroll {agentCount, plural, one {# agent} other {# agents}}"
+              values={{
+                agentCount,
+              }}
             />
           ),
           icon: <EuiIcon type="trash" size="m" />,
@@ -102,7 +108,10 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
             <FormattedMessage
               id="xpack.fleet.agentBulkActions.upgradeAgents"
               data-test-subj="agentBulkActionsUpgrade"
-              defaultMessage="Upgrade agents"
+              defaultMessage="Upgrade {agentCount, plural, one {# agent} other {# agents}}"
+              values={{
+                agentCount,
+              }}
             />
           ),
           icon: <EuiIcon type="refresh" size="m" />,
@@ -117,7 +126,10 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
             <FormattedMessage
               id="xpack.fleet.agentBulkActions.scheduleUpgradeAgents"
               data-test-subj="agentBulkActionsScheduleUpgrade"
-              defaultMessage="Schedule upgrade for agents"
+              defaultMessage="Schedule upgrade for {agentCount, plural, one {# agent} other {# agents}}"
+              values={{
+                agentCount,
+              }}
             />
           ),
           icon: <EuiIcon type="timeRefresh" size="m" />,
@@ -130,10 +142,6 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
       ],
     },
   ];
-
-  const totalActiveAgents = totalAgents - totalInactiveAgents;
-  const agentCount = selectionMode === 'manual' ? selectedAgents.length : totalActiveAgents;
-  const agents = selectionMode === 'manual' ? selectedAgents : currentQuery;
 
   return (
     <>

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -12221,8 +12221,6 @@
     "xpack.fleet.agentBulkActions.selectAll": "Tout sélectionner sur toutes les pages",
     "xpack.fleet.agentBulkActions.totalAgents": "Affichage {count, plural, one {d'# agent} other {de # agents}}",
     "xpack.fleet.agentBulkActions.totalAgentsWithLimit": "Affichage de {count} agent(s) sur {total}",
-    "xpack.fleet.agentBulkActions.unenrollAgents": "Désinscrire les agents",
-    "xpack.fleet.agentBulkActions.upgradeAgents": "Mettre à niveau les agents",
     "xpack.fleet.agentDetails.actionsButton": "Actions",
     "xpack.fleet.agentDetails.agentDetailsTitle": "Agent \"{id}\"",
     "xpack.fleet.agentDetails.agentNotFoundErrorDescription": "Impossible de trouver l'ID d'agent {agentId}",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -12320,8 +12320,6 @@
     "xpack.fleet.agentBulkActions.selectAll": "すべてのページのすべての項目を選択",
     "xpack.fleet.agentBulkActions.totalAgents": "{count, plural, other  {#個のエージェント}}を表示しています",
     "xpack.fleet.agentBulkActions.totalAgentsWithLimit": "{count}/{total}個のエージェントを表示しています",
-    "xpack.fleet.agentBulkActions.unenrollAgents": "エージェントの登録を解除",
-    "xpack.fleet.agentBulkActions.upgradeAgents": "エージェントをアップグレード",
     "xpack.fleet.agentDetails.actionsButton": "アクション",
     "xpack.fleet.agentDetails.agentDetailsTitle": "エージェント'{id}'",
     "xpack.fleet.agentDetails.agentNotFoundErrorDescription": "エージェントID {agentId}が見つかりません",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -12342,8 +12342,6 @@
     "xpack.fleet.agentBulkActions.selectAll": "选择所有页面上的所有内容",
     "xpack.fleet.agentBulkActions.totalAgents": "正在显示 {count, plural, other {# 个代理}}",
     "xpack.fleet.agentBulkActions.totalAgentsWithLimit": "正在显示 {count} 个代理（共 {total} 个）",
-    "xpack.fleet.agentBulkActions.unenrollAgents": "取消注册代理",
-    "xpack.fleet.agentBulkActions.upgradeAgents": "升级代理",
     "xpack.fleet.agentDetails.actionsButton": "操作",
     "xpack.fleet.agentDetails.agentDetailsTitle": "代理“{id}”",
     "xpack.fleet.agentDetails.agentNotFoundErrorDescription": "找不到代理 ID {agentId}",


### PR DESCRIPTION
## Summary

Resolve #133610

Display the number of agent impacted by the bulk actions 

## UI Changes

<img width="529" alt="Screen Shot 2022-06-07 at 1 55 39 PM" src="https://user-images.githubusercontent.com/1336873/172381389-0a7fb150-643a-46db-8199-6664f51021a0.png">
