### PR TITLE
[8.3.0][Session View][Bug]Updated Metadata test and 1st accordion name and content to match the…

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
@@ -115,12 +115,14 @@ describe('DetailPanelMetadataTab component', () => {
 
       // expand host os accordion
       renderResult.queryByText('Host OS')?.querySelector('button')?.click();
+      expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('os.family')).toBeVisible();
       expect(renderResult.queryByText('os.full')).toBeVisible();
       expect(renderResult.queryByText('os.kernel')).toBeVisible();
       expect(renderResult.queryByText('os.name')).toBeVisible();
       expect(renderResult.queryByText('os.platform')).toBeVisible();
       expect(renderResult.queryByText('os.version')).toBeVisible();
+      expect(renderResult.queryByText(TEST_ARCHITECTURE)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_FAMILY)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_FULL)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_KERNEL)).toBeVisible();
@@ -157,12 +159,14 @@ describe('DetailPanelMetadataTab component', () => {
 
       // expand host os accordion
       renderResult.queryByText('Host OS')?.querySelector('button')?.click();
+      expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('os.family')).toBeVisible();
       expect(renderResult.queryByText('os.full')).toBeVisible();
       expect(renderResult.queryByText('os.kernel')).toBeVisible();
       expect(renderResult.queryByText('os.name')).toBeVisible();
       expect(renderResult.queryByText('os.platform')).toBeVisible();
       expect(renderResult.queryByText('os.version')).toBeVisible();
+      expect(renderResult.queryByText(TEST_ARCHITECTURE)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_FAMILY)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_FULL)).toBeVisible();
       expect(renderResult.queryByText(TEST_OS_KERNEL)).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
@@ -102,13 +102,11 @@ describe('DetailPanelMetadataTab component', () => {
     it('renders DetailPanelMetadataTab correctly (non cloud environment)', async () => {
       renderResult = mockedContext.render(<DetailPanelMetadataTab processHost={TEST_HOST} />);
 
-      expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('hostname')).toBeVisible();
       expect(renderResult.queryAllByText('id').length).toBe(1);
       expect(renderResult.queryByText('ip')).toBeVisible();
       expect(renderResult.queryByText('mac')).toBeVisible();
       expect(renderResult.queryAllByText('name').length).toBe(1);
-      expect(renderResult.queryByText(TEST_ARCHITECTURE)).toBeVisible();
       expect(renderResult.queryByText(TEST_HOSTNAME)).toBeVisible();
       expect(renderResult.queryByText(TEST_ID)).toBeVisible();
       expect(renderResult.queryByText(TEST_IP.join(', '))).toBeVisible();
@@ -144,11 +142,9 @@ describe('DetailPanelMetadataTab component', () => {
         />
       );
 
-      expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('hostname')).toBeVisible();
       expect(renderResult.queryByText('ip')).toBeVisible();
       expect(renderResult.queryByText('mac')).toBeVisible();
-      expect(renderResult.queryByText(TEST_ARCHITECTURE)).toBeVisible();
       expect(renderResult.queryByText(TEST_HOSTNAME)).toBeVisible();
       expect(renderResult.queryByText(TEST_ID)).toBeVisible();
       expect(renderResult.queryByText(TEST_IP.join(', '))).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
@@ -47,7 +47,7 @@ export const DetailPanelMetadataTab = ({
       <DetailPanelAccordion
         id="metadataHost"
         title={i18n.translate('xpack.sessionView.metadataDetailsTab.metadata', {
-          defaultMessage: 'Metadata',
+          defaultMessage: 'Host',
         })}
         initialIsOpen={true}
         listItems={[
@@ -132,19 +132,6 @@ export const DetailPanelMetadataTab = ({
               defaultMessage: 'Host OS',
             })}
             listItems={[
-              {
-                title: <DetailPanelListItem>architecture</DetailPanelListItem>,
-                description: (
-                  <DetailPanelCopy
-                    textToCopy={`host.architecture: "${hostData.architecture}"`}
-                    tooltipContent={hostData.architecture}
-                  >
-                    <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
-                      {hostData.architecture}
-                    </EuiTextColor>
-                  </DetailPanelCopy>
-                ),
-              },
               {
                 title: <DetailPanelListItem>os.family</DetailPanelListItem>,
                 description: (

--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
@@ -47,7 +47,7 @@ export const DetailPanelMetadataTab = ({
       <DetailPanelAccordion
         id="metadataHost"
         title={i18n.translate('xpack.sessionView.metadataDetailsTab.metadata', {
-          defaultMessage: 'Host',
+          defaultMessage: 'Metadata',
         })}
         initialIsOpen={true}
         listItems={[
@@ -132,6 +132,19 @@ export const DetailPanelMetadataTab = ({
               defaultMessage: 'Host OS',
             })}
             listItems={[
+              {
+                title: <DetailPanelListItem>architecture</DetailPanelListItem>,
+                description: (
+                  <DetailPanelCopy
+                    textToCopy={`host.architecture: "${hostData.architecture}"`}
+                    tooltipContent={hostData.architecture}
+                  >
+                    <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
+                      {hostData.architecture}
+                    </EuiTextColor>
+                  </DetailPanelCopy>
+                ),
+              },
               {
                 title: <DetailPanelListItem>os.family</DetailPanelListItem>,
                 description: (


### PR DESCRIPTION
## Summary

Updated Metadata tab 
- Change 1st accordion name from Metadata -> Host
- Updated Metadata tab Jest

