### PR TITLE
[QA][Code Coverage] Add meta data links to ci runs.

### DIFF
--- a/.buildkite/pipelines/code_coverage/daily.yml
+++ b/.buildkite/pipelines/code_coverage/daily.yml
@@ -13,7 +13,7 @@ steps:
       queue: kibana-default
     env:
       FTR_CONFIGS_DEPS: ''
-#      LIMIT_CONFIG_TYPE: 'unit,functional,integration'
+      #      LIMIT_CONFIG_TYPE: 'unit,functional,integration'
       LIMIT_CONFIG_TYPE: 'unit,integration'
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/code_coverage/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/code_coverage/jest_integration.sh'
@@ -26,6 +26,6 @@ steps:
     depends_on:
       - jest
       - jest-integration
-#      - ftr-configs
+    #      - ftr-configs
     timeout_in_minutes: 30
     key: ingest

--- a/.buildkite/scripts/steps/code_coverage/ingest.sh
+++ b/.buildkite/scripts/steps/code_coverage/ingest.sh
@@ -17,14 +17,16 @@ export HOST_FROM_VAULT
 TIME_STAMP=$(date +"%Y-%m-%dT%H:%M:00Z")
 export TIME_STAMP
 
-echo "--- Download previous git sha"
-.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
-PREVIOUS_SHA=$(cat downloaded_previous.txt)
-
-echo "--- Upload new git sha"
-.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
-
 .buildkite/scripts/bootstrap.sh
