### PR TITLE
[Lens] Fix rotating number example

### DIFF
--- a/x-pack/examples/testing_embedded_lens/public/app.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/app.tsx
@@ -669,6 +669,7 @@ export const App = (props: {
                         value={undefined}
                         onChange={(e) => switchChartPreset(Number(e.target.value))}
                         aria-label="Load from a preset"
+                        prepend={'Load preset'}
                       />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/x-pack/examples/third_party_vis_lens_example/public/plugin.ts
+++ b/x-pack/examples/third_party_vis_lens_example/public/plugin.ts
@@ -91,18 +91,24 @@ export class EmbeddedLensExamplePlugin
       id: 'third_party_lens_vis_example',
       title: 'Third party Lens vis example',
       navLinkStatus: AppNavLinkStatus.hidden,
-      mount: (params) => {
+      mount: ({ history }) => {
         (async () => {
-          const [, { lens: lensStart, dataViews }] = await core.getStartServices();
-          const defaultDataView = await dataViews.getDefault();
-          lensStart.navigateToPrefilledEditor({
-            id: '',
-            timeRange: {
-              from: 'now-5d',
-              to: 'now',
-            },
-            attributes: getLensAttributes(defaultDataView!),
-          });
+          const [coreStart, { lens: lensStart, dataViews }] = await core.getStartServices();
+          // if it's a regular navigation, redirect to Lens
+          if (history.action === 'PUSH') {
+            const defaultDataView = await dataViews.getDefault();
+            lensStart.navigateToPrefilledEditor({
+              id: '',
+              timeRange: {
+                from: 'now-5d',
+                to: 'now',
+              },
+              attributes: getLensAttributes(defaultDataView!),
+            });
+          } else {
+            // if it's a "back" navigation, go to developer examples
+            coreStart.application.navigateToApp('developerExamples');
+          }
         })();
         return () => {};
       },

--- a/x-pack/examples/third_party_vis_lens_example/public/visualization.tsx
+++ b/x-pack/examples/third_party_vis_lens_example/public/visualization.tsx
@@ -16,7 +16,10 @@ import { layerTypes } from '@kbn/lens-plugin/public';
 import type { RotatingNumberState } from '../common/types';
 import { DEFAULT_COLOR } from '../common/constants';
 
-const toExpression = (state: RotatingNumberState): Ast | null => {
+const toExpression = (
+  state: RotatingNumberState,
+  datasourceExpressionsByLayers?: Record<string, Ast>
+): Ast | null => {
   if (!state.accessor) {
     return null;
   }
@@ -24,6 +27,7 @@ const toExpression = (state: RotatingNumberState): Ast | null => {
   return {
     type: 'expression',
     chain: [
+      ...Object.values(datasourceExpressionsByLayers || {})[0].chain,
       {
         type: 'function',
         function: 'rotating_number',
@@ -149,8 +153,10 @@ export const getRotatingNumberVisualization = ({
     }
   },
 
-  toExpression: (state) => toExpression(state),
-  toPreviewExpression: (state) => toExpression(state),
+  toExpression: (state, _layers, _attributes, datasourceExpression) =>
+    toExpression(state, datasourceExpression),
+  toPreviewExpression: (state, _layers, datasourceExpression) =>
+    toExpression(state, datasourceExpression),
 
   setDimension({ prevState, columnId }) {
     return { ...prevState, accessor: columnId };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134225
Fixes https://github.com/elastic/kibana/issues/134226

When restructuring how the expression is built we forgot the rotating number example - this PR makes sure the datasource expression is prepended to the visualization expression.

The back button didn't work because dev examples forces the user to specify an app to navigate to. This PR fixes it by checking whether the current navigation is a forward or backward navigation when loading the redirect app - if it's forward navigation go to Lens, if it's backward navigation go to developer examples page.

The embedding playground select is working correctly - it's not meant as a "current vis type" indicator, it's about loading one of multiple presets. Clarified that by adding a prepend label:
<img width="480" alt="Screenshot 2022-06-13 at 17 13 10" src="https://user-images.githubusercontent.com/1508364/173386694-155a30b1-db20-4385-bb50-ec27149776c3.png">
