### PR TITLE
[Fleet] added tags to agent update api

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1378,7 +1378,28 @@
           {
             "$ref": "#/components/parameters/kbn_xsrf"
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "user_provided_metadata": {
+                    "type": "object"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       },
       "delete": {
         "summary": "Agent - Delete",

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -854,6 +854,19 @@ paths:
       operationId: update-agent
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_provided_metadata:
+                  type: object
+                tags:
+                  type: array
+                  items:
+                    type: string
     delete:
       summary: Agent - Delete
       tags: []

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}.yaml
@@ -38,6 +38,19 @@ put:
   operationId: update-agent
   parameters:
     - $ref: ../components/headers/kbn_xsrf.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+              user_provided_metadata:
+                type: object  
+              tags:
+                type: array
+                items:
+                  type: string  
 delete:
   summary: Agent - Delete
   tags: []

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -87,10 +87,16 @@ export const updateAgentHandler: RequestHandler<
   const coreContext = await context.core;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
 
+  const partialAgent: any = {};
+  if (request.body.user_provided_metadata) {
+    partialAgent.user_provided_metadata = request.body.user_provided_metadata;
+  }
+  if (request.body.tags) {
+    partialAgent.tags = request.body.tags;
+  }
+
   try {
-    await AgentService.updateAgent(esClient, request.params.agentId, {
-      user_provided_metadata: request.body.user_provided_metadata,
-    });
+    await AgentService.updateAgent(esClient, request.params.agentId, partialAgent);
     const body = {
       item: await AgentService.getAgentById(esClient, request.params.agentId),
     };

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { uniq } from 'lodash';
 import type { RequestHandler } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
@@ -92,7 +93,7 @@ export const updateAgentHandler: RequestHandler<
     partialAgent.user_provided_metadata = request.body.user_provided_metadata;
   }
   if (request.body.tags) {
-    partialAgent.tags = request.body.tags;
+    partialAgent.tags = uniq(request.body.tags);
   }
 
   try {

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -127,7 +127,8 @@ export const UpdateAgentRequestSchema = {
     agentId: schema.string(),
   }),
   body: schema.object({
-    user_provided_metadata: schema.recordOf(schema.string(), schema.any()),
+    user_provided_metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+    tags: schema.maybe(schema.arrayOf(schema.string())),
   }),
 };
 

--- a/x-pack/test/fleet_api_integration/apis/agents/index.js
+++ b/x-pack/test/fleet_api_integration/apis/agents/index.js
@@ -15,5 +15,6 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./current_upgrades'));
     loadTestFile(require.resolve('./reassign'));
     loadTestFile(require.resolve('./status'));
+    loadTestFile(require.resolve('./update'));
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/agents/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/update.ts
@@ -33,6 +33,18 @@ export default function (providerContext: FtrProviderContext) {
       expect(apiResponse.item.tags).to.eql(['tag1']);
     });
 
+    it('should dedupe tags in agent update', async () => {
+      const { body: apiResponse } = await supertest
+        .put(`/api/fleet/agents/agent1`)
+        .set('kbn-xsrf', 'xx')
+        .send({
+          tags: ['tag1', 'tag2', 'tag1'],
+        })
+        .expect(200);
+
+      expect(apiResponse.item.tags).to.eql(['tag1', 'tag2']);
+    });
+
     it('should return a 200 if this a valid update request with user metadata', async () => {
       const { body: apiResponse } = await supertest
         .put(`/api/fleet/agents/agent1`)

--- a/x-pack/test/fleet_api_integration/apis/agents/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/update.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertest');
+
+  describe('fleet_agents_update', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/fleet/agents');
+    });
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/agents');
+    });
+
+    it('should return a 200 if this a valid update request with tags', async () => {
+      const { body: apiResponse } = await supertest
+        .put(`/api/fleet/agents/agent1`)
+        .set('kbn-xsrf', 'xx')
+        .send({
+          tags: ['tag1'],
+        })
+        .expect(200);
+
+      expect(apiResponse.item.tags).to.eql(['tag1']);
+    });
+
+    it('should return a 200 if this a valid update request with user metadata', async () => {
+      const { body: apiResponse } = await supertest
+        .put(`/api/fleet/agents/agent1`)
+        .set('kbn-xsrf', 'xx')
+        .send({
+          user_provided_metadata: {
+            data: 'test',
+          },
+        })
+        .expect(200);
+
+      expect(apiResponse.item.user_provided_metadata).to.eql({
+        data: 'test',
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Prep work for https://github.com/elastic/kibana/issues/133307
Extended agents update API to be able to update tags.

### Steps to verify:
- Enroll an agent (can be fleet server)
- Run the following API call in console with the created agent id
- **Expected:** the API response should contain the new list of tags, and the new tags are visible on the UI.



**Note:** the agent's existing tags will be overwritten by the update. I think this way it is easier to add/rename/remove tags, since tags are not stored as separate entities. The UI can prepare the changed list of tags.

The previous version only supported updating `user_provided_metadata` in agent update request. This functionality still works, with `user_provided_metadata` and `tags` both being optional request body properties. 
Added API integration test to cover both type of updates.

```
GET kbn:/api/fleet/agents

PUT kbn:/api/fleet/agents/f1ff15c4-f503-4817-b0b8-2000d1dc640b
{
  "tags": ["myServer2"]
}
```

<img width="724" alt="image" src="https://user-images.githubusercontent.com/90178898/173345807-52299690-4432-43bc-8cb8-dbc911505fa5.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
