### PR TITLE
[SUPT] fix apm reporting

### DIFF
--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -15,6 +15,21 @@ node scripts/es snapshot&
 
 esPid=$!
 
+# unset env vars defined in other parts of CI for automatic APM collection of
+# Kibana. We manage APM config in our FTR config and performance service, and
+# APM treats config in the ENV with a very high precedence.
+unset ELASTIC_APM_ENVIRONMENT
+unset ELASTIC_APM_TRANSACTION_SAMPLE_RATE
+unset ELASTIC_APM_SERVER_URL
+unset ELASTIC_APM_SECRET_TOKEN
+unset ELASTIC_APM_ACTIVE
+unset ELASTIC_APM_CONTEXT_PROPAGATION_ONLY
+unset ELASTIC_APM_ACTIVE
+unset ELASTIC_APM_SERVER_URL
+unset ELASTIC_APM_SECRET_TOKEN
+unset ELASTIC_APM_GLOBAL_LABELS
+
+
 export TEST_ES_URL=http://elastic:changeme@localhost:9200
 export TEST_ES_DISABLE_STARTUP=true
 
@@ -30,19 +45,19 @@ for i in "${journeys[@]}"; do
 
     checks-reporter-with-killswitch "Run Performance Tests with Playwright Config (Journey:${i},Phase: WARMUP)" \
       node scripts/functional_tests \
-      --config "x-pack/test/performance/journeys/${i}/config.ts" \
-      --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-      --debug \
-      --bail
+        --config "x-pack/test/performance/journeys/${i}/config.ts" \
+        --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+        --debug \
+        --bail
 
     export TEST_PERFORMANCE_PHASE=TEST
 
     checks-reporter-with-killswitch "Run Performance Tests with Playwright Config (Journey:${i},Phase: TEST)" \
       node scripts/functional_tests \
-      --config "x-pack/test/performance/journeys/${i}/config.ts" \
-      --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-      --debug \
-      --bail
+        --config "x-pack/test/performance/journeys/${i}/config.ts" \
+        --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+        --debug \
+        --bail
 done
 
 kill "$esPid"

--- a/x-pack/test/performance/services/performance.ts
+++ b/x-pack/test/performance/services/performance.ts
@@ -9,6 +9,7 @@
 
 import Url from 'url';
 import { inspect } from 'util';
+import { setTimeout } from 'timers/promises';
 import apm, { Span, Transaction } from 'elastic-apm-node';
 import playwright, { ChromiumBrowser, Page, BrowserContext, CDPSession } from 'playwright';
 import { FtrService, FtrProviderContext } from '../ftr_provider_context';
@@ -35,14 +36,45 @@ export class PerformanceTestingService extends FtrService {
     ctx.getService('lifecycle').beforeTests.add(() => {
       apm.start({
         serviceName: 'functional test runner',
+        environment: process.env.CI ? 'ci' : 'development',
+        active: this.config.get(`kbnTestServer.env`).ELASTIC_APM_ACTIVE !== 'false',
         serverUrl: this.config.get(`kbnTestServer.env`).ELASTIC_APM_SERVER_URL,
         secretToken: this.config.get(`kbnTestServer.env`).ELASTIC_APM_SECRET_TOKEN,
         globalLabels: this.config.get(`kbnTestServer.env`).ELASTIC_APM_GLOBAL_LABELS,
+        transactionSampleRate:
+          this.config.get(`kbnTestServer.env`).ELASTIC_APM_TRANSACTION_SAMPLE_RATE,
+        logger: process.env.VERBOSE_APM_LOGGING
+          ? {
+              warn(...args: any[]) {
+                console.log('APM WARN', ...args);
+              },
+              info(...args: any[]) {
+                console.log('APM INFO', ...args);
+              },
+              fatal(...args: any[]) {
+                console.log('APM FATAL', ...args);
+              },
+              error(...args: any[]) {
+                console.log('APM ERROR', ...args);
+              },
+              debug(...args: any[]) {
+                console.log('APM DEBUG', ...args);
+              },
+              trace(...args: any[]) {
+                console.log('APM TRACE', ...args);
+              },
+            }
+          : undefined,
       });
     });
 
     ctx.getService('lifecycle').cleanup.add(async () => {
       await this.shutdownBrowser();
+      await new Promise<void>((resolve) => apm.flush(() => resolve()));
+      // wait for the HTTP request that apm.flush() starts, which we
+      // can't track but hope is complete within 3 seconds
+      // https://github.com/elastic/apm-agent-nodejs/issues/2088
+      await setTimeout(3000);
     });
   }
 
@@ -173,7 +205,6 @@ export class PerformanceTestingService extends FtrService {
 
   private async tearDown(page: Page, client: CDPSession, context: BrowserContext) {
     if (page) {
-      apm.flush();
       await client.detach();
       await page.close();
       await context.close();


### PR DESCRIPTION
We've seen some inconsistencies in APM transactions being reported between CI and local development. This fixed CI reporting by clearing `ELASTIC_APM*` environment variables in the performance jobs, since APM places a high precedence for ENV vars and we tried and failed to mutate the process ENV in node. By clearing these out the explicitly defined config in the performance service and the Kibana server process are allowed to take precedence.

Additionally, we moved the `apm.flush()` call in the performance suite out of the `teardown()` method, which is called before the journey transaction is complete, and instead we flush in the cleanup lifecycle phase.