### PR TITLE
Fix share to space flyout sizing

### DIFF
--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/alias_table.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/alias_table.tsx
@@ -55,24 +55,26 @@ export const AliasTable: FunctionComponent<Props> = ({ spaces, aliasesToDisable 
 
   return (
     <>
-      <EuiCallOut
-        size="s"
-        title={
+      <EuiFlexItem grow={false}>
+        <EuiCallOut
+          size="s"
+          title={
+            <FormattedMessage
+              id="xpack.spaces.shareToSpace.aliasTableCalloutTitle"
+              defaultMessage="Legacy URL conflict"
+            />
+          }
+          color="warning"
+        >
           <FormattedMessage
-            id="xpack.spaces.shareToSpace.aliasTableCalloutTitle"
-            defaultMessage="Legacy URL conflict"
+            id="xpack.spaces.shareToSpace.aliasTableCalloutBody"
+            defaultMessage="{aliasesToDisableCount, plural, one {# legacy URL} other {# legacy URLs}} will be disabled."
+            values={{ aliasesToDisableCount }}
           />
-        }
-        color="warning"
-      >
-        <FormattedMessage
-          id="xpack.spaces.shareToSpace.aliasTableCalloutBody"
-          defaultMessage="{aliasesToDisableCount, plural, one {# legacy URL} other {# legacy URLs}} will be disabled."
-          values={{ aliasesToDisableCount }}
-        />
-      </EuiCallOut>
+        </EuiCallOut>
 
-      <EuiSpacer size="m" />
+        <EuiSpacer size="m" />
+      </EuiFlexItem>
 
       <EuiFlexItem>
         <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_mode_control.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_mode_control.tsx
@@ -110,7 +110,7 @@ export const ShareModeControl = (props: Props) => {
 
     const docLink = docLinks?.links.security.kibanaPrivileges;
     return (
-      <>
+      <EuiFlexItem grow={false}>
         <EuiCallOut
           size="s"
           iconType="help"
@@ -140,7 +140,7 @@ export const ShareModeControl = (props: Props) => {
         </EuiCallOut>
 
         <EuiSpacer size="m" />
-      </>
+      </EuiFlexItem>
     );
   };
 

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_to_space_form.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_to_space_form.tsx
@@ -7,8 +7,8 @@
 
 import './share_to_space_form.scss';
 
-import { EuiCallOut, EuiLink, EuiSpacer } from '@elastic/eui';
-import React, { Fragment } from 'react';
+import { EuiCallOut, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
+import React from 'react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -47,7 +47,7 @@ export const ShareToSpaceForm = (props: Props) => {
     onUpdate({ ...shareOptions, selectedSpaceIds });
 
   const createCopyCallout = showCreateCopyCallout ? (
-    <Fragment>
+    <EuiFlexItem grow={false}>
       <EuiCallOut
         size="s"
         title={
@@ -75,7 +75,7 @@ export const ShareToSpaceForm = (props: Props) => {
       </EuiCallOut>
 
       <EuiSpacer size="m" />
-    </Fragment>
+    </EuiFlexItem>
   ) : null;
 
   return (


### PR DESCRIPTION
### Overview

In #128946 I fixed some UX problems in the "Share to space" flyout (formerly "Assign to space" flyout). Those changes made it more resilient when rendered on smaller and larger screens.

However, there are three situations where a warning callout can be displayed at the top of the flyout:

1. If an object has not yet been shared anywhere
2. If an object is shared to All Spaces and the user doesn't have privileges to change that
3. If one or more destination spaces have legacy URL alias conflicts

Today I noticed that, due to my recent changes, these callouts were unintentionally stretching vertically when the viewport is tall. This PR fixes that so they don't stretch anymore.

### Release note

Fixed minor UI sizing problems when attempting to share saved objects.

### Screenshots before

#### Scenario 1

![image](https://user-images.githubusercontent.com/5295965/172698739-30541959-8a90-4995-b462-33b78503ee60.png)

#### Scenario 2

![image](https://user-images.githubusercontent.com/5295965/172698818-501ab472-38dd-4de0-9c93-5dbe03620fc4.png)

#### Scenario 3 (using stub data, no actual aliases)

![image](https://user-images.githubusercontent.com/5295965/172699068-817d54e3-ad3c-40c9-ba5c-5aa97a98b908.png)

### Screenshots after

#### Scenario 1

![image](https://user-images.githubusercontent.com/5295965/172699341-d91822c1-8671-4776-bae1-1f5d99501d5c.png)

#### Scenario 2

![image](https://user-images.githubusercontent.com/5295965/172699377-c4730f6b-df8f-4e26-8fcd-c86adfe01edb.png)

#### Scenario 3 (using stub data, no actual aliases)

![image](https://user-images.githubusercontent.com/5295965/172699220-eb5f10b6-bcf8-474f-b2f5-145591350fe8.png)
