### PR TITLE
Gracefully stop EBT server shipper

### DIFF
--- a/packages/analytics/shippers/elastic_v3/server/src/server_shipper.ts
+++ b/packages/analytics/shippers/elastic_v3/server/src/server_shipper.ts
@@ -10,6 +10,7 @@ import fetch from 'node-fetch';
 import {
   filter,
   Subject,
+  ReplaySubject,
   interval,
   concatMap,
   merge,
@@ -19,7 +20,7 @@ import {
   retryWhen,
   tap,
   delayWhen,
-  takeWhile,
+  takeUntil,
 } from 'rxjs';
 import type {
   AnalyticsClientInitContext,
@@ -60,7 +61,7 @@ export class ElasticV3ServerShipper implements IShipper {
   );
 
   private readonly internalQueue: Event[] = [];
-  private readonly shutdown$ = new Subject<void>();
+  private readonly shutdown$ = new ReplaySubject<void>(1);
 
   private readonly url: string;
 
@@ -154,6 +155,7 @@ export class ElasticV3ServerShipper implements IShipper {
    * Triggers a flush of the internal queue to attempt to send any events held in the queue.
    */
   public shutdown() {
+    this.shutdown$.next();
     this.shutdown$.complete();
   }
 
@@ -169,7 +171,7 @@ export class ElasticV3ServerShipper implements IShipper {
     let backoff = 1 * MINUTE;
     timer(0, 1 * MINUTE)
       .pipe(
-        takeWhile(() => this.shutdown$.isStopped === false),
+        takeUntil(this.shutdown$),
         filter(() => this.isOptedIn === true && this.firstTimeOffline !== null),
         concatMap(async () => {
           const { ok } = await fetch(this.url, {
@@ -185,7 +187,7 @@ export class ElasticV3ServerShipper implements IShipper {
         }),
         retryWhen((errors) =>
           errors.pipe(
-            takeWhile(() => this.shutdown$.isStopped === false),
+            takeUntil(this.shutdown$),
             tap(() => {
               if (!this.firstTimeOffline) {
                 this.firstTimeOffline = Date.now();
@@ -207,7 +209,7 @@ export class ElasticV3ServerShipper implements IShipper {
   private setInternalSubscriber() {
     // Check the status of the queues every 1 second.
     merge(
-      interval(1000),
+      interval(1000).pipe(takeUntil(this.shutdown$)),
       // Using a promise because complete does not emit through the pipe.
       from(firstValueFrom(this.shutdown$, { defaultValue: true }))
     )
@@ -235,10 +237,7 @@ export class ElasticV3ServerShipper implements IShipper {
           this.lastBatchSent = Date.now();
           const eventsToSend = this.getEventsToSend();
           await this.sendEvents(eventsToSend);
-        }),
-
-        // Stop the subscriber if we are shutting down.
-        takeWhile(() => !this.shutdown$.isStopped)
+        })
       )
       .subscribe();
   }


### PR DESCRIPTION
The `isStopped` property is deprecated and it does no longer seem to be reflecting the Observable state.

As a result, the RxJS timer started by the `ElasticV3ServerShipper` is never completed / stopped, leaving async logic running forever when we stop Kibana.