### PR TITLE
[Dashboard] [Controls] Fix bug when combining filters

### DIFF
--- a/src/plugins/dashboard/public/application/lib/dashboard_control_group.test.ts
+++ b/src/plugins/dashboard/public/application/lib/dashboard_control_group.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { mockControlGroupInput } from '@kbn/controls-plugin/common/mocks';
+import { ControlGroupContainer } from '@kbn/controls-plugin/public/control_group/embeddable/control_group_container';
+import { Filter } from '@kbn/es-query';
+import { combineDashboardFiltersWithControlGroupFilters } from './dashboard_control_group';
+
+jest.mock('@kbn/controls-plugin/public/control_group/embeddable/control_group_container');
+
+const testFilter1: Filter = {
+  meta: {
+    key: 'testfield',
+    alias: null,
+    disabled: false,
+    negate: false,
+  },
+  query: { match_phrase: { testfield: 'hello' } },
+};
+
+const testFilter2: Filter = {
+  meta: {
+    key: 'testfield',
+    alias: null,
+    disabled: false,
+    negate: false,
+  },
+  query: { match_phrase: { testfield: 'guten tag' } },
+};
+
+const testFilter3: Filter = {
+  meta: {
+    key: 'testfield',
+    alias: null,
+    disabled: false,
+    negate: false,
+  },
+  query: {
+    bool: {
+      should: {
+        0: { match_phrase: { testfield: 'hola' } },
+        1: { match_phrase: { testfield: 'bonjour' } },
+      },
+    },
+  },
+};
+
+const mockControlGroupContainer = new ControlGroupContainer(mockControlGroupInput());
+
+describe('Test dashboard control group', () => {
+  describe('Combine dashboard filters with control group filters test', () => {
+    it('Combined filter pills do not get overwritten', async () => {
+      const dashboardFilterPills = [testFilter1, testFilter2];
+      mockControlGroupContainer.getOutput = jest.fn().mockReturnValue({ filters: [] });
+      const combinedFilters = combineDashboardFiltersWithControlGroupFilters(
+        dashboardFilterPills,
+        mockControlGroupContainer
+      );
+      expect(combinedFilters).toEqual(dashboardFilterPills);
+    });
+
+    it('Combined control filters do not get overwritten', async () => {
+      const controlGroupFilters = [testFilter1, testFilter2];
+      mockControlGroupContainer.getOutput = jest
+        .fn()
+        .mockReturnValue({ filters: controlGroupFilters });
+      const combinedFilters = combineDashboardFiltersWithControlGroupFilters(
+        [] as Filter[],
+        mockControlGroupContainer
+      );
+      expect(combinedFilters).toEqual(controlGroupFilters);
+    });
+
+    it('Combined dashboard filter pills and control filters do not get overwritten', async () => {
+      const dashboardFilterPills = [testFilter1, testFilter2];
+      const controlGroupFilters = [testFilter3];
+      mockControlGroupContainer.getOutput = jest
+        .fn()
+        .mockReturnValue({ filters: controlGroupFilters });
+      const combinedFilters = combineDashboardFiltersWithControlGroupFilters(
+        dashboardFilterPills,
+        mockControlGroupContainer
+      );
+      expect(combinedFilters).toEqual(dashboardFilterPills.concat(controlGroupFilters));
+    });
+  });
+});

--- a/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
+++ b/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
@@ -186,22 +186,6 @@ export const deserializeControlGroupFromDashboardSavedObject = (
 export const combineDashboardFiltersWithControlGroupFilters = (
   dashboardFilters: Filter[],
   controlGroup: ControlGroupContainer
-) => {
-  const dashboardFiltersByKey = dashboardFilters.reduce(
-    (acc: { [key: string]: Filter }, current) => {
-      const key = current.meta.key;
-      if (key) acc[key] = current;
-      return acc;
-    },
-    {}
-  );
-  const controlGroupFiltersByKey = controlGroup
-    .getOutput()
-    .filters?.reduce((acc: { [key: string]: Filter }, current) => {
-      const key = current.meta.key;
-      if (key) acc[key] = current;
-      return acc;
-    }, {});
-  const finalFilters = { ...dashboardFiltersByKey, ...(controlGroupFiltersByKey ?? {}) };
-  return Object.values(finalFilters);
+): Filter[] => {
+  return [...dashboardFilters, ...(controlGroup.getOutput().filters ?? [])];
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/134698

## Summary

### Before

Before this change, when combining the dashboard filter pills with the control filters, if two or more filters were on the same field they would be overwritten - this happened both when the filters were combined in to their respective `...ByKey` dictionaries,  and when the filter pill dictionary was combined with the control dictionary. This resulted in the following scenarios:
1. When two filter pills shared the field `X`, the first filter would be overwritten by the second.
    
    ![image](https://user-images.githubusercontent.com/8698078/174335224-94d7cf2d-0eb0-47a1-a2af-88b0cce586b8.png)

2. When two controls were tied to field `X`, the second control would overwrite the first control (assuming they both had selections).

    ![image](https://user-images.githubusercontent.com/8698078/174353130-74036df5-9f3d-468b-ac14-8baf2377468c.png)

3. A filter pill on field `X` would always be overwritten by a control on that same `X` field (if there were selections).
    
    ![image](https://user-images.githubusercontent.com/8698078/174334489-9060a32e-f414-4612-98bc-ca5120f0bc0b.png)

### After

Now, after removing the `...ByKey` dictionary logic and simply combining the filter arrays directly without manipulation, the behaviour is more close to what you expect where no filters get overwritten, like so:

![image](https://user-images.githubusercontent.com/8698078/174333803-e3a80f3e-3901-4692-b1de-ca653135c085.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
