### PR TITLE
[8.3] Rollup Job a11y Tests (#134975)

### DIFF
--- a/x-pack/test/accessibility/apps/rollup_jobs.ts
+++ b/x-pack/test/accessibility/apps/rollup_jobs.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'settings', 'header', 'rollup']);
+  const a11y = getService('a11y');
+  const testSubjects = getService('testSubjects');
+  const kibanaServer = getService('kibanaServer');
+  const esArchiver = getService('esArchiver');
+  const es = getService('es');
+
+  describe('Stack management- rollup a11y tests', () => {
+    const rollupJobName = `rollup${Date.now().toString()}`;
+    before(async () => {
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await kibanaServer.uiSettings.update({
+        defaultIndex: 'logstash-*',
+      });
+      await PageObjects.settings.navigateTo();
+      await PageObjects.rollup.clickRollupJobsTab();
+    });
+
+    it('empty state', async () => {
+      await a11y.testAppSnapshot();
+    });
+
+    describe('create a rollup job wizard', async () => {
+      it('step 1 - logistics', async () => {
+        await testSubjects.click('createRollupJobButton');
+        await PageObjects.rollup.verifyStepIsActive(1);
+        await a11y.testAppSnapshot();
+      });
+
+      it('step 2 - date histogram', async () => {
+        await PageObjects.rollup.addRollupNameandIndexPattern(rollupJobName, 'logstash*');
+        await PageObjects.rollup.verifyIndexPatternAccepted();
+        await PageObjects.rollup.setIndexName('rollupindex');
+        await PageObjects.rollup.moveToNextStep(2);
+        await PageObjects.rollup.verifyStepIsActive(2);
+        await a11y.testAppSnapshot();
+      });
+
+      it('step 3 - terms', async () => {
+        await PageObjects.rollup.setJobInterval('24h');
+        await PageObjects.rollup.moveToNextStep(3);
+        await PageObjects.rollup.verifyStepIsActive(3);
+        await a11y.testAppSnapshot();
+      });
+
+      it('step 4 - histogram', async () => {
+        await PageObjects.rollup.moveToNextStep(4);
+        await PageObjects.rollup.verifyStepIsActive(4);
+        await a11y.testAppSnapshot();
+      });
+
+      it('step 5 - metrics', async () => {
+        await PageObjects.rollup.moveToNextStep(5);
+        await PageObjects.rollup.verifyStepIsActive(5);
+        await a11y.testAppSnapshot();
+      });
+
+      it('step 6 - review and save', async () => {
+        await PageObjects.rollup.moveToNextStep(6);
+        await PageObjects.rollup.verifyStepIsActive(6);
+        await a11y.testAppSnapshot();
+      });
+
+      it('submit form and snapshot rollup flyout', async () => {
+        await PageObjects.rollup.saveJob(false);
+        await a11y.testAppSnapshot();
+      });
+
+      it('rollup table', async () => {
+        await PageObjects.rollup.closeFlyout();
+        await a11y.testAppSnapshot();
+      });
+    });
+
+    after(async () => {
+      await es.transport.request({
+        path: `/_rollup/job/${rollupJobName}`,
+        method: 'DELETE',
+      });
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
+    });
+  });
+}

--- a/x-pack/test/functional/page_objects/rollup_page.ts
+++ b/x-pack/test/functional/page_objects/rollup_page.ts
@@ -13,6 +13,7 @@ export class RollupPageObject extends FtrService {
   private readonly log = this.ctx.getService('log');
   private readonly find = this.ctx.getService('find');
   private readonly header = this.ctx.getPageObject('header');
+  private readonly retry = this.ctx.getService('retry');
 
   async createNewRollUpJob(
     jobName: string,
@@ -54,6 +55,13 @@ export class RollupPageObject extends FtrService {
     // Step 6: saveJob and verify the name in the list
     await this.verifyStepIsActive(stepNum);
     await this.saveJob(startImmediately);
+  }
+
+  async clickRollupJobsTab() {
+    await this.testSubjects.click('rollup_jobs');
+    await this.retry.waitFor('create policy button to be visible', async () => {
+      return await this.testSubjects.isDisplayed('createRollupJobButton');
+    });
   }
 
   async verifyStepIsActive(stepNumber = 0) {
@@ -106,6 +114,16 @@ export class RollupPageObject extends FtrService {
     }
     await this.testSubjects.click('rollupJobSaveButton');
     await this.header.waitUntilLoadingHasFinished();
+    await this.retry.waitFor('detail flyout', async () => {
+      return await this.testSubjects.isDisplayed('rollupJobDetailsFlyoutTitle');
+    });
+  }
+
+  async closeFlyout() {
+    await this.testSubjects.click('euiFlyoutCloseButton');
+    await this.retry.waitFor('rollup list table', async () => {
+      return await this.testSubjects.isDisplayed('rollupJobsListTable');
+    });
   }
 
   async getJobList() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Rollup Job a11y Tests (#134975)](https://github.com/elastic/kibana/pull/134975)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)