### PR TITLE
Ensure monitoring indices get cleaned during tests

### DIFF
--- a/x-pack/test/api_integration/apis/monitoring/elasticsearch_settings/set_collection_enabled.js
+++ b/x-pack/test/api_integration/apis/monitoring/elasticsearch_settings/set_collection_enabled.js
@@ -28,7 +28,7 @@ export default function ({ getService }) {
       };
 
       await esSupertest.put('/_cluster/settings').send(disableCollection).expect(200);
-      await esDeleteAllIndices('/.monitoring-*');
+      await esDeleteAllIndices('.monitoring-*');
     });
 
     it('should set collection.enabled to true', async () => {

--- a/x-pack/test/functional/apps/monitoring/enable_monitoring/index.js
+++ b/x-pack/test/functional/apps/monitoring/enable_monitoring/index.js
@@ -40,7 +40,7 @@ export default function ({ getService, getPageObjects }) {
       };
 
       await esSupertest.put('/_cluster/settings').send(disableCollection).expect(200);
-      await esDeleteAllIndices('/.monitoring-*');
+      await esDeleteAllIndices('.monitoring-*');
     });
 
     it('Monitoring enabled', async function () {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/134977

## Testing

If you'd like to demonstrate the deletion for yourself, you'll need to slow down the tests long enough to ensure indices get created.

To do that you can add `await new Promise((resolve) => setTimeout(resolve, 10000));` above https://github.com/elastic/kibana/blob/3671a82473e1a43ac8517ad89687e6af71063517/x-pack/test/api_integration/apis/monitoring/elasticsearch_settings/set_collection_enabled.js#L30 

Then when you run that test you should see this debug log:

```
 debg Deleting indices [attempt=1] [pattern=.monitoring-*] ".monitoring-kibana-7-2022.06.23", ".monitoring-es-7-2022.06.23"
```

With the leading slash, you'll get `debg No indices to delete [pattern=/.monitoring-*]` even with the timeout.

When running at full speed, it's fairly likely internal collection will never get a chance to create any indices, so you'll get the "No indices to delete" with either pattern.
