### PR TITLE
[ci/screenshots] enable discovering truncated screenshot names

### DIFF
--- a/packages/kbn-test/src/failed_tests_reporter/report_failures_to_file.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/report_failures_to_file.ts
@@ -96,7 +96,10 @@ export function reportFailuresToFile(
     );
 
     let screenshot = '';
-    const screenshotName = `${failure.name.replace(/([^ a-zA-Z0-9-]+)/g, '_')}`;
+    const truncatedName = failure.name.replace(/([^ a-zA-Z0-9-]+)/g, '_').slice(0, 80);
+    const failureNameHash = createHash('sha256').update(failure.name).digest('hex');
+    const screenshotName = `${truncatedName}-${failureNameHash}`;
+
     if (screenshotsByName[screenshotName]) {
       try {
         screenshot = readFileSync(screenshotsByName[screenshotName]).toString('base64');


### PR DESCRIPTION
4 weeks ago I [quickly solved](https://github.com/elastic/kibana/commit/410f5cd36921e71b278c2bd663923ec6df2798e3) an issue in CI that was caused by extremely long test names leading to extremely long file names. To solve this I truncated all screenshot filenames which were over 100 characters and included a UUID in the filename to ensure they would be unique. This works, but produced non-deterministic filenames which prevents us from collecting the screenshots for a test failure for reporting.

This PR updates the screenshot and html filenames to always include the first 80 characters of the full test name and a sha256 hash of the full filename so that they are always unique and deterministic, enabling tests with really long file names to include screenshots in HTML reports like https://buildkite.com/organizations/elastic/pipelines/kibana-on-merge/builds/17007/jobs/01814465-74d7-4890-8a52-f930adc1e92a/artifacts/01814492-f207-41ac-a04c-fb7119a915ba