### PR TITLE
Add connector service package option to Content plugin

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connector_package.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connector_package.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface ConnectorPackage {
+  id: string;
+  indexName: string;
+  name: string;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector_package/add_connector_package_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector_package/add_connector_package_api_logic.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+interface AddConnectorValue {
+  id: string;
+  apiKey: string;
+}
+
+const addConnectorPackage = async ({ indexName }: { indexName: string }) => {
+  const route = '/internal/enterprise_search/connectors';
+
+  const params = {
+    index_name: indexName,
+  };
+  return await HttpLogic.values.http.post<AddConnectorValue>(route, {
+    body: JSON.stringify(params),
+  });
+};
+
+export const AddConnectorPackageApiLogic = createApiLogic(
+  ['add_connector_package_api_logic'],
+  addConnectorPackage
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_api.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_api.tsx
@@ -36,6 +36,7 @@ export const MethodApi: React.FC = () => {
       }
       docsUrl="#"
       type="api"
+      onSubmit={() => null}
     />
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
@@ -13,15 +13,21 @@
 
 import React from 'react';
 
-import { EuiPanel, EuiTitle } from '@elastic/eui';
+import { useActions, useValues } from 'kea';
+
 import { i18n } from '@kbn/i18n';
+
+import { Status } from '../../../../../common/types/api';
+import { AddConnectorPackageApiLogic } from '../../api/connector_package/add_connector_package_api_logic';
 
 import { NewSearchIndexTemplate } from './new_search_index_template';
 
 export const MethodConnector: React.FC = () => {
+  const { makeRequest } = useActions(AddConnectorPackageApiLogic);
+  const { status } = useValues(AddConnectorPackageApiLogic);
   return (
     <NewSearchIndexTemplate
-      title="Connector"
+      title="Build a custom connector package"
       description={i18n.translate(
         'xpack.enterpriseSearch.content.newIndex.methodConnector.description',
         {
@@ -31,20 +37,9 @@ export const MethodConnector: React.FC = () => {
       )}
       docsUrl="#"
       type="connector"
-    >
-      <EuiPanel
-        color="subdued"
-        style={{
-          minHeight: '30rem',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <EuiTitle size="s">
-          <h4>Place the connector flow here...</h4>
-        </EuiTitle>
-      </EuiPanel>
-    </NewSearchIndexTemplate>
+      onSubmit={(name) => makeRequest({ indexName: name })}
+      formDisabled={status === Status.LOADING}
+      buttonLoading={status === Status.LOADING}
+    />
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.tsx
@@ -31,6 +31,7 @@ export const MethodCrawler: React.FC = () => {
       )}
       docsUrl="#"
       type="crawler"
+      onSubmit={() => null}
     >
       <EuiPanel
         color="subdued"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_es.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_es.tsx
@@ -37,6 +37,7 @@ export const MethodEs: React.FC = () => {
       docsUrl="#"
       type="elasticsearch"
       onNameChange={(value: string) => onNameChange(value)}
+      onSubmit={() => null}
     >
       <EuiPanel
         color="subdued"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_json.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_json.tsx
@@ -34,6 +34,7 @@ export const MethodJson: React.FC = () => {
       docsUrl="#"
       type="json"
       onNameChange={(value: string) => onNameChange(value)}
+      onSubmit={() => null}
     >
       <EuiPanel
         color="subdued"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -49,14 +49,13 @@ interface ButtonGroupOption {
 
 export const NewIndex: React.FC = () => {
   const [selectedMethod, setSelectedMethod] = useState({ id: '', label: '' });
-  const [methodIsSelected, setMethodIsSelected] = useState(false);
 
   const { loadSearchEngines } = useActions(SearchIndicesLogic);
   useEffect(() => {
     loadSearchEngines();
   }, []);
 
-  const buttonGroupOptions = [
+  const buttonGroupOptions: ButtonGroupOption[] = [
     {
       id: 'crawler',
       icon: 'globe',
@@ -67,20 +66,6 @@ export const NewIndex: React.FC = () => {
         'xpack.enterpriseSearch.content.newIndex.buttonGroup.crawler.description',
         {
           defaultMessage: 'Index content from your websites',
-        }
-      ),
-    },
-    {
-      id: 'connector',
-      icon: 'package',
-      label: i18n.translate('xpack.enterpriseSearch.content.newIndex.buttonGroup.connector.label', {
-        defaultMessage: 'Use a data integration',
-      }),
-      description: i18n.translate(
-        'xpack.enterpriseSearch.content.newIndex.buttonGroup.connector.description',
-        {
-          defaultMessage:
-            'Index content frrom third-party services such as SharePoint and Google Drive',
         }
       ),
     },
@@ -98,27 +83,25 @@ export const NewIndex: React.FC = () => {
       ),
     },
     {
-      id: 'customIntegration',
+      id: 'connector',
       icon: 'package',
-      label: i18n.translate(
-        'xpack.enterpriseSearch.content.newIndex.buttonGroup.customIntegration.label',
-        {
-          defaultMessage: 'Build a custom data integration',
-        }
-      ),
+      label: i18n.translate('xpack.enterpriseSearch.content.newIndex.buttonGroup.connector.label', {
+        defaultMessage: 'Build a connector package',
+      }),
       description: i18n.translate(
-        'xpack.enterpriseSearch.content.newIndex.buttonGroup.customIntegration.description',
+        'xpack.enterpriseSearch.content.newIndex.buttonGroup.connector.description',
         {
-          defaultMessage: 'Clone the connector package repo and start customizing.',
+          defaultMessage: 'Clone the connector package repo and build a custom connector',
         }
       ),
     },
-  ] as ButtonGroupOption[];
+  ];
 
   const handleMethodChange = (val: string) => {
-    const selected = buttonGroupOptions.find((b) => b.id === val) as ButtonGroupOption;
-    setSelectedMethod(selected);
-    setMethodIsSelected(true);
+    const selected = buttonGroupOptions.find((b) => b.id === val);
+    if (selected) {
+      setSelectedMethod(selected);
+    }
   };
 
   const NewSearchIndexLayout = () => (
@@ -198,7 +181,7 @@ export const NewIndex: React.FC = () => {
           </EuiPanel>
         </EuiFlexItem>
         <EuiFlexItem>
-          {methodIsSelected ? <NewSearchIndexLayout /> : <SearchIndexEmptyState />}
+          {selectedMethod ? <NewSearchIndexLayout /> : <SearchIndexEmptyState />}
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -20,6 +20,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiForm,
   EuiFormRow,
   EuiLink,
   EuiPanel,
@@ -31,29 +32,28 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { Engine } from '../../../app_search/components/engine/types';
-
 import { SUPPORTED_LANGUAGES } from './constants';
 import { NewSearchIndexLogic } from './new_search_index_logic';
 
-export interface ISearchIndex {
+interface SearchIndex {
   title: React.ReactNode;
   description: React.ReactNode;
   docsUrl: string;
   type: string;
   onNameChange?(name: string): void;
+  onSubmit(name: string): void;
+  buttonLoading?: boolean;
+  formDisabled?: boolean;
 }
 
-export interface ISearchEngineOption {
-  label: string;
-  value: Engine;
-}
-
-export const NewSearchIndexTemplate: React.FC<ISearchIndex> = ({
+export const NewSearchIndexTemplate: React.FC<SearchIndex> = ({
   children,
   title,
   description,
   onNameChange,
+  onSubmit,
+  formDisabled,
+  buttonLoading,
 }) => {
   const { name, language, rawName } = useValues(NewSearchIndexLogic);
   const { setRawName, setLanguage } = useActions(NewSearchIndexLogic);
@@ -71,110 +71,125 @@ export const NewSearchIndexTemplate: React.FC<ISearchIndex> = ({
 
   return (
     <EuiPanel hasBorder>
-      <EuiFlexGroup direction="column">
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="s">
-            <h2>{title}</h2>
-          </EuiTitle>
-          <EuiText size="s" color="subdued">
-            <p>
-              {description}
-              <EuiLink target="_blank" href="#">
-                {i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.learnMore.linkText',
-                  {
-                    defaultMessage: 'Learn more',
-                  }
-                )}
-              </EuiLink>
-            </p>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow>
-          <EuiFlexGroup>
-            <EuiFlexItem grow>
-              <EuiFormRow
-                label={i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputLabel',
-                  {
-                    defaultMessage: 'Index name',
-                  }
-                )}
-                helpText={i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText',
-                  {
-                    defaultMessage:
-                      'Names cannot contain spaces or special characters. {indexName}',
-                    values: {
-                      indexName: name.length > 0 ? `Your index will be named: ${name}` : '',
-                    },
-                  }
-                )}
-                fullWidth
-              >
-                <EuiFieldText
-                  placeholder={i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputPlaceholder',
+      <EuiForm
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSubmit(name);
+        }}
+        component="form"
+        id="enterprise-search-add-connector"
+      >
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h2>{title}</h2>
+            </EuiTitle>
+            <EuiText size="s" color="subdued">
+              <p>
+                {description}
+                <EuiLink target="_blank" href="#">
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.learnMore.linkText',
                     {
-                      defaultMessage: 'Set a name for your index',
+                      defaultMessage: 'Learn more',
+                    }
+                  )}
+                </EuiLink>
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow>
+            <EuiFlexGroup>
+              <EuiFlexItem grow>
+                <EuiFormRow
+                  label={i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputLabel',
+                    {
+                      defaultMessage: 'Index name',
+                    }
+                  )}
+                  helpText={i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText',
+                    {
+                      defaultMessage:
+                        'Names cannot contain spaces or special characters. {indexName}',
+                      values: {
+                        indexName: name.length > 0 ? `Your index will be named: ${name}` : '',
+                      },
                     }
                   )}
                   fullWidth
-                  isInvalid={false}
-                  value={rawName}
-                  onChange={handleNameChange}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiFormRow
-                label={i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputLabel',
-                  {
-                    defaultMessage: 'Document language',
-                  }
-                )}
-                helpText={i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputHelpText',
-                  {
-                    defaultMessage: 'Analyzers can be changed later, but may require a reindex',
-                  }
-                )}
-              >
-                <EuiSelect
-                  options={SUPPORTED_LANGUAGES}
-                  onChange={handleLanguageChange}
-                  value={language}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-        <EuiFlexItem grow>{children}</EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer />
-      <EuiFlexGroup direction="row" alignItems="center" justifyContent="spaceBetween">
-        <EuiFlexItem grow={false}>
-          <EuiButton fill isDisabled={!name}>
-            {i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.createIndex.buttonText',
-              {
-                defaultMessage: 'Create index',
-              }
-            )}
-          </EuiButton>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiLink target="_blank" href="#">
-            {i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.viewDocumentation.linkText',
-              {
-                defaultMessage: 'View the documentation',
-              }
-            )}
-          </EuiLink>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+                >
+                  <EuiFieldText
+                    placeholder={i18n.translate(
+                      'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputPlaceholder',
+                      {
+                        defaultMessage: 'Set a name for your index',
+                      }
+                    )}
+                    fullWidth
+                    isInvalid={false}
+                    value={rawName}
+                    onChange={handleNameChange}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFormRow
+                  label={i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputLabel',
+                    {
+                      defaultMessage: 'Document language',
+                    }
+                  )}
+                  helpText={i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputHelpText',
+                    {
+                      defaultMessage: 'Analyzers can be changed later, but may require a reindex',
+                    }
+                  )}
+                >
+                  <EuiSelect
+                    options={SUPPORTED_LANGUAGES}
+                    onChange={handleLanguageChange}
+                    value={language}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem grow>{children}</EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer />
+        <EuiFlexGroup direction="row" alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              isDisabled={!name || formDisabled}
+              isLoading={buttonLoading}
+              type="submit"
+            >
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.createIndex.buttonText',
+                {
+                  defaultMessage: 'Create index',
+                }
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiLink target="_blank" href="#">
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.viewDocumentation.linkText',
+                {
+                  defaultMessage: 'View the documentation',
+                }
+              )}
+            </EuiLink>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiForm>
       <EuiSpacer />
 
       <EuiSteps

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -38,3 +38,5 @@ export const config: PluginConfigDescriptor<ConfigType> = {
     host: true,
   },
 };
+
+export const CONNECTORS_INDEX = '.ent-search-connectors';

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { CONNECTORS_INDEX } from '../..';
+
+interface ConnectorDocument {
+  index_name: string;
+}
+
+export const createConnectorsIndex = async (client: IScopedClusterClient): Promise<void> => {
+  const index = CONNECTORS_INDEX;
+  await client.asCurrentUser.indices.create({ index });
+};
+
+const createConnector = async (
+  index: string,
+  document: ConnectorDocument,
+  client: IScopedClusterClient
+): Promise<{ id: string; apiKey: string }> => {
+  const result = await client.asCurrentUser.index({
+    index,
+    document,
+  });
+  await client.asCurrentUser.indices.create({ index: document.index_name });
+  const apiKeyResult = await client.asCurrentUser.security.createApiKey({
+    name: `${document.index_name}-connector`,
+    role_descriptors: {
+      [`${document.index_name}-connector-name`]: {
+        cluster: [],
+        index: [
+          {
+            names: [document.index_name, index],
+            privileges: ['all'],
+          },
+        ],
+      },
+    },
+  });
+  return { apiKey: apiKeyResult.encoded, id: result._id };
+};
+
+export const addConnector = async (
+  client: IScopedClusterClient,
+  document: ConnectorDocument
+): Promise<{ apiKey: string; id: string }> => {
+  const index = CONNECTORS_INDEX;
+  try {
+    return createConnector(index, document, client);
+  } catch (error) {
+    if (error.statusCode === 404) {
+      // This means .ent-search-connectors index doesn't exist yet
+      // So we first have to create it, and then try inserting the document again
+      // TODO: Move index creation to Kibana startup instead
+      await createConnectorsIndex(client);
+      return createConnector(index, document, client);
+    } else {
+      throw error;
+    }
+  }
+};

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -46,6 +46,7 @@ import {
 
 import { registerAppSearchRoutes } from './routes/app_search';
 import { registerConfigDataRoute } from './routes/enterprise_search/config_data';
+import { registerConnectorRoutes } from './routes/enterprise_search/connectors';
 import { registerIndexRoutes } from './routes/enterprise_search/indices';
 import { registerTelemetryRoute } from './routes/enterprise_search/telemetry';
 import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
@@ -161,6 +162,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     registerAppSearchRoutes(dependencies);
     registerWorkplaceSearchRoutes(dependencies);
     registerIndexRoutes(dependencies);
+    registerConnectorRoutes(dependencies);
 
     /**
      * Bootstrap the routes, saved objects, and collector for telemetry

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { addConnector } from '../../lib/connectors/add_connector';
+
+import { RouteDependencies } from '../../plugin';
+
+export function registerConnectorRoutes({ router }: RouteDependencies) {
+  router.post(
+    {
+      path: '/internal/enterprise_search/connectors',
+      validate: {
+        body: schema.object({
+          index_name: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const { client } = (await context.core).elasticsearch;
+      try {
+        const body = await addConnector(client, request.body);
+        return response.ok({ body });
+      } catch (error) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Error fetching data from Enterprise Search',
+        });
+      }
+    }
+  );
+}


### PR DESCRIPTION
This adds the connector service package option to the Enterprise Search Content plugin. Mostly so that @byronhulcher and I can get on the same codebase and page. No tests.