### PR TITLE
[Fleet] increased checkin timeout to 10 intervals

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -34,7 +34,7 @@ export function getAgentStatus(agent: Agent): AgentStatus {
   if (agent.upgrade_started_at && !agent.upgraded_at) {
     return 'updating';
   }
-  if (intervalsSinceLastCheckIn >= 4) {
+  if (intervalsSinceLastCheckIn >= 10) {
     return 'offline';
   }
 

--- a/x-pack/plugins/fleet/server/services/agents/status.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.test.ts
@@ -7,6 +7,8 @@
 
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
+import { AGENT_POLLING_THRESHOLD_MS } from '../../../common/constants';
+
 import { getAgentStatusById } from './status';
 
 describe('Agent status service', () => {
@@ -79,5 +81,23 @@ describe('Agent status service', () => {
     );
     const status = await getAgentStatusById(mockElasticsearchClient, 'id');
     expect(status).toEqual('unenrolling');
+  });
+
+  it('should return offline when agent has not checked in for 10 intervals', async () => {
+    const mockElasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    mockElasticsearchClient.get.mockResponse(
+      // @ts-expect-error not full interface
+      {
+        _id: 'id',
+        _source: {
+          active: true,
+          last_checkin: new Date(Date.now() - 10 * AGENT_POLLING_THRESHOLD_MS - 1000).toISOString(),
+          local_metadata: {},
+          user_provided_metadata: {},
+        },
+      }
+    );
+    const status = await getAgentStatusById(mockElasticsearchClient, 'id');
+    expect(status).toEqual('offline');
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/134182

Increasing timeout when agents are considered offline from 4 intervals (2 mins) to 10 intervals (5 mins)

@joshdover should we increase the timeout to 12m as suggested in the original issue?

To verify, enroll an agent, unenroll it and wait for 5 minutes for it to appear offline on UI.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
