### PR TITLE
[APM] Fix reparenting in case of cyclic dependencies.

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -317,7 +317,16 @@ function reparentSpans(waterfallItems: IWaterfallSpanOrTransaction[]) {
       waterfallItems.map((waterfallItem) => {
         if (waterfallItem.docType === 'span') {
           const childIds = waterfallItem.doc.child?.id ?? [];
-          return childIds.map((id) => [id, waterfallItem.id]);
+          const childIdsMapping = childIds.map((id) => [id, waterfallItem.id]);
+          // if there is a cyclic dependency (e.g. inferred span with child.id = parent.id)
+          // then we need to update the parent of the waterfallItem to its current grandparent 
+          if(waterfallItem.parentId && childIds.includes(waterfallItem.parentId)){
+            const parent = waterfallItems.find(item => item.id === waterfallItem.parentId);
+            if(parent?.parentId){
+              return {...childIdsMapping, ...{[waterfallItem.id]: parent.parentId}}
+            }
+          }
+          return childIdsMapping;
         }
         return [];
       })


### PR DESCRIPTION
## Summary

The Java APM Agent can end up with inferred spans having same value for the `parent.id` and `child.id`. This leads to a cyclic dependency in the waterfall and, thus, breaks the waterfall view.

To fix this, reparenting of the spans needs an explicit handling of this case. In particular, the inferred span needs to be reparented in addition to its childer.

This PR implements this handling.
