### PR TITLE
[Fleet] Download Elastic GPG key during build

### DIFF
--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -88,6 +88,7 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
     await run(Tasks.CleanTypescript);
     await run(Tasks.CleanExtraFilesFromModules);
     await run(Tasks.CleanEmptyFolders);
+    await run(Tasks.FleetDownloadElasticGpgKey);
     await run(Tasks.BundleFleetPackages);
   }
 

--- a/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
@@ -33,8 +33,8 @@ export const FleetDownloadElasticGpgKey: Task = {
         maxAttempts: 3,
       });
     } catch (error) {
-      log.warning(`Failed to download Elastic GPG key`);
-      log.warning(error);
+      log.error(`Error downloading Elastic GPG key from ${gpgKeyUrl} to ${destination}`);
+      throw error;
     }
   },
 };

--- a/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
@@ -11,6 +11,8 @@ import { Task, downloadToDisk } from '../lib';
 const BUNDLED_KEYS_DIR = 'x-pack/plugins/fleet/target/keys';
 const ARTIFACTS_URL = 'https://artifacts.elastic.co/';
 const GPG_KEY_NAME = 'GPG-KEY-elasticsearch';
+const GPG_KEY_SHA512 =
+  '84ee193cc337344d9a7da9021daf3f5ede83f5f1ab049d169f3634921529dcd096abf7a91eec7f26f3a6913e5e38f88f69a5e2ce79ad155d46edc75705a648c6';
 
 export const FleetDownloadElasticGpgKey: Task = {
   description: 'Downloading Elastic GPG key for Fleet',
@@ -25,9 +27,9 @@ export const FleetDownloadElasticGpgKey: Task = {
         log,
         url: gpgKeyUrl,
         destination,
-        shaChecksum: '',
+        shaChecksum: GPG_KEY_SHA512,
         shaAlgorithm: 'sha512',
-        skipChecksumCheck: true,
+        skipChecksumCheck: false,
         maxAttempts: 3,
       });
     } catch (error) {

--- a/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
@@ -17,8 +17,8 @@ export const FleetDownloadElasticGpgKey: Task = {
 
   async run(config, log, build) {
     const gpgKeyUrl = ARTIFACTS_URL + GPG_KEY_NAME;
-    log.info(`Downloading Elastic GPG key from ${gpgKeyUrl}`);
     const destination = build.resolvePath(BUNDLED_KEYS_DIR, GPG_KEY_NAME);
+    log.info(`Downloading Elastic GPG key from ${gpgKeyUrl} to ${destination}`);
 
     try {
       await downloadToDisk({

--- a/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet_download_elastic_gpg_key.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Task, downloadToDisk } from '../lib';
+
+const BUNDLED_KEYS_DIR = 'x-pack/plugins/fleet/target/keys';
+const ARTIFACTS_URL = 'https://artifacts.elastic.co/';
+const GPG_KEY_NAME = 'GPG-KEY-elasticsearch';
+
+export const FleetDownloadElasticGpgKey: Task = {
+  description: 'Downloading Elastic GPG key for Fleet',
+
+  async run(config, log, build) {
+    const gpgKeyUrl = ARTIFACTS_URL + GPG_KEY_NAME;
+    log.info(`Downloading Elastic GPG key from ${gpgKeyUrl}`);
+    const destination = build.resolvePath(BUNDLED_KEYS_DIR, GPG_KEY_NAME);
+
+    try {
+      await downloadToDisk({
+        log,
+        url: gpgKeyUrl,
+        destination,
+        shaChecksum: '',
+        shaAlgorithm: 'sha512',
+        skipChecksumCheck: true,
+        maxAttempts: 3,
+      });
+    } catch (error) {
+      log.warning(`Failed to download Elastic GPG key`);
+      log.warning(error);
+    }
+  },
+};

--- a/src/dev/build/tasks/index.ts
+++ b/src/dev/build/tasks/index.ts
@@ -7,8 +7,8 @@
  */
 
 export * from './bin';
-export * from './build_kibana_platform_plugins';
 export * from './build_kibana_example_plugins';
+export * from './build_kibana_platform_plugins';
 export * from './build_packages_task';
 export * from './bundle_fleet_packages';
 export * from './clean_tasks';
@@ -18,6 +18,7 @@ export * from './create_archives_task';
 export * from './create_empty_dirs_and_files_task';
 export * from './create_readme_task';
 export * from './download_cloud_dependencies';
+export * from './fleet_download_elastic_gpg_key';
 export * from './generate_packages_optimized_assets';
 export * from './install_dependencies_task';
 export * from './license_file_task';
@@ -27,11 +28,11 @@ export * from './os_packages';
 export * from './package_json';
 export * from './patch_native_modules_task';
 export * from './path_length_task';
+export * from './replace_favicon';
 export * from './transpile_babel_task';
 export * from './uuid_verification_task';
 export * from './verify_env_task';
 export * from './write_sha_sums_task';
-export * from './replace_favicon';
 
 // @ts-expect-error this module can't be TS because it ends up pulling x-pack into Kibana
 export { InstallChromium } from './install_chromium';

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -33,6 +33,9 @@ export interface FleetConfigType {
   outputs?: PreconfiguredOutput[];
   agentIdVerificationEnabled?: boolean;
   enableExperimental?: string[];
+  packageVerification?: {
+    gpgKeyPath?: string;
+  };
   developer?: {
     disableRegistryVersionCheck?: boolean;
     allowAgentUpgradeSourceUri?: boolean;

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -47,6 +47,7 @@ export type {
 export { AgentNotFoundError, FleetUnauthorizedError } from './errors';
 
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
+const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {
@@ -142,6 +143,9 @@ export const config: PluginConfigDescriptor = {
       disableRegistryVersionCheck: schema.boolean({ defaultValue: false }),
       allowAgentUpgradeSourceUri: schema.boolean({ defaultValue: false }),
       bundledPackageLocation: schema.string({ defaultValue: DEFAULT_BUNDLED_PACKAGE_LOCATION }),
+    }),
+    packageVerification: schema.object({
+      gpgKeyPath: schema.string({ defaultValue: DEFAULT_GPG_KEY_PATH }),
     }),
     /**
      * For internal use. A list of string values (comma delimited) that will enable experimental

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.test.ts
@@ -8,6 +8,13 @@
 import { readFile } from 'fs/promises';
 
 import { getGpgKey } from './package_verification';
+
+jest.mock('../../app_context', () => ({
+  appContextService: {
+    getConfig: () => ({ packageVerification: { gpgKeyPath: 'somePath' } }),
+  },
+}));
+
 jest.mock('fs/promises', () => ({
   readFile: jest.fn(),
 }));
@@ -16,12 +23,11 @@ const mockedReadFile = readFile as jest.MockedFunction<typeof readFile>;
 
 describe('getGpgKey', () => {
   it('should cache the gpg key after reading file once', async () => {
-    const config = { gpgKeyPath: 'somePath' };
     const keyContent = 'this is the gpg key';
     mockedReadFile.mockResolvedValue(Buffer.from(keyContent));
 
-    expect(await getGpgKey(config)).toEqual(keyContent);
-    expect(await getGpgKey(config)).toEqual(keyContent);
+    expect(await getGpgKey()).toEqual(keyContent);
+    expect(await getGpgKey()).toEqual(keyContent);
     expect(mockedReadFile).toHaveBeenCalledWith('somePath');
     expect(mockedReadFile).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFile } from 'fs/promises';
+
+import { getGpgKey } from './package_verification';
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+const mockedReadFile = readFile as jest.MockedFunction<typeof readFile>;
+
+describe('getGpgKey', () => {
+  it('should cache the gpg key after reading file once', async () => {
+    const config = { gpgKeyPath: 'somePath' };
+    const keyContent = 'this is the gpg key';
+    mockedReadFile.mockResolvedValue(Buffer.from(keyContent));
+
+    expect(await getGpgKey(config)).toEqual(keyContent);
+    expect(await getGpgKey(config)).toEqual(keyContent);
+    expect(mockedReadFile).toHaveBeenCalledWith('somePath');
+    expect(mockedReadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
@@ -32,7 +32,7 @@ export async function _readGpgKey(): Promise<string | undefined> {
   try {
     buffer = await readFile(gpgKeyPath);
   } catch (e) {
-    logger.warn(`Unable to retrieve GPG key from '${gpgKeyPath}': ${e}`);
+    logger.warn(`Unable to retrieve GPG key from '${gpgKeyPath}': ${e.code}`);
     return undefined;
   }
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
@@ -7,17 +7,17 @@
 
 import { readFile } from 'fs/promises';
 
-import type { FleetConfigType } from '../../../../common/types';
+import { appContextService } from '../../app_context';
 
 let cachedKey: string = '';
 
-export async function getGpgKey(config: FleetConfigType['packageVerification']): Promise<string> {
+export async function getGpgKey(): Promise<string> {
   if (cachedKey) return cachedKey;
 
-  const gpgKeyPath = config?.gpgKeyPath;
+  const gpgKeyPath = appContextService.getConfig()?.packageVerification?.gpgKeyPath;
 
   if (!gpgKeyPath) {
-    throw new Error('No gpg key path specified, unable to get GPG key');
+    throw new Error('No path specified in "packageVerification.gpgKeyPath", unable to get GPG key');
   }
 
   const buffer = await readFile(gpgKeyPath);

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFile } from 'fs/promises';
+
+import type { FleetConfigType } from '../../../../common/types';
+
+let cachedKey: string = '';
+
+export async function getGpgKey(config: FleetConfigType['packageVerification']): Promise<string> {
+  if (cachedKey) return cachedKey;
+
+  const gpgKeyPath = config?.gpgKeyPath;
+
+  if (!gpgKeyPath) {
+    throw new Error('No gpg key path specified, unable to get GPG key');
+  }
+
+  const buffer = await readFile(gpgKeyPath);
+
+  const key = buffer.toString();
+
+  cachedKey = key;
+  return key;
+}


### PR DESCRIPTION
## Summary

Part of #133822.

Add a build step to add the Elastic GPG key from https://artifacts.elastic.co/GPG-KEY-elasticsearch to the kibana repo at `x-pack/plugins/fleet/target/keys`.

The location of the key can be overridden by users with the `xpack.fleet.packageVerification.gpgKeyPath` config item.

Add a function `getGpgKeyOrUndefined` in the fleet plugin to access the key, in the interest of keeping the PR's small this method isn't currently called but will be in subsequent verification work for 8.4.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
