### PR TITLE
fix: Alert Rule Action Params Body Must Be Array

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/webhook/webhook.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/webhook/webhook.tsx
@@ -39,7 +39,7 @@ export function getActionType(): ActionTypeModel<
       };
       const validationResult = { errors };
       validationResult.errors = errors;
-      if (!actionParams.body?.length) {
+      if (!actionParams.body) {
         errors.body.push(translations.BODY_REQUIRED);
       }
       return validationResult;


### PR DESCRIPTION
## Summary

When using the REST API to create an alerting rule with an action param to configure a webhook JSON body, there is validation forcing it to be an array. This change allows any JSON body to be configurable if present.


### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
