### PR TITLE
[8.3] Update Backport Github Action v8.5.2 (#134097)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,10 +1,7 @@
 on:
   pull_request_target:
-    branches:
-      - main
-    types:
-      - labeled
-      - closed
+    branches: ["main"]
+    types: ["labeled", "closed"]
 
 jobs:
   backport:
@@ -19,9 +16,14 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v7.4.0
+        uses: sqren/backport-github-action@v8.5.2
         with:
           github_token: ${{secrets.KIBANAMACHINE_TOKEN}}
 
-      - name: Backport log
-        run: cat ~/.backport/backport.log
+      - name: Info log
+        if: ${{ success() }}
+        run: cat /home/runner/.backport/backport.info.log
+        
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat /home/runner/.backport/backport.debug.log        


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Update Backport Github Action v8.5.2 (#134097)](https://github.com/elastic/kibana/pull/134097)

<!--- Backport version: 8.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)