### PR TITLE
[CI] Add opt-in on-merge action that automatically assigns version labels

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -29,6 +29,7 @@ jobs:
         )
         || (github.event.action == 'closed')
       )
+    steps:
       - name: Checkout Actions
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -7,7 +7,7 @@ on:
       - labeled
 
 jobs:
-  backport:
+  on-merge:
     name: 'Label and Backport'
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,41 +1,45 @@
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
       - closed
+      - labeled
 
 jobs:
-  gaps:
-    name: Fix Version Label Gaps
-    # This fix also runs as part of the backport action (because backport depends on the labels)
-    # So we only need to trigger it for merged PRs that also won't be auto-backported
+  backport:
+    name: 'Label and Backport'
+    runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true
-      && !contains(github.event.pull_request.labels.*.name, 'auto-backport')
-      && !(
+      && (
         contains(github.event.pull_request.labels.*.name, 'backport:prev-minor')
         || contains(github.event.pull_request.labels.*.name, 'backport:prev-major')
         || contains(github.event.pull_request.labels.*.name, 'backport:all-open')
         || contains(github.event.pull_request.labels.*.name, 'backport:auto-version')
       )
-      && !(
-        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+      && (
+        (
+          github.event.action == 'labeled' && (
+            github.event.label.name == 'backport:prev-minor'
+            || github.event.label.name == 'backport:prev-major'
+            || github.event.label.name == 'backport:all-open'
+            || github.event.label.name == 'backport:auto-version'
+          )
+        )
         || (github.event.action == 'closed')
       )
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout Actions
         uses: actions/checkout@v2
         with:
           repository: 'elastic/kibana-github-actions'
-          ref: main
+          ref: on-merge
           path: ./actions
 
       - name: Install Actions
         run: npm install --production --prefix ./actions
 
-      - name: Run Fix Gaps
-        uses: ./actions/fix-version-gaps
+      - name: Run On-Merge
+        uses: ./actions/on-merge
         with:
           github_token: ${{secrets.KIBANAMACHINE_TOKEN}}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'elastic/kibana-github-actions'
-          ref: on-merge
+          ref: main
           path: ./actions
 
       - name: Install Actions


### PR DESCRIPTION
Implements a portion of #127659 / https://github.com/elastic/kibana/issues/127659#issuecomment-1083615556

- Adds new on-merge github action that is currently opt-in until all functionality is complete
- Adds the `v<current-version>` label to all PRs targeting `main`
- Resolves `backport:prev-minor`, `backport:prev-major`, `backport:all-open` to a list of appropriate versions from [versions.json](https://github.com/elastic/kibana/blob/main/versions.json) and adds them as labels to the PR
  - Once all functionality is complete, these labels will be added when the PRs are merged, rather than at this moment
- Also adds labels for any open versions after the earliest version you specify.
  - During opt-in period, this requires specifying `backport:auto-version` if you don't use any of the other `backport:*` labels
- Creates backports to the resolved version branches

Tested in my fork: https://github.com/brianseeders/kibana/pull/48