### PR TITLE
[8.3] [Response Ops] Fixing scripted metric agg in actions telemetry (#133612)

### DIFF
--- a/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
@@ -7,7 +7,10 @@
 
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { elasticsearchClientMock } from '@kbn/core/server/elasticsearch/client/mocks';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { getExecutionsPerDayCount, getInUseTotalCount, getTotalCount } from './actions_telemetry';
+
+const mockLogger = loggingSystemMock.create().get();
 
 describe('actions telemetry', () => {
   test('getTotalCount should replace first symbol . to __ for action types names', async () => {
@@ -97,7 +100,7 @@ describe('actions telemetry', () => {
         },
       }
     );
-    const telemetry = await getTotalCount(mockEsClient, 'test');
+    const telemetry = await getTotalCount(mockEsClient, 'test', mockLogger);
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(1);
 
@@ -110,6 +113,24 @@ Object {
     "some.type": 1,
   },
   "countTotal": 4,
+}
+`);
+  });
+
+  test('getTotalCount should return empty results if query throws error', async () => {
+    const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    mockEsClient.search.mockRejectedValue(new Error('oh no'));
+
+    const telemetry = await getTotalCount(mockEsClient, 'test', mockLogger);
+
+    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `Error executing actions telemetry task: getTotalCount - {}`
+    );
+    expect(telemetry).toMatchInlineSnapshot(`
+Object {
+  "countByType": Object {},
+  "countTotal": 0,
 }
 `);
   });
@@ -161,7 +182,7 @@ Object {
         ],
       },
     });
-    const telemetry = await getInUseTotalCount(mockEsClient, 'test');
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test', mockLogger);
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(2);
     expect(telemetry).toMatchInlineSnapshot(`
@@ -238,7 +259,7 @@ Object {
         ],
       },
     });
-    const telemetry = await getInUseTotalCount(mockEsClient, 'test', undefined, [
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test', mockLogger, undefined, [
       {
         id: 'test',
         actionTypeId: '.email',
@@ -275,6 +296,27 @@ Object {
   "countEmailByService": Object {},
   "countNamespaces": 1,
   "countTotal": 4,
+}
+`);
+  });
+
+  test('getInUseTotalCount should return empty results if query throws error', async () => {
+    const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    mockEsClient.search.mockRejectedValue(new Error('oh no'));
+
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test', mockLogger);
+
+    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `Error executing actions telemetry task: getInUseTotalCount - {}`
+    );
+    expect(telemetry).toMatchInlineSnapshot(`
+Object {
+  "countByAlertHistoryConnectorType": 0,
+  "countByType": Object {},
+  "countEmailByService": Object {},
+  "countNamespaces": 0,
+  "countTotal": 0,
 }
 `);
   });
@@ -366,7 +408,7 @@ Object {
         },
       }
     );
-    const telemetry = await getTotalCount(mockEsClient, 'test', [
+    const telemetry = await getTotalCount(mockEsClient, 'test', mockLogger, [
       {
         id: 'test',
         actionTypeId: '.test',
@@ -479,7 +521,7 @@ Object {
         ],
       },
     });
-    const telemetry = await getInUseTotalCount(mockEsClient, 'test', undefined, [
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test', mockLogger, undefined, [
       {
         id: 'anotherServerLog',
         actionTypeId: '.server-log',
@@ -587,7 +629,7 @@ Object {
         ],
       },
     });
-    const telemetry = await getInUseTotalCount(mockEsClient, 'test');
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test', mockLogger);
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(2);
     expect(telemetry).toMatchInlineSnapshot(`
@@ -683,7 +725,7 @@ Object {
         },
       }
     );
-    const telemetry = await getExecutionsPerDayCount(mockEsClient, 'test');
+    const telemetry = await getExecutionsPerDayCount(mockEsClient, 'test', mockLogger);
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(1);
     expect(telemetry).toStrictEqual({
@@ -704,5 +746,27 @@ Object {
       },
       countTotal: 120,
     });
+  });
+
+  test('getExecutionsPerDayCount should return empty results if query throws error', async () => {
+    const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    mockEsClient.search.mockRejectedValue(new Error('oh no'));
+
+    const telemetry = await getExecutionsPerDayCount(mockEsClient, 'test', mockLogger);
+
+    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `Error executing actions telemetry task: getExecutionsPerDayCount - {}`
+    );
+    expect(telemetry).toMatchInlineSnapshot(`
+Object {
+  "avgExecutionTime": 0,
+  "avgExecutionTimeByType": Object {},
+  "countByType": Object {},
+  "countFailed": 0,
+  "countFailedByType": Object {},
+  "countTotal": 0,
+}
+`);
   });
 });

