### PR TITLE
bump bundled endpoint package to 8.3

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -23,7 +23,7 @@
   },
   {
     "name": "endpoint",
-    "version": "8.2.0"
+    "version": "8.3.0"
   },
   {
     "name": "fleet_server",


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/133255

Bumping endpoint bundle to 8.3

