### PR TITLE
[ML] Fixes error in categorization wizard summary step

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/metric_selection_summary.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/metric_selection_summary.tsx
@@ -79,8 +79,12 @@ export const CategorizationDetectorsSummary: FC = () => {
         loading={loadingData}
         fadeChart={jobIsRunning}
       />
-      <TopCategories />
-      <CategoryStoppedPartitions />
+      {jobIsRunning ? (
+        <>
+          <TopCategories />
+          <CategoryStoppedPartitions />
+        </>
+      ) : null}
     </>
   );
 };

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/metric_selection_summary.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/metric_selection_summary.tsx
@@ -79,12 +79,8 @@ export const CategorizationDetectorsSummary: FC = () => {
         loading={loadingData}
         fadeChart={jobIsRunning}
       />
-      {jobIsRunning ? (
-        <>
-          <TopCategories />
-          <CategoryStoppedPartitions />
-        </>
-      ) : null}
+      <TopCategories />
+      <CategoryStoppedPartitions />
     </>
   );
 };

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/top_categories.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/top_categories.tsx
@@ -12,9 +12,12 @@ import { JobCreatorContext } from '../../../job_creator_context';
 import { CategorizationJobCreator } from '../../../../../common/job_creator';
 import { Results } from '../../../../../common/results_loader';
 import { ml } from '../../../../../../../services/ml_api_service';
+import { useToastNotificationService } from '../../../../../../../services/toast_notification_service';
 import { NUMBER_OF_CATEGORY_EXAMPLES } from '../../../../../../../../../common/constants/categorization_job';
+import { extractErrorProperties } from '../../../../../../../../../common/util/errors';
 
 export const TopCategories: FC = () => {
+  const { displayErrorToast } = useToastNotificationService();
   const { jobCreator: jc, resultsLoader } = useContext(JobCreatorContext);
   const jobCreator = jc as CategorizationJobCreator;
 
@@ -26,14 +29,22 @@ export const TopCategories: FC = () => {
   }
 
   async function loadTopCats() {
-    const results = await ml.jobs.topCategories(jobCreator.jobId, NUMBER_OF_CATEGORY_EXAMPLES);
-    setTableRow(
-      results.categories.map((c) => ({
-        count: c.count,
-        example: c.category.examples?.length ? c.category.examples[0] : '',
-      }))
-    );
-    setTotalCategories(results.total);
+    try {
+      const results = await ml.jobs.topCategories(jobCreator.jobId, NUMBER_OF_CATEGORY_EXAMPLES);
+      setTableRow(
+        results.categories.map((c) => ({
+          count: c.count,
+          example: c.category.examples?.length ? c.category.examples[0] : '',
+        }))
+      );
+      setTotalCategories(results.total);
+    } catch (e) {
+      const error = extractErrorProperties(e);
+      // might get 404 because job has not been created yet
+      if (error.statusCode !== 404) {
+        displayErrorToast(e);
+      }
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
Fixes uncaught promise rejection on the categorization wizard summary step.
The results panels are displayed before the job has been created, which causes it to attempt to load the results for job that doesn't exist.

The error is only displayed in the browser's console.
