### PR TITLE
[migrations] Add descriptive logs for `unavailable_shards_exception`

### DIFF
--- a/src/core/server/saved_objects/migrations/actions/clone_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/clone_index.ts
@@ -23,8 +23,8 @@ import {
   INDEX_NUMBER_OF_SHARDS,
   WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
 } from './constants';
-import { isClusterShardLimitExceeded } from './es_errors';
-import { ClusterShardLimitExceeded } from './create_index';
+import { isClusterShardLimitExceeded, isUnavailableShardsException } from './es_errors';
+import { ClusterShardLimitExceeded, UnavailableShardsException } from './create_index';
 export type CloneIndexResponse = AcknowledgeResponse;
 
 /** @internal */
@@ -51,11 +51,15 @@ export const cloneIndex = ({
   target,
   timeout = DEFAULT_TIMEOUT,
 }: CloneIndexParams): TaskEither.TaskEither<
-  RetryableEsClientError | IndexNotFound | IndexNotYellowTimeout | ClusterShardLimitExceeded,
+  | RetryableEsClientError
+  | IndexNotFound
+  | IndexNotYellowTimeout
+  | ClusterShardLimitExceeded
+  | UnavailableShardsException,
   CloneIndexResponse
 > => {
   const cloneTask: TaskEither.TaskEither<
-    RetryableEsClientError | IndexNotFound | ClusterShardLimitExceeded,
+    RetryableEsClientError | IndexNotFound | ClusterShardLimitExceeded | UnavailableShardsException,
     AcknowledgeResponse
   > = () => {
     return client.indices
@@ -118,6 +122,10 @@ export const cloneIndex = ({
         } else if (isClusterShardLimitExceeded(error?.body?.error)) {
           return Either.left({
             type: 'cluster_shard_limit_exceeded' as const,
+          });
+        } else if (isUnavailableShardsException(error?.body?.error)) {
+          return Either.left({
+            type: 'unavailable_shards_exception' as const,
           });
         } else {
           throw error;

--- a/src/core/server/saved_objects/migrations/actions/es_errors.ts
+++ b/src/core/server/saved_objects/migrations/actions/es_errors.ts
@@ -30,3 +30,7 @@ export const isClusterShardLimitExceeded = ({ type, reason }: estypes.ErrorCause
     ) !== null
   );
 };
+
+export const isUnavailableShardsException = ({ type }: estypes.ErrorCause): boolean => {
+  return type === 'unavailable_shards_exception';
+};

--- a/src/core/server/saved_objects/migrations/actions/index.ts
+++ b/src/core/server/saved_objects/migrations/actions/index.ts
@@ -88,7 +88,7 @@ export { updateAndPickupMappings } from './update_and_pickup_mappings';
 
 import type { UnknownDocsFound } from './check_for_unknown_docs';
 import type { IncompatibleClusterRoutingAllocation } from './initialize_action';
-import { ClusterShardLimitExceeded } from './create_index';
+import { ClusterShardLimitExceeded, UnavailableShardsException } from './create_index';
 
 export type {
   CheckForUnknownDocsParams,
@@ -155,6 +155,7 @@ export interface ActionErrorTypeMap {
   incompatible_cluster_routing_allocation: IncompatibleClusterRoutingAllocation;
   index_not_yellow_timeout: IndexNotYellowTimeout;
   cluster_shard_limit_exceeded: ClusterShardLimitExceeded;
+  unavailable_shards_exception: UnavailableShardsException;
 }
 
 /**

--- a/src/core/server/saved_objects/migrations/model/model.ts
+++ b/src/core/server/saved_objects/migrations/model/model.ts
@@ -39,6 +39,7 @@ import { createBatches } from './create_batches';
 
 export const FATAL_REASON_REQUEST_ENTITY_TOO_LARGE = `While indexing a batch of saved objects, Elasticsearch returned a 413 Request Entity Too Large exception. Ensure that the Kibana configuration option 'migrations.maxBatchSizeBytes' is set to a value that is lower than or equal to the Elasticsearch 'http.max_content_length' configuration option.`;
 const CLUSTER_SHARD_LIMIT_EXCEEDED_REASON = `[cluster_shard_limit_exceeded] Upgrading Kibana requires adding a small number of new shards. Ensure that Kibana is able to add 10 more shards by increasing the cluster.max_shards_per_node setting, or removing indices to clear up resources.`;
+const UNAVAILABLE_SHARDS_EXCEPTION_REASON = `[unavailable_shards_exception] TODO`;
 
 export const model = (currentState: State, resW: ResponseType<AllActionStates>): State => {
   // The action response `resW` is weakly typed, the type includes all action
@@ -236,6 +237,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           ...stateP,
           controlState: 'FATAL',
           reason: `${CLUSTER_SHARD_LIMIT_EXCEEDED_REASON} See ${stateP.migrationDocLinks.clusterShardLimitExceeded}`,
+        };
+      } else if (isLeftTypeof(left, 'unavailable_shards_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `${UNAVAILABLE_SHARDS_EXCEPTION_REASON} See ${stateP.migrationDocLinks.unavailableShardsException}`,
         };
       } else {
         return throwBadResponse(stateP, left);
@@ -459,6 +466,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           ...stateP,
           controlState: 'FATAL',
           reason: `${CLUSTER_SHARD_LIMIT_EXCEEDED_REASON} See ${stateP.migrationDocLinks.clusterShardLimitExceeded}`,
+        };
+      } else if (isLeftTypeof(left, 'unavailable_shards_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `${UNAVAILABLE_SHARDS_EXCEPTION_REASON} See ${stateP.migrationDocLinks.unavailableShardsException}`,
         };
       } else {
         return throwBadResponse(stateP, left);
@@ -700,6 +713,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           ...stateP,
           controlState: 'FATAL',
           reason: `${CLUSTER_SHARD_LIMIT_EXCEEDED_REASON} See ${stateP.migrationDocLinks.clusterShardLimitExceeded}`,
+        };
+      } else if (isLeftTypeof(left, 'unavailable_shards_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `${UNAVAILABLE_SHARDS_EXCEPTION_REASON} See ${stateP.migrationDocLinks.unavailableShardsException}`,
         };
       } else {
         throwBadResponse(stateP, left);
@@ -961,6 +980,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           ...stateP,
           controlState: 'FATAL',
           reason: `${CLUSTER_SHARD_LIMIT_EXCEEDED_REASON} See ${stateP.migrationDocLinks.clusterShardLimitExceeded}`,
+        };
+      } else if (isLeftTypeof(left, 'unavailable_shards_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `${UNAVAILABLE_SHARDS_EXCEPTION_REASON} See ${stateP.migrationDocLinks.unavailableShardsException}`,
         };
       } else {
         return throwBadResponse(stateP, left);


### PR DESCRIPTION
Attempt to solve https://github.com/elastic/kibana/issues/127136

After adding the basic checks for an `unavailable_shards_exception`, I struggled to actually reproduce the exact problem described in the issue:

> After further investigation, we found-out that this issue is caused by the following:
>
> a) Orchestration issue in ESS/ECE where the shutdown metadata is not cleared (c.f [Get shutdown API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-shutdown.html)). This usually happens after some failed configuration changes. If so, the workaround here is to delete the shutdown metadata (c.f [Delete shutdown API](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-shutdown.html)). This will allow the shards to be allocated and the Kibana saved objects migration to complete.
>
> b) Related to the above, the number of replicas (set by index.auto_expand_replicas) may be incorrect in a single-node cluster (c.f https://github.com/elastic/elasticsearch/issues/84788).

Item `b` has already been resolved, and when writing an integration test for `a`, I couldn't reproduce the specific exception we see in the issue.

I tried a handful of things, including creating a transform job against the target index after I had already initiated a shutdown (transforms were specifically mentioned in the related cloud issue).

What am I overlooking? Perhaps what I'm missing is more context around `This usually happens after some failed configuration changes`?

