### PR TITLE
[DOCS] Removes tag from 8.2.3 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -31,8 +31,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.2.3]]
 == {kib} 8.2.3
 
-coming::[8.2.3]
-
 Review the following information about the {kib} 8.2.3 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 8.2.3 release notes.