### PR TITLE
[8.3] fix palette bug (#134159)

### DIFF
--- a/src/plugins/vis_types/metric/public/__snapshots__/to_ast.test.ts.snap
+++ b/src/plugins/vis_types/metric/public/__snapshots__/to_ast.test.ts.snap
@@ -34,6 +34,9 @@ Object {
     },
     Object {
       "arguments": Object {
+        "colorMode": Array [
+          "None",
+        ],
         "font": Array [
           Object {
             "chain": Array [
@@ -127,6 +130,9 @@ Object {
     },
     Object {
       "arguments": Object {
+        "colorMode": Array [
+          "None",
+        ],
         "font": Array [
           Object {
             "chain": Array [

--- a/src/plugins/vis_types/metric/public/to_ast.test.ts
+++ b/src/plugins/vis_types/metric/public/to_ast.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { ColorMode, ColorSchemas } from '@kbn/charts-plugin/public';
 import { TimefilterContract } from '@kbn/data-plugin/public';
 import { Vis } from '@kbn/visualizations-plugin/public';
 
@@ -46,5 +47,51 @@ describe('metric vis toExpressionAst function', () => {
       timefilter: {} as TimefilterContract,
     });
     expect(actual).toMatchSnapshot();
+  });
+
+  it('should pass color mode if color ranges are set', async () => {
+    vis.params = {
+      metric: {
+        metricColorMode: ColorMode.Background,
+        colorSchema: ColorSchemas.Greens,
+        colorsRange: [
+          {
+            type: 'range',
+            from: 0,
+            to: 1,
+          },
+          {
+            type: 'range',
+            from: 1,
+            to: 2,
+          },
+        ],
+      },
+    } as VisParams;
+    const actual = await toExpressionAst(vis, {
+      timefilter: {} as TimefilterContract,
+    });
+    expect(actual.chain[0].arguments.colorMode).toEqual([ColorMode.Background]);
+  });
+
+  it('should not pass color mode if there is just a single range, but still pass palette for percentage mode', async () => {
+    vis.params = {
+      metric: {
+        metricColorMode: ColorMode.Background,
+        colorSchema: ColorSchemas.Greens,
+        colorsRange: [
+          {
+            type: 'range',
+            from: 0,
+            to: 1,
+          },
+        ],
+      },
+    } as VisParams;
+    const actual = await toExpressionAst(vis, {
+      timefilter: {} as TimefilterContract,
+    });
+    expect(actual.chain[0].arguments.colorMode).toEqual([ColorMode.None]);
+    expect(actual.chain[0].arguments.palette.length).toEqual(1);
   });
 });

--- a/src/plugins/vis_types/metric/public/to_ast.test.ts
+++ b/src/plugins/vis_types/metric/public/to_ast.test.ts
@@ -71,7 +71,7 @@ describe('metric vis toExpressionAst function', () => {
     const actual = await toExpressionAst(vis, {
       timefilter: {} as TimefilterContract,
     });
-    expect(actual.chain[0].arguments.colorMode).toEqual([ColorMode.Background]);
+    expect(actual.chain[1].arguments.colorMode).toEqual([ColorMode.Background]);
   });
 
   it('should not pass color mode if there is just a single range, but still pass palette for percentage mode', async () => {
@@ -91,7 +91,7 @@ describe('metric vis toExpressionAst function', () => {
     const actual = await toExpressionAst(vis, {
       timefilter: {} as TimefilterContract,
     });
-    expect(actual.chain[0].arguments.colorMode).toEqual([ColorMode.None]);
-    expect(actual.chain[0].arguments.palette.length).toEqual(1);
+    expect(actual.chain[1].arguments.colorMode).toEqual([ColorMode.None]);
+    expect(actual.chain[1].arguments.palette.length).toEqual(1);
   });
 });

--- a/src/plugins/vis_types/metric/public/to_ast.ts
+++ b/src/plugins/vis_types/metric/public/to_ast.ts
@@ -15,6 +15,7 @@ import {
   EsaggsExpressionFunctionDefinition,
   IndexPatternLoadExpressionFunctionDefinition,
 } from '@kbn/data-plugin/public';
+import { ColorMode } from '@kbn/charts-plugin/public';
 import { VisParams } from './types';
 import { getStopsWithColorsFromRanges } from './utils';
 
@@ -64,9 +65,11 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = (vis, params) => {
     });
   }
 
+  const hasColorRanges = colorsRange && colorsRange.length > 1;
+
   const metricVis = buildExpressionFunction('metricVis', {
     percentageMode,
-    colorMode: metricColorMode,
+    colorMode: hasColorRanges ? metricColorMode : ColorMode.None,
     showLabels: labels?.show ?? false,
   });
 
@@ -85,7 +88,7 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = (vis, params) => {
 
   metricVis.addArgument('labelFont', buildExpression(`font size="14" align="center"`));
 
-  if (colorsRange && colorsRange.length > 1) {
+  if (colorsRange && colorsRange.length) {
     const stopsWithColors = getStopsWithColorsFromRanges(colorsRange, colorSchema, invertColors);
     const palette = buildExpressionFunction('palette', {
       ...stopsWithColors,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [fix palette bug (#134159)](https://github.com/elastic/kibana/pull/134159)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)