### PR TITLE
[ML] Fix advanced wizard detector combo box

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_detector_modal/advanced_detector_modal.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_detector_modal/advanced_detector_modal.tsx
@@ -240,7 +240,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={aggOptions}
-                selectedOptions={createSelectedOptions(aggOption, aggOptions)}
+                selectedOptions={createSelectedOptions(aggOption)}
                 onChange={onOptionChange(setAggOption)}
                 isClearable={true}
               />
@@ -251,7 +251,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={currentFieldOptions}
-                selectedOptions={createSelectedOptions(fieldOption, currentFieldOptions)}
+                selectedOptions={createSelectedOptions(fieldOption)}
                 onChange={onOptionChange(setFieldOption)}
                 isClearable={true}
                 isDisabled={fieldOptionEnabled === false}
@@ -266,7 +266,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={splitFieldOptions}
-                selectedOptions={createSelectedOptions(byFieldOption, splitFieldOptions)}
+                selectedOptions={createSelectedOptions(byFieldOption)}
                 onChange={onOptionChange(setByFieldOption)}
                 isClearable={true}
                 isDisabled={splitFieldsEnabled === false}
@@ -278,7 +278,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={splitFieldOptions}
-                selectedOptions={createSelectedOptions(overFieldOption, splitFieldOptions)}
+                selectedOptions={createSelectedOptions(overFieldOption)}
                 onChange={onOptionChange(setOverFieldOption)}
                 isClearable={true}
                 isDisabled={splitFieldsEnabled === false}
@@ -290,7 +290,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={splitFieldOptions}
-                selectedOptions={createSelectedOptions(partitionFieldOption, splitFieldOptions)}
+                selectedOptions={createSelectedOptions(partitionFieldOption)}
                 onChange={onOptionChange(setPartitionFieldOption)}
                 isClearable={true}
                 isDisabled={splitFieldsEnabled === false}
@@ -302,10 +302,7 @@ export const AdvancedDetectorModal: FC<Props> = ({
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={excludeFrequentOptions}
-                selectedOptions={createSelectedOptions(
-                  excludeFrequentOption,
-                  excludeFrequentOptions
-                )}
+                selectedOptions={createSelectedOptions(excludeFrequentOption)}
                 onChange={onOptionChange(setExcludeFrequentOption)}
                 isClearable={true}
                 isDisabled={splitFieldsEnabled === false || excludeFrequentEnabled === false}
@@ -427,17 +424,8 @@ function createDefaultDescription(dtr: RichDetector) {
   return detectorToString(basicDetector);
 }
 
-// fixes issue with EuiComboBox.
-// if the options list only contains one option and nothing has been selected, set
-// selectedOptions list to be an empty array
-function createSelectedOptions(
-  selectedOption: EuiComboBoxOptionOption,
-  options: EuiComboBoxOptionOption[]
-): EuiComboBoxOptionOption[] {
-  return (options.length === 1 && options[0].label !== selectedOption.label) ||
-    selectedOption.label === ''
-    ? []
-    : [selectedOption];
+function createSelectedOptions(selectedOption: EuiComboBoxOptionOption): EuiComboBoxOptionOption[] {
+  return selectedOption === undefined || selectedOption.label === '' ? [] : [selectedOption];
 }
 
 function comboBoxOptionsSort(a: EuiComboBoxOptionOption, b: EuiComboBoxOptionOption) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134636

PR https://github.com/elastic/kibana/pull/133018 removed the possibility of the combo box list containing the already selected option. 

If you had two options in the combo box and you select one of them, the list nows contains one item. This would trigger a check we had in place to fix an issue with `EuiComboBox` for lists of one, where the one item is not the same as the current item.

