### PR TITLE
[8.3] Add item descriptions to edit button screen reader labels in TableListView (#125334)

### DIFF
--- a/src/plugins/kibana_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/kibana_react/public/table_list_view/table_list_view.tsx
@@ -26,7 +26,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
 import { ThemeServiceStart, HttpFetchError, ToastsStart, ApplicationStart } from '@kbn/core/public';
-import { debounce, keyBy, sortBy, uniq } from 'lodash';
+import { debounce, keyBy, sortBy, uniq, get } from 'lodash';
 import React from 'react';
 import moment from 'moment';
 import { KibanaPageTemplate } from '../page_template';
@@ -583,9 +583,13 @@ class TableListView<V extends {}> extends React.Component<
     if (this.props.editItem) {
       const actions: EuiTableActionsColumnType<V>['actions'] = [
         {
-          name: i18n.translate('kibana-react.tableListView.listing.table.editActionName', {
-            defaultMessage: 'Edit',
-          }),
+          name: (item) =>
+            i18n.translate('kibana-react.tableListView.listing.table.editActionName', {
+              defaultMessage: 'Edit {itemDescription}',
+              values: {
+                itemDescription: get(item, this.props.rowHeader),
+              },
+            }),
           description: i18n.translate(
             'kibana-react.tableListView.listing.table.editActionDescription',
             {

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -5045,7 +5045,6 @@
     "kibana-react.tableListView.listing.listingLimitExceededTitle": "Limite de listing dépassée",
     "kibana-react.tableListView.listing.table.actionTitle": "Actions",
     "kibana-react.tableListView.listing.table.editActionDescription": "Modifier",
-    "kibana-react.tableListView.listing.table.editActionName": "Modifier",
     "kibana-react.tableListView.listing.unableToDeleteDangerMessage": "Impossible de supprimer la/le/les {entityName}(s)",
     "kibanaOverview.addData.sampleDataButtonLabel": "Essayer l’exemple de données",
     "kibanaOverview.addData.sectionTitle": "Ingérer des données",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -5141,7 +5141,6 @@
     "kibana-react.tableListView.listing.noMatchedItemsMessage": "検索条件に一致する {entityNamePlural} がありません。",
     "kibana-react.tableListView.listing.table.actionTitle": "アクション",
     "kibana-react.tableListView.listing.table.editActionDescription": "編集",
-    "kibana-react.tableListView.listing.table.editActionName": "編集",
     "kibana-react.tableListView.listing.unableToDeleteDangerMessage": "{entityName} を削除できません",
     "kibanaOverview.addData.sampleDataButtonLabel": "サンプルデータを試す",
     "kibanaOverview.addData.sectionTitle": "データを取り込む",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -5152,7 +5152,6 @@
     "kibana-react.tableListView.listing.noMatchedItemsMessage": "没有任何{entityNamePlural}匹配您的搜索。",
     "kibana-react.tableListView.listing.table.actionTitle": "操作",
     "kibana-react.tableListView.listing.table.editActionDescription": "编辑",
-    "kibana-react.tableListView.listing.table.editActionName": "编辑",
     "kibana-react.tableListView.listing.unableToDeleteDangerMessage": "无法删除{entityName}",
     "kibanaOverview.addData.sampleDataButtonLabel": "试用我们的样例数据",
     "kibanaOverview.addData.sectionTitle": "采集您的数据",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add item descriptions to edit button screen reader labels in TableListView (#125334)](https://github.com/elastic/kibana/pull/125334)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)