### PR TITLE
[Fleet] Re-enable Fleet api integration test again ES 8

### DIFF
--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.2.0/manifest-latest-verified.json"
+
 set -euo pipefail
 
 # Note, changes here might also need to be made in other scripts, e.g. uptime.sh

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-export ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.2.0/manifest-latest-verified.json"
-
 set -euo pipefail
 
 # Note, changes here might also need to be made in other scripts, e.g. uptime.sh

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -31,7 +31,7 @@ import * as AgentService from '../../services/agents';
 export const getAgentHandler: RequestHandler<TypeOf<typeof GetOneAgentRequestSchema.params>> =
   async (context, request, response) => {
     const soClient = context.core.savedObjects.client;
-    const esClient = context.core.elasticsearch.client.asCurrentUser;
+    const esClient = context.core.elasticsearch.client.asInternalUser;
 
     try {
       const body: GetOneAgentResponse = {
@@ -52,7 +52,7 @@ export const getAgentHandler: RequestHandler<TypeOf<typeof GetOneAgentRequestSch
 
 export const deleteAgentHandler: RequestHandler<TypeOf<typeof DeleteAgentRequestSchema.params>> =
   async (context, request, response) => {
-    const esClient = context.core.elasticsearch.client.asCurrentUser;
+    const esClient = context.core.elasticsearch.client.asInternalUser;
 
     try {
       await AgentService.deleteAgent(esClient, request.params.agentId);
@@ -79,7 +79,7 @@ export const updateAgentHandler: RequestHandler<
   undefined,
   TypeOf<typeof UpdateAgentRequestSchema.body>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
     await AgentService.updateAgent(esClient, request.params.agentId, {
@@ -105,7 +105,7 @@ export const getAgentsHandler: RequestHandler<
   undefined,
   TypeOf<typeof GetAgentsRequestSchema.query>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
     const { agents, total, page, perPage } = await AgentService.getAgentsByKuery(esClient, {
@@ -200,7 +200,7 @@ export const getAgentStatusForAgentPolicyHandler: RequestHandler<
   undefined,
   TypeOf<typeof GetAgentStatusRequestSchema.query>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
     // TODO change path

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
@@ -49,7 +49,7 @@ export const postEnrollmentApiKeyHandler: RequestHandler<
   TypeOf<typeof PostEnrollmentAPIKeyRequestSchema.body>
 > = async (context, request, response) => {
   const soClient = context.core.savedObjects.client;
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
   try {
     const apiKey = await APIKeyService.generateEnrollmentAPIKey(soClient, esClient, {
       name: request.body.name,
@@ -68,7 +68,7 @@ export const postEnrollmentApiKeyHandler: RequestHandler<
 export const deleteEnrollmentApiKeyHandler: RequestHandler<
   TypeOf<typeof DeleteEnrollmentAPIKeyRequestSchema.params>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  const esClient = context.core.elasticsearch.client.asInternalUser;
   try {
     await APIKeyService.deleteEnrollmentApiKey(esClient, request.params.keyId);
 

--- a/x-pack/plugins/fleet/server/services/agent_policy_update.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_update.ts
@@ -37,9 +37,10 @@ export async function agentPolicyUpdateEventHandler(
   // `soClient` from ingest `appContextService` is used to create policy change actions
   // to ensure encrypted SOs are handled correctly
   const internalSoClient = appContextService.getInternalUserSOClient(fakeRequest);
+  const internalEsClient = appContextService.getInternalUserESClient();
 
   if (action === 'created') {
-    await generateEnrollmentAPIKey(soClient, esClient, {
+    await generateEnrollmentAPIKey(soClient, internalEsClient, {
       name: 'Default',
       agentPolicyId,
     });
@@ -51,7 +52,7 @@ export async function agentPolicyUpdateEventHandler(
   }
 
   if (action === 'deleted') {
-    await unenrollForAgentPolicyId(soClient, esClient, agentPolicyId);
-    await deleteEnrollmentApiKeyForAgentPolicyId(esClient, agentPolicyId);
+    await unenrollForAgentPolicyId(soClient, internalEsClient, agentPolicyId);
+    await deleteEnrollmentApiKeyForAgentPolicyId(internalEsClient, agentPolicyId);
   }
 }

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -103,8 +103,10 @@ async function createSetupSideEffects(
 
   await cleanPreconfiguredOutputs(soClient, outputsOrUndefined ?? []);
 
-  await ensureDefaultEnrollmentAPIKeysExists(soClient, esClient);
-  await ensureFleetServerAgentPoliciesExists(soClient, esClient);
+  const internalEsClient = appContextService.getInternalUserESClient();
+
+  await ensureDefaultEnrollmentAPIKeysExists(soClient, internalEsClient);
+  await ensureFleetServerAgentPoliciesExists(soClient, internalEsClient);
 
   return {
     isInitialized: true,
@@ -120,6 +122,7 @@ export async function ensureFleetGlobalEsAssets(
   esClient: ElasticsearchClient
 ) {
   const logger = appContextService.getLogger();
+
   // Ensure Global Fleet ES assets are installed
   const globalAssetsRes = await Promise.all([
     ensureDefaultComponentTemplate(esClient),

--- a/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
@@ -113,6 +113,9 @@ export default function (providerContext: FtrProviderContext) {
         },
       }));
 
+      // omit routings
+      delete body.template.settings.index.routing;
+
       expect(body).to.eql({
         template: {
           settings: {

--- a/x-pack/test/fleet_api_integration/apis/index.js
+++ b/x-pack/test/fleet_api_integration/apis/index.js
@@ -9,9 +9,6 @@ import { setupTestUsers } from './test_users';
 
 export default function ({ loadTestFile, getService }) {
   describe('Fleet Endpoints', function () {
-    // SKIPPED: https://github.com/elastic/kibana/issues/127198
-    this.onlyEsVersion('<=7');
-
     before(async () => {
       await setupTestUsers(getService('security'));
     });


### PR DESCRIPTION
## Summary

Resolve #127198

## Description 

Re-enable Fleet api integration test again ES 8 

I had to use the ES internal client everytime we write to `.fleet-*` indices as we currently do on Fleet since 8.0

## How I tested this?

I added this line to `.buildkite/scripts/steps/functional/common.sh`

```
export ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.2.0/manifest-latest-verified.json"
```

see the result here https://buildkite.com/elastic/kibana-pull-request/builds/50101#01814812-2c2a-49d1-8823-4bfc1ebddef8