### PR TITLE
Clean static worker kibana installs

### DIFF
--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
+# These tests are running on static workers so we have to make sure we delete previous build of Kibana
+rm -rf "$KIBANA_BUILD_LOCATION"
 .buildkite/scripts/download_build_artifacts.sh
 
 echo --- Run Performance Tests with Playwright config


### PR DESCRIPTION
Currently kibana builds are not deleted from the static workers and it causes performance tests to use old version of kibana during the performance tests. This PR aims to force delete kibana build in static worker on each performance job.