### PR TITLE
[8.3] [Security Solution][Detections] Adds confirmation modal with docs link when updating rules if V1/V2 jobs are installed (#128334)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/affected_job_ids.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/affected_job_ids.ts
@@ -13,51 +13,60 @@
 // the IDs from those modules (as found in e.g.
 // x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json)
 // allows us to make this determination from a single API call.
+//
+// Note: In 8.3 the V3 ML modules were released (#131166) and a large portion of the V1/V2
+// jobs were removed or replaced. We'll use this same list of affectedJobIds to show a modal
+// before updating their Detection Rules to inform users of this change and any actions that
+// must be taken before updating  to ensure continued functionality if they still need to run
+// the V1/V2 jobs
+// For details see: https://github.com/elastic/kibana/issues/128121
 export const affectedJobIds: string[] = [
   // security_linux module
-  'v2_rare_process_by_host_linux_ecs',
-  'v2_linux_rare_metadata_user',
-  'v2_linux_rare_metadata_process',
-  'v2_linux_anomalous_user_name_ecs',
-  'v2_linux_anomalous_process_all_hosts_ecs',
-  'v2_linux_anomalous_network_port_activity_ecs',
+  'v2_rare_process_by_host_linux_ecs', // Replaced by: v3_rare_process_by_host_linux_ecs
+  'v2_linux_rare_metadata_user', // Replaced by: v3_linux_rare_metadata_user
+  'v2_linux_rare_metadata_process', // Replaced by: v3_linux_rare_metadata_process
+  'v2_linux_anomalous_user_name_ecs', // Replaced by: v3_linux_anomalous_user_name_ecs
+  'v2_linux_anomalous_process_all_hosts_ecs', // Replaced by: v3_linux_anomalous_process_all_hosts_ecs
+  'v2_linux_anomalous_network_port_activity_ecs', // Replaced by: v3_linux_anomalous_network_port_activity_ecs
   // security_windows module
-  'v2_rare_process_by_host_windows_ecs',
-  'v2_windows_anomalous_network_activity_ecs',
-  'v2_windows_anomalous_path_activity_ecs',
-  'v2_windows_anomalous_process_all_hosts_ecs',
-  'v2_windows_anomalous_process_creation',
-  'v2_windows_anomalous_user_name_ecs',
-  'v2_windows_rare_metadata_process',
-  'v2_windows_rare_metadata_user',
+  'v2_rare_process_by_host_windows_ecs', // Replaced by: v3_rare_process_by_host_windows_ecs
+  'v2_windows_anomalous_network_activity_ecs', // Replaced by: v3_windows_anomalous_network_activity_ecs
+  'v2_windows_anomalous_path_activity_ecs', // Replaced by: v3_windows_anomalous_path_activity_ecs
+  'v2_windows_anomalous_process_all_hosts_ecs', // Replaced by: v3_windows_anomalous_process_all_hosts_ecs
+  'v2_windows_anomalous_process_creation', // Replaced by: v3_windows_anomalous_process_creation
+  'v2_windows_anomalous_user_name_ecs', // Replaced by: v3_windows_anomalous_user_name_ecs
+  'v2_windows_rare_metadata_process', // Replaced by: v3_windows_rare_metadata_process
+  'v2_windows_rare_metadata_user', // Replaced by: v3_windows_rare_metadata_user
   // siem_auditbeat module
-  'rare_process_by_host_linux_ecs',
-  'linux_anomalous_network_activity_ecs',
-  'linux_anomalous_network_port_activity_ecs',
-  'linux_anomalous_network_service',
-  'linux_anomalous_network_url_activity_ecs',
-  'linux_anomalous_process_all_hosts_ecs',
-  'linux_anomalous_user_name_ecs',
-  'linux_rare_metadata_process',
-  'linux_rare_metadata_user',
-  'linux_rare_user_compiler',
-  'linux_rare_kernel_module_arguments',
-  'linux_rare_sudo_user',
-  'linux_system_user_discovery',
-  'linux_system_information_discovery',
-  'linux_system_process_discovery',
-  'linux_network_connection_discovery',
-  'linux_network_configuration_discovery',
+  'rare_process_by_host_linux_ecs', // Replaced by: v3_rare_process_by_host_linux_ecs
+  'linux_anomalous_network_activity_ecs', // Replaced by: v3_linux_anomalous_network_activity_ecs
+  'linux_anomalous_network_port_activity_ecs', // Replaced by: v3_linux_anomalous_network_port_activity_ecs
+  'linux_anomalous_network_service', // Deleted
+  'linux_anomalous_network_url_activity_ecs', // Deleted
+  'linux_anomalous_process_all_hosts_ecs', // Replaced by: v3_linux_anomalous_process_all_hosts_ecs
+  'linux_anomalous_user_name_ecs', // Replaced by: v3_linux_anomalous_user_name_ecs
+  'linux_rare_metadata_process', // Replaced by: v3_linux_rare_metadata_process
+  'linux_rare_metadata_user', // Replaced by: v3_linux_rare_metadata_user
+  'linux_rare_user_compiler', // Replaced by: v3_linux_rare_user_compiler
+  'linux_rare_kernel_module_arguments', // Deleted
+  'linux_rare_sudo_user', // Replaced by: v3_linux_rare_sudo_user
+  'linux_system_user_discovery', // Replaced by: v3_linux_system_user_discovery
+  'linux_system_information_discovery', // Replaced by: v3_linux_system_information_discovery
+  'linux_system_process_discovery', // Replaced by: v3_linux_system_process_discovery
+  'linux_network_connection_discovery', // Replaced by: v3_linux_network_connection_discovery
+  'linux_network_configuration_discovery', // Replaced by: v3_linux_network_configuration_discovery
   // siem_winlogbeat module
-  'rare_process_by_host_windows_ecs',
-  'windows_anomalous_network_activity_ecs',
-  'windows_anomalous_path_activity_ecs',
-  'windows_anomalous_process_all_hosts_ecs',
-  'windows_anomalous_process_creation',
-  'windows_anomalous_script',
-  'windows_anomalous_service',
-  'windows_anomalous_user_name_ecs',
-  'windows_rare_user_runas_event',
-  'windows_rare_metadata_process',
-  'windows_rare_metadata_user',
+  'rare_process_by_host_windows_ecs', // Replaced by: v3_rare_process_by_host_windows_ecs
+  'windows_anomalous_network_activity_ecs', // Replaced by: v3_windows_anomalous_network_activity_ecs
+  'windows_anomalous_path_activity_ecs', // Replaced by: v3_windows_anomalous_path_activity_ecs
+  'windows_anomalous_process_all_hosts_ecs', // Replaced by: v3_windows_anomalous_process_all_hosts_ecs
+  'windows_anomalous_process_creation', // Replaced by: v3_windows_anomalous_process_creation
+  'windows_anomalous_script', // Replaced by: v3_windows_anomalous_script
+  'windows_anomalous_service', // Replaced by: v3_windows_anomalous_service
+  'windows_anomalous_user_name_ecs', // Replaced by: v3_windows_anomalous_user_name_ecs
+  'windows_rare_user_runas_event', // Replaced by: v3_windows_rare_user_runas_event
+  'windows_rare_metadata_process', // Replaced by: v3_windows_rare_metadata_process
+  'windows_rare_metadata_user', // Replaced by: v3_windows_rare_metadata_user
+  // siem_winlogbeat_auth module
+  'windows_rare_user_type10_remote_login', // Replaced by: v3_windows_rare_user_type10_remote_login
 ];

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/index.test.tsx
@@ -44,7 +44,7 @@ describe('MlJobCompatibilityCallout', () => {
   it('does not render if no affected jobs are installed', () => {
     (useInstalledSecurityJobs as jest.Mock).mockReturnValue({
       loading: false,
-      jobs: [{ id: 'windows_rare_user_type10_remote_login' }],
+      jobs: [{ id: 'high_count_network_denies' }],
     });
     const wrapper = mount(
       <TestProviders>

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/ml_job_compatibility_callout/translations.tsx
@@ -26,15 +26,15 @@ export const MlJobCompatibilityCalloutBody = () => (
         <p>
           <FormattedMessage
             id="xpack.securitySolution.detectionEngine.mlJobCompatibilityCallout.messageBody.summary"
-            defaultMessage="Machine learning rules specify ML jobs that in
-            turn have dependencies on data fields populated by the Elastic
-            beats and agent integrations that were current when the ML job
-            was created. New ML jobs, prefixed with V2, have been updated to
-            operate on now-current ECS fields. If you are using multiple
-            versions of beats and agents, you need to create new machine
-            learning rules that specify the new ML (V2) jobs, and enable them
-            to run alongside your existing machine learning rules, in order
-            to ensure continued rule coverage."
+            defaultMessage="Machine learning rules use ML jobs that in
+            turn have dependencies on data fields populated by the Beats
+            and Elastic Agent integrations that were current when the ML
+            job was created. New ML jobs, prefixed with V3, have been released
+            to operate on now-current ECS fields. If you're using multiple
+            versions of Beats or Elastic Agent, you may need to duplicate
+            or create new machine learning rules that specify the new ML
+            (V3) jobs and enable them to run alongside your existing rules,
+            to ensure continued rule coverage using V1/V2 jobs."
           />
         </p>
       ),

--- a/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal/index.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiConfirmModal } from '@elastic/eui';
+import { MlSummaryJob } from '@kbn/ml-plugin/common';
+import React, { memo } from 'react';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+import * as i18n from './translations';
+
+const JobsUL = styled.ul`
+  max-height: 200px;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    height: ${({ theme }) => theme.eui.euiScrollBar};
+    width: ${({ theme }) => theme.eui.euiScrollBar};
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    background-color: ${({ theme }) => rgba(theme.eui.euiColorDarkShade, 0.5)};
+    border: ${({ theme }) => theme.eui.euiScrollBarCorner} solid transparent;
+  }
+
+  &::-webkit-scrollbar-corner,
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+`;
+
+export interface MlJobUpgradeModalProps {
+  jobs: MlSummaryJob[];
+  onCancel: (
+    event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement>
+  ) => void;
+  onConfirm?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+
+const MlJobUpgradeModalComponent = ({ jobs, onCancel, onConfirm }: MlJobUpgradeModalProps) => {
+  return (
+    <EuiConfirmModal
+      title={i18n.ML_JOB_UPGRADE_MODAL_TITLE}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      cancelButtonText={i18n.ML_JOB_UPGRADE_MODAL_CANCEL}
+      confirmButtonText={i18n.ML_JOB_UPGRADE_MODAL_CONFIRM}
+      buttonColor="danger"
+      defaultFocusedButton="confirm"
+    >
+      <i18n.MlJobUpgradeModalBody />
+      {i18n.ML_JOB_UPGRADE_MODAL_AFFECTED_JOBS}
+      <JobsUL>
+        {jobs.map((j) => {
+          return <li key={j.id}>{j.id}</li>;
+        })}
+      </JobsUL>
+    </EuiConfirmModal>
+  );
+};
+
+export const MlJobUpgradeModal = memo(MlJobUpgradeModalComponent);

--- a/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal/translations.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { MlJobCompatibilityLink } from '../../../../common/components/links_to_docs';
+
+export const ML_JOB_UPGRADE_MODAL_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageTitle',
+  {
+    defaultMessage: 'ML rule updates may override your existing rules',
+  }
+);
+
+export const ML_JOB_UPGRADE_MODAL_CANCEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.cancelTitle',
+  {
+    defaultMessage: 'Cancel',
+  }
+);
+
+export const ML_JOB_UPGRADE_MODAL_CONFIRM = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.confirmTitle',
+  {
+    defaultMessage: 'Load rules',
+  }
+);
+
+export const ML_JOB_UPGRADE_MODAL_AFFECTED_JOBS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.affectedJobsTitle',
+  {
+    defaultMessage: 'Affected jobs:',
+  }
+);
+
+export const MlJobUpgradeModalBody = () => (
+  <FormattedMessage
+    id="xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageBody"
+    defaultMessage="{summary} Documentation: {docs}"
+    values={{
+      summary: (
+        <p>
+          <FormattedMessage
+            id="xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageBody.summary"
+            defaultMessage="New V3 machine learning jobs have been released,
+            and the latest corresponding prebuilt detection rules now use these
+            new ML jobs. You're currently running one or more V1/V2 jobs, which
+            only work with legacy prebuilt rules. To ensure continued coverage using
+            V1/V2 jobs, you may need to duplicate or create new rules before
+            updating your Elastic prebuilt detection rules. Check the documentation
+            below for instructions on how to keep using the V1/V2 jobs, and how to
+            start using the new V3 jobs."
+          />
+        </p>
+      ),
+      docs: (
+        <ul>
+          <li>
+            <MlJobCompatibilityLink />
+          </li>
+        </ul>
+      ),
+    }}
+  />
+);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
@@ -6,7 +6,10 @@
  */
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { MlJobUpgradeModal } from '../../../components/modals/ml_job_upgrade_modal';
+import { affectedJobIds } from '../../../components/callouts/ml_job_compatibility_callout/affected_job_ids';
+import { useInstalledSecurityJobs } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
 
 import { usePrePackagedRules, importRules } from '../../../containers/detection_engine/rules';
 import { useListsConfig } from '../../../containers/detection_engine/lists/use_lists_config';
@@ -17,7 +20,7 @@ import { SpyRoute } from '../../../../common/utils/route/spy_routes';
 import { useUserData } from '../../../components/user_info';
 import { AllRules } from './all';
 import { ImportDataModal } from '../../../../common/components/import_data_modal';
-import { ValueListsModal } from '../../../components/value_lists_management_modal';
+import { ValueListsFlyout } from '../../../components/value_lists_management_flyout';
 import { UpdatePrePackagedRulesCallOut } from '../../../components/rules/pre_packaged_rules/update_callout';
 import {
   getPrePackagedRuleStatus,
@@ -42,10 +45,14 @@ import { useStartTransaction } from '../../../../common/lib/apm/use_start_transa
 
 const RulesPageComponent: React.FC = () => {
   const [isImportModalVisible, showImportModal, hideImportModal] = useBoolState();
-  const [isValueListModalVisible, showValueListModal, hideValueListModal] = useBoolState();
+  const [isValueListFlyoutVisible, showValueListFlyout, hideValueListFlyout] = useBoolState();
   const { navigateToApp } = useKibana().services.application;
   const { startTransaction } = useStartTransaction();
   const invalidateRules = useInvalidateRules();
+
+  const { loading: loadingJobs, jobs } = useInstalledSecurityJobs();
+  const legacyJobsInstalled = jobs.filter((job) => affectedJobIds.includes(job.id));
+  const [isUpgradeModalVisible, setIsUpgradeModalVisible] = useState(false);
 
   const [
     {
@@ -103,6 +110,21 @@ const RulesPageComponent: React.FC = () => {
     }
   }, [createPrePackagedRules, invalidateRules, startTransaction]);
 
+  // Wrapper to add confirmation modal for users who may be running older ML Jobs that would
+  // be overridden by updating their rules. For details, see: https://github.com/elastic/kibana/issues/128121
+  const mlJobUpgradeModalConfirm = useCallback(async () => {
+    setIsUpgradeModalVisible(false);
+    await handleCreatePrePackagedRules();
+  }, [handleCreatePrePackagedRules, setIsUpgradeModalVisible]);
+
+  const showMlJobUpgradeModal = useCallback(async () => {
+    if (legacyJobsInstalled.length > 0) {
+      setIsUpgradeModalVisible(true);
+    } else {
+      await handleCreatePrePackagedRules();
+    }
+  }, [handleCreatePrePackagedRules, legacyJobsInstalled.length]);
+
   const handleRefetchPrePackagedRulesStatus = useCallback(() => {
     if (refetchPrePackagedRulesStatus != null) {
       return refetchPrePackagedRulesStatus();
@@ -114,19 +136,31 @@ const RulesPageComponent: React.FC = () => {
   const loadPrebuiltRulesAndTemplatesButton = useMemo(
     () =>
       getLoadPrebuiltRulesAndTemplatesButton({
-        isDisabled: !userHasPermissions(canUserCRUD) || loading,
-        onClick: handleCreatePrePackagedRules,
+        isDisabled: !userHasPermissions(canUserCRUD) || loading || loadingJobs,
+        onClick: showMlJobUpgradeModal,
       }),
-    [canUserCRUD, getLoadPrebuiltRulesAndTemplatesButton, handleCreatePrePackagedRules, loading]
+    [
+      canUserCRUD,
+      getLoadPrebuiltRulesAndTemplatesButton,
+      showMlJobUpgradeModal,
+      loading,
+      loadingJobs,
+    ]
   );
 
   const reloadPrebuiltRulesAndTemplatesButton = useMemo(
     () =>
       getReloadPrebuiltRulesAndTemplatesButton({
-        isDisabled: !userHasPermissions(canUserCRUD) || loading,
-        onClick: handleCreatePrePackagedRules,
+        isDisabled: !userHasPermissions(canUserCRUD) || loading || loadingJobs,
+        onClick: showMlJobUpgradeModal,
       }),
-    [canUserCRUD, getReloadPrebuiltRulesAndTemplatesButton, handleCreatePrePackagedRules, loading]
+    [
+      canUserCRUD,
+      getReloadPrebuiltRulesAndTemplatesButton,
+      showMlJobUpgradeModal,
+      loading,
+      loadingJobs,
+    ]
   );
 
   if (
@@ -149,7 +183,14 @@ const RulesPageComponent: React.FC = () => {
       <NeedAdminForUpdateRulesCallOut />
       <MissingPrivilegesCallOut />
       <MlJobCompatibilityCallout />
-      <ValueListsModal showModal={isValueListModalVisible} onClose={hideValueListModal} />
+      {isUpgradeModalVisible && (
+        <MlJobUpgradeModal
+          jobs={legacyJobsInstalled}
+          onCancel={() => setIsUpgradeModalVisible(false)}
+          onConfirm={mlJobUpgradeModalConfirm}
+        />
+      )}
+      <ValueListsFlyout showFlyout={isValueListFlyoutVisible} onClose={hideValueListFlyout} />
       <ImportDataModal
         checkBoxLabel={i18n.OVERWRITE_WITH_SAME_NAME}
         closeModal={hideImportModal}
@@ -185,9 +226,9 @@ const RulesPageComponent: React.FC = () => {
                     data-test-subj="open-value-lists-modal-button"
                     iconType="importAction"
                     isDisabled={!canWriteListsIndex || !canUserCRUD || loading}
-                    onClick={showValueListModal}
+                    onClick={showValueListFlyout}
                   >
-                    {i18n.UPLOAD_VALUE_LISTS}
+                    {i18n.IMPORT_VALUE_LISTS}
                   </EuiButton>
                 </EuiToolTip>
               </EuiFlexItem>
@@ -221,7 +262,7 @@ const RulesPageComponent: React.FC = () => {
               loading={loadingCreatePrePackagedRules}
               numberOfUpdatedRules={rulesNotUpdated ?? 0}
               numberOfUpdatedTimelines={timelinesNotUpdated ?? 0}
-              updateRules={handleCreatePrePackagedRules}
+              updateRules={showMlJobUpgradeModal}
             />
           )}
           <AllRules


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Security Solution][Detections] Adds confirmation modal with docs link when updating rules if V1/V2 jobs are installed (#128334)](https://github.com/elastic/kibana/pull/128334)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)