### PR TITLE
poc split search options and disableShardWarning

### DIFF
--- a/src/plugins/data/common/search/search_source/fetch/types.ts
+++ b/src/plugins/data/common/search/search_source/fetch/types.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { SearchSourceSearchOptions } from '../../..';
 import { GetConfigFn } from '../../../types';
 import { IKibanaSearchResponse } from '../../types';
 
@@ -24,7 +25,11 @@ export interface FetchHandlers {
    * Callback which can be used to hook into responses, modify them, or perform
    * side effects like displaying UI errors on the client.
    */
-  onResponse: (request: SearchRequest, response: IKibanaSearchResponse) => IKibanaSearchResponse;
+  onResponse: (
+    request: SearchRequest,
+    response: IKibanaSearchResponse,
+    searchOptions: SearchSourceSearchOptions
+  ) => IKibanaSearchResponse;
 }
 
 export interface SearchError {

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -7,13 +7,13 @@
  */
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { SerializableRecord } from '@kbn/utility-types';
-import { PersistableStateService } from '@kbn/kibana-utils-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+import type { PersistableStateService } from '@kbn/kibana-utils-plugin/common';
+import type { RequestAdapter } from '@kbn/inspector-plugin/common';
+import type { Filter, Query } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/common';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { AggConfigSerialized, IAggConfigs } from '../../../public';
-import { Query } from '../..';
-import { Filter } from '../../es_query';
+import { AggConfigSerialized, IAggConfigs, ISearchOptions } from '../../../public';
 import type { SearchSource } from './search_source';
 
 /**
@@ -226,4 +226,23 @@ export function isSerializedSearchSource(
     maybeSerializedSearchSource !== null &&
     !Array.isArray(maybeSerializedSearchSource)
   );
+}
+
+export interface IInspectorInfo {
+  adapter?: RequestAdapter;
+  title: string;
+  id?: string;
+  description?: string;
+}
+
+export interface SearchSourceSearchOptions extends ISearchOptions {
+  /**
+   * Inspector integration options
+   */
+  inspector?: IInspectorInfo;
+
+  /**
+   * Disable default warnings of shard failures
+   */
+  disableShardFailureWarning?: boolean;
 }

--- a/src/plugins/data/common/search/types.ts
+++ b/src/plugins/data/common/search/types.ts
@@ -7,9 +7,7 @@
  */
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import { Observable } from 'rxjs';
-import type { RequestAdapter } from '@kbn/inspector-plugin/common';
-import type { DataView } from '@kbn/data-views-plugin/common';
-import { IEsSearchRequest, IEsSearchResponse } from '..';
+import { DataView, IEsSearchRequest, IEsSearchResponse } from '..';
 
 export type ISearchGeneric = <
   SearchStrategyRequest extends IKibanaSearchRequest = IEsSearchRequest,
@@ -91,13 +89,6 @@ export interface IKibanaSearchRequest<Params = any> {
   params?: Params;
 }
 
-export interface IInspectorInfo {
-  adapter?: RequestAdapter;
-  title: string;
-  id?: string;
-  description?: string;
-}
-
 export interface ISearchOptions {
   /**
    * An `AbortSignal` that allows the caller of `search` to abort a search request.
@@ -132,16 +123,14 @@ export interface ISearchOptions {
   isRestore?: boolean;
 
   /**
+   * Represents a meta-information about a Kibana entity initiating a search request.
+   */
+  executionContext?: KibanaExecutionContext;
+
+  /**
    * Index pattern reference is used for better error messages
    */
   indexPattern?: DataView;
-
-  /**
-   * Inspector integration options
-   */
-  inspector?: IInspectorInfo;
-
-  executionContext?: KibanaExecutionContext;
 }
 
 /**

--- a/src/plugins/data/public/search/fetch/handle_response.tsx
+++ b/src/plugins/data/public/search/fetch/handle_response.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiSpacer } from '@elastic/eui';
 import { ThemeServiceStart } from '@kbn/core/public';
 import { toMountPoint } from '@kbn/kibana-react-plugin/public';
-import { IKibanaSearchResponse } from '../../../common';
+import { IKibanaSearchResponse, SearchSourceSearchOptions } from '../../../common';
 import { ShardFailureOpenModalButton } from '../../shard_failure_modal';
 import { getNotifications } from '../../services';
 import type { SearchRequest } from '..';
@@ -19,6 +19,7 @@ import type { SearchRequest } from '..';
 export function handleResponse(
   request: SearchRequest,
   response: IKibanaSearchResponse,
+  searchOptions: SearchSourceSearchOptions,
   theme: ThemeServiceStart
 ) {
   const { rawResponse } = response;
@@ -31,7 +32,11 @@ export function handleResponse(
     });
   }
 
-  if (rawResponse._shards && rawResponse._shards.failed) {
+  if (
+    rawResponse._shards &&
+    rawResponse._shards.failed &&
+    !searchOptions.disableShardFailureWarning
+  ) {
     const title = i18n.translate('data.search.searchSource.fetch.shardsFailedNotificationMessage', {
       defaultMessage: '{shardsFailed} of {shardsTotal} shards failed',
       values: {

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -238,8 +238,8 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       aggs,
       getConfig: uiSettings.get.bind(uiSettings),
       search,
-      onResponse: (request: SearchRequest, response: IKibanaSearchResponse) =>
-        handleResponse(request, response, theme),
+      onResponse: (request: SearchRequest, response: IKibanaSearchResponse, searchOptions) =>
+        handleResponse(request, response, searchOptions, theme),
     };
 
     const config = this.initializerContext.config.get();


### PR DESCRIPTION
## Summary

poc for https://github.com/elastic/kibana/issues/131388


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
