### PR TITLE
[Telemetry] Allow message field though.

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/filterlists/endpoint_alerts.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/filterlists/endpoint_alerts.ts
@@ -75,6 +75,7 @@ const allowlistBaseEventFields: AllowlistFields = {
       quarantine_message: true,
     },
   },
+  message: true,
   process: {
     parent: baseAllowlistFields,
     ...baseAllowlistFields,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
@@ -86,6 +86,7 @@ describe('TelemetryEventsSender', () => {
             },
             something_else: 'nope',
           },
+          message: 'Malicious Behavior Detection Alert: Regsvr32 with Unusual Arguments',
           process: {
             name: 'foo.exe',
             nope: 'nope',
@@ -164,6 +165,7 @@ describe('TelemetryEventsSender', () => {
               name: 'windows',
             },
           },
+          message: 'Malicious Behavior Detection Alert: Regsvr32 with Unusual Arguments',
           process: {
             name: 'foo.exe',
             working_directory: '/some/usr/dir',


### PR DESCRIPTION
## Summary

Allows the `message` field through the filter list in regards to endpoint telemetry.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