+
+revolveBuildHashes() {
+  echo "--- Download previous git sha"
+  .buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
+  PREVIOUS_SHA=$(cat downloaded_previous.txt)
+
+  echo "--- Upload new git sha"
+  .buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
+}
 
 collectRan() {
   buildkite-agent artifact download target/ran_files/* .
@@ -59,9 +61,9 @@ archiveReports() {
   local xs=("$@")
   for x in "${xs[@]}"; do
     echo "### Collect and Upload for: ${x}"
-#    fileHeads "target/file-heads-archive-reports-for-${x}.txt" "target/kibana-coverage/${x}"
-#    dirListing "target/dir-listing-${x}-combined-during-archiveReports.txt" target/kibana-coverage/${x}-combined
-#    dirListing "target/dir-listing-${x}-during-archiveReports.txt" target/kibana-coverage/${x}
+    #    fileHeads "target/file-heads-archive-reports-for-${x}.txt" "target/kibana-coverage/${x}"
+    #    dirListing "target/dir-listing-${x}-combined-during-archiveReports.txt" target/kibana-coverage/${x}-combined
+    #    dirListing "target/dir-listing-${x}-during-archiveReports.txt" target/kibana-coverage/${x}
     collectAndUpload "target/kibana-coverage/${x}/kibana-${x}-coverage.tar.gz" "target/kibana-coverage/${x}-combined"
   done
 }
@@ -86,20 +88,50 @@ mergeAll() {
   done
 }
 
+annotateForStaticSite() {
+  local xs=("$@")
+  local markdownLinks=()
+
+  OLDIFS="${IFS}"
+  IFS=$'\n'
+
+  for x in "${xs[@]}"; do
+    markdownLinks+=(" - [$x](https://kibana-coverage.elastic.dev/${TIME_STAMP}/${x}-combined/index.html)")
+  done
+  echo "### markdownLinks: ${markdownLinks[*]}"
+
+  content=$(
+    cat <<-EOF
+### Browse the the Code Coverage Static Site
+
+_Links are pinned to the current build number._
+
+${markdownLinks[*]}
+EOF
+  )
+
+  IFS="${OLDIFS}"
+
+  buildkite-agent annotate --style "info" --context 'ctx-coverage-static-site' "${content}"
+}
+
 modularize() {
   collectRan
   if [ -d target/ran_files ]; then
+    revolveBuildHashes
     uniqueifyRanConfigs "${ran[@]}"
     fetchArtifacts "${uniqRanConfigs[@]}"
     mergeAll "${uniqRanConfigs[@]}"
     archiveReports "${uniqRanConfigs[@]}"
     .buildkite/scripts/steps/code_coverage/reporting/prokLinks.sh "${uniqRanConfigs[@]}"
     .buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh "${uniqRanConfigs[@]}"
+    annotateForStaticSite "${uniqRanConfigs[@]}"
     .buildkite/scripts/steps/code_coverage/reporting/collectVcsInfo.sh
     source .buildkite/scripts/steps/code_coverage/reporting/ingestData.sh 'elastic+kibana+code-coverage' \
       "${BUILDKITE_BUILD_NUMBER}" "${BUILDKITE_BUILD_URL}" "${PREVIOUS_SHA}" \
       'src/dev/code_coverage/ingest_coverage/team_assignment/team_assignments.txt'
     ingestModular "${uniqRanConfigs[@]}"
+    annotateForKibanaLinks
   else
     echo "--- Found zero configs that ran, cancelling ingestion."
     exit 11
@@ -107,4 +139,3 @@ modularize() {
 }
 
 modularize
-echo "### unique ran configs: ${uniqRanConfigs[*]}"

--- a/.buildkite/scripts/steps/code_coverage/ingest.sh
+++ b/.buildkite/scripts/steps/code_coverage/ingest.sh
@@ -102,7 +102,7 @@ annotateForStaticSite() {
 
   content=$(
     cat <<-EOF
-### Browse the the Code Coverage Static Site
+### Browse the Code Coverage Static Site
 
 _Links are pinned to the current build number._
 

--- a/.buildkite/scripts/steps/code_coverage/ingest.sh
+++ b/.buildkite/scripts/steps/code_coverage/ingest.sh
@@ -98,7 +98,6 @@ annotateForStaticSite() {
   for x in "${xs[@]}"; do
     markdownLinks+=(" - [$x](https://kibana-coverage.elastic.dev/${TIME_STAMP}/${x}-combined/index.html)")
   done
-  echo "### markdownLinks: ${markdownLinks[*]}"
 
   content=$(
     cat <<-EOF

--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -49,4 +49,11 @@ ingestModular() {
 
   echo "---  Ingesting Code Coverage - Complete"
   echo ""
+
+  currentBuildNumber="$BUILDKITE_BUILD_NUMBER"
+  url="https://kibana-stats.elastic.dev/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:'64419790-4218-11ea-b2d8-81bcbf78dfcb',interval:auto,query:(language:kuery,query:'BUILD_ID%20:%20${currentBuildNumber}'),sort:!(!('@timestamp',desc)))"
+
+  echo "--- Browse the following url to visually verify in Kibana (Disover):"
+  printf "%s \n" "'$url'"
+
 }

--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -54,6 +54,6 @@ ingestModular() {
   url="https://kibana-stats.elastic.dev/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:'64419790-4218-11ea-b2d8-81bcbf78dfcb',interval:auto,query:(language:kuery,query:'BUILD_ID%20:%20${currentBuildNumber}'),sort:!(!('@timestamp',desc)))"
 
   echo "--- Browse the following url to visually verify in Kibana (Disover):"
-  printf "%s \n" "'$url'"
+  printf "%s \n" "$url"
 
 }

--- a/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/ingestData.sh
@@ -29,6 +29,23 @@ echo "### debug TEAM_ASSIGN_PATH: ${TEAM_ASSIGN_PATH}"
 BUFFER_SIZE=500
 export BUFFER_SIZE
 
+annotateForKibanaLinks() {
+  local currentBuildNumber="$BUILDKITE_BUILD_NUMBER"
+  local coverageUrl="https://kibana-stats.elastic.dev/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:'64419790-4218-11ea-b2d8-81bcbf78dfcb',interval:auto,query:(language:kuery,query:'BUILD_ID%20:%20${currentBuildNumber}'),sort:!(!('@timestamp',desc)))"
+  local totalCoverageUrl="https://kibana-stats.elastic.dev/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:d78f9120-4218-11ea-b2d8-81bcbf78dfcb,interval:auto,query:(language:kuery,query:'BUILD_ID%20:%20${currentBuildNumber}'),sort:!(!('@timestamp',desc)))"
+
+  cat <<EOF | buildkite-agent annotate --style "info" --context 'ctx-kibana-links'
+### Browse the following url(s) to visually verify in Kibana
+
+_Links are pinned to the current build number._
+
+  - [Code Coverage]($coverageUrl)
+  - [Total Code Coverage]($totalCoverageUrl)
+
+EOF
+
+}
+
 ingestModular() {
   local xs=("$@")
 
@@ -49,11 +66,4 @@ ingestModular() {
 
   echo "---  Ingesting Code Coverage - Complete"
   echo ""
-
-  currentBuildNumber="$BUILDKITE_BUILD_NUMBER"
-  url="https://kibana-stats.elastic.dev/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:'64419790-4218-11ea-b2d8-81bcbf78dfcb',interval:auto,query:(language:kuery,query:'BUILD_ID%20:%20${currentBuildNumber}'),sort:!(!('@timestamp',desc)))"
-
-  echo "--- Browse the following url to visually verify in Kibana (Disover):"
-  printf "%s \n" "$url"
-
 }


### PR DESCRIPTION
When personnel other than myself wish to visually verify code coverage,
or the static site for code coverage, per build,
these links will be available in the ci meta data.
