### PR TITLE
FIx [test-failed]: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/lens/group1/persistent_context·ts - lens app - group 1 lens query context keeps selected index pattern after refresh

### DIFF
--- a/test/functional/page_objects/unified_search_page.ts
+++ b/test/functional/page_objects/unified_search_page.ts
@@ -34,7 +34,18 @@ export class UnifiedSearchPageObject extends FtrService {
 
     await this.retry.waitFor(
       'wait for updating switcher',
-      async () => (await this.testSubjects.getVisibleText(switchButtonSelector)) === dataViewTitle
+      async () => (await this.getSelectedDataView(switchButtonSelector)) === dataViewTitle
     );
+  }
+
+  public async getSelectedDataView(switchButtonSelector: string) {
+    let visibleText = '';
+
+    await this.retry.waitFor('wait for updating switcher', async () => {
+      visibleText = await this.testSubjects.getVisibleText(switchButtonSelector);
+      return Boolean(visibleText);
+    });
+
+    return visibleText;
   }
 }

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -860,14 +860,14 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
      * Returns the current index pattern of the data panel
      */
     async getDataPanelIndexPattern() {
-      return await (await testSubjects.find('lns-dataView-switch-link')).getAttribute('title');
+      return await PageObjects.unifiedSearch.getSelectedDataView('lns-dataView-switch-link');
     },
 
     /**
      * Returns the current index pattern of the first layer
      */
     async getFirstLayerIndexPattern() {
-      return await (await testSubjects.find('lns_layerIndexPatternLabel')).getAttribute('title');
+      return await PageObjects.unifiedSearch.getSelectedDataView('lns_layerIndexPatternLabel');
     },
 
     async linkedToOriginatingApp() {


### PR DESCRIPTION
Closes:  #133837

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/729