### PR TITLE
Reject promises awaiting on core.getStartServices() on stop()

### DIFF
--- a/src/core/public/plugins/plugin.test.ts
+++ b/src/core/public/plugins/plugin.test.ts
@@ -131,4 +131,10 @@ describe('PluginWrapper', () => {
     await plugin.setup({} as any, {} as any);
     expect(() => plugin.stop()).not.toThrow();
   });
+
+  test('`stop` completes `startDependencies$` Observable, unblocking dependant promises', async () => {
+    await plugin.setup({} as any, {} as any);
+    await plugin.stop();
+    await expect(plugin.startDependencies).resolves.toBeUndefined();
+  });
 });

--- a/src/core/public/plugins/plugin.ts
+++ b/src/core/public/plugins/plugin.ts
@@ -60,7 +60,9 @@ export class PluginWrapper<
   private instance?: Plugin<TSetup, TStart, TPluginsSetup, TPluginsStart>;
 
   private readonly startDependencies$ = new Subject<[CoreStart, TPluginsStart, TStart]>();
-  public readonly startDependencies = firstValueFrom(this.startDependencies$);
+  public readonly startDependencies = firstValueFrom(this.startDependencies$, {
+    defaultValue: undefined,
+  });
 
   constructor(
     public readonly discoveredPlugin: DiscoveredPlugin,

--- a/src/core/public/plugins/plugin.ts
+++ b/src/core/public/plugins/plugin.ts
@@ -115,6 +115,9 @@ export class PluginWrapper<
     }
 
     this.instance = undefined;
+
+    // some plugins might be awaiting for core.getStartServices(); reject these promises
+    this.startDependencies$.complete();
   }
 
   private createPluginInstance() {

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -460,6 +460,29 @@ test('`stop` calls `stop` defined by the plugin instance', async () => {
   expect(mockPluginInstance.stop).toHaveBeenCalledTimes(1);
 });
 
+test('`stop` completes `startDependencies$` Observable, unblocking dependant promises', async () => {
+  const manifest = createPluginManifest();
+  const opaqueId = Symbol();
+  const plugin = new PluginWrapper({
+    path: 'plugin-with-initializer-path',
+    manifest,
+    opaqueId,
+    initializerContext: createPluginInitializerContext(
+      coreContext,
+      opaqueId,
+      manifest,
+      instanceInfo
+    ),
+  });
+
+  const mockPluginInstance = { setup: jest.fn(), stop: jest.fn() };
+  mockPluginInitializer.mockReturnValue(mockPluginInstance);
+  await plugin.setup(createPluginSetupContext(coreContext, setupDeps, plugin), {});
+  await plugin.stop();
+
+  await expect(plugin.startDependencies).resolves.toEqual({});
+});
+
 describe('#getConfigSchema()', () => {
   it('reads config schema from plugin', () => {
     const pluginSchema = schema.any();

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -480,7 +480,7 @@ test('`stop` completes `startDependencies$` Observable, unblocking dependant pro
   await plugin.setup(createPluginSetupContext(coreContext, setupDeps, plugin), {});
   await plugin.stop();
 
-  await expect(plugin.startDependencies).resolves.toEqual({});
+  await expect(plugin.startDependencies).resolves.toBeUndefined();
 });
 
 describe('#getConfigSchema()', () => {

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -61,7 +61,9 @@ export class PluginWrapper<
     | AsyncPlugin<TSetup, TStart, TPluginsSetup, TPluginsStart>;
 
   private readonly startDependencies$ = new Subject<[CoreStart, TPluginsStart, TStart]>();
-  public readonly startDependencies = firstValueFrom(this.startDependencies$);
+  public readonly startDependencies = firstValueFrom(this.startDependencies$, {
+    defaultValue: undefined,
+  });
 
   constructor(
     public readonly params: {
@@ -147,6 +149,9 @@ export class PluginWrapper<
     }
 
     this.instance = undefined;
+
+    // some plugins might be awaiting for core.getStartServices(); reject these promises
+    this.startDependencies$.complete();
   }
 
   public getConfigDescriptor(): PluginConfigDescriptor | null {


### PR DESCRIPTION
In the scope of [graceful shutdown](https://github.com/elastic/kibana-team/issues/511), we want to ensure all async operations are correctly finished when stopping the Kibana server.
Some of the plugins make use of the core.getStartServices() functionality to retrieve some of the core's services.
This method returns a Promise that might never be resolved if the server is stopped.

The goal of this PR is to make sure all these promises are rejected, and thus the various plugins making use of this feature are signaled and can correctly handle promise rejection.