### PR TITLE
[Enterprise Search] Update steps New search index methods

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_api.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_api.tsx
@@ -12,7 +12,8 @@
 
 import React from 'react';
 
-import { EuiText } from '@elastic/eui';
+import { EuiSteps, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { NewSearchIndexTemplate } from './new_search_index_template';
@@ -37,6 +38,81 @@ export const MethodApi: React.FC = () => {
       docsUrl="#"
       type="api"
       onSubmit={() => null}
-    />
+    >
+      <EuiSteps
+        steps={[
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.createIndex.title',
+              {
+                defaultMessage: 'Create an Elasticsearch index',
+              }
+            ),
+
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.createIndex.content',
+                    {
+                      defaultMessage:
+                        'Provide a unique name for your index and select an optional language analyzer.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.configureIngestion.title',
+              {
+                defaultMessage: 'Configure ingestion settings',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.methodApi.steps.configureIngestion.content',
+                    {
+                      defaultMessage:
+                        'Generate an API key and view the documentation for posting documents to the Elasticsearch API endpoint. Language clients are available for streamlined integration.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.title',
+              {
+                defaultMessage: 'Build a search experience',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.content',
+                    {
+                      defaultMessage:
+                        'Connect your newly created Elasticsearch index to an App Search engine to build a cusomtizable search experience.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+        ]}
+      />
+    </NewSearchIndexTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.test.tsx
@@ -5,25 +5,31 @@
  * 2.0.
  */
 
+import { setMockActions, setMockValues } from '../../../__mocks__/kea_logic';
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
 
 import { EuiSteps } from '@elastic/eui';
 
-import { MethodApi } from './method_api';
+import { Status } from '../../../../../common/types/api';
+
+import { MethodConnector } from './method_connector';
 import { NewSearchIndexTemplate } from './new_search_index_template';
 
-describe('MethodApi', () => {
+describe('MethodConnector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setMockValues({ status: Status.IDLE });
+    setMockActions({ makeRequest: jest.fn() });
   });
 
-  it('renders API ingestion method tab', () => {
-    const wrapper = shallow(<MethodApi />);
+  it('renders connector ingestion method tab', () => {
+    const wrapper = shallow(<MethodConnector />);
     const template = wrapper.find(NewSearchIndexTemplate);
 
-    expect(template.prop('type')).toEqual('api');
+    expect(template.prop('type')).toEqual('connector');
     expect(template.find(EuiSteps)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
@@ -80,7 +80,7 @@ export const MethodConnector: React.FC = () => {
               <EuiText size="s">
                 <p>
                   {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.methodCrawler.steps.configureIngestion.content',
+                    'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.configureIngestion.content',
                     {
                       defaultMessage:
                         'Clone the connector package repository on GitHub and build a custom connector that suits your needs.',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import { EuiSteps, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { Status } from '../../../../../common/types/api';
@@ -40,6 +41,81 @@ export const MethodConnector: React.FC = () => {
       onSubmit={(name) => makeRequest({ indexName: name })}
       formDisabled={status === Status.LOADING}
       buttonLoading={status === Status.LOADING}
-    />
+    >
+      <EuiSteps
+        steps={[
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.createIndex.title',
+              {
+                defaultMessage: 'Create an Elasticsearch index',
+              }
+            ),
+
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.createIndex.content',
+                    {
+                      defaultMessage:
+                        'Provide a unique name for your index and select an optional language analyzer.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.configureIngestion.title',
+              {
+                defaultMessage: 'Configure ingestion settings',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.methodCrawler.steps.configureIngestion.content',
+                    {
+                      defaultMessage:
+                        'Clone the connector package repository on GitHub and build a custom connector that suits your needs.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.title',
+              {
+                defaultMessage: 'Build a search experience',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.content',
+                    {
+                      defaultMessage:
+                        'Connect your newly created Elasticsearch index to an App Search engine to build a cusomtizable search experience.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+        ]}
+      />
+    </NewSearchIndexTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.test.tsx
@@ -11,7 +11,7 @@ import { shallow } from 'enzyme';
 
 import { EuiSteps } from '@elastic/eui';
 
-import { MethodApi } from './method_api';
+import { MethodCrawler } from './method_crawler';
 import { NewSearchIndexTemplate } from './new_search_index_template';
 
 describe('MethodApi', () => {
@@ -20,10 +20,10 @@ describe('MethodApi', () => {
   });
 
   it('renders API ingestion method tab', () => {
-    const wrapper = shallow(<MethodApi />);
+    const wrapper = shallow(<MethodCrawler />);
     const template = wrapper.find(NewSearchIndexTemplate);
 
-    expect(template.prop('type')).toEqual('api');
+    expect(template.prop('type')).toEqual('crawler');
     expect(template.find(EuiSteps)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 
-import { EuiPanel, EuiTitle } from '@elastic/eui';
+import { EuiSteps, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { NewSearchIndexTemplate } from './new_search_index_template';
@@ -33,19 +33,80 @@ export const MethodCrawler: React.FC = () => {
       type="crawler"
       onSubmit={() => null}
     >
-      <EuiPanel
-        color="subdued"
-        style={{
-          minHeight: '30rem',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <EuiTitle size="s">
-          <h4>Place the crawler domain validation here...</h4>
-        </EuiTitle>
-      </EuiPanel>
+      <EuiSteps
+        steps={[
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.createIndex.title',
+              {
+                defaultMessage: 'Create an Elasticsearch index',
+              }
+            ),
+
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.createIndex.content',
+                    {
+                      defaultMessage:
+                        'Provide a unique name for your index and select an optional language analyzer.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.configureIngestion.title',
+              {
+                defaultMessage: 'Configure ingestion settings',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.methodCrawler.steps.configureIngestion.content',
+                    {
+                      defaultMessage:
+                        'Enter the domains you’d like to crawl, configure crawl rules and entry points, set up a crawl schedule and let Enterprise Search do the rest.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+          {
+            title: i18n.translate(
+              'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.title',
+              {
+                defaultMessage: 'Build a search experience',
+              }
+            ),
+            titleSize: 'xs',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.content.newIndex.steps.buildSearchExperience.content',
+                    {
+                      defaultMessage:
+                        'Connect your newly created Elasticsearch index to an App Search engine to build a cusomtizable search experience.',
+                    }
+                  )}
+                </p>
+              </EuiText>
+            ),
+            status: 'incomplete',
+          },
+        ]}
+      />
     </NewSearchIndexTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues, setMockActions } from '../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import {
+  NewSearchIndexTemplate,
+  Props as NewSearchIndexTemplateProps,
+} from './new_search_index_template';
+
+describe('NewSearchIndexTemplate', () => {
+  const mockProps: NewSearchIndexTemplateProps = {
+    title: 'Index using the API',
+    description: 'Provide a name and optionally select a language analyzer.',
+    docsUrl: 'http://www.elastic.co/guide',
+    onSubmit: jest.fn(),
+    type: 'api',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues({ name: 'my-name', rawName: 'MY$_RAW_$NAME', language: 'Universal' });
+    setMockActions({ makeRequest: jest.fn() });
+  });
+
+  it('renders children', () => {
+    const wrapper = shallow(
+      <NewSearchIndexTemplate {...mockProps}>
+        <div data-test-subj="ChildComponent" />
+      </NewSearchIndexTemplate>
+    );
+
+    expect(wrapper.find('[data-test-subj="ChildComponent"]')).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -35,7 +35,7 @@ import { i18n } from '@kbn/i18n';
 import { SUPPORTED_LANGUAGES } from './constants';
 import { NewSearchIndexLogic } from './new_search_index_logic';
 
-interface SearchIndex {
+export interface Props {
   title: React.ReactNode;
   description: React.ReactNode;
   docsUrl: string;
@@ -46,7 +46,7 @@ interface SearchIndex {
   formDisabled?: boolean;
 }
 
-export const NewSearchIndexTemplate: React.FC<SearchIndex> = ({
+export const NewSearchIndexTemplate: React.FC<Props> = ({
   children,
   title,
   description,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -22,11 +22,11 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiLink,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
-  EuiSteps,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -98,7 +98,6 @@ export const NewSearchIndexTemplate: React.FC<SearchIndex> = ({
               </p>
             </EuiText>
           </EuiFlexItem>
-
           <EuiFlexItem grow>
             <EuiFlexGroup>
               <EuiFlexItem grow>
@@ -159,7 +158,6 @@ export const NewSearchIndexTemplate: React.FC<SearchIndex> = ({
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          <EuiFlexItem grow>{children}</EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer />
         <EuiFlexGroup direction="row" alignItems="center" justifyContent="spaceBetween">
@@ -190,82 +188,8 @@ export const NewSearchIndexTemplate: React.FC<SearchIndex> = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiForm>
-      <EuiSpacer />
-
-      <EuiSteps
-        steps={[
-          {
-            title: i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.createIndex.title',
-              {
-                defaultMessage: 'Create an Elasticsearch index',
-              }
-            ),
-
-            titleSize: 'xs',
-            children: (
-              <EuiText size="s">
-                <p>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.createIndex.content',
-                    {
-                      defaultMessage:
-                        'Provide a unique name for your index and select an optional language analyzer.',
-                    }
-                  )}
-                </p>
-              </EuiText>
-            ),
-            status: 'incomplete',
-          },
-          {
-            title: i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.configureIngestion.title',
-              {
-                defaultMessage: 'Configure ingestion settings',
-              }
-            ),
-            titleSize: 'xs',
-            children: (
-              <EuiText size="s">
-                <p>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.configureIngestion.content',
-                    {
-                      defaultMessage:
-                        'Generate an API key and view the documentation for posting documents to the Elasticsearch API endpoint. Language clients are available for streamlined integration.',
-                    }
-                  )}
-                </p>
-              </EuiText>
-            ),
-            status: 'incomplete',
-          },
-          {
-            title: i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.buildSearchExperience.title',
-              {
-                defaultMessage: 'Build a search experience',
-              }
-            ),
-            titleSize: 'xs',
-            children: (
-              <EuiText size="s">
-                <p>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.steps.buildSearchExperience.content',
-                    {
-                      defaultMessage:
-                        'Connect your newly created Elasticsearch index to an App Search engine to build a cusomtizable search experience.',
-                    }
-                  )}
-                </p>
-              </EuiText>
-            ),
-            status: 'incomplete',
-          },
-        ]}
-      />
+      <EuiHorizontalRule />
+      {children}
     </EuiPanel>
   );
 };


### PR DESCRIPTION
## Summary

The only difference between the three new index views is the steps,  each method has a different step 2. Also Crawler won't need validation on this page, we do that after index creation on the index detail configuration tab, so we don't need to use the children for that.  

Did I write any tests? No.  


![Screen Shot 2022-06-23 at 1 11 43 PM](https://user-images.githubusercontent.com/2479295/175356900-c57e8022-b23d-40fe-be7f-672fbc9eb137.png)

![Screen Shot 2022-06-23 at 1 11 46 PM](https://user-images.githubusercontent.com/2479295/175356911-c8463842-44c3-4653-a07d-5535ca60785d.png)

![Screen Shot 2022-06-23 at 1 11 48 PM](https://user-images.githubusercontent.com/2479295/175356927-84df1c14-9fc6-42d4-94b4-cf74e8c33de5.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
