### PR TITLE
[Fleet] Remove invalid flag from README

### DIFF
--- a/x-pack/plugins/fleet/README.md
+++ b/x-pack/plugins/fleet/README.md
@@ -40,7 +40,7 @@ One common development workflow is:
   ```
 - Start Kibana in another shell
   ```
-  yarn start --xpack.fleet.enabled=true --no-base-path
+  yarn start --no-base-path
   ```
 
 This plugin follows the `common`, `server`, `public` structure from the [Architecture Style Guide


### PR DESCRIPTION
## Summary

Remove the invalid flag `--xpack.fleet.enabled=true`  from the `yarn start` command