### PR TITLE
[Lens] Fix voiceover drag and drop

### DIFF
--- a/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
+++ b/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
@@ -274,6 +274,7 @@ const DragInner = memo(function DragInner({
   );
   const modifierHandlers = useMemo(() => {
     const onKeyUp = (e: KeyboardEvent<HTMLButtonElement>) => {
+      e.preventDefault();
       if (activeDropTarget?.id && ['Shift', 'Alt', 'Control'].includes(e.key)) {
         if (e.altKey) {
           setTargetOfIndex(activeDropTarget.id, 1);
@@ -292,6 +293,7 @@ const DragInner = memo(function DragInner({
       }
     };
     const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+      e.preventDefault();
       if (e.key === 'Alt' && activeDropTarget?.id) {
         setTargetOfIndex(activeDropTarget.id, 1);
       } else if (e.key === 'Shift' && activeDropTarget?.id) {
@@ -410,7 +412,7 @@ const DragInner = memo(function DragInner({
           aria-describedby={ariaDescribedBy || `lnsDragDrop-keyboardInstructions`}
           className="lnsDragDrop__keyboardHandler"
           data-test-subj="lnsDragDrop-keyboardHandler"
-          onBlur={() => {
+          onBlur={(e) => {
             if (activeDraggingProps) {
               dragEnd();
             }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/133968

by `preventDefault` the key up and down events while drag is in progress (it seems like voiceover was reacting to them in a way that caused the field to lose focus). I didn't notice any negative effect of this change, @mbondyra could you take a look, too?