### PR TITLE
[Fleet] Fix wrong spelling in Agent upgrade modal

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -355,7 +355,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
             <EuiFlexGroup gutterSize="s">
               <EuiFlexItem grow={false}>
                 {i18n.translate('xpack.fleet.upgradeAgents.maintainanceAvailableLabel', {
-                  defaultMessage: 'Maintainance window available',
+                  defaultMessage: 'Maintenance window available',
                 })}
               </EuiFlexItem>
               <EuiSpacer size="xs" />
@@ -395,6 +395,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       ) : null}
       {errors ? (
         <>
+          <EuiSpacer size="s" />
           <EuiCallOut
             color="danger"
             title={i18n.translate('xpack.fleet.upgradeAgents.warningCalloutErrors', {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/134435

Fix wrong spelling of "maintenence" in Agent upgrade modal and add missing space above error message

![173799355-75566113-09a3-4b33-b3be-f18ee13ec03f](https://user-images.githubusercontent.com/16084106/174028466-52b7711d-3286-42ed-8778-f36f4c52c4a9.jpeg)


