### PR TITLE
[7.16] [DOCS] Fix broken link to allowlist details (#134612)

### DIFF
--- a/docs/management/connectors/action-types/email.asciidoc
+++ b/docs/management/connectors/action-types/email.asciidoc
@@ -115,7 +115,7 @@ For other email servers, you can check the list of well-known services that Node
 [[elasticcloud]]
 ==== Sending email from Elastic Cloud
 
-IMPORTANT: These instructions require you to link:{cloud}/ec-watcher.html#ec-watcher-whitelist[allowlist] the email addresses that notifications get sent.
+IMPORTANT: These instructions require you to link:{cloud}/ec-watcher.html#ec-watcher-allowlist[allowlist] the email addresses that notifications get sent.
 
 Use the following connector settings to send email from Elastic Cloud: 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.2` to `7.16`:
 - [[DOCS] Fix broken link to allowlist details (#134612)](https://github.com/elastic/kibana/pull/134612)

<!--- Backport version: 7.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)