### PR TITLE
[ML] Fix persisted page header from the Analytics Map view

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
@@ -108,7 +108,7 @@ export const Page: FC<{
         />
       ) : null}
       {jobIdToUse !== undefined && (
-        <MlPageHeader key={`${jobIdToUse}-id`}>
+        <MlPageHeader>
           <FormattedMessage
             id="xpack.ml.dataframe.analyticsExploration.titleWithId"
             defaultMessage="Explore results for job ID {id}"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -107,7 +107,7 @@ const modelColumns = [
 ];
 
 interface Props {
-  setAnalyticsId: React.Dispatch<React.SetStateAction<AnalyticsSelectorIds | undefined>>;
+  setAnalyticsId: (update: AnalyticsSelectorIds) => void;
   jobsOnly?: boolean;
   setIsIdSelectorFlyoutVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -27,16 +27,15 @@ import { AnalyticsEmptyPrompt } from '../analytics_management/components/empty_p
 
 export const Page: FC = () => {
   const [globalState, setGlobalState] = useUrlState('_g');
-  const mapJobId = globalState?.ml?.jobId;
-  const mapModelId = globalState?.ml?.modelId;
+  const jobId = globalState?.ml?.jobId;
+  const modelId = globalState?.ml?.modelId;
 
   const [isLoading, setIsLoading] = useState(false);
   const [isIdSelectorFlyoutVisible, setIsIdSelectorFlyoutVisible] = useState<boolean>(
-    !mapJobId && !mapModelId
+    !jobId && !modelId
   );
   const [jobsExist, setJobsExist] = useState(true);
   const { refresh } = useRefreshAnalyticsList({ isLoading: setIsLoading });
-  // const [analyticsId, setAnalyticsId] = useState<AnalyticsSelectorIds>();
 
   const setAnalyticsId = useCallback(
     (analyticsId: AnalyticsSelectorIds) => {
@@ -94,9 +93,6 @@ export const Page: FC = () => {
     );
   };
 
-  const jobId = mapJobId;
-  const modelId = mapModelId;
-
   return (
     <>
       <AnalyticsIdSelectorControls
@@ -118,7 +114,7 @@ export const Page: FC = () => {
           />
         </MlPageHeader>
       ) : null}
-      {jobId !== undefined && mapModelId === undefined ? (
+      {jobId !== undefined && modelId === undefined ? (
         <MlPageHeader>
           <FormattedMessage
             data-test-subj="mlPageDataFrameAnalyticsMapTitle"
@@ -145,7 +141,12 @@ export const Page: FC = () => {
       <UpgradeWarning />
 
       {jobId || modelId ? (
-        <JobMap analyticsId={jobId} modelId={modelId} forceRefresh={isLoading} />
+        <JobMap
+          key={`${jobId ?? modelId}-id`}
+          analyticsId={jobId}
+          modelId={modelId}
+          forceRefresh={isLoading}
+        />
       ) : (
         getEmptyState()
       )}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -120,7 +120,7 @@ export const Page: FC = () => {
         </MlPageHeader>
       ) : null}
       {jobId !== undefined ? (
-        <MlPageHeader key={`${jobId}-id`}>
+        <MlPageHeader>
           <FormattedMessage
             data-test-subj="mlPageDataFrameAnalyticsMapTitle"
             id="xpack.ml.dataframe.analyticsMap.analyticsIdTitle"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -119,7 +119,7 @@ export const Page: FC = () => {
           />
         </MlPageHeader>
       ) : null}
-      {jobId !== undefined ? (
+      {jobId !== undefined && mapModelId === undefined ? (
         <MlPageHeader>
           <FormattedMessage
             data-test-subj="mlPageDataFrameAnalyticsMapTitle"
@@ -129,7 +129,7 @@ export const Page: FC = () => {
           />
         </MlPageHeader>
       ) : null}
-      {modelId !== undefined ? (
+      {modelId !== undefined && jobId === undefined ? (
         <MlPageHeader>
           <FormattedMessage
             data-test-subj="mlPageDataFrameAnalyticsMapTitle"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -145,13 +145,8 @@ export const Page: FC = () => {
       <SavedObjectsWarning onCloseFlyout={refresh} />
       <UpgradeWarning />
 
-      {jobId ?? modelId ? (
-        <JobMap
-          key={`${jobId ?? modelId}-id`}
-          analyticsId={jobId}
-          modelId={modelId}
-          forceRefresh={isLoading}
-        />
+      {jobId || modelId ? (
+        <JobMap analyticsId={jobId} modelId={modelId} forceRefresh={isLoading} />
       ) : (
         getEmptyState()
       )}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useState, useEffect, useCallback } from 'react';
 import { EuiEmptyPrompt } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -36,7 +36,20 @@ export const Page: FC = () => {
   );
   const [jobsExist, setJobsExist] = useState(true);
   const { refresh } = useRefreshAnalyticsList({ isLoading: setIsLoading });
-  const [analyticsId, setAnalyticsId] = useState<AnalyticsSelectorIds>();
+  // const [analyticsId, setAnalyticsId] = useState<AnalyticsSelectorIds>();
+
+  const setAnalyticsId = useCallback(
+    (analyticsId: AnalyticsSelectorIds) => {
+      setGlobalState({
+        ml: {
+          ...(analyticsId.job_id && !analyticsId.model_id ? { jobId: analyticsId.job_id } : {}),
+          ...(analyticsId.model_id ? { modelId: analyticsId.model_id } : {}),
+        },
+      });
+    },
+    [setGlobalState]
+  );
+
   const {
     services: { docLinks },
   } = useMlKibana();
@@ -58,20 +71,6 @@ export const Page: FC = () => {
   useEffect(function checkJobs() {
     checkJobsExist();
   }, []);
-
-  useEffect(
-    function updateUrl() {
-      if (analyticsId !== undefined) {
-        setGlobalState({
-          ml: {
-            ...(analyticsId.job_id && !analyticsId.model_id ? { jobId: analyticsId.job_id } : {}),
-            ...(analyticsId.model_id ? { modelId: analyticsId.model_id } : {}),
-          },
-        });
-      }
-    },
-    [analyticsId?.job_id, analyticsId?.model_id]
-  );
 
   const getEmptyState = () => {
     if (jobsExist === false) {
@@ -95,8 +94,8 @@ export const Page: FC = () => {
     );
   };
 
-  const jobId = mapJobId ?? analyticsId?.job_id;
-  const modelId = mapModelId ?? analyticsId?.model_id;
+  const jobId = mapJobId;
+  const modelId = mapModelId;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes persisted page header from the Analytics Map view by removing the `key` prop with the job ID. 

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
