### PR TITLE
[Cloud Posture] fix tab scroll position

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -107,7 +107,7 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
           ))}
         </EuiTabs>
       </EuiFlyoutHeader>
-      <EuiFlyoutBody>
+      <EuiFlyoutBody key={tab.id}>
         <FindingsTab tab={tab} findings={findings} />
       </EuiFlyoutBody>
     </EuiFlyout>


### PR DESCRIPTION
remounts `EuiFlyoutBody` on `tab` change to force a `scrollTop` reset

https://user-images.githubusercontent.com/20814186/172599301-887869c8-c4d7-42a2-b6da-92102b06d1de.mov

