### PR TITLE
[8.3] [Response Ops] Fixing scripted metric agg in alerting telemetry (#132635)

### DIFF
--- a/x-pack/plugins/alerting/server/usage/alerting_telemetry.ts
+++ b/x-pack/plugins/alerting/server/usage/alerting_telemetry.ts
@@ -6,7 +6,7 @@
  */
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { ElasticsearchClient } from '@kbn/core/server';
+import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { get, merge } from 'lodash';
 import { AlertingUsage } from './types';
 import { NUM_ALERTING_RULE_TYPES } from './alerting_usage_collector';
@@ -34,14 +34,22 @@ const ruleTypeMetric = {
     // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
     // This also needs to account for having no data
     reduce_script: `
-      Map result = [:];
-      for (Map m : states.toArray()) {
-        if (m !== null) {
-          for (String k : m.keySet()) {
-            result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
-          }
+      HashMap result = new HashMap();
+      HashMap combinedRuleTypes = new HashMap();
+      HashMap combinedNamespaces = new HashMap();
+      for (state in states) {
+        for (String ruleType : state.ruleTypes.keySet()) {
+          int ruleTypeCount = combinedRuleTypes.containsKey(ruleType) ? combinedRuleTypes.get(ruleType) + state.ruleTypes.get(ruleType) : state.ruleTypes.get(ruleType);
+          combinedRuleTypes.put(ruleType, ruleTypeCount);
+        }
+
+        for (String namespace : state.namespaces.keySet()) {
+          combinedNamespaces.put(namespace, 1);
         }
       }
+
+      result.ruleTypes = combinedRuleTypes;
+      result.namespaces = combinedNamespaces;
       return result;
     `,
   },
@@ -81,14 +89,37 @@ const ruleTypeExecutionsWithDurationMetric = {
     // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
     // This also needs to account for having no data
     reduce_script: `
-      Map result = [:];
-      for (Map m : states.toArray()) {
-        if (m !== null) {
-          for (String k : m.keySet()) {
-            result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
-          }
+      HashMap result = new HashMap();
+      HashMap combinedRuleTypes = new HashMap();
+      HashMap combinedRuleTypeDurations = new HashMap();
+      HashMap combinedRuleTypeEsSearchDurations = new HashMap();
+      HashMap combinedRuleTypeTotalSearchDurations = new HashMap();
+      for (state in states) {
+        for (String ruleType : state.ruleTypes.keySet()) {
+          int ruleTypeCount = combinedRuleTypes.containsKey(ruleType) ? combinedRuleTypes.get(ruleType) + state.ruleTypes.get(ruleType) : state.ruleTypes.get(ruleType);
+          combinedRuleTypes.put(ruleType, ruleTypeCount);
+        }
+
+        for (String ruleType : state.ruleTypesDuration.keySet()) {
+          long ruleTypeDurationTotal = combinedRuleTypeDurations.containsKey(ruleType) ? combinedRuleTypeDurations.get(ruleType) + state.ruleTypesDuration.get(ruleType) : state.ruleTypesDuration.get(ruleType);
+          combinedRuleTypeDurations.put(ruleType, ruleTypeDurationTotal);
+        }
+
+        for (String ruleType : state.ruleTypesEsSearchDuration.keySet()) {
+          long ruleTypeEsSearchDurationTotal = combinedRuleTypeEsSearchDurations.containsKey(ruleType) ? combinedRuleTypeEsSearchDurations.get(ruleType) + state.ruleTypesEsSearchDuration.get(ruleType) : state.ruleTypesEsSearchDuration.get(ruleType);
+          combinedRuleTypeEsSearchDurations.put(ruleType, ruleTypeEsSearchDurationTotal);
+        }
+
+        for (String ruleType : state.ruleTypesTotalSearchDuration.keySet()) {
+          long ruleTypeTotalSearchDurationTotal = combinedRuleTypeTotalSearchDurations.containsKey(ruleType) ? combinedRuleTypeTotalSearchDurations.get(ruleType) + state.ruleTypesTotalSearchDuration.get(ruleType) : state.ruleTypesTotalSearchDuration.get(ruleType);
+          combinedRuleTypeTotalSearchDurations.put(ruleType, ruleTypeTotalSearchDurationTotal);
         }
       }
+
+      result.ruleTypes = combinedRuleTypes;
+      result.ruleTypesDuration = combinedRuleTypeDurations;
+      result.ruleTypesEsSearchDuration = combinedRuleTypeEsSearchDurations;
+      result.ruleTypesTotalSearchDuration = combinedRuleTypeTotalSearchDurations;
       return result;
     `,
   },
@@ -107,14 +138,16 @@ const ruleTypeExecutionsMetric = {
     // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
     // This also needs to account for having no data
     reduce_script: `
-      Map result = [:];
-      for (Map m : states.toArray()) {
-        if (m !== null) {
-          for (String k : m.keySet()) {
-            result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
-          }
+      HashMap result = new HashMap();
+      HashMap combinedRuleTypes = new HashMap();
+      for (state in states) {
+        for (String ruleType : state.ruleTypes.keySet()) {
+          int ruleTypeCount = combinedRuleTypes.containsKey(ruleType) ? combinedRuleTypes.get(ruleType) + state.ruleTypes.get(ruleType) : state.ruleTypes.get(ruleType);
+          combinedRuleTypes.put(ruleType, ruleTypeCount);
         }
       }
+
+      result.ruleTypes = combinedRuleTypes;
       return result;
     `,
   },
@@ -136,14 +169,21 @@ const taskTypeExecutionsMetric = {
     // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
     // This also needs to account for having no data
     reduce_script: `
-      Map result = [:];
-      for (Map m : states.toArray()) {
-        if (m !== null) {
-          for (String k : m.keySet()) {
-            result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
+      HashMap result = new HashMap();
+      HashMap combinedStatuses = new HashMap();
+      for (state in states) {
+        for (String status : state.statuses.keySet()) {
+          HashMap combinedTaskTypes = new HashMap();
+          Map statusTaskTypes = state.statuses.get(status);
+          for (String taskType : statusTaskTypes.keySet()) {
+            int statusByTaskTypeCount = combinedTaskTypes.containsKey(taskType) ? combinedTaskTypes.get(taskType) + statusTaskTypes.get(taskType) : statusTaskTypes.get(taskType);
+            combinedTaskTypes.put(taskType, statusByTaskTypeCount);
           }
+          
+          combinedStatuses.put(status, combinedTaskTypes);
         }
       }
+      result.statuses = combinedStatuses;
       return result;
     `,
   },
@@ -167,14 +207,21 @@ const ruleTypeFailureExecutionsMetric = {
     // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
     // This also needs to account for having no data
     reduce_script: `
-      Map result = [:];
-      for (Map m : states.toArray()) {
-        if (m !== null) {
-          for (String k : m.keySet()) {
-            result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
+      HashMap result = new HashMap();
+      HashMap combinedReasons = new HashMap();
+      for (state in states) {
+        for (String reason : state.reasons.keySet()) {
+          HashMap combinedRuleTypes = new HashMap();
+          Map reasonRuleTypes = state.reasons.get(reason);
+          for (String ruleType : state.reasons.get(reason).keySet()) {
+            int reasonByRuleTypeCount = combinedRuleTypes.containsKey(ruleType) ? combinedRuleTypes.get(ruleType) + reasonRuleTypes.get(ruleType) : reasonRuleTypes.get(ruleType);
+            combinedRuleTypes.put(ruleType, reasonByRuleTypeCount);
           }
+          
+          combinedReasons.put(reason, combinedRuleTypes);
         }
       }
+      result.reasons = combinedReasons;
       return result;
     `,
   },
@@ -182,7 +229,8 @@ const ruleTypeFailureExecutionsMetric = {
 
 export async function getTotalCountAggregations(
   esClient: ElasticsearchClient,
-  kibanaIndex: string
+  kibanaIndex: string,
+  logger: Logger
 ): Promise<
   Pick<
     AlertingUsage,
@@ -196,49 +244,85 @@ export async function getTotalCountAggregations(
     | 'count_rules_namespaces'
   >
 > {
-  const results = await esClient.search({
-    index: kibanaIndex,
-    body: {
-      size: 0,
-      query: {
-        bool: {
-          filter: [{ term: { type: 'alert' } }],
-        },
-      },
-      runtime_mappings: {
-        alert_action_count: {
-          type: 'long',
-          script: {
-            source: `
-              def alert = params._source['alert'];
-              if (alert != null) {
-                def actions = alert.actions;
-                if (actions != null) {
-                  emit(actions.length);
-                } else {
-                  emit(0);
-                }
-              }`,
+  try {
+    const results = await esClient.search({
+      index: kibanaIndex,
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            filter: [{ term: { type: 'alert' } }],
           },
         },
-        alert_interval: {
-          type: 'long',
-          script: {
-            source: `
-              int parsed = 0;
-              if (doc['alert.schedule.interval'].size() > 0) {
-                def interval = doc['alert.schedule.interval'].value;
-
-                if (interval.length() > 1) {
+        runtime_mappings: {
+          alert_action_count: {
+            type: 'long',
+            script: {
+              source: `
+                def alert = params._source['alert'];
+                if (alert != null) {
+                  def actions = alert.actions;
+                  if (actions != null) {
+                    emit(actions.length);
+                  } else {
+                    emit(0);
+                  }
+                }`,
+            },
+          },
+          alert_interval: {
+            type: 'long',
+            script: {
+              source: `
+                int parsed = 0;
+                if (doc['alert.schedule.interval'].size() > 0) {
+                  def interval = doc['alert.schedule.interval'].value;
+  
+                  if (interval.length() > 1) {
+                      // get last char
+                      String timeChar = interval.substring(interval.length() - 1);
+                      // remove last char
+                      interval = interval.substring(0, interval.length() - 1);
+  
+                      if (interval.chars().allMatch(Character::isDigit)) {
+                        // using of regex is not allowed in painless language
+                        parsed = Integer.parseInt(interval);
+  
+                        if (timeChar.equals("s")) {
+                          parsed = parsed;
+                        } else if (timeChar.equals("m")) {
+                          parsed = parsed * 60;
+                        } else if (timeChar.equals("h")) {
+                          parsed = parsed * 60 * 60;
+                        } else if (timeChar.equals("d")) {
+                          parsed = parsed * 24 * 60 * 60;
+                        }
+                        emit(parsed);
+                      }
+                  }
+                }
+                emit(parsed);
+              `,
+            },
+          },
+          alert_throttle: {
+            type: 'long',
+            script: {
+              source: `
+                int parsed = 0;
+                if (doc['alert.throttle'].size() > 0) {
+                def throttle = doc['alert.throttle'].value;
+  
+                if (throttle.length() > 1) {
                     // get last char
-                    String timeChar = interval.substring(interval.length() - 1);
+                    String timeChar = throttle.substring(throttle.length() - 1);
                     // remove last char
-                    interval = interval.substring(0, interval.length() - 1);
-
-                    if (interval.chars().allMatch(Character::isDigit)) {
+                    throttle = throttle.substring(0, throttle.length() - 1);
+  
+                    if (throttle.chars().allMatch(Character::isDigit)) {
                       // using of regex is not allowed in painless language
-                      parsed = Integer.parseInt(interval);
-
+                      parsed = Integer.parseInt(throttle);
+  
                       if (timeChar.equals("s")) {
                         parsed = parsed;
                       } else if (timeChar.equals("m")) {
@@ -253,519 +337,590 @@ export async function getTotalCountAggregations(
                 }
               }
               emit(parsed);
-            `,
+              `,
+            },
           },
         },
-        alert_throttle: {
-          type: 'long',
-          script: {
-            source: `
-              int parsed = 0;
-              if (doc['alert.throttle'].size() > 0) {
-              def throttle = doc['alert.throttle'].value;
-
-              if (throttle.length() > 1) {
-                  // get last char
-                  String timeChar = throttle.substring(throttle.length() - 1);
-                  // remove last char
-                  throttle = throttle.substring(0, throttle.length() - 1);
-
-                  if (throttle.chars().allMatch(Character::isDigit)) {
-                    // using of regex is not allowed in painless language
-                    parsed = Integer.parseInt(throttle);
-
-                    if (timeChar.equals("s")) {
-                      parsed = parsed;
-                    } else if (timeChar.equals("m")) {
-                      parsed = parsed * 60;
-                    } else if (timeChar.equals("h")) {
-                      parsed = parsed * 60 * 60;
-                    } else if (timeChar.equals("d")) {
-                      parsed = parsed * 24 * 60 * 60;
-                    }
-                    emit(parsed);
-                  }
-              }
-            }
-            emit(parsed);
-            `,
-          },
+        aggs: {
+          byRuleTypeId: ruleTypeMetric,
+          max_throttle_time: { max: { field: 'alert_throttle' } },
+          min_throttle_time: { min: { field: 'alert_throttle' } },
+          avg_throttle_time: { avg: { field: 'alert_throttle' } },
+          max_interval_time: { max: { field: 'alert_interval' } },
+          min_interval_time: { min: { field: 'alert_interval' } },
+          avg_interval_time: { avg: { field: 'alert_interval' } },
+          max_actions_count: { max: { field: 'alert_action_count' } },
+          min_actions_count: { min: { field: 'alert_action_count' } },
+          avg_actions_count: { avg: { field: 'alert_action_count' } },
         },
       },
-      aggs: {
-        byRuleTypeId: ruleTypeMetric,
-        max_throttle_time: { max: { field: 'alert_throttle' } },
-        min_throttle_time: { min: { field: 'alert_throttle' } },
-        avg_throttle_time: { avg: { field: 'alert_throttle' } },
-        max_interval_time: { max: { field: 'alert_interval' } },
-        min_interval_time: { min: { field: 'alert_interval' } },
-        avg_interval_time: { avg: { field: 'alert_interval' } },
-        max_actions_count: { max: { field: 'alert_action_count' } },
-        min_actions_count: { min: { field: 'alert_action_count' } },
-        avg_actions_count: { avg: { field: 'alert_action_count' } },
-      },
-    },
-  });
+    });
 
-  const aggregations = results.aggregations as {
-    byRuleTypeId: { value: { ruleTypes: Record<string, string> } };
-    max_throttle_time: { value: number };
-    min_throttle_time: { value: number };
-    avg_throttle_time: { value: number };
-    max_interval_time: { value: number };
-    min_interval_time: { value: number };
-    avg_interval_time: { value: number };
-    max_actions_count: { value: number };
-    min_actions_count: { value: number };
-    avg_actions_count: { value: number };
-  };
-
-  const totalRulesCount = Object.keys(aggregations.byRuleTypeId.value.ruleTypes).reduce(
-    (total: number, key: string) =>
-      parseInt(aggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
-    0
-  );
-
-  return {
-    count_total: totalRulesCount,
-    count_by_type: replaceDotSymbolsInRuleTypeIds(aggregations.byRuleTypeId.value.ruleTypes),
-    throttle_time: {
-      min: `${aggregations.min_throttle_time.value}s`,
-      avg: `${aggregations.avg_throttle_time.value}s`,
-      max: `${aggregations.max_throttle_time.value}s`,
-    },
-    schedule_time: {
-      min: `${aggregations.min_interval_time.value}s`,
-      avg: `${aggregations.avg_interval_time.value}s`,
-      max: `${aggregations.max_interval_time.value}s`,
-    },
-    throttle_time_number_s: {
-      min: aggregations.min_throttle_time.value,
-      avg: aggregations.avg_throttle_time.value,
-      max: aggregations.max_throttle_time.value,
-    },
-    schedule_time_number_s: {
-      min: aggregations.min_interval_time.value,
-      avg: aggregations.avg_interval_time.value,
-      max: aggregations.max_interval_time.value,
-    },
-    connectors_per_alert: {
-      min: aggregations.min_actions_count.value,
-      avg: aggregations.avg_actions_count.value,
-      max: aggregations.max_actions_count.value,
-    },
-    count_rules_namespaces: 0,
-  };
-}
-
-export async function getTotalCountInUse(esClient: ElasticsearchClient, kibanaIndex: string) {
-  const searchResult = await esClient.search({
-    index: kibanaIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: [{ term: { type: 'alert' } }, { term: { 'alert.enabled': true } }],
-        },
-      },
-      aggs: {
-        byRuleTypeId: ruleTypeMetric,
-      },
-    },
-  });
-
-  const aggregations = searchResult.aggregations as {
-    byRuleTypeId: {
-      value: { ruleTypes: Record<string, string>; namespaces: Record<string, string> };
+    const aggregations = results.aggregations as {
+      byRuleTypeId: { value: { ruleTypes: Record<string, string> } };
+      max_throttle_time: { value: number };
+      min_throttle_time: { value: number };
+      avg_throttle_time: { value: number };
+      max_interval_time: { value: number };
+      min_interval_time: { value: number };
+      avg_interval_time: { value: number };
+      max_actions_count: { value: number };
+      min_actions_count: { value: number };
+      avg_actions_count: { value: number };
     };
-  };
 
-  return {
-    countTotal: Object.keys(aggregations.byRuleTypeId.value.ruleTypes).reduce(
+    const totalRulesCount = Object.keys(aggregations.byRuleTypeId.value.ruleTypes).reduce(
       (total: number, key: string) =>
         parseInt(aggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
       0
-    ),
-    countByType: replaceDotSymbolsInRuleTypeIds(aggregations.byRuleTypeId.value.ruleTypes),
-    countNamespaces: Object.keys(aggregations.byRuleTypeId.value.namespaces).length,
-  };
+    );
+
+    return {
+      count_total: totalRulesCount,
+      count_by_type: replaceDotSymbolsInRuleTypeIds(aggregations.byRuleTypeId.value.ruleTypes),
+      throttle_time: {
+        min: `${aggregations.min_throttle_time.value}s`,
+        avg: `${aggregations.avg_throttle_time.value}s`,
+        max: `${aggregations.max_throttle_time.value}s`,
+      },
+      schedule_time: {
+        min: `${aggregations.min_interval_time.value}s`,
+        avg: `${aggregations.avg_interval_time.value}s`,
+        max: `${aggregations.max_interval_time.value}s`,
+      },
+      throttle_time_number_s: {
+        min: aggregations.min_throttle_time.value,
+        avg: aggregations.avg_throttle_time.value,
+        max: aggregations.max_throttle_time.value,
+      },
+      schedule_time_number_s: {
+        min: aggregations.min_interval_time.value,
+        avg: aggregations.avg_interval_time.value,
+        max: aggregations.max_interval_time.value,
+      },
+      connectors_per_alert: {
+        min: aggregations.min_actions_count.value,
+        avg: aggregations.avg_actions_count.value,
+        max: aggregations.max_actions_count.value,
+      },
+      count_rules_namespaces: 0,
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing alerting telemetry task: getTotalCountAggregations - ${JSON.stringify(err)}`
+    );
+    return {
+      count_total: 0,
+      count_by_type: {},
+      throttle_time: {
+        min: '0s',
+        avg: '0s',
+        max: '0s',
+      },
+      schedule_time: {
+        min: '0s',
+        avg: '0s',
+        max: '0s',
+      },
+      throttle_time_number_s: {
+        min: 0,
+        avg: 0,
+        max: 0,
+      },
+      schedule_time_number_s: {
+        min: 0,
+        avg: 0,
+        max: 0,
+      },
+      connectors_per_alert: {
+        min: 0,
+        avg: 0,
+        max: 0,
+      },
+      count_rules_namespaces: 0,
+    };
+  }
+}
+
+export async function getTotalCountInUse(
+  esClient: ElasticsearchClient,
+  kibanaIndex: string,
+  logger: Logger
+) {
+  try {
+    const searchResult = await esClient.search({
+      index: kibanaIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: [{ term: { type: 'alert' } }, { term: { 'alert.enabled': true } }],
+          },
+        },
+        aggs: {
+          byRuleTypeId: ruleTypeMetric,
+        },
+      },
+    });
+
+    const aggregations = searchResult.aggregations as {
+      byRuleTypeId: {
+        value: { ruleTypes: Record<string, string>; namespaces: Record<string, string> };
+      };
+    };
+
+    return {
+      countTotal: Object.keys(aggregations.byRuleTypeId.value.ruleTypes).reduce(
+        (total: number, key: string) =>
+          parseInt(aggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
+        0
+      ),
+      countByType: replaceDotSymbolsInRuleTypeIds(aggregations.byRuleTypeId.value.ruleTypes),
+      countNamespaces: Object.keys(aggregations.byRuleTypeId.value.namespaces).length,
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing alerting telemetry task: getTotalCountInUse - ${JSON.stringify(err)}`
+    );
+    return {
+      countTotal: 0,
+      countByType: {},
+      countNamespaces: 0,
+    };
+  }
 }
 
 export async function getExecutionsPerDayCount(
   esClient: ElasticsearchClient,
-  eventLogIndex: string
+  eventLogIndex: string,
+  logger: Logger
 ) {
-  const searchResult = await esClient.search({
-    index: eventLogIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: {
-            bool: {
-              must: [
-                {
-                  term: { 'event.action': 'execute' },
-                },
-                {
-                  term: { 'event.provider': 'alerting' },
-                },
-                {
-                  range: {
-                    '@timestamp': {
-                      gte: 'now-1d',
+  try {
+    const searchResult = await esClient.search({
+      index: eventLogIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    term: { 'event.action': 'execute' },
+                  },
+                  {
+                    term: { 'event.provider': 'alerting' },
+                  },
+                  {
+                    range: {
+                      '@timestamp': {
+                        gte: 'now-1d',
+                      },
                     },
                   },
-                },
-              ],
+                ],
+              },
+            },
+          },
+        },
+        aggs: {
+          byRuleTypeId: ruleTypeExecutionsWithDurationMetric,
+          failuresByReason: ruleTypeFailureExecutionsMetric,
+          avgDuration: { avg: { field: 'event.duration' } },
+          avgEsSearchDuration: {
+            avg: { field: 'kibana.alert.rule.execution.metrics.es_search_duration_ms' },
+          },
+          avgTotalSearchDuration: {
+            avg: { field: 'kibana.alert.rule.execution.metrics.total_search_duration_ms' },
+          },
+          percentileScheduledActions: generatedActionsPercentilesAgg,
+          percentileAlerts: alertsPercentilesAgg,
+          aggsByType: {
+            terms: {
+              field: 'rule.category',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
+            aggs: {
+              percentileScheduledActions: generatedActionsPercentilesAgg,
+              percentileAlerts: alertsPercentilesAgg,
             },
           },
         },
       },
-      aggs: {
-        byRuleTypeId: ruleTypeExecutionsWithDurationMetric,
-        failuresByReason: ruleTypeFailureExecutionsMetric,
-        avgDuration: { avg: { field: 'event.duration' } },
-        avgEsSearchDuration: {
-          avg: { field: 'kibana.alert.rule.execution.metrics.es_search_duration_ms' },
-        },
-        avgTotalSearchDuration: {
-          avg: { field: 'kibana.alert.rule.execution.metrics.total_search_duration_ms' },
-        },
-        percentileScheduledActions: generatedActionsPercentilesAgg,
-        percentileAlerts: alertsPercentilesAgg,
-        aggsByType: {
-          terms: {
-            field: 'rule.category',
-            size: NUM_ALERTING_RULE_TYPES,
-          },
-          aggs: {
-            percentileScheduledActions: generatedActionsPercentilesAgg,
-            percentileAlerts: alertsPercentilesAgg,
-          },
-        },
-      },
-    },
-  });
+    });
 
-  const executionsAggregations = searchResult.aggregations as {
-    byRuleTypeId: {
-      value: {
-        ruleTypes: Record<string, string>;
-        ruleTypesDuration: Record<string, number>;
-        ruleTypesEsSearchDuration: Record<string, number>;
-        ruleTypesTotalSearchDuration: Record<string, number>;
+    const executionsAggregations = searchResult.aggregations as {
+      byRuleTypeId: {
+        value: {
+          ruleTypes: Record<string, string>;
+          ruleTypesDuration: Record<string, number>;
+          ruleTypesEsSearchDuration: Record<string, number>;
+          ruleTypesTotalSearchDuration: Record<string, number>;
+        };
       };
     };
-  };
 
-  const aggsAvgExecutionTime = Math.round(
-    // @ts-expect-error aggegation type is not specified
-    // convert nanoseconds to milliseconds
-    searchResult.aggregations.avgDuration.value / (1000 * 1000)
-  );
+    const aggsAvgExecutionTime = Math.round(
+      // @ts-expect-error aggegation type is not specified
+      // convert nanoseconds to milliseconds
+      searchResult.aggregations.avgDuration.value / (1000 * 1000)
+    );
 
-  const aggsAvgEsSearchDuration = Math.round(
-    // @ts-expect-error aggegation type is not specified
-    searchResult.aggregations.avgEsSearchDuration.value
-  );
-  const aggsAvgTotalSearchDuration = Math.round(
-    // @ts-expect-error aggegation type is not specified
-    searchResult.aggregations.avgTotalSearchDuration.value
-  );
+    const aggsAvgEsSearchDuration = Math.round(
+      // @ts-expect-error aggegation type is not specified
+      searchResult.aggregations.avgEsSearchDuration.value
+    );
+    const aggsAvgTotalSearchDuration = Math.round(
+      // @ts-expect-error aggegation type is not specified
+      searchResult.aggregations.avgTotalSearchDuration.value
+    );
 
-  const aggsGeneratedActionsPercentiles =
-    // @ts-expect-error aggegation type is not specified
-    searchResult.aggregations.percentileScheduledActions.values;
+    const aggsGeneratedActionsPercentiles =
+      // @ts-expect-error aggegation type is not specified
+      searchResult.aggregations.percentileScheduledActions.values;
 
-  const aggsAlertsPercentiles =
-    // @ts-expect-error aggegation type is not specified
-    searchResult.aggregations.percentileAlerts.values;
+    const aggsAlertsPercentiles =
+      // @ts-expect-error aggegation type is not specified
+      searchResult.aggregations.percentileAlerts.values;
 
-  const aggsByTypeBuckets =
-    // @ts-expect-error aggegation type is not specified
-    searchResult.aggregations.aggsByType.buckets;
+    const aggsByTypeBuckets =
+      // @ts-expect-error aggegation type is not specified
+      searchResult.aggregations.aggsByType.buckets;
 
-  const executionFailuresAggregations = searchResult.aggregations as {
-    failuresByReason: { value: { reasons: Record<string, Record<string, string>> } };
-  };
+    const executionFailuresAggregations = searchResult.aggregations as {
+      failuresByReason: { value: { reasons: Record<string, Record<string, string>> } };
+    };
 
-  return {
-    countTotal: Object.keys(executionsAggregations.byRuleTypeId.value.ruleTypes).reduce(
-      (total: number, key: string) =>
-        parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
-      0
-    ),
-    countByType: replaceDotSymbolsInRuleTypeIds(
-      executionsAggregations.byRuleTypeId.value.ruleTypes
-    ),
-    countTotalFailures: Object.keys(
-      executionFailuresAggregations.failuresByReason.value.reasons
-    ).reduce((total: number, reason: string) => {
-      const byRuleTypesRefs = executionFailuresAggregations.failuresByReason.value.reasons[reason];
-      const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
-        (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
+    return {
+      countTotal: Object.keys(executionsAggregations.byRuleTypeId.value.ruleTypes).reduce(
+        (total: number, key: string) =>
+          parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
         0
-      );
-      return countByRuleTypes + total;
-    }, 0),
-    countFailuresByReason: Object.keys(
-      executionFailuresAggregations.failuresByReason.value.reasons
-    ).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, reason: string) => {
+      ),
+      countByType: replaceDotSymbolsInRuleTypeIds(
+        executionsAggregations.byRuleTypeId.value.ruleTypes
+      ),
+      countTotalFailures: Object.keys(
+        executionFailuresAggregations.failuresByReason.value.reasons
+      ).reduce((total: number, reason: string) => {
         const byRuleTypesRefs =
           executionFailuresAggregations.failuresByReason.value.reasons[reason];
         const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
           (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
           0
         );
-        return {
+        return countByRuleTypes + total;
+      }, 0),
+      countFailuresByReason: Object.keys(
+        executionFailuresAggregations.failuresByReason.value.reasons
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, reason: string) => {
+          const byRuleTypesRefs =
+            executionFailuresAggregations.failuresByReason.value.reasons[reason];
+          const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
+            (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
+            0
+          );
+          return {
+            ...obj,
+            [replaceDotSymbols(reason)]: countByRuleTypes,
+          };
+        },
+        {}
+      ),
+      countFailuresByReasonByType: Object.keys(
+        executionFailuresAggregations.failuresByReason.value.reasons
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, key: string) => ({
           ...obj,
-          [replaceDotSymbols(reason)]: countByRuleTypes,
-        };
-      },
-      {}
-    ),
-    countFailuresByReasonByType: Object.keys(
-      executionFailuresAggregations.failuresByReason.value.reasons
-    ).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, key: string) => ({
-        ...obj,
-        [key]: replaceDotSymbolsInRuleTypeIds(
-          executionFailuresAggregations.failuresByReason.value.reasons[key]
-        ),
-      }),
-      {}
-    ),
-    avgExecutionTime: aggsAvgExecutionTime,
-    avgExecutionTimeByType: Object.keys(executionsAggregations.byRuleTypeId.value.ruleTypes).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, key: string) => ({
-        ...obj,
-        [replaceDotSymbols(key)]: Math.round(
-          executionsAggregations.byRuleTypeId.value.ruleTypesDuration[key] /
-            parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
-        ),
-      }),
-      {}
-    ),
-    avgEsSearchDuration: aggsAvgEsSearchDuration,
-    avgEsSearchDurationByType: Object.keys(
-      executionsAggregations.byRuleTypeId.value.ruleTypes
-    ).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, key: string) => ({
-        ...obj,
-        [replaceDotSymbols(key)]: Math.round(
-          executionsAggregations.byRuleTypeId.value.ruleTypesEsSearchDuration[key] /
-            parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
-        ),
-      }),
-      {}
-    ),
-    avgTotalSearchDuration: aggsAvgTotalSearchDuration,
-    avgTotalSearchDurationByType: Object.keys(
-      executionsAggregations.byRuleTypeId.value.ruleTypes
-    ).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, key: string) => ({
-        ...obj,
-        [replaceDotSymbols(key)]: Math.round(
-          executionsAggregations.byRuleTypeId.value.ruleTypesTotalSearchDuration[key] /
-            parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
-        ),
-      }),
-      {}
-    ),
-    generatedActionsPercentiles: Object.keys(aggsGeneratedActionsPercentiles).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (acc: any, curr: string) => ({
-        ...acc,
-        ...(percentileFieldNameMapping[curr]
-          ? { [percentileFieldNameMapping[curr]]: aggsGeneratedActionsPercentiles[curr] }
-          : {}),
-      }),
-      {}
-    ),
-    generatedActionsPercentilesByType: parsePercentileAggsByRuleType(
-      aggsByTypeBuckets,
-      'percentileScheduledActions.values'
-    ),
-    alertsPercentiles: Object.keys(aggsAlertsPercentiles).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (acc: any, curr: string) => ({
-        ...acc,
-        ...(percentileFieldNameMapping[curr]
-          ? { [percentileFieldNameMapping[curr]]: aggsAlertsPercentiles[curr] }
-          : {}),
-      }),
-      {}
-    ),
-    alertsPercentilesByType: parsePercentileAggsByRuleType(
-      aggsByTypeBuckets,
-      'percentileAlerts.values'
-    ),
-  };
+          [key]: replaceDotSymbolsInRuleTypeIds(
+            executionFailuresAggregations.failuresByReason.value.reasons[key]
+          ),
+        }),
+        {}
+      ),
+      avgExecutionTime: aggsAvgExecutionTime,
+      avgExecutionTimeByType: Object.keys(
+        executionsAggregations.byRuleTypeId.value.ruleTypes
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, key: string) => ({
+          ...obj,
+          [replaceDotSymbols(key)]: Math.round(
+            executionsAggregations.byRuleTypeId.value.ruleTypesDuration[key] /
+              parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
+          ),
+        }),
+        {}
+      ),
+      avgEsSearchDuration: aggsAvgEsSearchDuration,
+      avgEsSearchDurationByType: Object.keys(
+        executionsAggregations.byRuleTypeId.value.ruleTypes
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, key: string) => ({
+          ...obj,
+          [replaceDotSymbols(key)]: Math.round(
+            executionsAggregations.byRuleTypeId.value.ruleTypesEsSearchDuration[key] /
+              parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
+          ),
+        }),
+        {}
+      ),
+      avgTotalSearchDuration: aggsAvgTotalSearchDuration,
+      avgTotalSearchDurationByType: Object.keys(
+        executionsAggregations.byRuleTypeId.value.ruleTypes
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, key: string) => ({
+          ...obj,
+          [replaceDotSymbols(key)]: Math.round(
+            executionsAggregations.byRuleTypeId.value.ruleTypesTotalSearchDuration[key] /
+              parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10)
+          ),
+        }),
+        {}
+      ),
+      generatedActionsPercentiles: Object.keys(aggsGeneratedActionsPercentiles).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (acc: any, curr: string) => ({
+          ...acc,
+          ...(percentileFieldNameMapping[curr]
+            ? { [percentileFieldNameMapping[curr]]: aggsGeneratedActionsPercentiles[curr] }
+            : {}),
+        }),
+        {}
+      ),
+      generatedActionsPercentilesByType: parsePercentileAggsByRuleType(
+        aggsByTypeBuckets,
+        'percentileScheduledActions.values'
+      ),
+      alertsPercentiles: Object.keys(aggsAlertsPercentiles).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (acc: any, curr: string) => ({
+          ...acc,
+          ...(percentileFieldNameMapping[curr]
+            ? { [percentileFieldNameMapping[curr]]: aggsAlertsPercentiles[curr] }
+            : {}),
+        }),
+        {}
+      ),
+      alertsPercentilesByType: parsePercentileAggsByRuleType(
+        aggsByTypeBuckets,
+        'percentileAlerts.values'
+      ),
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing alerting telemetry task: getExecutionsPerDayCount - ${JSON.stringify(err)}`
+    );
+    return {
+      countTotal: 0,
+      countByType: {},
+      countTotalFailures: 0,
+      countFailuresByReason: {},
+      countFailuresByReasonByType: {},
+      avgExecutionTime: 0,
+      avgExecutionTimeByType: {},
+      avgEsSearchDuration: 0,
+      avgEsSearchDurationByType: {},
+      avgTotalSearchDuration: 0,
+      avgTotalSearchDurationByType: {},
+      generatedActionsPercentiles: {},
+      generatedActionsPercentilesByType: {},
+      alertsPercentiles: {},
+      alertsPercentilesByType: {},
+    };
+  }
 }
 
 export async function getExecutionTimeoutsPerDayCount(
   esClient: ElasticsearchClient,
-  eventLogIndex: string
+  eventLogIndex: string,
+  logger: Logger
 ) {
-  const searchResult = await esClient.search({
-    index: eventLogIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: {
-            bool: {
-              must: [
-                {
-                  term: { 'event.action': 'execute-timeout' },
-                },
-                {
-                  term: { 'event.provider': 'alerting' },
-                },
-                {
-                  range: {
-                    '@timestamp': {
-                      gte: 'now-1d',
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        },
-      },
-      aggs: {
-        byRuleTypeId: ruleTypeExecutionsMetric,
-      },
-    },
-  });
-
-  const executionsAggregations = searchResult.aggregations as {
-    byRuleTypeId: {
-      value: { ruleTypes: Record<string, string>; ruleTypesDuration: Record<string, number> };
-    };
-  };
-
-  return {
-    countTotal: Object.keys(executionsAggregations.byRuleTypeId.value.ruleTypes).reduce(
-      (total: number, key: string) =>
-        parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
-      0
-    ),
-    countByType: replaceDotSymbolsInRuleTypeIds(
-      executionsAggregations.byRuleTypeId.value.ruleTypes
-    ),
-  };
-}
-
-export async function getFailedAndUnrecognizedTasksPerDay(
-  esClient: ElasticsearchClient,
-  taskManagerIndex: string
-) {
-  const searchResult = await esClient.search({
-    index: taskManagerIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          must: [
-            {
+  try {
+    const searchResult = await esClient.search({
+      index: eventLogIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: {
               bool: {
-                should: [
+                must: [
                   {
-                    term: {
-                      'task.status': 'unrecognized',
-                    },
+                    term: { 'event.action': 'execute-timeout' },
                   },
                   {
-                    term: {
-                      'task.status': 'failed',
+                    term: { 'event.provider': 'alerting' },
+                  },
+                  {
+                    range: {
+                      '@timestamp': {
+                        gte: 'now-1d',
+                      },
                     },
                   },
                 ],
               },
             },
-            {
-              wildcard: {
-                'task.taskType': {
-                  value: 'alerting:*',
-                },
-              },
-            },
-            {
-              range: {
-                'task.runAt': {
-                  gte: 'now-1d',
-                },
-              },
-            },
-          ],
+          },
+        },
+        aggs: {
+          byRuleTypeId: ruleTypeExecutionsMetric,
         },
       },
-      aggs: {
-        byTaskTypeId: taskTypeExecutionsMetric,
-      },
-    },
-  });
+    });
 
-  const executionsAggregations = searchResult.aggregations as {
-    byTaskTypeId: { value: { statuses: Record<string, Record<string, string>> } };
-  };
+    const executionsAggregations = searchResult.aggregations as {
+      byRuleTypeId: {
+        value: { ruleTypes: Record<string, string>; ruleTypesDuration: Record<string, number> };
+      };
+    };
 
-  return {
-    countTotal: Object.keys(executionsAggregations.byTaskTypeId.value.statuses).reduce(
-      (total: number, status: string) => {
-        const byRuleTypesRefs = executionsAggregations.byTaskTypeId.value.statuses[status];
-        const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
-          (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
-          0
-        );
-        return countByRuleTypes + total;
+    return {
+      countTotal: Object.keys(executionsAggregations.byRuleTypeId.value.ruleTypes).reduce(
+        (total: number, key: string) =>
+          parseInt(executionsAggregations.byRuleTypeId.value.ruleTypes[key], 10) + total,
+        0
+      ),
+      countByType: replaceDotSymbolsInRuleTypeIds(
+        executionsAggregations.byRuleTypeId.value.ruleTypes
+      ),
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing alerting telemetry task: getExecutionsTimeoutsPerDayCount - ${JSON.stringify(
+        err
+      )}`
+    );
+    return {
+      countTotal: 0,
+      countByType: {},
+    };
+  }
+}
+
+export async function getFailedAndUnrecognizedTasksPerDay(
+  esClient: ElasticsearchClient,
+  taskManagerIndex: string,
+  logger: Logger
+) {
+  try {
+    const searchResult = await esClient.search({
+      index: taskManagerIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                bool: {
+                  should: [
+                    {
+                      term: {
+                        'task.status': 'unrecognized',
+                      },
+                    },
+                    {
+                      term: {
+                        'task.status': 'failed',
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                wildcard: {
+                  'task.taskType': {
+                    value: 'alerting:*',
+                  },
+                },
+              },
+              {
+                range: {
+                  'task.runAt': {
+                    gte: 'now-1d',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        aggs: {
+          byTaskTypeId: taskTypeExecutionsMetric,
+        },
       },
-      0
-    ),
-    countByStatus: Object.keys(executionsAggregations.byTaskTypeId.value.statuses).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, status: string) => {
-        const byRuleTypesRefs = executionsAggregations.byTaskTypeId.value.statuses[status];
-        const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
-          (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
-          0
-        );
-        return {
+    });
+
+    const executionsAggregations = searchResult.aggregations as {
+      byTaskTypeId: { value: { statuses: Record<string, Record<string, string>> } };
+    };
+
+    return {
+      countTotal: Object.keys(executionsAggregations.byTaskTypeId.value.statuses).reduce(
+        (total: number, status: string) => {
+          const byRuleTypesRefs = executionsAggregations.byTaskTypeId.value.statuses[status];
+          const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
+            (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
+            0
+          );
+          return countByRuleTypes + total;
+        },
+        0
+      ),
+      countByStatus: Object.keys(executionsAggregations.byTaskTypeId.value.statuses).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, status: string) => {
+          const byRuleTypesRefs = executionsAggregations.byTaskTypeId.value.statuses[status];
+          const countByRuleTypes = Object.keys(byRuleTypesRefs).reduce(
+            (totalByType, ruleType) => parseInt(byRuleTypesRefs[ruleType] + totalByType, 10),
+            0
+          );
+          return {
+            ...obj,
+            [status]: countByRuleTypes,
+          };
+        },
+        {}
+      ),
+      countByStatusByRuleType: Object.keys(
+        executionsAggregations.byTaskTypeId.value.statuses
+      ).reduce(
+        // ES DSL aggregations are returned as `any` by esClient.search
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (obj: any, key: string) => ({
           ...obj,
-          [status]: countByRuleTypes,
-        };
-      },
-      {}
-    ),
-    countByStatusByRuleType: Object.keys(executionsAggregations.byTaskTypeId.value.statuses).reduce(
-      // ES DSL aggregations are returned as `any` by esClient.search
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (obj: any, key: string) => ({
-        ...obj,
-        [key]: replaceDotSymbolsInRuleTypeIds(
-          executionsAggregations.byTaskTypeId.value.statuses[key]
-        ),
-      }),
-      {}
-    ),
-  };
+          [key]: replaceDotSymbolsInRuleTypeIds(
+            executionsAggregations.byTaskTypeId.value.statuses[key]
+          ),
+        }),
+        {}
+      ),
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing alerting telemetry task: getFailedAndUnrecognizedTasksPerDay - ${JSON.stringify(
+        err
+      )}`
+    );
+    return {
+      countTotal: 0,
+      countByStatus: {},
+      countByStatusByRuleType: {},
+    };
+  }
 }
 
 function replaceDotSymbols(strToReplace: string) {

--- a/x-pack/plugins/alerting/server/usage/task.ts
+++ b/x-pack/plugins/alerting/server/usage/task.ts
@@ -98,11 +98,11 @@ export function telemetryTaskRunner(
       async run() {
         const esClient = await getEsClient();
         return Promise.all([
-          getTotalCountAggregations(esClient, kibanaIndex),
-          getTotalCountInUse(esClient, kibanaIndex),
-          getExecutionsPerDayCount(esClient, eventLogIndex),
-          getExecutionTimeoutsPerDayCount(esClient, eventLogIndex),
-          getFailedAndUnrecognizedTasksPerDay(esClient, taskManagerIndex),
+          getTotalCountAggregations(esClient, kibanaIndex, logger),
+          getTotalCountInUse(esClient, kibanaIndex, logger),
+          getExecutionsPerDayCount(esClient, eventLogIndex, logger),
+          getExecutionTimeoutsPerDayCount(esClient, eventLogIndex, logger),
+          getFailedAndUnrecognizedTasksPerDay(esClient, taskManagerIndex, logger),
         ])
           .then(
             ([

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_telemetry.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_telemetry.ts
@@ -11,11 +11,11 @@ import {
   getUrlPrefix,
   getEventLog,
   getTestRuleData,
-  ObjectRemover,
   TaskManagerDoc,
   ESTestIndexTool,
 } from '../../../../common/lib';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertingTelemetryTests({ getService }: FtrProviderContext) {
@@ -24,26 +24,18 @@ export default function createAlertingTelemetryTests({ getService }: FtrProvider
   const retry = getService('retry');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const esTestIndexTool = new ESTestIndexTool(es, retry);
+  const esArchiver = getService('esArchiver');
 
   describe('alerting telemetry', () => {
     const alwaysFiringRuleId: { [key: string]: string } = {};
-    const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {
-      // reset the state in the telemetry task
-      await es.update({
-        id: `task:Alerting-alerting_telemetry`,
-        index: '.kibana_task_manager',
-        body: {
-          doc: {
-            task: {
-              state: '{}',
-            },
-          },
-        },
-      });
+      await esArchiver.load('x-pack/test/functional/es_archives/event_log_telemetry');
+      await setupSpacesAndUsers(getService);
     });
-    after(() => objectRemover.removeAll());
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/event_log_telemetry');
+    });
 
     beforeEach(async () => {
       await esTestIndexTool.destroy();
@@ -63,7 +55,6 @@ export default function createAlertingTelemetryTests({ getService }: FtrProvider
           secrets: {},
         })
         .expect(200);
-      objectRemover.add(space, createdConnector.id, 'action', 'actions');
       return createdConnector.id;
     }
 
@@ -75,7 +66,6 @@ export default function createAlertingTelemetryTests({ getService }: FtrProvider
         .auth(Superuser.username, Superuser.password)
         .send(getTestRuleData(ruleOverwrites));
       expect(ruleResponse.status).to.eql(200);
-      objectRemover.add(space, ruleResponse.body.id, 'rule', 'alerting');
       return ruleResponse.body.id;
     }
 

--- a/x-pack/test/functional/es_archives/event_log_telemetry/data.json
+++ b/x-pack/test/functional/es_archives/event_log_telemetry/data.json
@@ -1,0 +1,193 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "task:Alerting-alerting_telemetry",
+    "index": ".kibana_task_manager_1",
+    "source": {
+      "migrationVersion": {
+        "task": "8.2.0"
+      },
+      "references": [
+      ],
+      "task": {
+        "attempts": 0,
+        "params": "{}",
+        "retryAt": null,
+        "runAt": "2020-09-04T11:51:05.197Z",
+        "scheduledAt": "2020-09-04T11:51:05.197Z",
+        "startedAt": null,
+        "state": "{}",
+        "ownerId": null,
+        "status": "idle",
+        "taskType": "alerting_telemetry"
+      },
+      "type": "task",
+      "updated_at": "2020-09-04T11:51:05.197Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "X6bLb3UBt6Z_MVvSTfYk",
+    "index": ".kibana-event-log-8.0.0-000001",
+    "source": {
+      "@timestamp": "2020-10-28T15:19:55.933Z",
+      "ecs": {
+        "version": "1.5.0"
+      },
+      "event": {
+        "action": "test",
+        "duration": 0,
+        "end": "2020-10-28T15:19:55.933Z",
+        "provider": "event_log_fixture",
+        "start": "2020-10-28T15:19:55.933Z"
+      },
+      "kibana": {
+        "saved_objects": [
+          {
+            "id": "621f2511-5cd1-44fd-95df-e0df83e354d5",
+            "rel": "primary",
+            "type": "event_log_test"
+          }
+        ],
+        "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
+        "version": "8.0.0"
+      },
+      "message": "test 2020-10-28T15:19:55.913Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "X6bLb3UBt6Z_MVvSTfYk0000",
+    "index": ".kibana-event-log-8.0.0-000001",
+    "source": {
+      "@timestamp": "2020-10-28T15:19:55.933Z",
+      "ecs": {
+        "version": "1.5.0"
+      },
+      "event": {
+        "action": "test legacy",
+        "duration": 0,
+        "end": "2020-10-28T15:19:55.933Z",
+        "provider": "event_log_fixture",
+        "start": "2020-10-28T15:19:55.933Z"
+      },
+      "kibana": {
+        "saved_objects": [
+          {
+            "id": "521f2511-5cd1-44fd-95df-e0df83e354d5",
+            "rel": "primary",
+            "type": "event_log_test"
+          }
+        ],
+        "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
+        "version": "7.14.0"
+      },
+      "message": "test legacy 2020-10-28T15:19:55.913Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "YKbLb3UBt6Z_MVvSTfY8",
+    "index": ".kibana-event-log-8.0.0-000001",
+    "source": {
+      "@timestamp": "2020-10-28T15:19:55.957Z",
+      "ecs": {
+        "version": "1.5.0"
+      },
+      "event": {
+        "action": "test",
+        "duration": 0,
+        "end": "2020-10-28T15:19:55.957Z",
+        "provider": "event_log_fixture",
+        "start": "2020-10-28T15:19:55.957Z"
+      },
+      "kibana": {
+        "saved_objects": [
+          {
+            "id": "621f2511-5cd1-44fd-95df-e0df83e354d5",
+            "rel": "primary",
+            "type": "event_log_test"
+          }
+        ],
+        "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
+        "version": "8.0.0"
+      },
+      "message": "test 2020-10-28T15:19:55.938Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "YabLb3UBt6Z_MVvSTfZc0000",
+    "index": ".kibana-event-log-8.0.0-000001",
+    "source": {
+      "@timestamp": "2020-10-28T15:19:55.991Z",
+      "ecs": {
+        "version": "1.5.0"
+      },
+      "event": {
+        "action": "test",
+        "duration": 0,
+        "end": "2020-10-28T15:19:55.991Z",
+        "provider": "event_log_fixture",
+        "start": "2020-10-28T15:19:55.991Z"
+      },
+      "kibana": {
+        "saved_objects": [
+          {
+            "id": "521f2511-5cd1-44fd-95df-e0df83e354d5",
+            "rel": "primary",
+            "type": "event_log_test"
+          }
+        ],
+        "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
+        "version": "7.0.0"
+      },
+      "message": "test legacy 2020-10-28T15:19:55.962Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "YabLb3UBt6Z_MVvSTfZc",
+    "index": ".kibana-event-log-8.0.0-000001",
+    "source": {
+      "@timestamp": "2020-10-28T15:19:55.991Z",
+      "ecs": {
+        "version": "1.5.0"
+      },
+      "event": {
+        "action": "test",
+        "duration": 0,
+        "end": "2020-10-28T15:19:55.991Z",
+        "provider": "event_log_fixture",
+        "start": "2020-10-28T15:19:55.991Z"
+      },
+      "kibana": {
+        "saved_objects": [
+          {
+            "id": "621f2511-5cd1-44fd-95df-e0df83e354d5",
+            "rel": "primary",
+            "type": "event_log_test"
+          }
+        ],
+        "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
+        "version": "8.0.0"
+      },
+      "message": "test 2020-10-28T15:19:55.962Z"
+    }
+  }
+}

--- a/x-pack/test/functional/es_archives/event_log_telemetry/mappings.json
+++ b/x-pack/test/functional/es_archives/event_log_telemetry/mappings.json
@@ -1,0 +1,700 @@
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".kibana": {
+      }
+    },
+    "index": ".kibana_1",
+    "mappings": {
+      "_meta": {
+        "migrationMappingPropertyHashes": {
+          "action": "6e96ac5e648f57523879661ea72525b7",
+          "action_task_params": "a9d49f184ee89641044be0ca2950fa3a",
+          "alert": "eaf6f5841dbf4cb5e3045860f75f53ca",
+          "apm-indices": "9bb9b2bf1fa636ed8619cbab5ce6a1dd",
+          "apm-telemetry": "3d1b76c39bfb2cc8296b024d73854724",
+          "app_search_telemetry": "3d1b76c39bfb2cc8296b024d73854724",
+          "application_usage_daily": "43b8830d5d0df85a6823d290885fc9fd",
+          "application_usage_totals": "3d1b76c39bfb2cc8296b024d73854724",
+          "application_usage_transactional": "3d1b76c39bfb2cc8296b024d73854724",
+          "canvas-element": "7390014e1091044523666d97247392fc",
+          "canvas-workpad": "b0a1706d356228dbdcb4a17e6b9eb231",
+          "canvas-workpad-template": "ae2673f678281e2c055d764b153e9715",
+          "cases": "477f214ff61acc3af26a7b7818e380c1",
+          "cases-comments": "c2061fb929f585df57425102fa928b4b",
+          "cases-configure": "387c5f3a3bda7e0ae0dd4e106f914a69",
+          "cases-user-actions": "32277330ec6b721abe3b846cfd939a71",
+          "config": "c63748b75f39d0c54de12d12c1ccbc20",
+          "dashboard": "40554caf09725935e2c02e02563a2d07",
+          "endpoint:user-artifact": "4a11183eee21e6fbad864f7a30b39ad0",
+          "endpoint:user-artifact-manifest": "a0d7b04ad405eed54d76e279c3727862",
+          "enterprise_search_telemetry": "3d1b76c39bfb2cc8296b024d73854724",
+          "epm-packages": "2b83397e3eaaaa8ef15e38813f3721c3",
+          "event_log_test": "bef808d4a9c27f204ffbda3359233931",
+          "exception-list": "67f055ab8c10abd7b2ebfd969b836788",
+          "exception-list-agnostic": "67f055ab8c10abd7b2ebfd969b836788",
+          "file-upload-telemetry": "0ed4d3e1983d1217a30982630897092e",
+          "fleet-agent-actions": "9511b565b1cc6441a42033db3d5de8e9",
+          "fleet-agent-events": "e20a508b6e805189356be381dbfac8db",
+          "fleet-agents": "cb661e8ede2b640c42c8e5ef99db0683",
+          "fleet-enrollment-api-keys": "a69ef7ae661dab31561d6c6f052ef2a7",
+          "graph-workspace": "cd7ba1330e6682e9cc00b78850874be1",
+          "index-pattern": "45915a1ad866812242df474eb0479052",
+          "infrastructure-ui-source": "3d1b76c39bfb2cc8296b024d73854724",
+          "ingest-agent-policies": "8b0733cce189659593659dad8db426f0",
+          "ingest-outputs": "8854f34453a47e26f86a29f8f3b80b4e",
+          "ingest-package-policies": "f74dfe498e1849267cda41580b2be110",
+          "ingest_manager_settings": "02a03095f0e05b7a538fa801b88a217f",
+          "inventory-view": "3d1b76c39bfb2cc8296b024d73854724",
+          "kql-telemetry": "d12a98a6f19a2d273696597547e064ee",
+          "lens": "52346cfec69ff7b47d5f0c12361a2797",
+          "lens-ui-telemetry": "509bfa5978586998e05f9e303c07a327",
+          "map": "4a05b35c3a3a58fbc72dd0202dc3487f",
+          "maps-telemetry": "5ef305b18111b77789afefbd36b66171",
+          "metrics-explorer-view": "3d1b76c39bfb2cc8296b024d73854724",
+          "migrationVersion": "4a1746014a75ade3a714e1db5763276f",
+          "ml-telemetry": "257fd1d4b4fdbb9cb4b8a3b27da201e9",
+          "monitoring-telemetry": "2669d5ec15e82391cf58df4294ee9c68",
+          "namespace": "2f4316de49999235636386fe51dc06c1",
+          "namespaces": "2f4316de49999235636386fe51dc06c1",
+          "originId": "2f4316de49999235636386fe51dc06c1",
+          "query": "11aaeb7f5f7fa5bb43f25e18ce26e7d9",
+          "references": "7997cf5a56cc02bdc9c93361bde732b0",
+          "sample-data-telemetry": "7d3cfeb915303c9641c59681967ffeb4",
+          "search": "43012c7ebc4cb57054e0a490e4b43023",
+          "search-telemetry": "3d1b76c39bfb2cc8296b024d73854724",
+          "siem-detection-engine-rule-actions": "6569b288c169539db10cb262bf79de18",
+          "siem-detection-engine-rule-status": "ae783f41c6937db6b7a2ef5c93a9e9b0",
+          "siem-ui-timeline": "d12c5474364d737d17252acf1dc4585c",
+          "siem-ui-timeline-note": "8874706eedc49059d4cf0f5094559084",
+          "siem-ui-timeline-pinned-event": "20638091112f0e14f0e443d512301c29",
+          "space": "c5ca8acafa0beaa4d08d014a97b6bc6b",
+          "telemetry": "36a616f7026dfa617d6655df850fe16d",
+          "timelion-sheet": "9a2a2748877c7a7b582fef201ab1d4cf",
+          "tsvb-validation-telemetry": "3a37ef6c8700ae6fc97d5c7da00e9215",
+          "type": "2f4316de49999235636386fe51dc06c1",
+          "ui-metric": "0d409297dc5ebe1e3a1da691c6ee32e3",
+          "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+          "upgrade-assistant-reindex-operation": "215107c281839ea9b3ad5f6419819763",
+          "upgrade-assistant-telemetry": "56702cec857e0a9dacfb696655b4ff7b",
+          "uptime-dynamic-settings": "3d1b76c39bfb2cc8296b024d73854724",
+          "url": "c7f66a0df8b1b52f17c28c4adb111105",
+          "visualization": "f819cf6636b75c9e76ba733a0c6ef355",
+          "workplace_search_telemetry": "3d1b76c39bfb2cc8296b024d73854724"
+        }
+      },
+      "dynamic": "strict",
+      "properties": {
+        "config": {
+          "dynamic": "false",
+          "properties": {
+            "buildNum": {
+              "type": "keyword"
+            }
+          }
+        },
+        "event_log_test": {
+          "type": "object"
+        },
+        "migrationVersion": {
+          "dynamic": "true",
+          "properties": {
+            "config": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            },
+            "space": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "ml-telemetry": {
+          "properties": {
+            "file_data_visualizer": {
+              "properties": {
+                "index_creation_count": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "monitoring-telemetry": {
+          "properties": {
+            "reportedClusterUuids": {
+              "type": "keyword"
+            }
+          }
+        },
+        "namespace": {
+          "type": "keyword"
+        },
+        "namespaces": {
+          "type": "keyword"
+        },
+        "originId": {
+          "type": "keyword"
+        },
+        "query": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "filters": {
+              "enabled": false,
+              "type": "object"
+            },
+            "query": {
+              "properties": {
+                "language": {
+                  "type": "keyword"
+                },
+                "query": {
+                  "index": false,
+                  "type": "keyword"
+                }
+              }
+            },
+            "timefilter": {
+              "enabled": false,
+              "type": "object"
+            },
+            "title": {
+              "type": "text"
+            }
+          }
+        },
+        "references": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          },
+          "type": "nested"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "space": {
+          "properties": {
+            "_reserved": {
+              "type": "boolean"
+            },
+            "color": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "disabledFeatures": {
+              "type": "keyword"
+            },
+            "imageUrl": {
+              "index": false,
+              "type": "text"
+            },
+            "initials": {
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 2048,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "ui-metric": {
+          "properties": {
+            "count": {
+              "type": "integer"
+            }
+          }
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "url": {
+          "properties": {
+            "accessCount": {
+              "type": "long"
+            },
+            "accessDate": {
+              "type": "date"
+            },
+            "createDate": {
+              "type": "date"
+            },
+            "url": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 2048,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "visualization": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "index": false,
+                  "type": "text"
+                }
+              }
+            },
+            "savedSearchRefName": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "index": false,
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "visState": {
+              "index": false,
+              "type": "text"
+            }
+          }
+        },
+        "workplace_search_telemetry": {
+          "dynamic": "false",
+          "type": "object"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".kibana-event-log-7.9.0": {
+        "is_write_index": true
+      }
+    },
+    "index": ".kibana-event-log-7.9.0-000001",
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "error": {
+          "properties": {
+            "message": {
+              "norms": false,
+              "type": "text"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "action": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "date"
+            },
+            "outcome": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "start": {
+              "type": "date"
+            }
+          }
+        },
+        "kibana": {
+          "properties": {
+            "alerting": {
+              "properties": {
+                "instance_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "saved_objects": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "namespace": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "rel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            },
+            "server_uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "meta": {
+            "isArray": "true"
+          },
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "lifecycle": {
+          "name": "kibana-event-log-policy",
+          "rollover_alias": ".kibana-event-log-7.9.0"
+        },
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".kibana-event-log-8.0.0": {
+        "is_write_index": true
+      }
+    },
+    "index": ".kibana-event-log-8.0.0-000001",
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "error": {
+          "properties": {
+            "message": {
+              "norms": false,
+              "type": "text"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "action": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "date"
+            },
+            "outcome": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "start": {
+              "type": "date"
+            }
+          }
+        },
+        "kibana": {
+          "properties": {
+            "alerting": {
+              "properties": {
+                "instance_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "saved_objects": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "namespace": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "rel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            },
+            "server_uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "type": "version"
+            }
+          }
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "meta": {
+            "isArray": "true"
+          },
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "name": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "lifecycle": {
+          "name": "kibana-event-log-policy",
+          "rollover_alias": ".kibana-event-log-8.0.0"
+        },
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".kibana_task_manager": {
+      }
+    },
+    "index": ".kibana_task_manager_1",
+    "mappings": {
+      "_meta": {
+        "migrationMappingPropertyHashes": {
+          "migrationVersion": "4a1746014a75ade3a714e1db5763276f",
+          "namespace": "2f4316de49999235636386fe51dc06c1",
+          "namespaces": "2f4316de49999235636386fe51dc06c1",
+          "references": "7997cf5a56cc02bdc9c93361bde732b0",
+          "task": "235412e52d09e7165fac8a67a43ad6b4",
+          "type": "2f4316de49999235636386fe51dc06c1",
+          "updated_at": "00da57df13e94e9d98437d13ace4bfe0"
+        }
+      },
+      "dynamic": "strict",
+      "properties": {
+        "migrationVersion": {
+          "dynamic": "true",
+          "properties": {
+            "task": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "namespace": {
+          "type": "keyword"
+        },
+        "namespaces": {
+          "type": "keyword"
+        },
+        "references": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          },
+          "type": "nested"
+        },
+        "task": {
+          "properties": {
+            "attempts": {
+              "type": "integer"
+            },
+            "ownerId": {
+              "type": "keyword"
+            },
+            "params": {
+              "type": "text"
+            },
+            "retryAt": {
+              "type": "date"
+            },
+            "runAt": {
+              "type": "date"
+            },
+            "schedule": {
+              "properties": {
+                "interval": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "scheduledAt": {
+              "type": "date"
+            },
+            "scope": {
+              "type": "keyword"
+            },
+            "startedAt": {
+              "type": "date"
+            },
+            "state": {
+              "type": "text"
+            },
+            "status": {
+              "type": "keyword"
+            },
+            "taskType": {
+              "type": "keyword"
+            },
+            "user": {
+              "type": "keyword"
+            }
+          }
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "updated_at": {
+          "type": "date"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Response Ops] Fixing scripted metric agg in alerting telemetry (#132635)](https://github.com/elastic/kibana/pull/132635)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)