### PR TITLE
[Infra Monitoring UI] Fix Metrics Table Pod link to Details Page

### DIFF
--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
@@ -17,6 +17,7 @@ import { createStartServicesAccessorMock } from '../test_helpers';
 import { createLazyContainerMetricsTable } from './create_lazy_container_metrics_table';
 import IntegratedContainerMetricsTable from './integrated_container_metrics_table';
 import { metricByField } from './use_container_metrics_table';
+import type { MetricsExplorerSeries } from '../../../../common/http_api';
 
 describe('ContainerMetricsTable', () => {
   const timerange = {
@@ -113,7 +114,7 @@ function createContainer(
   uptimeMs: number,
   cpuUsagePct: number,
   memoryUsageBytes: number
-) {
+): Partial<MetricsExplorerSeries> {
   return {
     id: name,
     rows: [
@@ -121,7 +122,7 @@ function createContainer(
         [metricByField['kubernetes.container.start_time']]: uptimeMs,
         [metricByField['kubernetes.container.cpu.usage.node.pct']]: cpuUsagePct,
         [metricByField['kubernetes.container.memory.usage.bytes']]: memoryUsageBytes,
-      },
+      } as MetricsExplorerSeries['rows'][number],
     ],
   };
 }

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
@@ -111,7 +111,14 @@ function containerNodeColumns(
       truncateText: true,
       textOnly: true,
       render: (name: string) => {
-        return <MetricsNodeDetailsLink id={name} nodeType={'container'} timerange={timerange} />;
+        return (
+          <MetricsNodeDetailsLink
+            id={name}
+            label={name}
+            nodeType={'container'}
+            timerange={timerange}
+          />
+        );
       },
     },
     {

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
@@ -17,6 +17,7 @@ import { createStartServicesAccessorMock } from '../test_helpers';
 import { createLazyHostMetricsTable } from './create_lazy_host_metrics_table';
 import IntegratedHostMetricsTable from './integrated_host_metrics_table';
 import { metricByField } from './use_host_metrics_table';
+import type { MetricsExplorerSeries } from '../../../../common/http_api';
 
 describe('HostMetricsTable', () => {
   const timerange = {
@@ -114,7 +115,7 @@ function createHost(
   cpuUsagePct: number,
   memoryBytes: number,
   memoryUsagePct: number
-) {
+): Partial<MetricsExplorerSeries> {
   return {
     id: name,
     rows: [
@@ -123,7 +124,7 @@ function createHost(
         [metricByField['system.cpu.total.norm.pct']]: cpuUsagePct,
         [metricByField['system.memory.total']]: memoryBytes,
         [metricByField['system.memory.used.pct']]: memoryUsagePct,
-      },
+      } as MetricsExplorerSeries['rows'][number],
     ],
   };
 }

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.tsx
@@ -111,7 +111,7 @@ function hostMetricsColumns(
       truncateText: true,
       textOnly: true,
       render: (name: string) => (
-        <MetricsNodeDetailsLink id={name} nodeType={'host'} timerange={timerange} />
+        <MetricsNodeDetailsLink id={name} label={name} nodeType={'host'} timerange={timerange} />
       ),
     },
     {

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
@@ -46,30 +46,35 @@ const storyArgs: Omit<PodMetricsTableProps, 'setSortState' | 'setCurrentPageInde
   isLoading: false,
   pods: [
     {
+      id: '358d96e3-026f-4440-a487-f6c2301884c0',
       name: 'gke-edge-oblt-pool-1-9a60016d-lgg1',
       uptime: 23000000,
       averageCpuUsagePercent: 99,
       averageMemoryUsageMegabytes: 34,
     },
     {
+      id: '358d96e3-026f-4440-a487-f6c2301884c1',
       name: 'gke-edge-oblt-pool-1-9a60016d-lgg2',
       uptime: 43000000,
       averageCpuUsagePercent: 72,
       averageMemoryUsageMegabytes: 68,
     },
     {
+      id: '358d96e3-026f-4440-a487-f6c2301884c0',
       name: 'gke-edge-oblt-pool-1-9a60016d-lgg3',
       uptime: 53000000,
       averageCpuUsagePercent: 54,
       averageMemoryUsageMegabytes: 132,
     },
     {
+      id: '358d96e3-026f-4440-a487-f6c2301884c0',
       name: 'gke-edge-oblt-pool-1-9a60016d-lgg4',
       uptime: 63000000,
       averageCpuUsagePercent: 34,
       averageMemoryUsageMegabytes: 264,
     },
     {
+      id: '358d96e3-026f-4440-a487-f6c2301884c0',
       name: 'gke-edge-oblt-pool-1-9a60016d-lgg5',
       uptime: 83000000,
       averageCpuUsagePercent: 13,

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
@@ -17,6 +17,7 @@ import { createStartServicesAccessorMock } from '../test_helpers';
 import { createLazyPodMetricsTable } from './create_lazy_pod_metrics_table';
 import IntegratedPodMetricsTable from './integrated_pod_metrics_table';
 import { metricByField } from './use_pod_metrics_table';
+import type { MetricsExplorerSeries } from '../../../../common/http_api';
 
 describe('PodMetricsTable', () => {
   const timerange = {
@@ -91,8 +92,8 @@ function createFetchMock(): NodeMetricsTableFetchMock {
 
   const mockData: DataResponseMock = {
     series: [
-      createPod('some-pod', 23000000, 76, 3671700000),
-      createPod('some-other-pod', 32000000, 67, 716300000),
+      createPod('358d96e3-026f-4440-a487-f6c2301884c0', 'some-pod', 23000000, 76, 3671700000),
+      createPod('358d96e3-026f-4440-a487-f6c2301884c1', 'some-other-pod', 32000000, 67, 716300000),
     ],
   };
 
@@ -108,15 +109,22 @@ function createFetchMock(): NodeMetricsTableFetchMock {
   };
 }
 
-function createPod(name: string, uptimeMs: number, cpuUsagePct: number, memoryUsageBytes: number) {
+function createPod(
+  id: string,
+  name: string,
+  uptimeMs: number,
+  cpuUsagePct: number,
+  memoryUsageBytes: number
+): Partial<MetricsExplorerSeries> {
   return {
-    id: name,
+    id: `${id} / ${name}`,
+    keys: [id, name],
     rows: [
       {
         [metricByField['kubernetes.pod.start_time']]: uptimeMs,
         [metricByField['kubernetes.pod.cpu.usage.node.pct']]: cpuUsagePct,
         [metricByField['kubernetes.pod.memory.usage.bytes']]: memoryUsageBytes,
-      },
+      } as MetricsExplorerSeries['rows'][number],
     ],
   };
 }

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.tsx
@@ -108,8 +108,10 @@ function podNodeColumns(
       field: 'name',
       truncateText: true,
       textOnly: true,
-      render: (name: string) => {
-        return <MetricsNodeDetailsLink id={name} nodeType={'pod'} timerange={timerange} />;
+      render: (_, { id, name }) => {
+        return (
+          <MetricsNodeDetailsLink id={id} label={name} nodeType={'pod'} timerange={timerange} />
+        );
       },
     },
     {

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
@@ -17,12 +17,14 @@ type ExtractStrict<T, U extends T> = Extract<T, U>;
 
 interface MetricsNodeDetailsLinkProps {
   id: string;
+  label: string;
   nodeType: ExtractStrict<InventoryItemType, 'host' | 'container' | 'pod'>;
   timerange: Pick<MetricsExplorerTimeOptions, 'from' | 'to'>;
 }
 
 export const MetricsNodeDetailsLink = ({
   id,
+  label,
   nodeType,
   timerange,
 }: MetricsNodeDetailsLinkProps) => {
@@ -35,5 +37,5 @@ export const MetricsNodeDetailsLink = ({
     })
   );
 
-  return <EuiLink href={linkProps.href}>{id}</EuiLink>;
+  return <EuiLink href={linkProps.href}>{label}</EuiLink>;
 };

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -57,7 +57,10 @@ export interface NodeMetricsExplorerOptionsMetric<Field extends string>
   field: Field;
 }
 
-export function metricsToApiOptions<T extends string>(metricsMap: MetricsMap<T>, groupBy: string) {
+export function metricsToApiOptions<T extends string>(
+  metricsMap: MetricsMap<T>,
+  groupBy: string | string[]
+) {
   const metrics = Object.values(metricsMap) as Array<NodeMetricsExplorerOptionsMetric<T>>;
 
   const options: MetricsExplorerOptions = {


### PR DESCRIPTION
## Summary

This PR partially fixes #128639.

It addresses the link to the Pods details page problem. Because the Pods details page needs to receive the `uid` and not the `name`, I had to add this field to the group by list in the query, so that it could be propagated to the table and present the name in the row and build the link with the uid.

## Screenshot
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/2767137/173598971-5b5fd993-a88a-4918-865e-00cc57bbb328.png">


### TODO
- [ ] fix Kubernetes Container details page (for more details: [#134331](https://github.com/elastic/kibana/issues/134331))

### How to test

* Create a cluster using the oblt-cli tool
* Enable `Infrastructure feature` on Advanced Settings
* Go to APM > Services or Trace > Infrastructure  tab