### PR TITLE
Use icon for baseServiceType when available for adding a custom api source

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/configure_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/configure_custom.tsx
@@ -63,7 +63,7 @@ export const ConfigureCustom: React.FC<ConfigureCustomProps> = ({ sourceData }) 
     <>
       <AddSourceHeader
         name={name}
-        serviceType={baseServiceType || serviceType}
+        serviceType={baseServiceType ?? serviceType}
         categories={categories}
       />
       <EuiSpacer size="xxl" />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/configure_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/configure_custom.tsx
@@ -53,6 +53,7 @@ export const ConfigureCustom: React.FC<ConfigureCustomProps> = ({ sourceData }) 
 
   const {
     serviceType,
+    baseServiceType,
     configuration: { documentationUrl, githubRepository },
     name,
     categories = [],
@@ -60,7 +61,11 @@ export const ConfigureCustom: React.FC<ConfigureCustomProps> = ({ sourceData }) 
 
   return (
     <>
-      <AddSourceHeader name={name} serviceType={serviceType} categories={categories} />
+      <AddSourceHeader
+        name={name}
+        serviceType={baseServiceType || serviceType}
+        categories={categories}
+      />
       <EuiSpacer size="xxl" />
       <EuiFlexGroup
         justifyContent="flexStart"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
@@ -48,7 +48,11 @@ export const SaveCustom: React.FC<SaveCustomProps> = ({ sourceData }) => {
 
   return (
     <>
-      <AddSourceHeader name={name} serviceType={serviceType} categories={categories} />
+      <AddSourceHeader
+        name={name}
+        serviceType={baseServiceType || serviceType}
+        categories={categories}
+      />
       <EuiSpacer size="xxl" />
       <EuiFlexGroup>
         <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_custom_source/save_custom.tsx
@@ -50,7 +50,7 @@ export const SaveCustom: React.FC<SaveCustomProps> = ({ sourceData }) => {
     <>
       <AddSourceHeader
         name={name}
-        serviceType={baseServiceType || serviceType}
+        serviceType={baseServiceType ?? serviceType}
         categories={categories}
       />
       <EuiSpacer size="xxl" />


### PR DESCRIPTION
## Summary

When adding a custom source for a known service type, like Sharepoint Server, we were not using the icon of that service during the onboarding flow.  This now will use the icon for the service, aligning it with the onboarding flow for external connectors with known services like Confluence.  This does not affect the icon for the source after it has already been added, all custom sources will default to the custom source icon, like how all external sources default to the external icon.


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
