### PR TITLE
[es-snapshots] Disable caching on es snapshot manifests

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/create_manifest.js
+++ b/.buildkite/scripts/steps/es_snapshots/create_manifest.js
@@ -96,7 +96,7 @@ const { BASE_BUCKET_DAILY } = require('./bucket_config');
       cd "${destination}"
       gsutil -m cp -r *.* gs://${BASE_BUCKET_DAILY}/${DESTINATION}
       cp manifest.json manifest-latest.json
-      gsutil cp manifest-latest.json gs://${BASE_BUCKET_DAILY}/${VERSION}
+      gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest-latest.json gs://${BASE_BUCKET_DAILY}/${VERSION}
 
       buildkite-agent meta-data set ES_SNAPSHOT_MANIFEST 'https://storage.googleapis.com/${BASE_BUCKET_DAILY}/${DESTINATION}/manifest.json'
       buildkite-agent meta-data set ES_SNAPSHOT_VERSION '${VERSION}'

--- a/.buildkite/scripts/steps/es_snapshots/promote_manifest.js
+++ b/.buildkite/scripts/steps/es_snapshots/promote_manifest.js
@@ -39,11 +39,11 @@ const { BASE_BUCKET_DAILY, BASE_BUCKET_PERMANENT } = require('./bucket_config');
       `
       set -euo pipefail
       cp manifest.json manifest-latest-verified.json
-      gsutil cp manifest-latest-verified.json gs://${BASE_BUCKET_DAILY}/${version}/
+      gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest-latest-verified.json gs://${BASE_BUCKET_DAILY}/${version}/
       rm manifest.json
       cp manifest-permanent.json manifest.json
       gsutil -m cp -r gs://${bucket}/* gs://${BASE_BUCKET_PERMANENT}/${version}/
-      gsutil cp manifest.json gs://${BASE_BUCKET_PERMANENT}/${version}/
+      gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest.json gs://${BASE_BUCKET_PERMANENT}/${version}/
     `,
       { shell: '/bin/bash' }
     );


### PR DESCRIPTION
I noticed today that Buildkite jobs are getting an old ES snapshot for the first 30-45 minutes right after promotion. GCS is setting `cache-control: public, max-age=3600`, and I believe this causes *their* servers to also potentially serve up cached versions. Hopefully, these changes help with this.