### PR TITLE
[Security Telemetry] Don't send telemetry if alert timeline is empty.

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/index.ts
@@ -64,8 +64,13 @@ const stubLicenseInfo = {
 };
 
 export const createMockTelemetryReceiver = (
-  diagnosticsAlert?: unknown
+  diagnosticsAlert?: unknown,
+  emptyTimelineTree?: boolean
 ): jest.Mocked<TelemetryReceiver> => {
+  const processTreeResponse = emptyTimelineTree
+    ? Promise.resolve([])
+    : Promise.resolve(Promise.resolve(stubProcessTree()));
+
   return {
     start: jest.fn(),
     fetchClusterInfo: jest.fn().mockReturnValue(stubClusterInfo),
@@ -82,7 +87,7 @@ export const createMockTelemetryReceiver = (
     fetchTimelineEndpointAlerts: jest
       .fn()
       .mockReturnValue(Promise.resolve(stubEndpointAlertResponse())),
-    buildProcessTree: jest.fn().mockReturnValue(Promise.resolve(stubProcessTree())),
+    buildProcessTree: jest.fn().mockReturnValue(processTreeResponse),
     fetchTimelineEvents: jest.fn().mockReturnValue(Promise.resolve(stubFetchTimelineEvents())),
   } as unknown as jest.Mocked<TelemetryReceiver>;
 };

--- a/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/timeline.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/timeline.ts
@@ -20,7 +20,7 @@ export const stubEndpointAlertResponse = () => {
     },
     hits: {
       total: {
-        value: 47,
+        value: 1,
         relation: 'eq',
       },
       max_score: 0,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/timelines.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/timelines.test.ts
@@ -36,5 +36,29 @@ describe('timeline telemetry task test', () => {
     expect(mockTelemetryReceiver.buildProcessTree).toHaveBeenCalled();
     expect(mockTelemetryReceiver.fetchTimelineEvents).toHaveBeenCalled();
     expect(mockTelemetryReceiver.fetchTimelineEndpointAlerts).toHaveBeenCalled();
+    expect(mockTelemetryEventsSender.sendOnDemand).toHaveBeenCalled();
+  });
+
+  test('if no timeline events received it should not send a telemetry record', async () => {
+    const testTaskExecutionPeriod = {
+      last: undefined,
+      current: new Date().toISOString(),
+    };
+    const mockTelemetryEventsSender = createMockTelemetryEventsSender();
+    const mockTelemetryReceiver = createMockTelemetryReceiver(null, true);
+    const telemetryTelemetryTaskConfig = createTelemetryTimelineTaskConfig();
+
+    await telemetryTelemetryTaskConfig.runTask(
+      'test-timeline-task-id',
+      logger,
+      mockTelemetryReceiver,
+      mockTelemetryEventsSender,
+      testTaskExecutionPeriod
+    );
+
+    expect(mockTelemetryReceiver.buildProcessTree).toHaveBeenCalled();
+    expect(mockTelemetryReceiver.fetchTimelineEvents).toHaveBeenCalled();
+    expect(mockTelemetryReceiver.fetchTimelineEndpointAlerts).toHaveBeenCalled();
+    expect(mockTelemetryEventsSender.sendOnDemand).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/timelines.ts
@@ -130,19 +130,23 @@ export function createTelemetryTimelineTaskConfig() {
           telemetryTimeline.push(timelineTelemetryEvent);
         }
 
-        const record: TimelineTelemetryTemplate = {
-          '@timestamp': moment().toISOString(),
-          ...baseDocument,
-          alert_id: alertUUID,
-          event_id: eventId,
-          timeline: telemetryTimeline,
-        };
+        if (telemetryTimeline.length >= 1) {
+          const record: TimelineTelemetryTemplate = {
+            '@timestamp': moment().toISOString(),
+            ...baseDocument,
+            alert_id: alertUUID,
+            event_id: eventId,
+            timeline: telemetryTimeline,
+          };
 
-        sender.sendOnDemand(TELEMETRY_CHANNEL_TIMELINE, [record]);
-        counter += 1;
+          sender.sendOnDemand(TELEMETRY_CHANNEL_TIMELINE, [record]);
+          counter += 1;
+        } else {
+          logger.debug('no events in timeline');
+        }
       }
 
-      logger.debug(`sent ${counter} timelines. exiting telemetry task.`);
+      logger.debug(`sent ${counter} timelines. concluding timeline task.`);
       return counter;
     },
   };


### PR DESCRIPTION
## Summary

I noticed when analyzing dev telemetry that it's not always possible to resolve the timeline, particularly from stub test data created by internal testing tools. This PR doesn't send those records to us if the timeline events payload is empty. 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
