### PR TITLE
[Fleet] fix missing fleet server policy from enroll command

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -63,7 +63,7 @@ export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({ selecte
       isFleetServerReady,
       serviceToken,
       fleetServerHost: fleetServerHostForm.fleetServerHost,
-      fleetServerPolicyId,
+      fleetServerPolicyId: fleetServerPolicyId || selectedPolicyId,
       deploymentMode,
       disabled: !Boolean(serviceToken),
     }),


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/132691

To verify locally:
- Create a managed fleet server policy with preconfig
- Start kibana, create another fleet server policy with quick start/advanced instruction
- Enroll fleet server
- Reload the page, open Add agent flyout, select `Fleet server policy` (only in the list, because managed is not showing up)
- Verify that enroll command contains `fleet-server-policy` parameter

<img width="487" alt="image" src="https://user-images.githubusercontent.com/90178898/175244979-ff8da175-8ee3-4ae9-9793-0a64b51c44da.png">

