### PR TITLE
[SecuritySolution][Timelines] Fixing timeline null field migration bug

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.test.ts
@@ -13,6 +13,7 @@ import {
   getExistingPrepackagedTimelines,
   getAllTimeline,
   resolveTimelineOrNull,
+  updatePartialSavedTimeline,
 } from '.';
 import { convertSavedObjectToSavedTimeline } from './convert_saved_object_to_savedtimeline';
 import { getNotesByTimelineId } from '../notes/saved_object';
@@ -20,6 +21,7 @@ import { getAllPinnedEventsByTimelineId } from '../pinned_events';
 import {
   AllTimelinesResponse,
   ResolvedTimelineWithOutcomeSavedObject,
+  SavedTimeline,
 } from '../../../../../common/types/timeline';
 import {
   mockResolvedSavedObject,
@@ -28,6 +30,7 @@ import {
 } from '../../__mocks__/resolve_timeline';
 import { DATA_VIEW_ID_REF_NAME, SAVED_QUERY_ID_REF_NAME, SAVED_QUERY_TYPE } from '../../constants';
 import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
+import { SavedObjectsUpdateResponse } from '@kbn/core/server';
 
 jest.mock('./convert_saved_object_to_savedtimeline', () => ({
   convertSavedObjectToSavedTimeline: jest.fn(),
@@ -358,6 +361,62 @@ describe('saved_object', () => {
       const { attributes } = convertSavedObjectToSavedTimelineMock.mock.calls[0][0];
       expect(attributes.dataViewId).toEqual('also-boo');
       expect(attributes.savedQueryId).toEqual('boo');
+    });
+  });
+
+  describe('updatePartialSavedTimeline', () => {
+    let mockSOClientGet: jest.Mock;
+    let mockSOClientUpdate: jest.Mock;
+    let mockRequest: FrameworkRequest;
+
+    const patchTimelineRequest: SavedTimeline = {
+      savedQueryId: null,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockSOClientUpdate = jest.fn(() => ({
+        ...mockResolvedSavedObject.saved_object,
+        attributes: {},
+      }));
+
+      mockSOClientGet = jest.fn(async () => ({
+        ...mockResolvedSavedObject.saved_object,
+        references: [
+          {
+            id: 'boo',
+            name: SAVED_QUERY_ID_REF_NAME,
+            type: SAVED_QUERY_TYPE,
+          },
+        ],
+      }));
+
+      mockRequest = {
+        user: {
+          username: 'username',
+        },
+        context: {
+          core: {
+            savedObjects: {
+              client: {
+                get: mockSOClientGet,
+                update: mockSOClientUpdate,
+              },
+            },
+          },
+        },
+      } as unknown as FrameworkRequest;
+    });
+
+    it('does not remove savedQueryId when it is null in the patch request', async () => {
+      const resp = (await updatePartialSavedTimeline(
+        mockRequest,
+        '760d3d20-2142-11ec-a46f-051cb8e3154c',
+        patchTimelineRequest
+      )) as SavedObjectsUpdateResponse<SavedTimeline>;
+
+      expect(resp.attributes.savedQueryId).toBeNull();
     });
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -493,7 +493,7 @@ const updateTimeline = async ({
   };
 };
 
-const updatePartialSavedTimeline = async (
+export const updatePartialSavedTimeline = async (
   request: FrameworkRequest,
   timelineId: string,
   timeline: SavedTimeline
@@ -528,7 +528,7 @@ const updatePartialSavedTimeline = async (
 
   const populatedTimeline =
     timelineFieldsMigrator.populateFieldsFromReferencesForPatch<TimelineWithoutExternalRefs>({
-      dataBeforeRequest: timelineUpdateAttributes,
+      dataBeforeRequest: timeline,
       dataReturnedFromRequest: updatedTimeline,
     });
 


### PR DESCRIPTION
This PR fixes an issue @cnasikas and I noticed will reading through the `FieldMigrator` code.

The issue is that we're not passing in the original request of a timeline to the migrator. Instead we're passing in the timeline that is modified by the migrator which effectively does nothing. The issue is that if the `updatePartialSavedTimeline` is called with a migrated field set to `null` it will remove the field in the response instead of placing it back as `null`.

After looking at it further I don't think there is any impact to the user if we left the code the way it is. This is because the `resetTimelines` does not return any documents and it doesn't include any of the migrated fields in the patch requests it makes. The implementation was confusing us so to avoid that in the future I'm suggesting we fix it :)