### PR TITLE
[Security Solution][Investigations] - Fix resolver horizontal rule icon

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiDescriptionList,
+  EuiHorizontalRule,
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
@@ -330,20 +331,12 @@ const StyledDescriptiveName = memo(styled(EuiText)`
 `);
 
 const StyledFlexTitle = memo(styled('h3')`
+  align-items: center;
   display: flex;
   flex-flow: row;
   font-size: 1.2em;
 `);
-const StyledTitleRule = memo(styled('hr')`
-  &.euiHorizontalRule.euiHorizontalRule--full.euiHorizontalRule--marginSmall.override {
-    display: block;
-    flex: 1;
-    margin-left: 0.5em;
-  }
-`);
 
 const TitleHr = memo(() => {
-  return (
-    <StyledTitleRule className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall override" />
-  );
+  return <EuiHorizontalRule margin="none" size="half" />;
 });


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/132216 by fixing the css for the horizontal rule

<img width="351" alt="Screen Shot 2022-06-21 at 8 52 23 AM" src="https://user-images.githubusercontent.com/17211684/174805984-00f66b2a-40fa-4a5c-8db5-9c450641ac62.png">

