### PR TITLE
[ML] Add API tests for filters stats endpoint

### DIFF
--- a/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { Job } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
+import { FilterStats } from '@kbn/ml-plugin/common/types/filters';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  // @ts-expect-error not full interface
+  const jobConfig1: Job = {
+    job_id: `fq_filter_stats_1`,
+    description: 'mean(responsetime) partition=airline on farequote dataset with 1h bucket span',
+    groups: ['farequote', 'automated', 'multi-metric'],
+    analysis_config: {
+      bucket_span: '1h',
+      influencers: ['airline'],
+      detectors: [
+        {
+          function: 'mean',
+          field_name: 'responsetime',
+          partition_field_name: 'airline',
+          detector_description: 'mean(responsetime) partitionfield=airline',
+          custom_rules: [
+            {
+              actions: ['skip_result'],
+              scope: {
+                airline: {
+                  filter_id: 'ignore_a_airlines',
+                  filter_type: 'include',
+                },
+              },
+            },
+            {
+              actions: ['skip_result'],
+              scope: {
+                airline: {
+                  filter_id: 'ignore_b_airlines',
+                  filter_type: 'include',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    data_description: { time_field: '@timestamp' },
+    analysis_limits: { model_memory_limit: '20mb' },
+    model_plot_config: { enabled: true },
+  };
+
+  // @ts-expect-error not full interface
+  const jobConfig2: Job = {
+    job_id: `fq_filter_stats_2`,
+    description: 'max(responsetime) partition=airline on farequote dataset with 30m bucket span',
+    groups: ['farequote', 'automated', 'multi-metric'],
+    analysis_config: {
+      bucket_span: '30m',
+      influencers: ['airline'],
+      detectors: [
+        {
+          function: 'max',
+          field_name: 'responsetime',
+          partition_field_name: 'airline',
+          detector_description: 'max(responsetime) partitionfield=airline',
+          custom_rules: [
+            {
+              actions: ['skip_result'],
+              scope: {
+                airline: {
+                  filter_id: 'ignore_a_airlines',
+                  filter_type: 'include',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    data_description: { time_field: '@timestamp' },
+    analysis_limits: { model_memory_limit: '20mb' },
+    model_plot_config: { enabled: true },
+  };
+
+  const testJobConfigs = [jobConfig1, jobConfig2];
+
+  const testDataList = [
+    {
+      filterId: 'ignore_a_airlines',
+      requestBody: {
+        description: 'Airlines starting with A',
+        items: ['AAL'],
+      },
+      expected: {
+        item_count: 1,
+        used_by: {
+          jobs: [jobConfig1.job_id, jobConfig2.job_id],
+          detectors: [
+            jobConfig1.analysis_config.detectors[0].detector_description,
+            jobConfig2.analysis_config.detectors[0].detector_description,
+          ],
+        },
+      },
+    },
+    {
+      filterId: 'ignore_b_airlines',
+      requestBody: {
+        description: 'Airlines starting with B',
+        items: ['BAA', 'BAB'],
+      },
+      expected: {
+        item_count: 2,
+        used_by: {
+          jobs: [jobConfig1.job_id],
+          detectors: [jobConfig1.analysis_config.detectors[0].detector_description],
+        },
+      },
+    },
+    {
+      filterId: 'ignore_c_airlines',
+      requestBody: {
+        description: 'Airlines starting with C',
+        items: ['CAA', 'CAB', 'CCC'],
+      },
+      expected: {
+        item_count: 3,
+      },
+    },
+  ];
+
+  describe('get_filters_stats', function () {
+    before(async () => {
+      await ml.testResources.setKibanaTimeZoneToUTC();
+      for (const testData of testDataList) {
+        const { filterId, requestBody } = testData;
+        await ml.api.createFilter(filterId, requestBody);
+      }
+
+      for (const job of testJobConfigs) {
+        await ml.api.createAnomalyDetectionJob(job);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+    });
+
+    it(`should fetch all filters stats`, async () => {
+      const { body, status } = await supertest
+        .get(`/api/ml/filters/_stats`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body).to.have.length(testDataList.length);
+
+      // Validate the contents of the stats response
+      for (const testData of testDataList) {
+        const { filterId, expected } = testData;
+
+        const actualFilterStats = body.find(
+          (filterStats: FilterStats) => filterStats.filter_id === filterId
+        );
+
+        expect(actualFilterStats).to.have.property('item_count').eql(expected.item_count);
+        if (expected.used_by !== undefined) {
+          expect(actualFilterStats).to.have.property('used_by');
+          expect(actualFilterStats.used_by).to.have.property('jobs');
+          expect(actualFilterStats.used_by.jobs).to.have.length(expected.used_by.jobs.length);
+          expect(actualFilterStats.used_by).to.have.property('detectors');
+          expect(actualFilterStats.used_by.detectors).to.have.length(
+            expected.used_by.detectors.length
+          );
+        } else {
+          expect(actualFilterStats).not.to.have.property('used_by');
+        }
+      }
+    });
+
+    it(`should not allow retrieving filters stats for user without required permission`, async () => {
+      const { body, status } = await supertest
+        .get(`/api/ml/filters/_stats`)
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
+
+      expect(body.error).to.eql('Forbidden');
+      expect(body.message).to.eql('Forbidden');
+    });
+
+    it(`should not allow retrieving filters stats for unauthorized user`, async () => {
+      const { body, status } = await supertest
+        .get(`/api/ml/filters/_stats`)
+        .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
+        .set(COMMON_REQUEST_HEADERS);
+      ml.api.assertResponseStatusCode(403, status, body);
+
+      expect(body.error).to.eql('Forbidden');
+      expect(body.message).to.eql('Forbidden');
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
@@ -192,14 +192,10 @@ export default ({ getService }: FtrProviderContext) => {
         expect(actualFilterStats).to.have.property('item_count').eql(expected.item_count);
         if (expected.used_by !== undefined) {
           expect(actualFilterStats).to.have.property('used_by');
-          expect(actualFilterStats.used_by).to.have.property('jobs');
-          expect(actualFilterStats.used_by.jobs).to.have.length(expected.used_by.jobs.length);
-          expect(actualFilterStats.used_by.jobs).to.eql(expected.used_by.jobs);
-          expect(actualFilterStats.used_by).to.have.property('detectors');
-          expect(actualFilterStats.used_by.detectors).to.have.length(
-            expected.used_by.detectors.length
-          );
-          expect(actualFilterStats.used_by.detectors).to.eql(expected.used_by.detectors);
+          expect(actualFilterStats.used_by).to.have.property('jobs').eql(expected.used_by.jobs);
+          expect(actualFilterStats.used_by)
+            .to.have.property('detectors')
+            .eql(expected.used_by.detectors);
         } else {
           expect(actualFilterStats).not.to.have.property('used_by');
         }

--- a/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
@@ -192,10 +192,12 @@ export default ({ getService }: FtrProviderContext) => {
         expect(actualFilterStats).to.have.property('item_count').eql(expected.item_count);
         if (expected.used_by !== undefined) {
           expect(actualFilterStats).to.have.property('used_by');
-          expect(actualFilterStats.used_by).to.have.property('jobs').eql(expected.used_by.jobs);
-          expect(actualFilterStats.used_by)
-            .to.have.property('detectors')
-            .eql(expected.used_by.detectors);
+          expect(actualFilterStats.used_by).to.have.property('jobs');
+          expect(actualFilterStats.used_by.jobs.sort()).to.eql(expected.used_by.jobs.sort());
+          expect(actualFilterStats.used_by).to.have.property('detectors');
+          expect(actualFilterStats.used_by.detectors.sort()).to.eql(
+            expected.used_by.detectors.sort()
+          );
         } else {
           expect(actualFilterStats).not.to.have.property('used_by');
         }

--- a/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/get_filters_stats.ts
@@ -72,7 +72,23 @@ export default ({ getService }: FtrProviderContext) => {
           field_name: 'responsetime',
           partition_field_name: 'airline',
           detector_description: 'max(responsetime) partitionfield=airline',
+        },
+        {
+          function: 'min',
+          field_name: 'responsetime',
+          partition_field_name: 'airline',
+          detector_description: 'min(responsetime) partitionfield=airline',
           custom_rules: [
+            {
+              actions: ['skip_result'],
+              conditions: [
+                {
+                  applies_to: 'actual',
+                  operator: 'lt',
+                  value: 100,
+                },
+              ],
+            },
             {
               actions: ['skip_result'],
               scope: {
@@ -105,8 +121,8 @@ export default ({ getService }: FtrProviderContext) => {
         used_by: {
           jobs: [jobConfig1.job_id, jobConfig2.job_id],
           detectors: [
-            jobConfig1.analysis_config.detectors[0].detector_description,
-            jobConfig2.analysis_config.detectors[0].detector_description,
+            `${jobConfig1.analysis_config.detectors[0].detector_description} (${jobConfig1.job_id})`,
+            `${jobConfig2.analysis_config.detectors[1].detector_description} (${jobConfig2.job_id})`,
           ],
         },
       },
@@ -121,7 +137,9 @@ export default ({ getService }: FtrProviderContext) => {
         item_count: 2,
         used_by: {
           jobs: [jobConfig1.job_id],
-          detectors: [jobConfig1.analysis_config.detectors[0].detector_description],
+          detectors: [
+            `${jobConfig1.analysis_config.detectors[0].detector_description} (${jobConfig1.job_id})`,
+          ],
         },
       },
     },
@@ -176,10 +194,12 @@ export default ({ getService }: FtrProviderContext) => {
           expect(actualFilterStats).to.have.property('used_by');
           expect(actualFilterStats.used_by).to.have.property('jobs');
           expect(actualFilterStats.used_by.jobs).to.have.length(expected.used_by.jobs.length);
+          expect(actualFilterStats.used_by.jobs).to.eql(expected.used_by.jobs);
           expect(actualFilterStats.used_by).to.have.property('detectors');
           expect(actualFilterStats.used_by.detectors).to.have.length(
             expected.used_by.detectors.length
           );
+          expect(actualFilterStats.used_by.detectors).to.eql(expected.used_by.detectors);
         } else {
           expect(actualFilterStats).not.to.have.property('used_by');
         }

--- a/x-pack/test/api_integration/apis/ml/filters/index.ts
+++ b/x-pack/test/api_integration/apis/ml/filters/index.ts
@@ -11,6 +11,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('filters', function () {
     loadTestFile(require.resolve('./create_filters'));
     loadTestFile(require.resolve('./get_filters'));
+    loadTestFile(require.resolve('./get_filters_stats'));
     loadTestFile(require.resolve('./delete_filters'));
     loadTestFile(require.resolve('./update_filters'));
   });


### PR DESCRIPTION
## Summary

Adds tests to check the response of the filters stats endpoint:

`/api/ml/filters/_stats`

Part of https://github.com/elastic/kibana/issues/133871


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

