### PR TITLE
[Discover] [Alerting] Make 'Test query' button pretty

### DIFF
--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/es_query_expression.test.tsx
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/es_query_expression.test.tsx
@@ -179,7 +179,7 @@ describe('EsQueryAlertTypeExpression', () => {
     expect(wrapper.find('[data-test-subj="thresholdExpression"]').exists()).toBeTruthy();
     expect(wrapper.find('[data-test-subj="forLastExpression"]').exists()).toBeTruthy();
 
-    const testQueryButton = wrapper.find('EuiButtonEmpty[data-test-subj="testQuery"]');
+    const testQueryButton = wrapper.find('EuiButton[data-test-subj="testQuery"]');
     expect(testQueryButton.exists()).toBeTruthy();
     expect(testQueryButton.prop('disabled')).toBe(false);
   });
@@ -189,7 +189,7 @@ describe('EsQueryAlertTypeExpression', () => {
       ...defaultEsQueryExpressionParams,
       timeField: null,
     } as unknown as EsQueryAlertParams<SearchType.esQuery>);
-    const testQueryButton = wrapper.find('EuiButtonEmpty[data-test-subj="testQuery"]');
+    const testQueryButton = wrapper.find('EuiButton[data-test-subj="testQuery"]');
     expect(testQueryButton.exists()).toBeTruthy();
     expect(testQueryButton.prop('disabled')).toBe(true);
   });
@@ -204,7 +204,7 @@ describe('EsQueryAlertTypeExpression', () => {
     });
     dataMock.search.search.mockImplementation(() => searchResponseMock$);
     const wrapper = await setup(defaultEsQueryExpressionParams);
-    const testQueryButton = wrapper.find('EuiButtonEmpty[data-test-subj="testQuery"]');
+    const testQueryButton = wrapper.find('EuiButton[data-test-subj="testQuery"]');
 
     testQueryButton.simulate('click');
     expect(dataMock.search.search).toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe('EsQueryAlertTypeExpression', () => {
       throw new Error('What is this query');
     });
     const wrapper = await setup(defaultEsQueryExpressionParams);
-    const testQueryButton = wrapper.find('EuiButtonEmpty[data-test-subj="testQuery"]');
+    const testQueryButton = wrapper.find('EuiButton[data-test-subj="testQuery"]');
 
     testQueryButton.simulate('click');
     expect(dataMock.search.search).toHaveBeenCalled();

--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/test_query_row.tsx
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/test_query_row.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiButtonEmpty, EuiFormRow, EuiText } from '@elastic/eui';
+import { EuiButton, EuiFormRow, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTestQuery } from './use_test_query';
 
@@ -21,21 +21,21 @@ export function TestQueryRow({
   return (
     <>
       <EuiFormRow>
-        <EuiButtonEmpty
+        <EuiButton
           data-test-subj="testQuery"
           color="primary"
           iconSide="left"
-          flush="left"
-          iconType="play"
+          iconType="playFilled"
           onClick={onTestQuery}
           disabled={hasValidationErrors}
           isLoading={testQueryLoading}
+          size="s"
         >
           <FormattedMessage
             id="xpack.stackAlerts.esQuery.ui.testQuery"
             defaultMessage="Test query"
           />
-        </EuiButtonEmpty>
+        </EuiButton>
       </EuiFormRow>
       {testQueryLoading && (
         <EuiFormRow>


### PR DESCRIPTION
## Summary

This PR makes the 'Test query' button in the 'Create rule' flyout prettier:
![pretty_test_query_button](https://user-images.githubusercontent.com/25592674/174161208-e753a4b6-d4a5-4a08-b823-e83bf51cbbff.png)

Resolves #134322.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
