### PR TITLE
[Discover] Include current filters into "Test query" request

### DIFF
--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
@@ -172,10 +172,10 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
       from: `now-${timeWindow}`,
       to: 'now',
     });
-    testSearchSource.setField('filter', timeFilter);
+    testSearchSource.setField('filter', timeFilter ? [timeFilter, ...filters] : filters);
     const { rawResponse } = await firstValueFrom(testSearchSource.fetch$());
     return { nrOfDocs: totalHitsToNumber(rawResponse.hits.total), timeWindow };
-  }, [searchSource, timeWindowSize, timeWindowUnit]);
+  }, [searchSource, timeWindowSize, timeWindowUnit, filters]);
 
   return (
     <Fragment>

--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
@@ -72,26 +72,33 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
 
   useEffect(() => setSavedQuery(initialSavedQuery), [initialSavedQuery]);
 
-  const [{ index: dataView, query, filter: filters, threshold, timeWindowSize, size }, dispatch] =
-    useReducer<LocalStateReducer>(
-      (currentState, action) => {
-        if (isSearchSourceParam(action)) {
-          searchSource.setParent(undefined).setField(action.type, action.payload);
-          setParam('searchConfiguration', searchSource.getSerializedFields());
-        } else {
-          setParam(action.type, action.payload);
-        }
-        return { ...currentState, [action.type]: action.payload };
-      },
-      {
-        index: searchSource.getField('index')!,
-        query: searchSource.getField('query')!,
-        filter: mapAndFlattenFilters(searchSource.getField('filter') as Filter[]),
-        threshold: ruleParams.threshold,
-        timeWindowSize: ruleParams.timeWindowSize,
-        size: ruleParams.size,
+  const [ruleConfiguration, dispatch] = useReducer<LocalStateReducer>(
+    (currentState, action) => {
+      if (isSearchSourceParam(action)) {
+        searchSource.setParent(undefined).setField(action.type, action.payload);
+        setParam('searchConfiguration', searchSource.getSerializedFields());
+      } else {
+        setParam(action.type, action.payload);
       }
-    );
+      return { ...currentState, [action.type]: action.payload };
+    },
+    {
+      index: searchSource.getField('index')!,
+      query: searchSource.getField('query')!,
+      filter: mapAndFlattenFilters(searchSource.getField('filter') as Filter[]),
+      threshold: ruleParams.threshold,
+      timeWindowSize: ruleParams.timeWindowSize,
+      size: ruleParams.size,
+    }
+  );
+  const {
+    index: dataView,
+    query,
+    filter: filters,
+    threshold,
+    timeWindowSize,
+    size,
+  } = ruleConfiguration;
   const dataViews = useMemo(() => [dataView], [dataView]);
 
   const onSelectDataView = useCallback(
@@ -172,10 +179,13 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
       from: `now-${timeWindow}`,
       to: 'now',
     });
-    testSearchSource.setField('filter', timeFilter ? [timeFilter, ...filters] : filters);
+    testSearchSource.setField(
+      'filter',
+      timeFilter ? [timeFilter, ...ruleConfiguration.filter] : ruleConfiguration.filter
+    );
     const { rawResponse } = await firstValueFrom(testSearchSource.fetch$());
     return { nrOfDocs: totalHitsToNumber(rawResponse.hits.total), timeWindow };
-  }, [searchSource, timeWindowSize, timeWindowUnit, filters]);
+  }, [searchSource, timeWindowSize, timeWindowUnit, ruleConfiguration]);
 
   return (
     <Fragment>

--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/use_test_query.ts
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/use_test_query.ts
@@ -5,50 +5,72 @@
  * 2.0.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+interface TestQueryResponse {
+  result: string | null;
+  error: string | null;
+  isLoading: boolean;
+}
+
+const TEST_QUERY_INITIAL_RESPONSE: TestQueryResponse = {
+  result: null,
+  error: null,
+  isLoading: false,
+};
 
 /**
  * Hook used to test the data fetching execution by returning a number of found documents
  * Or in error in case it's failing
  */
 export function useTestQuery(fetch: () => Promise<{ nrOfDocs: number; timeWindow: string }>) {
-  const [testQueryResult, setTestQueryResult] = useState<string | null>(null);
-  const [testQueryError, setTestQueryError] = useState<string | null>(null);
-  const [testQueryLoading, setTestQueryLoading] = useState<boolean>(false);
+  const [testQueryResponse, setTestQueryResponse] = useState<TestQueryResponse>(
+    TEST_QUERY_INITIAL_RESPONSE
+  );
+
+  useEffect(() => {
+    setTestQueryResponse(TEST_QUERY_INITIAL_RESPONSE);
+  }, [fetch]);
 
   const onTestQuery = useCallback(async () => {
-    setTestQueryLoading(true);
-    setTestQueryError(null);
-    setTestQueryResult(null);
+    setTestQueryResponse({
+      result: null,
+      error: null,
+      isLoading: true,
+    });
+
     try {
       const { nrOfDocs, timeWindow } = await fetch();
 
-      setTestQueryResult(
-        i18n.translate('xpack.stackAlerts.esQuery.ui.numQueryMatchesText', {
+      setTestQueryResponse({
+        result: i18n.translate('xpack.stackAlerts.esQuery.ui.numQueryMatchesText', {
           defaultMessage: 'Query matched {count} documents in the last {window}.',
           values: { count: nrOfDocs, window: timeWindow },
-        })
-      );
+        }),
+        error: null,
+        isLoading: false,
+      });
     } catch (err) {
       const message = err?.body?.attributes?.error?.root_cause[0]?.reason || err?.body?.message;
-      setTestQueryError(
-        i18n.translate('xpack.stackAlerts.esQuery.ui.queryError', {
+
+      setTestQueryResponse({
+        result: null,
+        error: i18n.translate('xpack.stackAlerts.esQuery.ui.queryError', {
           defaultMessage: 'Error testing query: {message}',
           values: { message: message ? `${err.message}: ${message}` : err.message },
-        })
-      );
-    } finally {
-      setTestQueryLoading(false);
+        }),
+        isLoading: false,
+      });
     }
   }, [fetch]);
 
   return {
     onTestQuery,
-    testQueryResult,
-    testQueryError,
-    testQueryLoading,
+    testQueryResult: testQueryResponse.result,
+    testQueryError: testQueryResponse.error,
+    testQueryLoading: testQueryResponse.isLoading,
   };
 }
 

--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/use_test_query.ts
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/use_test_query.ts
@@ -30,6 +30,7 @@ export function useTestQuery(fetch: () => Promise<{ nrOfDocs: number; timeWindow
     TEST_QUERY_INITIAL_RESPONSE
   );
 
+  // Reset query response when criteria got changed
   useEffect(() => {
     setTestQueryResponse(TEST_QUERY_INITIAL_RESPONSE);
   }, [fetch]);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/134180

## Summary

This PR fixes "Test query" button when user changes current Rule filters.

It also removes number of matches from a previous test run if configuration (query, filter, etc) was updated. This way user would be confused whether it's a previous calculation or a new one.

Steps to test:
1. Start creating an alert from Discover page
2. Press "Test query" and note number of found matches
3. Edit filters or query for the rule
4. Notice that the previous number of found matches is removed
5. Press "Test query" again to check if it made an effect on number of matches
