### PR TITLE
[ci] Fix ci:build-* labels

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 export KBN_NP_PLUGINS_BUILT=true
 
 echo "--- Build Kibana Distribution"
+echo is_pr_with_label "ci:build-os-packages"
 if is_pr_with_label "ci:build-all-platforms"; then
   node scripts/build --all-platforms --skip-os-packages
 elif is_pr_with_label "ci:build-os-packages"; then

--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/common/util.sh
+
 export KBN_NP_PLUGINS_BUILT=true
 
 echo "--- Build Kibana Distribution"
-echo is_pr_with_label "ci:build-os-packages"
 if is_pr_with_label "ci:build-all-platforms"; then
   node scripts/build --all-platforms --skip-os-packages
 elif is_pr_with_label "ci:build-os-packages"; then

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -21,6 +21,7 @@ is_pr_with_label() {
 
   for label in "${labels[@]}"
   do
+    echo $label $match
     if [ "$label" == "$match" ]; then
       return
     fi

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -21,7 +21,6 @@ is_pr_with_label() {
 
   for label in "${labels[@]}"
   do
-    echo $label $match
     if [ "$label" == "$match" ]; then
       return
     fi


### PR DESCRIPTION
The ci:build* labels are currently not working due to the `is_pr_with_label` function not being sourced.  This imports the function.