### PR TITLE
[8.3] Collect analytics for the used authentication mechanisms. (#129302)

### DIFF
--- a/x-pack/plugins/security/common/licensing/index.mock.ts
+++ b/x-pack/plugins/security/common/licensing/index.mock.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import type { LicenseType } from '@kbn/licensing-plugin/common/types';
 import { LICENSE_TYPE } from '@kbn/licensing-plugin/common/types';
@@ -15,7 +15,7 @@ import type { SecurityLicense } from './license_service';
 
 export const licenseMock = {
   create: (
-    features: Partial<SecurityLicenseFeatures> = {},
+    features: Partial<SecurityLicenseFeatures> | Observable<Partial<SecurityLicenseFeatures>> = {},
     licenseType: LicenseType = 'basic' // default to basic if this is not specified
   ): jest.Mocked<SecurityLicense> => ({
     isLicenseAvailable: jest.fn().mockReturnValue(true),
@@ -27,6 +27,9 @@ export const licenseMock = {
         (licenseTypeToCheck: LicenseType) =>
           LICENSE_TYPE[licenseTypeToCheck] <= LICENSE_TYPE[licenseType]
       ),
-    features$: features ? of(features as SecurityLicenseFeatures) : of(),
+    features$:
+      features instanceof Observable
+        ? (features as Observable<SecurityLicenseFeatures>)
+        : of((features ?? {}) as SecurityLicenseFeatures),
   }),
 };

--- a/x-pack/plugins/security/public/analytics/analytics_service.test.ts
+++ b/x-pack/plugins/security/public/analytics/analytics_service.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { nextTick } from '@kbn/test-jest-helpers';
+
+import { licenseMock } from '../../common/licensing/index.mock';
+import { AnalyticsService } from './analytics_service';
+
+describe('AnalyticsService', () => {
+  let analyticsService: AnalyticsService;
+  beforeEach(() => {
+    analyticsService = new AnalyticsService();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(AnalyticsService.AuthTypeInfoStorageKey);
+  });
+
+  it('reports authentication type when security is enabled', async () => {
+    const mockCore = coreMock.createStart();
+    mockCore.http.post.mockResolvedValue({ signature: 'some-signature', timestamp: 1234 });
+
+    expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toBeNull();
+
+    analyticsService.setup({ securityLicense: licenseMock.create({ allowLogin: true }) });
+    analyticsService.start({ http: mockCore.http });
+
+    await nextTick();
+
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+    expect(mockCore.http.post).toHaveBeenCalledWith(
+      '/internal/security/analytics/_record_auth_type',
+      { body: null }
+    );
+    expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toMatchInlineSnapshot(
+      `"{\\"signature\\":\\"some-signature\\",\\"timestamp\\":1234}"`
+    );
+  });
+
+  it('throttle reporting of the authentication type events', async () => {
+    jest.useFakeTimers();
+
+    const mockCore = coreMock.createStart();
+    mockCore.http.post.mockResolvedValue({ signature: 'some-signature', timestamp: 1234 });
+
+    const licenseFeatures$ = new BehaviorSubject({ allowLogin: true });
+    analyticsService.setup({
+      securityLicense: licenseMock.create(licenseFeatures$.asObservable()),
+    });
+    analyticsService.start({ http: mockCore.http });
+
+    await nextTick();
+
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+    expect(mockCore.http.post).toHaveBeenCalledWith(
+      '/internal/security/analytics/_record_auth_type',
+      { body: null }
+    );
+    mockCore.http.post.mockClear();
+
+    // Changes that lead to disabled login should be ignored.
+    licenseFeatures$.next({ allowLogin: false });
+    jest.runAllTimers();
+    expect(mockCore.http.post).not.toHaveBeenCalled();
+
+    // The "leading" event indicating enabled login should be reported immediately.
+    licenseFeatures$.next({ allowLogin: true });
+    jest.advanceTimersByTime(1000);
+    licenseFeatures$.next({ allowLogin: true });
+    jest.advanceTimersByTime(1000);
+    licenseFeatures$.next({ allowLogin: true });
+    jest.advanceTimersByTime(1000);
+
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+    expect(mockCore.http.post).toHaveBeenCalledWith(
+      '/internal/security/analytics/_record_auth_type',
+      { body: JSON.stringify({ signature: 'some-signature', timestamp: 1234 }) }
+    );
+
+    // The rest of the events should be throttled away.
+    jest.runAllTimers();
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends existing authentication type info if available', async () => {
+    const mockCore = coreMock.createStart();
+    mockCore.http.post.mockResolvedValue({ signature: 'some-new-signature', timestamp: 5678 });
+
+    const mockCurrentAuthTypeInfo = JSON.stringify({
+      signature: 'some-signature',
+      timestamp: 1234,
+    });
+    localStorage.setItem(AnalyticsService.AuthTypeInfoStorageKey, mockCurrentAuthTypeInfo);
+
+    analyticsService.setup({ securityLicense: licenseMock.create({ allowLogin: true }) });
+    analyticsService.start({ http: mockCore.http });
+
+    await nextTick();
+
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+    expect(mockCore.http.post).toHaveBeenCalledWith(
+      '/internal/security/analytics/_record_auth_type',
+      { body: mockCurrentAuthTypeInfo }
+    );
+    expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toMatchInlineSnapshot(
+      `"{\\"signature\\":\\"some-new-signature\\",\\"timestamp\\":5678}"`
+    );
+  });
+
+  it('does not report authentication type if security is not available', async () => {
+    const mockCore = coreMock.createStart();
+
+    analyticsService.setup({ securityLicense: licenseMock.create({ allowLogin: false }) });
+    analyticsService.start({ http: mockCore.http });
+
+    await nextTick();
+
+    expect(mockCore.http.post).not.toHaveBeenCalled();
+    expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toBeNull();
+  });
+
+  it('does not alter stored authentication type if reporting attempt fails', async () => {
+    const mockCore = coreMock.createStart();
+    mockCore.http.post.mockRejectedValue(new Error('Oh no!'));
+
+    const mockCurrentAuthTypeInfo = JSON.stringify({
+      signature: 'some-signature',
+      timestamp: 1234,
+    });
+    localStorage.setItem(AnalyticsService.AuthTypeInfoStorageKey, mockCurrentAuthTypeInfo);
+
+    analyticsService.setup({ securityLicense: licenseMock.create({ allowLogin: true }) });
+    analyticsService.start({ http: mockCore.http });
+
+    await nextTick();
+
+    expect(mockCore.http.post).toHaveBeenCalledTimes(1);
+    expect(mockCore.http.post).toHaveBeenCalledWith(
+      '/internal/security/analytics/_record_auth_type',
+      { body: mockCurrentAuthTypeInfo }
+    );
+    expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toBe(
+      mockCurrentAuthTypeInfo
+    );
+  });
+});

--- a/x-pack/plugins/security/public/analytics/analytics_service.ts
+++ b/x-pack/plugins/security/public/analytics/analytics_service.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Subscription } from 'rxjs';
+import { filter } from 'rxjs';
+import { throttleTime } from 'rxjs/operators';
+
+import type { HttpStart } from '@kbn/core/public';
+
+import type { SecurityLicense } from '../../common';
+
+interface AnalyticsServiceSetupParams {
+  securityLicense: SecurityLicense;
+}
+
+interface AnalyticsServiceStartParams {
+  http: HttpStart;
+}
+
+/**
+ * The signature of the authentication type used by the user and the timestamp
+ * indicating when the signature was calculated.
+ */
+interface AuthTypeInfo {
+  signature: string;
+  timestamp: number;
+}
+
+export class AnalyticsService {
+  public static AuthTypeInfoStorageKey = 'kibana.security.userAuthType';
+  private securityLicense!: SecurityLicense;
+  private securityFeaturesSubscription?: Subscription;
+
+  public setup({ securityLicense }: AnalyticsServiceSetupParams) {
+    this.securityLicense = securityLicense;
+  }
+
+  public start({ http }: AnalyticsServiceStartParams) {
+    // Wait for the license info before recording authentication type. License
+    // change events are throttled with 5s interval.
+    this.securityFeaturesSubscription = this.securityLicense.features$
+      .pipe(
+        filter(({ allowLogin }) => allowLogin),
+        throttleTime(5000)
+      )
+      .subscribe(async () => {
+        try {
+          await AnalyticsService.recordAuthTypeAnalytics(http);
+        } catch {
+          // do nothing
+        }
+      });
+  }
+
+  public stop() {
+    if (this.securityFeaturesSubscription) {
+      this.securityFeaturesSubscription.unsubscribe();
+      this.securityFeaturesSubscription = undefined;
+    }
+  }
+
+  private static async recordAuthTypeAnalytics(http: HttpStart) {
+    localStorage.setItem(
+      AnalyticsService.AuthTypeInfoStorageKey,
+      JSON.stringify(
+        await http.post<AuthTypeInfo>('/internal/security/analytics/_record_auth_type', {
+          body: localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey),
+        })
+      )
+    );
+  }
+}

