### PR TITLE
[Security Solution][Detections] Adds SOM privilege check for Related Integrations

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/integrations_description/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/integrations_description/index.tsx
@@ -12,7 +12,7 @@ import { useInstalledIntegrations } from '../use_installed_integrations';
 import { getInstalledRelatedIntegrations, getIntegrationLink, IntegrationDetails } from '../utils';
 
 import { RelatedIntegrationArray } from '../../../../../../common/detection_engine/schemas/common';
-import { useBasePath } from '../../../../../common/lib/kibana';
+import { useBasePath, useKibana } from '../../../../../common/lib/kibana';
 import { ListItems } from '../../description_step/types';
 import * as i18n from '../translations';
 
@@ -32,6 +32,9 @@ export const IntegrationDescriptionComponent: React.FC<{ integration: Integratio
   integration,
 }) => {
   const basePath = useBasePath();
+  const services = useKibana().services;
+  const isSOMAvailable = services.application.capabilities.savedObjectsManagement.read;
+
   const badgeInstalledColor = 'success';
   const badgeUninstalledColor = '#E0E5EE';
   const badgeColor = integration.is_installed ? badgeInstalledColor : badgeUninstalledColor;
@@ -49,10 +52,12 @@ export const IntegrationDescriptionComponent: React.FC<{ integration: Integratio
   return (
     <Wrapper>
       {getIntegrationLink(integration, basePath)}{' '}
-      <EuiToolTip content={badgeTooltip}>
-        <PaddedBadge color={badgeColor}>{badgeText}</PaddedBadge>
-      </EuiToolTip>
-      {integration.is_installed && !integration.version_satisfied && (
+      {isSOMAvailable && (
+        <EuiToolTip content={badgeTooltip}>
+          <PaddedBadge color={badgeColor}>{badgeText}</PaddedBadge>
+        </EuiToolTip>
+      )}
+      {isSOMAvailable && integration.is_installed && !integration.version_satisfied && (
         <VersionWarningIconContainer>
           <EuiIconTip
             type={'alert'}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/integrations_popover/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/integrations_popover/index.tsx
@@ -15,6 +15,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import styled from 'styled-components';
+import { useKibana } from '../../../../../common/lib/kibana';
 import { IntegrationDescription } from '../integrations_description';
 import { getInstalledRelatedIntegrations } from '../utils';
 import { useInstalledIntegrations } from '../use_installed_integrations';
@@ -54,6 +55,8 @@ const IntegrationListItem = styled('li')`
 const IntegrationsPopoverComponent = ({ integrations }: IntegrationsPopoverProps) => {
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const { data: allInstalledIntegrations } = useInstalledIntegrations({ packages: [] });
+  const services = useKibana().services;
+  const isSOMAvailable = services.application.capabilities.savedObjectsManagement.read;
 
   const integrationDetails = getInstalledRelatedIntegrations(
     integrations,
@@ -62,7 +65,7 @@ const IntegrationsPopoverComponent = ({ integrations }: IntegrationsPopoverProps
 
   const totalRelatedIntegrationsInstalled = integrationDetails.filter((i) => i.is_enabled).length;
   const badgeTitle =
-    allInstalledIntegrations != null
+    allInstalledIntegrations != null && isSOMAvailable
       ? `${totalRelatedIntegrationsInstalled}/${integrations.length} ${i18n.INTEGRATIONS_BADGE}`
       : `${integrations.length} ${i18n.INTEGRATIONS_BADGE}`;
 


### PR DESCRIPTION
## Summary

If SOM privileges are `None` the Related Integrations feature incorrectly shows all integrations as `Not Installed` even if some of them may be. This PR adds a client-side privilege check and falls back to the basic UI that just shows the integration name+link and not any install information.

#### Test instructions:

To test, configure a role with SOM privileges as `None`, e.g.

<p align="center">
  <img width="500" src="https://user-images.githubusercontent.com/2946766/173156872-dfaece7e-a6ef-4774-b01d-e2fa7b66a068.png" />
</p>

Then UI should fall back to no installed information:
##### Rule Details:
<p align="center">
  <img width="500" src="https://user-images.githubusercontent.com/2946766/173156901-572c4eb3-661f-4edf-974d-ec8ee13d849c.png" />
</p>

Rule Management:
<p align="center">
  <img width="500" src="https://user-images.githubusercontent.com/2946766/173156924-fbfec8ef-cbff-4966-8bee-bf3e29678cb9.png" />
</p>


TODO: 
- [ ] A test to exercise this fallback (either unit or cypress w/ specific role should do)
- [ ] Ensure docs mention the required privileges for this feature

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

