### PR TITLE
[Uptime] use dynamic heartbeatIndices for use_monitor_histogram hook

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useMonitorHistogram } from './use_monitor_histogram';
+import { WrappedHelper } from '../../../../apps/synthetics/utils/testing';
+import * as searchHooks from '@kbn/observability-plugin/public/hooks/use_es_search';
+import * as reduxHooks from 'react-redux';
+
+describe('useMonitorHistogram', () => {
+  const dynamicIndexPattern = 'synthetics-*';
+  const useEsSearch = jest.fn().mockReturnValue({});
+  jest
+    .spyOn(reduxHooks, 'useSelector')
+    .mockReturnValue({ settings: { heartbeatIndices: dynamicIndexPattern } });
+  jest.spyOn(searchHooks, 'useEsSearch').mockImplementation(useEsSearch);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls dynamic heartbeat index', () => {
+    renderHook(() => useMonitorHistogram({ items: [] }), {
+      wrapper: WrappedHelper,
+    });
+    expect(useEsSearch).toBeCalledWith(
+      expect.objectContaining({ index: dynamicIndexPattern }),
+      ['[]', 0],
+      { name: 'getMonitorDownHistory' }
+    );
+  });
+});

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
@@ -16,25 +16,24 @@ import {
 } from '../../../../../common/runtime_types/monitor';
 import { useGetUrlParams } from '../../../hooks';
 import { UptimeRefreshContext } from '../../../contexts';
-import { esKuerySelector } from '../../../state/selectors';
+import { selectDynamicSettings } from '../../../state/selectors';
 import { getHistogramInterval } from '../../../../../common/lib/get_histogram_interval';
 import { Ping } from '../../../../../common/runtime_types';
 
 export const useMonitorHistogram = ({ items }: { items: MonitorSummary[] }) => {
-  const { dateRangeStart, dateRangeEnd, statusFilter } = useGetUrlParams();
+  const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
 
   const { lastRefresh } = useContext(UptimeRefreshContext);
 
-  const filters = useSelector(esKuerySelector);
+  const { settings } = useSelector(selectDynamicSettings);
 
   const monitorIds = (items ?? []).map(({ monitor_id: monitorId }) => monitorId);
 
   const { queryParams, minInterval } = getQueryParams(
     dateRangeStart,
     dateRangeEnd,
-    filters,
-    statusFilter,
-    monitorIds
+    monitorIds,
+    settings?.heartbeatIndices || 'heartbeat-*'
   );
 
   const { data, loading } = useEsSearch<Ping, typeof queryParams>(
@@ -77,14 +76,13 @@ export const useMonitorHistogram = ({ items }: { items: MonitorSummary[] }) => {
 const getQueryParams = (
   dateRangeStart: string,
   dateRangeEnd: string,
-  filters: string,
-  statusFilter: string,
-  monitorIds: string[]
+  monitorIds: string[],
+  index: string
 ) => {
   const minInterval = getHistogramInterval(dateRangeStart, dateRangeEnd, 12);
 
   const queryParams = {
-    index: 'heartbeat-*',
+    index,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
@@ -33,7 +33,7 @@ export const useMonitorHistogram = ({ items }: { items: MonitorSummary[] }) => {
     dateRangeStart,
     dateRangeEnd,
     monitorIds,
-    settings?.heartbeatIndices
+    settings?.heartbeatIndices || ''
   );
 
   const { data, loading } = useEsSearch<Ping, typeof queryParams>(

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/use_monitor_histogram.ts
@@ -33,7 +33,7 @@ export const useMonitorHistogram = ({ items }: { items: MonitorSummary[] }) => {
     dateRangeStart,
     dateRangeEnd,
     monitorIds,
-    settings?.heartbeatIndices || 'heartbeat-*'
+    settings?.heartbeatIndices
   );
 
   const { data, loading } = useEsSearch<Ping, typeof queryParams>(


### PR DESCRIPTION
## Summary
Ensures monitor downtime history histogram is rendered for monitors indexed into `synthetics-*`.

Uses dynamic Heartbeat indices instead of hard-coded heartbeat index pattern for querying data for the monitor downtime histogram. 

Before (Any monitor with data not saved against heartbeat-* would not display downtime history)
<img width="1410" alt="Screen Shot 2022-06-21 at 3 45 27 PM" src="https://user-images.githubusercontent.com/11356435/174885083-080cae5b-7e12-4faf-bff2-11005029e593.png">

After
<img width="1406" alt="Screen Shot 2022-06-21 at 3 38 54 PM" src="https://user-images.githubusercontent.com/11356435/174884629-7cc860c6-0301-430e-b70e-95ddeb106636.png">

Testing
1. Add the following to your `kibana.dev.yml`: https://p.elstc.co/paste/CDp+9p4d#FllgNi9eqNnLzOWxzuvQKd71QgBx9rSlbf-dSL75zF5
2. Navigate to Uptime monitor management
3. Create a monitor that will resolve to down
4. Navigate to Uptime overview page. Ensure that the monitor downtime history histogram appears. 