### PR TITLE
[Visualize] Better default for date_range agg

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/date_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_range.ts
@@ -55,7 +55,7 @@ export const getDateRangeBucketAgg = ({ aggExecutionContext, getConfig }: AggTyp
         type: 'field',
         filterFieldTypes: [KBN_FIELD_TYPES.DATE, KBN_FIELD_TYPES.DATE_RANGE],
         default(agg: IBucketAggConfig) {
-          return agg.getIndexPattern().timeFieldName;
+          return agg.getIndexPattern().getTimeField?.()?.name;
         },
       },
       {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134069

by setting the default of the `field` param to `undefined` instead of empty string in case the current data view doesn't have a default time field.