### PR TITLE
[Discover][Embeddable] Fix multiple renderings

### DIFF
--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
@@ -125,12 +125,15 @@ export class SavedSearchEmbeddable
     this.inspectorAdapters = {
       requests: new RequestAdapter(),
     };
+    this.panelTitle = savedSearch.title ?? '';
     this.initializeSearchEmbeddableProps();
 
     this.subscription = this.getUpdated$().subscribe(() => {
-      this.panelTitle = this.output.title || '';
-
-      if (this.searchProps) {
+      const titleChanged = this.output.title && this.panelTitle !== this.output.title;
+      if (titleChanged) {
+        this.panelTitle = this.output.title || '';
+      }
+      if (this.searchProps && (titleChanged || this.isFetchRequired(this.searchProps))) {
         this.pushContainerStateParamsToProps(this.searchProps);
       }
     });
@@ -323,16 +326,24 @@ export class SavedSearchEmbeddable
     }
   }
 
-  private async pushContainerStateParamsToProps(
-    searchProps: SearchProps,
-    { forceFetch = false }: { forceFetch: boolean } = { forceFetch: false }
-  ) {
-    const isFetchRequired =
+  private isFetchRequired(searchProps?: SearchProps) {
+    if (!searchProps) {
+      return false;
+    }
+    return (
       !onlyDisabledFiltersChanged(this.input.filters, this.prevFilters) ||
       !isEqual(this.prevQuery, this.input.query) ||
       !isEqual(this.prevTimeRange, this.input.timeRange) ||
       !isEqual(searchProps.sort, this.input.sort || this.savedSearch.sort) ||
-      this.prevSearchSessionId !== this.input.searchSessionId;
+      this.prevSearchSessionId !== this.input.searchSessionId
+    );
+  }
+
+  private async pushContainerStateParamsToProps(
+    searchProps: SearchProps,
+    { forceFetch = false }: { forceFetch: boolean } = { forceFetch: false }
+  ) {
+    const isFetchRequired = this.isFetchRequired(searchProps);
 
     // If there is column or sort data on the panel, that means the original columns or sort settings have
     // been overridden in a dashboard.
@@ -387,7 +398,7 @@ export class SavedSearchEmbeddable
   }
 
   private renderReactComponent(domNode: HTMLElement, searchProps: SearchProps) {
-    if (!this.searchProps) {
+    if (!searchProps) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Before this PR, changes of the embeddable input AND output triggered a React re-rendering of Discover's embeddable. 
With this PR, only when data is fetched or the panel title changes, this change is propagated, and this triggers a re-rendering, which is fine.

### Testing
* Best way to test, add a simple `console.count` L404 
https://github.com/elastic/kibana/blob/aa5d0a17d6ae0f2698ccb9bc401f058a29e77f95/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx#L400-L405
* Check if it's just executed once when initially rendered, when the query, filter, time range changes, or when the query is refreshed 

### What's more
We should take care of the embeddable code, refactor it, add unit tests, unify data fetching with 'main' Discover
