### PR TITLE
[8.3] move bottom bar offset outside generic grouped nav (#134357)

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
@@ -10,7 +10,6 @@
 import React from 'react';
 import { KibanaPageTemplateProps } from '@kbn/shared-ux-components';
 import { AppLeaveHandler } from '@kbn/core/public';
-import { useShowTimeline } from '../../../../common/utils/timeline/use_show_timeline';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { AutoSaveWarningMsg } from '../../../../timelines/components/timeline/auto_save_warning';
 import { Flyout } from '../../../../timelines/components/flyout';
@@ -20,15 +19,13 @@ export const BOTTOM_BAR_CLASSNAME = 'timeline-bottom-bar';
 
 export const SecuritySolutionBottomBar = React.memo(
   ({ onAppLeave }: { onAppLeave: (handler: AppLeaveHandler) => void }) => {
-    const [showTimeline] = useShowTimeline();
-
     useResolveRedirect();
-    return showTimeline ? (
+    return (
       <>
         <AutoSaveWarningMsg />
         <Flyout timelineId={TimelineId.active} onAppLeave={onAppLeave} />
       </>
-    ) : null;
+    );
   }
 );
 

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
@@ -11,34 +11,16 @@ import React from 'react';
 import { TestProviders } from '../../../common/mock';
 import { SecuritySolutionTemplateWrapper } from '.';
 
+const mockUseShowTimeline = jest.fn((): [boolean] => [false]);
 jest.mock('../../../common/utils/timeline/use_show_timeline', () => ({
   ...jest.requireActual('../../../common/utils/timeline/use_show_timeline'),
-  useShowTimeline: () => [true],
+  useShowTimeline: () => mockUseShowTimeline(),
 }));
 
 jest.mock('./bottom_bar', () => ({
   ...jest.requireActual('./bottom_bar'),
   SecuritySolutionBottomBar: () => <div>{'Bottom Bar'}</div>,
 }));
-
-const mockSiemUserCanCrud = jest.fn();
-jest.mock('../../../common/lib/kibana', () => {
-  const original = jest.requireActual('../../../common/lib/kibana');
-
-  return {
-    ...original,
-    useKibana: () => ({
-      services: {
-        ...original.useKibana().services,
-        application: {
-          capabilities: {
-            siem: mockSiemUserCanCrud(),
-          },
-        },
-      },
-    }),
-  };
-});
 
 jest.mock('../../../common/components/navigation/use_security_solution_navigation', () => {
   return {
@@ -82,8 +64,8 @@ describe('SecuritySolutionTemplateWrapper', () => {
     jest.clearAllMocks();
   });
 
-  it('Should render to the page with bottom bar if user has SIEM show', async () => {
-    mockSiemUserCanCrud.mockReturnValue({ show: true });
+  it('Should render with bottom bar when user allowed', async () => {
+    mockUseShowTimeline.mockReturnValue([true]);
     const { getByText } = renderComponent();
 
     await waitFor(() => {
@@ -92,8 +74,8 @@ describe('SecuritySolutionTemplateWrapper', () => {
     });
   });
 
-  it('Should not show bottom bar if user does not have SIEM show', async () => {
-    mockSiemUserCanCrud.mockReturnValue({ show: false });
+  it('Should not show bottom bar when user not allowed', async () => {
+    mockUseShowTimeline.mockReturnValue([false]);
 
     const { getByText, queryByText } = renderComponent();
 

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -23,7 +23,6 @@ import {
 } from './bottom_bar';
 import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 import { gutterTimeline } from '../../../common/lib/helpers';
-import { useKibana } from '../../../common/lib/kibana';
 import { useShowPagesWithEmptyView } from '../../../common/utils/empty_view/use_show_pages_with_empty_view';
 import { useIsPolicySettingsBarVisible } from '../../../management/pages/policy/view/policy_hooks';
 import { useIsGroupedNavigationEnabled } from '../../../common/components/navigation/helpers';
@@ -91,7 +90,6 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapp
     const addBottomPadding =
       isTimelineBottomBarVisible || isPolicySettingsVisible || isGroupedNavEnabled;
 
-    const userHasSecuritySolutionVisible = useKibana().services.application.capabilities.siem.show;
     const showEmptyState = useShowPagesWithEmptyView();
     const emptyStateProps = showEmptyState
       ? {
@@ -113,7 +111,7 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapp
         $isShowingTimelineOverlay={isShowingTimelineOverlay}
         bottomBarProps={SecuritySolutionBottomBarProps}
         bottomBar={
-          userHasSecuritySolutionVisible && <SecuritySolutionBottomBar onAppLeave={onAppLeave} />
+          isTimelineBottomBarVisible && <SecuritySolutionBottomBar onAppLeave={onAppLeave} />
         }
         paddingSize="none"
         solutionNav={solutionNav}

--- a/x-pack/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.test.tsx
@@ -12,6 +12,7 @@ import { TestProviders } from '../../../mock';
 import { SecuritySideNav } from './security_side_nav';
 import { SolutionGroupedNavProps } from '../solution_grouped_nav/solution_grouped_nav';
 import { NavLinkItem } from '../types';
+import { bottomNavOffset } from '../../../lib/helpers';
 
 const manageNavLink: NavLinkItem = {
   id: SecurityPageName.administration,
@@ -59,6 +60,15 @@ jest.mock('../../links', () => ({
     ({ deepLinkId }: { deepLinkId: SecurityPageName }) => ({
       href: `/${deepLinkId}`,
     }),
+}));
+
+const mockUseShowTimeline = jest.fn((): [boolean] => [false]);
+jest.mock('../../../utils/timeline/use_show_timeline', () => ({
+  useShowTimeline: () => mockUseShowTimeline(),
+}));
+const mockUseIsPolicySettingsBarVisible = jest.fn((): boolean => false);
+jest.mock('../../../../management/pages/policy/view/policy_hooks', () => ({
+  useIsPolicySettingsBarVisible: () => mockUseIsPolicySettingsBarVisible(),
 }));
 
 const renderNav = () =>
@@ -252,5 +262,40 @@ describe('SecuritySideNav', () => {
         ],
       })
     );
+  });
+
+  describe('bottom offset', () => {
+    it('should render with bottom offset when timeline bar visible', () => {
+      mockUseIsPolicySettingsBarVisible.mockReturnValueOnce(false);
+      mockUseShowTimeline.mockReturnValueOnce([true]);
+      renderNav();
+      expect(mockSolutionGroupedNav).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bottomOffset: bottomNavOffset,
+        })
+      );
+    });
+
+    it('should render with bottom offset when policy settings bar visible', () => {
+      mockUseShowTimeline.mockReturnValueOnce([false]);
+      mockUseIsPolicySettingsBarVisible.mockReturnValueOnce(true);
+      renderNav();
+      expect(mockSolutionGroupedNav).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bottomOffset: bottomNavOffset,
+        })
+      );
+    });
+
+    it('should not render with bottom offset when not needed', () => {
+      mockUseShowTimeline.mockReturnValueOnce([false]);
+      mockUseIsPolicySettingsBarVisible.mockReturnValueOnce(false);
+      renderNav();
+      expect(mockSolutionGroupedNav).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          bottomOffset: bottomNavOffset,
+        })
+      );
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/security_side_nav/security_side_nav.tsx
@@ -17,6 +17,9 @@ import { CustomSideNavItem, DefaultSideNavItem, SideNavItem } from '../solution_
 import { NavLinkItem } from '../types';
 import { EuiIconLaunch } from './icons/launch';
 import { useCanSeeHostIsolationExceptionsMenu } from '../../../../management/pages/host_isolation_exceptions/view/hooks';
+import { useShowTimeline } from '../../../utils/timeline/use_show_timeline';
+import { useIsPolicySettingsBarVisible } from '../../../../management/pages/policy/view/policy_hooks';
+import { bottomNavOffset } from '../../../lib/helpers';
 
 const isFooterNavItem = (id: SecurityPageName) =>
   id === SecurityPageName.landing || id === SecurityPageName.administration;
@@ -148,9 +151,21 @@ export const SecuritySideNav: React.FC = () => {
   const [items, footerItems] = useSideNavItems();
   const selectedId = useSelectedId();
 
+  const isPolicySettingsVisible = useIsPolicySettingsBarVisible();
+  const [isTimelineBottomBarVisible] = useShowTimeline();
+  const bottomOffset =
+    isTimelineBottomBarVisible || isPolicySettingsVisible ? bottomNavOffset : undefined;
+
   if (items.length === 0 && footerItems.length === 0) {
     return <EuiLoadingSpinner size="m" data-test-subj="sideNavLoader" />;
   }
 
-  return <SolutionGroupedNav items={items} footerItems={footerItems} selectedId={selectedId} />;
+  return (
+    <SolutionGroupedNav
+      items={items}
+      footerItems={footerItems}
+      selectedId={selectedId}
+      bottomOffset={bottomOffset}
+    />
+  );
 };

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.test.tsx
@@ -12,11 +12,6 @@ import { TestProviders } from '../../../mock';
 import { SolutionGroupedNav, SolutionGroupedNavProps } from './solution_grouped_nav';
 import { SideNavItem } from './types';
 
-const mockUseShowTimeline = jest.fn((): [boolean] => [false]);
-jest.mock('../../../utils/timeline/use_show_timeline', () => ({
-  useShowTimeline: () => mockUseShowTimeline(),
-}));
-
 const mockItems: SideNavItem[] = [
   {
     id: SecurityPageName.dashboardsLanding,

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav.tsx
@@ -25,6 +25,7 @@ export interface SolutionGroupedNavProps {
   items: SideNavItem[];
   selectedId: string;
   footerItems?: SideNavItem[];
+  bottomOffset?: string;
 }
 export interface SolutionNavItemsProps {
   items: SideNavItem[];
@@ -52,6 +53,7 @@ export const SolutionGroupedNavComponent: React.FC<SolutionGroupedNavProps> = ({
   items,
   selectedId,
   footerItems = [],
+  bottomOffset,
 }) => {
   const isMobileSize = useIsWithinBreakpoints(['xs', 's']);
 
@@ -108,9 +110,10 @@ export const SolutionGroupedNavComponent: React.FC<SolutionGroupedNavProps> = ({
         items={panelItems}
         title={title}
         categories={categories}
+        bottomOffset={bottomOffset}
       />
     );
-  }, [activePanelNavId, navItemsById, onClosePanelNav, onOutsidePanelClick]);
+  }, [activePanelNavId, bottomOffset, navItemsById, onClosePanelNav, onOutsidePanelClick]);
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.styles.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.styles.tsx
@@ -7,7 +7,7 @@
 import { EuiPanel } from '@elastic/eui';
 import styled from 'styled-components';
 
-export const EuiPanelStyled = styled(EuiPanel)<{ $hasBottomBar: boolean }>`
+export const EuiPanelStyled = styled(EuiPanel)<{ $bottomOffset?: string }>`
   position: fixed;
   top: 95px;
   left: 247px;
@@ -16,11 +16,11 @@ export const EuiPanelStyled = styled(EuiPanel)<{ $hasBottomBar: boolean }>`
   height: inherit;
 
   // If the bottom bar is visible add padding to the navigation
-  ${({ $hasBottomBar, theme }) =>
-    $hasBottomBar &&
+  ${({ $bottomOffset, theme }) =>
+    $bottomOffset != null &&
     `
       height: inherit;
-      bottom: 51px;
+      bottom: ${$bottomOffset};
       box-shadow:
         // left
         -${theme.eui.euiSizeS} 0 ${theme.eui.euiSizeS} -${theme.eui.euiSizeS} rgb(0 0 0 / 15%), 

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.test.tsx
@@ -11,11 +11,16 @@ import { SecurityPageName } from '../../../../app/types';
 import { TestProviders } from '../../../mock';
 import { SolutionNavPanel, SolutionNavPanelProps } from './solution_grouped_nav_panel';
 import { DefaultSideNavItem } from './types';
+import { bottomNavOffset } from '../../../lib/helpers';
 
-const mockUseShowTimeline = jest.fn((): [boolean] => [false]);
-jest.mock('../../../utils/timeline/use_show_timeline', () => ({
-  useShowTimeline: () => mockUseShowTimeline(),
-}));
+const mockUseIsWithinBreakpoints = jest.fn(() => true);
+jest.mock('@elastic/eui', () => {
+  const original = jest.requireActual('@elastic/eui');
+  return {
+    ...original,
+    useIsWithinBreakpoints: () => mockUseIsWithinBreakpoints(),
+  };
+});
 
 const mockItems: DefaultSideNavItem[] = [
   {
@@ -97,6 +102,22 @@ describe('SolutionGroupedNav', () => {
       const result = renderNavPanel({ items });
       result.getByTestId(`groupedNavPanelLink-${SecurityPageName.users}`).click();
       expect(mockOnClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('bottom offset', () => {
+    it('should add bottom offset', () => {
+      mockUseIsWithinBreakpoints.mockReturnValueOnce(true);
+      const result = renderNavPanel({ bottomOffset: bottomNavOffset });
+
+      expect(result.getByTestId('groupedNavPanel')).toHaveStyle({ bottom: bottomNavOffset });
+    });
+
+    it('should not add bottom offset if not large screen', () => {
+      mockUseIsWithinBreakpoints.mockReturnValueOnce(false);
+      const result = renderNavPanel({ bottomOffset: bottomNavOffset });
+
+      expect(result.getByTestId('groupedNavPanel')).not.toHaveStyle({ bottom: bottomNavOffset });
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/solution_grouped_nav/solution_grouped_nav_panel.tsx
@@ -24,7 +24,6 @@ import {
 } from '@elastic/eui';
 import classNames from 'classnames';
 import { EuiPanelStyled } from './solution_grouped_nav_panel.styles';
-import { useShowTimeline } from '../../../utils/timeline/use_show_timeline';
 import type { DefaultSideNavItem } from './types';
 import type { LinkCategories } from '../../../links/types';
 
@@ -34,6 +33,7 @@ export interface SolutionNavPanelProps {
   title: string;
   items: DefaultSideNavItem[];
   categories?: LinkCategories;
+  bottomOffset?: string;
 }
 export interface SolutionNavPanelCategoriesProps {
   categories: LinkCategories;
@@ -58,11 +58,13 @@ const SolutionNavPanelComponent: React.FC<SolutionNavPanelProps> = ({
   title,
   categories,
   items,
+  bottomOffset,
 }) => {
-  const [hasTimelineBar] = useShowTimeline();
   const isLargerBreakpoint = useIsWithinBreakpoints(['l', 'xl']);
-  const isTimelineVisible = hasTimelineBar && isLargerBreakpoint;
   const panelClasses = classNames('eui-yScroll');
+
+  // Only larger breakpoint needs to add bottom offset, other sizes should have full height
+  const bottomOffsetLargerBreakpoint = isLargerBreakpoint ? bottomOffset : undefined;
 
   // ESC key closes PanelNav
   const onKeyDown = useCallback(
@@ -82,8 +84,8 @@ const SolutionNavPanelComponent: React.FC<SolutionNavPanelProps> = ({
           <EuiOutsideClickDetector onOutsideClick={onOutsideClick}>
             <EuiPanelStyled
               className={panelClasses}
-              hasShadow={!isTimelineVisible}
-              $hasBottomBar={isTimelineVisible}
+              hasShadow={!bottomOffsetLargerBreakpoint}
+              $bottomOffset={bottomOffsetLargerBreakpoint}
               borderRadius="none"
               paddingSize="l"
               data-test-subj="groupedNavPanel"

--- a/x-pack/plugins/security_solution/public/common/lib/helpers/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/helpers/index.tsx
@@ -30,3 +30,4 @@ export type ValueOf<T> = T[keyof T];
  */
 
 export const gutterTimeline = '70px'; // Michael: Temporary until timeline is moved.
+export const bottomNavOffset = '51px';

--- a/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
@@ -31,11 +31,32 @@ const mockUseSourcererDataView = jest.fn(
 jest.mock('../../containers/sourcerer', () => ({
   useSourcererDataView: () => mockUseSourcererDataView(),
 }));
-const mockedUseIsGroupedNavigationEnabled = jest.fn();
 
+const mockedUseIsGroupedNavigationEnabled = jest.fn();
 jest.mock('../../components/navigation/helpers', () => ({
   useIsGroupedNavigationEnabled: () => mockedUseIsGroupedNavigationEnabled(),
 }));
+
+const mockSiemUserCanRead = jest.fn(() => true);
+jest.mock('../../lib/kibana', () => {
+  const original = jest.requireActual('../../lib/kibana');
+
+  return {
+    ...original,
+    useKibana: () => ({
+      services: {
+        ...original.useKibana().services,
+        application: {
+          capabilities: {
+            siem: {
+              show: mockSiemUserCanRead(),
+            },
+          },
+        },
+      },
+    }),
+  };
+});
 
 describe('use show timeline', () => {
   beforeAll(async () => {
@@ -156,6 +177,20 @@ describe('use show timeline', () => {
 
     it('should not show timeline when dataViewId is not null and indices does not exist', () => {
       mockUseSourcererDataView.mockReturnValueOnce({ indicesExist: false, dataViewId: 'test' });
+      const { result } = renderHook(() => useShowTimeline());
+      expect(result.current).toEqual([false]);
+    });
+  });
+
+  describe('Security solution capabilities', () => {
+    it('should show timeline when user has read capabilities', () => {
+      mockSiemUserCanRead.mockReturnValueOnce(true);
+      const { result } = renderHook(() => useShowTimeline());
+      expect(result.current).toEqual([true]);
+    });
+
+    it('should not show timeline when user does not have read capabilities', () => {
+      mockSiemUserCanRead.mockReturnValueOnce(false);
       const { result } = renderHook(() => useShowTimeline());
       expect(result.current).toEqual([false]);
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [move bottom bar offset outside generic grouped nav (#134357)](https://github.com/elastic/kibana/pull/134357)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)