### PR TITLE
fix: New Datafeed has no Indices

### DIFF
--- a/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
@@ -637,7 +637,7 @@ export function alertingServiceProvider(
       anomalyScoreField: resultTypeScoreMapping[params.resultType],
       includeInterimResults: params.includeInterim,
       resultType: params.resultType,
-      indexPattern: datafeeds![0]!.indices[0],
+      indexPattern: datafeeds![0]?.indices[0],
       anomalyScoreThreshold: params.severity,
     };
   };


### PR DESCRIPTION
## Summary

When using the REST API to create an alerting rule based on an anomaly detection ML job, the rule will fail to find indices for the corresponding data feed (if there aren't any yet). This null check prevents the behavior and allows the rule to continue checking until the data feed fully loads.

### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
