### PR TITLE
[8.3] [ML] Fix bucket span initialisation on the Anomaly Explorer page (#133366)

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/anomaly_timeline_state_service.ts
+++ b/x-pack/plugins/ml/public/application/explorer/anomaly_timeline_state_service.ts
@@ -14,6 +14,7 @@ import {
   startWith,
   tap,
   debounceTime,
+  filter,
 } from 'rxjs/operators';
 import { isEqual, sortBy, uniq } from 'lodash';
 import type { TimefilterContract } from '@kbn/data-plugin/public';
@@ -731,8 +732,7 @@ export class AnomalyTimelineStateService extends StateService {
 
   public getSwimLaneBucketInterval$(): Observable<TimeBucketsInterval> {
     return this._swimLaneBucketInterval$.pipe(
-      // @ts-ignore
-      skipWhile((v) => !v),
+      filter((v): v is TimeBucketsInterval => !!v),
       distinctUntilChanged((prev, curr) => {
         return prev.asSeconds() === curr.asSeconds();
       })

--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -62,6 +62,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
   const elasticChart = getService('elasticChart');
+  const browser = getService('browser');
 
   describe('anomaly explorer', function () {
     this.tags(['ml']);
@@ -213,6 +214,19 @@ export default function ({ getService }: FtrProviderContext) {
             'selectedLanes%3A!(Overall)%2CselectedTimes%3A!(1454846400%2C1454860800)%2CselectedType%3Aoverall%2CshowTopFieldValues%3A!t'
           );
 
+          await ml.testExecution.logTestStep('restores app state from the URL state');
+          await browser.refresh();
+          await elasticChart.setNewChartUiDebugFlag(true);
+          await ml.swimLane.waitForSwimLanesToLoad();
+          await ml.swimLane.assertSelection(overallSwimLaneTestSubj, {
+            x: [1454846400000, 1454860800000],
+            y: ['Overall'],
+          });
+          await ml.swimLane.assertAxisLabels(viewBySwimLaneTestSubj, 'y', ['EGF', 'DAL']);
+          await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(5);
+          await ml.anomalyExplorer.assertInfluencerFieldListLength('airline', 2);
+          await ml.anomaliesTable.assertTableRowsCount(4);
+
           await ml.testExecution.logTestStep('clears the selection');
           await ml.anomalyExplorer.clearSwimLaneSelection();
           await ml.swimLane.waitForSwimLanesToLoad();
@@ -269,6 +283,22 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(1);
 
           await ml.testExecution.logTestStep('highlights the Overall swim lane');
+          await ml.swimLane.assertSelection(overallSwimLaneTestSubj, {
+            x: [1454817600000, 1454832000000],
+            y: ['Overall'],
+          });
+
+          await ml.testExecution.logTestStep('restores app state from the URL state');
+          await browser.refresh();
+          await elasticChart.setNewChartUiDebugFlag(true);
+          await ml.swimLane.waitForSwimLanesToLoad();
+          await ml.swimLane.assertSelection(viewBySwimLaneTestSubj, {
+            x: [1454817600000, 1454832000000],
+            y: ['AAL'],
+          });
+          await ml.anomaliesTable.assertTableRowsCount(1);
+          await ml.anomalyExplorer.assertInfluencerFieldListLength('airline', 1);
+          await ml.anomalyExplorer.assertAnomalyExplorerChartsCount(1);
           await ml.swimLane.assertSelection(overallSwimLaneTestSubj, {
             x: [1454817600000, 1454832000000],
             y: ['Overall'],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[ML] Fix bucket span initialisation on the Anomaly Explorer page (#133366)](https://github.com/elastic/kibana/pull/133366)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)