### PR TITLE
[Security Solution] Global nav links updated

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
@@ -43,10 +43,9 @@ import {
 import {
   CASES_PAGE,
   ALERTS_PAGE,
-  HOSTS_PAGE,
-  ENDPOINTS_PAGE,
-  NETWORK_PAGE,
-  OVERVIEW_PAGE,
+  EXPLORE_PAGE,
+  MANAGE_PAGE,
+  DASHBOARDS_PAGE,
   TIMELINES_PAGE,
 } from '../../screens/kibana_navigation';
 
@@ -120,24 +119,14 @@ describe('Kibana navigation to all pages in the Security app ', () => {
   beforeEach(() => {
     openKibanaNavigation();
   });
-  it('navigates to the Overview page', () => {
-    navigateFromKibanaCollapsibleTo(OVERVIEW_PAGE);
+  it('navigates to the Dashboards page', () => {
+    navigateFromKibanaCollapsibleTo(DASHBOARDS_PAGE);
     cy.url().should('include', OVERVIEW_URL);
   });
 
   it('navigates to the Alerts page', () => {
     navigateFromKibanaCollapsibleTo(ALERTS_PAGE);
     cy.url().should('include', ALERTS_URL);
-  });
-
-  it('navigates to the Hosts page', () => {
-    navigateFromKibanaCollapsibleTo(HOSTS_PAGE);
-    cy.url().should('include', HOSTS_URL);
-  });
-
-  it('navigates to the Network page', () => {
-    navigateFromKibanaCollapsibleTo(NETWORK_PAGE);
-    cy.url().should('include', NETWORK_URL);
   });
 
   it('navigates to the Timelines page', () => {
@@ -150,8 +139,13 @@ describe('Kibana navigation to all pages in the Security app ', () => {
     cy.url().should('include', CASES_URL);
   });
 
-  it('navigates to the Endpoints page', () => {
-    navigateFromKibanaCollapsibleTo(ENDPOINTS_PAGE);
+  it('navigates to the Explore page', () => {
+    navigateFromKibanaCollapsibleTo(EXPLORE_PAGE);
+    cy.url().should('include', HOSTS_URL);
+  });
+
+  it('navigates to the Manage page', () => {
+    navigateFromKibanaCollapsibleTo(MANAGE_PAGE);
     cy.url().should('include', ENDPOINTS_URL);
   });
 });

--- a/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
@@ -5,26 +5,24 @@
  * 2.0.
  */
 
+export const DASHBOARDS_PAGE =
+  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Dashboards"]';
+
 export const ALERTS_PAGE =
   '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Alerts"]';
 
-export const CASES_PAGE = '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Cases"]';
-
-export const HOSTS_PAGE = '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Hosts"]';
-
-export const KIBANA_NAVIGATION_TOGGLE = '[data-test-subj="toggleNavButton"]';
-
-export const ENDPOINTS_PAGE =
-  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Endpoints"]';
-
-export const NETWORK_PAGE =
-  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Network"]';
-
-export const OVERVIEW_PAGE =
-  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Overview"]';
-
 export const TIMELINES_PAGE =
   '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Timelines"]';
+
+export const CASES_PAGE = '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Cases"]';
+
+export const EXPLORE_PAGE =
+  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Explore"]';
+
+export const MANAGE_PAGE =
+  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Manage"]';
+
+export const KIBANA_NAVIGATION_TOGGLE = '[data-test-subj="toggleNavButton"]';
 
 export const SPACES_BUTTON = '[data-test-subj="spacesNavSelector"]';
 

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -59,9 +59,6 @@ import {
   SERVER_APP_ID,
   USERS_PATH,
   KUBERNETES_PATH,
-  EXPLORE_PATH,
-  DASHBOARDS_PATH,
-  MANAGE_PATH,
   RULES_CREATE_PATH,
 } from '../../../common/constants';
 import { ExperimentalFeatures } from '../../../common/experimental_features';
@@ -92,23 +89,9 @@ type SecuritySolutionDeepLink = AppDeepLink & {
 
 export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
   {
-    id: SecurityPageName.overview,
-    title: OVERVIEW,
-    path: OVERVIEW_PATH,
-    navLinkStatus: AppNavLinkStatus.visible,
-    features: [FEATURE.general],
-    keywords: [
-      i18n.translate('xpack.securitySolution.search.overview', {
-        defaultMessage: 'Overview',
-      }),
-    ],
-    order: 9000,
-  },
-  {
     id: SecurityPageName.landing,
     title: GETTING_STARTED,
     path: LANDING_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
     features: [FEATURE.general],
     keywords: [
       i18n.translate('xpack.securitySolution.search.getStarted', {
@@ -119,27 +102,40 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
   {
     id: SecurityPageName.dashboardsLanding,
     title: DASHBOARDS,
-    path: DASHBOARDS_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
+    path: OVERVIEW_PATH,
+    navLinkStatus: AppNavLinkStatus.visible,
+    searchable: false,
+    order: 9000,
     features: [FEATURE.general],
     keywords: [
       i18n.translate('xpack.securitySolution.search.dashboards', {
         defaultMessage: 'Dashboards',
       }),
     ],
-  },
-  {
-    id: SecurityPageName.detectionAndResponse,
-    title: DETECTION_RESPONSE,
-    path: DETECTION_RESPONSE_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
-    features: [FEATURE.general],
-    keywords: [
-      i18n.translate('xpack.securitySolution.search.detectionAndResponse', {
-        defaultMessage: 'Detection & Response',
-      }),
+    deepLinks: [
+      {
+        id: SecurityPageName.overview,
+        title: OVERVIEW,
+        path: OVERVIEW_PATH,
+        features: [FEATURE.general],
+        keywords: [
+          i18n.translate('xpack.securitySolution.search.overview', {
+            defaultMessage: 'Overview',
+          }),
+        ],
+      },
+      {
+        id: SecurityPageName.detectionAndResponse,
+        title: DETECTION_RESPONSE,
+        path: DETECTION_RESPONSE_PATH,
+        features: [FEATURE.general],
+        keywords: [
+          i18n.translate('xpack.securitySolution.search.detectionAndResponse', {
+            defaultMessage: 'Detection & Response',
+          }),
+        ],
+      },
     ],
-    searchable: true,
   },
   {
     id: SecurityPageName.detections,
@@ -158,25 +154,22 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         title: ALERTS,
         path: ALERTS_PATH,
         navLinkStatus: AppNavLinkStatus.visible,
+        order: 9001,
         keywords: [
           i18n.translate('xpack.securitySolution.search.alerts', {
             defaultMessage: 'Alerts',
           }),
         ],
-        searchable: true,
-        order: 9001,
       },
       {
         id: SecurityPageName.rules,
         title: RULES,
         path: RULES_PATH,
-        navLinkStatus: AppNavLinkStatus.hidden,
         keywords: [
           i18n.translate('xpack.securitySolution.search.rules', {
             defaultMessage: 'Rules',
           }),
         ],
-        searchable: true,
         deepLinks: [
           {
             id: SecurityPageName.rulesCreate,
@@ -191,21 +184,21 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         id: SecurityPageName.exceptions,
         title: EXCEPTIONS,
         path: EXCEPTIONS_PATH,
-        navLinkStatus: AppNavLinkStatus.hidden,
         keywords: [
           i18n.translate('xpack.securitySolution.search.exceptions', {
             defaultMessage: 'Exception lists',
           }),
         ],
-        searchable: true,
       },
     ],
   },
   {
     id: SecurityPageName.exploreLanding,
     title: EXPLORE,
-    path: EXPLORE_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
+    path: HOSTS_PATH,
+    navLinkStatus: AppNavLinkStatus.visible,
+    order: 9004,
+    searchable: false,
     features: [FEATURE.general],
     keywords: [
       i18n.translate('xpack.securitySolution.search.explore', {
@@ -217,13 +210,11 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         id: SecurityPageName.hosts,
         title: HOSTS,
         path: HOSTS_PATH,
-        navLinkStatus: AppNavLinkStatus.visible,
         keywords: [
           i18n.translate('xpack.securitySolution.search.hosts', {
             defaultMessage: 'Hosts',
           }),
         ],
-        order: 9002,
         deepLinks: [
           {
             id: SecurityPageName.uncommonProcesses,
@@ -275,13 +266,11 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         id: SecurityPageName.network,
         title: NETWORK,
         path: NETWORK_PATH,
-        navLinkStatus: AppNavLinkStatus.visible,
         keywords: [
           i18n.translate('xpack.securitySolution.search.network', {
             defaultMessage: 'Network',
           }),
         ],
-        order: 9003,
         deepLinks: [
           {
             id: SecurityPageName.networkDns,
@@ -325,13 +314,11 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         id: SecurityPageName.users,
         title: USERS,
         path: USERS_PATH,
-        navLinkStatus: AppNavLinkStatus.visible,
         keywords: [
           i18n.translate('xpack.securitySolution.search.users', {
             defaultMessage: 'Users',
           }),
         ],
-        order: 9004,
         deepLinks: [
           {
             id: SecurityPageName.usersAuthentications,
@@ -376,14 +363,12 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         id: SecurityPageName.kubernetes,
         title: KUBERNETES,
         path: KUBERNETES_PATH,
-        navLinkStatus: AppNavLinkStatus.hidden,
         experimentalKey: 'kubernetesEnabled',
         keywords: [
           i18n.translate('xpack.securitySolution.search.kubernetes', {
             defaultMessage: 'Kubernetes',
           }),
         ],
-        order: 9005,
       },
     ],
   },
@@ -403,13 +388,13 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         title: TIMELINES,
         path: TIMELINES_PATH,
         navLinkStatus: AppNavLinkStatus.visible,
+        order: 9002,
         features: [FEATURE.general],
         keywords: [
           i18n.translate('xpack.securitySolution.search.timelines', {
             defaultMessage: 'Timelines',
           }),
         ],
-        order: 9006,
         deepLinks: [
           {
             id: SecurityPageName.timelinesTemplates,
@@ -425,7 +410,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
         extend: {
           [SecurityPageName.case]: {
             navLinkStatus: AppNavLinkStatus.visible,
-            order: 9007,
+            order: 9003,
             features: [FEATURE.casesRead],
           },
           [SecurityPageName.caseConfigure]: {
@@ -442,9 +427,11 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
   {
     id: SecurityPageName.administration,
     title: MANAGE,
-    path: MANAGE_PATH,
-    navLinkStatus: AppNavLinkStatus.hidden,
+    path: ENDPOINTS_PATH,
     features: [FEATURE.general],
+    navLinkStatus: AppNavLinkStatus.visible,
+    order: 9005,
+    searchable: false,
     keywords: [
       i18n.translate('xpack.securitySolution.search.manage', {
         defaultMessage: 'Manage',
@@ -453,9 +440,7 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
     deepLinks: [
       {
         id: SecurityPageName.endpoints,
-        navLinkStatus: AppNavLinkStatus.visible,
         title: ENDPOINTS,
-        order: 9008,
         path: ENDPOINTS_PATH,
       },
       {

--- a/x-pack/plugins/security_solution/public/cases/links.ts
+++ b/x-pack/plugins/security_solution/public/cases/links.ts
@@ -15,7 +15,7 @@ export const getCasesLinkItems = (): LinkItem => {
     extend: {
       [SecurityPageName.case]: {
         globalNavEnabled: true,
-        globalNavOrder: 9007,
+        globalNavOrder: 4,
         capabilities: [`${CASES_FEATURE_ID}.read_cases`],
       },
       [SecurityPageName.caseConfigure]: {

--- a/x-pack/plugins/security_solution/public/detections/links.ts
+++ b/x-pack/plugins/security_solution/public/detections/links.ts
@@ -15,10 +15,10 @@ export const links: LinkItem = {
   path: ALERTS_PATH,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalNavEnabled: true,
+  globalNavOrder: 2,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.alerts', {
       defaultMessage: 'Alerts',
     }),
   ],
-  globalNavOrder: 9001,
 };

--- a/x-pack/plugins/security_solution/public/hosts/links.ts
+++ b/x-pack/plugins/security_solution/public/hosts/links.ts
@@ -18,13 +18,11 @@ export const links: LinkItem = {
     defaultMessage: 'A comprehensive overview of all hosts and host-related security events.',
   }),
   path: HOSTS_PATH,
-  globalNavEnabled: true,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.hosts', {
       defaultMessage: 'Hosts',
     }),
   ],
-  globalNavOrder: 9002,
   links: [
     {
       id: SecurityPageName.uncommonProcesses,

--- a/x-pack/plugins/security_solution/public/landing_pages/links.ts
+++ b/x-pack/plugins/security_solution/public/landing_pages/links.ts
@@ -24,7 +24,8 @@ export const dashboardsLandingLinks: LinkItem = {
   id: SecurityPageName.dashboardsLanding,
   title: DASHBOARDS,
   path: DASHBOARDS_PATH,
-  globalNavEnabled: false,
+  globalNavEnabled: true,
+  globalNavOrder: 1,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.dashboards', {
@@ -40,7 +41,8 @@ export const threatHuntingLandingLinks: LinkItem = {
   id: SecurityPageName.exploreLanding,
   title: EXPLORE,
   path: EXPLORE_PATH,
-  globalNavEnabled: false,
+  globalNavEnabled: true,
+  globalNavOrder: 5,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.explore', {

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -73,7 +73,8 @@ export const links: LinkItem = {
   path: MANAGE_PATH,
   skipUrlState: true,
   hideTimeline: true,
-  globalNavEnabled: false,
+  globalNavEnabled: true,
+  globalNavOrder: 6,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.manage', {
@@ -92,7 +93,6 @@ export const links: LinkItem = {
 
       landingIcon: IconSiemRules,
       path: RULES_PATH,
-      globalNavEnabled: false,
       globalSearchKeywords: [
         i18n.translate('xpack.securitySolution.appLinks.rules', {
           defaultMessage: 'Rules',
@@ -103,7 +103,6 @@ export const links: LinkItem = {
           id: SecurityPageName.rulesCreate,
           title: CREATE_NEW_RULE,
           path: RULES_CREATE_PATH,
-          globalNavEnabled: false,
           skipUrlState: true,
           hideTimeline: true,
         },
@@ -117,7 +116,6 @@ export const links: LinkItem = {
       }),
       landingIcon: IconExceptionLists,
       path: EXCEPTIONS_PATH,
-      globalNavEnabled: false,
       globalSearchKeywords: [
         i18n.translate('xpack.securitySolution.appLinks.exceptions', {
           defaultMessage: 'Exception lists',
@@ -130,9 +128,7 @@ export const links: LinkItem = {
         defaultMessage: 'Hosts running endpoint security.',
       }),
       landingIcon: IconEndpoints,
-      globalNavEnabled: true,
       title: ENDPOINTS,
-      globalNavOrder: 9008,
       path: ENDPOINTS_PATH,
       skipUrlState: true,
       hideTimeline: true,

--- a/x-pack/plugins/security_solution/public/network/links.ts
+++ b/x-pack/plugins/security_solution/public/network/links.ts
@@ -20,13 +20,11 @@ export const links: LinkItem = {
       'Provides key activity metrics in an interactive map as well as event tables that enable interaction with the Timeline.',
   }),
   path: NETWORK_PATH,
-  globalNavEnabled: true,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.network', {
       defaultMessage: 'Network',
     }),
   ],
-  globalNavOrder: 9003,
   links: [
     {
       id: SecurityPageName.networkDns,

--- a/x-pack/plugins/security_solution/public/overview/links.ts
+++ b/x-pack/plugins/security_solution/public/overview/links.ts
@@ -26,21 +26,18 @@ export const overviewLinks: LinkItem = {
     defaultMessage: 'What is going on in your security environment.',
   }),
   path: OVERVIEW_PATH,
-  globalNavEnabled: true,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.overview', {
       defaultMessage: 'Overview',
     }),
   ],
-  globalNavOrder: 9000,
 };
 
 export const gettingStartedLinks: LinkItem = {
   id: SecurityPageName.landing,
   title: GETTING_STARTED,
   path: LANDING_PATH,
-  globalNavEnabled: false,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.getStarted', {
@@ -60,7 +57,6 @@ export const detectionResponseLinks: LinkItem = {
       "Monitor the impact of application and device performance from the end user's point of view.",
   }),
   path: DETECTION_RESPONSE_PATH,
-  globalNavEnabled: false,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.detectionAndResponse', {

--- a/x-pack/plugins/security_solution/public/timelines/links.ts
+++ b/x-pack/plugins/security_solution/public/timelines/links.ts
@@ -15,13 +15,13 @@ export const links: LinkItem = {
   title: TIMELINES,
   path: TIMELINES_PATH,
   globalNavEnabled: true,
+  globalNavOrder: 3,
   capabilities: [`${SERVER_APP_ID}.show`],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.timelines', {
       defaultMessage: 'Timelines',
     }),
   ],
-  globalNavOrder: 9006,
   links: [
     {
       id: SecurityPageName.timelinesTemplates,

--- a/x-pack/plugins/security_solution/public/users/links.ts
+++ b/x-pack/plugins/security_solution/public/users/links.ts
@@ -20,13 +20,11 @@ export const links: LinkItem = {
       'A comprehensive overview of user data that enables understanding of authentication and user behavior within your environment.',
   }),
   path: USERS_PATH,
-  globalNavEnabled: true,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.users', {
       defaultMessage: 'Users',
     }),
   ],
-  globalNavOrder: 9004,
   links: [
     {
       id: SecurityPageName.usersAuthentications,

--- a/x-pack/test/functional/apps/dashboard/group1/preserve_url.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/preserve_url.ts
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.loadSavedDashboard('A Dashboard');
       await PageObjects.common.navigateToApp('home');
-      await appsMenu.clickLink('Dashboard');
+      await appsMenu.clickLink('Dashboard', { category: 'kibana' });
       await PageObjects.dashboard.loadSavedDashboard('A Dashboard');
       await PageObjects.header.waitUntilLoadingHasFinished();
       const activeTitle = await globalNav.getLastBreadcrumb();
@@ -44,7 +44,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('another-space');
 
       // other space
-      await appsMenu.clickLink('Dashboard');
+      await appsMenu.clickLink('Dashboard', { category: 'kibana' });
       await PageObjects.dashboard.loadSavedDashboard('A Dashboard in another space');
 
       await PageObjects.spaceSelector.openSpacesNav();
@@ -52,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('default');
 
       // default space
-      await appsMenu.clickLink('Dashboard');
+      await appsMenu.clickLink('Dashboard', { category: 'kibana' });
       await PageObjects.dashboard.waitForRenderComplete();
       const activeTitleDefaultSpace = await globalNav.getLastBreadcrumb();
       expect(activeTitleDefaultSpace).to.be('A Dashboard');
@@ -62,7 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('another-space');
 
       // other space
-      await appsMenu.clickLink('Dashboard');
+      await appsMenu.clickLink('Dashboard', { category: 'kibana' });
       await PageObjects.dashboard.waitForRenderComplete();
       const activeTitleOtherSpace = await globalNav.getLastBreadcrumb();
       expect(activeTitleOtherSpace).to.be('A Dashboard in another space');


### PR DESCRIPTION
## Summary

The global nav links have been updated to be consistent with the new security navigation architecture.

Changes:

- ~~Overview~~ -> **Dashboards** (updated)
- **Alerts** (same)
- ~~Hosts~~ (removed)
- ~~Network~~ (removed)
- ~~Users~~ (removed)
- **Timelines** (same)
- **Cases** (same)
- **Explore** (new)
- ~~Endpoints~~ -> **Manage** (updated)

For the previous navigation, where section headers are not clickable and no landing pages exist, they default to the first page of the respective section.

- Dashboards -> Overview
- Alerts -> Alerts
- Timelines -> Timelines
- Cases -> Cases
- Explore -> Hosts
- Manage -> Endpoints

Result:

![global_nav](https://user-images.githubusercontent.com/17747913/173032344-99e085af-518a-4d65-976f-3de559b0d0ba.png)
