### PR TITLE
[Exploratory View] Re-introduce required id types for `FormatType`

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts
@@ -123,6 +123,10 @@ export interface ConfigProps {
   series?: SeriesUrl;
 }
 
+interface FormatType extends SerializedFieldFormat<FieldFormatParams> {
+  id: 'duration' | 'number' | 'bytes' | 'percent';
+}
+
 export type AppDataType = 'synthetics' | 'ux' | 'infra_logs' | 'infra_metrics' | 'apm' | 'mobile';
 
 type InputFormat = 'microseconds' | 'milliseconds' | 'seconds';
@@ -138,7 +142,7 @@ export interface FieldFormatParams extends BaseFieldFormatParams {
 
 export interface FieldFormat {
   field: string;
-  format: SerializedFieldFormat<FieldFormatParams>;
+  format: FormatType;
 }
 
 export interface BuilderItem {


### PR DESCRIPTION
## Summary

Recently, [a change](https://github.com/elastic/kibana/pull/132959) removed the opinionated `id` type from one of Exploratory View's types. This change reintroduces that type requirement. The reasoning is that DX will be nicer because TypeScript will force the user to choose valid id types and give them the selection via Intellisense.

