### PR TITLE
[ResponseOps][Cases] Implement delete sub-feature privilege

### DIFF
--- a/x-pack/plugins/cases/public/client/helpers/capabilities.ts
+++ b/x-pack/plugins/cases/public/client/helpers/capabilities.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart } from '@kbn/core/public';
+import { OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
+
+export type CasesOwners = typeof SECURITY_SOLUTION_OWNER | typeof OBSERVABILITY_OWNER;
+
+export interface CasesPermissions {
+  all: boolean;
+  create: boolean;
+  read: boolean;
+  update: boolean;
+  delete: boolean;
+}
+
+export const getUICapabilities = (
+  featureCapabilities: Partial<Record<string, boolean | Record<string, boolean>>>
+): CasesPermissions => {
+  const create = !!featureCapabilities?.create_cases;
+  const read = !!featureCapabilities?.read_cases;
+  const update = !!featureCapabilities?.update_cases;
+  const deleteCases = !!featureCapabilities?.delete_cases;
+  const all = create && read && update && deleteCases;
+
+  // TODO: remove
+  console.log({
+    featureCapabilities,
+    deleteCases,
+    all,
+  });
+  return {
+    all,
+    create,
+    read,
+    update,
+    delete: deleteCases,
+  };
+};
+
+/*
+ * Returns an object denoting the current user's ability to read and crud cases.
+ * If any owner(securitySolution, Observability) is found with crud or read capability respectively,
+ * then crud or read is set to true.
+ * Permissions for a specific owners can be found by passing an owner array
+ */
+
+export const canUseCases =
+  (capabilities: Partial<ApplicationStart['capabilities']>) =>
+  (
+    owners: CasesOwners[] = [OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER]
+  ): { crud: boolean; read: boolean } => ({
+    crud:
+      (capabilities && owners.some((owner) => capabilities[`${owner}Cases`]?.crud_cases)) ?? false,
+    read:
+      (capabilities && owners.some((owner) => capabilities[`${owner}Cases`]?.read_cases)) ?? false,
+  });

--- a/x-pack/plugins/cases/public/client/ui/get_all_cases_selector_modal.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_all_cases_selector_modal.tsx
@@ -17,12 +17,12 @@ const AllCasesSelectorModalLazy: React.FC<AllCasesSelectorModalProps> = lazy(
 );
 export const getAllCasesSelectorModalLazy = ({
   owner,
-  userCanCrud,
+  permissions,
   hiddenStatuses,
   onRowClick,
   onClose,
 }: GetAllCasesSelectorModalProps) => (
-  <CasesProvider value={{ owner, userCanCrud }}>
+  <CasesProvider value={{ owner, permissions }}>
     <Suspense fallback={<EuiLoadingSpinner />}>
       <AllCasesSelectorModalLazy
         hiddenStatuses={hiddenStatuses}

--- a/x-pack/plugins/cases/public/client/ui/get_cases.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_cases.tsx
@@ -16,7 +16,7 @@ const CasesRoutesLazy: React.FC<CasesProps> = lazy(() => import('../../component
 
 export const getCasesLazy = ({
   owner,
-  userCanCrud,
+  permissions,
   basePath,
   onComponentInitialized,
   actionsNavigation,
@@ -28,7 +28,7 @@ export const getCasesLazy = ({
   features,
   releasePhase,
 }: GetCasesProps) => (
-  <CasesProvider value={{ owner, userCanCrud, basePath, features, releasePhase }}>
+  <CasesProvider value={{ owner, permissions, basePath, features, releasePhase }}>
     <Suspense fallback={<EuiLoadingSpinner />}>
       <CasesRoutesLazy
         onComponentInitialized={onComponentInitialized}

--- a/x-pack/plugins/cases/public/client/ui/get_cases_context.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_cases_context.tsx
@@ -17,14 +17,14 @@ const CasesProviderLazy: React.FC<{ value: GetCasesContextProps }> = lazy(
 
 const CasesProviderLazyWrapper = ({
   owner,
-  userCanCrud,
+  permissions,
   features,
   children,
   releasePhase,
 }: GetCasesContextProps & { children: ReactNode }) => {
   return (
     <Suspense fallback={<EuiLoadingSpinner />}>
-      <CasesProviderLazy value={{ owner, userCanCrud, features, releasePhase }}>
+      <CasesProviderLazy value={{ owner, permissions, features, releasePhase }}>
         {children}
       </CasesProviderLazy>
     </Suspense>

--- a/x-pack/plugins/cases/public/client/ui/get_create_case_flyout.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_create_case_flyout.tsx
@@ -17,14 +17,14 @@ export const CreateCaseFlyoutLazy: React.FC<CreateCaseFlyoutProps> = lazy(
 );
 export const getCreateCaseFlyoutLazy = ({
   owner,
-  userCanCrud,
+  permissions,
   features,
   afterCaseCreated,
   onClose,
   onSuccess,
   attachments,
 }: GetCreateCaseFlyoutProps) => (
-  <CasesProvider value={{ owner, userCanCrud, features }}>
+  <CasesProvider value={{ owner, permissions, features }}>
     <Suspense fallback={<EuiLoadingSpinner />}>
       <CreateCaseFlyoutLazy
         afterCaseCreated={afterCaseCreated}

--- a/x-pack/plugins/cases/public/client/ui/get_recent_cases.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_recent_cases.tsx
@@ -15,8 +15,8 @@ export type GetRecentCasesProps = RecentCasesProps & CasesContextProps;
 const RecentCasesLazy: React.FC<RecentCasesProps> = lazy(
   () => import('../../components/recent_cases')
 );
-export const getRecentCasesLazy = ({ owner, userCanCrud, maxCasesToShow }: GetRecentCasesProps) => (
-  <CasesProvider value={{ owner, userCanCrud }}>
+export const getRecentCasesLazy = ({ owner, permissions, maxCasesToShow }: GetRecentCasesProps) => (
+  <CasesProvider value={{ owner, permissions }}>
     <Suspense fallback={<EuiLoadingSpinner />}>
       <RecentCasesLazy maxCasesToShow={maxCasesToShow} />
     </Suspense>

--- a/x-pack/plugins/cases/public/common/lib/kibana/hooks.test.tsx
+++ b/x-pack/plugins/cases/public/common/lib/kibana/hooks.test.tsx
@@ -23,7 +23,7 @@ describe('hooks', () => {
 
       expect(result.current).toEqual({
         actions: { crud: true, read: true },
-        generalCases: { crud: true, read: true },
+        generalCases: { all: true, read: true, create: true, update: true, delete: true },
         visualize: { crud: true, read: true },
         dashboard: { crud: true, read: true },
       });

--- a/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
+++ b/x-pack/plugins/cases/public/common/lib/kibana/hooks.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../common/constants';
 import { StartServices } from '../../../types';
 import { useUiSetting, useKibana } from './kibana_react';
+import { CasesPermissions, getUICapabilities } from '../../../client/helpers/capabilities';
 
 export const useDateFormat = (): string => useUiSetting<string>(DEFAULT_DATE_FORMAT);
 
@@ -166,7 +167,7 @@ interface Capabilities {
 }
 interface UseApplicationCapabilities {
   actions: Capabilities;
-  generalCases: Capabilities;
+  generalCases: CasesPermissions;
   visualize: Capabilities;
   dashboard: Capabilities;
 }
@@ -179,14 +180,12 @@ interface UseApplicationCapabilities {
 export const useApplicationCapabilities = (): UseApplicationCapabilities => {
   const capabilities = useKibana().services?.application?.capabilities;
   const casesCapabilities = capabilities[FEATURE_ID];
+  const permissions = getUICapabilities(casesCapabilities);
 
   return useMemo(
     () => ({
       actions: { crud: !!capabilities.actions?.save, read: !!capabilities.actions?.show },
-      generalCases: {
-        crud: !!casesCapabilities?.crud_cases,
-        read: !!casesCapabilities?.read_cases,
-      },
+      generalCases: permissions,
       visualize: { crud: !!capabilities.visualize?.save, read: !!capabilities.visualize?.show },
       dashboard: {
         crud: !!capabilities.dashboard?.createNew,
@@ -200,8 +199,7 @@ export const useApplicationCapabilities = (): UseApplicationCapabilities => {
       capabilities.dashboard?.show,
       capabilities.visualize?.save,
       capabilities.visualize?.show,
-      casesCapabilities?.crud_cases,
-      casesCapabilities?.read_cases,
+      permissions,
     ]
   );
 };

--- a/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.test.tsx
@@ -29,7 +29,7 @@ const createAttachments = jest.fn();
 const addCommentProps: AddCommentProps = {
   id: 'newComment',
   caseId: '1234',
-  userCanCrud: true,
+  userCanCreate: true,
   onCommentSaving,
   onCommentPosted,
   showLoading: false,
@@ -121,7 +121,7 @@ describe('AddComment ', () => {
     }));
     const wrapper = mount(
       <TestProviders>
-        <AddComment {...{ ...addCommentProps, userCanCrud: false }} />
+        <AddComment {...{ ...addCommentProps, userCanCreate: false }} />
       </TestProviders>
     );
 

--- a/x-pack/plugins/cases/public/components/add_comment/index.tsx
+++ b/x-pack/plugins/cases/public/components/add_comment/index.tsx
@@ -47,7 +47,7 @@ export interface AddCommentRefObject {
 export interface AddCommentProps {
   id: string;
   caseId: string;
-  userCanCrud?: boolean;
+  userCanCreate?: boolean;
   onCommentSaving?: () => void;
   onCommentPosted: (newCase: Case) => void;
   showLoading?: boolean;
@@ -57,20 +57,12 @@ export interface AddCommentProps {
 export const AddComment = React.memo(
   forwardRef<AddCommentRefObject, AddCommentProps>(
     (
-      {
-        id,
-        caseId,
-        userCanCrud,
-        onCommentPosted,
-        onCommentSaving,
-        showLoading = true,
-        statusActionButton,
-      },
+      { id, caseId, onCommentPosted, onCommentSaving, showLoading = true, statusActionButton },
       ref
     ) => {
       const editorRef = useRef<EuiMarkdownEditorRef>(null);
       const [focusOnContext, setFocusOnContext] = useState(false);
-      const { owner } = useCasesContext();
+      const { permissions, owner } = useCasesContext();
       const { isLoading, createAttachments } = useCreateAttachments();
 
       const { form } = useForm<AddCommentFormSchema>({
@@ -156,7 +148,7 @@ export const AddComment = React.memo(
       return (
         <span id="add-comment-permLink">
           {isLoading && showLoading && <MySpinner data-test-subj="loading-spinner" size="xl" />}
-          {userCanCrud && (
+          {permissions.create && (
             <Form form={form}>
               <UseField
                 path={fieldName}

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -139,7 +139,6 @@ describe('AllCasesListGeneric', () => {
     handleIsLoading: jest.fn(),
     isLoadingCases: [],
     isSelectorView: false,
-    userCanCrud: true,
   };
 
   let appMockRenderer: AppMockRenderer;

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -61,7 +61,7 @@ export interface AllCasesListProps {
 
 export const AllCasesList = React.memo<AllCasesListProps>(
   ({ hiddenStatuses = [], isSelectorView = false, onRowClick, doRefresh }) => {
-    const { owner, userCanCrud } = useCasesContext();
+    const { owner, permissions } = useCasesContext();
     const availableSolutions = useAvailableCasesOwners();
     const [refresh, setRefresh] = useState(0);
 
@@ -185,14 +185,13 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       [deselectCases, setFilterOptions, refreshCases, setQueryParams]
     );
 
-    const showActions = userCanCrud && !isSelectorView;
+    const showActions = permissions.all && !isSelectorView;
 
     const columns = useCasesColumns({
       filterStatus: filterOptions.status ?? StatusAll,
       handleIsLoading,
       refreshCases,
       isSelectorView,
-      userCanCrud,
       connectors,
       onRowClick,
       showSolutionColumn: !hasOwner && availableSolutions.length > 1,
@@ -271,7 +270,6 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           sorting={sorting}
           tableRef={tableRef}
           tableRowProps={tableRowProps}
-          userCanCrud={userCanCrud}
         />
       </>
     );

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -43,6 +43,7 @@ import type { CasesOwners } from '../../client/helpers/can_use_cases';
 import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { severities } from '../severity/config';
 import { useUpdateCase } from '../../containers/use_update_case';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 export type CasesColumns =
   | EuiTableActionsColumnType<Case>
@@ -61,7 +62,6 @@ export interface GetCasesColumn {
   handleIsLoading: (a: boolean) => void;
   refreshCases?: (a?: boolean) => void;
   isSelectorView: boolean;
-  userCanCrud: boolean;
   connectors?: ActionConnector[];
   onRowClick?: (theCase: Case) => void;
 
@@ -72,7 +72,6 @@ export const useCasesColumns = ({
   handleIsLoading,
   refreshCases,
   isSelectorView,
-  userCanCrud,
   connectors = [],
   onRowClick,
   showSolutionColumn,
@@ -88,6 +87,7 @@ export const useCasesColumns = ({
   } = useDeleteCases();
 
   const { isAlertsEnabled } = useCasesFeatures();
+  const { permissions } = useCasesContext();
 
   const [deleteThisCase, setDeleteThisCase] = useState<DeleteCase>({
     id: '',
@@ -319,7 +319,7 @@ export const useCasesColumns = ({
               return (
                 <StatusContextMenu
                   currentStatus={theCase.status}
-                  disabled={!userCanCrud || isLoadingUpdateCase}
+                  disabled={!permissions.update || isLoadingUpdateCase}
                   onStatusChanged={(status) =>
                     handleDispatchUpdate({
                       updateKey: 'status',
@@ -372,7 +372,7 @@ export const useCasesColumns = ({
           },
         ]
       : []),
-    ...(userCanCrud && !isSelectorView
+    ...(permissions.update && !isSelectorView
       ? [
           {
             name: (

--- a/x-pack/plugins/cases/public/components/all_cases/header.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/header.tsx
@@ -11,23 +11,32 @@ import { HeaderPage } from '../header_page';
 import * as i18n from './translations';
 import { ErrorMessage } from '../use_push_to_service/callout/types';
 import { NavButtons } from './nav_buttons';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 interface OwnProps {
   actionsErrors: ErrorMessage[];
-  userCanCrud: boolean;
 }
 
 type Props = OwnProps;
 
-export const CasesTableHeader: FunctionComponent<Props> = ({ actionsErrors, userCanCrud }) => (
-  <HeaderPage title={i18n.PAGE_TITLE} border data-test-subj="cases-all-title">
-    <EuiFlexGroup alignItems="center" gutterSize="m" wrap={true} data-test-subj="all-cases-header">
-      {userCanCrud ? (
-        <EuiFlexItem>
-          <NavButtons actionsErrors={actionsErrors} />
-        </EuiFlexItem>
-      ) : null}
-    </EuiFlexGroup>
-  </HeaderPage>
-);
+export const CasesTableHeader: FunctionComponent<Props> = ({ actionsErrors }) => {
+  const { permissions } = useCasesContext();
+
+  return (
+    <HeaderPage title={i18n.PAGE_TITLE} border data-test-subj="cases-all-title">
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="m"
+        wrap={true}
+        data-test-subj="all-cases-header"
+      >
+        {permissions.create ? (
+          <EuiFlexItem>
+            <NavButtons actionsErrors={actionsErrors} />
+          </EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+    </HeaderPage>
+  );
+};
 CasesTableHeader.displayName = 'CasesTableHeader';

--- a/x-pack/plugins/cases/public/components/all_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/index.tsx
@@ -8,14 +8,12 @@
 import React, { useMemo } from 'react';
 import { CasesDeepLinkId } from '../../common/navigation';
 import { useGetActionLicense } from '../../containers/use_get_action_license';
-import { useCasesContext } from '../cases_context/use_cases_context';
 import { useCasesBreadcrumbs } from '../use_breadcrumbs';
 import { getActionLicenseError } from '../use_push_to_service/helpers';
 import { AllCasesList } from './all_cases_list';
 import { CasesTableHeader } from './header';
 
 export const AllCases: React.FC = () => {
-  const { userCanCrud } = useCasesContext();
   useCasesBreadcrumbs(CasesDeepLinkId.cases);
 
   const { data: actionLicense = null } = useGetActionLicense();
@@ -23,7 +21,7 @@ export const AllCases: React.FC = () => {
 
   return (
     <>
-      <CasesTableHeader actionsErrors={actionsErrors} userCanCrud={userCanCrud} />
+      <CasesTableHeader actionsErrors={actionsErrors} />
       <AllCasesList />
     </>
   );

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -57,7 +57,13 @@ describe('use cases add to existing case modal hook', () => {
       <CasesContext.Provider
         value={{
           owner: ['test'],
-          userCanCrud: true,
+          permissions: {
+            all: true,
+            create: true,
+            read: true,
+            update: true,
+            delete: true,
+          },
           appId: 'test',
           appTitle: 'jest',
           basePath: '/jest',

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -22,6 +22,7 @@ import { LinkButton } from '../links';
 import { Cases, Case, FilterOptions } from '../../../common/ui/types';
 import * as i18n from './translations';
 import { useCreateCaseNavigation } from '../../common/navigation';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 interface CasesTableProps {
   columns: EuiBasicTableProps<Case>['columns'];
@@ -42,7 +43,6 @@ interface CasesTableProps {
   sorting: EuiBasicTableProps<Case>['sorting'];
   tableRef: MutableRefObject<EuiBasicTable | null>;
   tableRowProps: EuiBasicTableProps<Case>['rowProps'];
-  userCanCrud: boolean;
 }
 
 const Div = styled.div`
@@ -68,8 +68,8 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
   sorting,
   tableRef,
   tableRowProps,
-  userCanCrud,
 }) => {
+  const { permissions } = useCasesContext();
   const { getCreateCaseUrl, navigateToCreateCase } = useCreateCaseNavigation();
   const navigateToCreateCaseClick = useCallback(
     (ev) => {
@@ -109,11 +109,11 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
           <EuiEmptyPrompt
             title={<h3>{i18n.NO_CASES}</h3>}
             titleSize="xs"
-            body={userCanCrud ? i18n.NO_CASES_BODY : i18n.NO_CASES_BODY_READ_ONLY}
+            body={permissions.create ? i18n.NO_CASES_BODY : i18n.NO_CASES_BODY_READ_ONLY}
             actions={
-              userCanCrud && (
+              permissions.create && (
                 <LinkButton
-                  isDisabled={!userCanCrud}
+                  isDisabled={!permissions.create}
                   fill
                   size="s"
                   onClick={navigateToCreateCaseClick}

--- a/x-pack/plugins/cases/public/components/app/index.tsx
+++ b/x-pack/plugins/cases/public/components/app/index.tsx
@@ -23,7 +23,7 @@ const CasesAppComponent: React.FC = () => {
       {getCasesLazy({
         owner: [APP_OWNER],
         useFetchAlertData: () => [false, {}],
-        userCanCrud: userCapabilities.generalCases.crud,
+        permissions: userCapabilities.generalCases,
         basePath: '/',
         features: { alerts: { enabled: false } },
         releasePhase: 'experimental',

--- a/x-pack/plugins/cases/public/components/app/routes.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.test.tsx
@@ -10,8 +10,9 @@ import React from 'react';
 import { MemoryRouterProps } from 'react-router';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { TestProviders } from '../../common/mock';
+import { readCasesPermissions, TestProviders } from '../../common/mock';
 import { CasesRoutes } from './routes';
+import { CasesPermissions } from '../../client/helpers/capabilities';
 
 jest.mock('../all_cases', () => ({
   AllCases: () => <div>{'All cases'}</div>,
@@ -29,10 +30,10 @@ const getCaseViewPaths = () => ['/cases/test-id', '/cases/test-id/comment-id'];
 
 const renderWithRouter = (
   initialEntries: MemoryRouterProps['initialEntries'] = ['/cases'],
-  userCanCrud = true
+  permissions?: CasesPermissions
 ) => {
   return render(
-    <TestProviders userCanCrud={userCanCrud}>
+    <TestProviders permissions={permissions}>
       <MemoryRouter initialEntries={initialEntries}>
         <CasesRoutes useFetchAlertData={(alertIds) => [false, {}]} />
       </MemoryRouter>
@@ -48,8 +49,8 @@ describe('Cases routes', () => {
     });
 
     // User has read only privileges
-    it('user can navigate to the all cases page with userCanCrud = false', () => {
-      renderWithRouter(['/cases'], false);
+    it('user can navigate to the all cases page with only read permissions', () => {
+      renderWithRouter(['/cases'], readCasesPermissions());
       expect(screen.getByText('All cases')).toBeInTheDocument();
     });
   });
@@ -68,9 +69,9 @@ describe('Cases routes', () => {
     );
 
     it.each(getCaseViewPaths())(
-      'user can navigate to the cases view page with userCanCrud = false and path: %s',
+      'user can navigate to the cases view page with read privileges and path: %s',
       async (path: string) => {
-        renderWithRouter([path], false);
+        renderWithRouter([path], readCasesPermissions());
         await waitFor(() => {
           expect(screen.getByTestId('case-view-loading')).toBeInTheDocument();
         });
@@ -84,8 +85,8 @@ describe('Cases routes', () => {
       expect(screen.getByText('Create case')).toBeInTheDocument();
     });
 
-    it('shows the no privileges page if userCanCrud = false', () => {
-      renderWithRouter(['/cases/create'], false);
+    it('shows the no privileges page if user is read only', () => {
+      renderWithRouter(['/cases/create'], readCasesPermissions());
       expect(screen.getByText('Privileges required')).toBeInTheDocument();
     });
   });
@@ -96,8 +97,8 @@ describe('Cases routes', () => {
       expect(screen.getByText('Configure cases')).toBeInTheDocument();
     });
 
-    it('shows the no privileges page if userCanCrud = false', () => {
-      renderWithRouter(['/cases/configure'], false);
+    it('shows the no privileges page if user is read only', () => {
+      renderWithRouter(['/cases/configure'], readCasesPermissions());
       expect(screen.getByText('Privileges required')).toBeInTheDocument();
     });
   });

--- a/x-pack/plugins/cases/public/components/app/routes.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.tsx
@@ -40,7 +40,7 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
   refreshRef,
   timelineIntegration,
 }) => {
-  const { basePath, userCanCrud } = useCasesContext();
+  const { basePath, permissions } = useCasesContext();
   const { navigateToAllCases } = useAllCasesNavigation();
   const { navigateToCaseView } = useCaseViewNavigation();
   useReadonlyHeader();
@@ -58,7 +58,7 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
         </Route>
 
         <Route path={getCreateCasePath(basePath)}>
-          {userCanCrud ? (
+          {permissions.create ? (
             <CreateCase
               onSuccess={onCreateCaseSuccess}
               onCancel={navigateToAllCases}
@@ -70,7 +70,7 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
         </Route>
 
         <Route path={getCasesConfigurePath(basePath)}>
-          {userCanCrud ? (
+          {permissions.create ? (
             <ConfigureCases />
           ) : (
             <NoPrivilegesPage pageName={i18n.CONFIGURE_CASES_PAGE_NAME} />

--- a/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
+++ b/x-pack/plugins/cases/public/components/app/use_readonly_header.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useKibana } from '../../common/lib/kibana';
-import { TestProviders } from '../../common/mock';
+import { readCasesPermissions, TestProviders } from '../../common/mock';
 import { useReadonlyHeader } from './use_readonly_header';
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
@@ -33,7 +33,9 @@ describe('CaseContainerComponent', () => {
 
   it('displays the readonly glasses badge read permissions but not write', () => {
     renderHook(() => useReadonlyHeader(), {
-      wrapper: ({ children }) => <TestProviders userCanCrud={false}>{children}</TestProviders>,
+      wrapper: ({ children }) => (
+        <TestProviders permissions={readCasesPermissions()}>{children}</TestProviders>
+      ),
     });
 
     expect(mockedSetBadge).toBeCalledTimes(1);

--- a/x-pack/plugins/cases/public/components/app/use_readonly_header.ts
+++ b/x-pack/plugins/cases/public/components/app/use_readonly_header.ts
@@ -15,19 +15,19 @@ import { useCasesContext } from '../cases_context/use_cases_context';
  * This component places a read-only icon badge in the header if user only has read permissions
  */
 export function useReadonlyHeader() {
-  const { userCanCrud } = useCasesContext();
+  const { permissions } = useCasesContext();
   const chrome = useKibana().services.chrome;
 
   // if the user is read only then display the glasses badge in the global navigation header
   const setBadge = useCallback(() => {
-    if (!userCanCrud) {
+    if (!permissions.create && !permissions.delete && !permissions.update && permissions.read) {
       chrome.setBadge({
         text: i18n.READ_ONLY_BADGE_TEXT,
         tooltip: i18n.READ_ONLY_BADGE_TOOLTIP,
         iconType: 'glasses',
       });
     }
-  }, [chrome, userCanCrud]);
+  }, [chrome, permissions]);
 
   useEffect(() => {
     setBadge();

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -42,7 +42,6 @@ describe('CaseActionBar', () => {
     isLoading: false,
     onUpdateField,
     currentExternalIncident: null,
-    userCanCrud: true,
     metricsFeatures: [],
   };
 

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.tsx
@@ -29,6 +29,7 @@ import { useCasesFeatures } from '../cases_context/use_cases_features';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { getStatusDate, getStatusTitle } from './helpers';
 import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 const MyDescriptionList = styled(EuiDescriptionList)`
   ${({ theme }) => css`
@@ -45,16 +46,15 @@ const MyDescriptionList = styled(EuiDescriptionList)`
 
 export interface CaseActionBarProps {
   caseData: Case;
-  userCanCrud: boolean;
   isLoading: boolean;
   onUpdateField: (args: OnUpdateFields) => void;
 }
 const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
   caseData,
-  userCanCrud,
   isLoading,
   onUpdateField,
 }) => {
+  const { permissions } = useCasesContext();
   const { isSyncAlertsEnabled, metricsFeatures } = useCasesFeatures();
   const date = useMemo(() => getStatusDate(caseData), [caseData]);
   const title = useMemo(() => getStatusTitle(caseData.status), [caseData.status]);
@@ -107,7 +107,7 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
                   <EuiDescriptionListDescription>
                     <StatusContextMenu
                       currentStatus={caseData.status}
-                      disabled={!userCanCrud || isLoading}
+                      disabled={!permissions.update || isLoading}
                       onStatusChanged={onStatusChanged}
                     />
                   </EuiDescriptionListDescription>
@@ -134,7 +134,7 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
                 responsive={false}
                 justifyContent="spaceBetween"
               >
-                {userCanCrud && isSyncAlertsEnabled && (
+                {permissions.update && isSyncAlertsEnabled && (
                   <EuiFlexItem grow={false}>
                     <EuiDescriptionListTitle>
                       <EuiFlexGroup
@@ -172,7 +172,9 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
                     </EuiButtonEmpty>
                   </span>
                 </EuiFlexItem>
-                {userCanCrud && (
+                {/* We might be able to get away with more granular permissions here because at the moment all this
+                depends on is the ability to delete*/}
+                {permissions.all && (
                   <EuiFlexItem grow={false} data-test-subj="case-view-actions">
                     <Actions
                       caseData={caseData}

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -40,7 +40,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     showAlertDetails,
     useFetchAlertData,
   }) => {
-    const { userCanCrud, features } = useCasesContext();
+    const { features } = useCasesContext();
     const { navigateToCaseView } = useCaseViewNavigation();
     const { urlParams } = useUrlParams();
     const refreshCaseViewPage = useRefreshCaseViewPage();
@@ -171,7 +171,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           data-test-subj="case-view-title"
           titleNode={
             <EditableTitle
-              userCanCrud={userCanCrud}
               isLoading={isLoading && loadingKey === 'title'}
               title={caseData.title}
               onSubmit={onSubmitTitle}
@@ -181,7 +180,6 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
         >
           <CaseActionBar
             caseData={caseData}
-            userCanCrud={userCanCrud}
             isLoading={isLoading && (loadingKey === 'status' || loadingKey === 'settings')}
             onUpdateField={onUpdateField}
           />

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -39,7 +39,7 @@ export const CaseViewActivity = ({
   showAlertDetails?: (alertId: string, index: string) => void;
   useFetchAlertData: UseFetchAlertData;
 }) => {
-  const { userCanCrud } = useCasesContext();
+  const { permissions } = useCasesContext();
   const { getCaseViewUrl } = useCaseViewNavigation();
 
   const { data: userActionsData, isLoading: isLoadingUserActions } = useGetCaseUserActions(
@@ -133,7 +133,7 @@ export const CaseViewActivity = ({
                 onShowAlertDetails={onShowAlertDetails}
                 onUpdateField={onUpdateField}
                 statusActionButton={
-                  userCanCrud ? (
+                  permissions.update ? (
                     <StatusActionButton
                       status={caseData.status}
                       onStatusChanged={changeStatus}
@@ -142,7 +142,6 @@ export const CaseViewActivity = ({
                   ) : null
                 }
                 useFetchAlertData={useFetchAlertData}
-                userCanCrud={userCanCrud}
               />
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -150,7 +149,7 @@ export const CaseViewActivity = ({
       </EuiFlexItem>
       <EuiFlexItem grow={2}>
         <SeveritySidebarSelector
-          isDisabled={!userCanCrud}
+          isDisabled={!permissions.update}
           isLoading={isLoading}
           selectedSeverity={caseData.severity}
           onSeverityChange={onUpdateSeverity}
@@ -171,7 +170,6 @@ export const CaseViewActivity = ({
           />
         ) : null}
         <TagList
-          userCanCrud={userCanCrud}
           tags={caseData.tags}
           onSubmit={onSubmitTags}
           isLoading={isLoading && loadingKey === 'tags'}
@@ -182,12 +180,11 @@ export const CaseViewActivity = ({
             caseServices={userActionsData.caseServices}
             connectorName={connectorName}
             connectors={connectors}
-            hasDataToPush={userActionsData.hasDataToPush && userCanCrud}
+            hasDataToPush={userActionsData.hasDataToPush}
             isLoading={isLoadingConnectors || (isLoading && loadingKey === 'connector')}
             isValidConnector={isLoadingConnectors ? true : isValidConnector}
             onSubmit={onSubmitConnector}
             userActions={userActionsData.caseUserActions}
-            userCanCrud={userCanCrud}
           />
         ) : null}
       </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/case_view/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.test.tsx
@@ -189,7 +189,6 @@ describe('CaseView', () => {
             onComponentInitialized: jest.fn(),
             showAlertDetails: jest.fn(),
             useFetchAlertData: jest.fn().mockReturnValue([false, alertsHit[0]]),
-            userCanCrud: true,
           }}
         />
       );

--- a/x-pack/plugins/cases/public/components/cases_context/index.tsx
+++ b/x-pack/plugins/cases/public/components/cases_context/index.tsx
@@ -25,14 +25,20 @@ export interface CasesContextValue {
   owner: string[];
   appId: string;
   appTitle: string;
-  userCanCrud: boolean;
+  permissions: {
+    all: boolean;
+    create: boolean;
+    read: boolean;
+    update: boolean;
+    delete: boolean;
+  };
   basePath: string;
   features: CasesFeaturesAllRequired;
   releasePhase: ReleasePhase;
   dispatch: CasesContextValueDispatch;
 }
 
-export interface CasesContextProps extends Pick<CasesContextValue, 'owner' | 'userCanCrud'> {
+export interface CasesContextProps extends Pick<CasesContextValue, 'owner' | 'permissions'> {
   basePath?: string;
   features?: CasesFeatures;
   releasePhase?: ReleasePhase;
@@ -47,13 +53,13 @@ export interface CasesContextStateValue extends Omit<CasesContextValue, 'appId' 
 
 export const CasesProvider: React.FC<{ value: CasesContextProps }> = ({
   children,
-  value: { owner, userCanCrud, basePath = DEFAULT_BASE_PATH, features = {}, releasePhase = 'ga' },
+  value: { owner, permissions, basePath = DEFAULT_BASE_PATH, features = {}, releasePhase = 'ga' },
 }) => {
   const { appId, appTitle } = useApplication();
   const [state, dispatch] = useReducer(casesContextReducer, getInitialCasesContextState());
   const [value, setValue] = useState<CasesContextStateValue>(() => ({
     owner,
-    userCanCrud,
+    permissions,
     basePath,
     /**
      * The empty object at the beginning avoids the mutation
@@ -69,7 +75,7 @@ export const CasesProvider: React.FC<{ value: CasesContextProps }> = ({
   }));
 
   /**
-   * `userCanCrud` prop may change by the parent plugin.
+   * `permissions` prop may change by the parent plugin.
    * `appId` and `appTitle` are dynamically retrieved from kibana context.
    * We need to update the state if any of these values change, the rest of props are never updated.
    */
@@ -79,10 +85,10 @@ export const CasesProvider: React.FC<{ value: CasesContextProps }> = ({
         ...prev,
         appId,
         appTitle,
-        userCanCrud,
+        permissions,
       }));
     }
-  }, [appTitle, appId, userCanCrud]);
+  }, [appTitle, appId, permissions]);
 
   return isCasesContextValue(value) ? (
     <CasesContext.Provider value={value}>
@@ -94,7 +100,7 @@ export const CasesProvider: React.FC<{ value: CasesContextProps }> = ({
 CasesProvider.displayName = 'CasesProvider';
 
 function isCasesContextValue(value: CasesContextStateValue): value is CasesContextValue {
-  return value.appId != null && value.appTitle != null && value.userCanCrud != null;
+  return value.appId != null && value.appTitle != null && value.permissions != null;
 }
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.test.tsx
@@ -10,7 +10,7 @@ import { ReactWrapper, mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
 import { ConfigureCases } from '.';
-import { TestProviders } from '../../common/mock';
+import { noCasesPermissions, TestProviders } from '../../common/mock';
 import { Connectors } from './connectors';
 import { ClosureOptions } from './closure_options';
 
@@ -191,7 +191,7 @@ describe('ConfigureCases', () => {
     test('it disables correctly when the user cannot crud', () => {
       const newWrapper = mount(<ConfigureCases />, {
         wrappingComponent: TestProviders,
-        wrappingComponentProps: { userCanCrud: false },
+        wrappingComponentProps: { permissions: noCasesPermissions() },
       });
 
       expect(newWrapper.find('button[data-test-subj="dropdown-connectors"]').prop('disabled')).toBe(

--- a/x-pack/plugins/cases/public/components/configure_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/index.tsx
@@ -51,7 +51,7 @@ const FormWrapper = styled.div`
 `;
 
 export const ConfigureCases: React.FC = React.memo(() => {
-  const { userCanCrud } = useCasesContext();
+  const { permissions } = useCasesContext();
   const { triggersActionsUi } = useKibana().services;
   useCasesBreadcrumbs(CasesDeepLinkId.casesConfigure);
 
@@ -227,7 +227,7 @@ export const ConfigureCases: React.FC = React.memo(() => {
             <SectionWrapper>
               <ClosureOptions
                 closureTypeSelected={closureType}
-                disabled={persistLoading || isLoadingConnectors || !userCanCrud}
+                disabled={persistLoading || isLoadingConnectors || !permissions.update}
                 onChangeClosureType={onChangeClosureType}
               />
             </SectionWrapper>
@@ -235,13 +235,13 @@ export const ConfigureCases: React.FC = React.memo(() => {
               <Connectors
                 actionTypes={actionTypes}
                 connectors={connectors ?? []}
-                disabled={persistLoading || isLoadingConnectors || !userCanCrud}
+                disabled={persistLoading || isLoadingConnectors || !permissions.update}
                 handleShowEditFlyout={onClickUpdateConnector}
                 isLoading={isLoadingAny}
                 mappings={mappings}
                 onChangeConnector={onChangeConnector}
                 selectedConnector={connector}
-                updateConnectorDisabled={updateConnectorDisabled || !userCanCrud}
+                updateConnectorDisabled={updateConnectorDisabled || !permissions.update}
               />
             </SectionWrapper>
             {ConnectorAddFlyout}

--- a/x-pack/plugins/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { CasesContext } from '../../cases_context';
 import { CasesContextStoreActionsList } from '../../cases_context/cases_context_reducer';
 import { useCasesAddToNewCaseFlyout } from './use_cases_add_to_new_case_flyout';
+import { allCasesPermissions } from '../../../common/mock';
 jest.mock('../../../common/use_cases_toast');
 
 describe('use cases add to new case flyout hook', () => {
@@ -25,7 +26,7 @@ describe('use cases add to new case flyout hook', () => {
         <CasesContext.Provider
           value={{
             owner: ['test'],
-            userCanCrud: true,
+            permissions: allCasesPermissions(),
             appId: 'test',
             appTitle: 'jest',
             basePath: '/jest',

--- a/x-pack/plugins/cases/public/components/edit_connector/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/index.test.tsx
@@ -11,7 +11,12 @@ import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { EditConnector, EditConnectorProps } from '.';
-import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
+import {
+  AppMockRenderer,
+  createAppMockRenderer,
+  readCasesPermissions,
+  TestProviders,
+} from '../../common/mock';
 import { basicCase, basicPush, caseUserActions, connectorsMock } from '../../containers/mock';
 import { CaseConnector } from '../../containers/configure/types';
 
@@ -36,7 +41,6 @@ const getDefaultProps = (): EditConnectorProps => {
     isValidConnector: true,
     onSubmit,
     userActions: caseUserActions,
-    userCanCrud: true,
   };
 };
 
@@ -202,10 +206,9 @@ describe('EditConnector ', () => {
 
   it('does not allow the connector to be edited when the user does not have write permissions', async () => {
     const defaultProps = getDefaultProps();
-    const props = { ...defaultProps, userCanCrud: false };
     const wrapper = mount(
-      <TestProviders>
-        <EditConnector {...props} />
+      <TestProviders permissions={readCasesPermissions()}>
+        <EditConnector {...defaultProps} />
       </TestProviders>
     );
     await waitFor(() =>

--- a/x-pack/plugins/cases/public/components/edit_connector/index.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/index.tsx
@@ -32,6 +32,7 @@ import { getConnectorById, getConnectorsFormValidators } from '../utils';
 import { usePushToService } from '../use_push_to_service';
 import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { useApplicationCapabilities } from '../../common/lib/kibana';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 export interface EditConnectorProps {
   caseData: Case;
@@ -48,7 +49,6 @@ export interface EditConnectorProps {
     onSuccess: () => void
   ) => void;
   userActions: CaseUserActions[];
-  userCanCrud?: boolean;
 }
 
 const MyFlexGroup = styled(EuiFlexGroup)`
@@ -119,8 +119,8 @@ export const EditConnector = React.memo(
     isValidConnector,
     onSubmit,
     userActions,
-    userCanCrud = true,
   }: EditConnectorProps) => {
+    const { permissions } = useCasesContext();
     const caseFields = caseData.connector.fields;
     const selectedConnector = caseData.connector.id;
 
@@ -273,7 +273,6 @@ export const EditConnector = React.memo(
       connectors,
       hasDataToPush,
       onEditClick,
-      userCanCrud,
       isValidConnector,
     });
 
@@ -289,7 +288,7 @@ export const EditConnector = React.memo(
             <h4>{i18n.CONNECTORS}</h4>
           </EuiFlexItem>
           {isLoading && <EuiLoadingSpinner data-test-subj="connector-loading" />}
-          {!isLoading && !editConnector && userCanCrud && actionsReadCapabilities && (
+          {!isLoading && !editConnector && permissions.update && actionsReadCapabilities && (
             <EuiFlexItem data-test-subj="connector-edit" grow={false}>
               <EuiButtonIcon
                 data-test-subj="connector-edit-button"
@@ -317,7 +316,7 @@ export const EditConnector = React.memo(
                       connectors,
                       dataTestSubj: 'caseConnectors',
                       defaultValue: selectedConnector,
-                      disabled: !userCanCrud,
+                      disabled: !permissions.update,
                       idAria: 'caseConnectors',
                       isEdit: editConnector,
                       isLoading,
@@ -373,7 +372,7 @@ export const EditConnector = React.memo(
           {pushCallouts == null &&
             !isLoading &&
             !editConnector &&
-            userCanCrud &&
+            permissions.all &&
             actionsReadCapabilities && (
               <EuiFlexItem data-test-subj="has-data-to-push-button" grow={false}>
                 <span>{pushButton}</span>

--- a/x-pack/plugins/cases/public/components/header_page/editable_title.test.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/editable_title.test.tsx
@@ -9,7 +9,12 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import '../../common/mock/match_media';
-import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
+import {
+  AppMockRenderer,
+  createAppMockRenderer,
+  readCasesPermissions,
+  TestProviders,
+} from '../../common/mock';
 import { EditableTitle, EditableTitleProps } from './editable_title';
 import { useMountAppended } from '../../utils/use_mount_appended';
 
@@ -20,7 +25,6 @@ describe('EditableTitle', () => {
     title: 'Test title',
     onSubmit: submitTitle,
     isLoading: false,
-    userCanCrud: true,
   };
 
   beforeEach(() => {
@@ -39,8 +43,8 @@ describe('EditableTitle', () => {
 
   it('does not show the edit icon when the user does not have edit permissions', () => {
     const wrapper = mount(
-      <TestProviders>
-        <EditableTitle {...{ ...defaultProps, userCanCrud: false }} />
+      <TestProviders permissions={readCasesPermissions()}>
+        <EditableTitle {...{ ...defaultProps }} />
       </TestProviders>
     );
 

--- a/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
+++ b/x-pack/plugins/cases/public/components/header_page/editable_title.tsx
@@ -37,19 +37,13 @@ const MySpinner = styled(EuiLoadingSpinner)`
 `;
 
 export interface EditableTitleProps {
-  userCanCrud: boolean;
   isLoading: boolean;
   title: string;
   onSubmit: (title: string) => void;
 }
 
-const EditableTitleComponent: React.FC<EditableTitleProps> = ({
-  userCanCrud = false,
-  onSubmit,
-  isLoading,
-  title,
-}) => {
-  const { releasePhase } = useCasesContext();
+const EditableTitleComponent: React.FC<EditableTitleProps> = ({ onSubmit, isLoading, title }) => {
+  const { releasePhase, permissions } = useCasesContext();
   const [editMode, setEditMode] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
   const [newTitle, setNewTitle] = useState<string>(title);
@@ -124,7 +118,7 @@ const EditableTitleComponent: React.FC<EditableTitleProps> = ({
   ) : (
     <Title title={title} releasePhase={releasePhase}>
       {isLoading && <MySpinner data-test-subj="editable-title-loading" />}
-      {!isLoading && userCanCrud && (
+      {!isLoading && permissions.update && (
         <MyEuiButtonIcon
           aria-label={i18n.EDIT_TITLE_ARIA(title as string)}
           iconType="pencil"

--- a/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { TestProviders } from '../../../common/mock';
+import { readCasesPermissions, TestProviders } from '../../../common/mock';
 import { NoCases } from '.';
 
 jest.mock('../../../common/navigation/hooks');
@@ -27,7 +27,7 @@ describe('NoCases', () => {
 
   it('displays a message without a link to create a case when the user does not have write permissions', () => {
     const wrapper = mount(
-      <TestProviders userCanCrud={false}>
+      <TestProviders permissions={readCasesPermissions()}>
         <NoCases />
       </TestProviders>
     );

--- a/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/no_cases/index.tsx
@@ -13,7 +13,7 @@ import { useCasesContext } from '../../cases_context/use_cases_context';
 import { useCreateCaseNavigation } from '../../../common/navigation';
 
 const NoCasesComponent = () => {
-  const { userCanCrud } = useCasesContext();
+  const { permissions } = useCasesContext();
   const { getCreateCaseUrl, navigateToCreateCase } = useCreateCaseNavigation();
 
   const navigateToCreateCaseClick = useCallback(
@@ -24,7 +24,7 @@ const NoCasesComponent = () => {
     [navigateToCreateCase]
   );
 
-  return userCanCrud ? (
+  return permissions.create ? (
     <>
       <span>{i18n.NO_CASES}</span>
       <LinkAnchor

--- a/x-pack/plugins/cases/public/components/tag_list/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/tag_list/index.test.tsx
@@ -10,7 +10,7 @@ import { mount } from 'enzyme';
 
 import { TagList, TagListProps } from '.';
 import { getFormMock } from '../__mock__/form';
-import { TestProviders } from '../../common/mock';
+import { readCasesPermissions, TestProviders } from '../../common/mock';
 import { waitFor } from '@testing-library/react';
 import { useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib/hooks/use_form';
 import { useGetTags } from '../../containers/use_get_tags';
@@ -33,7 +33,6 @@ jest.mock('@elastic/eui', () => {
 });
 const onSubmit = jest.fn();
 const defaultProps: TagListProps = {
-  userCanCrud: true,
   isLoading: false,
   onSubmit,
   tags: [],
@@ -109,10 +108,9 @@ describe('TagList ', () => {
   });
 
   it('does not render when the user does not have write permissions', () => {
-    const props = { ...defaultProps, userCanCrud: false };
     const wrapper = mount(
-      <TestProviders>
-        <TagList {...props} />
+      <TestProviders permissions={readCasesPermissions()}>
+        <TagList {...defaultProps} />
       </TestProviders>
     );
     expect(wrapper.find(`[data-test-subj="tag-list-edit"]`).exists()).toBeFalsy();

--- a/x-pack/plugins/cases/public/components/tag_list/index.tsx
+++ b/x-pack/plugins/cases/public/components/tag_list/index.tsx
@@ -24,11 +24,11 @@ import { schema } from './schema';
 import { useGetTags } from '../../containers/use_get_tags';
 
 import { Tags } from './tags';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 const CommonUseField = getUseField({ component: Field });
 
 export interface TagListProps {
-  userCanCrud?: boolean;
   isLoading: boolean;
   onSubmit: (a: string[]) => void;
   tags: string[];
@@ -55,144 +55,143 @@ const ColumnFlexGroup = styled(EuiFlexGroup)`
   `}
 `;
 
-export const TagList = React.memo(
-  ({ userCanCrud = true, isLoading, onSubmit, tags }: TagListProps) => {
-    const initialState = { tags };
-    const { form } = useForm({
-      defaultValue: initialState,
-      options: { stripEmptyFields: false },
-      schema,
-    });
-    const { submit } = form;
-    const [isEditTags, setIsEditTags] = useState(false);
+export const TagList = React.memo(({ isLoading, onSubmit, tags }: TagListProps) => {
+  const { permissions } = useCasesContext();
+  const initialState = { tags };
+  const { form } = useForm({
+    defaultValue: initialState,
+    options: { stripEmptyFields: false },
+    schema,
+  });
+  const { submit } = form;
+  const [isEditTags, setIsEditTags] = useState(false);
 
-    const onSubmitTags = useCallback(async () => {
-      const { isValid, data: newData } = await submit();
-      if (isValid && newData.tags) {
-        onSubmit(newData.tags);
-        form.reset({ defaultValue: newData });
-        setIsEditTags(false);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [onSubmit, submit]);
+  const onSubmitTags = useCallback(async () => {
+    const { isValid, data: newData } = await submit();
+    if (isValid && newData.tags) {
+      onSubmit(newData.tags);
+      form.reset({ defaultValue: newData });
+      setIsEditTags(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onSubmit, submit]);
 
-    const { data: tagOptions = [] } = useGetTags();
-    const [options, setOptions] = useState(
-      tagOptions.map((label) => ({
-        label,
-      }))
-    );
+  const { data: tagOptions = [] } = useGetTags();
+  const [options, setOptions] = useState(
+    tagOptions.map((label) => ({
+      label,
+    }))
+  );
 
-    useEffect(
-      () =>
-        setOptions(
-          tagOptions.map((label) => ({
-            label,
-          }))
-        ),
-      [tagOptions]
-    );
-    return (
-      <EuiText data-test-subj="case-view-tag-list">
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          justifyContent="spaceBetween"
-          responsive={false}
-        >
-          <EuiFlexItem grow={false}>
-            <h4>{i18n.TAGS}</h4>
+  useEffect(
+    () =>
+      setOptions(
+        tagOptions.map((label) => ({
+          label,
+        }))
+      ),
+    [tagOptions]
+  );
+  return (
+    <EuiText data-test-subj="case-view-tag-list">
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="xs"
+        justifyContent="spaceBetween"
+        responsive={false}
+      >
+        <EuiFlexItem grow={false}>
+          <h4>{i18n.TAGS}</h4>
+        </EuiFlexItem>
+        {isLoading && <EuiLoadingSpinner data-test-subj="tag-list-loading" />}
+        {!isLoading && permissions.update && (
+          <EuiFlexItem data-test-subj="tag-list-edit" grow={false}>
+            <EuiButtonIcon
+              data-test-subj="tag-list-edit-button"
+              aria-label={i18n.EDIT_TAGS_ARIA}
+              iconType={'pencil'}
+              onClick={setIsEditTags.bind(null, true)}
+            />
           </EuiFlexItem>
-          {isLoading && <EuiLoadingSpinner data-test-subj="tag-list-loading" />}
-          {!isLoading && userCanCrud && (
-            <EuiFlexItem data-test-subj="tag-list-edit" grow={false}>
-              <EuiButtonIcon
-                data-test-subj="tag-list-edit-button"
-                aria-label={i18n.EDIT_TAGS_ARIA}
-                iconType={'pencil'}
-                onClick={setIsEditTags.bind(null, true)}
-              />
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-        <EuiHorizontalRule margin="xs" />
-        <MyFlexGroup gutterSize="none" data-test-subj="case-tags">
-          {tags.length === 0 && !isEditTags && <p data-test-subj="no-tags">{i18n.NO_TAGS}</p>}
-          {!isEditTags && (
+        )}
+      </EuiFlexGroup>
+      <EuiHorizontalRule margin="xs" />
+      <MyFlexGroup gutterSize="none" data-test-subj="case-tags">
+        {tags.length === 0 && !isEditTags && <p data-test-subj="no-tags">{i18n.NO_TAGS}</p>}
+        {!isEditTags && (
+          <EuiFlexItem>
+            <Tags tags={tags} color="hollow" />
+          </EuiFlexItem>
+        )}
+        {isEditTags && (
+          <ColumnFlexGroup data-test-subj="edit-tags" direction="column">
             <EuiFlexItem>
-              <Tags tags={tags} color="hollow" />
-            </EuiFlexItem>
-          )}
-          {isEditTags && (
-            <ColumnFlexGroup data-test-subj="edit-tags" direction="column">
-              <EuiFlexItem>
-                <Form form={form}>
-                  <CommonUseField
-                    path="tags"
-                    componentProps={{
-                      idAria: 'caseTags',
-                      'data-test-subj': 'caseTags',
-                      euiFieldProps: {
-                        fullWidth: true,
-                        placeholder: '',
-                        options,
-                        noSuggestions: false,
-                      },
-                    }}
-                  />
-                  <FormDataProvider pathsToWatch="tags">
-                    {({ tags: anotherTags }) => {
-                      const current: string[] = options.map((opt) => opt.label);
-                      const newOptions = anotherTags.reduce((acc: string[], item: string) => {
-                        if (!acc.includes(item)) {
-                          return [...acc, item];
-                        }
-                        return acc;
-                      }, current);
-                      if (!isEqual(current, newOptions)) {
-                        setOptions(
-                          newOptions.map((label: string) => ({
-                            label,
-                          }))
-                        );
+              <Form form={form}>
+                <CommonUseField
+                  path="tags"
+                  componentProps={{
+                    idAria: 'caseTags',
+                    'data-test-subj': 'caseTags',
+                    euiFieldProps: {
+                      fullWidth: true,
+                      placeholder: '',
+                      options,
+                      noSuggestions: false,
+                    },
+                  }}
+                />
+                <FormDataProvider pathsToWatch="tags">
+                  {({ tags: anotherTags }) => {
+                    const current: string[] = options.map((opt) => opt.label);
+                    const newOptions = anotherTags.reduce((acc: string[], item: string) => {
+                      if (!acc.includes(item)) {
+                        return [...acc, item];
                       }
-                      return null;
-                    }}
-                  </FormDataProvider>
-                </Form>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      color="success"
-                      data-test-subj="edit-tags-submit"
-                      fill
-                      iconType="save"
-                      onClick={onSubmitTags}
-                      size="s"
-                    >
-                      {i18n.SAVE}
-                    </EuiButton>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      data-test-subj="edit-tags-cancel"
-                      iconType="cross"
-                      onClick={setIsEditTags.bind(null, false)}
-                      size="s"
-                    >
-                      {i18n.CANCEL}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-            </ColumnFlexGroup>
-          )}
-        </MyFlexGroup>
-      </EuiText>
-    );
-  }
-);
+                      return acc;
+                    }, current);
+                    if (!isEqual(current, newOptions)) {
+                      setOptions(
+                        newOptions.map((label: string) => ({
+                          label,
+                        }))
+                      );
+                    }
+                    return null;
+                  }}
+                </FormDataProvider>
+              </Form>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color="success"
+                    data-test-subj="edit-tags-submit"
+                    fill
+                    iconType="save"
+                    onClick={onSubmitTags}
+                    size="s"
+                  >
+                    {i18n.SAVE}
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj="edit-tags-cancel"
+                    iconType="cross"
+                    onClick={setIsEditTags.bind(null, false)}
+                    size="s"
+                  >
+                    {i18n.CANCEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </ColumnFlexGroup>
+        )}
+      </MyFlexGroup>
+    </EuiText>
+  );
+});
 
 TagList.displayName = 'TagList';

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.test.tsx
@@ -11,7 +11,7 @@ import { render, screen } from '@testing-library/react';
 
 import '../../common/mock/match_media';
 import { usePushToService, ReturnUsePushToService, UsePushToService } from '.';
-import { TestProviders } from '../../common/mock';
+import { readCasesPermissions, TestProviders } from '../../common/mock';
 import { CaseStatuses, ConnectorTypes } from '../../../common/api';
 import { usePostPushToService } from '../../containers/use_post_push_to_service';
 import { basicPush, actionLicenses, connectorsMock } from '../../containers/mock';
@@ -70,7 +70,6 @@ describe('usePushToService', () => {
     hasDataToPush: true,
     onEditClick,
     isValidConnector: true,
-    userCanCrud: true,
   };
 
   beforeEach(() => {
@@ -281,8 +280,6 @@ describe('usePushToService', () => {
   });
 
   describe('user does not have write permissions', () => {
-    const noWriteProps = { ...defaultArgs, userCanCrud: false };
-
     it('does not display a message when user does not have a premium license', async () => {
       useFetchActionLicenseMock.mockImplementation(() => ({
         isLoading: false,
@@ -293,9 +290,11 @@ describe('usePushToService', () => {
       }));
       await act(async () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
-          () => usePushToService(noWriteProps),
+          () => usePushToService(defaultArgs),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -313,9 +312,11 @@ describe('usePushToService', () => {
       }));
       await act(async () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
-          () => usePushToService(noWriteProps),
+          () => usePushToService(defaultArgs),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -328,7 +329,7 @@ describe('usePushToService', () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
           () =>
             usePushToService({
-              ...noWriteProps,
+              ...defaultArgs,
               connectors: [],
               connector: {
                 id: 'none',
@@ -338,7 +339,9 @@ describe('usePushToService', () => {
               },
             }),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -351,7 +354,7 @@ describe('usePushToService', () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
           () =>
             usePushToService({
-              ...noWriteProps,
+              ...defaultArgs,
               connector: {
                 id: 'none',
                 name: 'none',
@@ -360,7 +363,9 @@ describe('usePushToService', () => {
               },
             }),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -373,7 +378,7 @@ describe('usePushToService', () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
           () =>
             usePushToService({
-              ...noWriteProps,
+              ...defaultArgs,
               connector: {
                 id: 'not-exist',
                 name: 'not-exist',
@@ -383,7 +388,9 @@ describe('usePushToService', () => {
               isValidConnector: false,
             }),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -396,7 +403,7 @@ describe('usePushToService', () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
           () =>
             usePushToService({
-              ...noWriteProps,
+              ...defaultArgs,
               connectors: [],
               connector: {
                 id: 'not-exist',
@@ -407,7 +414,9 @@ describe('usePushToService', () => {
               isValidConnector: false,
             }),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();
@@ -420,11 +429,13 @@ describe('usePushToService', () => {
         const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
           () =>
             usePushToService({
-              ...noWriteProps,
+              ...defaultArgs,
               caseStatus: CaseStatuses.closed,
             }),
           {
-            wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+            wrapper: ({ children }) => (
+              <TestProviders permissions={readCasesPermissions()}> {children}</TestProviders>
+            ),
           }
         );
         await waitForNextUpdate();

--- a/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/cases/public/components/use_push_to_service/index.tsx
@@ -23,6 +23,7 @@ import { CaseServices } from '../../containers/use_get_case_user_actions';
 import { ErrorMessage } from './callout/types';
 import { useRefreshCaseViewPage } from '../case_view/use_on_refresh_case_view_page';
 import { useGetActionLicense } from '../../containers/use_get_action_license';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 export interface UsePushToService {
   caseId: string;
@@ -33,7 +34,6 @@ export interface UsePushToService {
   hasDataToPush: boolean;
   isValidConnector: boolean;
   onEditClick: () => void;
-  userCanCrud: boolean;
 }
 
 export interface ReturnUsePushToService {
@@ -50,8 +50,8 @@ export const usePushToService = ({
   hasDataToPush,
   isValidConnector,
   onEditClick,
-  userCanCrud,
 }: UsePushToService): ReturnUsePushToService => {
+  const { permissions } = useCasesContext();
   const { isLoading, pushCaseToExternalService } = usePostPushToService();
 
   const { isLoading: loadingLicense, data: actionLicense = null } = useGetActionLicense();
@@ -76,7 +76,7 @@ export const usePushToService = ({
 
     // these message require that the user do some sort of write action as a result of the message, readonly users won't
     // be able to perform such an action so let's not display the error to the user in that situation
-    if (!userCanCrud) {
+    if (!permissions.all) {
       return errors;
     }
 
@@ -114,7 +114,7 @@ export const usePushToService = ({
 
     return errors;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actionLicense, caseStatus, connectors.length, connector, loadingLicense, userCanCrud]);
+  }, [actionLicense, caseStatus, connectors.length, connector, loadingLicense, permissions]);
 
   const pushToServiceButton = useMemo(
     () => (
@@ -126,7 +126,7 @@ export const usePushToService = ({
           isLoading ||
           loadingLicense ||
           errorsMsg.length > 0 ||
-          !userCanCrud ||
+          !permissions.all ||
           !isValidConnector ||
           !hasDataToPush
         }
@@ -146,7 +146,7 @@ export const usePushToService = ({
       hasDataToPush,
       isLoading,
       loadingLicense,
-      userCanCrud,
+      permissions,
       isValidConnector,
     ]
   );
@@ -154,7 +154,7 @@ export const usePushToService = ({
   const objToReturn = useMemo(
     () => ({
       pushButton:
-        errorsMsg.length > 0 || !hasDataToPush ? (
+        errorsMsg.length > 0 || !hasDataToPush || !permissions.all ? (
           <EuiToolTip
             position="top"
             title={
@@ -187,6 +187,7 @@ export const usePushToService = ({
       hasLicenseError,
       onEditClick,
       pushToServiceButton,
+      permissions,
     ]
   );
 

--- a/x-pack/plugins/cases/public/components/user_actions/comment/comment.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/comment.tsx
@@ -39,7 +39,6 @@ const getDeleteCommentUserAction = ({
 const getCreateCommentUserAction = ({
   userAction,
   comment,
-  userCanCrud,
   commentRefs,
   manageMarkdownEditIds,
   selectedOutlineCommentId,
@@ -65,7 +64,6 @@ const getCreateCommentUserAction = ({
     case CommentType.user:
       const userBuilder = createUserAttachmentUserActionBuilder({
         comment,
-        userCanCrud,
         outlined: comment.id === selectedOutlineCommentId,
         isEdit: manageMarkdownEditIds.includes(comment.id),
         commentRefs,
@@ -104,7 +102,6 @@ const getCreateCommentUserAction = ({
 export const createCommentUserActionBuilder: UserActionBuilder = ({
   caseData,
   userAction,
-  userCanCrud,
   commentRefs,
   manageMarkdownEditIds,
   selectedOutlineCommentId,
@@ -137,7 +134,6 @@ export const createCommentUserActionBuilder: UserActionBuilder = ({
       const commentAction = getCreateCommentUserAction({
         userAction: commentUserAction,
         comment,
-        userCanCrud,
         commentRefs,
         manageMarkdownEditIds,
         selectedOutlineCommentId,

--- a/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/user.tsx
@@ -20,7 +20,6 @@ import { UserActionBuilderArgs, UserActionBuilder } from '../types';
 
 type BuilderArgs = Pick<
   UserActionBuilderArgs,
-  | 'userCanCrud'
   | 'handleManageMarkdownEditId'
   | 'handleSaveComment'
   | 'handleManageQuote'
@@ -35,7 +34,6 @@ type BuilderArgs = Pick<
 
 export const createUserAttachmentUserActionBuilder = ({
   comment,
-  userCanCrud,
   outlined,
   isEdit,
   isLoading,
@@ -95,7 +93,6 @@ export const createUserAttachmentUserActionBuilder = ({
           onEdit={handleManageMarkdownEditId.bind(null, comment.id)}
           onQuote={handleManageQuote.bind(null, comment.comment)}
           onDelete={handleDeleteComment.bind(null, comment.id)}
-          userCanCrud={userCanCrud}
         />
       ),
     },

--- a/x-pack/plugins/cases/public/components/user_actions/content_toolbar.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/content_toolbar.test.tsx
@@ -17,7 +17,6 @@ const props: UserActionContentToolbarProps = {
   id: '1',
   editLabel: 'edit',
   quoteLabel: 'quote',
-  userCanCrud: true,
   isLoading: false,
   onEdit: jest.fn(),
   onQuote: jest.fn(),

--- a/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
@@ -22,7 +22,6 @@ export interface UserActionContentToolbarProps {
   onEdit: (id: string) => void;
   onQuote: (id: string) => void;
   onDelete?: (id: string) => void;
-  userCanCrud: boolean;
 }
 
 const UserActionContentToolbarComponent = ({
@@ -36,7 +35,6 @@ const UserActionContentToolbarComponent = ({
   onEdit,
   onQuote,
   onDelete,
-  userCanCrud,
 }: UserActionContentToolbarProps) => (
   <EuiFlexGroup responsive={false} alignItems="center">
     <EuiFlexItem grow={false}>
@@ -53,7 +51,6 @@ const UserActionContentToolbarComponent = ({
         onEdit={onEdit}
         onQuote={onQuote}
         onDelete={onDelete}
-        userCanCrud={userCanCrud}
         commentMarkdown={commentMarkdown}
       />
     </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/user_actions/description.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/description.tsx
@@ -27,7 +27,6 @@ type GetDescriptionUserActionArgs = Pick<
   | 'caseData'
   | 'commentRefs'
   | 'manageMarkdownEditIds'
-  | 'userCanCrud'
   | 'handleManageMarkdownEditId'
   | 'handleManageQuote'
 > &
@@ -38,7 +37,6 @@ export const getDescriptionUserAction = ({
   commentRefs,
   manageMarkdownEditIds,
   isLoadingDescription,
-  userCanCrud,
   onUpdateField,
   handleManageMarkdownEditId,
   handleManageQuote,
@@ -85,7 +83,6 @@ export const getDescriptionUserAction = ({
         isLoading={isLoadingDescription}
         onEdit={handleManageMarkdownEditId.bind(null, DESCRIPTION_ID)}
         onQuote={handleManageQuote.bind(null, caseData.description)}
-        userCanCrud={userCanCrud}
       />
     ),
   };

--- a/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
@@ -44,7 +44,6 @@ const defaultProps = {
   selectedAlertPatterns: ['some-test-pattern'],
   statusActionButton: null,
   updateCase,
-  userCanCrud: true,
   useFetchAlertData: (): [boolean, Record<string, unknown>] => [
     false,
     { 'some-id': { _id: 'some-id' } },

--- a/x-pack/plugins/cases/public/components/user_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.tsx
@@ -27,6 +27,7 @@ import type { UserActionTreeProps } from './types';
 import { getDescriptionUserAction } from './description';
 import { useUserActionsHandler } from './use_user_actions_handler';
 import { NEW_COMMENT_ID } from './constants';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 const MyEuiFlexGroup = styled(EuiFlexGroup)`
   margin-bottom: 8px;
@@ -90,7 +91,6 @@ export const UserActions = React.memo(
     onUpdateField,
     statusActionButton,
     useFetchAlertData,
-    userCanCrud,
   }: UserActionTreeProps) => {
     const { detailName: caseId, commentId } = useCaseViewParams();
     const [initLoading, setInitLoading] = useState(true);
@@ -121,7 +121,6 @@ export const UserActions = React.memo(
         <AddComment
           id={NEW_COMMENT_ID}
           caseId={caseId}
-          userCanCrud={userCanCrud}
           ref={(element) => (commentRefs.current[NEW_COMMENT_ID] = element)}
           onCommentPosted={handleUpdate}
           onCommentSaving={handleManageMarkdownEditId.bind(null, NEW_COMMENT_ID)}
@@ -129,14 +128,7 @@ export const UserActions = React.memo(
           statusActionButton={statusActionButton}
         />
       ),
-      [
-        caseId,
-        userCanCrud,
-        handleUpdate,
-        handleManageMarkdownEditId,
-        statusActionButton,
-        commentRefs,
-      ]
+      [caseId, handleUpdate, handleManageMarkdownEditId, statusActionButton, commentRefs]
     );
 
     useEffect(() => {
@@ -155,7 +147,6 @@ export const UserActions = React.memo(
           commentRefs,
           manageMarkdownEditIds,
           isLoadingDescription,
-          userCanCrud,
           onUpdateField,
           handleManageMarkdownEditId,
           handleManageQuote,
@@ -165,7 +156,6 @@ export const UserActions = React.memo(
         commentRefs,
         manageMarkdownEditIds,
         isLoadingDescription,
-        userCanCrud,
         onUpdateField,
         handleManageMarkdownEditId,
         handleManageQuote,
@@ -192,7 +182,6 @@ export const UserActions = React.memo(
               caseServices,
               comments: caseData.comments,
               index,
-              userCanCrud,
               commentRefs,
               manageMarkdownEditIds,
               selectedOutlineCommentId,
@@ -218,7 +207,6 @@ export const UserActions = React.memo(
         descriptionCommentListObj,
         caseData,
         caseServices,
-        userCanCrud,
         commentRefs,
         manageMarkdownEditIds,
         selectedOutlineCommentId,
@@ -237,7 +225,9 @@ export const UserActions = React.memo(
       ]
     );
 
-    const bottomActions = userCanCrud
+    const { permissions } = useCasesContext();
+
+    const bottomActions = permissions.update
       ? [
           {
             username: (

--- a/x-pack/plugins/cases/public/components/user_actions/mock.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/mock.ts
@@ -64,7 +64,6 @@ export const getMockBuilderArgs = (): UserActionBuilderArgs => {
     caseServices,
     index: 0,
     alertData,
-    userCanCrud: true,
     commentRefs,
     manageMarkdownEditIds: [],
     selectedOutlineCommentId: '',

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions.test.tsx
@@ -24,7 +24,6 @@ const props = {
   isLoading: false,
   onEdit,
   onQuote,
-  userCanCrud: true,
 };
 
 describe('UserActionPropertyActions ', () => {

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions.tsx
@@ -11,6 +11,7 @@ import { EuiConfirmModal, EuiLoadingSpinner } from '@elastic/eui';
 import { PropertyActions } from '../property_actions';
 import { useLensOpenVisualization } from '../markdown_editor/plugins/lens/use_lens_open_visualization';
 import { CANCEL_BUTTON, CONFIRM_BUTTON } from './translations';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 interface UserActionPropertyActionsProps {
   id: string;
@@ -22,7 +23,6 @@ interface UserActionPropertyActionsProps {
   onEdit: (id: string) => void;
   onDelete?: (id: string) => void;
   onQuote: (id: string) => void;
-  userCanCrud: boolean;
   commentMarkdown: string;
 }
 
@@ -36,9 +36,9 @@ const UserActionPropertyActionsComponent = ({
   onEdit,
   onDelete,
   onQuote,
-  userCanCrud,
   commentMarkdown,
 }: UserActionPropertyActionsProps) => {
+  const { permissions } = useCasesContext();
   const { canUseEditor, actionConfig } = useLensOpenVisualization({ comment: commentMarkdown });
   const onEditClick = useCallback(() => onEdit(id), [id, onEdit]);
   const onQuoteClick = useCallback(() => onQuote(id), [id, onQuote]);
@@ -62,7 +62,7 @@ const UserActionPropertyActionsComponent = ({
   const propertyActions = useMemo(
     () =>
       [
-        userCanCrud
+        permissions.all
           ? [
               {
                 iconType: 'pencil',
@@ -88,7 +88,7 @@ const UserActionPropertyActionsComponent = ({
         canUseEditor && actionConfig ? [actionConfig] : [],
       ].flat(),
     [
-      userCanCrud,
+      permissions,
       editLabel,
       onEditClick,
       deleteLabel,

--- a/x-pack/plugins/cases/public/components/user_actions/types.ts
+++ b/x-pack/plugins/cases/public/components/user_actions/types.ts
@@ -29,7 +29,6 @@ export interface UserActionTreeProps {
   onUpdateField: ({ key, value, onSuccess, onError }: OnUpdateFields) => void;
   statusActionButton: JSX.Element | null;
   useFetchAlertData: UseFetchAlertData;
-  userCanCrud: boolean;
 }
 
 type UnsupportedUserActionTypes = typeof UNSUPPORTED_ACTION_TYPES[number];
@@ -41,7 +40,6 @@ export interface UserActionBuilderArgs {
   caseServices: CaseServices;
   comments: Comment[];
   index: number;
-  userCanCrud: boolean;
   commentRefs: React.MutableRefObject<
     Record<string, AddCommentRefObject | UserActionMarkdownRefObject | null | undefined>
   >;

--- a/x-pack/plugins/cases/public/plugin.ts
+++ b/x-pack/plugins/cases/public/plugin.ts
@@ -24,6 +24,7 @@ import { getCasesContextLazy } from './client/ui/get_cases_context';
 import { getCreateCaseFlyoutLazy } from './client/ui/get_create_case_flyout';
 import { getRecentCasesLazy } from './client/ui/get_recent_cases';
 import { groupAlertsByRule } from './client/helpers/group_alerts_by_rule';
+import { getUICapabilities } from './client/helpers/capabilities';
 
 /**
  * @public
@@ -104,6 +105,7 @@ export class CasesUiPlugin
         canUseCases: canUseCases(core.application.capabilities),
         getRuleIdFromEvent,
         groupAlertsByRule,
+        getUICapabilities,
       },
     };
   }

--- a/x-pack/plugins/cases/public/types.ts
+++ b/x-pack/plugins/cases/public/types.ts
@@ -37,6 +37,7 @@ import { GetCreateCaseFlyoutProps } from './client/ui/get_create_case_flyout';
 import { GetRecentCasesProps } from './client/ui/get_recent_cases';
 import { Cases, CasesStatus, CasesMetrics } from '../common/ui';
 import { groupAlertsByRule } from './client/helpers/group_alerts_by_rule';
+import { getUICapabilities } from './client/helpers/capabilities';
 
 export interface CasesPluginSetup {
   security: SecurityPluginSetup;
@@ -131,6 +132,8 @@ export interface CasesUiStart {
     canUseCases: (owners?: CasesOwners[]) => { crud: boolean; read: boolean };
     getRuleIdFromEvent: typeof getRuleIdFromEvent;
     groupAlertsByRule: typeof groupAlertsByRule;
+    // TODO: implement a helper that takes care of setting the create, read, update, and delete based on the capabilities provided
+    getUICapabilities: typeof getUICapabilities;
   };
 }
 

--- a/x-pack/plugins/cases/server/capabilties.ts
+++ b/x-pack/plugins/cases/server/capabilties.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Return the UI capabilities for each type of operation. These strings must match the values defined in the UI
+ * here: x-pack/plugins/cases/public/client/helpers/capabilities.ts
+ */
+export const createUICapabilities = () => ({
+  all: ['create_cases', 'read_cases', 'update_cases'] as const,
+  read: ['read_cases'] as const,
+  delete: ['delete_cases'] as const,
+});

--- a/x-pack/plugins/cases/server/features.ts
+++ b/x-pack/plugins/cases/server/features.ts
@@ -11,6 +11,7 @@ import { KibanaFeatureConfig } from '@kbn/features-plugin/common';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 
 import { APP_ID, FEATURE_ID } from '../common/constants';
+import { createUICapabilities } from './capabilties';
 
 /**
  * The order of appearance in the feature privilege page
@@ -20,44 +21,75 @@ import { APP_ID, FEATURE_ID } from '../common/constants';
 
 const FEATURE_ORDER = 3100;
 
-export const getCasesKibanaFeature = (): KibanaFeatureConfig => ({
-  id: FEATURE_ID,
-  name: i18n.translate('xpack.cases.features.casesFeatureName', {
-    defaultMessage: 'Cases',
-  }),
-  category: DEFAULT_APP_CATEGORIES.management,
-  app: [],
-  order: FEATURE_ORDER,
-  management: {
-    insightsAndAlerting: [APP_ID],
-  },
-  cases: [APP_ID],
-  privileges: {
-    all: {
-      cases: {
-        all: [APP_ID],
-      },
-      management: {
-        insightsAndAlerting: [APP_ID],
-      },
-      savedObject: {
-        all: [],
-        read: [],
-      },
-      ui: ['crud_cases', 'read_cases'],
+export const getCasesKibanaFeature = (): KibanaFeatureConfig => {
+  const capabilities = createUICapabilities();
+
+  return {
+    id: FEATURE_ID,
+    name: i18n.translate('xpack.cases.features.casesFeatureName', {
+      defaultMessage: 'Cases',
+    }),
+    category: DEFAULT_APP_CATEGORIES.management,
+    app: [],
+    order: FEATURE_ORDER,
+    management: {
+      insightsAndAlerting: [APP_ID],
     },
-    read: {
-      cases: {
-        read: [APP_ID],
+    cases: [APP_ID],
+    privileges: {
+      all: {
+        cases: {
+          all: [APP_ID],
+        },
+        management: {
+          insightsAndAlerting: [APP_ID],
+        },
+        savedObject: {
+          all: [],
+          read: [],
+        },
+        ui: capabilities.all,
       },
-      management: {
-        insightsAndAlerting: [APP_ID],
+      read: {
+        cases: {
+          read: [APP_ID],
+        },
+        management: {
+          insightsAndAlerting: [APP_ID],
+        },
+        savedObject: {
+          all: [],
+          read: [],
+        },
+        ui: capabilities.read,
       },
-      savedObject: {
-        all: [],
-        read: [],
-      },
-      ui: ['read_cases'],
     },
-  },
-});
+    subFeatures: [
+      {
+        name: i18n.translate('xpack.cases.features.deleteSubFeatureName', {
+          defaultMessage: 'Delete',
+        }),
+        privilegeGroups: [
+          {
+            groupType: 'independent',
+            privileges: [
+              {
+                api: [],
+                id: 'cases_delete',
+                name: i18n.translate('xpack.cases.features.deleteSubFeatureDetails', {
+                  defaultMessage: 'Delete entities',
+                }),
+                includeIn: 'all',
+                savedObject: {
+                  all: [],
+                  read: [],
+                },
+                ui: capabilities.delete,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+};

--- a/x-pack/plugins/cases/server/index.ts
+++ b/x-pack/plugins/cases/server/index.ts
@@ -22,4 +22,4 @@ export const config: PluginConfigDescriptor<ConfigType> = {
 export const plugin = (initializerContext: PluginInitializerContext) =>
   new CasePlugin(initializerContext);
 
-export type { PluginStartContract } from './plugin';
+export type { PluginStartContract, PluginSetupContract } from './plugin';

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -49,6 +49,7 @@ import { registerRoutes } from './routes/api/register_routes';
 import { getExternalRoutes } from './routes/api/get_external_routes';
 import { createCasesTelemetry, scheduleCasesTelemetryTask } from './telemetry';
 import { getInternalRoutes } from './routes/api/get_internal_routes';
+import { createUICapabilities } from './capabilties';
 
 export interface PluginsSetup {
   actions: ActionsPluginSetup;
@@ -65,6 +66,10 @@ export interface PluginsStart {
   taskManager?: TaskManagerStartContract;
   security?: SecurityPluginStart;
   spaces?: SpacesPluginStart;
+}
+
+export interface PluginSetupContract {
+  createUICapabilities: typeof createUICapabilities;
 }
 
 /**
@@ -145,6 +150,10 @@ export class CasePlugin {
       kibanaVersion: this.kibanaVersion,
       telemetryUsageCounter,
     });
+
+    return {
+      createUICapabilities,
+    };
   }
 
   public start(core: CoreStart, plugins: PluginsStart): PluginStartContract {

--- a/x-pack/plugins/observability/public/hooks/use_alert_bulk_case_actions.ts
+++ b/x-pack/plugins/observability/public/hooks/use_alert_bulk_case_actions.ts
@@ -25,8 +25,7 @@ export interface UseAddToCaseActions {
 export const useBulkAddToCaseActions = ({ onClose, onSuccess }: UseAddToCaseActions = {}) => {
   const { cases: casesUi } = useKibana<ObservabilityAppServices>().services;
 
-  const casePermissions = useGetUserCasesPermissions();
-  const hasWritePermissions = casePermissions?.crud ?? false;
+  const casesPermissions = useGetUserCasesPermissions();
 
   const createCaseFlyout = casesUi.hooks.getUseCasesAddToNewCaseFlyout({
     onClose,
@@ -38,7 +37,7 @@ export const useBulkAddToCaseActions = ({ onClose, onSuccess }: UseAddToCaseActi
   });
 
   return useMemo(() => {
-    return hasWritePermissions
+    return casesPermissions.create
       ? [
           {
             label: ADD_TO_NEW_CASE,
@@ -68,5 +67,5 @@ export const useBulkAddToCaseActions = ({ onClose, onSuccess }: UseAddToCaseActi
           },
         ]
       : [];
-  }, [casesUi.helpers, createCaseFlyout, hasWritePermissions, selectCaseModal]);
+  }, [casesUi.helpers, createCaseFlyout, casesPermissions, selectCaseModal]);
 };

--- a/x-pack/plugins/observability/public/hooks/use_get_user_cases_permissions.test.ts
+++ b/x-pack/plugins/observability/public/hooks/use_get_user_cases_permissions.test.ts
@@ -28,14 +28,22 @@ describe('useGetUserCasesPermissions', function () {
           ...mockUseKibanaReturnValue.services.application,
           capabilities: {
             ...applicationServiceMock.createStartContract().capabilities,
-            [casesFeatureId]: { crud_cases: false, read_cases: true },
+            [casesFeatureId]: {
+              create_cases: false,
+              update_cases: true,
+              delete_cases: false,
+              read_cases: true,
+            },
           },
         },
       },
     };
     const { result } = renderHook(() => useGetUserCasesPermissions(), {});
     expect(result.current?.read).toBe(true);
-    expect(result.current?.crud).toBe(false);
+    expect(result.current?.all).toBe(false);
+    expect(result.current?.create).toBe(false);
+    expect(result.current?.update).toBe(true);
+    expect(result.current?.delete).toBe(false);
   });
 
   it('returns false when capabilities entry permissions are missing', () => {
@@ -56,7 +64,10 @@ describe('useGetUserCasesPermissions', function () {
     };
     const { result } = renderHook(() => useGetUserCasesPermissions(), {});
     expect(result.current?.read).toBe(false);
-    expect(result.current?.crud).toBe(false);
+    expect(result.current?.all).toBe(false);
+    expect(result.current?.create).toBe(false);
+    expect(result.current?.update).toBe(false);
+    expect(result.current?.delete).toBe(false);
   });
 
   it('returns false when capabilities entry is missing entirely', () => {
@@ -74,6 +85,9 @@ describe('useGetUserCasesPermissions', function () {
     };
     const { result } = renderHook(() => useGetUserCasesPermissions(), {});
     expect(result.current?.read).toBe(false);
-    expect(result.current?.crud).toBe(false);
+    expect(result.current?.all).toBe(false);
+    expect(result.current?.create).toBe(false);
+    expect(result.current?.update).toBe(false);
+    expect(result.current?.delete).toBe(false);
   });
 });

--- a/x-pack/plugins/observability/public/hooks/use_get_user_cases_permissions.tsx
+++ b/x-pack/plugins/observability/public/hooks/use_get_user_cases_permissions.tsx
@@ -10,28 +10,36 @@ import { useKibana } from '../utils/kibana_react';
 import { casesFeatureId } from '../../common';
 
 export interface UseGetUserCasesPermissions {
-  crud: boolean;
+  all: boolean;
   read: boolean;
+  create: boolean;
+  update: boolean;
+  delete: boolean;
 }
 
 export function useGetUserCasesPermissions() {
-  const [casesPermissions, setCasesPermissions] = useState<UseGetUserCasesPermissions | null>(null);
+  const [casesPermissions, setCasesPermissions] = useState<UseGetUserCasesPermissions>({
+    all: false,
+    read: false,
+    create: false,
+    update: false,
+    delete: false,
+  });
   const uiCapabilities = useKibana().services.application.capabilities;
 
+  const casesCapabilities = useKibana().services.cases.helpers.getUICapabilities(
+    uiCapabilities[casesFeatureId]
+  );
+
   useEffect(() => {
-    const capabilitiesCanUserCRUD: boolean =
-      typeof uiCapabilities[casesFeatureId]?.crud_cases === 'boolean'
-        ? (uiCapabilities[casesFeatureId].crud_cases as boolean)
-        : false;
-    const capabilitiesCanUserRead: boolean =
-      typeof uiCapabilities[casesFeatureId]?.read_cases === 'boolean'
-        ? (uiCapabilities[casesFeatureId].read_cases as boolean)
-        : false;
     setCasesPermissions({
-      crud: capabilitiesCanUserCRUD,
-      read: capabilitiesCanUserRead,
+      all: casesCapabilities.all,
+      read: casesCapabilities.read,
+      update: casesCapabilities.update,
+      delete: casesCapabilities.delete,
+      create: casesCapabilities.create,
     });
-  }, [uiCapabilities]);
+  }, [casesCapabilities]);
 
   return casesPermissions;
 }

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -264,7 +264,7 @@ function AlertsPage() {
         <EuiFlexItem>
           <CasesContext
             owner={[observabilityFeatureId]}
-            userCanCrud={userPermissions?.crud ?? false}
+            permissions={userPermissions}
             features={{ alerts: { sync: false } }}
           >
             <AlertsTableTGrid

--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_table_t_grid/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_table_t_grid/alerts_table_t_grid.tsx
@@ -201,7 +201,7 @@ function ObservabilityActions({
 
   const actionsMenuItems = useMemo(() => {
     return [
-      ...(casePermissions?.crud
+      ...(casePermissions.create
         ? [
             <EuiContextMenuItem
               data-test-subj="add-to-existing-case-action"
@@ -246,7 +246,7 @@ function ObservabilityActions({
       ],
     ];
   }, [
-    casePermissions?.crud,
+    casePermissions.create,
     handleAddToExistingCaseClick,
     handleAddToNewCaseClick,
     linkToRule,

--- a/x-pack/plugins/observability/public/pages/cases/cases.tsx
+++ b/x-pack/plugins/observability/public/pages/cases/cases.tsx
@@ -13,11 +13,12 @@ import { usePluginContext } from '../../hooks/use_plugin_context';
 import { LazyAlertsFlyout } from '../..';
 import { useFetchAlertDetail } from './use_fetch_alert_detail';
 import { useFetchAlertData } from './use_fetch_alert_data';
+import { UseGetUserCasesPermissions } from '../../hooks/use_get_user_cases_permissions';
 
 interface CasesProps {
-  userCanCrud: boolean;
+  permissions: UseGetUserCasesPermissions;
 }
-export const Cases = React.memo<CasesProps>(({ userCanCrud }) => {
+export const Cases = React.memo<CasesProps>(({ permissions }) => {
   const {
     cases,
     application: { getUrlForApp, navigateToApp },
@@ -44,7 +45,7 @@ export const Cases = React.memo<CasesProps>(({ userCanCrud }) => {
       )}
       {cases.ui.getCases({
         basePath: CASES_PATH,
-        userCanCrud,
+        permissions,
         owner: [CASES_OWNER],
         features: { alerts: { sync: false } },
         useFetchAlertData,

--- a/x-pack/plugins/observability/public/pages/cases/index.tsx
+++ b/x-pack/plugins/observability/public/pages/cases/index.tsx
@@ -38,12 +38,12 @@ export const CasesPage = React.memo(() => {
     docsLink: docLinks.links.observability.guide,
   });
 
-  return userPermissions == null || userPermissions?.read ? (
+  return userPermissions.read ? (
     <ObservabilityPageTemplate
       data-test-subj={noDataConfig ? 'noDataPage' : undefined}
       noDataConfig={noDataConfig}
     >
-      <Cases userCanCrud={userPermissions?.crud ?? false} />
+      <Cases permissions={userPermissions} />
     </ObservabilityPageTemplate>
   ) : (
     <CaseFeatureNoPermissions />

--- a/x-pack/plugins/observability/public/pages/overview/index.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/index.tsx
@@ -198,7 +198,7 @@ export function OverviewPage({ routeParams }: Props) {
               >
                 <CasesContext
                   owner={[observabilityFeatureId]}
-                  userCanCrud={userPermissions?.crud ?? false}
+                  permissions={userPermissions}
                   features={{ alerts: { sync: false } }}
                 >
                   <AlertsTableTGrid

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -14,6 +14,7 @@ import {
 } from '@kbn/core/server';
 import { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
 import { PluginSetupContract as FeaturesSetup } from '@kbn/features-plugin/server';
+import { PluginSetupContract as CasesPluginSetup } from '@kbn/cases-plugin/server';
 import { ObservabilityConfig } from '.';
 import {
   bootstrapAnnotations,
@@ -30,6 +31,7 @@ export type ObservabilityPluginSetup = ReturnType<ObservabilityPlugin['setup']>;
 interface PluginSetup {
   features: FeaturesSetup;
   ruleRegistry: RuleRegistryPluginSetupContract;
+  cases?: CasesPluginSetup;
 }
 
 export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
@@ -39,6 +41,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
 
   public setup(core: CoreSetup, plugins: PluginSetup) {
     const config = this.initContext.config.get<ObservabilityConfig>();
+    const casesCapabilities = plugins.cases?.createUICapabilities();
 
     plugins.features.registerKibanaFeature({
       id: casesFeatureId,
@@ -62,7 +65,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
             all: [],
             read: [],
           },
-          ui: ['crud_cases', 'read_cases'], // uiCapabilities[casesFeatureId].crud_cases or read_cases
+          ui: casesCapabilities?.all ?? [''],
         },
         read: {
           app: [casesFeatureId, 'kibana'],
@@ -75,9 +78,39 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
             all: [],
             read: [],
           },
-          ui: ['read_cases'], // uiCapabilities[uiCapabilities[casesFeatureId]].read_cases
+          ui: casesCapabilities?.read ?? [''],
         },
       },
+      subFeatures: [
+        {
+          name: i18n.translate('xpack.observability.featureRegistry.deleteSubFeatureName', {
+            defaultMessage: 'Delete',
+          }),
+          privilegeGroups: [
+            {
+              groupType: 'independent',
+              privileges: [
+                {
+                  api: [],
+                  id: 'cases_delete',
+                  name: i18n.translate(
+                    'xpack.observability.featureRegistry.deleteSubFeatureDetails',
+                    {
+                      defaultMessage: 'Delete entities',
+                    }
+                  ),
+                  includeIn: 'all',
+                  savedObject: {
+                    all: [],
+                    read: [],
+                  },
+                  ui: casesCapabilities?.delete ?? [''],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
 
     let annotationsApiPromise: Promise<AnnotationsAPI> | undefined;

--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -69,10 +69,7 @@ const StartAppComponent: FC<StartAppComponent> = ({
                   <UserPrivilegesProvider kibanaCapabilities={capabilities}>
                     <ManageUserInfo>
                       <ReactQueryClientProvider>
-                        <CasesContext
-                          owner={[APP_ID]}
-                          userCanCrud={casesPermissions?.crud ?? false}
-                        >
+                        <CasesContext owner={[APP_ID]} permissions={casesPermissions}>
                           <PageRouter
                             history={history}
                             onAppLeave={onAppLeave}

--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -147,7 +147,7 @@ const CaseContainerComponent: React.FC = () => {
             },
           },
           useFetchAlertData,
-          userCanCrud: userPermissions?.crud ?? false,
+          permissions: userPermissions,
         })}
       </CaseDetailsRefreshContext.Provider>
       <SpyRoute pageName={SecurityPageName.case} />

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.test.tsx
@@ -44,6 +44,10 @@ describe('Related Cases', () => {
     test('should not show related cases when user does not have permissions', () => {
       (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
         read: false,
+        update: false,
+        create: false,
+        delete: false,
+        all: false,
       });
       act(() => {
         render(
@@ -60,6 +64,10 @@ describe('Related Cases', () => {
     beforeEach(() => {
       (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
         read: true,
+        update: false,
+        create: false,
+        delete: false,
+        all: false,
       });
     });
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/related_cases.tsx
@@ -29,7 +29,7 @@ export const RelatedCases: React.FC<Props> = React.memo(({ eventId, isReadOnly }
   const [relatedCases, setRelatedCases] = useState<RelatedCaseList>([]);
   const [areCasesLoading, setAreCasesLoading] = useState(true);
   const [hasError, setHasError] = useState<boolean>(false);
-  const hasCasesReadPermissions = casePermissions?.read ?? false;
+  const hasCasesReadPermissions = casePermissions.read;
 
   const getRelatedCases = useCallback(async () => {
     let relatedCaseList: RelatedCaseList = [];

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -151,8 +151,11 @@ describe('useSecuritySolutionNavigation', () => {
     describe('cases', () => {
       it('should display the cases navigation item when the user has read permissions', () => {
         (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-          crud: true,
           read: true,
+          update: true,
+          create: true,
+          delete: true,
+          all: true,
         });
 
         const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(
@@ -179,8 +182,11 @@ describe('useSecuritySolutionNavigation', () => {
 
       it('should not display the cases navigation item when the user does not have read permissions', () => {
         (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-          crud: false,
           read: false,
+          update: false,
+          create: false,
+          delete: false,
+          all: false,
         });
 
         const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
@@ -65,7 +65,7 @@ export const usePrimaryNavigationItems = ({
 };
 
 function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
-  const hasCasesReadPermissions = useGetUserCasesPermissions()?.read;
+  const hasCasesReadPermissions = useGetUserCasesPermissions().read;
   const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
   const isPolicyListEnabled = useIsExperimentalFeatureEnabled('policyListEnabled');
   const uiCapabilities = useKibana().services.application.capabilities;

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/index.tsx
@@ -14,7 +14,6 @@ import { ModalInspectQuery } from '../inspect/modal';
 import { useInspect } from '../inspect/use_inspect';
 import { useLensAttributes } from './use_lens_attributes';
 import { useAddToExistingCase } from './use_add_to_existing_case';
-import { useGetUserCasesPermissions } from '../../lib/kibana';
 import { useAddToNewCase } from './use_add_to_new_case';
 import { VisualizationActionsProps } from './types';
 import {
@@ -54,8 +53,6 @@ const VisualizationActionsComponent: React.FC<VisualizationActionsProps> = ({
   stackByField,
 }) => {
   const { lens } = useKibana().services;
-  const userPermissions = useGetUserCasesPermissions();
-  const userCanCrud = userPermissions?.crud ?? false;
 
   const { canUseEditor, navigateToPrefilledEditor } = lens;
   const [isPopoverOpen, setPopover] = useState(false);
@@ -82,14 +79,12 @@ const VisualizationActionsComponent: React.FC<VisualizationActionsProps> = ({
       onAddToCaseClicked: closePopover,
       lensAttributes: attributes,
       timeRange: timerange,
-      userCanCrud,
     });
 
   const { onAddToNewCaseClicked, disabled: isAddToNewCaseDisabled } = useAddToNewCase({
     onClick: closePopover,
     timeRange: timerange,
     lensAttributes: attributes,
-    userCanCrud,
   });
 
   const onOpenInLens = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_existing_case.tsx
@@ -12,6 +12,7 @@ import { useKibana } from '../../lib/kibana/kibana_react';
 import { ADD_TO_CASE_SUCCESS } from './translations';
 
 import { LensAttributes } from './types';
+import { useGetUserCasesPermissions } from '../../lib/kibana';
 
 const owner = APP_ID;
 
@@ -19,13 +20,13 @@ export const useAddToExistingCase = ({
   onAddToCaseClicked,
   lensAttributes,
   timeRange,
-  userCanCrud,
 }: {
   onAddToCaseClicked?: () => void;
   lensAttributes: LensAttributes | null;
   timeRange: { from: string; to: string } | null;
-  userCanCrud: boolean;
 }) => {
+  const userPermissions = useGetUserCasesPermissions();
+
   const { cases } = useKibana().services;
   const attachments = useMemo(() => {
     return [
@@ -54,6 +55,6 @@ export const useAddToExistingCase = ({
 
   return {
     onAddToExistingCaseClicked,
-    disabled: lensAttributes == null || timeRange == null || !userCanCrud,
+    disabled: lensAttributes == null || timeRange == null || !userPermissions.create,
   };
 };

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_add_to_new_case.tsx
@@ -13,22 +13,19 @@ import { useKibana } from '../../lib/kibana/kibana_react';
 import { ADD_TO_CASE_SUCCESS } from './translations';
 
 import { LensAttributes } from './types';
+import { useGetUserCasesPermissions } from '../../lib/kibana';
 
 export interface UseAddToNewCaseProps {
   onClick?: () => void;
   timeRange: { from: string; to: string } | null;
   lensAttributes: LensAttributes | null;
-  userCanCrud: boolean;
 }
 
 const owner = APP_ID;
 
-export const useAddToNewCase = ({
-  onClick,
-  timeRange,
-  lensAttributes,
-  userCanCrud,
-}: UseAddToNewCaseProps) => {
+export const useAddToNewCase = ({ onClick, timeRange, lensAttributes }: UseAddToNewCaseProps) => {
+  const userPermissions = useGetUserCasesPermissions();
+
   const { cases } = useKibana().services;
   const attachments = useMemo(() => {
     return [
@@ -57,6 +54,6 @@ export const useAddToNewCase = ({
 
   return {
     onAddToNewCaseClicked,
-    disabled: lensAttributes == null || timeRange == null || !userCanCrud,
+    disabled: lensAttributes == null || timeRange == null || !userPermissions.create,
   };
 };

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/hooks.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/hooks.ts
@@ -147,20 +147,35 @@ export const useCurrentUser = (): AuthenticatedElasticUser | null => {
 };
 
 export interface UseGetUserCasesPermissions {
-  crud: boolean;
+  all: boolean;
+  create: boolean;
   read: boolean;
+  update: boolean;
+  delete: boolean;
 }
 
 export const useGetUserCasesPermissions = () => {
-  const [casesPermissions, setCasesPermissions] = useState<UseGetUserCasesPermissions | null>(null);
+  const [casesPermissions, setCasesPermissions] = useState<UseGetUserCasesPermissions>({
+    all: false,
+    create: false,
+    read: false,
+    update: false,
+    delete: false,
+  });
   const uiCapabilities = useKibana().services.application.capabilities;
+  const casesCapabilities = useKibana().services.cases.helpers.getUICapabilities(
+    uiCapabilities[CASES_FEATURE_ID]
+  );
 
   useEffect(() => {
     setCasesPermissions({
-      crud: !!uiCapabilities[CASES_FEATURE_ID]?.crud_cases,
-      read: !!uiCapabilities[CASES_FEATURE_ID]?.read_cases,
+      all: casesCapabilities.all,
+      create: casesCapabilities.create,
+      read: casesCapabilities.read,
+      update: casesCapabilities.update,
+      delete: casesCapabilities.delete,
     });
-  }, [uiCapabilities]);
+  }, [casesCapabilities]);
 
   return casesPermissions;
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -63,7 +63,10 @@ jest.mock('../../../../common/lib/kibana', () => ({
     },
   }),
   useGetUserCasesPermissions: jest.fn().mockReturnValue({
-    crud: true,
+    all: true,
+    create: true,
+    update: true,
+    delete: true,
     read: true,
   }),
 }));

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -35,7 +35,7 @@ export const useAddToCaseActions = ({
 }: UseAddToCaseActions) => {
   const { cases: casesUi } = useKibana().services;
   const casePermissions = useGetUserCasesPermissions();
-  const hasWritePermissions = casePermissions?.crud ?? false;
+  const hasWritePermissions = casePermissions.create;
 
   const isAlert = useMemo(() => {
     return ecsData?.event?.kind?.includes('signal');

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_bulk_add_to_case_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_bulk_add_to_case_actions.tsx
@@ -20,7 +20,7 @@ export const useBulkAddToCaseActions = ({ onClose, onSuccess }: UseAddToCaseActi
   const { cases: casesUi } = useKibana().services;
 
   const casePermissions = useGetUserCasesPermissions();
-  const hasWritePermissions = casePermissions?.crud ?? false;
+  const hasWritePermissions = casePermissions.create;
 
   const createCaseFlyout = casesUi.hooks.getUseCasesAddToNewCaseFlyout({
     onClose,

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
@@ -41,7 +41,13 @@ jest.mock('../user_info', () => ({
 }));
 
 jest.mock('../../../common/lib/kibana');
-(useGetUserCasesPermissions as jest.Mock).mockReturnValue({ crud: true });
+(useGetUserCasesPermissions as jest.Mock).mockReturnValue({
+  all: true,
+  create: true,
+  update: true,
+  delete: true,
+  read: true,
+});
 
 jest.mock('../../containers/detection_engine/alerts/use_alerts_privileges', () => ({
   useAlertsPrivileges: jest.fn().mockReturnValue({ hasIndexWrite: true, hasKibanaCRUD: true }),

--- a/x-pack/plugins/security_solution/public/overview/components/recent_cases/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/recent_cases/index.tsx
@@ -14,10 +14,10 @@ const MAX_CASES_TO_SHOW = 3;
 const RecentCasesComponent = () => {
   const { cases } = useKibana().services;
 
-  const userCanCrud = useGetUserCasesPermissions()?.crud ?? false;
+  const permissions = useGetUserCasesPermissions();
 
   return cases.ui.getRecentCases({
-    userCanCrud,
+    permissions,
     maxCasesToShow: MAX_CASES_TO_SHOW,
     owner: [APP_ID],
   });

--- a/x-pack/plugins/security_solution/public/overview/components/sidebar/sidebar.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/sidebar/sidebar.test.tsx
@@ -37,7 +37,10 @@ describe('Sidebar', () => {
 
   it('does not render the recently created cases section when the user does not have read permissions', async () => {
     (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-      crud: false,
+      all: false,
+      create: false,
+      update: false,
+      delete: false,
       read: false,
     });
 
@@ -54,7 +57,10 @@ describe('Sidebar', () => {
 
   it('does render the recently created cases section when the user has read permissions', async () => {
     (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-      crud: false,
+      all: false,
+      create: false,
+      update: false,
+      delete: false,
       read: true,
     });
 

--- a/x-pack/plugins/security_solution/public/overview/components/sidebar/sidebar.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/sidebar/sidebar.tsx
@@ -41,7 +41,7 @@ export const Sidebar = React.memo<{
   );
 
   // only render the recently created cases view if the user has at least read permissions
-  const hasCasesReadPermissions = useGetUserCasesPermissions()?.read;
+  const hasCasesReadPermissions = useGetUserCasesPermissions().read;
 
   return (
     <EuiFlexGroup direction="column" responsive={false} gutterSize="l">

--- a/x-pack/plugins/security_solution/public/overview/pages/detection_response.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/detection_response.test.tsx
@@ -67,7 +67,13 @@ jest.mock('../../detections/containers/detection_engine/alerts/use_alerts_privil
   useAlertsPrivileges: () => mockUseAlertsPrivileges(),
 }));
 
-const defaultUseCasesPermissionsReturn = { read: true };
+const defaultUseCasesPermissionsReturn = {
+  all: false,
+  create: false,
+  update: false,
+  delete: false,
+  read: true,
+};
 const mockUseCasesPermissions = jest.fn(() => defaultUseCasesPermissionsReturn);
 jest.mock('../../common/lib/kibana/hooks', () => {
   const original = jest.requireActual('../../common/lib/kibana/hooks');
@@ -190,7 +196,13 @@ describe('DetectionResponse', () => {
   });
 
   it('should not render cases data sections if user has not cases read permission', () => {
-    mockUseCasesPermissions.mockReturnValue({ read: false });
+    mockUseCasesPermissions.mockReturnValue({
+      all: false,
+      create: false,
+      update: false,
+      delete: false,
+      read: false,
+    });
 
     const result = render(
       <TestProviders>
@@ -211,7 +223,13 @@ describe('DetectionResponse', () => {
   });
 
   it('should render page permissions message if user has any read permission', () => {
-    mockUseCasesPermissions.mockReturnValue({ read: false });
+    mockUseCasesPermissions.mockReturnValue({
+      all: false,
+      create: false,
+      update: false,
+      delete: false,
+      read: false,
+    });
     mockUseAlertsPrivileges.mockReturnValue({
       hasKibanaREAD: true,
       hasIndexRead: false,

--- a/x-pack/plugins/security_solution/public/overview/pages/detection_response.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/detection_response.tsx
@@ -53,7 +53,7 @@ const DetectionResponseComponent = () => {
   const { indicesExist, indexPattern, loading: isSourcererLoading } = useSourcererDataView();
   const { signalIndexName } = useSignalIndex();
   const { hasKibanaREAD, hasIndexRead } = useAlertsPrivileges();
-  const canReadCases = useGetUserCasesPermissions()?.read;
+  const canReadCases = useGetUserCasesPermissions().read;
   const canReadAlerts = hasKibanaREAD && hasIndexRead;
 
   if (!canReadAlerts && !canReadCases) {

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/add_to_case_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/add_to_case_button/index.tsx
@@ -163,7 +163,7 @@ const AddToCaseButtonComponent: React.FC<Props> = ({ timelineId }) => {
       {isCaseModalOpen &&
         cases.ui.getAllCasesSelectorModal({
           onRowClick,
-          userCanCrud: userPermissions?.crud ?? false,
+          permissions: userPermissions,
           owner: [APP_ID],
         })}
     </>

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.test.tsx
@@ -82,8 +82,11 @@ describe('header', () => {
 
     it('renders the button when the user has write permissions', () => {
       (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-        crud: true,
-        read: false,
+        all: true,
+        create: true,
+        update: true,
+        delete: true,
+        read: true,
       });
 
       const wrapper = mount(
@@ -97,7 +100,10 @@ describe('header', () => {
 
     it('does not render the button when the user does not have write permissions', () => {
       (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-        crud: false,
+        all: false,
+        create: false,
+        update: false,
+        delete: false,
         read: false,
       });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
@@ -415,7 +415,7 @@ const FlyoutHeaderComponent: React.FC<FlyoutHeaderProps> = ({ timelineId }) => {
     filterQuery: combinedQueries?.filterQuery ?? '',
   });
 
-  const hasWritePermissions = useGetUserCasesPermissions()?.crud ?? false;
+  const hasWritePermissions = useGetUserCasesPermissions().create;
 
   return (
     <StyledTimelineHeader alignItems="center" gutterSize="s">

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
@@ -144,7 +144,10 @@ describe('event details footer component', () => {
       },
     });
     (useGetUserCasesPermissions as jest.Mock).mockReturnValue({
-      crud: true,
+      all: true,
+      create: true,
+      update: true,
+      delete: true,
       read: true,
     });
   });

--- a/x-pack/plugins/security_solution/server/features.ts
+++ b/x-pack/plugins/security_solution/server/features.ts
@@ -7,13 +7,16 @@
 
 import { i18n } from '@kbn/i18n';
 
+import { PluginSetupContract as CasesPluginSetup } from '@kbn/cases-plugin/server';
 import { KibanaFeatureConfig, SubFeatureConfig } from '@kbn/features-plugin/common';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
 import { APP_ID, CASES_FEATURE_ID, SERVER_APP_ID } from '../common/constants';
 import { savedObjectTypes } from './saved_objects';
 
-export const getCasesKibanaFeature = (): KibanaFeatureConfig => ({
+export const getCasesKibanaFeature = (
+  casesCapabilities: ReturnType<CasesPluginSetup['createUICapabilities']> | undefined
+): KibanaFeatureConfig => ({
   id: CASES_FEATURE_ID,
   name: i18n.translate('xpack.securitySolution.featureRegistry.linkSecuritySolutionCaseTitle', {
     defaultMessage: 'Cases',
@@ -35,7 +38,7 @@ export const getCasesKibanaFeature = (): KibanaFeatureConfig => ({
         all: [],
         read: [],
       },
-      ui: ['crud_cases', 'read_cases'], // uiCapabilities[CASES_FEATURE_ID].crud_cases or read_cases
+      ui: casesCapabilities?.all ?? [''],
     },
     read: {
       app: [CASES_FEATURE_ID, 'kibana'],
@@ -48,9 +51,39 @@ export const getCasesKibanaFeature = (): KibanaFeatureConfig => ({
         all: [],
         read: [],
       },
-      ui: ['read_cases'], // uiCapabilities[CASES_FEATURE_ID].read_cases
+      ui: casesCapabilities?.read ?? [''],
     },
   },
+  subFeatures: [
+    {
+      name: i18n.translate('xpack.securitySolution.featureRegistry.deleteSubFeatureName', {
+        defaultMessage: 'Delete',
+      }),
+      privilegeGroups: [
+        {
+          groupType: 'independent',
+          privileges: [
+            {
+              api: [],
+              id: 'cases_delete',
+              name: i18n.translate(
+                'xpack.securitySolution.featureRegistry.deleteSubFeatureDetails',
+                {
+                  defaultMessage: 'Delete entities',
+                }
+              ),
+              includeIn: 'all',
+              savedObject: {
+                all: [],
+                read: [],
+              },
+              ui: casesCapabilities?.delete ?? [''],
+            },
+          ],
+        },
+      ],
+    },
+  ],
 });
 
 export const getAlertsSubFeature = (ruleTypes: string[]): SubFeatureConfig => ({

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -285,7 +285,9 @@ export class Plugin implements ISecuritySolutionPlugin {
     ];
 
     plugins.features.registerKibanaFeature(getKibanaPrivilegesFeaturePrivileges(ruleTypes));
-    plugins.features.registerKibanaFeature(getCasesKibanaFeature());
+    plugins.features.registerKibanaFeature(
+      getCasesKibanaFeature(plugins.cases?.createUICapabilities())
+    );
 
     if (plugins.alerting != null) {
       const ruleNotificationType = legacyRulesNotificationAlertType({ logger });

--- a/x-pack/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/plugins/security_solution/server/plugin_contract.ts
@@ -15,7 +15,10 @@ import {
   PluginSetupContract as AlertingPluginSetup,
   PluginStartContract as AlertingPluginStart,
 } from '@kbn/alerting-plugin/server';
-import { PluginStartContract as CasesPluginStart } from '@kbn/cases-plugin/server';
+import {
+  PluginStartContract as CasesPluginStart,
+  PluginSetupContract as CasesPluginSetup,
+} from '@kbn/cases-plugin/server';
 import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-plugin/server';
 import { IEventLogClientService, IEventLogService } from '@kbn/event-log-plugin/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '@kbn/features-plugin/server';
@@ -50,6 +53,7 @@ export interface SecuritySolutionPluginSetupDependencies {
   telemetry?: TelemetryPluginSetup;
   usageCollection?: UsageCollectionPluginSetup;
   licensing: LicensingPluginSetup;
+  cases?: CasesPluginSetup;
 }
 
 export interface SecuritySolutionPluginStartDependencies {


### PR DESCRIPTION
WIP

This PR splits out the deletion privilege into its own sub-feature privilege so admins can control a user's ability to delete cases and comments.