### PR TITLE
 Enable adding BYOEI engines to Meta Engines via UI

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
@@ -138,7 +138,7 @@ describe('MetaEngineCreationLogic', () => {
         );
         MetaEngineCreationLogic.actions.fetchIndexedEngineNames();
         await nextTick();
-        expect(MetaEngineCreationLogic.actions.setIndexedEngineNames).toHaveBeenCalledWith(['foo']);
+        expect(MetaEngineCreationLogic.actions.setIndexedEngineNames).toHaveBeenCalledWith(['foo', 'elasticsearch-engine']);
       });
 
       it('if there are remaining pages it should call fetchIndexedEngineNames recursively with an incremented page', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
@@ -138,7 +138,10 @@ describe('MetaEngineCreationLogic', () => {
         );
         MetaEngineCreationLogic.actions.fetchIndexedEngineNames();
         await nextTick();
-        expect(MetaEngineCreationLogic.actions.setIndexedEngineNames).toHaveBeenCalledWith(['foo', 'elasticsearch-engine']);
+        expect(MetaEngineCreationLogic.actions.setIndexedEngineNames).toHaveBeenCalledWith([
+          'foo',
+          'elasticsearch-engine',
+        ]);
       });
 
       it('if there are remaining pages it should call fetchIndexedEngineNames recursively with an incremented page', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
@@ -78,7 +78,8 @@ export const MetaEngineCreationLogic = kea<
     selectedIndexedEngineNames: [
       [],
       {
-        setSelectedIndexedEngineNames: (_, { selectedIndexedEngineNames }) => selectedIndexedEngineNames,
+        setSelectedIndexedEngineNames: (_, { selectedIndexedEngineNames }) =>
+          selectedIndexedEngineNames,
       },
     ],
   },
@@ -99,8 +100,7 @@ export const MetaEngineCreationLogic = kea<
       }
 
       if (response) {
-        const engineNames = response.results
-          .map((result) => result.name);
+        const engineNames = response.results.map((result) => result.name);
         actions.setIndexedEngineNames([...values.indexedEngineNames, ...engineNames]);
 
         if (page < response.meta.page.total_pages) {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
@@ -16,7 +16,7 @@ import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
 import { ENGINE_PATH } from '../../routes';
 import { formatApiName } from '../../utils/format_api_name';
-import { EngineDetails, EngineTypes } from '../engine/types';
+import { EngineDetails } from '../engine/types';
 
 import { META_ENGINE_CREATION_SUCCESS_MESSAGE } from './constants';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
@@ -78,8 +78,7 @@ export const MetaEngineCreationLogic = kea<
     selectedIndexedEngineNames: [
       [],
       {
-        setSelectedIndexedEngineNames: (_, { selectedIndexedEngineNames }) =>
-          selectedIndexedEngineNames,
+        setSelectedIndexedEngineNames: (_, { selectedIndexedEngineNames }) => selectedIndexedEngineNames,
       },
     ],
   },
@@ -101,7 +100,6 @@ export const MetaEngineCreationLogic = kea<
 
       if (response) {
         const engineNames = response.results
-          .filter(({ type }) => type !== EngineTypes.elasticsearch)
           .map((result) => result.name);
         actions.setIndexedEngineNames([...values.indexedEngineNames, ...engineNames]);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
@@ -98,30 +98,12 @@ describe('SourceEnginesLogic', () => {
 
         SourceEnginesLogic.actions.setIndexedEngines([
           { name: 'source-engine-1' },
-          { name: 'source-engine-2' },
+          { name: 'source-engine-2', 'type': 'elasticsearch' },
         ] as EngineDetails[]);
 
         expect(SourceEnginesLogic.values).toEqual({
           ...DEFAULT_VALUES,
-          indexedEngines: [{ name: 'source-engine-1' }, { name: 'source-engine-2' }],
-          // Selectors
-          indexedEngineNames: ['source-engine-1', 'source-engine-2'],
-          selectableEngineNames: ['source-engine-1', 'source-engine-2'],
-        });
-      });
-
-      it('sets indexedEngines filters out elasticsearch type engines', () => {
-        mount();
-
-        SourceEnginesLogic.actions.setIndexedEngines([
-          { name: 'source-engine-1' },
-          { name: 'source-engine-2' },
-          { name: 'source-engine-elasticsearch', type: 'elasticsearch' },
-        ] as EngineDetails[]);
-
-        expect(SourceEnginesLogic.values).toEqual({
-          ...DEFAULT_VALUES,
-          indexedEngines: [{ name: 'source-engine-1' }, { name: 'source-engine-2' }],
+          indexedEngines: [{ name: 'source-engine-1' }, { name: 'source-engine-2', 'type': 'elasticsearch' }],
           // Selectors
           indexedEngineNames: ['source-engine-1', 'source-engine-2'],
           selectableEngineNames: ['source-engine-1', 'source-engine-2'],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.test.ts
@@ -98,12 +98,15 @@ describe('SourceEnginesLogic', () => {
 
         SourceEnginesLogic.actions.setIndexedEngines([
           { name: 'source-engine-1' },
-          { name: 'source-engine-2', 'type': 'elasticsearch' },
+          { name: 'source-engine-2', type: 'elasticsearch' },
         ] as EngineDetails[]);
 
         expect(SourceEnginesLogic.values).toEqual({
           ...DEFAULT_VALUES,
-          indexedEngines: [{ name: 'source-engine-1' }, { name: 'source-engine-2', 'type': 'elasticsearch' }],
+          indexedEngines: [
+            { name: 'source-engine-1' },
+            { name: 'source-engine-2', type: 'elasticsearch' },
+          ],
           // Selectors
           indexedEngineNames: ['source-engine-1', 'source-engine-2'],
           selectableEngineNames: ['source-engine-1', 'source-engine-2'],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
@@ -88,8 +88,7 @@ export const SourceEnginesLogic = kea<
     indexedEngines: [
       [],
       {
-        setIndexedEngines: (_, { indexedEngines }) =>
-          indexedEngines.filter(({ type }) => type !== EngineTypes.elasticsearch),
+        setIndexedEngines: (_, { indexedEngines }) => indexedEngines,
       },
     ],
     selectedEngineNamesToAdd: [

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/source_engines/source_engines_logic.ts
@@ -11,7 +11,7 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { recursivelyFetchEngines } from '../../utils/recursively_fetch_engines';
 import { EngineLogic } from '../engine';
-import { EngineDetails, EngineTypes } from '../engine/types';
+import { EngineDetails } from '../engine/types';
 
 import { ADD_SOURCE_ENGINES_SUCCESS_MESSAGE, REMOVE_SOURCE_ENGINE_SUCCESS_MESSAGE } from './i18n';
 


### PR DESCRIPTION
## Summary

The PR is intended to solve elastic/enterprise-search-team#2082.
Elasticsearch based engines are not filtered out anymore and can be added to meta engines.

Screens affected:

- Create meta engine:

![image](https://user-images.githubusercontent.com/529238/173785125-994db014-debf-4d5d-9411-762733a08674.png)

- Add a source to an existing meta engine:

![image](https://user-images.githubusercontent.com/529238/173785223-e9c2ab76-9be8-45db-bc45-a581be1c10a6.png)

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
