### PR TITLE
[8.3] [Synthetics] adjust enabled key for browser monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/normalizers/browser.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/normalizers/browser.ts
@@ -101,7 +101,7 @@ export const normalizeProjectMonitor = ({
     [ConfigKey.ORIGINAL_SPACE]: namespace || defaultFields[ConfigKey.ORIGINAL_SPACE],
     [ConfigKey.CUSTOM_HEARTBEAT_ID]: `${monitor.id}-${projectId}-${namespace}`,
     [ConfigKey.TIMEOUT]: null,
-    [ConfigKey.ENABLED]: monitor.enabled || defaultFields[ConfigKey.ENABLED],
+    [ConfigKey.ENABLED]: monitor.enabled ?? defaultFields[ConfigKey.ENABLED],
   };
   return {
     ...DEFAULT_FIELDS[DataStream.BROWSER],

--- a/x-pack/test/api_integration/apis/uptime/rest/add_monitor_project.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/add_monitor_project.ts
@@ -653,7 +653,7 @@ export default function ({ getService }: FtrProviderContext) {
         const response = await supertest
           .get(API_URLS.SYNTHETICS_MONITORS)
           .query({
-            filter: `${syntheticsMonitorType}.attributes.journey_id: ${projectMonitors.monitors[0].id}`,
+            query: `${syntheticsMonitorType}.attributes.journey_id: ${projectMonitors.monitors[0].id}`,
           })
           .set('kbn-xsrf', 'true')
           .expect(200);


### PR DESCRIPTION
## Summary

Adjusts the enabled key so it doesn't end up being overwitten. 

Run
```
npx @elastic/synthetics push examples/todos/basic.journey.ts --auth [YOUR API KEY]  --url [YOUR KIBANA URL] --project test-project --schedule 10 --locations us_east
```
With a monitor disabled via

```
monitor.use({ enabled: false });
```
Then confirm in Kibana that the monitor displays as disabled.