### PR TITLE
[Fleet] fix flickering create agent policy when adding fleet server agent

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/select_agent_policy.tsx
@@ -26,7 +26,7 @@ export const getSelectAgentPolicyStep = ({
 }): EuiStepProps => {
   return {
     title:
-      eligibleFleetServerPolicies.length === 0
+      eligibleFleetServerPolicies.length === 0 && !policyId
         ? i18n.translate('xpack.fleet.fleetServerSetup.stepCreateAgentPolicyTitle', {
             defaultMessage: 'Create a policy for Fleet Server',
           })

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_policy_select_create.tsx
@@ -79,9 +79,9 @@ export const SelectCreateAgentPolicy: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    setShowCreatePolicy(regularAgentPolicies.length === 0);
+    setShowCreatePolicy(regularAgentPolicies.length === 0 && !selectedPolicyId);
     setNewName(incrementPolicyName(regularAgentPolicies, isFleetServerPolicy));
-  }, [regularAgentPolicies, isFleetServerPolicy]);
+  }, [regularAgentPolicies, isFleetServerPolicy, selectedPolicyId]);
 
   const onAgentPolicyCreated = useCallback(
     async (policy: AgentPolicy | null, errorMessage?: JSX.Element) => {


### PR DESCRIPTION
## Summary

Resolves #134882

Do not show create agent policy if we have a selected policy. Tested on a fresh install with no policies, + switching between create and select policy views. 

When adding a policy fleet server, regularAgentPolicies is empty, when adding fleet server, eligibleFLeetServerPolicies is empty on first render but we do have a selected policy.