### PR TITLE
[ci] remove requirement that CI runs for readme changes

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -35,8 +35,7 @@
         "^\\.buildkite/pull_requests\\.json$"
       ],
       "always_require_ci_on_changed": [
-        "^docs/developer/plugin-list.asciidoc$",
-        "/plugins/[^/]+/readme\\.(md|asciidoc)$"
+        "^docs/developer/plugin-list.asciidoc$"
       ],
       "kibana_versions_check": true
     }


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/74388 I added a requirement that CI runs for plugin readme changes. With the changes to the docs in the last year it seems this requirement can be lifted and PRs shouldn't need to run full CI just because some plugin readmes have been updated.