### PR TITLE
Enterprise Search: change route for curations/find_or_create

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/shared_columns.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/shared_columns.tsx
@@ -86,9 +86,9 @@ export const ACTIONS_COLUMN = {
 
         try {
           const query = (item as Query).key || (item as RecentQuery).query_string || '""';
-          const response = await http.get<{ id: string }>(
+          const response = await http.post<{ id: string }>(
             `/internal/app_search/engines/${engineName}/curations/find_or_create`,
-            { query: { query } }
+            { body: JSON.stringify({ query }) }
           );
           navigateToUrl(generateEnginePath(ENGINE_CURATION_PATH, { curationId: response.id }));
         } catch (e) {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/test_helpers/shared_columns_tests.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/test_helpers/shared_columns_tests.tsx
@@ -44,7 +44,7 @@ export const runActionColumnTests = (wrapper: ReactWrapper) => {
 
   describe('edit action', () => {
     it('calls the find_or_create curation API, then navigates the user to the curation', async () => {
-      http.get.mockReturnValue(Promise.resolve({ id: 'cur-123456789' }));
+      http.post.mockReturnValue(Promise.resolve({ id: 'cur-123456789' }));
       wrapper.find('[data-test-subj="AnalyticsTableEditQueryButton"]').first().simulate('click');
       await nextTick();
 
@@ -58,7 +58,7 @@ export const runActionColumnTests = (wrapper: ReactWrapper) => {
     });
 
     it('falls back to "" for the empty query', async () => {
-      http.get.mockReturnValue(Promise.resolve({ id: 'cur-987654321' }));
+      http.post.mockReturnValue(Promise.resolve({ id: 'cur-987654321' }));
       wrapper.find('[data-test-subj="AnalyticsTableEditQueryButton"]').last().simulate('click');
       await nextTick();
 
@@ -72,7 +72,7 @@ export const runActionColumnTests = (wrapper: ReactWrapper) => {
     });
 
     it('handles API errors', async () => {
-      http.get.mockReturnValue(Promise.reject());
+      http.post.mockReturnValue(Promise.reject());
       wrapper.find('[data-test-subj="AnalyticsTableEditQueryButton"]').first().simulate('click');
       await nextTick();
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/test_helpers/shared_columns_tests.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/test_helpers/shared_columns_tests.tsx
@@ -48,10 +48,10 @@ export const runActionColumnTests = (wrapper: ReactWrapper) => {
       wrapper.find('[data-test-subj="AnalyticsTableEditQueryButton"]').first().simulate('click');
       await nextTick();
 
-      expect(http.get).toHaveBeenCalledWith(
+      expect(http.post).toHaveBeenCalledWith(
         '/internal/app_search/engines/some-engine/curations/find_or_create',
         {
-          query: { query: 'some search' },
+          body: JSON.stringify({ query: 'some search' }),
         }
       );
       expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/curations/cur-123456789');
@@ -62,10 +62,10 @@ export const runActionColumnTests = (wrapper: ReactWrapper) => {
       wrapper.find('[data-test-subj="AnalyticsTableEditQueryButton"]').last().simulate('click');
       await nextTick();
 
-      expect(http.get).toHaveBeenCalledWith(
+      expect(http.post).toHaveBeenCalledWith(
         '/internal/app_search/engines/some-engine/curations/find_or_create',
         {
-          query: { query: '""' },
+          body: JSON.stringify({ query: '""' }),
         }
       );
       expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/curations/cur-987654321');

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.test.ts
@@ -195,13 +195,13 @@ describe('curations routes', () => {
     });
   });
 
-  describe('GET /internal/app_search/engines/{engineName}/curations/find_or_create', () => {
+  describe('POST /internal/app_search/engines/{engineName}/curations/find_or_create', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
       mockRouter = new MockRouter({
-        method: 'get',
+        method: 'post',
         path: '/internal/app_search/engines/{engineName}/curations/find_or_create',
       });
 
@@ -219,12 +219,12 @@ describe('curations routes', () => {
 
     describe('validates', () => {
       it('required query param', () => {
-        const request = { query: { query: 'some query' } };
+        const request = { body: { query: 'some query' } };
         mockRouter.shouldValidate(request);
       });
 
       it('missing query', () => {
-        const request = { query: {} };
+        const request = { body: {} };
         mockRouter.shouldThrow(request);
       });
     });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
@@ -105,14 +105,14 @@ export function registerCurationsRoutes({
     })
   );
 
-  router.get(
+  router.post(
     {
       path: '/internal/app_search/engines/{engineName}/curations/find_or_create',
       validate: {
         params: schema.object({
           engineName: schema.string(),
         }),
-        query: schema.object({
+        body: schema.object({
           query: schema.string(),
         }),
       },


### PR DESCRIPTION
The route was already changed in Enterprise Search.
It's used in the Analytics view, for managing curations for a given query:

<img width="613" alt="Screenshot 2022-06-22 at 12 46 29" src="https://user-images.githubusercontent.com/16032709/175011091-433ca1ee-1fdc-488d-b162-37fabbe2ee31.png">
