### PR TITLE
[maps] rename cluster 'resolution' to 'size'

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
@@ -51,34 +51,35 @@ export class ResolutionEditor extends Component<Props, State> {
 
   _getTicks() {
     const scale = this._getScale();
-    const unlabeledTicks = [
+    const ticks = [
       {
-        label: '',
+        label: i18n.translate('xpack.maps.source.esGrid.largeSizeLabel', {
+          defaultMessage: `large`,
+        }),
+        value: scale[GRID_RESOLUTION.COARSE],
+      },
+      {
+        label: i18n.translate('xpack.maps.source.esGrid.mediumSizeLabel', {
+          defaultMessage: `medium`,
+        }),
         value: scale[GRID_RESOLUTION.FINE],
       },
     ];
     if (scale[GRID_RESOLUTION.FINE] !== scale[GRID_RESOLUTION.MOST_FINE]) {
-      unlabeledTicks.push({
-        label: '',
+      ticks.push({
+        label: i18n.translate('xpack.maps.source.esGrid.mediumSmallSizeLabel', {
+          defaultMessage: `medium-small`,
+        }),
         value: scale[GRID_RESOLUTION.MOST_FINE],
       });
     }
-
-    return [
-      {
-        label: i18n.translate('xpack.maps.source.esGrid.lowLabel', {
-          defaultMessage: `low`,
-        }),
-        value: scale[GRID_RESOLUTION.COARSE],
-      },
-      ...unlabeledTicks,
-      {
-        label: i18n.translate('xpack.maps.source.esGrid.highLabel', {
-          defaultMessage: `high`,
-        }),
-        value: scale[GRID_RESOLUTION.SUPER_FINE],
-      },
-    ];
+    ticks.push({
+      label: i18n.translate('xpack.maps.source.esGrid.smallSizeLabel', {
+        defaultMessage: `small`,
+      }),
+      value: scale[GRID_RESOLUTION.SUPER_FINE],
+    });
+    return ticks;
   }
 
   _resolutionToSliderValue(resolution: GRID_RESOLUTION): number {
@@ -150,7 +151,7 @@ export class ResolutionEditor extends Component<Props, State> {
         <p>
           <FormattedMessage
             id="xpack.maps.source.esGrid.vectorTileModal.message"
-            defaultMessage="High resolution uses vector tiles from the Elasticsearch vector tile API. Elasticsearch vector tile API does not support 'Top terms' metric. Switching to super fine grid resolution will remove all 'Top terms' metrics from your layer configuration."
+            defaultMessage="Small size uses vector tiles from the Elasticsearch vector tile API. Elasticsearch vector tile API does not support 'Top terms' metric. Switching to small size will remove all 'Top terms' metrics from your layer configuration."
           />
         </p>
       </EuiConfirmModal>
@@ -158,22 +159,14 @@ export class ResolutionEditor extends Component<Props, State> {
   }
 
   render() {
-    const helpText =
-      (this.props.renderAs === RENDER_AS.POINT || this.props.renderAs === RENDER_AS.GRID) &&
-      this.props.resolution === GRID_RESOLUTION.SUPER_FINE
-        ? i18n.translate('xpack.maps.source.esGrid.superFineHelpText', {
-            defaultMessage: 'High resolution uses vector tiles.',
-          })
-        : undefined;
     const ticks = this._getTicks();
     return (
       <>
         {this._renderModal()}
         <EuiFormRow
           label={i18n.translate('xpack.maps.geoGrid.resolutionLabel', {
-            defaultMessage: 'Resolution',
+            defaultMessage: 'Size',
           })}
-          helpText={helpText}
           display="columnCompressed"
         >
           <EuiRange

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
@@ -67,15 +67,15 @@ export class ResolutionEditor extends Component<Props, State> {
     ];
     if (scale[GRID_RESOLUTION.FINE] !== scale[GRID_RESOLUTION.MOST_FINE]) {
       ticks.push({
-        label: i18n.translate('xpack.maps.source.esGrid.mediumSmallSizeLabel', {
-          defaultMessage: `medium-small`,
+        label: i18n.translate('xpack.maps.source.esGrid.smallSizeLabel', {
+          defaultMessage: `small`,
         }),
         value: scale[GRID_RESOLUTION.MOST_FINE],
       });
     }
     ticks.push({
-      label: i18n.translate('xpack.maps.source.esGrid.smallSizeLabel', {
-        defaultMessage: `small`,
+      label: i18n.translate('xpack.maps.source.esGrid.extraSmallSizeLabel', {
+        defaultMessage: `extra small`,
       }),
       value: scale[GRID_RESOLUTION.SUPER_FINE],
     });
@@ -151,7 +151,7 @@ export class ResolutionEditor extends Component<Props, State> {
         <p>
           <FormattedMessage
             id="xpack.maps.source.esGrid.vectorTileModal.message"
-            defaultMessage="Small size uses vector tiles from the Elasticsearch vector tile API. Elasticsearch vector tile API does not support 'Top terms' metric. Switching to small size will remove all 'Top terms' metrics from your layer configuration."
+            defaultMessage="Extra small size uses vector tiles from the Elasticsearch vector tile API. Elasticsearch vector tile API does not support 'Top terms' metric. Switching to extra small size will remove all 'Top terms' metrics from your layer configuration."
           />
         </p>
       </EuiConfirmModal>


### PR DESCRIPTION
Current "resolution" editor is not intuitive. The editor provides values starting at "low" and going to "high". Selecting "low" creates large clusters, while selecting "high" creates small clusters. The editor leaks implementation details instead of signaling the effect of the change.
<img width="250" alt="Screen Shot 2022-06-16 at 1 40 22 PM" src="https://user-images.githubusercontent.com/373691/174151342-2f0e595d-6cdd-4efb-bc19-8120cec9c226.png">

This PR renames the editor to "size" and provides values from "large" to "extra small". Selecting a value directly correlates the cluster size and better aligns the editor with the expected user outcome.
<img width="250" alt="Screen Shot 2022-06-16 at 2 11 22 PM" src="https://user-images.githubusercontent.com/373691/174155750-2d0e4d80-b554-4caa-ab17-dc833e7c9aec.png">

Questions
1) Does the editor change work for heat maps? Does "Size" still make sense?
   <img width="250" alt="Screen Shot 2022-06-16 at 2 16 05 PM" src="https://user-images.githubusercontent.com/373691/174156405-f19e0134-316f-4b11-9d22-d27c71d3ae88.png">
2) When showing clusters as "points", vector style specifies symbol size. Is the difference between cluster size and symbol size clear? Does this add confusion? I was thinking that one way to clear things up a bit would be to auto-adjust symbol size when cluster size changes so that the symbol size better reflects cluster size.



cc @teresaalvarezsoler 
