### PR TITLE
[Lens] Fixes broken drilldowns for gauges and heatmaps

### DIFF
--- a/x-pack/plugins/lens/public/heatmap_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/heatmap_visualization/visualization.tsx
@@ -14,6 +14,7 @@ import { Position } from '@elastic/charts';
 import { CUSTOM_PALETTE, PaletteRegistry, CustomPaletteParams } from '@kbn/coloring';
 import { ThemeServiceStart } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { HeatmapIcon } from '@kbn/expression-heatmap-plugin/public';
 import type { OperationMetadata, Visualization } from '../types';
 import type { HeatmapVisualizationState } from './types';
@@ -153,6 +154,8 @@ export const getHeatmapVisualization = ({
   },
 
   getSuggestions,
+
+  triggers: [VIS_EVENT_TO_TRIGGER.filter, VIS_EVENT_TO_TRIGGER.brush],
 
   getConfiguration({ state, frame, layerId }) {
     const datasourceLayer = frame.datasourceLayers[layerId];

--- a/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
@@ -13,7 +13,6 @@ import { Ast } from '@kbn/interpreter';
 import { DatatableRow } from '@kbn/expressions-plugin';
 import { PaletteRegistry, CustomPaletteParams, CUSTOM_PALETTE } from '@kbn/coloring';
 import type { GaugeArguments } from '@kbn/expression-gauge-plugin/common';
-import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { GaugeShapes, EXPRESSION_GAUGE_NAME } from '@kbn/expression-gauge-plugin/common';
 import {
   getGoalValue,
@@ -222,8 +221,6 @@ export const getGaugeVisualization = ({
     );
   },
   getSuggestions,
-
-  triggers: [VIS_EVENT_TO_TRIGGER.filter],
 
   getConfiguration({ state, frame }) {
     const hasColoring = Boolean(state.colorMode !== 'none' && state.palette?.params?.stops);

--- a/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
@@ -13,6 +13,7 @@ import { Ast } from '@kbn/interpreter';
 import { DatatableRow } from '@kbn/expressions-plugin';
 import { PaletteRegistry, CustomPaletteParams, CUSTOM_PALETTE } from '@kbn/coloring';
 import type { GaugeArguments } from '@kbn/expression-gauge-plugin/common';
+import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { GaugeShapes, EXPRESSION_GAUGE_NAME } from '@kbn/expression-gauge-plugin/common';
 import {
   getGoalValue,
@@ -221,6 +222,8 @@ export const getGaugeVisualization = ({
     );
   },
   getSuggestions,
+
+  triggers: [VIS_EVENT_TO_TRIGGER.filter],
 
   getConfiguration({ state, frame }) {
     const hasColoring = Boolean(state.colorMode !== 'none' && state.palette?.params?.stops);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/133883

This PR adds the triggers to heatmap and gauges visualizations in order to enable the drilldowns.

Testing is easy. On main if you add a gauge or heatmap Lens viz, the drilldown option is not present for these panels. In this branch the drilldown option is present.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/17003240/172812025-890f22d4-f66d-4ebb-bc06-8b0bdea2889c.png">
