### PR TITLE
[Fleet] fix schedule upgrade if no versions available

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -82,11 +82,16 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     const displayVersions = minVersion
       ? fallbackVersions.filter((v) => semverGt(v, minVersion))
       : fallbackVersions;
-    return displayVersions.map((option) => ({
+    const options = displayVersions.map((option) => ({
       label: option,
       value: option,
     }));
+    if (options.length === 0) {
+      return [{ label: '', value: '' }];
+    }
+    return options;
   }, [fallbackVersions, minVersion]);
+  const noVersions = versionOptions[0]?.value === '';
 
   const maintainanceOptions: Array<EuiComboBoxOptionOption<number>> = MAINTAINANCE_VALUES.map(
     (option) => ({
@@ -252,7 +257,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           defaultMessage="Cancel"
         />
       }
-      confirmButtonDisabled={isSubmitting}
+      confirmButtonDisabled={isSubmitting || noVersions}
       confirmButtonText={
         isSingleAgent ? (
           <FormattedMessage
@@ -274,7 +279,12 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       }
     >
       <p>
-        {isSingleAgent ? (
+        {noVersions ? (
+          <FormattedMessage
+            id="xpack.fleet.upgradeAgents.noVersionsText"
+            defaultMessage="No versions available to upgrade to. Please select agents which have upgrade available."
+          />
+        ) : isSingleAgent ? (
           <FormattedMessage
             id="xpack.fleet.upgradeAgents.upgradeSingleDescription"
             defaultMessage="This action will upgrade the agent running on '{hostName}' to version {version}. This action can not be undone. Are you sure you wish to continue?"
@@ -302,6 +312,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           fullWidth
           singleSelection={{ asPlainText: true }}
           options={versionOptions}
+          isDisabled={noVersions}
           isClearable={false}
           selectedOptions={selectedVersion}
           onChange={(selected: Array<EuiComboBoxOptionOption<string>>) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -282,7 +282,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
         {noVersions ? (
           <FormattedMessage
             id="xpack.fleet.upgradeAgents.noVersionsText"
-            defaultMessage="No versions available to upgrade to. Please select agents which have upgrade available."
+            defaultMessage="No selected agents are eligible for an upgrade. Please select one or more eligible agents."
           />
         ) : isSingleAgent ? (
           <FormattedMessage


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/134715

To test:
- Enroll an agent with latest version (8.4.0-SNAPSHOT)
- Select from agent list and click `Schedule upgrade` from bulk action list
- Verify that modal window loads and doesn't allow to submit action

<img width="865" alt="image" src="https://user-images.githubusercontent.com/90178898/174596882-84de1e75-4a4d-4f06-a515-d907614330c7.png">

<img width="659" alt="image" src="https://user-images.githubusercontent.com/90178898/174597456-6ca902b6-3cd8-454d-8121-edaeabddc2f9.png">




### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
