### PR TITLE
[Security Solution] Skips `Auto refreshes rules` failing test to unblock main

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
@@ -101,7 +101,8 @@ describe('Alerts detection rules', () => {
       .should('have.class', 'euiPaginationButton-isActive');
   });
 
-  it('Auto refreshes rules', () => {
+  // Refer to https://github.com/elastic/kibana/issues/135057 for the skipped test
+  it.skip('Auto refreshes rules', () => {
     /**
      * Ran into the error: timer created with setInterval() but cleared with cancelAnimationFrame()
      * There are no cancelAnimationFrames in the codebase that are used to clear a setInterval so


### PR DESCRIPTION
## Summary

Refer to: https://github.com/elastic/kibana/issues/135057
