### PR TITLE
Fix flaky tag cloud test

### DIFF
--- a/test/functional/apps/visualize/group6/_tag_cloud.ts
+++ b/test/functional/apps/visualize/group6/_tag_cloud.ts
@@ -29,8 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'tagCloud',
   ]);
 
-  // Failing: See https://github.com/elastic/kibana/issues/134515
-  describe.skip('tag cloud chart', function () {
+  describe('tag cloud chart', function () {
     const vizName1 = 'Visualization tagCloud';
     const termsField = 'machine.ram';
 
@@ -146,7 +145,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickKibanaIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
-        await PageObjects.settings.filterField(termsField);
         await PageObjects.settings.openControlsByName(termsField);
         await (
           await (
@@ -169,7 +167,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickKibanaIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
-        await PageObjects.settings.filterField(termsField);
         await PageObjects.settings.openControlsByName(termsField);
         await PageObjects.settings.setFieldFormat('');
         await PageObjects.settings.controlChangeSave();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134515

The test would fail because the name is entered twice:
<img width="801" alt="Screenshot 2022-06-17 at 09 56 34" src="https://user-images.githubusercontent.com/1508364/174253309-571a6980-128c-4963-aa06-608ab73e5a9f.png">

This happens because `openControlsByName` is already calling `filterField` on its own, so no need to call it twice: https://github.com/elastic/kibana/blob/96f31938fa0d87536739fd8c606380679a4a9327/test/functional/page_objects/settings_page.ts#L353