### PR TITLE
Exclude scalability dataset extraction from single user performance tests

### DIFF
--- a/.buildkite/pipelines/performance/daily.yml
+++ b/.buildkite/pipelines/performance/daily.yml
@@ -19,11 +19,11 @@ steps:
     depends_on: build
     key: tests
 
-  - label: ':shipit: Performance Tests dataset extraction for scalability benchmarking'
-    command: .buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
-    agents:
-      queue: n2-2
-    depends_on: tests
+  # - label: ':shipit: Performance Tests dataset extraction for scalability benchmarking'
+  #   command: .buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+  #   agents:
+  #     queue: n2-2
+  #   depends_on: tests
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
Temporarily we are excluding scalability dataset extraction from single user performance tests in order to prevent getting alerts repeatedly.