### PR TITLE
[Fleet] Schedule uprade should only be enabled for platinium licence

### DIFF
--- a/x-pack/plugins/fleet/common/constants/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/constants/agent_policy.ts
@@ -27,4 +27,4 @@ export const AGENT_POLICY_DEFAULT_MONITORING_DATASETS = [
   'elastic_agent.cloudbeat',
 ];
 
-export const LICENCE_FOR_SCHEDULE_UPGRADE = 'platinum';
+export const LICENSE_FOR_SCHEDULE_UPGRADE = 'platinum';

--- a/x-pack/plugins/fleet/common/constants/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/constants/agent_policy.ts
@@ -26,3 +26,5 @@ export const AGENT_POLICY_DEFAULT_MONITORING_DATASETS = [
   'elastic_agent.heartbeat',
   'elastic_agent.cloudbeat',
 ];
+
+export const LICENCE_FOR_SCHEDULE_UPGRADE = 'platinum';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -25,7 +25,7 @@ import {
   AgentUpgradeAgentModal,
 } from '../../components';
 import { useLicense } from '../../../../hooks';
-import { LICENCE_FOR_SCHEDULE_UPGRADE } from '../../../../../../../common';
+import { LICENSE_FOR_SCHEDULE_UPGRADE } from '../../../../../../../common';
 
 import type { SelectionMode } from './types';
 
@@ -50,7 +50,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   refreshAgents,
 }) => {
   const licenseService = useLicense();
-  const isLicenceAllowingScheduleUpgrade = licenseService.hasAtLeast(LICENCE_FOR_SCHEDULE_UPGRADE);
+  const isLicenceAllowingScheduleUpgrade = licenseService.hasAtLeast(LICENSE_FOR_SCHEDULE_UPGRADE);
 
   // Bulk actions menu states
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -24,6 +24,8 @@ import {
   AgentUnenrollAgentModal,
   AgentUpgradeAgentModal,
 } from '../../components';
+import { useLicense } from '../../../../hooks';
+import { LICENCE_FOR_SCHEDULE_UPGRADE } from '../../../../../../../common';
 
 import type { SelectionMode } from './types';
 
@@ -47,6 +49,9 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   selectedAgents,
   refreshAgents,
 }) => {
+  const licenseService = useLicense();
+  const isLicenceAllowingScheduleUpgrade = licenseService.hasAtLeast(LICENCE_FOR_SCHEDULE_UPGRADE);
+
   // Bulk actions menu states
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const closeMenu = () => setIsMenuOpen(false);
@@ -133,7 +138,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
             />
           ),
           icon: <EuiIcon type="timeRefresh" size="m" />,
-          disabled: !atLeastOneActiveAgentSelected,
+          disabled: !atLeastOneActiveAgentSelected || !isLicenceAllowingScheduleUpgrade,
           onClick: () => {
             closeMenu();
             setUpgradeModalState({ isOpen: true, isScheduled: true });


### PR DESCRIPTION
## Summary

Schedule upgrade should only be available for platinium user

## UI changes 

### Without licence
<img width="592" alt="Screen Shot 2022-06-21 at 9 03 28 AM" src="https://user-images.githubusercontent.com/1336873/174806681-d7ba4ddb-2051-40a7-9e8d-89754066efcd.png">

### With licence
<img width="590" alt="Screen Shot 2022-06-21 at 9 04 23 AM" src="https://user-images.githubusercontent.com/1336873/174806684-0965620a-e6bd-44d0-a31c-39004f110d03.png">

## How to test?

You can enable a trial licence in the stack managent plugin
