### PR TITLE
ES Client: use `ClusterConnectionPool` instead of `WeightedConnectionPool`

### DIFF
--- a/src/core/server/elasticsearch/client/configure_client.test.ts
+++ b/src/core/server/elasticsearch/client/configure_client.test.ts
@@ -17,6 +17,7 @@ import {
   ClientMock,
 } from './configure_client.test.mocks';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
+import { ClusterConnectionPool } from '@elastic/elasticsearch';
 import type { ElasticsearchClientConfig } from './client_config';
 import { configureClient } from './configure_client';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -107,6 +108,21 @@ describe('configureClient', () => {
     expect(ClientMock).toHaveBeenCalledWith(
       expect.objectContaining({
         Transport: mockedTransport,
+      })
+    );
+    expect(client).toBe(ClientMock.mock.results[0].value);
+  });
+
+  it('constructs a client using `ClusterConnectionPool` for `ConnectionPool` ', () => {
+    const mockedTransport = { mockTransport: true };
+    createTransportMock.mockReturnValue(mockedTransport);
+
+    const client = configureClient(config, { logger, type: 'test', scoped: false });
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(ClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ConnectionPool: ClusterConnectionPool,
       })
     );
     expect(client).toBe(ClientMock.mock.results[0].value);

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Client, HttpConnection } from '@elastic/elasticsearch';
+import { Client, HttpConnection, ClusterConnectionPool } from '@elastic/elasticsearch';
 import type { Logger } from '@kbn/logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -35,6 +35,8 @@ export const configureClient = (
     ...clientOptions,
     Transport: KibanaTransport,
     Connection: HttpConnection,
+    // using ClusterConnectionPool until https://github.com/elastic/elasticsearch-js/issues/1714 is addressed
+    ConnectionPool: ClusterConnectionPool,
   });
 
   instrumentEsQueryAndDeprecationLogger({ logger, client, type });


### PR DESCRIPTION
## Summary

We discovered a bug in `@elastic/elasticsearch-js` that causes Kibana to not be able to connect to ES nodes for a predetermined amount of requests when using a multi-node configuration and when some, or all, nodes go down then up again: https://github.com/elastic/elasticsearch-js/issues/1714

Until the upstream issue is addressed, we will fall back to using the `ClusterConnectionPool` implementation instead of `WeightedConnectionPool`, as this implementation (which was the one used by the version `7.x` of the client) doesn't have this issue.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

## Release Note

Fix a bug causing ES nodes going down then up again to be unreachable by Kibana for a given amount of requests, when Kibana is configured to connect to multiple ES node