--- a/x-pack/plugins/actions/server/usage/actions_telemetry.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.ts
@@ -6,13 +6,14 @@
  */
 
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { ElasticsearchClient } from '@kbn/core/server';
+import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { AlertHistoryEsIndexConnectorId } from '../../common';
 import { ActionResult, PreConfiguredAction } from '../types';
 
 export async function getTotalCount(
   esClient: ElasticsearchClient,
   kibanaIndex: string,
+  logger: Logger,
   preconfiguredActions?: PreConfiguredAction[]
 ) {
   const scriptedMetric = {
@@ -28,62 +29,75 @@ export async function getTotalCount(
       // Reduce script is executed across all clusters, so we need to add up all the total from each cluster
       // This also needs to account for having no data
       reduce_script: `
-        Map result = [:];
-        for (Map m : states.toArray()) {
-          if (m !== null) {
-            for (String k : m.keySet()) {
-              result.put(k, result.containsKey(k) ? result.get(k) + m.get(k) : m.get(k));
-            }
+        HashMap result = new HashMap();
+        HashMap combinedTypes = new HashMap();
+        for (state in states) {
+          for (String type : state.types.keySet()) {
+            int typeCount = combinedTypes.containsKey(type) ? combinedTypes.get(type) + state.types.get(type) : state.types.get(type);
+            combinedTypes.put(type, typeCount);
           }
         }
+
+        result.types = combinedTypes;
         return result;
       `,
     },
   };
 
-  const searchResult = await esClient.search({
-    index: kibanaIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: [{ term: { type: 'action' } }],
+  try {
+    const searchResult = await esClient.search({
+      index: kibanaIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: [{ term: { type: 'action' } }],
+          },
+        },
+        aggs: {
+          byActionTypeId: scriptedMetric,
         },
       },
-      aggs: {
-        byActionTypeId: scriptedMetric,
-      },
-    },
-  });
-  // @ts-expect-error aggegation type is not specified
-  const aggs = searchResult.aggregations?.byActionTypeId.value?.types;
-  const countByType = Object.keys(aggs).reduce(
-    // ES DSL aggregations are returned as `any` by esClient.search
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (obj: any, key: string) => ({
-      ...obj,
-      [replaceFirstAndLastDotSymbols(key)]: aggs[key],
-    }),
-    {}
-  );
-  if (preconfiguredActions && preconfiguredActions.length) {
-    for (const preconfiguredAction of preconfiguredActions) {
-      const actionTypeId = replaceFirstAndLastDotSymbols(preconfiguredAction.actionTypeId);
-      countByType[actionTypeId] = countByType[actionTypeId] || 0;
-      countByType[actionTypeId]++;
+    });
+    // @ts-expect-error aggegation type is not specified
+    const aggs = searchResult.aggregations?.byActionTypeId.value?.types;
+    const countByType = Object.keys(aggs).reduce(
+      // ES DSL aggregations are returned as `any` by esClient.search
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (obj: any, key: string) => ({
+        ...obj,
+        [replaceFirstAndLastDotSymbols(key)]: aggs[key],
+      }),
+      {}
+    );
+    if (preconfiguredActions && preconfiguredActions.length) {
+      for (const preconfiguredAction of preconfiguredActions) {
+        const actionTypeId = replaceFirstAndLastDotSymbols(preconfiguredAction.actionTypeId);
+        countByType[actionTypeId] = countByType[actionTypeId] || 0;
+        countByType[actionTypeId]++;
+      }
     }
