### PR TITLE
[Logging][Docs] Add upper limit to rolling file appender numeric strategy

### DIFF
--- a/docs/developer/architecture/core/logging-service.asciidoc
+++ b/docs/developer/architecture/core/logging-service.asciidoc
@@ -274,7 +274,7 @@ will be `/var/logs/kibana-1.log`, `/var/logs/kibana-2.log`, and so on. The defau
 
 - `max`
 
-The maximum number of files to keep. Once this number is reached, oldest files will be deleted. The default value is `7`
+The maximum number of files to keep. Once this number is reached, oldest files will be deleted. The default value is `7` and maximum is `100`
 
 ==== Rewrite Appender
 

--- a/docs/developer/architecture/core/logging-service.asciidoc
+++ b/docs/developer/architecture/core/logging-service.asciidoc
@@ -274,7 +274,7 @@ will be `/var/logs/kibana-1.log`, `/var/logs/kibana-2.log`, and so on. The defau
 
 - `max`
 
-The maximum number of files to keep. Once this number is reached, oldest files will be deleted. The default value is `7` and maximum is `100`
+The maximum number of files to keep. Once this number is reached, oldest files will be deleted. The default value is `7` and the maximum is `100`.
 
 ==== Rewrite Appender
 


### PR DESCRIPTION
There's a hard-coded upper limit to the rolling file appender numeric strategy that, when exceeded, will throw [config errors](https://github.com/elastic/sdh-kibana/issues/2975) on Kibana startup but is not documented.
This PR adds the max to the 7.17 docs.

Note: Kibana's docs were rearranged in v8 and this PR makes the doc change only to the 7.17 branch. we will still need to add the change to subsequent versions.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
