### PR TITLE
[8.2] improve text on reporting setup and dependencies (#134406)

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -41,12 +41,8 @@ If you are using Ubuntu/Debian systems, install the following packages:
 * `libfontconfig1`
 * `libnss3`
 
-If the system is missing dependencies, a screenshot report job may fail in a non-deterministic way. {kib} runs a self-test at server startup, and
-if it encounters errors, logs them in the Console. The error message does not include
-information about why Chromium failed to run. The most common error message is `Error: connect ECONNREFUSED`, which indicates
-that {kib} could not connect to the Chromium process.
-
-To troubleshoot the problem, start the {kib} server with environment variables that tell Chromium to print verbose logs. For more information, refer to <<reporting-troubleshooting-puppeteer-debug-logs>>.
+The reporting plugin has a built-in utility to check for common issues, such as missing dependencies. See
+<<reporting-diagnostics>> for more information.
 
 [float]
 [[grant-user-access]]

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -21,10 +21,13 @@ Having trouble? Here are solutions to common problems you might encounter while 
 [float]
 [[reporting-diagnostics]]
 === Reporting diagnostics
-Reporting comes with a built-in utility to try to automatically find common issues.
-When {kib} is running, navigate to the Report Listing page, and click *Run reporting diagnostics*.
-This will open up a diagnostic tool that checks various parts of the {kib} deployment and
-come up with any relevant recommendations.
+Reporting comes with a built-in utility to try to automatically find common issues. When {kib} is running,
+navigate to the Report Listing page, and click *Run reporting diagnostics*. This will open up a diagnostic tool
+that checks various parts of the {kib} deployment and come up with any relevant recommendations.
+
+If the diagnostic information doesn't reveal the problem, you can troubleshoot further by starting the Kibana
+server with an environment variable for revealing additional debugging logs. Refer to
+<<reporting-troubleshooting-puppeteer-debug-logs>>.
 
 [float]
 [[reporting-troubleshooting-text-incorrect]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [improve text on reporting setup and dependencies (#134406)](https://github.com/elastic/kibana/pull/134406)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)