--- a/x-pack/plugins/security/public/analytics/index.ts
+++ b/x-pack/plugins/security/public/analytics/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { AnalyticsService } from './analytics_service';

--- a/x-pack/plugins/security/public/authentication/logout/logout_app.test.ts
+++ b/x-pack/plugins/security/public/authentication/logout/logout_app.test.ts
@@ -8,12 +8,17 @@
 import type { AppMount } from '@kbn/core/public';
 import { coreMock, scopedHistoryMock, themeServiceMock } from '@kbn/core/public/mocks';
 
+import { AnalyticsService } from '../../analytics';
 import { logoutApp } from './logout_app';
 
 describe('logoutApp', () => {
   beforeAll(() => {
     Object.defineProperty(window, 'sessionStorage', {
       value: { clear: jest.fn() },
+      writable: true,
+    });
+    Object.defineProperty(window, 'localStorage', {
+      value: { removeItem: jest.fn() },
       writable: true,
     });
     Object.defineProperty(window, 'location', {
@@ -59,6 +64,10 @@ describe('logoutApp', () => {
     });
 
     expect(window.sessionStorage.clear).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith(
+      AnalyticsService.AuthTypeInfoStorageKey
+    );
     expect(window.location.href).toBe('/mock-base-path/api/security/logout?arg=true');
   });
 });

--- a/x-pack/plugins/security/public/authentication/logout/logout_app.ts
+++ b/x-pack/plugins/security/public/authentication/logout/logout_app.ts
@@ -8,6 +8,8 @@
 import type { CoreSetup, HttpSetup } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 
+import { AnalyticsService } from '../../analytics';
+
 interface CreateDeps {
   application: CoreSetup['application'];
   http: HttpSetup;
@@ -24,6 +26,7 @@ export const logoutApp = Object.freeze({
       appRoute: '/logout',
       async mount() {
         window.sessionStorage.clear();
+        window.localStorage.removeItem(AnalyticsService.AuthTypeInfoStorageKey);
 
         // Redirect user to the server logout endpoint to complete logout.
         window.location.href = http.basePath.prepend(

--- a/x-pack/plugins/security/public/plugin.tsx
+++ b/x-pack/plugins/security/public/plugin.tsx
@@ -21,9 +21,10 @@ import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/pu
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 
-import { SecurityLicenseService } from '../common/licensing';
 import type { SecurityLicense } from '../common/licensing';
+import { SecurityLicenseService } from '../common/licensing';
 import { accountManagementApp } from './account_management';
+import { AnalyticsService } from './analytics';
 import { AnonymousAccessService } from './anonymous_access';
 import type { AuthenticationServiceSetup, AuthenticationServiceStart } from './authentication';
 import { AuthenticationService } from './authentication';
@@ -68,6 +69,7 @@ export class SecurityPlugin
   private readonly managementService = new ManagementService();
   private readonly securityCheckupService: SecurityCheckupService;
   private readonly anonymousAccessService = new AnonymousAccessService();
+  private readonly analyticsService = new AnalyticsService();
   private authc!: AuthenticationServiceSetup;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
@@ -96,6 +98,8 @@ export class SecurityPlugin
       authc: this.authc,
       logoutUrl: getLogoutUrl(core.http),
     });
+
+    this.analyticsService.setup({ securityLicense: license });
 
     accountManagementApp.create({
       authc: this.authc,
@@ -165,6 +169,8 @@ export class SecurityPlugin
       this.anonymousAccessService.start({ http });
     }
 
+    this.analyticsService.start({ http: core.http });
+
     return {
       uiApi: getUiApi({ core }),
       navControlService: this.navControlService.start({ core }),
@@ -177,6 +183,7 @@ export class SecurityPlugin
     this.navControlService.stop();
     this.securityLicenseService.stop();
     this.managementService.stop();
+    this.analyticsService.stop();
   }
 }
 

--- a/x-pack/plugins/security/server/analytics/analytics_service.mock.ts
+++ b/x-pack/plugins/security/server/analytics/analytics_service.mock.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup } from './analytics_service';
+
+export const analyticsServiceMock = {
+  createSetup: (): jest.Mocked<AnalyticsServiceSetup> => ({
+    reportAuthenticationTypeEvent: jest.fn(),
+  }),
+};

--- a/x-pack/plugins/security/server/analytics/analytics_service.test.ts
+++ b/x-pack/plugins/security/server/analytics/analytics_service.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { coreMock, loggingSystemMock } from '@kbn/core/server/mocks';
+
+import { AnalyticsService, AUTHENTICATION_TYPE_EVENT_TYPE } from './analytics_service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+  let logger: jest.Mocked<Logger>;
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    service = new AnalyticsService(logger);
+  });
+
+  describe('#setup()', () => {
+    const getSetupParams = () => {
+      const mockCoreStart = coreMock.createSetup();
+      return {
+        analytics: mockCoreStart.analytics,
+      };
+    };
+
+    it('returns proper contract', () => {
+      const setupParams = getSetupParams();
+      expect(service.setup(setupParams)).toEqual({
+        reportAuthenticationTypeEvent: expect.any(Function),
+      });
+      expect(setupParams.analytics.registerEventType).toHaveBeenCalledTimes(1);
+      expect(setupParams.analytics.registerEventType).toHaveBeenCalledWith({
+        eventType: AUTHENTICATION_TYPE_EVENT_TYPE,
+        schema: expect.objectContaining({
+          authentication_provider_type: expect.anything(),
+          authentication_realm_type: expect.anything(),
+          http_authentication_scheme: expect.anything(),
+        }),
+      });
+    });
+
+    describe('#reportAuthenticationTypeEvent', () => {
+      it('properly reports authentication event', async () => {
+        const setupParams = getSetupParams();
+        const analyticsSetup = service.setup(setupParams);
+
+        analyticsSetup.reportAuthenticationTypeEvent({
+          authenticationProviderType: 'Basic',
+          authenticationRealmType: 'Native',
+          httpAuthenticationScheme: 'Bearer',
+        });
+
+        expect(setupParams.analytics.reportEvent).toHaveBeenCalledTimes(1);
+        expect(setupParams.analytics.reportEvent).toHaveBeenCalledWith(
+          AUTHENTICATION_TYPE_EVENT_TYPE,
+          {
+            authentication_provider_type: 'basic',
+            authentication_realm_type: 'native',
+            http_authentication_scheme: 'bearer',
+          }
+        );
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security/server/analytics/analytics_service.ts
+++ b/x-pack/plugins/security/server/analytics/analytics_service.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup as CoreAnalyticsServiceSetup, Logger } from '@kbn/core/server';
+
+export const AUTHENTICATION_TYPE_EVENT_TYPE = 'security_authentication_type';
+
+export interface AnalyticsServiceSetupParams {
+  analytics: CoreAnalyticsServiceSetup;
+}
+
+export interface AnalyticsServiceSetup {
+  /**
+   * Registers event describing the type of the authentication used to authenticate user's request.
+   * @param event Instance of the AuthenticationTypeEvent.
+   */
+  reportAuthenticationTypeEvent(event: AuthenticationTypeAnalyticsEvent): void;
+}
+
+/**
+ * Describes the shape of the authentication type event.
+ */
+export interface AuthenticationTypeAnalyticsEvent {
+  /**
+   * Type of the Kibana authentication provider (`basic`, `saml`, `pki` etc.).
+   */
+  authenticationProviderType: string;
+
+  /**
+   * Type of the Elasticsearch security realm (`native`, `ldap`, `file` etc.).
+   */
+  authenticationRealmType: string;
+
+  /**
+   * If user is authenticated using HTTP authentication this field will include
+   * HTTP authentication scheme (`Basic`, `Bearer`, `ApiKey` etc.).
+   */
+  httpAuthenticationScheme?: string;
+}
+
+/**
+ * Service that interacts with the Core's analytics module to collect usage of
+ * the various Security plugin features (e.g. type of the authentication used).
+ */
+export class AnalyticsService {
+  constructor(private readonly logger: Logger) {}
+
+  public setup({ analytics }: AnalyticsServiceSetupParams): AnalyticsServiceSetup {
+    this.logger.debug(`Registering ${AUTHENTICATION_TYPE_EVENT_TYPE} event type.`);
+
+    analytics.registerEventType({
+      eventType: AUTHENTICATION_TYPE_EVENT_TYPE,
+      schema: {
+        authentication_provider_type: {
+          type: 'keyword',
+          _meta: {
+            description: 'Type of the Kibana authentication provider.',
+            optional: false,
+          },
+        },
+        authentication_realm_type: {
+          type: 'keyword',
+          _meta: {
+            description: 'Type of the Elasticsearch security realm.',
+            optional: false,
+          },
+        },
+        http_authentication_scheme: {
+          type: 'keyword',
+          _meta: {
+            description:
+              'Authentication scheme from the `Authorization` HTTP header, if present in the client request.',
+            // The field is populated only if authentication_provider_type === `http`.
+            optional: true,
+          },
+        },
+      },
+    });
+
+    return {
+      reportAuthenticationTypeEvent(event: AuthenticationTypeAnalyticsEvent) {
+        analytics.reportEvent(AUTHENTICATION_TYPE_EVENT_TYPE, {
+          authentication_provider_type: event.authenticationProviderType.toLowerCase(),
+          authentication_realm_type: event.authenticationRealmType.toLowerCase(),
+          http_authentication_scheme: event.httpAuthenticationScheme?.toLowerCase(),
+        });
+      },
+    };
+  }
+}

--- a/x-pack/plugins/security/server/analytics/index.ts
+++ b/x-pack/plugins/security/server/analytics/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { AnalyticsService } from './analytics_service';
+export type { AnalyticsServiceSetup, AuthenticationTypeAnalyticsEvent } from './analytics_service';

--- a/x-pack/plugins/security/server/authentication/index.ts
+++ b/x-pack/plugins/security/server/authentication/index.ts
@@ -21,6 +21,7 @@ export {
   SAMLAuthenticationProvider,
   OIDCAuthenticationProvider,
   AnonymousAuthenticationProvider,
+  HTTPAuthenticationProvider,
 } from './providers';
 export {
   BasicHTTPAuthorizationHeaderCredentials,

--- a/x-pack/plugins/security/server/plugin.ts
+++ b/x-pack/plugins/security/server/plugin.ts
@@ -31,6 +31,7 @@ import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
 import type { AuthenticatedUser, PrivilegeDeprecationsService, SecurityLicense } from '../common';
 import { SecurityLicenseService } from '../common/licensing';
+import { AnalyticsService } from './analytics';
 import type { AnonymousAccessServiceStart } from './anonymous_access';
 import { AnonymousAccessService } from './anonymous_access';
 import type { AuditServiceSetup } from './audit';
@@ -176,6 +177,7 @@ export class SecurityPlugin
 
   private readonly auditService: AuditService;
   private readonly securityLicenseService = new SecurityLicenseService();
+  private readonly analyticsService: AnalyticsService;
   private readonly authorizationService = new AuthorizationService();
   private readonly elasticsearchService: ElasticsearchService;
   private readonly sessionManagementService: SessionManagementService;
@@ -205,6 +207,7 @@ export class SecurityPlugin
       this.initializerContext.logger.get('anonymous-access'),
       this.getConfig
     );
+    this.analyticsService = new AnalyticsService(this.initializerContext.logger.get('analytics'));
   }
 
   public setup(
@@ -311,6 +314,7 @@ export class SecurityPlugin
       getFeatureUsageService: this.getFeatureUsageService,
       getAuthenticationService: this.getAuthentication,
       getAnonymousAccessService: this.getAnonymousAccess,
+      analyticsService: this.analyticsService.setup({ analytics: core.analytics }),
     });
 
     return Object.freeze<SecurityPluginSetup>({

--- a/x-pack/plugins/security/server/routes/analytics/authentication_type.test.ts
+++ b/x-pack/plugins/security/server/routes/analytics/authentication_type.test.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock } from '@kbn/core/server/mocks';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import type { RouteDefinitionParams } from '..';
+import { mockAuthenticatedUser } from '../../../common/model/authenticated_user.mock';
+import { HTTPAuthenticationProvider, TokenAuthenticationProvider } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import type { SecurityRequestHandlerContext } from '../../types';
+import { routeDefinitionParamsMock } from '../index.mock';
+import { defineRecordAnalyticsOnAuthTypeRoutes } from './authentication_type';
+
+const FAKE_TIMESTAMP = 1637665318135;
+function getMockContext(
+  licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+) {
+  return {
+    licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+  } as unknown as SecurityRequestHandlerContext;
+}
+
+describe('POST /internal/security/analytics/_record_auth_type', () => {
+  beforeAll(() => {
+    jest.useFakeTimers('modern').setSystemTime(FAKE_TIMESTAMP);
+  });
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let routeParamsMock: DeeplyMockedKeys<RouteDefinitionParams>;
+  beforeEach(() => {
+    routeParamsMock = routeDefinitionParamsMock.create();
+    defineRecordAnalyticsOnAuthTypeRoutes(routeParamsMock);
+
+    const [, recordAnalyticsOnAuthTypeRouteHandler] = routeParamsMock.router.post.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/analytics/_record_auth_type'
+    )!;
+    routeHandler = recordAnalyticsOnAuthTypeRouteHandler;
+  });
+
+  it('does not report authentication type if user cannot be authenticated', async () => {
+    const request = httpServerMock.createKibanaRequest();
+    const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+
+    expect(response.status).toBe(204);
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports authentication type for a new user', async () => {
+    const request = httpServerMock.createKibanaRequest();
+
+    const mockAuthc = authenticationServiceMock.createStart();
+    mockAuthc.getCurrentUser.mockReturnValue(mockAuthenticatedUser());
+    routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+    const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual({
+      timestamp: FAKE_TIMESTAMP,
+      signature: '139e39121f10f5ce5275883f6b65cd511f1cd51ec71464558a376731bb9b0630',
+    });
+
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(1);
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+      authenticationProviderType: 'basic',
+      authenticationRealmType: 'native',
+    });
+  });
+
+  it('does not report authentication type for the same user within first 12 hours', async () => {
+    const initialRequest = httpServerMock.createKibanaRequest();
+
+    const mockAuthc = authenticationServiceMock.createStart();
+    mockAuthc.getCurrentUser.mockReturnValue(mockAuthenticatedUser());
+    routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+    const initialResponse = await routeHandler(
+      getMockContext(),
+      initialRequest,
+      kibanaResponseFactory
+    );
+    expect(initialResponse.status).toBe(200);
+    expect(initialResponse.payload).toEqual({
+      timestamp: FAKE_TIMESTAMP,
+      signature: '139e39121f10f5ce5275883f6b65cd511f1cd51ec71464558a376731bb9b0630',
+    });
+
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(1);
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+      authenticationProviderType: 'basic',
+      authenticationRealmType: 'native',
+    });
+    routeParamsMock.analyticsService.reportAuthenticationTypeEvent.mockClear();
+
+    const secondRequest = httpServerMock.createKibanaRequest({
+      body: {
+        timestamp: initialResponse.payload.timestamp - 11 * 60 * 60 * 1000,
+        signature: initialResponse.payload.signature,
+      },
+    });
+    const secondResponse = await routeHandler(
+      getMockContext(),
+      secondRequest,
+      kibanaResponseFactory
+    );
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.payload).toEqual({
+      timestamp: initialResponse.payload.timestamp - 11 * 60 * 60 * 1000,
+      signature: '139e39121f10f5ce5275883f6b65cd511f1cd51ec71464558a376731bb9b0630',
+    });
+
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).not.toHaveBeenCalled();
+  });
+
+  describe('re-report authentication type', () => {
+    let initialTimestamp: number;
+    let initialSignature: string;
+    beforeEach(async () => {
+      const mockAuthc = authenticationServiceMock.createStart();
+      mockAuthc.getCurrentUser.mockReturnValue(mockAuthenticatedUser());
+      routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+      const response = await routeHandler(
+        getMockContext(),
+        httpServerMock.createKibanaRequest(),
+        kibanaResponseFactory
+      );
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: FAKE_TIMESTAMP,
+        signature: '139e39121f10f5ce5275883f6b65cd511f1cd51ec71464558a376731bb9b0630',
+      });
+      routeParamsMock.analyticsService.reportAuthenticationTypeEvent.mockClear();
+
+      initialTimestamp = response.payload.timestamp;
+      initialSignature = response.payload.signature;
+    });
+
+    it('for the same user after 12 hours', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        body: { timestamp: initialTimestamp - 13 * 60 * 60 * 1000, signature: initialSignature },
+      });
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: initialTimestamp,
+        signature: initialSignature,
+      });
+
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+        authenticationProviderType: 'basic',
+        authenticationRealmType: 'native',
+      });
+    });
+
+    it('if username changes', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        body: { timestamp: initialTimestamp - 1000, signature: initialSignature },
+      });
+
+      const mockAuthc = authenticationServiceMock.createStart();
+      mockAuthc.getCurrentUser.mockReturnValue(mockAuthenticatedUser({ username: 'new-username' }));
+      routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: initialTimestamp,
+        signature: '614d8f0280b2b117d6004411d048702746d412af5e5817677149718725cdb0fd',
+      });
+      expect(response.payload.signature).not.toEqual(initialSignature);
+
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+        authenticationProviderType: 'basic',
+        authenticationRealmType: 'native',
+      });
+    });
+
+    it('if Kibana provider changes', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        body: { timestamp: initialTimestamp - 1000, signature: initialSignature },
+      });
+
+      const mockAuthc = authenticationServiceMock.createStart();
+      mockAuthc.getCurrentUser.mockReturnValue(
+        mockAuthenticatedUser({
+          authentication_provider: { type: TokenAuthenticationProvider.type, name: 'token' },
+        })
+      );
+      routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: initialTimestamp,
+        signature: '7a5738db93df725d8550fce1e922a6cd7d3b3b6d2484e1ef4584735c23501139',
+      });
+      expect(response.payload.signature).not.toEqual(initialSignature);
+
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+        authenticationProviderType: 'token',
+        authenticationRealmType: 'native',
+      });
+    });
+
+    it('if Elasticsearch realm changes', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        body: { timestamp: initialTimestamp - 1000, signature: initialSignature },
+      });
+
+      const mockAuthc = authenticationServiceMock.createStart();
+      mockAuthc.getCurrentUser.mockReturnValue(
+        mockAuthenticatedUser({ authentication_realm: { type: 'file', name: 'file1' } })
+      );
+      routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: initialTimestamp,
+        signature: '583bd29b2db33abf51ff8eb585bd09128115f47c33a5a4a1b8d2135bdbeab5fd',
+      });
+      expect(response.payload.signature).not.toEqual(initialSignature);
+
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+        authenticationProviderType: 'basic',
+        authenticationRealmType: 'file',
+      });
+    });
+  });
+
+  it('reports HTTP scheme for a new user', async () => {
+    const request = httpServerMock.createKibanaRequest({
+      headers: { authorization: 'Bearer token' },
+    });
+
+    const mockAuthc = authenticationServiceMock.createStart();
+    mockAuthc.getCurrentUser.mockReturnValue(
+      mockAuthenticatedUser({
+        authentication_provider: { type: HTTPAuthenticationProvider.type, name: '__http__' },
+      })
+    );
+    routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+    const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual({
+      timestamp: FAKE_TIMESTAMP,
+      signature: 'f4f6b485690816127c33d5aa13cd6cd12c9892641ba23b5d58e5c6590cd43db0',
+    });
+
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(1);
+    expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+      authenticationProviderType: 'http',
+      authenticationRealmType: 'native',
+      httpAuthenticationScheme: 'Bearer',
+    });
+  });
+
+  describe('re-report authentication type for HTTP authentication', () => {
+    let initialTimestamp: number;
+    let initialSignature: string;
+    beforeEach(async () => {
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: 'Bearer token' },
+      });
+
+      const mockAuthc = authenticationServiceMock.createStart();
+      mockAuthc.getCurrentUser.mockReturnValue(
+        mockAuthenticatedUser({
+          authentication_provider: { type: HTTPAuthenticationProvider.type, name: '__http__' },
+        })
+      );
+      routeParamsMock.getAuthenticationService.mockReturnValue(mockAuthc);
+
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: FAKE_TIMESTAMP,
+        signature: 'f4f6b485690816127c33d5aa13cd6cd12c9892641ba23b5d58e5c6590cd43db0',
+      });
+      routeParamsMock.analyticsService.reportAuthenticationTypeEvent.mockClear();
+
+      initialTimestamp = response.payload.timestamp;
+      initialSignature = response.payload.signature;
+    });
+
+    it('if HTTP authentication scheme changes', async () => {
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: 'Custom token' },
+        body: { timestamp: initialTimestamp - 1000, signature: initialSignature },
+      });
+
+      const response = await routeHandler(getMockContext(), request, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        timestamp: initialTimestamp,
+        signature: '46d5841ad21d29ca6c7c1c639adc6294c176c394adb0b40dfc05797cfe29218e',
+      });
+      expect(response.payload.signature).not.toEqual(initialSignature);
+
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledTimes(
+        1
+      );
+      expect(routeParamsMock.analyticsService.reportAuthenticationTypeEvent).toHaveBeenCalledWith({
+        authenticationProviderType: 'http',
+        authenticationRealmType: 'native',
+        httpAuthenticationScheme: 'Custom',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security/server/routes/analytics/index.ts
+++ b/x-pack/plugins/security/server/routes/analytics/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteDefinitionParams } from '..';
+import { defineRecordAnalyticsOnAuthTypeRoutes } from './authentication_type';
+
+export function defineAnalyticsRoutes(params: RouteDefinitionParams) {
+  defineRecordAnalyticsOnAuthTypeRoutes(params);
+}

--- a/x-pack/plugins/security/server/routes/index.mock.ts
+++ b/x-pack/plugins/security/server/routes/index.mock.ts
@@ -18,6 +18,7 @@ import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
 import type { RouteDefinitionParams } from '.';
 import { licenseMock } from '../../common/licensing/index.mock';
+import { analyticsServiceMock } from '../analytics/analytics_service.mock';
 import { authenticationServiceMock } from '../authentication/authentication_service.mock';
 import { authorizationMock } from '../authorization/index.mock';
 import { ConfigSchema, createConfig } from '../config';
@@ -46,6 +47,7 @@ export const routeDefinitionParamsMock = {
       getSession: jest.fn().mockReturnValue(sessionMock.create()),
       getAuthenticationService: jest.fn().mockReturnValue(authenticationServiceMock.createStart()),
       getAnonymousAccessService: jest.fn(),
+      analyticsService: analyticsServiceMock.createSetup(),
     } as unknown as DeeplyMockedKeys<RouteDefinitionParams>;
   },
 };

