### PR TITLE
[kbn/optimizer] fix --update-limits

### DIFF
--- a/scripts/build_kibana_platform_plugins.js
+++ b/scripts/build_kibana_platform_plugins.js
@@ -8,6 +8,10 @@
 
 require('../src/setup_node_env/ensure_node_preserve_symlinks');
 require('source-map-support/register');
+
+var Path = require('path');
+var REPO_ROOT = require('@kbn/utils').REPO_ROOT;
+
 require('@kbn/optimizer').runKbnOptimizerCli({
-  defaultLimitsPath: require.resolve('@kbn/optimizer/limits.yml'),
+  defaultLimitsPath: Path.resolve(REPO_ROOT, 'packages/kbn-optimizer/limits.yml'),
 });


### PR DESCRIPTION
We used to use require.resolve() to point to the `limits.yml` file in the source code so that the optimizer would know where to read/write the limits file when `--update-limits` was passed. This resolve call pointed to the optimizer source so ESLint interpreted it as a relative path to a package, which it corrected to use the `@kbn/optimizer` prefix instead of a relative path. This instead points to the file in the `node_modules` directory which isn't not editable. This changes the code use `Path.resolve(REPO_ROOT, '...')` so that we have full control over the path.