### PR TITLE
[PoC] EQL in discover

### DIFF
--- a/src/plugins/discover/public/application/main/utils/fetch_documents.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_documents.ts
@@ -12,6 +12,8 @@ import { isCompleteResponse, ISearchSource } from '@kbn/data-plugin/public';
 import { SAMPLE_SIZE_SETTING } from '../../../../common';
 import { FetchDeps } from './fetch_all';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Requests the documents for Discover. This will return a promise that will resolve
  * with the documents.
@@ -36,7 +38,7 @@ export const fetchDocuments = (
     description: 'fetch documents',
   };
 
-  const _flattenHits = (hits, sequenceKeys = []) => {
+  const _flattenHits = (hits: any, sequenceKeys = []) => {
     const flat: any = {};
     const _flatten = (_hits: any, path: string[] = []) => {
       Object.keys(_hits).forEach((key) => {
@@ -53,9 +55,9 @@ export const fetchDocuments = (
     return flat;
   };
 
-  const flattenHits = (hits) => {
+  const flattenHits = (hits: any) => {
     if (!hits.sequences) {
-      return hits.events.map((event) => {
+      return hits.events.map((event: any) => {
         return {
           ...event,
           _source: _flattenHits(event._source),
@@ -63,8 +65,8 @@ export const fetchDocuments = (
       });
     }
 
-    return hits.sequences.flatMap((sequence) => {
-      return sequence.events.map((event) => {
+    return hits.sequences.flatMap((sequence: any) => {
+      return sequence.events.map((event: any) => {
         return {
           ...event,
           sequence: sequence.join_keys.join('.'),
@@ -93,7 +95,9 @@ export const fetchDocuments = (
       filter((res) => isCompleteResponse(res)),
       map((res) => {
         const { rawResponse } = res;
-        return rawResponse.hits ? rawResponse.hits.hits : flattenHits(rawResponse.body.hits);
+        return rawResponse.hits
+          ? rawResponse.hits.hits
+          : flattenHits((rawResponse as any).body.hits);
       })
     );
 

--- a/src/plugins/unified_search/public/query_string_input/language_switcher.tsx
+++ b/src/plugins/unified_search/public/query_string_input/language_switcher.tsx
@@ -74,6 +74,16 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
       >
         {toSentenceCase(nonKqlMode)}
       </EuiContextMenuItem>
+      <EuiContextMenuItem
+        key="EQL"
+        icon={language === 'eql' ? 'check' : 'empty'}
+        data-test-subj="eqlLanguageMenuItem"
+        onClick={() => {
+          onSelectLanguage('eql');
+        }}
+      >
+        EQL
+      </EuiContextMenuItem>
       <EuiHorizontalRule margin="none" />
       <EuiContextMenuItem
         key={'documentation'}


### PR DESCRIPTION
## Summary

Allows using EQL as your query language in Discover Application.

Known limitations:
- [ ] sorting is not possible in EQL and should be disabled in the UI
- [ ] chart does not reflect the documents in the document table but rather shows all the documents in the selected time range. This could be OK but would require additional explanation to the user, or we could disable the chart.
- [ ] sequence column is currently not automatically added to the table when relevant (but it could). For now you need to manually select it from the available fields.
- [ ] Query editor is just a single line, multiline would be required
- [ ] **Additional settings might be needed in the search bar for EQL,** for example the ability to set the event category field would be very nice, as without it we can only use EQL fully on indexes where they have the `event.category` field (which is the default setting)

All the other functionality in Discover app should continue to work normally.

How to test this:
- instance: https://kibana-pr-134539.kb.us-west2.gcp.elastic-cloud.com:9243/ 
  username: elastic, 
  password: [ping me on slack]
- go to discover, in the  `saved query menu`  select `language` -> `eql`
- try some of this queries: (using `Kibana Sample Data Logs` dataset)
  -  `any where machine.os == "ios"`
  - `sequence by geo.dest [any where machine.os == "osx"] [any where machine.os == "ios"]`


![image](https://user-images.githubusercontent.com/13629809/173992591-9114f12f-b94c-4e0e-8932-61d2564a6b29.png)
