### PR TITLE
Hide source config for Custom API sources

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -25,7 +25,7 @@ describe('SourceSettings', () => {
   const updateContentSource = jest.fn();
   const removeContentSource = jest.fn();
   const getSourceConfigData = jest.fn();
-  const contentSource = fullContentSources[0];
+  const contentSource = fullContentSources[1];
   const buttonLoading = false;
   const isOrganization = true;
 
@@ -37,6 +37,7 @@ describe('SourceSettings', () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     setMockValues({ ...mockValues });
     setMockActions({
       updateContentSource,
@@ -63,7 +64,7 @@ describe('SourceSettings', () => {
     wrapper.find('form').simulate('submit', { preventDefault });
 
     expect(preventDefault).toHaveBeenCalled();
-    expect(updateContentSource).toHaveBeenCalledWith(fullContentSources[0].id, { name: TEXT });
+    expect(updateContentSource).toHaveBeenCalledWith(contentSource.id, { name: TEXT });
   });
 
   it('handles confirmModal submission', () => {
@@ -95,7 +96,7 @@ describe('SourceSettings', () => {
     setMockValues({
       ...mockValues,
       contentSource: {
-        ...fullContentSources[0],
+        ...contentSource,
         serviceType: 'confluence_server',
       },
     });
@@ -105,5 +106,60 @@ describe('SourceSettings', () => {
     expect(wrapper.find(SourceConfigFields).prop('publicKey')).toEqual(
       sourceConfigData.configuredFields.publicKey
     );
+  });
+
+  it('hides source config for github apps', () => {
+    setMockValues({
+      ...mockValues,
+      contentSource: {
+        ...contentSource,
+        serviceType: 'github_via_app',
+        secret: {},
+      },
+    });
+
+    const wrapper = shallow(<SourceSettings />);
+
+    expect(wrapper.find(SourceConfigFields)).toHaveLength(0);
+  });
+
+  it('hides source config for github enterprise apps', () => {
+    setMockValues({
+      ...mockValues,
+      contentSource: {
+        ...contentSource,
+        serviceType: 'github_enterprise_server_via_app',
+        secret: {},
+      },
+    });
+
+    const wrapper = shallow(<SourceSettings />);
+
+    expect(wrapper.find(SourceConfigFields)).toHaveLength(0);
+  });
+
+  it('hides source config for custom sources', () => {
+    setMockValues({
+      ...mockValues,
+      contentSource: {
+        ...contentSource,
+        serviceType: 'custom',
+      },
+    });
+
+    const wrapper = shallow(<SourceSettings />);
+
+    expect(wrapper.find(SourceConfigFields)).toHaveLength(0);
+  });
+
+  it('hides source config for non-organization sources', () => {
+    setMockValues({
+      ...mockValues,
+      isOrganization: false,
+    });
+
+    const wrapper = shallow(<SourceSettings />);
+
+    expect(wrapper.find(SourceConfigFields)).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -102,6 +102,8 @@ export const SourceSettings: React.FC = () => {
     serviceType === GITHUB_VIA_APP_SERVICE_TYPE ||
     serviceType === GITHUB_ENTERPRISE_SERVER_VIA_APP_SERVICE_TYPE;
 
+  const isCustomSource = serviceType === 'custom';
+
   const editPath = isGithubApp
     ? undefined // undefined for GitHub apps, as they are configured source-wide, and don't use a connector where you can edit the configuration
     : getEditPath(serviceType);
@@ -111,7 +113,7 @@ export const SourceSettings: React.FC = () => {
   const showConfirm = () => setModalVisibility(true);
   const hideConfirm = () => setModalVisibility(false);
 
-  const showOauthConfig = !isGithubApp && isOrganization;
+  const showSourceConfig = !isGithubApp && !isCustomSource && isOrganization;
   const showGithubAppConfig = isGithubApp;
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
@@ -192,7 +194,7 @@ export const SourceSettings: React.FC = () => {
           </EuiFlexGroup>
         </form>
       </ContentSection>
-      {showOauthConfig && (
+      {showSourceConfig && (
         <ContentSection title={SOURCE_CONFIG_TITLE}>
           <SourceConfigFields isOauth1={isOauth1} sourceConfigData={sourceConfigData} />
           <EuiFormRow>


### PR DESCRIPTION
## Summary

Custom API sources are push based, and don't have an internal or external connector associated with them. However on the source settings page for these Custom API sources we were incorrectly linking users to the connector settings page for a `custom` connector, which did not exist.  This remedies that by adding a check for whether the source has a Custom API service type

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios