### PR TITLE
[Discover] Update toast copy for "Copy column" action

### DIFF
--- a/src/plugins/discover/public/utils/copy_value_to_clipboard.test.tsx
+++ b/src/plugins/discover/public/utils/copy_value_to_clipboard.test.tsx
@@ -127,7 +127,7 @@ describe('copyValueToClipboard', () => {
       '"bool_enabled"\nfalse\ntrue'
     );
     expect(discoverServiceMock.toastNotifications.addInfo).toHaveBeenCalledWith({
-      title: 'Copied values of "bool_enabled" column to clipboard',
+      title: 'Values of "bool_enabled" column copied to clipboard',
     });
   });
 
@@ -142,8 +142,8 @@ describe('copyValueToClipboard', () => {
 
     expect(result).toBe('"scripted_string"\n"hi there"\n"\'=1+2"";=1+2"');
     expect(discoverServiceMock.toastNotifications.addWarning).toHaveBeenCalledWith({
-      title: 'Copied values of "scripted_string" column to clipboard',
-      text: 'It may contain formulas whose values have been escaped.',
+      title: 'Values of "scripted_string" column copied to clipboard',
+      text: 'Values may contain formulas that are escaped.',
     });
   });
 });

--- a/src/plugins/discover/public/utils/copy_value_to_clipboard.ts
+++ b/src/plugins/discover/public/utils/copy_value_to_clipboard.ts
@@ -15,7 +15,7 @@ import { convertNameToString } from './convert_value_to_string';
 const WARNING_FOR_FORMULAS = i18n.translate(
   'discover.grid.copyEscapedValueWithFormulasToClipboardWarningText',
   {
-    defaultMessage: 'It may contain formulas whose values have been escaped.',
+    defaultMessage: 'Values may contain formulas that are escaped.',
   }
 );
 const COPY_FAILED_ERROR_MESSAGE = i18n.translate('discover.grid.copyFailedErrorText', {
@@ -107,7 +107,7 @@ export const copyColumnValuesToClipboard = async ({
   }
 
   const toastTitle = i18n.translate('discover.grid.copyColumnValuesToClipboard.toastTitle', {
-    defaultMessage: 'Copied values of "{column}" column to clipboard',
+    defaultMessage: 'Values of "{column}" column copied to clipboard',
     values: { column: columnId },
   });
 


### PR DESCRIPTION
Follow up for https://github.com/elastic/kibana/pull/132330

## Summary

This PR updates copy for a warning that is shown when user copies column values via "Copy column" dropdown action.

<img width="390" alt="Screenshot 2022-06-13 at 09 27 17" src="https://user-images.githubusercontent.com/1415710/173302596-69972389-b7d9-44d2-ac99-9f9a38ea89df.png">