--- a/x-pack/plugins/security/server/routes/index.ts
+++ b/x-pack/plugins/security/server/routes/index.ts
@@ -12,6 +12,7 @@ import type { KibanaFeature } from '@kbn/features-plugin/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import type { SecurityLicense } from '../../common';
+import type { AnalyticsServiceSetup } from '../analytics';
 import type { AnonymousAccessServiceStart } from '../anonymous_access';
 import type { InternalAuthenticationServiceStart } from '../authentication';
 import type { AuthorizationServiceSetupInternal } from '../authorization';
@@ -19,6 +20,7 @@ import type { ConfigType } from '../config';
 import type { SecurityFeatureUsageServiceStart } from '../feature_usage';
 import type { Session } from '../session_management';
 import type { SecurityRouter } from '../types';
+import { defineAnalyticsRoutes } from './analytics';
 import { defineAnonymousAccessRoutes } from './anonymous_access';
 import { defineApiKeysRoutes } from './api_keys';
 import { defineAuthenticationRoutes } from './authentication';
@@ -48,6 +50,7 @@ export interface RouteDefinitionParams {
   getFeatureUsageService: () => SecurityFeatureUsageServiceStart;
   getAuthenticationService: () => InternalAuthenticationServiceStart;
   getAnonymousAccessService: () => AnonymousAccessServiceStart;
+  analyticsService: AnalyticsServiceSetup;
 }
 
 export function defineRoutes(params: RouteDefinitionParams) {
@@ -62,4 +65,5 @@ export function defineRoutes(params: RouteDefinitionParams) {
   defineDeprecationsRoutes(params);
   defineAnonymousAccessRoutes(params);
   defineSecurityCheckupGetStateRoutes(params);
+  defineAnalyticsRoutes(params);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Collect analytics for the used authentication mechanisms. (#129302)](https://github.com/elastic/kibana/pull/129302)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)