### PR TITLE
[Enterprise Search] Add eslint warning for unsorted keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1442,6 +1442,8 @@ module.exports = {
         'import/newline-after-import': 'error',
         'react-hooks/exhaustive-deps': 'off',
         'react/jsx-boolean-value': ['error', 'never'],
+        'sort-keys': 1, // warning
+        '@typescript-eslint/member-ordering': [1, { default: { order: 'alphabetically' } }], // warning
         '@typescript-eslint/no-unused-vars': [
           'error',
           { vars: 'all', args: 'after-used', ignoreRestSiblings: true, varsIgnorePattern: '^_' },

--- a/x-pack/plugins/enterprise_search/.eslintrc.json
+++ b/x-pack/plugins/enterprise_search/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "sort-keys": 1,
+    "@typescript-eslint/member-ordering": [
+      1,
+      { "default": {"order": "alphabetically"}}
+    ]
+  }
+}

--- a/x-pack/plugins/enterprise_search/.eslintrc.json
+++ b/x-pack/plugins/enterprise_search/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-  "rules": {
-    "sort-keys": 1,
-    "@typescript-eslint/member-ordering": [
-      1,
-      { "default": {"order": "alphabetically"}}
-    ]
-  }
-}


### PR DESCRIPTION
## Summary

We've discussed that we'd like to enforce these rules in the future through eslint.  However it would be a very large undertaking to fix this in our existing codebase, these rules do not have autofix capabilities available out of the box.  So I've elected to add these rules as a warning, they will appear in VSCode while writing code and in the command line during pre-commit hooks.  This will encourage us to write new code with sorted keys, and to fix files as we go along.  


`sort-keys` affects normal JavaScript objects, but not typescript interfaces.  To sort those I added the `@typescript-eslint/member-ordering` rule as well