### PR TITLE
Licensing plugin graceful setup() + stop()

### DIFF
--- a/x-pack/plugins/licensing/common/license_update.test.ts
+++ b/x-pack/plugins/licensing/common/license_update.test.ts
@@ -152,11 +152,11 @@ describe('licensing update', () => {
     const fetcher = jest
       .fn()
       .mockImplementationOnce(async () => {
-        await delay(100);
+        await delay(2);
         return firstLicense;
       })
       .mockImplementationOnce(async () => {
-        await delay(100);
+        await delay(2);
         return secondLicense;
       });
 

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -47,13 +47,13 @@ export function createLicenseUpdate(
   );
 
   // start periodic license fetch right away
-  const makeItHot = license$.subscribe();
+  const licenseSub = license$.subscribe();
 
   stop$
     .pipe(
       finalize(() => {
         manuallyRefresh$.complete();
-        makeItHot.unsubscribe();
+        licenseSub.unsubscribe();
       })
     )
     .subscribe();

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { ConnectableObservable, Observable, Subject, from, merge, firstValueFrom } from 'rxjs';
+import { ConnectableObservable, type Observable, Subject, from, merge, firstValueFrom } from 'rxjs';
 
 import { filter, map, pairwise, exhaustMap, publishReplay, share, takeUntil } from 'rxjs/operators';
 import { hasLicenseInfoChanged } from './has_license_info_changed';
-import { ILicense } from './types';
+import type { ILicense } from './types';
 
 export function createLicenseUpdate(
   triggerRefresh$: Observable<unknown>,
@@ -18,7 +18,10 @@ export function createLicenseUpdate(
   initialValues?: ILicense
 ) {
   const manuallyRefresh$ = new Subject<void>();
-  const fetched$ = merge(triggerRefresh$, manuallyRefresh$).pipe(exhaustMap(fetcher), share());
+  const fetched$ = merge(triggerRefresh$.pipe(takeUntil(stop$)), manuallyRefresh$).pipe(
+    exhaustMap(fetcher),
+    share()
+  );
 
   const cached$ = fetched$.pipe(
     takeUntil(stop$),

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -7,7 +7,16 @@
 
 import { ConnectableObservable, type Observable, Subject, from, merge, firstValueFrom } from 'rxjs';
 
-import { filter, map, pairwise, exhaustMap, publishReplay, share, takeUntil } from 'rxjs/operators';
+import {
+  filter,
+  map,
+  pairwise,
+  exhaustMap,
+  publishReplay,
+  share,
+  takeUntil,
+  tap,
+} from 'rxjs/operators';
 import { hasLicenseInfoChanged } from './has_license_info_changed';
 import type { ILicense } from './types';
 
@@ -18,10 +27,10 @@ export function createLicenseUpdate(
   initialValues?: ILicense
 ) {
   const manuallyRefresh$ = new Subject<void>();
-  const fetched$ = merge(triggerRefresh$.pipe(takeUntil(stop$)), manuallyRefresh$).pipe(
-    exhaustMap(fetcher),
-    share()
-  );
+  const fetched$ = merge(
+    triggerRefresh$.pipe(takeUntil(stop$.pipe(tap(() => manuallyRefresh$.complete())))),
+    manuallyRefresh$
+  ).pipe(exhaustMap(fetcher), share());
 
   const cached$ = fetched$.pipe(
     takeUntil(stop$),

--- a/x-pack/plugins/licensing/server/plugin.ts
+++ b/x-pack/plugins/licensing/server/plugin.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import { Observable, Subject, Subscription, timer } from 'rxjs';
+import type { Observable, Subject, Subscription } from 'rxjs';
+import { ReplaySubject, timer } from 'rxjs';
 import moment from 'moment';
 import { createHash } from 'crypto';
 import stringify from 'json-stable-stringify';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { MaybePromise } from '@kbn/utility-types';
+import type { MaybePromise } from '@kbn/utility-types';
 import { isPromise } from '@kbn/std';
-import {
+import type {
   CoreSetup,
   Logger,
   Plugin,
@@ -22,22 +23,22 @@ import {
 } from '@kbn/core/server';
 
 import { registerAnalyticsContextProvider } from '../common/register_analytics_context_provider';
-import {
+import type {
   ILicense,
   PublicLicense,
   PublicFeatures,
   LicenseType,
   LicenseStatus,
 } from '../common/types';
-import { LicensingPluginSetup, LicensingPluginStart } from './types';
+import type { LicensingPluginSetup, LicensingPluginStart } from './types';
 import { License } from '../common/license';
 import { createLicenseUpdate } from '../common/license_update';
 
-import { ElasticsearchError } from './types';
+import type { ElasticsearchError } from './types';
 import { registerRoutes } from './routes';
 import { FeatureUsageService } from './services';
 
-import { LicenseConfigType } from './licensing_config';
+import type { LicenseConfigType } from './licensing_config';
 import { createRouteHandlerContext } from './licensing_route_handler_context';
 import { createOnPreResponseHandler } from './on_pre_response_handler';
 import { getPluginStatus$ } from './plugin_status';
@@ -94,7 +95,7 @@ function sign({
  * current Kibana instance.
  */
 export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPluginStart, {}, {}> {
-  private stop$ = new Subject<void>();
+  private stop$: Subject<void> = new ReplaySubject<void>(1);
   private readonly logger: Logger;
   private readonly config: LicenseConfigType;
   private loggingSubscription?: Subscription;


### PR DESCRIPTION
In the scope of graceful shutdown, this PR makes sure we cancel all timers and async tasks started by the _Licensing_ plugin's `setup()` method.