### PR TITLE
[Fleet] Improve pagination experience on large scale (10k+ agents) 

### DIFF
--- a/x-pack/plugins/fleet/common/constants/routes.ts
+++ b/x-pack/plugins/fleet/common/constants/routes.ts
@@ -119,6 +119,8 @@ export const AGENT_API_ROUTES = {
   UPGRADE_PATTERN: `${API_ROOT}/agents/{agentId}/upgrade`,
   BULK_UPGRADE_PATTERN: `${API_ROOT}/agents/bulk_upgrade`,
   CURRENT_UPGRADES_PATTERN: `${API_ROOT}/agents/current_upgrades`,
+  CLOSE_PIT_PATTERN: `${API_ROOT}/agents/closePit/{pitId}`,
+  OPEN_PIT_PATTERN: `${API_ROOT}/agents/openPit`,
 };
 
 export const ENROLLMENT_API_KEY_ROUTES = {

--- a/x-pack/plugins/fleet/common/services/routes.ts
+++ b/x-pack/plugins/fleet/common/services/routes.ts
@@ -179,6 +179,8 @@ export const agentRouteService = {
   getCancelActionPath: (actionId: string) =>
     AGENT_API_ROUTES.CANCEL_ACTIONS_PATTERN.replace('{actionId}', actionId),
   getListPath: () => AGENT_API_ROUTES.LIST_PATTERN,
+  getOpenPitPath: () => AGENT_API_ROUTES.OPEN_PIT_PATTERN,
+  getClosePitPath: (pitId: string) => AGENT_API_ROUTES.CLOSE_PIT_PATTERN.replace('{pitId}', pitId),
   getStatusPath: () => AGENT_API_ROUTES.STATUS_PATTERN,
   getIncomingDataPath: () => AGENT_API_ROUTES.DATA_PATTERN,
   getCreateActionPath: (agentId: string) =>

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -15,6 +15,7 @@ export interface GetAgentsRequest {
   query: ListWithKuery & {
     showInactive: boolean;
     showUpgradeable?: boolean;
+    pitId?: string;
   };
 }
 
@@ -22,6 +23,10 @@ export interface GetAgentsResponse extends ListResult<Agent> {
   totalInactive: number;
   // deprecated in 8.x
   list?: Agent[];
+}
+
+export interface OpenAgentsPitResponse {
+  pitId: string;
 }
 
 export interface GetOneAgentRequest {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -233,7 +233,6 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
               kuery: kuery && kuery !== '' ? kuery : undefined,
               showInactive,
               showUpgradeable,
-              usePit: true,
               pitId,
             }),
             sendGetAgentStatus({

--- a/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
@@ -30,6 +30,7 @@ import type {
   PostNewAgentActionRequest,
   PostNewAgentActionResponse,
   GetCurrentUpgradesResponse,
+  OpenAgentsPitResponse,
 } from '../../types';
 
 import { useRequest, sendRequest } from './use_request';
@@ -60,6 +61,20 @@ export function sendGetAgents(query: GetAgentsRequest['query'], options?: Reques
     path: agentRouteService.getListPath(),
     query,
     ...options,
+  });
+}
+
+export function openGetAgentsPit() {
+  return sendRequest<OpenAgentsPitResponse>({
+    method: 'post',
+    path: agentRouteService.getOpenPitPath(),
+  });
+}
+
+export function closeGetAgentsPit(pitId: string) {
+  return sendRequest<{}>({
+    method: 'post',
+    path: agentRouteService.getClosePitPath(pitId),
   });
 }
 

--- a/x-pack/plugins/fleet/public/types/index.ts
+++ b/x-pack/plugins/fleet/public/types/index.ts
@@ -121,6 +121,7 @@ export type {
   PackageSpecCategory,
   UpdatePackageRequest,
   UpdatePackageResponse,
+  OpenAgentsPitResponse,
 } from '../../common';
 export { entries, ElasticsearchAssetType, KibanaAssetType, InstallStatus } from '../../common';
 

--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -21,6 +21,7 @@ import {
   PostAgentUpgradeRequestSchema,
   PostBulkAgentUpgradeRequestSchema,
   PostCancelActionRequestSchema,
+  CloseAgentsPitRequestSchema,
 } from '../../types';
 import * as AgentService from '../../services/agents';
 import type { FleetConfigType } from '../..';
@@ -35,6 +36,8 @@ import {
   putAgentsReassignHandler,
   postBulkAgentsReassignHandler,
   getAgentDataHandler,
+  closeAgentsPitHandler,
+  openAgentsPitHandler,
 } from './handlers';
 import {
   postNewAgentActionHandlerBuilder,
@@ -91,6 +94,30 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       },
     },
     getAgentsHandler
