### PR TITLE
[CI] Trigger pipeline deploy when versions.json changes

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -13,7 +13,7 @@ steps:
           limit: 1
   - wait
 
-  - label: 'Triggering pipelines'
+  - label: 'Triggering changes-based pipelines'
     branches: main
     agents:
       queue: kibana-default

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -11,8 +11,21 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-
   - wait
+
+  - label: 'Triggering pipelines'
+    agents:
+      queue: kibana-default
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          watch:
+            - path:
+                - 'versions.json'
+              config:
+                command: 'node .buildkite/scripts/steps/trigger_pipeline.js kibana-buildkite-pipelines-deploy main'
+                label: 'Trigger pipeline deploy'
+                agents:
+                  queue: 'kibana-default'
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution and Plugins

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -14,6 +14,7 @@ steps:
   - wait
 
   - label: 'Triggering pipelines'
+    branches: main
     agents:
       queue: kibana-default
     plugins:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,6 +7,20 @@ steps:
 
   - wait
 
+  - label: 'Triggering pipelines'
+    agents:
+      queue: kibana-default
+    plugins:
+      - chronotc/monorepo-diff#v2.0.4:
+          watch:
+            - path:
+                - 'versions.json'
+              config:
+                command: 'node .buildkite/scripts/steps/trigger_pipeline.js kibana-buildkite-pipelines-deploy main'
+                label: 'Trigger pipeline deploy'
+                agents:
+                  queue: 'kibana-default'
+
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution and Plugins
     agents:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,20 +7,6 @@ steps:
 
   - wait
 
-  - label: 'Triggering pipelines'
-    agents:
-      queue: kibana-default
-    plugins:
-      - chronotc/monorepo-diff#v2.0.4:
-          watch:
-            - path:
-                - 'versions.json'
-              config:
-                command: 'node .buildkite/scripts/steps/trigger_pipeline.js kibana-buildkite-pipelines-deploy main'
-                label: 'Trigger pipeline deploy'
-                agents:
-                  queue: 'kibana-default'
-
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution and Plugins
     agents:

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -15,5 +15,5 @@ node "$(dirname "${0}")/promote_manifest.js" "$ES_SNAPSHOT_MANIFEST"
 
 if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   echo "--- Trigger agent packer cache pipeline"
-  node .buildkite/scripts/steps/trigger_packer_cache.js
+  node .buildkite/scripts/steps/trigger_pipeline.js kibana-agent-packer-cache main
 fi

--- a/.buildkite/scripts/steps/trigger_pipeline.js
+++ b/.buildkite/scripts/steps/trigger_pipeline.js
@@ -8,12 +8,16 @@
 
 const { BuildkiteClient } = require('kibana-buildkite-library');
 
+const pipelineSlug = process.argv[2];
+const branch = process.argv[3] || 'main';
+const commit = process.argv[4] || 'HEAD';
+
 (async () => {
   try {
     const client = new BuildkiteClient();
-    const build = await client.triggerBuild('kibana-agent-packer-cache', {
-      commit: 'HEAD',
-      branch: 'main',
+    const build = await client.triggerBuild(pipelineSlug, {
+      commit,
+      branch,
       ignore_pipeline_branch_filters: true, // Required because of a Buildkite bug
     });
     console.log(`Triggered build: ${build.web_url}`);

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "notice": "This file is not maintained outside of the main branch and should only be used for tooling...",
+  "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
   "versions": [
     {
       "version": "8.4.0",

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
+  "notice": "This file is not maintained outside of the main branch and should only be used for tooling...",
   "versions": [
     {
       "version": "8.4.0",


### PR DESCRIPTION
There are several things in our Buildkite pipelines that rely upon [versions.json](https://github.com/elastic/kibana/blob/main/versions.json). We should trigger the pipeline deployment whenever the file changes in `main`.

Tested here: https://buildkite.com/elastic/kibana-pull-request/builds/50868#01816386-65b8-4289-91fe-8b7b17072980

Uses: https://github.com/chronotc/monorepo-diff-buildkite-plugin