### PR TITLE
[ML] Anomaly Detection: allow snapshot to be reverted from the view datafeed flyout

### DIFF
--- a/x-pack/plugins/ml/common/types/results.ts
+++ b/x-pack/plugins/ml/common/types/results.ts
@@ -21,14 +21,13 @@ export interface MLRectAnnotationDatum extends RectAnnotationDatum {
   header: number;
 }
 export interface LineAnnotationDatumWithModelSnapshot extends LineAnnotationDatum {
-  modelSnapshot: ModelSnapshot;
+  modelSnapshot?: ModelSnapshot;
 }
 export interface GetDatafeedResultsChartDataResult {
   bucketResults: number[][];
   datafeedResults: number[][];
   annotationResultsRect: MLRectAnnotationDatum[];
   annotationResultsLine: LineAnnotationDatum[];
-  modelSnapshotResultsLine: LineAnnotationDatumWithModelSnapshot[];
 }
 
 export interface DatafeedResultsChartDataParams {

--- a/x-pack/plugins/ml/common/types/results.ts
+++ b/x-pack/plugins/ml/common/types/results.ts
@@ -9,7 +9,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { LineAnnotationDatum, RectAnnotationDatum } from '@elastic/charts';
 import type { ErrorType } from '../util/errors';
 import type { EntityField } from '../util/anomaly_utils';
-import type { Datafeed, JobId } from './anomaly_detection_jobs';
+import type { Datafeed, JobId, ModelSnapshot } from './anomaly_detection_jobs';
 import { ES_AGGREGATION, ML_JOB_AGGREGATION } from '../constants/aggregation_types';
 import type { RecordForInfluencer } from './anomalies';
 
@@ -20,12 +20,15 @@ export interface GetStoppedPartitionResult {
 export interface MLRectAnnotationDatum extends RectAnnotationDatum {
   header: number;
 }
+export interface LineAnnotationDatumWithModelSnapshot extends LineAnnotationDatum {
+  modelSnapshot: ModelSnapshot;
+}
 export interface GetDatafeedResultsChartDataResult {
   bucketResults: number[][];
   datafeedResults: number[][];
   annotationResultsRect: MLRectAnnotationDatum[];
   annotationResultsLine: LineAnnotationDatum[];
-  modelSnapshotResultsLine: LineAnnotationDatum[];
+  modelSnapshotResultsLine: LineAnnotationDatumWithModelSnapshot[];
 }
 
 export interface DatafeedResultsChartDataParams {

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -126,6 +126,8 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
   const [showModelSnapshots, setShowModelSnapshots] = useState<boolean>(true);
   const [range, setRange] = useState<{ start: string; end: string } | undefined>();
   const canUpdateDatafeed = useMemo(() => checkPermission('canUpdateDatafeed'), []);
+  const canCreateJob = useMemo(() => checkPermission('canCreateJob'), []);
+  const canStartStopDatafeed = useMemo(() => checkPermission('canStartStopDatafeed'), []);
 
   const {
     getModelSnapshots,
@@ -376,8 +378,9 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                           }) => {
                             // If it's not a line annotation or if it's not a model snapshot annotation then do nothing
                             if (
+                              !(canCreateJob && canStartStopDatafeed) ||
                               annotations.lines?.length === 0 ||
-                              (annotations.lines && annotations.lines[0].id !== 'Model snapshots')
+                              (annotations.lines && !annotations.lines[0].id.includes('Model snapshots'))
                             )
                               return;
 

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -117,7 +117,9 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
     rect: RectAnnotationDatum[];
     line: LineAnnotationDatum[];
   }>({ rect: [], line: [] });
-  // const [modelSnapshotData, setModelSnapshotData] = useState<LineAnnotationDatum[]>([]);
+  const [modelSnapshotDataForTimeRange, setModelSnapshotDataForTimeRange] = useState<
+    LineAnnotationDatumWithModelSnapshot[]
+  >([]);
   const [messageData, setMessageData] = useState<LineAnnotationDatum[]>([]);
   const [sourceData, setSourceData] = useState<number[][]>([]);
   const [showAnnotations, setShowAnnotations] = useState<boolean>(true);
@@ -171,6 +173,11 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
         rect: chartData.annotationResultsRect,
         line: chartData.annotationResultsLine.map(setLineAnnotationHeader),
       });
+      setModelSnapshotDataForTimeRange(
+        data.modelSnapshotData.filter(
+          (datum) => datum.dataValue >= startTimestamp && datum.dataValue <= endTimestamp
+        )
+      );
     } catch (error) {
       const title = i18n.translate('xpack.ml.jobsList.datafeedChart.errorToastTitle', {
         defaultMessage: 'Error fetching data',
@@ -415,7 +422,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                             )}
                             key="model-snapshots-results-line"
                             domainType={AnnotationDomainType.XDomain}
-                            dataValues={data.modelSnapshotData}
+                            dataValues={modelSnapshotDataForTimeRange}
                             marker={<EuiIcon type="asterisk" />}
                             markerPosition={Position.Top}
                             style={{

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -380,7 +380,8 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                             if (
                               !(canCreateJob && canStartStopDatafeed) ||
                               annotations.lines?.length === 0 ||
-                              (annotations.lines && !annotations.lines[0].id.includes('Model snapshots'))
+                              (annotations.lines &&
+                                !annotations.lines[0].id.includes('Model snapshots'))
                             )
                               return;
 

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -418,28 +418,6 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                           })}
                           position={Position.Left}
                         />