+  );
+
+  // Open PIT
+  router.post(
+    {
+      path: AGENT_API_ROUTES.OPEN_PIT_PATTERN,
+      validate: {},
+      fleetAuthz: {
+        fleet: { all: true },
+      },
+    },
+    openAgentsPitHandler
+  );
+
+  // Close PIT
+  router.post(
+    {
+      path: AGENT_API_ROUTES.CLOSE_PIT_PATTERN,
+      validate: CloseAgentsPitRequestSchema,
+      fleetAuthz: {
+        fleet: { all: true },
+      },
+    },
+    closeAgentsPitHandler
   );
 
   // Agent actions

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -90,6 +90,106 @@ export async function getAgents(esClient: ElasticsearchClient, options: GetAgent
   return agents;
 }
 
+// TODO replace getAgentsByKuery by getAgentsByKueryPit when moving to pit everywhere
+export async function getAgentsByKueryPit(
+  esClient: ElasticsearchClient,
+  options: ListWithKuery & {
+    showInactive: boolean;
+    pitId: string;
+  }
+): Promise<{
+  agents: Agent[];
+  total: number;
+  page: number;
+  perPage: number;
+}> {
+  const {
+    page = 1,
+    perPage = 20,
+    sortField = 'enrolled_at',
+    sortOrder = 'desc',
+    kuery,
+    showInactive = false,
+    showUpgradeable,
+  } = options;
+  const { pitId } = options;
+  const filters = [];
+
+  if (kuery && kuery !== '') {
+    filters.push(kuery);
+  }
+
+  if (showInactive === false) {
+    filters.push(ACTIVE_AGENT_CONDITION);
+  }
+
+  const kueryNode = _joinFilters(filters);
+  const body = kueryNode ? { query: toElasticsearchQuery(kueryNode) } : {};
+
+  const queryAgents = async (from: number, size: number) => {
+    return esClient.search<FleetServerAgent, {}>({
+      from,
+      size,
+      track_total_hits: true,
+      rest_total_hits_as_int: true,
+      body: {
+        ...body,
+        sort: [{ [sortField]: { order: sortOrder } }],
+      },
+      pit: {
+        id: pitId,
+        keep_alive: '1m',
+      },
+    });
+  };
+
+  const res = await queryAgents((page - 1) * perPage, perPage);
+
+  let agents = res.hits.hits.map(searchHitToAgent);
+  let total = res.hits.total as number;
+
+  // filtering for a range on the version string will not work,
+  // nor does filtering on a flattened field (local_metadata), so filter here
+  if (showUpgradeable) {
+    // fixing a bug where upgradeable filter was not returning right results https://github.com/elastic/kibana/issues/117329
+    // query all agents, then filter upgradeable, and return the requested page and correct total
+    // if there are more than SO_SEARCH_LIMIT agents, the logic falls back to same as before
+    if (total < SO_SEARCH_LIMIT) {
+      const response = await queryAgents(0, SO_SEARCH_LIMIT);
+      agents = response.hits.hits
+        .map(searchHitToAgent)
+        .filter((agent) => isAgentUpgradeable(agent, appContextService.getKibanaVersion()));
+      total = agents.length;
+      const start = (page - 1) * perPage;
+      agents = agents.slice(start, start + perPage);
+    } else {
+      agents = agents.filter((agent) =>
+        isAgentUpgradeable(agent, appContextService.getKibanaVersion())
+      );
+    }
+  }
+
+  return {
+    agents,
+    total,
+    page,
+    perPage,
+  };
+}
+
+export async function openAgentsPointInTime(esClient: ElasticsearchClient): string {
+  const pitKeepAlive = '10m';
+  const pitRes = await esClient.openPointInTime({
+    index: AGENTS_INDEX,
+    keep_alive: pitKeepAlive,
+  });
+  return pitRes.id;
+}
+
+export async function closeAgentsPointInTime(esClient: ElasticsearchClient, pitId: string) {
+  await esClient.closePointInTime({ id: pitId });
+}
+
 export async function getAgentsByKuery(
   esClient: ElasticsearchClient,
   options: ListWithKuery & {

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -177,7 +177,7 @@ export async function getAgentsByKueryPit(
   };
 }
 
-export async function openAgentsPointInTime(esClient: ElasticsearchClient): string {
+export async function openAgentsPointInTime(esClient: ElasticsearchClient): Promise<string> {
   const pitKeepAlive = '10m';
   const pitRes = await esClient.openPointInTime({
     index: AGENTS_INDEX,

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -18,6 +18,13 @@ export const GetAgentsRequestSchema = {
     kuery: schema.maybe(schema.string()),
     showInactive: schema.boolean({ defaultValue: false }),
     showUpgradeable: schema.boolean({ defaultValue: false }),
+    pitId: schema.maybe(schema.string()),
+  }),
+};
+
+export const CloseAgentsPitRequestSchema = {
+  params: schema.object({
+    pitId: schema.string(),
   }),
 };
 

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -73,9 +73,14 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should work with pit', async () => {
-      let { body: apiResponse } = await supertest.get(`/api/fleet/agents/openPit`).expect(200);
+      let { body: apiResponse } = await supertest
+        .post(`/api/fleet/agents/openPit`)
+        .set('kbn-xsrf', 'xxx')
+        .expect(200);
 
-      expect(apiResponse.pitId).not.to.be(undefined);
+      const pitId = apiResponse.pitId;
+
+      expect(pitId).not.to.be(undefined);
 
       ({ body: apiResponse } = await supertest
         .get(`/api/fleet/agents?pitId=${apiResponse.pitId}`)
@@ -83,9 +88,10 @@ export default function ({ getService }: FtrProviderContext) {
 
       expect(apiResponse.items.length).to.be.greaterThan(0);
 
-      ({ body: apiResponse } = await supertest
-        .post(`/api/fleet/agents/closePit/${apiResponse.pitId}`)
-        .expect(200));
+      await supertest
+        .post(`/api/fleet/agents/closePit/${pitId}`)
+        .set('kbn-xsrf', 'xxx')
+        .expect(200);
     });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -71,5 +71,21 @@ export default function ({ getService }: FtrProviderContext) {
       const agent = apiResponse.items[0];
       expect(agent.access_api_key_id).to.eql('api-key-2');
     });
+
+    it('should work with pit', async () => {
+      let { body: apiResponse } = await supertest.get(`/api/fleet/agents/openPit`).expect(200);
+
+      expect(apiResponse.pitId).not.to.be(undefined);
+
+      ({ body: apiResponse } = await supertest
+        .get(`/api/fleet/agents?pitId=${apiResponse.pitId}`)
+        .expect(200));
+
+      expect(apiResponse.items.length).to.be.greaterThan(0);
+
+      ({ body: apiResponse } = await supertest
+        .post(`/api/fleet/agents/closePit/${apiResponse.pitId}`)
+        .expect(200));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fix for https://github.com/elastic/kibana/issues/91562

Changing `/agents` to use point in time request.
Created new API endpoints to open and close PIT request. This is needed so that the same PIT request is reused across many requests on Agent list page.

Remaining work:
- other usages of `getAgentsByKuery` to be replaced with PIT, e.g. `/agent_status` call, bulk actions
- fix `showUpgradeable` filter for >10k agents

WIP: logic works for a few agents, will test with 10k+ with horde.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
