### PR TITLE
[Shared UX] Restore SVG CSS in Data View Illustration by using `raw-loader`

### DIFF
--- a/packages/shared-ux/prompt/no_data_views/src/data_view_illustration.tsx
+++ b/packages/shared-ux/prompt/no_data_views/src/data_view_illustration.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { css as emotion } from '@emotion/css';
 
-import svg from '!raw-loader!./data_view_illustration.svg';
+import svg from '!!raw-loader!./data_view_illustration.svg';
 
 export const DataViewIllustration = () => {
   const { euiTheme } = useEuiTheme();

--- a/packages/shared-ux/prompt/no_data_views/src/data_view_illustration.tsx
+++ b/packages/shared-ux/prompt/no_data_views/src/data_view_illustration.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { css as emotion } from '@emotion/css';
 
-import svg from './data_view_illustration.svg';
+import svg from '!raw-loader!./data_view_illustration.svg';
 
 export const DataViewIllustration = () => {
   const { euiTheme } = useEuiTheme();
@@ -25,5 +25,6 @@ export const DataViewIllustration = () => {
     }
   `;
 
-  return <img src={svg} css={css} alt="Data view illustration" />;
+  /* eslint-disable react/no-danger */
+  return <span css={css} dangerouslySetInnerHTML={{ __html: svg }} />;
 };

--- a/packages/shared-ux/prompt/no_data_views/src/no_data_views.component.tsx
+++ b/packages/shared-ux/prompt/no_data_views/src/no_data_views.component.tsx
@@ -16,6 +16,16 @@ import { withSuspense } from '@kbn/shared-ux-utility';
 
 import { DocumentationLink } from './documentation_link';
 
+// Load this illustration lazily
+const Illustration = withSuspense(
+  React.lazy(() =>
+    import('./data_view_illustration').then(({ DataViewIllustration }) => {
+      return { default: DataViewIllustration };
+    })
+  ),
+  <EuiPanel color="subdued" style={{ width: 226, height: 206 }} />
+);
+
 export interface Props {
   canCreateNewDataView: boolean;
   onClickCreate?: () => void;
@@ -88,17 +98,6 @@ export const NoDataViewsPrompt = ({
   );
 
   const footer = dataViewsDocLink ? <DocumentationLink href={dataViewsDocLink} /> : undefined;
-
-  // Load this illustration lazily
-  const Illustration = withSuspense(
-    React.lazy(() =>
-      import('./data_view_illustration').then(({ DataViewIllustration }) => {
-        return { default: DataViewIllustration };
-      })
-    ),
-    <EuiPanel color="subdued" style={{ width: 226, height: 206 }} />
-  );
-
   const icon = <Illustration />;
 
   return (


### PR DESCRIPTION
> Reverts a portion of #133679 

While #133679 removed a large portion of JS from the async bundle to a static SVG file, it broke the light/dark mode CSS, (in my testing, I couldn't tell the shade change hadn't been correct).

It is still clear, though, that the SVG shouldn't be included in the React component directly.  Doing so means each SVG node is compiled to `React.createComponent(` and included in the React DOM.

By loading the SVG file statically through `raw-loader` and setting the `innerHTML` of the node, we can still apply CSS to the SVG image without compiling it to React JS calls.  This saves about 7k in the async bundle.