-                        {showModelSnapshots ? (
-                          <LineAnnotation
-                            id={i18n.translate(
-                              'xpack.ml.jobsList.datafeedChart.modelSnapshotsLineSeriesId',
-                              {
-                                defaultMessage: 'Model snapshots',
-                              }
-                            )}
-                            key="model-snapshots-results-line"
-                            domainType={AnnotationDomainType.XDomain}
-                            dataValues={modelSnapshotDataForTimeRange}
-                            marker={<EuiIcon type="asterisk" />}
-                            markerPosition={Position.Top}
-                            style={{
-                              line: {
-                                strokeWidth: 3,
-                                stroke: euiTheme.euiColorVis1,
-                                opacity: 0.5,
-                              },
-                            }}
-                          />
-                        ) : null}
                         {showAnnotations ? (
                           <>
                             <LineAnnotation
@@ -475,6 +453,28 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                               style={{ fill: euiTheme.euiColorDangerText }}
                             />
                           </>
+                        ) : null}
+                        {showModelSnapshots ? (
+                          <LineAnnotation
+                            id={i18n.translate(
+                              'xpack.ml.jobsList.datafeedChart.modelSnapshotsLineSeriesId',
+                              {
+                                defaultMessage: 'Model snapshots',
+                              }
+                            )}
+                            key="model-snapshots-results-line"
+                            domainType={AnnotationDomainType.XDomain}
+                            dataValues={modelSnapshotDataForTimeRange}
+                            marker={<EuiIcon type="asterisk" />}
+                            markerPosition={Position.Top}
+                            style={{
+                              line: {
+                                strokeWidth: 3,
+                                stroke: euiTheme.euiColorVis1,
+                                opacity: 0.5,
+                              },
+                            }}
+                          />
                         ) : null}
                         {messageData.length > 0 ? (
                           <>

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -200,7 +200,9 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
 
         modelSnapshotResultsLine.push({
           dataValue: timestamp,
-          details: `${modelSnapshot.description}. ${(canCreateJob && canStartStopDatafeed) ? revertSnapshotMessage : ''}`,
+          details: `${modelSnapshot.description}. ${
+            canCreateJob && canStartStopDatafeed ? revertSnapshotMessage : ''
+          }`,
           modelSnapshot,
         });
       });

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -200,7 +200,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
 
         modelSnapshotResultsLine.push({
           dataValue: timestamp,
-          details: `${modelSnapshot.description}. ${revertSnapshotMessage}`,
+          details: `${modelSnapshot.description}. ${(canCreateJob && canStartStopDatafeed) ? revertSnapshotMessage : ''}`,
           modelSnapshot,
         });
       });

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -194,9 +194,9 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
       const job: CombinedJobWithStats = await loadFullJob(jobId);
       const modelSnapshotResultsLine: LineAnnotationDatumWithModelSnapshot[] = [];
       const modelSnapshotsResp = await getModelSnapshots(jobId);
