### PR TITLE
[Fleet] Promote Logstash output support to GA

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -46,7 +46,7 @@ export interface EditOutputFlyoutProps {
 
 const OUTPUT_TYPE_OPTIONS = [
   { value: 'elasticsearch', text: 'Elasticsearch' },
-  { value: 'logstash', text: 'Logstash (beta)' },
+  { value: 'logstash', text: 'Logstash' },
 ];
 
 export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = ({
@@ -133,24 +133,6 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
                 id="xpack.fleet.settings.editOutputFlyout.typeInputLabel"
                 defaultMessage="Type"
               />
-            }
-            helpText={
-              isLogstashOutput && (
-                <FormattedMessage
-                  id="xpack.fleet.editOutputFlyout.logstashTypeOutputBetaHelpText"
-                  defaultMessage="Logstash output is in beta. Click {sendFeedback} to report bugs and suggest improvements."
-                  values={{
-                    sendFeedback: (
-                      <strong>
-                        <FormattedMessage
-                          id="xpack.fleet.editOutputFlyout.sendFeedback"
-                          defaultMessage="Send feedback"
-                        />
-                      </strong>
-                    ),
-                  }}
-                />
-              )
             }
           >
             <EuiSelect


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/131533

Remove beta note + help text from Logstash form in output flyout as it's considered GA in 8.4

![image](https://user-images.githubusercontent.com/6766512/175317120-585d6aa8-5796-4579-971a-2663c472ada1.png)

