### PR TITLE
Document rolling file appender numeric strategy max.

### DIFF
--- a/docs/settings/logging-settings.asciidoc
+++ b/docs/settings/logging-settings.asciidoc
@@ -60,7 +60,7 @@ The following table serves as a quick reference for different logging configurat
 | The suffix to append to the file path when rolling. Must include `%i`.
 
 | `logging.appenders[].<appender-name>.strategy.max`
-| The maximum number of files to keep. Optional. Default is `7` and maximum is `100`.
+| The maximum number of files to keep. Optional. Default is `7` and the maximum is `100`.
 
 | `logging.appenders[].<appender-name>.layout.type`
 | Determines how the log messages are displayed. Options are `pattern`, which provides human-readable output, or `json`, which provides ECS-compliant output. Required.

--- a/docs/settings/logging-settings.asciidoc
+++ b/docs/settings/logging-settings.asciidoc
@@ -60,7 +60,7 @@ The following table serves as a quick reference for different logging configurat
 | The suffix to append to the file path when rolling. Must include `%i`.
 
 | `logging.appenders[].<appender-name>.strategy.max`
-| The maximum number of files to keep. Optional. Default is `7`.
+| The maximum number of files to keep. Optional. Default is `7` and maximum is `100`.
 
 | `logging.appenders[].<appender-name>.layout.type`
 | Determines how the log messages are displayed. Options are `pattern`, which provides human-readable output, or `json`, which provides ECS-compliant output. Required.


### PR DESCRIPTION
There's a hard-coded upper limit to the rolling file appender numeric strategy that, when exceeded, will throw config errors on Kibana startup but is not documented.
This PR adds the max to the `8.x` docs.

Note: Kibana's docs were rearranged in v8. The update to the `7.17` docs is handled in https://github.com/elastic/kibana/pull/134170

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials