### PR TITLE
[Fleet] Fix all add agent steps disabled when fleet server policy selected

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -47,7 +47,7 @@ export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({ selecte
     getSetDeploymentModeStep({
       deploymentMode,
       setDeploymentMode,
-      disabled: !Boolean(fleetServerPolicyId),
+      disabled: !Boolean(fleetServerPolicyId || selectedPolicyId),
     }),
     getAddFleetServerHostStep({ fleetServerHostForm, disabled: !Boolean(fleetServerPolicyId) }),
     getGenerateServiceTokenStep({

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -11,14 +11,15 @@ import { PLUGIN_ID, INTEGRATIONS_PLUGIN_ID, pagePathGetters } from '../../../../
 // or are otherwise not accounted for by verbiage and elements throughout the multi-step UI
 const EXCLUDED_PACKAGES = [
   'apm',
-  'endpoint',
-  'synthetics',
-  'security_detection_engine',
-  'osquery_manager',
-  'dga',
   'cloud_security_posture',
-  'problemchild',
+  'dga',
+  'endpoint',
+  'fleet_server',
   'kubernetes',
+  'osquery_manager',
+  'problemchild',
+  'security_detection_engine',
+  'synthetics',
 ];
 
 interface GetInstallPkgRouteOptionsParams {


### PR DESCRIPTION
## Summary

Resolves #134177 

`fleetServerPolicyId` was undefined as the state is not initialized, however the selected policy is passed in the props as selectedPolicyId, so this should be used in the `disabled` check as well.

Bonus change: Add fleet server to list of integrations not to use new add integration UI for #134187