### PR TITLE
Fix integrations with a long name break Host page UI

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/page/index.tsx
@@ -153,6 +153,7 @@ export const AppGlobalStyle = createGlobalStyle<{ theme: { eui: { euiColorPrimar
 
 export const DescriptionListStyled = styled(EuiDescriptionList)`
   ${({ theme }) => `
+    word-break: break-word;
     dt {
       font-size: ${theme.eui.euiFontSizeXS} !important;
     }

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -237,6 +237,10 @@ exports[`Details Panel Component DetailsPanel:HostDetails: rendering it should r
   color: #535966;
 }
 
+.c2 {
+  word-break: break-word;
+}
+
 .c2 dt {
   font-size: 12px !important;
 }
@@ -569,6 +573,10 @@ exports[`Details Panel Component DetailsPanel:HostDetails: rendering it should r
 exports[`Details Panel Component DetailsPanel:NetworkDetails: rendering it should render the Network Details view in the Details Panel when the panelView is networkDetail and the ip is set 1`] = `
 .c3 {
   color: #535966;
+}
+
+.c2 {
+  word-break: break-word;
 }
 
 .c2 dt {

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/host_details/__snapshots__/expandable_host.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/host_details/__snapshots__/expandable_host.test.tsx.snap
@@ -5,6 +5,10 @@ exports[`Expandable Host Component ExpandableHostDetails: rendering it should re
   color: #535966;
 }
 
+.c2 {
+  word-break: break-word;
+}
+
 .c2 dt {
   font-size: 12px !important;
 }


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/102858

## Summary
Force words to break on the Host details page by adding `word-break: break-word;` to the `DescriptionList` component.

![Screenshot 2022-06-20 at 12 12 57](https://user-images.githubusercontent.com/1490444/174580429-6136d647-d0af-48fe-bea3-f184abd648c2.png)
![Screenshot 2022-06-20 at 12 13 16](https://user-images.githubusercontent.com/1490444/174580435-2dd95301-a5eb-4442-90ea-75d87a3028df.png)




### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

