### PR TITLE
[8.3] fix drilldown for nontimebased data views (#134188)

### DIFF
--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -228,6 +228,7 @@ export class LensPlugin {
   private gaugeVisualization: GaugeVisualizationType | undefined;
   private topNavMenuEntries: LensTopNavMenuEntryGenerator[] = [];
   private hasDiscoverAccess: boolean = false;
+  private dataViewsService: DataViewsPublicPluginStart | undefined;
 
   private stopReportManager?: () => void;
 
@@ -295,6 +296,7 @@ export class LensPlugin {
       uiActionsEnhanced.registerDrilldown(
         new OpenInDiscoverDrilldown({
           discover,
+          dataViews: () => this.dataViewsService!,
           hasDiscoverAccess: () => this.hasDiscoverAccess,
         })
       );
@@ -434,6 +436,7 @@ export class LensPlugin {
 
   start(core: CoreStart, startDependencies: LensPluginStartDependencies): LensPublicStart {
     this.hasDiscoverAccess = core.application.capabilities.discover.show as boolean;
+    this.dataViewsService = startDependencies.dataViews;
     // unregisters the Visualize action and registers the lens one
     if (startDependencies.uiActions.hasAction(ACTION_VISUALIZE_FIELD)) {
       startDependencies.uiActions.unregisterAction(ACTION_VISUALIZE_FIELD);
@@ -450,7 +453,11 @@ export class LensPlugin {
 
     startDependencies.uiActions.addTriggerAction(
       CONTEXT_MENU_TRIGGER,
-      createOpenInDiscoverAction(startDependencies.discover!, this.hasDiscoverAccess)
+      createOpenInDiscoverAction(
+        startDependencies.discover!,
+        startDependencies.dataViews!,
+        this.hasDiscoverAccess
+      )
     );
 
     return {

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.test.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { DataViewsService } from '@kbn/data-views-plugin/public';
 import { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
@@ -17,11 +18,13 @@ describe('open in discover action', () => {
     it('is incompatible with non-lens embeddables', async () => {
       const embeddable = { type: 'NOT_LENS' } as IEmbeddable;
 
-      const isCompatible = await createOpenInDiscoverAction({} as DiscoverStart, true).isCompatible(
-        {
-          embeddable,
-        } as ActionExecutionContext<{ embeddable: IEmbeddable }>
-      );
+      const isCompatible = await createOpenInDiscoverAction(
+        {} as DiscoverStart,
+        {} as DataViewsService,
+        true
+      ).isCompatible({
+        embeddable,
+      } as ActionExecutionContext<{ embeddable: IEmbeddable }>);
 
       expect(isCompatible).toBeFalsy();
     });
@@ -33,7 +36,11 @@ describe('open in discover action', () => {
       let hasDiscoverAccess = true;
       // make sure it would work if we had access to Discover
       expect(
-        await createOpenInDiscoverAction({} as DiscoverStart, hasDiscoverAccess).isCompatible({
+        await createOpenInDiscoverAction(
+          {} as DiscoverStart,
+          {} as DataViewsService,
+          hasDiscoverAccess
+        ).isCompatible({
           embeddable,
         } as unknown as ActionExecutionContext<{ embeddable: IEmbeddable }>)
       ).toBeTruthy();
@@ -41,7 +48,11 @@ describe('open in discover action', () => {
       // make sure no Discover access makes the action incompatible
       hasDiscoverAccess = false;
       expect(
-        await createOpenInDiscoverAction({} as DiscoverStart, hasDiscoverAccess).isCompatible({
+        await createOpenInDiscoverAction(
+          {} as DiscoverStart,
+          {} as DataViewsService,
+          hasDiscoverAccess
+        ).isCompatible({
           embeddable,
         } as unknown as ActionExecutionContext<{ embeddable: IEmbeddable }>)
       ).toBeFalsy();
@@ -53,7 +64,11 @@ describe('open in discover action', () => {
       // test false
       embeddable.canViewUnderlyingData = jest.fn(() => Promise.resolve(false));
       expect(
-        await createOpenInDiscoverAction({} as DiscoverStart, true).isCompatible({
+        await createOpenInDiscoverAction(
+          {} as DiscoverStart,
+          {} as DataViewsService,
+          true
+        ).isCompatible({
           embeddable,
         } as unknown as ActionExecutionContext<{ embeddable: IEmbeddable }>)
       ).toBeFalsy();
@@ -63,7 +78,11 @@ describe('open in discover action', () => {
       // test true
       embeddable.canViewUnderlyingData = jest.fn(() => Promise.resolve(true));
       expect(
-        await createOpenInDiscoverAction({} as DiscoverStart, true).isCompatible({
+        await createOpenInDiscoverAction(
+          {} as DiscoverStart,
+          {} as DataViewsService,
+          true
+        ).isCompatible({
           embeddable,
         } as unknown as ActionExecutionContext<{ embeddable: IEmbeddable }>)
       ).toBeTruthy();
@@ -95,7 +114,11 @@ describe('open in discover action', () => {
 
     globalThis.open = jest.fn();
 
-    await createOpenInDiscoverAction(discover, true).execute({
+    await createOpenInDiscoverAction(
+      discover,
+      { get: () => ({ isTimeBased: () => true }) } as unknown as DataViewsService,
+      true
+    ).execute({
       embeddable,
     } as unknown as ActionExecutionContext<{
       embeddable: IEmbeddable;

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import { IEmbeddable } from '@kbn/embeddable-plugin/public';
+import { DataViewsService } from '@kbn/data-views-plugin/public';
 import { execute, isCompatible } from './open_in_discover_helpers';
 
 const ACTION_OPEN_IN_DISCOVER = 'ACTION_OPEN_IN_DISCOVER';
@@ -19,6 +20,7 @@ interface Context {
 
 export const createOpenInDiscoverAction = (
   discover: Pick<DiscoverStart, 'locator'>,
+  dataViews: Pick<DataViewsService, 'get'>,
   hasDiscoverAccess: boolean
 ) =>
   createAction<Context>({
@@ -31,9 +33,14 @@ export const createOpenInDiscoverAction = (
         defaultMessage: 'Explore data in Discover',
       }),
     isCompatible: async (context: Context) => {
-      return isCompatible({ hasDiscoverAccess, discover, embeddable: context.embeddable });
+      return isCompatible({
+        hasDiscoverAccess,
+        discover,
+        dataViews,
+        embeddable: context.embeddable,
+      });
     },
     execute: async (context: Context) => {
-      return execute({ ...context, discover, hasDiscoverAccess });
+      return execute({ ...context, discover, dataViews, hasDiscoverAccess });
     },
   });

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.test.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.test.tsx
@@ -16,6 +16,7 @@ import {
   CollectConfigProps,
   OpenInDiscoverDrilldown,
 } from './open_in_discover_drilldown';
+import { DataViewsService } from '@kbn/data-views-plugin/public';
 
 jest.mock('./open_in_discover_helpers', () => ({
   isCompatible: jest.fn(() => true),
@@ -27,6 +28,7 @@ describe('open in discover drilldown', () => {
   beforeEach(() => {
     drilldown = new OpenInDiscoverDrilldown({
       discover: {} as DiscoverSetup,
+      dataViews: () => ({} as DataViewsService),
       hasDiscoverAccess: () => true,
     });
   });

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
@@ -7,13 +7,7 @@
 
 import React from 'react';
 import { IEmbeddable, EmbeddableInput } from '@kbn/embeddable-plugin/public';
-import {
-  Query,
-  Filter,
-  TimeRange,
-  extractTimeRange,
-  APPLY_FILTER_TRIGGER,
-} from '@kbn/data-plugin/public';
+import { Query, Filter, TimeRange, APPLY_FILTER_TRIGGER } from '@kbn/data-plugin/public';
 import { CollectConfigProps as CollectConfigPropsBase } from '@kbn/kibana-utils-plugin/public';
 import { reactToUiComponent } from '@kbn/kibana-react-plugin/public';
 import {

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
@@ -24,6 +24,7 @@ import { EuiFormRow, EuiSwitch } from '@elastic/eui';
 import { DiscoverSetup } from '@kbn/discover-plugin/public';
 import { ApplyGlobalFilterActionContext } from '@kbn/unified-search-plugin/public';
 import { i18n } from '@kbn/i18n';
+import { DataViewsService } from '@kbn/data-views-plugin/public';
 import { execute, isCompatible, isLensEmbeddable } from './open_in_discover_helpers';
 
 interface EmbeddableQueryInput extends EmbeddableInput {
@@ -37,6 +38,7 @@ export type EmbeddableWithQueryInput = IEmbeddable<EmbeddableQueryInput>;
 
 interface UrlDrilldownDeps {
   discover: Pick<DiscoverSetup, 'locator'>;
+  dataViews: () => Pick<DataViewsService, 'get'>;
   hasDiscoverAccess: () => boolean;
 }
 
@@ -110,6 +112,7 @@ export class OpenInDiscoverDrilldown
   public readonly isCompatible = async (config: Config, context: ActionContext) => {
     return isCompatible({
       discover: this.deps.discover,
+      dataViews: this.deps.dataViews(),
       hasDiscoverAccess: this.deps.hasDiscoverAccess(),
       ...context,
       embeddable: context.embeddable as IEmbeddable,
@@ -122,18 +125,13 @@ export class OpenInDiscoverDrilldown
   };
 
   public readonly execute = async (config: Config, context: ActionContext) => {
-    const { restOfFilters: filters, timeRange: timeRange } = extractTimeRange(
-      context.filters,
-      context.timeFieldName
-    );
     execute({
       discover: this.deps.discover,
+      dataViews: this.deps.dataViews(),
       hasDiscoverAccess: this.deps.hasDiscoverAccess(),
       ...context,
       embeddable: context.embeddable as IEmbeddable,
       openInSameTab: !config.openInNewTab,
-      filters,
-      timeRange,
     });
   };
 }

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_helpers.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_helpers.ts
@@ -9,6 +9,7 @@ import type { DiscoverSetup } from '@kbn/discover-plugin/public';
 import { Filter } from '@kbn/es-query';
 import { IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { DataViewsService } from '@kbn/data-views-plugin/public';
+import { extractTimeRange } from '@kbn/data-plugin/public';
 import type { Embeddable } from '../embeddable';
 import { DOC_TYPE } from '../../common';
 
@@ -53,7 +54,6 @@ export async function execute({
   let timeRangeToApply = args.timeRange;
   // if the target data view is time based, attempt to split out a time range from the provided filters
   if (dataView.isTimeBased() && dataView.timeFieldName === timeFieldName) {
-    const { extractTimeRange } = await import('@kbn/es-query');
     const { restOfFilters, timeRange } = extractTimeRange(filters || [], timeFieldName);
     filtersToApply = restOfFilters;
     if (timeRange) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [fix drilldown for nontimebased data views (#134188)](https://github.com/elastic/kibana/pull/134188)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)