### PR TITLE
Revert "[Console] Handle encoded characters in API requests (#132191)"

### DIFF
--- a/src/plugins/console/server/lib/proxy_request.test.ts
+++ b/src/plugins/console/server/lib/proxy_request.test.ts
@@ -149,21 +149,5 @@ describe(`Console's send request`, () => {
       const [httpRequestOptions] = stub.firstCall.args;
       expect((httpRequestOptions as any).path).toEqual('/%3Cmy-index-%7Bnow%2Fd%7D%3E');
     });
-
-    it('should not encode path if it does not require encoding', async () => {
-      const result = await proxyRequest({
-        agent: null as any,
-        headers: {},
-        method: 'get',
-        payload: null as any,
-        timeout: 30000,
-        uri: new URL(`http://noone.nowhere.none/my-index/_doc/this%2Fis%2Fa%2Fdoc`),
-        originalPath: 'my-index/_doc/this%2Fis%2Fa%2Fdoc',
-      });
-
-      expect(result).toEqual('done');
-      const [httpRequestOptions] = stub.firstCall.args;
-      expect((httpRequestOptions as any).path).toEqual('/my-index/_doc/this%2Fis%2Fa%2Fdoc');
-    });
   });
 });

--- a/src/plugins/console/server/lib/proxy_request.ts
+++ b/src/plugins/console/server/lib/proxy_request.ts
@@ -22,7 +22,6 @@ interface Args {
   timeout: number;
   headers: http.OutgoingHttpHeaders;
   rejectUnauthorized?: boolean;
-  originalPath?: string;
 }
 
 /**
@@ -40,6 +39,11 @@ const sanitizeHostname = (hostName: string): string =>
 const encodePathname = (pathname: string) => {
   const decodedPath = new URLSearchParams(`path=${pathname}`).get('path') ?? '';
 
+  // Skip if it is valid
+  if (pathname === decodedPath) {
+    return pathname;
+  }
+
   return `/${encodeURIComponent(trimStart(decodedPath, '/'))}`;
 };
 
@@ -54,17 +58,11 @@ export const proxyRequest = ({
   timeout,
   payload,
   rejectUnauthorized,
-  originalPath,
 }: Args) => {
-  const { hostname, port, protocol, search, pathname: percentEncodedPath } = uri;
+  const { hostname, port, protocol, pathname, search } = uri;
   const client = uri.protocol === 'https:' ? https : http;
-  let pathname = uri.pathname;
+  const encodedPath = encodePathname(pathname);
   let resolved = false;
-  const requiresEncoding = trimStart(originalPath, '/') !== trimStart(percentEncodedPath, '/');
-
-  if (requiresEncoding) {
-    pathname = encodePathname(pathname);
-  }
 
   let resolve: (res: http.IncomingMessage) => void;
   let reject: (res: unknown) => void;
@@ -86,7 +84,7 @@ export const proxyRequest = ({
     host: sanitizeHostname(hostname),
     port: port === '' ? undefined : parseInt(port, 10),
     protocol,
-    path: `${pathname}${search || ''}`,
+    path: `${encodedPath}${search || ''}`,
     headers: {
       ...finalUserHeaders,
       'content-type': 'application/json',

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -175,7 +175,6 @@ export const createHandler =
           payload: body,
           rejectUnauthorized,
           agent,
-          originalPath: path,
         });
 
         break;


### PR DESCRIPTION
This reverts commit 52dca01b231372129a76e885c283a5eaab51e889, introduced by https://github.com/elastic/kibana/pull/132191, until we fix https://github.com/elastic/kibana/issues/133965.
