### PR TITLE
[XY] Wrong `visType` for `horizontal_bar` visualization

### DIFF
--- a/src/plugins/vis_types/xy/public/expression_functions/xy_vis_fn.ts
+++ b/src/plugins/vis_types/xy/public/expression_functions/xy_vis_fn.ts
@@ -19,13 +19,13 @@ import {
   DEFAULT_LEGEND_SIZE,
   LegendSize,
 } from '@kbn/visualizations-plugin/public';
-import type { ChartType } from '../../common';
 import type { VisParams, XYVisConfig } from '../types';
+import type { XyVisType } from '../../common';
 
 export const visName = 'xy_vis';
 export interface RenderValue {
   visData: Datatable;
-  visType: ChartType;
+  visType: XyVisType;
   visConfig: VisParams;
   syncColors: boolean;
   syncTooltips: boolean;
@@ -262,7 +262,7 @@ export const visTypeXyVisFn = (): VisTypeXyExpressionFunctionDefinition => ({
     },
   },
   fn(context, args, handlers) {
-    const visType = args.chartType;
+    const visType = args.type;
     const visConfig = {
       ariaLabel:
         args.ariaLabel ??


### PR DESCRIPTION
## Summary

During working on #132396 I found that for some reasons for `Horizontal and Vertical Bar visualizations` we use one `visType`.  Probably it's a regression of #98897

As a result now we cannot recognize specific type of visualization (`horizontal` or `vertical`)


What was done: 
`visType = args.chartType` was changed to `visType = args.type`

## Screens

### before

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/20072247/175291336-9ba98aa7-2f98-471b-8d05-9b5c8542fd7f.png">


### after

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/20072247/175291231-56a54b79-a750-49b5-bcd9-60e3980da067.png">
