### PR TITLE
Decrease number of buckets from 100 to 50

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/get_bucket_size_for_aggregated_transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/get_bucket_size_for_aggregated_transactions/index.ts
@@ -10,7 +10,7 @@ import { getBucketSize } from '../get_bucket_size';
 export function getBucketSizeForAggregatedTransactions({
   start,
   end,
-  numBuckets = 100,
+  numBuckets = 50,
   searchAggregatedTransactions,
 }: {
   start: number;
@@ -18,6 +18,6 @@ export function getBucketSizeForAggregatedTransactions({
   numBuckets?: number;
   searchAggregatedTransactions?: boolean;
 }) {
-  const minBucketSize = searchAggregatedTransactions ? 60 : undefined;
+  const minBucketSize = searchAggregatedTransactions ? 60 * 5 : undefined;
   return getBucketSize({ start, end, numBuckets, minBucketSize });
 }

--- a/x-pack/plugins/apm/server/lib/helpers/get_bucket_size_for_aggregated_transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/get_bucket_size_for_aggregated_transactions/index.ts
@@ -18,6 +18,6 @@ export function getBucketSizeForAggregatedTransactions({
   numBuckets?: number;
   searchAggregatedTransactions?: boolean;
 }) {
-  const minBucketSize = searchAggregatedTransactions ? 60 * 5 : undefined;
+  const minBucketSize = searchAggregatedTransactions ? 60 : undefined;
   return getBucketSize({ start, end, numBuckets, minBucketSize });
 }

--- a/x-pack/test/apm_api_integration/tests/services/throughput.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/throughput.spec.ts
@@ -150,11 +150,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             );
           });
 
-          it('has a bucket size of 10 seconds for transactions data', () => {
+          it('has a bucket size of 30 seconds for transactions data', () => {
             const firstTimerange = throughputTransactions.currentPeriod[0].x;
             const secondTimerange = throughputTransactions.currentPeriod[1].x;
             const timeIntervalAsSeconds = (secondTimerange - firstTimerange) / 1000;
-            expect(timeIntervalAsSeconds).to.equal(10);
+            expect(timeIntervalAsSeconds).to.equal(30);
           });
 
           it('has a bucket size of 1 minute for metrics data', () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/134291

Reducing the number of buckets (by increasing the bucket size) both have performance and usability improvements. 

There might be times when end users want the higher accuracy that comes with a higher number of buckets but I think we should focus on the primary use cases and make sure they work well. At the end of the day, users can always create their own dashboards/visualisations.

## Before

![image](https://user-images.githubusercontent.com/209966/173460418-6d6b3507-90d0-4ea8-9c94-e8f329109fc2.png)


## After

![image](https://user-images.githubusercontent.com/209966/173460449-19ce87f1-8cbd-4bd3-9d59-c224f6657a70.png)

