### PR TITLE
[8.2] [Canvas] Fix by-reference embeddable migration error during workpad migration (#133911)

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -62,10 +62,12 @@ export function embeddableFunctionFactory({
         const embeddableInput = decode(state.arguments.config[0] as string);
 
         const embeddableType = state.arguments.type[0];
-        const migratedInput = migrateFn({ ...embeddableInput, type: embeddableType });
 
-        state.arguments.config[0] = encode(migratedInput);
-        state.arguments.type[0] = migratedInput.type as string;
+        if (embeddableInput.explicitInput.attributes || embeddableInput.explicitInput.savedVis) {
+          const migratedInput = migrateFn({ ...embeddableInput, type: embeddableType });
+          state.arguments.config[0] = encode(migratedInput);
+          state.arguments.type[0] = migratedInput.type as string;
+        }
 
         return state;
       };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[Canvas] Fix by-reference embeddable migration error during workpad migration (#133911)](https://github.com/elastic/kibana/pull/133911)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)