### PR TITLE
[CI] Skip CI on api_docs/*.devdocs.json changes

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -28,6 +28,7 @@
         "^\\.github/",
         "\\.md$",
         "\\.mdx$",
+        "^api_docs/.+\\.devdocs\\.json$",
         "^\\.backportrc\\.json$",
         "^nav-kibana-dev\\.docnav\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",


### PR DESCRIPTION
These auto-generated files shouldn't need CI. The *.mdx files in the same directory are covered by another skip rule already.