### PR TITLE
[artifacts] Remove docker cloud context verification

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -51,18 +51,6 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - command: KIBANA_DOCKER_CONTEXT=cloud .buildkite/scripts/steps/artifacts/docker_context.sh
-    label: 'Docker Context Verification'
-    soft_fail: true
-    agents:
-      queue: n2-2
-    timeout_in_minutes: 30
-    if: "build.env('RELEASE_BUILD') == null || build.env('RELEASE_BUILD') == '' || build.env('RELEASE_BUILD') == 'false'"
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
   - command: KIBANA_DOCKER_CONTEXT=ubi .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:

--- a/.buildkite/scripts/steps/artifacts/docker_context.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_context.sh
@@ -26,11 +26,5 @@ fi
 tar -xf "target/$DOCKER_CONTEXT_FILE" -C "$DOCKER_BUILD_FOLDER"
 cd $DOCKER_BUILD_FOLDER
 
-buildkite-agent artifact download "kibana-$FULL_VERSION-linux-x86_64.tar.gz" . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-if [[ "$KIBANA_DOCKER_CONTEXT" == "cloud" ]]; then
-  buildkite-agent artifact download "metricbeat-$FULL_VERSION-linux-x86_64.tar.gz" . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-  buildkite-agent artifact download "filebeat-$FULL_VERSION-linux-x86_64.tar.gz" . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-fi
-
 echo "--- Build context"
 docker build .


### PR DESCRIPTION
This test was added as a verification step for daily releasable
artifacts.  We had originally planned on the release manager consuming
this context.  The expected workflow has changed now to us building and
publishing the docker image instead, which already has coverage in the
Build and Deploy to Cloud step.