+    return {
+      countTotal:
+        Object.keys(aggs).reduce(
+          (total: number, key: string) => parseInt(aggs[key], 10) + total,
+          0
+        ) + (preconfiguredActions?.length ?? 0),
+      countByType,
+    };
+  } catch (err) {
+    logger.warn(`Error executing actions telemetry task: getTotalCount - ${JSON.stringify(err)}`);
+    return {
+      countTotal: 0,
+      countByType: {},
+    };
   }
-  return {
-    countTotal:
-      Object.keys(aggs).reduce((total: number, key: string) => parseInt(aggs[key], 10) + total, 0) +
-      (preconfiguredActions?.length ?? 0),
-    countByType,
-  };
 }
 
 export async function getInUseTotalCount(
   esClient: ElasticsearchClient,
   kibanaIndex: string,
+  logger: Logger,
   referenceType?: string,
   preconfiguredActions?: PreConfiguredAction[]
 ): Promise<{
@@ -223,142 +237,156 @@ export async function getInUseTotalCount(
     });
   }
 
-  const actionResults = await esClient.search({
-    index: kibanaIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: {
-            bool: {
-              must_not: {
-                term: {
-                  type: 'action_task_params',
+  try {
+    const actionResults = await esClient.search({
+      index: kibanaIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: {
+              bool: {
+                must_not: {
+                  term: {
+                    type: 'action_task_params',
+                  },
+                },
+                must: mustQuery,
+              },
+            },
+          },
+        },
+        aggs: {
+          refs: {
+            nested: {
+              path: 'references',
+            },
+            aggs: {
+              actionRefIds: scriptedMetric,
+            },
+          },
+          preconfigured_actions: {
+            nested: {
+              path: 'alert.actions',
+            },
+            aggs: {
+              preconfiguredActionRefIds: preconfiguredActionsScriptedMetric,
+            },
+          },
+        },
+      },
+    });
+
+    // @ts-expect-error aggegation type is not specified
+    const aggs = actionResults.aggregations.refs.actionRefIds.value;
+    const preconfiguredActionsAggs =
+      // @ts-expect-error aggegation type is not specified
+      actionResults.aggregations.preconfigured_actions?.preconfiguredActionRefIds.value;
+
+    const { hits: actions } = await esClient.search<{
+      action: ActionResult;
+      namespaces: string[];
+    }>({
+      index: kibanaIndex,
+      _source_includes: ['action', 'namespaces'],
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                term: { type: 'action' },
+              },
+              {
+                terms: {
+                  _id: Object.entries(aggs.connectorIds).map(([key]) => `action:${key}`),
                 },
               },
-              must: mustQuery,
-            },
+            ],
           },
         },
       },
