### PR TITLE
minimum artifacts manifest update interval

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -66,7 +66,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.artifacts.global.interval',
       {
         defaultMessage:
-          'Interval between global artifact manifest download attempts, in seconds. Default: 3600.',
+          'Interval between global artifact manifest download attempts, in seconds. Default: 3600, minimum 300.',
       }
     ),
   },
@@ -194,7 +194,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.artifacts.global.interval',
       {
         defaultMessage:
-          'Interval between global artifact manifest download attempts, in seconds. Default: 3600.',
+          'Interval between global artifact manifest download attempts, in seconds. Default: 3600, minimum 300.',
       }
     ),
   },
@@ -397,7 +397,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.artifacts.global.interval',
       {
         defaultMessage:
-          'Interval between global artifact manifest download attempts, in seconds. Default: 3600.',
+          'Interval between global artifact manifest download attempts, in seconds. Default: 3600, minimum 300.',
       }
     ),
   },


### PR DESCRIPTION
## Summary

This PR changes the inline documentation provided by a tooltip in Kibana.

Endpoint Security Integration policy allows for artifacts update interval customization via advanced fields. This field is useful to lower the burden on infrastructure by minimizing the number of lookups per day. However we noticed via telemetry that some endpoints check for new artifacts config every few seconds. This serves no meaningful purpose, most likely has been configured by mistake, thus we decided to enforce a minimum interval value of 300 seconds (5 minutes) at the endpoint side. 

![image](https://user-images.githubusercontent.com/39905449/174603443-e26b7cbc-b58b-48da-82e4-1ff50feeb955.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
