### PR TITLE
[CI] Disable running CI for kibana branches that will not see a release

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -36,7 +36,8 @@
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",
         "/plugins/[^/]+/readme\\.(md|asciidoc)$"
-      ]
+      ],
+      "kibana_versions_check": true
     }
   ]
 }


### PR DESCRIPTION
Enables a new feature in the PR bot.

With this enabled, a PR's target branch will be checked right before CI would normally get triggered to see if it exists in [versions.json](https://github.com/elastic/kibana/blob/main/versions.json). If it doesn't, CI will be skipped, and a comment will be posted to the PR that looks like this:

```
CI was triggered for this PR, but this PR targets 8.1 which should not receive a future release. CI is not supported for these branches. Please consult the release schedule, or contact `#kibana-operations` if you believe this is an error.

The following branches are currently considered to be open:
* main
* 8.3
* 8.2
* 7.17
```

This is to help address some of the confusion with backporting to old branches, as we get tons of questions about it.

Note that this comment only gets triggered for PRs when CI would have otherwise been triggered. This means that docs-only changes in old branches, for example, will still continue to get skipped without a comment.