-      aggs: {
-        refs: {
-          nested: {
-            path: 'references',
-          },
-          aggs: {
-            actionRefIds: scriptedMetric,
-          },
-        },
-        preconfigured_actions: {
-          nested: {
-            path: 'alert.actions',
-          },
-          aggs: {
-            preconfiguredActionRefIds: preconfiguredActionsScriptedMetric,
-          },
-        },
-      },
-    },
-  });
-
-  // @ts-expect-error aggegation type is not specified
-  const aggs = actionResults.aggregations.refs.actionRefIds.value;
-  const preconfiguredActionsAggs =
-    // @ts-expect-error aggegation type is not specified
-    actionResults.aggregations.preconfigured_actions?.preconfiguredActionRefIds.value;
-
-  const { hits: actions } = await esClient.search<{
-    action: ActionResult;
-    namespaces: string[];
-  }>({
-    index: kibanaIndex,
-    _source_includes: ['action', 'namespaces'],
-    body: {
-      query: {
-        bool: {
-          must: [
-            {
-              term: { type: 'action' },
-            },
-            {
-              terms: {
-                _id: Object.entries(aggs.connectorIds).map(([key]) => `action:${key}`),
-              },
-            },
-          ],
-        },
-      },
-    },
-  });
-
-  const countByActionTypeId = actions.hits.reduce(
-    (actionTypeCount: Record<string, number>, action) => {
-      const actionSource = action._source!;
-      const alertTypeId = replaceFirstAndLastDotSymbols(actionSource.action.actionTypeId);
-      const currentCount =
-        actionTypeCount[alertTypeId] !== undefined ? actionTypeCount[alertTypeId] : 0;
-      actionTypeCount[alertTypeId] = currentCount + 1;
-      return actionTypeCount;
-    },
-    {}
-  );
-
-  const namespacesList = actions.hits.reduce((_namespaces: Set<string>, action) => {
-    const namespaces = action._source?.namespaces ?? ['default'];
-    namespaces.forEach((namespace) => {
-      if (!_namespaces.has(namespace)) {
-        _namespaces.add(namespace);
-      }
     });
-    return _namespaces;
-  }, new Set<string>());
 
-  const countEmailByService = actions.hits
-    .filter((action) => action._source!.action.actionTypeId === '.email')
-    .reduce((emailServiceCount: Record<string, number>, action) => {
-      const service = (action._source!.action.config?.service ?? 'other') as string;
-      const currentCount =
-        emailServiceCount[service] !== undefined ? emailServiceCount[service] : 0;
-      emailServiceCount[service] = currentCount + 1;
-      return emailServiceCount;
-    }, {});
+    const countByActionTypeId = actions.hits.reduce(
+      (actionTypeCount: Record<string, number>, action) => {
+        const actionSource = action._source!;
+        const alertTypeId = replaceFirstAndLastDotSymbols(actionSource.action.actionTypeId);
+        const currentCount =
+          actionTypeCount[alertTypeId] !== undefined ? actionTypeCount[alertTypeId] : 0;
+        actionTypeCount[alertTypeId] = currentCount + 1;
+        return actionTypeCount;
+      },
+      {}
+    );
 
