### PR TITLE
[DOCS] Adds prerequisites to delete rule API

### DIFF
--- a/docs/api/alerting.asciidoc
+++ b/docs/api/alerting.asciidoc
@@ -32,9 +32,9 @@ The following APIs are available for Alerting.
 For deprecated APIs, refer to <<alerts-api>>.
 
 include::alerting/create_rule.asciidoc[leveloffset=+1]
+include::alerting/delete_rule.asciidoc[leveloffset=+1]
 include::alerting/update_rule.asciidoc[]
 include::alerting/get_rules.asciidoc[]
-include::alerting/delete_rule.asciidoc[]
 include::alerting/find_rules.asciidoc[]
 include::alerting/list_rule_types.asciidoc[]
 include::alerting/enable_rule.asciidoc[]

--- a/docs/api/alerting/delete_rule.asciidoc
+++ b/docs/api/alerting/delete_rule.asciidoc
@@ -4,9 +4,9 @@
 <titleabbrev>Delete rule</titleabbrev>
 ++++
 
-Permanently remove a rule.
+Permanently removes a rule.
 
-WARNING: Once you delete a rule, you cannot recover it.
+WARNING: After you delete a rule, you cannot recover it.
 
 [[delete-rule-api-request]]
 === {api-request-title}
@@ -15,35 +15,29 @@ WARNING: Once you delete a rule, you cannot recover it.
 
 `DELETE <kibana host>:<port>/s/<space_id>/api/alerting/rule/<id>`
 
-////
 === {api-prereq-title}
 
 You must have `all` privileges for the *Management* > *Stack Rules* feature or
 for the *{ml-app}*, *{observability}*, or *Security* features, depending on the
-`consumer` and `rule_type_id` of the rule you're creating. If the rule has
-`actions`, you must also have `read` privileges for the *Management* >
-*Actions and Connectors* feature. For more details, refer to
-<<kibana-feature-privileges>>.
-////
+`consumer` and `rule_type_id` of the rule you're deleting.
 
 [[delete-rule-api-path-params]]
 === {api-path-parms-title}
 
 `id`::
-  (Required, string) The ID of the rule that you want to remove.
+(Required, string) The identifier of the rule that you want to remove.
 
 `space_id`::
-  (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
+(Optional, string) An identifier for the space. If it is not specified, the
+default space is used.
 
 [[delete-rule-api-response-codes]]
 === {api-response-codes-title}
 
 `200`::
-  Indicates a successful call.
+Indicates a successful call.
 
 === {api-examples-title}
-
-Delete a rule with ID:
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/alerting/delete_rule.asciidoc
+++ b/docs/api/alerting/delete_rule.asciidoc
@@ -1,5 +1,5 @@
 [[delete-rule-api]]
-=== Delete rule API
+== Delete rule API
 ++++
 <titleabbrev>Delete rule</titleabbrev>
 ++++
@@ -9,14 +9,25 @@ Permanently remove a rule.
 WARNING: Once you delete a rule, you cannot recover it.
 
 [[delete-rule-api-request]]
-==== Request
+=== {api-request-title}
 
 `DELETE <kibana host>:<port>/api/alerting/rule/<id>`
 
 `DELETE <kibana host>:<port>/s/<space_id>/api/alerting/rule/<id>`
 
+////
+=== {api-prereq-title}
+
+You must have `all` privileges for the *Management* > *Stack Rules* feature or
+for the *{ml-app}*, *{observability}*, or *Security* features, depending on the
+`consumer` and `rule_type_id` of the rule you're creating. If the rule has
+`actions`, you must also have `read` privileges for the *Management* >
+*Actions and Connectors* feature. For more details, refer to
+<<kibana-feature-privileges>>.
+////
+
 [[delete-rule-api-path-params]]
-==== Path parameters
+=== {api-path-parms-title}
 
 `id`::
   (Required, string) The ID of the rule that you want to remove.
@@ -25,17 +36,17 @@ WARNING: Once you delete a rule, you cannot recover it.
   (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
 
 [[delete-rule-api-response-codes]]
-==== Response code
+=== {api-response-codes-title}
 
 `200`::
   Indicates a successful call.
 
-==== Example
+=== {api-examples-title}
 
 Delete a rule with ID:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X DELETE api/alerting/rule/41893910-6bca-11eb-9e0d-85d233e3ee35
+DELETE api/alerting/rule/41893910-6bca-11eb-9e0d-85d233e3ee35
 --------------------------------------------------
 // KIBANA


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/133672

This PR updates https://www.elastic.co/guide/en/kibana/master/delete-rule-api.html to:

- Add a prerequisites section
- Use shared attributes for the section titles
- Remove the "curl" from the example, since it's already added when you "Copy as curl"
- More minor edits

### Preview

https://kibana_134408.docs-preview.app.elstc.co/guide/en/kibana/master/delete-rule-api.html