### PR TITLE
[Synthetics] Allow using local service alongside manifest url

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
@@ -55,8 +55,11 @@ export class ServiceAPIClient {
     this.server = server;
   }
 
-  getHttpsAgent() {
+  getHttpsAgent(url: string) {
     const config = this.config;
+    if (url !== this.config.devUrl && this.authorization && this.server.isDev) {
+      return;
+    }
     if (config.tls && config.tls.certificate && config.tls.key) {
       const tlsConfig = new SslConfig(config.tls);
 
@@ -151,7 +154,7 @@ export class ServiceAPIClient {
                 Authorization: this.authorization,
               }
             : undefined,
-        httpsAgent: this.getHttpsAgent(),
+        httpsAgent: this.getHttpsAgent(url),
       });
     };
 

--- a/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
@@ -95,29 +95,30 @@ export class ServiceAPIClient {
       return { allowed: true, signupUrl: null };
     }
 
-    const httpsAgent = this.getHttpsAgent();
-
-    if (this.locations.length > 0 && httpsAgent) {
+    if (this.locations.length > 0) {
       // get a url from a random location
       const url = this.locations[Math.floor(Math.random() * this.locations.length)].url;
+      const httpsAgent = this.getHttpsAgent(url);
 
-      try {
-        const { data } = await axios({
-          method: 'GET',
-          url: url + '/allowed',
-          headers:
-            process.env.NODE_ENV !== 'production' && this.authorization
-              ? {
-                  Authorization: this.authorization,
-                }
-              : undefined,
-          httpsAgent,
-        });
+      if (httpsAgent) {
+        try {
+          const { data } = await axios({
+            method: 'GET',
+            url: url + '/allowed',
+            headers:
+              process.env.NODE_ENV !== 'production' && this.authorization
+                ? {
+                    Authorization: this.authorization,
+                  }
+                : undefined,
+            httpsAgent,
+          });
 
-        const { allowed, signupUrl } = data;
-        return { allowed, signupUrl };
-      } catch (e) {
-        this.logger.error(e);
+          const { allowed, signupUrl } = data;
+          return { allowed, signupUrl };
+        } catch (e) {
+          this.logger.error(e);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Allow using local service alongside manifest url !!

In a dev environment if we need to use multiple locations that can be done using local service and dev manifest url

but problem is that local service works with mtls and we can connect to dev service with basic auth. 

So if we specify both type of auth in kibana config. It will be passed to dev service as well. 

So this PR adds a condition that if it's dev service and basic auth is defined it will not pass mTls.