### PR TITLE
[8.3] [No Data] Allow access to the app if there are user created data views (#134068)

### DIFF
--- a/packages/kbn-shared-ux-components/src/empty_state/kibana_no_data_page.tsx
+++ b/packages/kbn-shared-ux-components/src/empty_state/kibana_no_data_page.tsx
@@ -48,10 +48,6 @@ export const KibanaNoDataPage = ({ onDataViewCreated, noDataConfig }: Props) => 
     return <EuiLoadingElastic css={{ margin: 'auto' }} size="xxl" />;
   }
 
-  if (!dataExists) {
-    return <NoDataConfigPage noDataConfig={noDataConfig} />;
-  }
-
   /*
     TODO: clintandrewhall - the use and population of `NoDataViewPromptProvider` here is temporary,
     until `KibanaNoDataPage` is moved to a package of its own.
@@ -60,7 +56,7 @@ export const KibanaNoDataPage = ({ onDataViewCreated, noDataConfig }: Props) => 
     with `KibanaNoDataPageProvider`, creating a single Provider that manages contextual dependencies
     throughout the React tree from the top-level of composition and consumption.
   */
-  if (!hasUserDataViews) {
+  if (!hasUserDataViews && dataExists) {
     const services: NoDataViewsPromptServices = {
       canCreateNewDataView,
       dataViewsDocLink,
@@ -72,6 +68,10 @@ export const KibanaNoDataPage = ({ onDataViewCreated, noDataConfig }: Props) => 
         <NoDataViewsPrompt onDataViewCreated={onDataViewCreated} />
       </NoDataViewsPromptProvider>
     );
+  }
+
+  if (!dataExists) {
+    return <NoDataConfigPage noDataConfig={noDataConfig} />;
   }
 
   return null;

--- a/src/plugins/dashboard/public/application/dashboard_app_no_data.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_no_data.tsx
@@ -42,6 +42,5 @@ export const isDashboardAppInNoDataState = async (
   dataViews: DataPublicPluginStart['dataViews']
 ) => {
   const hasUserDataView = await dataViews.hasData.hasUserDataView().catch(() => false);
-  const hasEsData = await dataViews.hasData.hasESData().catch(() => true);
-  return !hasUserDataView || !hasEsData;
+  return !hasUserDataView;
 };

--- a/src/plugins/discover/public/application/main/discover_main_route.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.tsx
@@ -69,12 +69,15 @@ export function DiscoverMainRoute() {
   const loadDefaultOrCurrentIndexPattern = useCallback(
     async (searchSource: ISearchSource) => {
       try {
-        const hasUserDataView = await data.dataViews.hasData.hasUserDataView().catch(() => false);
-        const hasEsData = await data.dataViews.hasData.hasESData().catch(() => false);
-        if (!hasUserDataView || !hasEsData) {
+        const hasUserDataViewValue = await data.dataViews.hasData
+          .hasUserDataView()
+          .catch(() => false);
+
+        if (!hasUserDataViewValue) {
           setShowNoDataPage(true);
           return;
         }
+
         const defaultDataView = await data.dataViews.getDefaultDataView();
         if (!defaultDataView) {
           setShowNoDataPage(true);

--- a/src/plugins/visualizations/public/visualize_app/app.tsx
+++ b/src/plugins/visualizations/public/visualize_app/app.tsx
@@ -90,15 +90,17 @@ export const VisualizeApp = ({ onAppLeave }: VisualizeAppProps) => {
     const checkESOrDataViewExist = async () => {
       // check if there is any data view or data source
       const hasUserDataView = await dataViews.hasData.hasUserDataView().catch(() => false);
-      const hasEsData = await dataViews.hasData.hasESData().catch(() => false);
-      if (!hasUserDataView || !hasEsData) {
-        setShowNoDataPage(true);
+      if (hasUserDataView) {
+        // Adding this check as TSVB asks for the default dataview on initialization
+        const defaultDataView = await dataViews.getDefaultDataView();
+        if (!defaultDataView) {
+          setShowNoDataPage(true);
+        }
+        setIsLoading(false);
+        return;
       }
-      // Adding this check as TSVB asks for the default dataview on initialization
-      const defaultDataView = await dataViews.getDefaultDataView();
-      if (!defaultDataView) {
-        setShowNoDataPage(true);
-      }
+
+      setShowNoDataPage(true);
       setIsLoading(false);
     };
 

--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -243,8 +243,7 @@ export async function mountApp(
       useEffect(() => {
         (async () => {
           const hasUserDataView = await data.dataViews.hasData.hasUserDataView().catch(() => false);
-          const hasEsData = await data.dataViews.hasData.hasESData().catch(() => true);
-          if (!hasUserDataView || !hasEsData) {
+          if (!hasUserDataView) {
             setEditorState('no_data');
             return;
           }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[No Data] Allow access to the app if there are user created data views (#134068)](https://github.com/elastic/kibana/pull/134068)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)