### PR TITLE
[Security Solution][Detections] Fixes `Auto refreshes rules` cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
@@ -102,7 +102,7 @@ describe('Alerts detection rules', () => {
   });
 
   // Refer to https://github.com/elastic/kibana/issues/135057 for the skipped test
-  it.skip('Auto refreshes rules', () => {
+  it('Auto refreshes rules', () => {
     /**
      * Ran into the error: timer created with setInterval() but cleared with cancelAnimationFrame()
      * There are no cancelAnimationFrames in the codebase that are used to clear a setInterval so
@@ -111,7 +111,7 @@ describe('Alerts detection rules', () => {
 
     visit(DETECTIONS_RULE_MANAGEMENT_URL);
 
-    cy.clock(Date.now(), ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date']);
+    cy.clock(Date.now(), ['setInterval', 'clearInterval', 'Date']);
 
     waitForRulesTableToBeLoaded();
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
@@ -101,7 +101,6 @@ describe('Alerts detection rules', () => {
       .should('have.class', 'euiPaginationButton-isActive');
   });
 
-  // Refer to https://github.com/elastic/kibana/issues/135057 for the skipped test
   it('Auto refreshes rules', () => {
     /**
      * Ran into the error: timer created with setInterval() but cleared with cancelAnimationFrame()


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/135057

I noticed the `react-query` `refetchInterval` configuration was only leveraging `setInterval` within its implementation, so I went ahead and removed the `set/clearTimeout` overrides and that appears to have resolved the `Cannot access 'appSub' before initialization` error. Relevant `react-query` source [here](https://github.com/TanStack/query/blob/cca1bbfb9abf12bf3341c7cfb6e034a5ebab1379/src/core/queryObserver.ts#L367-L374).

Note: I was not able to identify what introduced this issue, but presumably it was either a cypress/react-query upgrade, or perhaps a change in solution code that removed a `setTimeout` from the codepaths touched as part of this test. 🤷 


### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