-      const modelSnapshots = modelSnapshotsResp?.model_snapshots ?? [];
+      const modelSnapshots = modelSnapshotsResp.model_snapshots ?? [];
       modelSnapshots.forEach((modelSnapshot) => {
-        const timestamp = Number(modelSnapshot?.latest_record_time_stamp);
+        const timestamp = Number(modelSnapshot.latest_record_time_stamp);
 
         modelSnapshotResultsLine.push({
           dataValue: timestamp,

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -47,7 +47,10 @@ import {
 } from '@elastic/charts';
 
 import { DATAFEED_STATE } from '../../../../../../common/constants/states';
-import { CombinedJobWithStats, ModelSnapshot } from '../../../../../../common/types/anomaly_detection_jobs';
+import {
+  CombinedJobWithStats,
+  ModelSnapshot,
+} from '../../../../../../common/types/anomaly_detection_jobs';
 import { JobMessage } from '../../../../../../common/types/audit_message';
 import { useToastNotificationService } from '../../../../services/toast_notification_service';
 import { useMlApiContext } from '../../../../contexts/kibana';
@@ -65,9 +68,7 @@ interface DatafeedChartFlyoutProps {
   jobId: string;
   end: number;
   onClose: () => void;
-  onModelSnapshotAnnotationClick: (
-    modelSnapshot: ModelSnapshot
-  ) => void;
+  onModelSnapshotAnnotationClick: (modelSnapshot: ModelSnapshot) => void;
 }
 
 function setLineAnnotationHeader(lineDatum: LineAnnotationDatum) {

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_details.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_details.js
@@ -17,6 +17,7 @@ import { DatafeedPreviewPane } from './datafeed_preview_tab';
 import { AnnotationsTable } from '../../../../components/annotations/annotations_table';
 import { DatafeedChartFlyout } from '../datafeed_chart_flyout';
 import { AnnotationFlyout } from '../../../../components/annotations/annotation_flyout';
+import { RevertModelSnapshotFlyout } from '../../../../components/model_snapshots/revert_model_snapshot_flyout';
 import { ModelSnapshotTable } from '../../../../components/model_snapshots';
 import { ForecastsTable } from './forecasts_table';
 import { JobDetailsPane } from './job_details_pane';
@@ -29,6 +30,8 @@ export class JobDetailsUI extends Component {
 
     this.state = {
       datafeedChartFlyoutVisible: false,
+      modelSnapshot: null,
+      revertSnapshotFlyoutVisible: false,
     };
     if (this.props.addYourself) {
       this.props.addYourself(props.jobId, (j) => this.updateJob(j));
@@ -151,8 +154,29 @@ export class JobDetailsUI extends Component {
                       datafeedChartFlyoutVisible: false,
                     });
                   }}
+                  onModelSnapshotAnnotationClick={(modelSnapshot) => {
+                    this.setState({
+                      modelSnapshot,
+                      revertSnapshotFlyoutVisible: true,
+                      datafeedChartFlyoutVisible: false,
+                    });
+                  }}
                   end={job.data_counts.latest_bucket_timestamp}
                   jobId={this.props.jobId}
+                />
+              ) : null}
+              {this.state.revertSnapshotFlyoutVisible === true &&
+              this.state.modelSnapshot !== null ? (
+                <RevertModelSnapshotFlyout
+                  snapshot={this.state.modelSnapshot}
+                  snapshots={[this.state.modelSnapshot]}
+                  job={job}
+                  closeFlyout={() => {
+                    this.setState({
+                      revertSnapshotFlyoutVisible: false,
+                    });
+                  }}
+                  refresh={refreshJobList}
                 />
               ) : null}
             </>

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -796,7 +796,7 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
         modelSnapshot,
       });
     });
-    
+
     return finalResults;
   }
 

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -752,8 +752,6 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
       }),
       mlClient.getModelSnapshots({
         job_id: jobId,
-        start: String(start),
-        end: String(end),
       }),
     ]);
 
@@ -788,7 +786,7 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
 
     const modelSnapshots = modelSnapshotsResp?.model_snapshots ?? [];
     modelSnapshots.forEach((modelSnapshot) => {
-      const timestamp = Number(modelSnapshot?.timestamp);
+      const timestamp = Number(modelSnapshot?.latest_record_time_stamp);
 
       finalResults.modelSnapshotResultsLine.push({
         dataValue: timestamp,

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -793,9 +793,10 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
       finalResults.modelSnapshotResultsLine.push({
         dataValue: timestamp,
         details: modelSnapshot.description,
+        modelSnapshot,
       });
     });
-
+    
     return finalResults;
   }
 

--- a/x-pack/plugins/ml/server/models/results_service/results_service.ts
+++ b/x-pack/plugins/ml/server/models/results_service/results_service.ts
@@ -657,7 +657,6 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
       datafeedResults: [],
       annotationResultsRect: [],
       annotationResultsLine: [],
-      modelSnapshotResultsLine: [],
     };
 
     const { getDatafeedByJobId } = datafeedsProvider(client!, mlClient);
@@ -739,7 +738,7 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
 
     const { getAnnotations } = annotationServiceProvider(client!);
 
-    const [bucketResp, annotationResp, modelSnapshotsResp] = await Promise.all([
+    const [bucketResp, annotationResp] = await Promise.all([
       mlClient.getBuckets({
         job_id: jobId,
         body: { desc: true, start: String(start), end: String(end), page: { from: 0, size: 1000 } },
@@ -749,9 +748,6 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
         earliestMs: start,
         latestMs: end,
         maxAnnotations: 1000,
-      }),
-      mlClient.getModelSnapshots({
-        job_id: jobId,
       }),
     ]);
 
@@ -782,17 +778,6 @@ export function resultsServiceProvider(mlClient: MlClient, client?: IScopedClust
           header: timestamp,
         });
       }
-    });
-
-    const modelSnapshots = modelSnapshotsResp?.model_snapshots ?? [];
-    modelSnapshots.forEach((modelSnapshot) => {
-      const timestamp = Number(modelSnapshot?.latest_record_time_stamp);
-
-      finalResults.modelSnapshotResultsLine.push({
-        dataValue: timestamp,
-        details: modelSnapshot.description,
-        modelSnapshot,
-      });
     });
 
     return finalResults;


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/99510

This PR allows the user to revert to a particular model snapshot from the visualize delayed data chart when clicking on a model snapshot annotation.


https://user-images.githubusercontent.com/6446462/172495279-fff0e3af-ea70-4293-ad2b-5475d2bb8bc5.mp4


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


