### PR TITLE
Upgrade `@elastic/elasticsearch-canary@8.3.0-canary.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "resolutions": {
     "**/@babel/runtime": "^7.17.9",
-    "**/@types/node": "16.11.7",
+    "**/@types/node": "16.11.41",
     "**/chokidar": "^3.4.3",
     "**/deepmerge": "^4.2.2",
     "**/fast-deep-equal": "^3.1.1",
@@ -794,7 +794,7 @@
     "@types/mustache": "^0.8.31",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^10.0.3",
-    "@types/node": "16.11.7",
+    "@types/node": "16.11.41",
     "@types/node-fetch": "^2.6.0",
     "@types/node-forge": "^1.0.2",
     "@types/nodemailer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
     "@elastic/charts": "46.10.2",
     "@elastic/datemath": "5.0.3",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.2.0-canary.2",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.3.0-canary.1",
     "@elastic/ems-client": "8.3.3",
     "@elastic/eui": "59.0.1",
     "@elastic/filesaver": "1.1.2",

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/trained_models.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/trained_models.ts
@@ -48,7 +48,7 @@ export interface InferenceStatsResponse {
 }
 
 export interface MlInferTrainedModelDeploymentResponse {
-  inference_results: estypes.MlInferTrainedModelDeploymentResponse[];
+  inference_results: estypes.MlInferenceResponseResult[];
 }
 
 /**

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/inference_base.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/inference_base.ts
@@ -74,17 +74,17 @@ export abstract class InferenceBase<TInferResponse> {
 
   protected abstract infer(): Promise<TInferResponse>;
 
-  protected getInferenceConfig(): estypes.AggregationsClassificationInferenceOptions | undefined {
+  protected getInferenceConfig(): estypes.MlInferenceConfigCreateContainer[keyof estypes.MlInferenceConfigCreateContainer] {
     return this.model.inference_config[
-      this.inferenceType as keyof estypes.AggregationsInferenceConfigContainer
+      this.inferenceType as keyof estypes.MlInferenceConfigCreateContainer
     ];
   }
 
   protected getNumTopClassesConfig(defaultOverride = 5) {
-    const options: estypes.AggregationsClassificationInferenceOptions | undefined =
+    const options: estypes.MlInferenceConfigCreateContainer[keyof estypes.MlInferenceConfigCreateContainer] =
       this.getInferenceConfig();
 
-    if (options?.num_top_classes !== undefined && options?.num_top_classes > 0) {
+    if (options && 'num_top_classes' in options && (options?.num_top_classes ?? 0 > 0)) {
       return {};
     }
 

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/common.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/test_models/models/text_classification/common.ts
@@ -39,9 +39,7 @@ export function processResponse(
   const {
     inference_results: [inferenceResults],
   } = resp;
-  const labels: string[] =
-    // @ts-expect-error inference config is wrong
-    model.inference_config.text_classification?.classification_labels ?? [];
+  const labels: string[] = model.inference_config.text_classification?.classification_labels ?? [];
 
   let formattedResponse = [
     {

--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -494,7 +494,7 @@ export function getMlClient(
       await modelIdsCheck(p);
       return mlClient.stopTrainedModelDeployment(...p);
     },
-    async inferTrainedModelDeployment(...p: Parameters<MlClient['inferTrainedModelDeployment']>) {
+    async inferTrainedModel(...p: Parameters<MlClient['inferTrainedModel']>) {
       await modelIdsCheck(p);
       // Temporary workaround for the incorrect inferTrainedModelDeployment function in the esclient
       if (

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -112,7 +112,6 @@ export function modelsProvider(client: IScopedClusterClient, mlClient: MlClient)
      */
     async getNodesOverview(): Promise<NodesOverviewResponse> {
       // TODO set node_id to ml:true when elasticsearch client is updated.
-      // @ts-expect-error typo in type definition: MlGetMemoryStatsResponse.cluser_name
       const response = (await mlClient.getMemoryStats()) as MemoryStatsResponse;
 
       const { trained_model_stats: trainedModelStats } = await mlClient.getTrainedModelsStats({

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -377,7 +377,7 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
     routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
       try {
         const { modelId } = request.params;
-        const body = await mlClient.inferTrainedModelDeployment({
+        const body = await mlClient.inferTrainedModel({
           model_id: modelId,
           body: {
             docs: request.body.docs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,13 +1476,13 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.2.0-canary.2":
-  version "8.2.0-canary.2"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.2.0-canary.2.tgz#2513926cdbfe7c070e1fa6926f7829171b27cdba"
-  integrity sha512-Ki2lQ3/UlOnBaf5EjNw0WmCdXiW+J020aYtdVnIuCNhPSLoNPKoM7P+MlggdfeRnENvINlStrMy4bkYF/h6Vbw==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.3.0-canary.1":
+  version "8.3.0-canary.1"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.3.0-canary.1.tgz#31dc18f724433c4135ed85fde5fd018393134552"
+  integrity sha512-CSNP4vTL/90VRD3MbvfBggy4VBxEgNmlHQf7mlWiPRTxo24t68PqNS+TnsfzO7fbY/nOALoX9hE8VlxRcMo0iA==
   dependencies:
-    "@elastic/transport" "^8.0.2"
-    tslib "^2.3.0"
+    "@elastic/transport" "^8.2.0"
+    tslib "^2.4.0"
 
 "@elastic/ems-client@8.3.3":
   version "8.3.3"
@@ -1661,17 +1661,17 @@
     ts-node "^10.5.0"
     typescript "^4.5.5"
 
-"@elastic/transport@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.0.2.tgz#715f06c7739516867508108df30c33973ca8e81c"
-  integrity sha512-OlDz3WO3pKE9vSxW4wV/mn7rYCtBmSsDwxr64h/S1Uc/zrIBXb0iUsRMSkiybXugXhjwyjqG2n1Wc7jjFxrskQ==
+"@elastic/transport@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.2.0.tgz#f292cb79c918a36268dd853431e41f13544814ad"
+  integrity sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==
   dependencies:
-    debug "^4.3.2"
-    hpagent "^0.1.2"
+    debug "^4.3.4"
+    hpagent "^1.0.0"
     ms "^2.1.3"
     secure-json-parse "^2.4.0"
-    tslib "^2.3.0"
-    undici "^4.14.1"
+    tslib "^2.4.0"
+    undici "^5.1.1"
 
 "@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
   version "0.1.5"
@@ -3376,10 +3376,6 @@
   uid ""
 
 "@kbn/shared-ux-services@link:bazel-bin/packages/kbn-shared-ux-services":
-  version "0.0.0"
-  uid ""
-
-"@kbn/shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar":
   version "0.0.0"
   uid ""
 
@@ -6730,6 +6726,10 @@
   version "0.0.0"
   uid ""
 
+"@types/kbn__shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar/npm_module_types":
+  version "0.0.0"
+  uid ""
+
 "@types/kbn__shared-ux-components@link:bazel-bin/packages/kbn-shared-ux-components/npm_module_types":
   version "0.0.0"
   uid ""
@@ -6751,10 +6751,6 @@
   uid ""
 
 "@types/kbn__shared-ux-services@link:bazel-bin/packages/kbn-shared-ux-services/npm_module_types":
-  version "0.0.0"
-  uid ""
-
-"@types/kbn__shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar/npm_module_types":
   version "0.0.0"
   uid ""
 
@@ -12538,6 +12534,13 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -16590,10 +16593,10 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-hpagent@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-0.1.2.tgz#cab39c66d4df2d4377dbd212295d878deb9bdaa9"
-  integrity sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==
+hpagent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.0.0.tgz#c68f68b3df845687dbdc4896546713ce09cc6bee"
+  integrity sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==
 
 hsl-regex@^1.0.0:
   version "1.0.0"
@@ -28448,7 +28451,7 @@ tsd@^0.20.0:
     path-exists "^4.0.0"
     read-pkg-up "^7.0.0"
 
-tslib@2.3.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@~2.3.1:
+tslib@2.3.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -28462,6 +28465,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.1.0:
   version "2.1.0"
@@ -28727,10 +28735,10 @@ undertaker@^1.2.1:
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
 
-undici@^4.14.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.14.1.tgz#7633b143a8a10d6d63335e00511d071e8d52a1d9"
-  integrity sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==
+undici@^5.1.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.5.1.tgz#baaf25844a99eaa0b22e1ef8d205bffe587c8f43"
+  integrity sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==
 
 unfetch@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7041,10 +7041,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.20.24", "@types/node@16.11.7", "@types/node@>= 8", "@types/node@>=8.9.0", "@types/node@^10.1.0", "@types/node@^14.0.10", "@types/node@^14.14.31":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+"@types/node@*", "@types/node@12.20.24", "@types/node@16.11.41", "@types/node@>= 8", "@types/node@>=8.9.0", "@types/node@^10.1.0", "@types/node@^14.0.10", "@types/node@^14.14.31":
+  version "16.11.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.41.tgz#88eb485b1bfdb4c224d878b7832239536aa2f813"
+  integrity sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==
 
 "@types/nodemailer@^6.4.0":
   version "6.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,6 +3351,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar":
+  version "0.0.0"
+  uid ""
+
 "@kbn/shared-ux-card-no-data@link:bazel-bin/packages/shared-ux/card/no_data":
   version "0.0.0"
   uid ""
@@ -6722,11 +6726,11 @@
   version "0.0.0"
   uid ""
 
-"@types/kbn__shared-ux-card-no-data@link:bazel-bin/packages/shared-ux/card/no_data/npm_module_types":
+"@types/kbn__shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar/npm_module_types":
   version "0.0.0"
   uid ""
 
-"@types/kbn__shared-ux-button-toolbar@link:bazel-bin/packages/shared-ux/button_toolbar/npm_module_types":
+"@types/kbn__shared-ux-card-no-data@link:bazel-bin/packages/shared-ux/card/no_data/npm_module_types":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
## Summary

This PR upgrades the elasticsearch client to the latest in `main`. The main reason to upgrade is that it includes a more recent version of the transitive dependency `undici`, fixing a security issue.

We don't use that transport in Kibana, but it could still raise some alerts on the users' security monitors.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
