### PR TITLE
[8.3] [ci] remove requirement that CI runs for readme changes (#134504)

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -32,8 +32,7 @@
         "^\\.buildkite/pull_requests\\.json$"
       ],
       "always_require_ci_on_changed": [
-        "^docs/developer/plugin-list.asciidoc$",
-        "/plugins/[^/]+/readme\\.(md|asciidoc)$"
+        "^docs/developer/plugin-list.asciidoc$"
       ]
     }
   ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[ci] remove requirement that CI runs for readme changes (#134504)](https://github.com/elastic/kibana/pull/134504)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)