### PR TITLE
[8.3] ES Client: use `ClusterConnectionPool` (#134628)

### DIFF
--- a/src/core/server/elasticsearch/client/configure_client.test.ts
+++ b/src/core/server/elasticsearch/client/configure_client.test.ts
@@ -17,6 +17,7 @@ import {
   ClientMock,
 } from './configure_client.test.mocks';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
+import { ClusterConnectionPool } from '@elastic/elasticsearch';
 import type { ElasticsearchClientConfig } from './client_config';
 import { configureClient } from './configure_client';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -107,6 +108,21 @@ describe('configureClient', () => {
     expect(ClientMock).toHaveBeenCalledWith(
       expect.objectContaining({
         Transport: mockedTransport,
+      })
+    );
+    expect(client).toBe(ClientMock.mock.results[0].value);
+  });
+
+  it('constructs a client using `ClusterConnectionPool` for `ConnectionPool` ', () => {
+    const mockedTransport = { mockTransport: true };
+    createTransportMock.mockReturnValue(mockedTransport);
+
+    const client = configureClient(config, { logger, type: 'test', scoped: false });
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(ClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ConnectionPool: ClusterConnectionPool,
       })
     );
     expect(client).toBe(ClientMock.mock.results[0].value);

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Client, HttpConnection } from '@elastic/elasticsearch';
+import { Client, HttpConnection, ClusterConnectionPool } from '@elastic/elasticsearch';
 import { Logger } from '../../logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
@@ -35,6 +35,8 @@ export const configureClient = (
     ...clientOptions,
     Transport: KibanaTransport,
     Connection: HttpConnection,
+    // using ClusterConnectionPool until https://github.com/elastic/elasticsearch-js/issues/1714 is addressed
+    ConnectionPool: ClusterConnectionPool,
   });
 
   instrumentEsQueryAndDeprecationLogger({ logger, client, type });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [ES Client: use `ClusterConnectionPool` (#134628)](https://github.com/elastic/kibana/pull/134628)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)