### PR TITLE
Fix sort orders for meta engines.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -80,8 +80,8 @@ export const SearchExperience: React.FC = () => {
       sortFields: [],
     }
   );
-  const sortOptions =
-    engine.type === 'elasticsearch' ? RELEVANCE_SORT_OPTIONS : DEFAULT_SORT_OPTIONS;
+  const useRelevance = engine.type === 'elasticsearch' || engine.type === 'meta';
+  const sortOptions = useRelevance ? RELEVANCE_SORT_OPTIONS : DEFAULT_SORT_OPTIONS;
 
   const sortingOptions = buildSortOptions(fields, sortOptions);
 
@@ -95,7 +95,7 @@ export const SearchExperience: React.FC = () => {
   });
 
   const initialState = {
-    sortField: engine.type === 'elasticsearch' ? '_score' : 'id',
+    sortField: sortOptions[0].value,
     sortDirection: 'desc',
   };
 


### PR DESCRIPTION
## Summary

Meta engines can now use an Elasticsearch-based index as a source engine. It means that we can not safely assume that it is possible to sort by id. To avoid errors, available sort orders will be the same as those used for BYOEI engines.