-  let preconfiguredAlertHistoryConnectors = 0;
-  const preconfiguredActionsRefs: Array<{
-    actionTypeId: string;
-    actionRef: string;
-  }> = preconfiguredActionsAggs ? Object.values(preconfiguredActionsAggs?.actionRefs) : [];
-  for (const { actionRef, actionTypeId: rawActionTypeId } of preconfiguredActionsRefs) {
-    const actionTypeId = replaceFirstAndLastDotSymbols(rawActionTypeId);
-    countByActionTypeId[actionTypeId] = countByActionTypeId[actionTypeId] || 0;
-    countByActionTypeId[actionTypeId]++;
-    if (actionRef === `preconfigured:${AlertHistoryEsIndexConnectorId}`) {
-      preconfiguredAlertHistoryConnectors++;
+    const namespacesList = actions.hits.reduce((_namespaces: Set<string>, action) => {
+      const namespaces = action._source?.namespaces ?? ['default'];
+      namespaces.forEach((namespace) => {
+        if (!_namespaces.has(namespace)) {
+          _namespaces.add(namespace);
+        }
+      });
+      return _namespaces;
+    }, new Set<string>());
+
+    const countEmailByService = actions.hits
+      .filter((action) => action._source!.action.actionTypeId === '.email')
+      .reduce((emailServiceCount: Record<string, number>, action) => {
+        const service = (action._source!.action.config?.service ?? 'other') as string;
+        const currentCount =
+          emailServiceCount[service] !== undefined ? emailServiceCount[service] : 0;
+        emailServiceCount[service] = currentCount + 1;
+        return emailServiceCount;
+      }, {});
+
+    let preconfiguredAlertHistoryConnectors = 0;
+    const preconfiguredActionsRefs: Array<{
+      actionTypeId: string;
+      actionRef: string;
+    }> = preconfiguredActionsAggs ? Object.values(preconfiguredActionsAggs?.actionRefs) : [];
+    for (const { actionRef, actionTypeId: rawActionTypeId } of preconfiguredActionsRefs) {
+      const actionTypeId = replaceFirstAndLastDotSymbols(rawActionTypeId);
+      countByActionTypeId[actionTypeId] = countByActionTypeId[actionTypeId] || 0;
+      countByActionTypeId[actionTypeId]++;
+      if (actionRef === `preconfigured:${AlertHistoryEsIndexConnectorId}`) {
+        preconfiguredAlertHistoryConnectors++;
+      }
+      if (preconfiguredActions && actionTypeId === '__email') {
+        const preconfiguredConnectorId = actionRef.split(':')[1];
+        const service = (preconfiguredActions.find(
+          (preconfConnector) => preconfConnector.id === preconfiguredConnectorId
+        )?.config?.service ?? 'other') as string;
+        const currentCount =
+          countEmailByService[service] !== undefined ? countEmailByService[service] : 0;
+        countEmailByService[service] = currentCount + 1;
+      }
     }
-    if (preconfiguredActions && actionTypeId === '__email') {
-      const preconfiguredConnectorId = actionRef.split(':')[1];
-      const service = (preconfiguredActions.find(
-        (preconfConnector) => preconfConnector.id === preconfiguredConnectorId
-      )?.config?.service ?? 'other') as string;
-      const currentCount =
-        countEmailByService[service] !== undefined ? countEmailByService[service] : 0;
-      countEmailByService[service] = currentCount + 1;
-    }
+
+    return {
+      countTotal: aggs.total + (preconfiguredActionsAggs?.total ?? 0),
+      countByType: countByActionTypeId,
+      countByAlertHistoryConnectorType: preconfiguredAlertHistoryConnectors,
+      countEmailByService,
+      countNamespaces: namespacesList.size,
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing actions telemetry task: getInUseTotalCount - ${JSON.stringify(err)}`
+    );
+    return {
+      countTotal: 0,
+      countByType: {},
+      countByAlertHistoryConnectorType: 0,
+      countEmailByService: {},
+      countNamespaces: 0,
+    };
   }
-
-  return {
-    countTotal: aggs.total + (preconfiguredActionsAggs?.total ?? 0),
-    countByType: countByActionTypeId,
-    countByAlertHistoryConnectorType: preconfiguredAlertHistoryConnectors,
-    countEmailByService,
-    countNamespaces: namespacesList.size,
-  };
 }
 
 export async function getInUseByAlertingTotalCounts(
   esClient: ElasticsearchClient,
   kibanaIndex: string,
+  logger: Logger,
   preconfiguredActions?: PreConfiguredAction[]
 ): Promise<{
   countTotal: number;
@@ -367,7 +395,7 @@ export async function getInUseByAlertingTotalCounts(
   countEmailByService: Record<string, number>;
   countNamespaces: number;
 }> {
-  return await getInUseTotalCount(esClient, kibanaIndex, 'alert', preconfiguredActions);
+  return await getInUseTotalCount(esClient, kibanaIndex, logger, 'alert', preconfiguredActions);
 }
 
 function replaceFirstAndLastDotSymbols(strToReplace: string) {
@@ -379,7 +407,8 @@ function replaceFirstAndLastDotSymbols(strToReplace: string) {
 
 export async function getExecutionsPerDayCount(
   esClient: ElasticsearchClient,
-  eventLogIndex: string
+  eventLogIndex: string,
+  logger: Logger
 ): Promise<{
   countTotal: number;
   countByType: Record<string, number>;
@@ -422,83 +451,85 @@ export async function getExecutionsPerDayCount(
     },
   };
 
-  const actionResults = await esClient.search({
-    index: eventLogIndex,
-    size: 0,
-    body: {
-      query: {
-        bool: {
-          filter: {
-            bool: {
-              must: [
-                {
-                  term: { 'event.action': 'execute' },
-                },
-                {
-                  term: { 'event.provider': 'actions' },
-                },
-                {
-                  range: {
-                    '@timestamp': {
-                      gte: 'now-1d',
+  try {
+    const actionResults = await esClient.search({
+      index: eventLogIndex,
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    term: { 'event.action': 'execute' },
+                  },
+                  {
+                    term: { 'event.provider': 'actions' },
+                  },
+                  {
+                    range: {
+                      '@timestamp': {
+                        gte: 'now-1d',
+                      },
                     },
                   },
-                },
-              ],
-            },
-          },
-        },
-      },
-      aggs: {
-        totalExecutions: {
-          nested: {
-            path: 'kibana.saved_objects',
-          },
-          aggs: {
-            byConnectorTypeId: scriptedMetric,
-          },
-        },
-        failedExecutions: {
-          filter: {
-            bool: {
-              filter: [
-                {
-                  term: {
-                    'event.outcome': 'failure',
-                  },
-                },
-              ],
-            },
-          },
-          aggs: {
-            refs: {
-              nested: {
-                path: 'kibana.saved_objects',
-              },
-              aggs: {
-                byConnectorTypeId: scriptedMetric,
+                ],
               },
             },
           },
         },
-        avgDuration: { avg: { field: 'event.duration' } },
-        avgDurationByType: {
-          nested: {
-            path: 'kibana.saved_objects',
+        aggs: {
+          totalExecutions: {
+            nested: {
+              path: 'kibana.saved_objects',
+            },
+            aggs: {
+              byConnectorTypeId: scriptedMetric,
+            },
           },
-          aggs: {
-            actionSavedObjects: {
-              filter: { term: { 'kibana.saved_objects.type': 'action' } },
-              aggs: {
-                byTypeId: {
-                  terms: {
-                    field: 'kibana.saved_objects.type_id',
+          failedExecutions: {
+            filter: {
+              bool: {
+                filter: [
+                  {
+                    term: {
+                      'event.outcome': 'failure',
+                    },
                   },
-                  aggs: {
-                    refs: {
-                      reverse_nested: {},
-                      aggs: {
-                        avgDuration: { avg: { field: 'event.duration' } },
+                ],
+              },
+            },
+            aggs: {
+              refs: {
+                nested: {
+                  path: 'kibana.saved_objects',
+                },
+                aggs: {
+                  byConnectorTypeId: scriptedMetric,
+                },
+              },
+            },
+          },
+          avgDuration: { avg: { field: 'event.duration' } },
+          avgDurationByType: {
+            nested: {
+              path: 'kibana.saved_objects',
+            },
+            aggs: {
+              actionSavedObjects: {
+                filter: { term: { 'kibana.saved_objects.type': 'action' } },
+                aggs: {
+                  byTypeId: {
+                    terms: {
+                      field: 'kibana.saved_objects.type_id',
+                    },
+                    aggs: {
+                      refs: {
+                        reverse_nested: {},
+                        aggs: {
+                          avgDuration: { avg: { field: 'event.duration' } },
+                        },
                       },
                     },
                   },
@@ -508,53 +539,65 @@ export async function getExecutionsPerDayCount(
           },
         },
       },
-    },
-  });
+    });
 
-  // @ts-expect-error aggegation type is not specified
-  const aggsExecutions = actionResults.aggregations.totalExecutions?.byConnectorTypeId.value;
-  // convert nanoseconds to milliseconds
-  const aggsAvgExecutionTime = Math.round(
     // @ts-expect-error aggegation type is not specified
-    actionResults.aggregations.avgDuration.value / (1000 * 1000)
-  );
-  const aggsFailedExecutions =
-    // @ts-expect-error aggegation type is not specified
-    actionResults.aggregations.failedExecutions?.refs?.byConnectorTypeId.value;
+    const aggsExecutions = actionResults.aggregations.totalExecutions?.byConnectorTypeId.value;
+    // convert nanoseconds to milliseconds
+    const aggsAvgExecutionTime = Math.round(
+      // @ts-expect-error aggegation type is not specified
+      actionResults.aggregations.avgDuration.value / (1000 * 1000)
+    );
+    const aggsFailedExecutions =
+      // @ts-expect-error aggegation type is not specified
+      actionResults.aggregations.failedExecutions?.refs?.byConnectorTypeId.value;
 
-  const avgDurationByType =
-    // @ts-expect-error aggegation type is not specified
-    actionResults.aggregations.avgDurationByType?.actionSavedObjects?.byTypeId?.buckets;
+    const avgDurationByType =
+      // @ts-expect-error aggegation type is not specified
+      actionResults.aggregations.avgDurationByType?.actionSavedObjects?.byTypeId?.buckets;
 
-  const avgExecutionTimeByType: Record<string, number> = avgDurationByType.reduce(
-    // @ts-expect-error aggegation type is not specified
-    (res: Record<string, number>, bucket) => {
-      res[replaceFirstAndLastDotSymbols(bucket.key)] = bucket?.refs.avgDuration.value;
-      return res;
-    },
-    {}
-  );
-
-  return {
-    countTotal: aggsExecutions.total,
-    countByType: Object.entries(aggsExecutions.connectorTypes).reduce(
-      (res: Record<string, number>, [key, value]) => {
-        // @ts-expect-error aggegation type is not specified
-        res[replaceFirstAndLastDotSymbols(key)] = value;
+    const avgExecutionTimeByType: Record<string, number> = avgDurationByType.reduce(
+      // @ts-expect-error aggegation type is not specified
+      (res: Record<string, number>, bucket) => {
+        res[replaceFirstAndLastDotSymbols(bucket.key)] = bucket?.refs.avgDuration.value;
         return res;
       },
       {}
-    ),
-    countFailed: aggsFailedExecutions.total,
-    countFailedByType: Object.entries(aggsFailedExecutions.connectorTypes).reduce(
-      (res: Record<string, number>, [key, value]) => {
-        // @ts-expect-error aggegation type is not specified
-        res[replaceFirstAndLastDotSymbols(key)] = value;
-        return res;
-      },
-      {}
-    ),
-    avgExecutionTime: aggsAvgExecutionTime,
-    avgExecutionTimeByType,
-  };
+    );
+
+    return {
+      countTotal: aggsExecutions.total,
+      countByType: Object.entries(aggsExecutions.connectorTypes).reduce(
+        (res: Record<string, number>, [key, value]) => {
+          // @ts-expect-error aggegation type is not specified
+          res[replaceFirstAndLastDotSymbols(key)] = value;
+          return res;
+        },
+        {}
+      ),
+      countFailed: aggsFailedExecutions.total,
+      countFailedByType: Object.entries(aggsFailedExecutions.connectorTypes).reduce(
+        (res: Record<string, number>, [key, value]) => {
+          // @ts-expect-error aggegation type is not specified
+          res[replaceFirstAndLastDotSymbols(key)] = value;
+          return res;
+        },
+        {}
+      ),
+      avgExecutionTime: aggsAvgExecutionTime,
+      avgExecutionTimeByType,
+    };
+  } catch (err) {
+    logger.warn(
+      `Error executing actions telemetry task: getExecutionsPerDayCount - ${JSON.stringify(err)}`
+    );
+    return {
+      countTotal: 0,
+      countByType: {},
+      countFailed: 0,
+      countFailedByType: {},
+      avgExecutionTime: 0,
+      avgExecutionTimeByType: {},
+    };
+  }
 }

--- a/x-pack/plugins/actions/server/usage/task.ts
+++ b/x-pack/plugins/actions/server/usage/task.ts
@@ -98,9 +98,9 @@ export function telemetryTaskRunner(
       async run() {
         const esClient = await getEsClient();
         return Promise.all([
-          getTotalCount(esClient, kibanaIndex, preconfiguredActions),
-          getInUseTotalCount(esClient, kibanaIndex, undefined, preconfiguredActions),
-          getExecutionsPerDayCount(esClient, eventLogIndex),
+          getTotalCount(esClient, kibanaIndex, logger, preconfiguredActions),
+          getInUseTotalCount(esClient, kibanaIndex, logger, undefined, preconfiguredActions),
+          getExecutionsPerDayCount(esClient, eventLogIndex, logger),
         ])
           .then(([totalAggegations, totalInUse, totalExecutionsPerDay]) => {
             return {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/actions_telemetry.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/actions_telemetry.ts
@@ -7,14 +7,9 @@
 
 import expect from '@kbn/expect';
 import { Spaces, Superuser } from '../../../scenarios';
-import {
-  getUrlPrefix,
-  getEventLog,
-  getTestRuleData,
-  ObjectRemover,
-  TaskManagerDoc,
-} from '../../../../common/lib';
+import { getUrlPrefix, getEventLog, getTestRuleData, TaskManagerDoc } from '../../../../common/lib';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export
 export default function createActionsTelemetryTests({ getService }: FtrProviderContext) {
@@ -22,26 +17,19 @@ export default function createActionsTelemetryTests({ getService }: FtrProviderC
   const es = getService('es');
   const retry = getService('retry');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const esArchiver = getService('esArchiver');
 
   describe('actions telemetry', () => {
     const alwaysFiringRuleId: { [key: string]: string } = {};
-    const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/event_log_telemetry');
       // reset the state in the telemetry task
-      await es.update({
-        id: `task:Actions-actions_telemetry`,
-        index: '.kibana_task_manager',
-        body: {
-          doc: {
-            task: {
-              state: '{}',
-            },
-          },
-        },
-      });
+      await setupSpacesAndUsers(getService);
     });
-    after(() => objectRemover.removeAll());
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/event_log_telemetry');
+    });
 
     async function createConnector(opts: { name: string; space: string; connectorTypeId: string }) {
       const { name, space, connectorTypeId } = opts;
@@ -56,7 +44,6 @@ export default function createActionsTelemetryTests({ getService }: FtrProviderC
           secrets: {},
         })
         .expect(200);
-      objectRemover.add(space, createdConnector.id, 'action', 'actions');
       return createdConnector.id;
     }
 
@@ -68,7 +55,6 @@ export default function createActionsTelemetryTests({ getService }: FtrProviderC
         .auth(Superuser.username, Superuser.password)
         .send(getTestRuleData(ruleOverwrites));
       expect(ruleResponse.status).to.eql(200);
-      objectRemover.add(space, ruleResponse.body.id, 'rule', 'alerting');
       return ruleResponse.body.id;
     }
 

--- a/x-pack/test/functional/es_archives/event_log_telemetry/data.json
+++ b/x-pack/test/functional/es_archives/event_log_telemetry/data.json
@@ -30,6 +30,35 @@
 {
   "type": "doc",
   "value": {
+    "id": "task:Actions-actions_telemetry",
+    "index": ".kibana_task_manager_1",
+    "source": {
+      "migrationVersion": {
+        "task": "8.2.0"
+      },
+      "references": [
+      ],
+      "task": {
+        "attempts": 0,
+        "params": "{}",
+        "retryAt": null,
+        "runAt": "2020-09-04T11:51:05.197Z",
+        "scheduledAt": "2020-09-04T11:51:05.197Z",
+        "startedAt": null,
+        "state": "{}",
+        "ownerId": null,
+        "status": "idle",
+        "taskType": "actions_telemetry"
+      },
+      "type": "task",
+      "updated_at": "2020-09-04T11:51:05.197Z"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
     "id": "X6bLb3UBt6Z_MVvSTfYk",
     "index": ".kibana-event-log-8.0.0-000001",
     "source": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Response Ops] Fixing scripted metric agg in actions telemetry (#133612)](https://github.com/elastic/kibana/pull/133612)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)