### PR TITLE
[8.3] Improved the consistency of the icons (#134416)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -102,7 +102,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
             />
           </EuiContextMenuItem>,
           <EuiContextMenuItem
-            icon="cross"
+            icon="trash"
             disabled={!hasFleetAllPrivileges || !agent.active}
             onClick={() => {
               setIsUnenrollModalOpen(true);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Improved the consistency of the icons (#134416)](https://github.com/elastic/kibana/pull/134416)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)