### PR TITLE
[8.3] [Synthetics] Update API key to create monitors (#130920)

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/rest_api.ts
+++ b/x-pack/plugins/synthetics/common/constants/rest_api.ts
@@ -44,6 +44,7 @@ export enum API_URLS {
   RUN_ONCE_MONITOR = '/internal/uptime/service/monitors/run_once',
   TRIGGER_MONITOR = '/internal/uptime/service/monitors/trigger',
   SERVICE_ALLOWED = '/internal/uptime/service/allowed',
+  SYNTHETICS_APIKEY = '/internal/uptime/service/api_key',
 
   // Project monitor public endpoint
   SYNTHETICS_MONITORS_PROJECT = '/api/synthetics/service/project/monitors',

--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/state.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/state.ts
@@ -23,6 +23,7 @@ export type FetchMonitorManagementListQueryArgs = t.TypeOf<
 export const MonitorManagementEnablementResultCodec = t.type({
   isEnabled: t.boolean,
   canEnable: t.boolean,
+  canManageApiKeys: t.boolean,
   areApiKeysEnabled: t.boolean,
 });
 

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/hooks/use_enablement.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/hooks/use_enablement.ts
@@ -33,6 +33,7 @@ export function useEnablement() {
   return {
     enablement: {
       areApiKeysEnabled: enablement?.areApiKeysEnabled,
+      canManageApiKeys: enablement?.canManageApiKeys,
       canEnable: enablement?.canEnable,
       isEnabled: enablement?.isEnabled,
     },

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/api_key_btn.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/api_key_btn.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import { render } from '../../../lib/helper/rtl_helpers';
+import { ApiKeyBtn } from './api_key_btn';
+
+describe('<APIKeyButton />', () => {
+  const setLoadAPIKey = jest.fn();
+
+  it('calls delete monitor on monitor deletion', () => {
+    render(<ApiKeyBtn setLoadAPIKey={setLoadAPIKey} apiKey="" loading={false} />);
+
+    expect(screen.getByText('Generate API key')).toBeInTheDocument();
+    userEvent.click(screen.getByTestId('uptimeMonitorManagementApiKeyGenerate'));
+    expect(setLoadAPIKey).toHaveBeenCalled();
+  });
+
+  it('shows correct content on loading', () => {
+    render(<ApiKeyBtn setLoadAPIKey={setLoadAPIKey} apiKey="" loading={true} />);
+
+    expect(screen.getByText('Generating API key')).toBeInTheDocument();
+  });
+
+  it('shows api key when available and hides button', () => {
+    const apiKey = 'sampleApiKey';
+    render(<ApiKeyBtn setLoadAPIKey={setLoadAPIKey} apiKey={apiKey} loading={false} />);
+
+    expect(screen.getByText(apiKey)).toBeInTheDocument();
+    expect(screen.queryByText('Generate API key')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/api_key_btn.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/api_key_btn.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiButton, EuiCodeBlock, EuiSpacer, EuiText, EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export const ApiKeyBtn = ({
+  apiKey,
+  loading,
+  setLoadAPIKey,
+}: {
+  loading?: boolean;
+  apiKey?: string;
+  setLoadAPIKey: (val: boolean) => void;
+}) => {
+  return (
+    <>
+      <EuiSpacer size="m" />
+      {!apiKey && (
+        <>
+          <EuiButton
+            fill
+            fullWidth={true}
+            isLoading={loading}
+            color="primary"
+            onClick={() => {
+              setLoadAPIKey(true);
+            }}
+            data-test-subj="uptimeMonitorManagementApiKeyGenerate"
+          >
+            {loading ? GET_API_KEY_LOADING_LABEL : GET_API_KEY_LABEL}
+          </EuiButton>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {apiKey && (
+        <>
+          <EuiCallOut title={API_KEY_WARNING_LABEL} iconType="iInCircle" size="s" />
+          <EuiSpacer size="s" />
+          <EuiText size="s">
+            <strong>{API_KEY_LABEL}</strong>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiCodeBlock
+            language="javascript"
+            isCopyable
+            fontSize="s"
+            paddingSize="m"
+            whiteSpace="pre"
+          >
+            {apiKey}
+          </EuiCodeBlock>
+        </>
+      )}
+    </>
+  );
+};
+
+const API_KEY_LABEL = i18n.translate('xpack.synthetics.monitorManagement.apiKey.label', {
+  defaultMessage: 'API key',
+});
+
+const GET_API_KEY_LABEL = i18n.translate('xpack.synthetics.monitorManagement.getApiKey.label', {
+  defaultMessage: 'Generate API key',
+});
+
+const API_KEY_WARNING_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.apiKeyWarning.label',
+  {
+    defaultMessage:
+      'This API key will only be shown once. Please keep a copy for your own records.',
+  }
+);
+
+const GET_API_KEY_LOADING_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.getAPIKeyLabel.loading',
+  {
+    defaultMessage: 'Generating API key',
+  }
+);

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import * as observabilityPublic from '@kbn/observability-plugin/public';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import { render, makeUptimePermissionsCore } from '../../../lib/helper/rtl_helpers';
+import { ManagementSettings } from './management_settings';
+
+jest.mock('@kbn/observability-plugin/public');
+
+describe('<ManagementSettings />', () => {
+  const state = {
+    monitorManagementList: {
+      enablement: {
+        canManageApiKeys: true,
+      },
+    },
+  };
+
+  beforeAll(() => {
+    jest.spyOn(observabilityPublic, 'useFetcher').mockReturnValue({
+      data: undefined,
+      status: observabilityPublic.FETCH_STATUS.SUCCESS,
+      refetch: () => {},
+    });
+  });
+
+  it('shows popover on click', () => {
+    jest.spyOn(observabilityPublic, 'useFetcher').mockReturnValue({
+      data: undefined,
+      status: observabilityPublic.FETCH_STATUS.SUCCESS,
+      refetch: () => {},
+    });
+    render(<ManagementSettings />);
+
+    expect(screen.queryByText('Generate API key')).not.toBeInTheDocument();
+    userEvent.click(screen.getByTestId('uptimeMonitorManagementApiKeyPopoverTrigger'));
+    expect(
+      screen.getByText(/Use an API key to push monitors remotely from a CLI or CD pipeline/)
+    ).toBeInTheDocument();
+  });
+
+  it('shows appropriate content when user does not have correct uptime save permissions', () => {
+    // const apiKey = 'sampleApiKey';
+    render(<ManagementSettings />, {
+      state,
+      core: makeUptimePermissionsCore({ save: false }),
+    });
+
+    userEvent.click(screen.getByTestId('uptimeMonitorManagementApiKeyPopoverTrigger'));
+    expect(screen.getByText(/Please contact your administrator./)).toBeInTheDocument();
+  });
+
+  it('shows appropriate content when user does not api key management permissions', () => {
+    render(<ManagementSettings />, {
+      state: {
+        monitorManagementList: {
+          enablement: {
+            canManageApiKeys: false,
+          },
+        },
+      },
+      core: makeUptimePermissionsCore({ save: true }),
+    });
+
+    userEvent.click(screen.getByTestId('uptimeMonitorManagementApiKeyPopoverTrigger'));
+    expect(screen.getByText(/Please contact your administrator./)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useState } from 'react';
+import { EuiPopover, EuiPopoverTitle, EuiText, EuiButtonEmpty, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFetcher } from '@kbn/observability-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { ApiKeyBtn } from './api_key_btn';
+import { fetchServiceAPIKey } from '../../../state/api';
+import { useEnablement } from '../hooks/use_enablement';
+
+export const ManagementSettings = () => {
+  const {
+    enablement: { canManageApiKeys },
+  } = useEnablement();
+  const [apiKey, setApiKey] = useState<string | undefined>(undefined);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [loadAPIKey, setLoadAPIKey] = useState(false);
+
+  const { data, loading } = useFetcher(async () => {
+    if (loadAPIKey) {
+      return fetchServiceAPIKey();
+    }
+    return null;
+  }, [loadAPIKey]);
+
+  useEffect(() => {
+    setApiKey(data?.apiKey.encoded);
+  }, [data]);
+
+  const canSave: boolean = !!useKibana().services?.application?.capabilities.uptime.save;
+
+  return (
+    <EuiPopover
+      isOpen={isPopoverOpen}
+      id="managementSettingsPopover"
+      button={
+        <EuiButtonEmpty
+          onClick={() => {
+            if (!isPopoverOpen) {
+              setIsPopoverOpen(true);
+            }
+          }}
+          data-test-subj="uptimeMonitorManagementApiKeyPopoverTrigger"
+        >
+          {API_KEYS_LABEL}
+        </EuiButtonEmpty>
+      }
+      closePopover={() => {
+        setApiKey(undefined);
+        setLoadAPIKey(false);
+        setIsPopoverOpen(false);
+      }}
+      style={{ margin: 'auto' }}
+    >
+      <div style={{ maxWidth: 350 }}>
+        {canSave && canManageApiKeys ? (
+          <>
+            <EuiPopoverTitle>{GET_API_KEY_GENERATE}</EuiPopoverTitle>
+            <EuiText size="s">
+              {GET_API_KEY_LABEL_DESCRIPTION}{' '}
+              <EuiLink href="#" external target="_blank">
+                {LEARN_MORE_LABEL}
+              </EuiLink>
+            </EuiText>
+            <ApiKeyBtn loading={loading} setLoadAPIKey={setLoadAPIKey} apiKey={apiKey} />
+          </>
+        ) : (
+          <>
+            <EuiPopoverTitle>{GET_API_KEY_GENERATE}</EuiPopoverTitle>
+            <EuiText size="s">
+              {GET_API_KEY_REDUCED_PERMISSIONS_LABEL}{' '}
+              <EuiLink href="#" external target="_blank">
+                {LEARN_MORE_LABEL}
+              </EuiLink>
+            </EuiText>
+          </>
+        )}
+      </div>
+    </EuiPopover>
+  );
+};
+
+const API_KEYS_LABEL = i18n.translate('xpack.synthetics.monitorManagement.getAPIKeyLabel.label', {
+  defaultMessage: 'API Keys',
+});
+
+const LEARN_MORE_LABEL = i18n.translate('xpack.synthetics.monitorManagement.learnMore.label', {
+  defaultMessage: 'Learn more',
+});
+
+const GET_API_KEY_GENERATE = i18n.translate(
+  'xpack.synthetics.monitorManagement.getAPIKeyLabel.generate',
+  {
+    defaultMessage: 'Generate API Key',
+  }
+);
+
+const GET_API_KEY_LABEL_DESCRIPTION = i18n.translate(
+  'xpack.synthetics.monitorManagement.getAPIKeyLabel.description',
+  {
+    defaultMessage: 'Use an API key to push monitors remotely from a CLI or CD pipeline.',
+  }
+);
+
+const GET_API_KEY_REDUCED_PERMISSIONS_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.getAPIKeyReducedPermissions.description',
+  {
+    defaultMessage:
+      'Use an API key to push monitors remotely from a CLI or CD pipeline. To generate an API key, you must have permissions to manage API keys and Uptime write access. Please contact your administrator.',
+  }
+);

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings_portal.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/management_settings_portal.tsx
@@ -7,14 +7,14 @@
 
 import React from 'react';
 import { InPortal } from 'react-reverse-portal';
-import { ActionBarPortalNode } from '../../../pages/monitor_management/portals';
+import { APIKeysPortalNode } from '../../../pages/monitor_management/portals';
 
-import { ActionBar, ActionBarProps } from './action_bar';
+import { ManagementSettings } from './management_settings';
 
-export const ActionBarPortal = (props: ActionBarProps) => {
+export const ManagementSettingsPortal = () => {
   return (
-    <InPortal node={ActionBarPortalNode}>
-      <ActionBar {...props} />
+    <InPortal node={APIKeysPortalNode}>
+      <ManagementSettings />
     </InPortal>
   );
 };

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
@@ -36,6 +36,7 @@ import * as labels from '../../overview/monitor_list/translations';
 import { Actions } from './actions';
 import { MonitorEnabled } from './monitor_enabled';
 import { MonitorLocations } from './monitor_locations';
+import { ManagementSettingsPortal } from './management_settings_portal';
 import { MonitorTags } from './tags';
 
 export interface MonitorManagementListPageState {
@@ -222,6 +223,7 @@ export const MonitorManagementList = ({
 
   return (
     <EuiPanel hasBorder>
+      <ManagementSettingsPortal />
       <EuiSpacer size="m" />
       <EuiBasicTable
         aria-label={i18n.translate('xpack.synthetics.monitorManagement.monitorList.title', {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/pages/index.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/pages/index.ts
@@ -14,3 +14,4 @@ export { AddMonitorPage } from './monitor_management/add_monitor';
 export { EditMonitorPage } from './monitor_management/edit_monitor';
 export { MonitorManagementPage } from './monitor_management/monitor_management';
 export { MonitorManagementBottomBar } from './monitor_management/bottom_bar';
+export { APIKeysButton } from './monitor_management/api_keys_btn';

--- a/x-pack/plugins/synthetics/public/legacy_uptime/pages/monitor_management/api_keys_btn.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/pages/monitor_management/api_keys_btn.tsx
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import { OutPortal } from 'react-reverse-portal';
-import { ActionBarPortalNode } from './portals';
+import { APIKeysPortalNode } from './portals';
 
-export const MonitorManagementBottomBar = () => {
+export const APIKeysButton = () => {
   return (
     <div>
-      <OutPortal node={ActionBarPortalNode} />
+      <OutPortal node={APIKeysPortalNode} />
     </div>
   );
 };

--- a/x-pack/plugins/synthetics/public/legacy_uptime/pages/monitor_management/portals.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/pages/monitor_management/portals.tsx
@@ -8,3 +8,5 @@
 import { createPortalNode } from 'react-reverse-portal';
 
 export const ActionBarPortalNode = createPortalNode();
+
+export const APIKeysPortalNode = createPortalNode();

--- a/x-pack/plugins/synthetics/public/legacy_uptime/routes.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/routes.tsx
@@ -34,6 +34,7 @@ import {
   NotFoundPage,
   SettingsPage,
   MonitorManagementBottomBar,
+  APIKeysButton,
 } from './pages';
 import { CertificatesPage } from './pages/certificates';
 import { UptimePage, useUptimeTelemetry } from './hooks';
@@ -272,7 +273,7 @@ const getRoutes = (): RouteProps[] => {
             </EuiFlexItem>
           </EuiFlexGroup>
         ),
-        rightSideItems: [<AddMonitorBtn />],
+        rightSideItems: [<AddMonitorBtn />, <APIKeysButton />],
       },
     },
   ];

--- a/x-pack/plugins/synthetics/public/legacy_uptime/state/api/monitor_management.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/state/api/monitor_management.ts
@@ -119,3 +119,9 @@ export const fetchEnableSynthetics = async (): Promise<void> => {
 export const fetchServiceAllowed = async (): Promise<SyntheticsServiceAllowed> => {
   return await apiService.get(API_URLS.SERVICE_ALLOWED);
 };
+
+export const fetchServiceAPIKey = async (): Promise<{
+  apiKey: { encoded: string };
+}> => {
+  return await apiService.get(API_URLS.SYNTHETICS_APIKEY);
+};

--- a/x-pack/plugins/synthetics/public/legacy_uptime/state/reducers/monitor_management.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/state/reducers/monitor_management.ts
@@ -209,6 +209,7 @@ export const monitorManagementListReducer = createReducer(initialState, (builder
         enablement: null,
       },
       enablement: {
+        canManageApiKeys: state.enablement?.canManageApiKeys || false,
         canEnable: state.enablement?.canEnable || false,
         areApiKeysEnabled: state.enablement?.areApiKeysEnabled || false,
         isEnabled: false,
@@ -246,6 +247,7 @@ export const monitorManagementListReducer = createReducer(initialState, (builder
         enablement: null,
       },
       enablement: {
+        canManageApiKeys: state.enablement?.canManageApiKeys || false,
         canEnable: state.enablement?.canEnable || false,
         areApiKeysEnabled: state.enablement?.areApiKeysEnabled || false,
         isEnabled: true,

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { getAPIKeySyntheticsRoute } from './monitor_cruds/get_api_key';
 import { getServiceLocationsRoute } from './synthetics_service/get_service_locations';
 import { deleteSyntheticsMonitorRoute } from './monitor_cruds/delete_monitor';
 import {
@@ -40,4 +41,5 @@ export const syntheticsAppRestApiRoutes: UMRestApiRouteFactory[] = [
   runOnceSyntheticsMonitorRoute,
   testNowMonitorRoute,
   getServiceAllowedRoute,
+  getAPIKeySyntheticsRoute,
 ];

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_api_key.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_api_key.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { UMRestApiRouteFactory } from '../../legacy_uptime/routes';
+import { generateAPIKey } from '../../synthetics_service/get_api_key';
+import { API_URLS } from '../../../common/constants';
+
+export const getAPIKeySyntheticsRoute: UMRestApiRouteFactory = (libs) => ({
+  method: 'GET',
+  path: API_URLS.SYNTHETICS_APIKEY,
+  validate: {},
+  handler: async ({ request, response, server }): Promise<any> => {
+    const { security } = server;
+
+    const apiKey = await generateAPIKey({
+      request,
+      security,
+      server,
+      uptimePrivileges: true,
+    });
+
+    return { apiKey };
+  },
+});

--- a/x-pack/plugins/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/get_api_key.ts
@@ -11,9 +11,10 @@ import type {
 import { KibanaRequest, SavedObjectsClientContract } from '@kbn/core/server';
 
 import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { ALL_SPACES_ID } from '@kbn/security-plugin/common/constants';
 import {
-  getSyntheticsServiceAPIKey,
   deleteSyntheticsServiceApiKey,
+  getSyntheticsServiceAPIKey,
   setSyntheticsServiceApiKey,
   syntheticsServiceApiKey,
 } from '../legacy_uptime/lib/saved_objects/service_api_key';
@@ -56,17 +57,16 @@ export const getAPIKeyForSyntheticsService = async ({
   }
 };
 
-export const generateAndSaveServiceAPIKey = async ({
+export const generateAPIKey = async ({
   server,
   security,
   request,
-  authSavedObjectsClient,
+  uptimePrivileges = false,
 }: {
   server: UptimeServerSetup;
   request?: KibanaRequest;
   security: SecurityPluginStart;
-  // authSavedObject is needed for write operations
-  authSavedObjectsClient?: SavedObjectsClientContract;
+  uptimePrivileges?: boolean;
 }) => {
   const isApiKeysEnabled = await security.authc.apiKeys?.areAPIKeysEnabled();
 
@@ -83,7 +83,31 @@ export const generateAndSaveServiceAPIKey = async ({
     throw new SyntheticsForbiddenError();
   }
 
-  const apiKeyResult = await security.authc.apiKeys?.create(request, {
+  if (uptimePrivileges) {
+    return security.authc.apiKeys?.create(request, {
+      name: 'uptime-api-key',
+      kibana_role_descriptors: {
+        uptime_save: {
+          elasticsearch: {},
+          kibana: [
+            {
+              base: [],
+              spaces: [ALL_SPACES_ID],
+              feature: {
+                uptime: ['all'],
+              },
+            },
+          ],
+        },
+      },
+      metadata: {
+        description:
+          'Created for the Synthetics Agent to be able to communicate with Kibana for generating monitors for projects',
+      },
+    });
+  }
+
+  return security.authc.apiKeys?.create(request, {
     name: 'synthetics-api-key',
     role_descriptors: {
       synthetics_writer: serviceApiKeyPrivileges,
@@ -93,6 +117,21 @@ export const generateAndSaveServiceAPIKey = async ({
         'Created for synthetics service to be passed to the heartbeat to communicate with ES',
     },
   });
+};
+
+export const generateAndSaveServiceAPIKey = async ({
+  server,
+  security,
+  request,
+  authSavedObjectsClient,
+}: {
+  server: UptimeServerSetup;
+  request?: KibanaRequest;
+  security: SecurityPluginStart;
+  // authSavedObject is needed for write operations
+  authSavedObjectsClient?: SavedObjectsClientContract;
+}) => {
+  const apiKeyResult = await generateAPIKey({ server, request, security });
 
   if (apiKeyResult) {
     const { id, name, api_key: apiKey } = apiKeyResult;
@@ -162,6 +201,7 @@ export const getSyntheticsEnablement = async ({
 
   return {
     canEnable: canManageApiKeys && hasClusterPermissions && hasIndexPermissions,
+    canManageApiKeys,
     isEnabled: Boolean(apiKey),
     areApiKeysEnabled,
   };

--- a/x-pack/test/api_integration/apis/uptime/rest/synthetics_enablement.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/synthetics_enablement.ts
@@ -57,6 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
 
             expect(apiResponse.body).eql({
               areApiKeysEnabled: true,
+              canManageApiKeys: true,
               canEnable: true,
               isEnabled: false,
             });
@@ -98,6 +99,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: false,
             canEnable: false,
             isEnabled: false,
           });
@@ -148,6 +150,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: true,
             canEnable: true,
             isEnabled: true,
           });
@@ -197,6 +200,7 @@ export default function ({ getService }: FtrProviderContext) {
             .expect(200);
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: false,
             canEnable: false,
             isEnabled: false,
           });
@@ -252,6 +256,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: true,
             canEnable: true,
             isEnabled: false,
           });
@@ -300,6 +305,7 @@ export default function ({ getService }: FtrProviderContext) {
             .expect(200);
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: false,
             canEnable: false,
             isEnabled: true,
           });
@@ -361,6 +367,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(apiResponse.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: true,
             canEnable: true,
             isEnabled: false,
           });
@@ -384,6 +391,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(apiResponse2.body).eql({
             areApiKeysEnabled: true,
+            canManageApiKeys: true,
             canEnable: true,
             isEnabled: false,
           });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Synthetics] Update API key to create monitors (#130920)](https://github.com/elastic/kibana/pull/130920)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)