### PR TITLE
[Fleet] limit agent list total count to 10k

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -626,7 +626,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         pagination={{
           pageIndex: pagination.currentPage - 1,
           pageSize: pagination.pageSize,
-          totalItemCount: totalAgents,
+          totalItemCount: Math.min(totalAgents, SO_SEARCH_LIMIT),
           pageSizeOptions,
         }}
         isSelectable={true}


### PR DESCRIPTION
## Summary

Improvement for https://github.com/elastic/kibana/issues/91562
Limiting total size of agent list page to 10k, so that users can't click on page > 500 (for pageSize 20).

This is a small improvement as agreed in [comment](https://github.com/elastic/kibana/issues/91562#issuecomment-1157866528), because implementing pagination after 10k items are more complex, and not in scope for now.

Tested locally by setting limit to 100, enrolling 200 agents with horde, and checking that there are 5 visible pages only (for pageSize: 20). The page count is automatically adjusted when changing pageSize, e.g. max 2 pages for pageSize 50.

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/90178898/175315777-9c352470-4187-40bf-801f-24c1cc6c8fcc.png">
<img width="997" alt="image" src="https://user-images.githubusercontent.com/90178898/175315966-a9f21747-9153-4f9f-9c4c-2c4982e6ca2d.png">


