### PR TITLE
[Fleet] Add a pipeline processor to all the ingest_pipeline installed by fleet

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
@@ -4,10 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { safeDump, safeLoad } from 'js-yaml';
 
 import { ElasticsearchAssetType } from '../../../../types';
 import type { RegistryDataStream } from '../../../../types';
 import { getPathParts } from '../../archive';
+
+import type { PipelineInstall, RewriteSubstitution } from './types';
 
 export const isTopLevelPipeline = (path: string) => {
   const pathParts = getPathParts(path);
@@ -45,11 +48,9 @@ export const getPipelineNameForDatastream = ({
   return `${dataStream.type}-${dataStream.dataset}-${packageVersion}`;
 };
 
-export interface RewriteSubstitution {
-  source: string;
-  target: string;
-  templateFunction: string;
-}
+export const getCustomPipelineNameForDatastream = (dataStream: RegistryDataStream): string => {
+  return `${dataStream.type}-${dataStream.dataset}@custom`;
+};
 
 export function rewriteIngestPipeline(
   pipeline: string,
@@ -70,4 +71,42 @@ export function rewriteIngestPipeline(
     pipeline = pipeline.replace(regexStandardStyle, target).replace(regexBeatsStyle, target);
   });
   return pipeline;
+}
+
+function _mutatePipelineContentWithNewProcessor(jsonPipelineContent: any, processor: any) {
+  if (!jsonPipelineContent.processors) {
+    jsonPipelineContent.processors = [];
+  }
+
+  jsonPipelineContent.processors.push(processor);
+}
+
+export function addCustomPipelineProcessor(pipeline: PipelineInstall): PipelineInstall {
+  if (!pipeline.customIngestPipelineNameForInstallation) {
+    return pipeline;
+  }
+
+  const customPipelineProcessor = {
+    pipeline: {
+      name: pipeline.customIngestPipelineNameForInstallation,
+      ignore_missing_pipeline: true,
+    },
+  };
+
+  if (pipeline.extension === 'yml') {
+    const parsedPipelineContent = safeLoad(pipeline.contentForInstallation);
+    _mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
+    return {
+      ...pipeline,
+      contentForInstallation: `---\n${safeDump(parsedPipelineContent)}`,
+    };
+  }
+
+  const parsedPipelineContent = JSON.parse(pipeline.contentForInstallation);
+  _mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
+
+  return {
+    ...pipeline,
+    contentForInstallation: JSON.stringify(parsedPipelineContent),
+  };
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/helpers.ts
@@ -73,7 +73,7 @@ export function rewriteIngestPipeline(
   return pipeline;
 }
 
-function _mutatePipelineContentWithNewProcessor(jsonPipelineContent: any, processor: any) {
+function mutatePipelineContentWithNewProcessor(jsonPipelineContent: any, processor: any) {
   if (!jsonPipelineContent.processors) {
     jsonPipelineContent.processors = [];
   }
@@ -95,7 +95,7 @@ export function addCustomPipelineProcessor(pipeline: PipelineInstall): PipelineI
 
   if (pipeline.extension === 'yml') {
     const parsedPipelineContent = safeLoad(pipeline.contentForInstallation);
-    _mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
+    mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
     return {
       ...pipeline,
       contentForInstallation: `---\n${safeDump(parsedPipelineContent)}`,
@@ -103,7 +103,7 @@ export function addCustomPipelineProcessor(pipeline: PipelineInstall): PipelineI
   }
 
   const parsedPipelineContent = JSON.parse(pipeline.contentForInstallation);
-  _mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
+  mutatePipelineContentWithNewProcessor(parsedPipelineContent, customPipelineProcessor);
 
   return {
     ...pipeline,

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/index.ts
@@ -5,6 +5,6 @@
  * 2.0.
  */
 
-export { prepareToInstallPipelines, isTopLevelPipeline } from './install';
-export { getPipelineNameForDatastream } from './helpers';
+export { prepareToInstallPipelines } from './install';
+export { getPipelineNameForDatastream, isTopLevelPipeline } from './helpers';
 export { deletePreviousPipelines, deletePipeline } from './remove';

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/install.ts
@@ -231,7 +231,10 @@ async function installPipeline({
 
   const esClientParams = {
     id: pipelineToInstall.nameForInstallation,
-    body: pipelineToInstall.contentForInstallation,
+    body:
+      pipelineToInstall.extension === 'yml'
+        ? pipelineToInstall.contentForInstallation
+        : JSON.parse(pipelineToInstall.contentForInstallation),
   };
 
   const esClientRequestOptions: TransportRequestOptions = {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/types.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ingest_pipeline/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface PipelineInstall {
+  nameForInstallation: string;
+  contentForInstallation: string;
+  customIngestPipelineNameForInstallation?: string;
+  extension: string;
+}
+
+export interface RewriteSubstitution {
+  source: string;
+  target: string;
+  templateFunction: string;
+}

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
@@ -58,6 +58,6 @@ export function appendMetadataToIngestPipeline({
 
   return {
     ...pipeline,
-    contentForInstallation: parsedPipelineContent,
+    contentForInstallation: JSON.stringify(parsedPipelineContent),
   };
 }

--- a/x-pack/test/fleet_api_integration/apis/epm/custom_ingest_pipeline.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/custom_ingest_pipeline.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { setupFleetAndAgents } from '../agents/services';
+import { skipIfNoDockerRegistry } from '../../helpers';
+
+const TEST_INDEX = 'logs-log.log-test';
+
+const CUSTOM_PIPELINE = 'logs-log.log@custom';
+
+let pkgVersion: string;
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const esArchiver = getService('esArchiver');
+
+  describe('custom ingest pipeline for fleet managed datastreams', () => {
+    skipIfNoDockerRegistry(providerContext);
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+    });
+    setupFleetAndAgents(providerContext);
+
+    // Use the custom log package to test the custom ingest pipeline
+    before(async () => {
+      const { body: getPackagesRes } = await supertest.get(
+        `/api/fleet/epm/packages?experimental=true`
+      );
+      const logPackage = getPackagesRes.items.find((p: any) => p.name === 'log');
+      if (!logPackage) {
+        throw new Error('No log package');
+      }
+
+      pkgVersion = logPackage.version;
+
+      await supertest
+        .post(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+    });
+    after(async () => {
+      await supertest
+        .delete(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
+    });
+
+    after(async () => {
+      const res = await es.search({
+        index: TEST_INDEX,
+      });
+
+      for (const hit of res.hits.hits) {
+        await es.delete({
+          id: hit._id,
+          index: hit._index,
+        });
+      }
+    });
+
+    describe('Without custom pipeline', () => {
+      it('Should write doc correctly', async () => {
+        const res = await es.index({
+          index: 'logs-log.log-test',
+          body: {
+            '@timestamp': '2020-01-01T09:09:00',
+            message: 'hello',
+          },
+        });
+
+        await es.get({
+          id: res._id,
+          index: res._index,
+        });
+      });
+    });
+
+    describe('Without custom pipeline', () => {
+      before(() =>
+        es.ingest.putPipeline({
+          id: CUSTOM_PIPELINE,
+          processors: [
+            {
+              set: {
+                field: 'test',
+                value: 'itworks',
+              },
+            },
+          ],
+        })
+      );
+
+      after(() =>
+        es.ingest.deletePipeline({
+          id: CUSTOM_PIPELINE,
+        })
+      );
+      it('Should write doc correctly', async () => {
+        const res = await es.index({
+          index: 'logs-log.log-test',
+          body: {
+            '@timestamp': '2020-01-01T09:09:00',
+            message: 'hello',
+          },
+        });
+
+        const doc = await es.get<{ test: string }>({
+          id: res._id,
+          index: res._index,
+        });
+        expect(doc._source?.test).to.eql('itworks');
+      });
+    });
+  });
+}

--- a/x-pack/test/fleet_api_integration/apis/epm/index.js
+++ b/x-pack/test/fleet_api_integration/apis/epm/index.js
@@ -30,5 +30,6 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./remove_legacy_templates'));
     loadTestFile(require.resolve('./install_error_rollback'));
     loadTestFile(require.resolve('./final_pipeline'));
+    loadTestFile(require.resolve('./custom_ingest_pipeline'));
   });
 }


### PR DESCRIPTION
## Description

Related to #133740 

To allow users to write custom ingest pipeline, we add a new processor at the end at the end of the fleet install ingest_pipeline that will call the user custom ingest pipeline if it exists.

## Release notes

That PR will enable user to write custom ingest pipeline for Fleet installed datastream.

## Tests and how to manually test?

This features is tested with some unit tests and a new API integration test that index data with and without custom pipeline

If you want to manually test it you can use the custom log integration

#### 1.  check that the pipeline processor is correctly added to the datastream ingest pipeline

<img width="628" alt="Screen Shot 2022-06-16 at 12 06 36 PM" src="https://user-images.githubusercontent.com/1336873/174116171-f1a5d8d1-780a-4e92-b66c-3c8c7fe0d54d.png">

#### 2. create a custom pipeline `logs-log.log@custom ` (could be done in the ingest pipeline UI)
<img width="598" alt="Screen Shot 2022-06-16 at 12 16 42 PM" src="https://user-images.githubusercontent.com/1336873/174117841-c4fd8077-d251-4fd0-9d6b-3a144254b2e3.png">



#### 3. send data to the datastream and the custom ingest pipeline is called

<img width="340" alt="Screen Shot 2022-06-16 at 12 17 31 PM" src="https://user-images.githubusercontent.com/1336873/174117943-9f9f5bd2-00b1-4c30-aa86-08e92004dae0.png">
<img width="639" alt="Screen Shot 2022-06-16 at 12 17 34 PM" src="https://user-images.githubusercontent.com/1336873/174117948-9aabe9e6-11e7-49b5-8d4a-79eed5b78c08.png">





