### PR TITLE
[ML] Docs screenshots - support to set window size per screenshot

### DIFF
--- a/x-pack/test/functional/services/ml/anomalies_table.ts
+++ b/x-pack/test/functional/services/ml/anomalies_table.ts
@@ -173,5 +173,10 @@ export function MachineLearningAnomaliesTableProvider({ getService }: FtrProvide
     async scrollTableIntoView() {
       await testSubjects.scrollIntoView('mlAnomaliesTable');
     },
+
+    async scrollRowIntoView(rowIndex: number) {
+      const rowSubj = await this.getRowSubjByRowIndex(rowIndex);
+      await testSubjects.scrollIntoView(rowSubj);
+    },
   };
 }

--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/population_analysis.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/population_analysis.ts
@@ -109,8 +109,14 @@ export default function ({ getService }: FtrProviderContext) {
 
       await ml.anomalyExplorer.scrollChartsContainerIntoView();
       await ml.anomaliesTable.ensureDetailsOpen(0);
+      await ml.anomaliesTable.scrollRowIntoView(0);
       await ml.testExecution.logTestStep('take screenshot');
-      await mlScreenshots.takeScreenshot('ml-population-anomaly', screenshotDirectories);
+      await mlScreenshots.takeScreenshot(
+        'ml-population-anomaly',
+        screenshotDirectories,
+        1500,
+        1300
+      );
     });
   });
 }

--- a/x-pack/test/screenshot_creation/services/ml_screenshots.ts
+++ b/x-pack/test/screenshot_creation/services/ml_screenshots.ts
@@ -8,12 +8,18 @@
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function MachineLearningScreenshotsProvider({ getService }: FtrProviderContext) {
+  const browser = getService('browser');
   const ml = getService('ml');
   const screenshot = getService('screenshots');
 
+  const DEFAULT_WIDTH = 1920;
+  const DEFAULT_HEIGHT = 1080;
+
   return {
-    async takeScreenshot(name: string, subDirectories: string[]) {
+    async takeScreenshot(name: string, subDirectories: string[], width?: number, height?: number) {
+      await browser.setWindowSize(width ?? DEFAULT_WIDTH, height ?? DEFAULT_HEIGHT);
       await screenshot.take(`${name}_new`, undefined, subDirectories);
+      await browser.setWindowSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
     },
 
     async removeFocusFromElement() {


### PR DESCRIPTION
## Summary

This PR enhances the service method that takes screenshots for the docs to specify the browser window size.

### Details

- Before this PR, all docs screenshots are taken with the same browser window size (1920 x 1080)
- Some screenshots require a different window size so the show the relevant part of the screen
- To demonstrate the usage, this PR fixes a screenshot, where changes were requested:
  - For `ml-population-anomaly.png` we got the feedback `If possible, the screenshot should focus on the anomalies table, since that is the section discussed in the docs and its cut off in the screenshot.`
  - To fix this, the windows size on screenshot capture is changed to 1500 x 1300
  - After the window size change, the page scrolling was still not quite right, so this PR also adds a service method that allows to scroll a row of the anomalies table into view

### Screenshots

**Currently used in the docs (with manual cropping):**
- The expanded row is visible
![image](https://user-images.githubusercontent.com/1945390/175505998-0c8e7af3-1296-44a7-abf8-50049570f277.png)

**Automated screenshot before this PR:**
- The expanded row is cut off
![ml-population-anomaly_new](https://user-images.githubusercontent.com/1945390/175506365-4fbea262-d12f-4636-af39-48238e33fd9b.png)

**Automated screenshot with this PR:**
- The expanded row is visible
- This screenshot can be cropped to the region that's required for the docs
![ml-population-anomaly_new](https://user-images.githubusercontent.com/1945390/175505795-9676f035-6364-4e18-9f30-8d651f4ce448.png)

