### PR TITLE
Kibana usage collection plugin graceful setup() + stop()

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { Observable } from 'rxjs';
 import { savedObjectsRepositoryMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import {
   Collector,
@@ -47,7 +48,8 @@ describe('telemetry_application_usage', () => {
       logger,
       usageCollectionMock,
       registerType,
-      getSavedObjectClient
+      getSavedObjectClient,
+      new Observable<void>()
     );
   });
 

--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { savedObjectsRepositoryMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import {
   Collector,
@@ -22,9 +22,6 @@ import { ApplicationUsageViews } from './types';
 
 import { SAVED_OBJECTS_DAILY_TYPE, SAVED_OBJECTS_TOTAL_TYPE } from './saved_objects_types';
 
-// use fake timers to avoid triggering rollups during tests
-jest.useFakeTimers();
-
 describe('telemetry_application_usage', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
   let collector: Collector<unknown>;
@@ -35,6 +32,8 @@ describe('telemetry_application_usage', () => {
   const registerType = jest.fn();
   const mockedFetchContext = createCollectorFetchContextMock();
 
+  let pluginStop$: Subject<void>;
+
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
     usageCollectionMock = createUsageCollectionSetupMock();
@@ -44,17 +43,19 @@ describe('telemetry_application_usage', () => {
       collector = new Collector(logger, config);
       return createUsageCollectionSetupMock().makeUsageCollector(config);
     });
+    pluginStop$ = new Subject();
     registerApplicationUsageCollector(
       logger,
       usageCollectionMock,
       registerType,
       getSavedObjectClient,
-      new Observable<void>()
+      pluginStop$
     );
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
+    pluginStop$.next();
+    pluginStop$.complete();
   });
 
   test('registered collector is set', () => {

--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.ts
@@ -7,7 +7,7 @@
  */
 
 import moment from 'moment';
-import { timer } from 'rxjs';
+import { type Observable, takeUntil, timer } from 'rxjs';
 import { ISavedObjectsRepository, Logger, SavedObjectsServiceSetup } from '@kbn/core/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { MAIN_APP_DEFAULT_VIEW_ID } from '@kbn/usage-collection-plugin/common/constants';
@@ -48,13 +48,14 @@ export function registerApplicationUsageCollector(
   logger: Logger,
   usageCollection: UsageCollectionSetup,
   registerType: SavedObjectsServiceSetup['registerType'],
-  getSavedObjectsClient: () => ISavedObjectsRepository | undefined
+  getSavedObjectsClient: () => ISavedObjectsRepository | undefined,
+  pluginStop$: Observable<void>
 ) {
   registerMappings(registerType);
 
-  timer(ROLL_INDICES_START, ROLL_TOTAL_INDICES_INTERVAL).subscribe(() =>
-    rollTotals(logger, getSavedObjectsClient())
-  );
+  timer(ROLL_INDICES_START, ROLL_TOTAL_INDICES_INTERVAL)
+    .pipe(takeUntil(pluginStop$))
+    .subscribe(() => rollTotals(logger, getSavedObjectsClient()));
 
   const collector = usageCollection.makeUsageCollector<ApplicationUsageTelemetryReport | undefined>(
     {

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/cloud_provider_collector.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/cloud_provider_collector.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { firstValueFrom, type Observable } from 'rxjs';
+import AbortController from 'abort-controller';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { CloudDetector } from './detector';
 
@@ -16,10 +18,21 @@ interface Usage {
   zone?: string;
 }
 
-export function registerCloudProviderUsageCollector(usageCollection: UsageCollectionSetup) {
+export function registerCloudProviderUsageCollector(
+  usageCollection: UsageCollectionSetup,
+  pluginStop$: Observable<void>
+) {
+  const ac = new AbortController();
+  // we are stopping, we need to cancel async requests
+  firstValueFrom(pluginStop$).then(
+    () => ac.abort(),
+    // if we try to get the first value from a completed Observable, the promise will reject
+    () => ac.abort()
+  );
+
   const cloudDetector = new CloudDetector();
   // determine the cloud service in the background
-  cloudDetector.detectCloudService();
+  cloudDetector.detectCloudService(ac.signal);
 
   const collector = usageCollection.makeUsageCollector<Usage | undefined>({
     type: 'cloud_provider',

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/cloud_provider_collector.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/cloud_provider_collector.ts
@@ -24,11 +24,7 @@ export function registerCloudProviderUsageCollector(
 ) {
   const ac = new AbortController();
   // we are stopping, we need to cancel async requests
-  firstValueFrom(pluginStop$).then(
-    () => ac.abort(),
-    // if we try to get the first value from a completed Observable, the promise will reject
-    () => ac.abort()
-  );
+  firstValueFrom(pluginStop$).finally(() => ac.abort());
 
   const cloudDetector = new CloudDetector();
   // determine the cloud service in the background

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/aws.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/aws.ts
@@ -9,6 +9,7 @@
 import { readFile } from 'fs/promises';
 import { get, omit } from 'lodash';
 import fetch from 'node-fetch';
+import { AbortSignal } from 'abort-controller';
 import { CloudService } from './cloud_service';
 import { CloudServiceResponse } from './cloud_response';
 
@@ -95,10 +96,11 @@ export class AWSCloudService extends CloudService {
     return process.platform.startsWith('win');
   };
 
-  protected _checkIfService = async () => {
+  protected _checkIfService = async (signal?: AbortSignal) => {
     try {
       const response = await fetch(SERVICE_ENDPOINT, {
         method: 'GET',
+        signal,
       });
 
       if (!response.ok || response.status === 404) {

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/azure.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/azure.ts
@@ -8,6 +8,7 @@
 
 import { get, omit } from 'lodash';
 import fetch from 'node-fetch';
+import { AbortSignal } from 'abort-controller';
 import { CloudService } from './cloud_service';
 import { CloudServiceResponse } from './cloud_response';
 
@@ -78,13 +79,14 @@ export class AzureCloudService extends CloudService {
     return null;
   };
 
-  protected _checkIfService = async () => {
+  protected _checkIfService = async (signal?: AbortSignal) => {
     const response = await fetch(SERVICE_ENDPOINT, {
       method: 'GET',
       headers: {
         // Azure requires this header
         Metadata: 'true',
       },
+      signal,
     });
 
     if (!response.ok || response.status === 404) {

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/cloud_service.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/cloud_service.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { AbortSignal } from 'abort-controller';
 import { isObject, isPlainObject } from 'lodash';
 import { CloudServiceResponse } from './cloud_response';
 
@@ -31,15 +32,15 @@ export abstract class CloudService {
    * Using whatever mechanism is required by the current Cloud Service,
    * determine if Kibana is running in it and return relevant metadata.
    */
-  public checkIfService = async () => {
+  public checkIfService = async (signal?: AbortSignal) => {
     try {
-      return await this._checkIfService();
+      return await this._checkIfService(signal);
     } catch (e) {
       return this._createUnconfirmedResponse();
     }
   };
 
-  protected _checkIfService = async (): Promise<CloudServiceResponse> => {
+  protected _checkIfService = async (signal?: AbortSignal): Promise<CloudServiceResponse> => {
     // should always be overridden by a subclass
     return Promise.reject(new Error('not implemented'));
   };

--- a/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/gcp.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/cloud/detector/gcp.ts
@@ -7,6 +7,7 @@
  */
 
 import fetch, { Response } from 'node-fetch';
+import { AbortSignal } from 'abort-controller';
 import { CloudService } from './cloud_service';
 import { CloudServiceResponse } from './cloud_response';
 
@@ -26,7 +27,7 @@ export class GCPCloudService extends CloudService {
     super('gcp');
   }
 
-  protected _checkIfService = async () => {
+  protected _checkIfService = async (signal?: AbortSignal) => {
     // we need to call GCP individually for each field we want metadata for
     const fields = ['id', 'machine-type', 'zone'];
 
@@ -35,6 +36,7 @@ export class GCPCloudService extends CloudService {
         return await fetch(`${SERVICE_ENDPOINT}/${field}`, {
           method: 'GET',
           headers: { ...SERVICE_HEADERS },
+          signal,
         });
       })
     );

--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/event_loop_delays_usage_collector.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/event_loop_delays_usage_collector.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import {
   Collector,
   createUsageCollectionSetupMock,
@@ -31,15 +31,23 @@ describe('registerEventLoopDelaysCollector', () => {
   });
 
   const collectorFetchContext = createCollectorFetchContextMock();
+  let pluginStop$: Subject<void>;
 
   beforeAll(() => {
+    pluginStop$ = new Subject<void>();
+
     registerEventLoopDelaysCollector(
       logger,
       usageCollectionMock,
       mockRegisterType,
       mockGetSavedObjectsClient,
-      new Observable<void>()
+      pluginStop$
     );
+  });
+
+  afterAll(() => {
+    pluginStop$.next();
+    pluginStop$.complete();
   });
 
   it('registers event_loop_delays collector', () => {

--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/event_loop_delays_usage_collector.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/event_loop_delays_usage_collector.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { Observable } from 'rxjs';
 import {
   Collector,
   createUsageCollectionSetupMock,
@@ -36,7 +37,8 @@ describe('registerEventLoopDelaysCollector', () => {
       logger,
       usageCollectionMock,
       mockRegisterType,
-      mockGetSavedObjectsClient
+      mockGetSavedObjectsClient,
+      new Observable<void>()
     );
   });
 

--- a/src/plugins/kibana_usage_collection/server/collectors/usage_counters/rollups/register_rollups.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/usage_counters/rollups/register_rollups.ts
@@ -6,16 +6,17 @@
  * Side Public License, v 1.
  */
 
-import { timer } from 'rxjs';
+import { type Observable, timer, takeUntil } from 'rxjs';
 import { Logger, ISavedObjectsRepository } from '@kbn/core/server';
 import { ROLL_INDICES_INTERVAL, ROLL_INDICES_START } from './constants';
 import { rollUsageCountersIndices } from './rollups';
 
 export function registerUsageCountersRollups(
   logger: Logger,
-  getSavedObjectsClient: () => ISavedObjectsRepository | undefined
+  getSavedObjectsClient: () => ISavedObjectsRepository | undefined,
+  pluginStop$: Observable<void>
 ) {
-  timer(ROLL_INDICES_START, ROLL_INDICES_INTERVAL).subscribe(() =>
-    rollUsageCountersIndices(logger, getSavedObjectsClient())
-  );
+  timer(ROLL_INDICES_START, ROLL_INDICES_INTERVAL)
+    .pipe(takeUntil(pluginStop$))
+    .subscribe(() => rollUsageCountersIndices(logger, getSavedObjectsClient()));
 }


### PR DESCRIPTION
In the scope of graceful shutdown, this PR makes sure we cancel all timers and async tasks started by the _Kibana usage collection_ plugin's `setup()` method.