### PR TITLE
[Files] Blob storage with attributes

### DIFF
--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -30,7 +30,7 @@ describe('ContentStream', () => {
   beforeEach(() => {
     client = elasticsearchServiceMock.createClusterClient().asInternalUser;
     logger = loggingSystemMock.createLogger();
-    client.get.mockResponse(set<any>({}, '_source.content', 'some content'));
+    client.get.mockResponse(set<any>({}, '_source.data', 'some content'));
   });
 
   describe('read', () => {
@@ -76,7 +76,7 @@ describe('ContentStream', () => {
 
     it('should decode base64 encoded content', async () => {
       client.get.mockResponseOnce(
-        set<any>({}, '_source.content', Buffer.from('encoded content').toString('base64'))
+        set<any>({}, '_source.data', Buffer.from('encoded content').toString('base64'))
       );
       const data = await new Promise((resolve) => base64Stream.once('data', resolve));
 
@@ -84,9 +84,9 @@ describe('ContentStream', () => {
     });
 
     it('should compound content from multiple chunks', async () => {
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '12'));
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '34'));
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '56'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '12'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '34'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '56'));
       stream = getContentStream({
         params: { encoding: 'raw', size: 6 },
       });
@@ -109,9 +109,9 @@ describe('ContentStream', () => {
     });
 
     it('should stop reading on empty chunk', async () => {
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '12'));
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '34'));
-      client.get.mockResponseOnce(set<any>({}, '_source.content', ''));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '12'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '34'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', ''));
       stream = getContentStream({ params: { encoding: 'raw', size: 12 } });
       let data = '';
       for await (const chunk of stream) {
@@ -123,8 +123,8 @@ describe('ContentStream', () => {
     });
 
     it('should read until chunks are present when there is no size', async () => {
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '12'));
-      client.get.mockResponseOnce(set<any>({}, '_source.content', '34'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '12'));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', '34'));
       client.get.mockResponseOnce({} as any);
       stream = getContentStream({ params: { size: undefined, encoding: 'raw' } });
       let data = '';
@@ -138,15 +138,15 @@ describe('ContentStream', () => {
 
     it('should decode every chunk separately', async () => {
       client.get.mockResponseOnce(
-        set<any>({}, '_source.content', Buffer.from('12').toString('base64'))
+        set<any>({}, '_source.data', Buffer.from('12').toString('base64'))
       );
       client.get.mockResponseOnce(
-        set<any>({}, '_source.content', Buffer.from('34').toString('base64'))
+        set<any>({}, '_source.data', Buffer.from('34').toString('base64'))
       );
       client.get.mockResponseOnce(
-        set<any>({}, '_source.content', Buffer.from('56').toString('base64'))
+        set<any>({}, '_source.data', Buffer.from('56').toString('base64'))
       );
-      client.get.mockResponseOnce(set<any>({}, '_source.content', ''));
+      client.get.mockResponseOnce(set<any>({}, '_source.data', ''));
       base64Stream = getContentStream({ params: { size: 12 } });
       let data = '';
       for await (const chunk of base64Stream) {
@@ -188,7 +188,7 @@ describe('ContentStream', () => {
 
       expect(request).toHaveProperty('id', '0.something');
       expect(request).toHaveProperty('index', 'somewhere');
-      expect(request).toHaveProperty('document.content', '123456');
+      expect(request).toHaveProperty('document.data', '123456');
     });
 
     it('should update a number of written bytes', async () => {
@@ -230,7 +230,7 @@ describe('ContentStream', () => {
       expect(client.index).toHaveBeenCalledTimes(3);
       expect(client.index).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining(set({}, 'document.content', '12'))
+        expect.objectContaining(set({}, 'document.data', '12'))
       );
       expect(client.index).toHaveBeenNthCalledWith(
         2,
@@ -239,7 +239,7 @@ describe('ContentStream', () => {
           index: 'somewhere',
           document: {
             head_chunk_id: '0.something',
-            content: '34',
+            data: '34',
           },
         })
       );
@@ -250,7 +250,7 @@ describe('ContentStream', () => {
           index: 'somewhere',
           document: {
             head_chunk_id: '0.something',
-            content: '56',
+            data: '56',
           },
         })
       );
@@ -264,7 +264,7 @@ describe('ContentStream', () => {
       expect(client.index).toHaveBeenCalledTimes(3);
       expect(client.index).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining(set({}, 'document.content', Buffer.from('123').toString('base64')))
+        expect.objectContaining(set({}, 'document.data', Buffer.from('123').toString('base64')))
       );
       expect(client.index).toHaveBeenNthCalledWith(
         2,
@@ -272,7 +272,7 @@ describe('ContentStream', () => {
           id: '1.something',
           index: 'somewhere',
           document: {
-            content: Buffer.from('456').toString('base64'),
+            data: Buffer.from('456').toString('base64'),
             head_chunk_id: '0.something',
           },
         })
@@ -283,7 +283,7 @@ describe('ContentStream', () => {
           id: '2.something',
           index: 'somewhere',
           document: {
-            content: Buffer.from('78').toString('base64'),
+            data: Buffer.from('78').toString('base64'),
             head_chunk_id: '0.something',
           },
         })

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -379,7 +379,7 @@ describe('ContentStream', () => {
       );
     });
 
-    it('does not allow duplicate attribute names', async () => {
+    it('should not allow duplicate attribute names', async () => {
       base64Stream = getContentStream({
         attributes: [
           ['myName', 'myValue'],

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -317,7 +317,7 @@ describe('ContentStream', () => {
       await new Promise((resolve) => base64Stream.once('finish', resolve));
 
       const expectedAttributeData = {
-        app_meta_data: { myName: 'myValue' },
+        app_metadata: { myName: 'myValue' },
       };
 
       expect(client.index).toHaveBeenCalledTimes(3);

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -310,18 +310,13 @@ describe('ContentStream', () => {
 
     it('should store the attributes on the first document it creates', async () => {
       base64Stream = getContentStream({
-        attributes: [
-          ['myName', 'myValue'],
-          ['myOtherName', 'myOtherValue', { searchable: true }],
-          ['myOtherNameAsObject', { a: 1 }, { searchable: true }],
-        ],
+        attributes: [['myName', 'myValue']],
         params: { encoding: 'base64', maxChunkSize: '1028B' },
       });
       base64Stream.end('12345678');
       await new Promise((resolve) => base64Stream.once('finish', resolve));
 
       const expectedAttributeData = {
-        app_search_data: { myOtherName: 'myOtherValue', myOtherNameAsObject: { a: 1 } },
         app_meta_data: { myName: 'myValue' },
       };
 

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -172,10 +172,10 @@ describe('ContentStream', () => {
 
     it('should provide a document ID after writing to a destination', async () => {
       stream = new ContentStream(client, undefined, 'somewhere', logger);
-      expect(stream.getDocumentId()).toBe(undefined);
+      expect(stream.getContentReferenceId()).toBe(undefined);
       stream.end('some data');
       await new Promise((resolve) => stream.once('finish', resolve));
-      expect(stream.getDocumentId()).toEqual(expect.any(String));
+      expect(stream.getContentReferenceId()).toEqual(expect.any(String));
     });
 
     it('should send the contents when stream ends', async () => {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -317,7 +317,17 @@ export class ContentStream extends Duplex {
       .catch(callback);
   }
 
-  public getDocumentId(): undefined | string {
+  /**
+   * This ID can be used to retrieve or delete all of the file chunks but does
+   * not necessarily correspond to an existing document.
+   *
+   * @note do not use this ID with anything other than a {@link ContentStream}
+   * compatible implementation for reading blob-like structures from ES.
+   *
+   * @note When creating a new blob, this value may be undefined until the first
+   * chunk is written.
+   */
+  public getContentReferenceId(): undefined | string {
     return this.id;
   }
 
@@ -358,7 +368,8 @@ function getContentStream({
   return new ContentStream(client, id, index, logger, parameters, attributes);
 }
 
-type WritableContentStream = Writable & Pick<ContentStream, 'getDocumentId' | 'getBytesWritten'>;
+type WritableContentStream = Writable &
+  Pick<ContentStream, 'getContentReferenceId' | 'getBytesWritten'>;
 
 export function getWritableContentStream(args: ContentStreamArgs): WritableContentStream {
   return getContentStream(args);

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -221,15 +221,11 @@ export class ContentStream extends Duplex {
     }
   }
 
-  private getAttributes: () =>
-    | undefined
-    | Pick<FileChunkDocument, 'app_meta_data' | 'app_search_data'> = once(() => {
+  private getAttributes: () => undefined | Pick<FileChunkDocument, 'app_meta_data'> = once(() => {
     if (!this.attributes.length) return undefined;
     this.throwIfDuplicateAttributeKeyNames();
-    return this.attributes.reduce((acc, [key, value, options]) => {
-      return options?.searchable
-        ? set(acc, `app_search_data.${key}`, value)
-        : set(acc, `app_meta_data.${key}`, value);
+    return this.attributes.reduce((acc, [key, value]) => {
+      return set(acc, `app_meta_data.${key}`, value);
     }, {});
   });
 

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -221,11 +221,11 @@ export class ContentStream extends Duplex {
     }
   }
 
-  private getAttributes: () => undefined | Pick<FileChunkDocument, 'app_meta_data'> = once(() => {
+  private getAttributes: () => undefined | Pick<FileChunkDocument, 'app_metadata'> = once(() => {
     if (!this.attributes.length) return undefined;
     this.throwIfDuplicateAttributeKeyNames();
     return this.attributes.reduce((acc, [key, value]) => {
-      return set(acc, `app_meta_data.${key}`, value);
+      return set(acc, `app_metadata.${key}`, value);
     }, {});
   });
 

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -334,6 +334,13 @@ export class ContentStream extends Duplex {
   public getBytesWritten(): number {
     return this.bytesWritten;
   }
+
+  /**
+   * Get the ID of the document containing all attributes for the current file id.
+   */
+  public getAttributesChunkId(): string {
+    return this.getHeadChunkId();
+  }
 }
 
 export interface ContentStreamArgs {
@@ -368,14 +375,14 @@ function getContentStream({
   return new ContentStream(client, id, index, logger, parameters, attributes);
 }
 
-type WritableContentStream = Writable &
+export type WritableContentStream = Writable &
   Pick<ContentStream, 'getContentReferenceId' | 'getBytesWritten'>;
 
 export function getWritableContentStream(args: ContentStreamArgs): WritableContentStream {
   return getContentStream(args);
 }
 
-type ReadableContentStream = Readable;
+export type ReadableContentStream = Readable & Pick<ContentStream, 'getAttributesChunkId'>;
 
 export function getReadableContentStream(
   args: Omit<ContentStreamArgs, 'id' | 'attributes'> & { id: string }

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -123,9 +123,9 @@ export class ContentStream extends Duplex {
       const response = await this.client.get<FileChunkDocument>({
         id,
         index: this.index,
-        _source_includes: ['content'],
+        _source_includes: ['data'],
       });
-      return response?._source?.content;
+      return response?._source?.data;
     } catch (e) {
       if (e instanceof esErrors.ResponseError && e.statusCode === 404) {
         const readingHeadChunk = this.chunksRead <= 0;
@@ -213,7 +213,7 @@ export class ContentStream extends Duplex {
     return chunkNumber === 0 ? this.getHeadChunkId() : `${chunkNumber}.${this.getId()}`;
   }
 
-  private async writeChunk(content: string) {
+  private async writeChunk(data: string) {
     const chunkId = this.getChunkId(this.chunksWritten);
 
     this.logger.debug(`Writing chunk #${this.chunksWritten} (${chunkId}).`);
@@ -222,7 +222,7 @@ export class ContentStream extends Duplex {
       id: chunkId,
       index: this.index,
       document: {
-        content,
+        data,
         head_chunk_id: this.chunksWritten > 0 ? this.getHeadChunkId() : undefined,
       },
     });

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -87,7 +87,6 @@ export class ContentStream extends Duplex {
       encoding: 'base64',
       size: -1,
       maxChunkSize: '4mb',
-      attributes: {},
     });
   }
 

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/index.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/index.ts
@@ -15,4 +15,6 @@ export type {
   ContentStreamArgs,
   ContentStreamEncoding,
   ContentStreamParameters,
+  ReadableContentStream,
+  WritableContentStream,
 } from './content_stream';

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -84,6 +84,9 @@ export class ElasticsearchBlobStorage implements BlobStorage {
         attributes,
       });
       await pipeline(src, dest);
+
+      if (attributes) this.esClient.indices.refresh({ index: this.index }).catch(() => {}); // Enable search on attrs, fire and forget
+
       return {
         id: dest.getDocumentId()!,
         size: dest.getBytesWritten(),

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -10,7 +10,7 @@ import { errors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { pipeline as _pipeline, Readable } from 'stream';
 import { promisify } from 'util';
-import type { BlobStorage } from '../../types';
+import type { BlobAttributes, BlobStorage } from '../../types';
 import { getReadableContentStream, getWritableContentStream } from './content_stream';
 import { mappings } from './mappings';
 
@@ -65,6 +65,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     }
   }
 
+  // TODO: Use blob attributes!
   public async upload(src: Readable): Promise<{ id: string; size: number }> {
     await this.createIndexIfNotExists();
 
@@ -101,6 +102,10 @@ export class ElasticsearchBlobStorage implements BlobStorage {
         size,
       },
     });
+  }
+
+  public async getAttributes(id: string): Promise<BlobAttributes> {
+    throw new Error('Method not implemented.');
   }
 
   public async delete(id: string): Promise<void> {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -10,7 +10,7 @@ import { errors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { pipeline as _pipeline, Readable } from 'stream';
 import { promisify } from 'util';
-import type { BlobAttributes, BlobStorage } from '../../types';
+import type { BlobAttributes, BlobStorage, CreateBlobAttributes } from '../../types';
 import { getReadableContentStream, getWritableContentStream } from './content_stream';
 import { mappings } from './mappings';
 
@@ -65,8 +65,10 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     }
   }
 
-  // TODO: Use blob attributes!
-  public async upload(src: Readable): Promise<{ id: string; size: number }> {
+  public async upload(
+    src: Readable,
+    attributes?: CreateBlobAttributes
+  ): Promise<{ id: string; size: number }> {
     await this.createIndexIfNotExists();
 
     try {
@@ -79,6 +81,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
           encoding: 'base64',
           maxChunkSize: this.chunkSize,
         },
+        attributes,
       });
       await pipeline(src, dest);
       return {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -119,7 +119,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     const doc = await this.esClient.getSource<FileChunkDocument>({
       index: this.index,
       id: this.getReadableContentStream(id).getAttributesChunkId(),
-      _source_includes: ['app_search_data', 'app_meta_data'],
+      _source_includes: ['app_meta_data'],
       refresh: true,
     });
 
@@ -127,7 +127,6 @@ export class ElasticsearchBlobStorage implements BlobStorage {
       throw new Error('File not found');
     }
     return {
-      ...doc.app_search_data,
       ...doc.app_meta_data,
     };
   }

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -88,7 +88,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
       if (attributes) this.esClient.indices.refresh({ index: this.index }).catch(() => {}); // Enable search on attrs, fire and forget
 
       return {
-        id: dest.getDocumentId()!,
+        id: dest.getContentReferenceId()!,
         size: dest.getBytesWritten(),
       };
     } catch (e) {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -119,7 +119,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     const doc = await this.esClient.getSource<FileChunkDocument>({
       index: this.index,
       id: this.getReadableContentStream(id).getAttributesChunkId(),
-      _source_includes: ['app_meta_data'],
+      _source_includes: ['app_metadata'],
       refresh: true,
     });
 
@@ -127,7 +127,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
       throw new Error('File not found');
     }
     return {
-      ...doc.app_meta_data,
+      ...doc.app_metadata,
     };
   }
 

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -136,16 +136,20 @@ describe('Elasticsearch blob storage', () => {
   });
 
   it('sets attributes on a blob', async () => {
-    const attrs: BlobAttributes = [['foo', 'bar']];
+    const attrs: BlobAttributes = [
+      ['foo', 'bar'],
+      ['myObject', { foo: 'bar' }],
+    ];
     const { id } = await esBlobStorage.upload(Readable.from(['upload this']), attrs);
     const attrsResponse = await esBlobStorage.getAttributes(id);
     expect(attrsResponse).toEqual(
       expect.objectContaining({
         foo: 'bar',
+        myObject: { foo: 'bar' },
       })
     );
 
-    const unsearchableAttributePath = 'app_meta_data.foo';
+    const unsearchableAttributePath = 'app_metadata.foo';
 
     // We cannot search by metadata
     const {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -149,23 +149,24 @@ describe('Elasticsearch blob storage', () => {
       })
     );
 
-    // We can search by searchable attributes
+    const searchableAttributePath = 'app_search_data.searchable.a';
+    const unsearchableAttributePath = 'app_meta_data.foo';
 
-    await esClient.indices.refresh({ index: BLOB_STORAGE_SYSTEM_INDEX_NAME });
+    // We can search by searchable attributes
     const {
       hits: { hits: hits1 },
     } = await esClient.search<FileChunkDocument>({
       index: BLOB_STORAGE_SYSTEM_INDEX_NAME,
       query: {
         match: {
-          'app_search_data.searchable.a': 1,
+          [searchableAttributePath]: 1,
         },
       },
       _source_includes: ['app_search_data', 'app_meta_data'],
     });
     expect(hits1).toHaveLength(1);
-    expect(hits1[0]).toHaveProperty('_source.app_search_data.searchable.a', 1);
-    expect(hits1[0]).toHaveProperty('_source.app_meta_data.foo', 'bar'); // non searchable attributes are included
+    expect(hits1[0]).toHaveProperty(`_source.${searchableAttributePath}`, 1);
+    expect(hits1[0]).toHaveProperty(`_source.${unsearchableAttributePath}`, 'bar'); // non searchable attributes are included
 
     // We cannot search by other attributes
     const {
@@ -174,7 +175,7 @@ describe('Elasticsearch blob storage', () => {
       index: BLOB_STORAGE_SYSTEM_INDEX_NAME,
       query: {
         match: {
-          'app_meta_data.searchable.foo': 'bar',
+          [unsearchableAttributePath]: 'bar',
         },
       },
     });

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -6,7 +6,6 @@
  */
 
 import sinon from 'sinon';
-import {} from 'lodash';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { Readable } from 'stream';
 import {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -5,16 +5,79 @@
  * 2.0.
  */
 
-import { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type {
+  MappingTypeMapping,
+  MappingProperty,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { JsonValue } from '@kbn/utility-types';
 
 export interface FileChunkDocument {
-  content: string;
+  /**
+   * Data contents. Could be part of a file (chunk) or the entire file.
+   */
+  data: string;
+
+  /**
+   * If a file spans multiple documents, this field points to the first document.
+   *
+   * @note This is used to conveniently delete all of a file's chunks by
+   * issuing a single delete-by query.
+   *
+   * @note It is not recommended to use this for file retrieval by query because
+   * loading all file chunks into ES memory can degrade cluster performance.
+   */
   head_chunk_id?: string;
+
+  /**
+   * Size of this document-part (chunk) in bytes.
+   */
+  size?: number;
+
+  /**
+   * Compression used on the file.
+   */
+  compression?: 'gzip' | string;
+
+  /**
+   * Custom data that can be added by any application for retrieval purposes.
+   *
+   * @note Suitable for tags or other identifiers.
+   */
+  app_search_data?: {
+    [key: string]: JsonValue | undefined;
+  };
+
+  /**
+   * Custom data that can be added by an application for its own purposes.
+   *
+   * @note Suitable for data about a file chunk that should not be searchable but
+   * used by an application when downloaded later.
+   */
+  app_extra_data?: {
+    [key: string]: JsonValue | undefined;
+  };
 }
 
 export const mappings: MappingTypeMapping = {
   properties: {
-    content: { type: 'binary' }, // Base64 encoded content, binary fields are automatically marked as not searchable
-    head_chunk_id: { type: 'keyword' },
-  },
+    data: { type: 'binary' }, // Base64 encoded content, binary fields are automatically marked as not searchable
+    head_chunk_id: { type: 'keyword', index: true },
+    size: {
+      index: false,
+      type: 'long',
+    },
+    compression: {
+      index: false,
+      type: 'keyword',
+    },
+    app_search_data: {
+      type: 'object',
+      dynamic: true,
+      properties: {},
+    },
+    app_extra_data: {
+      enabled: false, // Do not parse this value for mapping in ES
+      type: 'object',
+    },
+  } as Record<keyof FileChunkDocument, MappingProperty>, // Ensure that our ES types and TS types stay somewhat in sync
 } as const;

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -59,6 +59,7 @@ export interface FileChunkDocument {
 }
 
 export const mappings: MappingTypeMapping = {
+  dynamic: false,
   properties: {
     data: { type: 'binary' }, // Base64 encoded content, binary fields are automatically marked as not searchable
     head_chunk_id: { type: 'keyword', index: true },
@@ -78,6 +79,7 @@ export const mappings: MappingTypeMapping = {
     app_extra_data: {
       enabled: false, // Do not parse this value for mapping in ES
       type: 'object',
+      properties: {},
     },
   } as Record<keyof FileChunkDocument, MappingProperty>, // Ensure that our ES types and TS types stay somewhat in sync
 } as const;

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -50,7 +50,7 @@ export interface FileChunkDocument {
    * @note Suitable for data about a file chunk that should not be searchable but
    * used by an application when downloaded later.
    */
-  app_meta_data?: {
+  app_metadata?: {
     [key: string]: JsonValue;
   };
 }
@@ -68,7 +68,7 @@ export const mappings: MappingTypeMapping = {
       index: false,
       type: 'keyword',
     },
-    app_meta_data: {
+    app_metadata: {
       enabled: false, // Do not parse this value for mapping in ES
       type: 'object',
       properties: {},

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -11,6 +11,12 @@ import type {
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { JsonValue } from '@kbn/utility-types';
 
+/**
+ * These are the fields we expect to find a given document acting as a file chunk.
+ *
+ * @note not all fields are used by this adapter but this represents the standard
+ * shape for any consumers of BlobStorage in ES.
+ */
 export interface FileChunkDocument {
   /**
    * Data contents. Could be part of a file (chunk) or the entire file.

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -50,7 +50,7 @@ export interface FileChunkDocument {
    * @note Suitable for tags or other identifiers.
    */
   app_search_data?: {
-    [key: string]: JsonValue | undefined;
+    [key: string]: JsonValue;
   };
 
   /**
@@ -59,8 +59,8 @@ export interface FileChunkDocument {
    * @note Suitable for data about a file chunk that should not be searchable but
    * used by an application when downloaded later.
    */
-  app_extra_data?: {
-    [key: string]: JsonValue | undefined;
+  app_meta_data?: {
+    [key: string]: JsonValue;
   };
 }
 
@@ -82,7 +82,7 @@ export const mappings: MappingTypeMapping = {
       dynamic: true,
       properties: {},
     },
-    app_extra_data: {
+    app_meta_data: {
       enabled: false, // Do not parse this value for mapping in ES
       type: 'object',
       properties: {},

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -45,15 +45,6 @@ export interface FileChunkDocument {
   compression?: 'gzip' | string;
 
   /**
-   * Custom data that can be added by any application for retrieval purposes.
-   *
-   * @note Suitable for tags or other identifiers.
-   */
-  app_search_data?: {
-    [key: string]: JsonValue;
-  };
-
-  /**
    * Custom data that can be added by an application for its own purposes.
    *
    * @note Suitable for data about a file chunk that should not be searchable but
@@ -76,11 +67,6 @@ export const mappings: MappingTypeMapping = {
     compression: {
       index: false,
       type: 'keyword',
-    },
-    app_search_data: {
-      type: 'object',
-      dynamic: true,
-      properties: {},
     },
     app_meta_data: {
       enabled: false, // Do not parse this value for mapping in ES

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -8,11 +8,16 @@
 import type { JsonValue } from '@kbn/utility-types';
 import type { Readable } from 'stream';
 
-type CreateBlobAttribute = [key: string, value: JsonValue, options?: { searchable?: boolean }];
+export type BlobAttribute = [key: string, value: JsonValue, options?: { searchable?: boolean }];
 
-export type CreateBlobAttributes = CreateBlobAttribute[];
+/**
+ * An array of {@link BlobAttribute}.
+ *
+ * @note Each key value must be unique.
+ */
+export type BlobAttributes = BlobAttribute[];
 
-export interface BlobAttributes {
+export interface BlobAttributesResponse {
   [key: string]: JsonValue;
 }
 
@@ -35,7 +40,7 @@ export interface BlobStorage {
    * Generates a random file ID and returns it upon successfully uploading a
    * file. The file size can be used when downloading the file later.
    */
-  upload(content: Readable, attrs?: CreateBlobAttributes): Promise<{ id: string; size: number }>;
+  upload(content: Readable, attrs?: BlobAttributes): Promise<{ id: string; size: number }>;
 
   /**
    * Download a file.
@@ -48,7 +53,7 @@ export interface BlobStorage {
   /**
    * Get attributes of a blob.
    */
-  getAttributes(id: string): Promise<BlobAttributes>;
+  getAttributes(id: string): Promise<BlobAttributesResponse>;
 
   /**
    * Delete a file given a unique ID.

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -8,17 +8,9 @@
 import type { JsonValue } from '@kbn/utility-types';
 import type { Readable } from 'stream';
 
-interface CreateBlobAttribute {
-  /**
-   * Whether this attribute is intended to be used for searching against.
-   */
-  searchable?: boolean;
-  value: JsonValue;
-}
+type CreateBlobAttribute = [key: string, value: JsonValue, options?: { searchable?: boolean }];
 
-export interface CreateBlobAttributes {
-  [attributeKey: string]: CreateBlobAttribute;
-}
+export type CreateBlobAttributes = CreateBlobAttribute[];
 
 export interface BlobAttributes {
   [key: string]: JsonValue;
@@ -43,7 +35,7 @@ export interface BlobStorage {
    * Generates a random file ID and returns it upon successfully uploading a
    * file. The file size can be used when downloading the file later.
    */
-  upload(content: Readable, attrs?: BlobAttributes): Promise<{ id: string; size: number }>;
+  upload(content: Readable, attrs?: CreateBlobAttributes): Promise<{ id: string; size: number }>;
 
   /**
    * Download a file.

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -5,7 +5,24 @@
  * 2.0.
  */
 
+import type { JsonValue } from '@kbn/utility-types';
 import type { Readable } from 'stream';
+
+interface CreateBlobAttribute {
+  /**
+   * Whether this attribute is intended to be used for searching against.
+   */
+  searchable?: boolean;
+  value: JsonValue;
+}
+
+export interface CreateBlobAttributes {
+  [attributeKey: string]: CreateBlobAttribute;
+}
+
+export interface BlobAttributes {
+  [key: string]: JsonValue;
+}
 
 /**
  * An interface that must be implemented by any blob storage adapter.
@@ -26,7 +43,7 @@ export interface BlobStorage {
    * Generates a random file ID and returns it upon successfully uploading a
    * file. The file size can be used when downloading the file later.
    */
-  upload(content: Readable): Promise<{ id: string; size: number }>;
+  upload(content: Readable, attrs?: BlobAttributes): Promise<{ id: string; size: number }>;
 
   /**
    * Download a file.
@@ -35,6 +52,11 @@ export interface BlobStorage {
    * stream.
    */
   download(args: { id: string; size?: number }): Promise<Readable>;
+
+  /**
+   * Get attributes of a blob.
+   */
+  getAttributes(id: string): Promise<BlobAttributes>;
 
   /**
    * Delete a file given a unique ID.

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -8,7 +8,7 @@
 import type { JsonValue } from '@kbn/utility-types';
 import type { Readable } from 'stream';
 
-export type BlobAttribute = [key: string, value: JsonValue, options?: { searchable?: boolean }];
+export type BlobAttribute = [key: string, value: JsonValue];
 
 /**
  * An array of {@link BlobAttribute}.


### PR DESCRIPTION
## Summary

Expands the blob storage mappings to include fields for storing blob store attributes.

## Notes to reviewer

Currently the assumption is that we have attributes that will be searched over and attributes that will not. To optimize for storing this data in ES we will require that consumers need to choose up front which attributes that want to search over (like tags).