### PR TITLE
[scalability testing] filtering out setup/teardown related APM transactions

### DIFF
--- a/packages/kbn-performance-testing-dataset-extractor/BUILD.bazel
+++ b/packages/kbn-performance-testing-dataset-extractor/BUILD.bazel
@@ -41,6 +41,7 @@ RUNTIME_DEPS = [
   "//packages/kbn-test",
   "//packages/kbn-tooling-log",
   "@npm//@elastic/elasticsearch",
+  "@npm//moment",
 ]
 
 # In this array place dependencies necessary to build the types, which will include the

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
@@ -7,6 +7,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
 interface ClientOptions {
   node: string;
@@ -33,6 +34,7 @@ interface Transaction {
   id: string;
   name: string;
   type: string;
+  duration: { us: number };
 }
 
 export interface Document {
@@ -52,6 +54,33 @@ export interface Document {
   transaction: Transaction;
 }
 
+const addBooleanFilter = (filter: { field: string; value: string }): QueryDslQueryContainer => {
+  return {
+    bool: {
+      should: [
+        {
+          match_phrase: {
+            [filter.field]: filter.value,
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+};
+
+const addRangeFilter = (range: { startTime: string; endTime: string }): QueryDslQueryContainer => {
+  return {
+    range: {
+      '@timestamp': {
+        format: 'strict_date_optional_time',
+        gte: range.startTime,
+        lte: range.endTime,
+      },
+    },
+  };
+};
+
 export function initClient(options: ClientOptions) {
   const client = new Client({
     node: options.node,
@@ -62,7 +91,34 @@ export function initClient(options: ClientOptions) {
   });
 
   return {
-    async getTransactions(buildId: string, journeyName: string) {
+    async getKibanaServerTransactions(
+      buildId: string,
+      journeyName: string,
+      range?: { startTime: string; endTime: string }
+    ) {
+      const filters = [
+        { field: 'transaction.type', value: 'request' },
+        { field: 'processor.event', value: 'transaction' },
+        { field: 'labels.testBuildId', value: buildId },
+        { field: 'labels.journeyName', value: journeyName },
+      ];
+      const queryFilters = filters.map((filter) => addBooleanFilter(filter));
+      if (range) {
+        queryFilters.push(addRangeFilter(range));
+      }
+      return await this.getTransactions(queryFilters);
+    },
+    async getFtrTransactions(buildId: string, journeyName: string) {
+      const filters = [
+        { field: 'service.name', value: 'functional test runner' },
+        { field: 'processor.event', value: 'transaction' },
+        { field: 'labels.testBuildId', value: buildId },
+        { field: 'labels.journeyName', value: journeyName },
+      ];
+      const queryFilters = filters.map((filter) => addBooleanFilter(filter));
+      return await this.getTransactions(queryFilters);
+    },
+    async getTransactions(queryFilters: QueryDslQueryContainer[]) {
       const result = await client.search<Document>({
         body: {
           track_total_hits: true,
@@ -83,56 +139,7 @@ export function initClient(options: ClientOptions) {
               filter: [
                 {
                   bool: {
-                    filter: [
-                      {
-                        bool: {
-                          should: [
-                            {
-                              match_phrase: {
-                                'transaction.type': 'request',
-                              },
-                            },
-                          ],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          should: [
-                            {
-                              match_phrase: {
-                                'processor.event': 'transaction',
-                              },
-                            },
-                          ],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          should: [
-                            {
-                              match_phrase: {
-                                'labels.testBuildId': buildId,
-                              },
-                            },
-                          ],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          should: [
-                            {
-                              match_phrase: {
-                                'labels.journeyName': journeyName,
-                              },
-                            },
-                          ],
-                          minimum_should_match: 1,
-                        },
-                      },
-                    ],
+                    filter: queryFilters,
                   },
                 },
               ],

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -78,6 +78,11 @@ export const extractor = async ({ param, client, log }: CLIParams) => {
   }
 
   // There should be a single top-level transaction, representing journey browser starting time and session duration.
+  if (ftrTransactionHits.length > 1) {
+    log.warning(`Filtering doesn't work, more than 1 'functional test runner' transaction found`);
+    return;
+  }
+
   const trSource = ftrTransactionHits[0]!._source as Document;
   const startTime = trSource['@timestamp'];
   const duration = trSource.transaction.duration.us / 1000; // convert microseconds as milliseconds


### PR DESCRIPTION
## Summary

Follow-up to #134568
This PR adds filtering APM transactions by journey time range, so that final output file contains only the server requests collected during the time browser was open (single user journey actual scenario run)
It also fixes a problem with trimmed payloads as it is related to `before` hook (journey setup), but not the actual scenario.

```
node scripts/extract_performance_testing_dataset \
        --config x-pack/test/performance/journeys/promotion_tracking_dashboard/config.ts \
        --buildId local-8337b12c-260a-40da-be8d-058f9eb6039f \
        --es-url "https://kibana-ops-e2e-perf.es.us-central1.gcp.cloud.es.io:9243" \
        --es-username <username> \
        --es-password <password>
 info  👷‍♀️ BUILD ID local-367f26be-7092-43c4-be05-a3c28ce38b34
       👷 JOB ID local-cacb22ca-892c-49fd-9d4a-55c376eb57b5
       👷‍♂️ EXECUTION ID:2ef387ba-adea-4a91-a5d3-aabacdf977db
 info Searching transactions with 'labels.testBuildId=local-8337b12c-260a-40da-be8d-058f9eb6039f' and 'labels.journeyName=promotion_tracking_dashboard'
 info Found 243 transactions, output file: /Users/dmle/github/kibana/target/scalability_traces/promotion_tracking_dashboard-local-8337b12c-260a-40da-be8d-058f9eb6039f.json
```