### PR TITLE
[APM] Improves, smoothes shared pointer events across different charts

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
@@ -69,7 +69,7 @@ export function BreakdownChart({
   const history = useHistory();
   const chartTheme = useChartTheme();
   const { core } = useApmPluginContext();
-  const { chartRef, setPointerEvent } = useChartPointerEventContext();
+  const { chartRef, updatePointerEvent } = useChartPointerEventContext();
   const {
     query: { rangeFrom, rangeTo },
   } = useApmParams('/services/{serviceName}');
@@ -107,7 +107,7 @@ export function BreakdownChart({
           theme={chartTheme}
           xDomain={{ min, max }}
           flatLegend
-          onPointerUpdate={setPointerEvent}
+          onPointerUpdate={updatePointerEvent}
           externalPointerEvents={{
             tooltip: {
               visible: true,

--- a/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
@@ -86,7 +86,7 @@ export function TimeseriesChart({
   const history = useHistory();
   const { core } = useApmPluginContext();
   const { annotations } = useAnnotationsContext();
-  const { setPointerEvent, chartRef } = useChartPointerEventContext();
+  const { chartRef, updatePointerEvent } = useChartPointerEventContext();
   const theme = useTheme();
   const chartTheme = useChartTheme();
   const {
@@ -169,7 +169,7 @@ export function TimeseriesChart({
             },
             ...chartTheme,
           ]}
-          onPointerUpdate={setPointerEvent}
+          onPointerUpdate={updatePointerEvent}
           externalPointerEvents={{
             tooltip: { visible: true },
           }}

--- a/x-pack/plugins/apm/public/context/chart_pointer_event/chart_pointer_event_context.tsx
+++ b/x-pack/plugins/apm/public/context/chart_pointer_event/chart_pointer_event_context.tsx
@@ -5,19 +5,14 @@
  * 2.0.
  */
 
-import React, {
-  createContext,
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useState,
-} from 'react';
+import React, { createContext, ReactNode, useRef } from 'react';
 
 import { PointerEvent } from '@elastic/charts';
 
+export const UPDATE_POINTER_EVENT = 'updatePointerEvent';
 export const ChartPointerEventContext = createContext<{
-  pointerEvent: PointerEvent | null;
-  setPointerEvent: Dispatch<SetStateAction<PointerEvent | null>>;
+  pointerEventTargetRef: React.MutableRefObject<EventTarget>;
+  updatePointerEvent: (pointerEvent: PointerEvent) => void;
 } | null>(null);
 
 export function ChartPointerEventContextProvider({
@@ -25,11 +20,19 @@ export function ChartPointerEventContextProvider({
 }: {
   children: ReactNode;
 }) {
-  const [pointerEvent, setPointerEvent] = useState<PointerEvent | null>(null);
+  const pointerEventTargetRef = useRef(new EventTarget());
+  const updatePointerEventRef = useRef((pointerEvent: PointerEvent) => {
+    pointerEventTargetRef.current.dispatchEvent(
+      new CustomEvent(UPDATE_POINTER_EVENT, { detail: pointerEvent })
+    );
+  });
 
   return (
     <ChartPointerEventContext.Provider
-      value={{ pointerEvent, setPointerEvent }}
+      value={{
+        pointerEventTargetRef,
+        updatePointerEvent: updatePointerEventRef.current,
+      }}
       children={children}
     />
   );

--- a/x-pack/plugins/apm/public/context/chart_pointer_event/use_chart_pointer_event_context.tsx
+++ b/x-pack/plugins/apm/public/context/chart_pointer_event/use_chart_pointer_event_context.tsx
@@ -5,9 +5,13 @@
  * 2.0.
  */
 
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useCallback, useRef } from 'react';
 import { Chart } from '@elastic/charts';
-import { ChartPointerEventContext } from './chart_pointer_event_context';
+import {
+  ChartPointerEventContext,
+  UPDATE_POINTER_EVENT,
+} from './chart_pointer_event_context';
+import { PointerEvent } from '@elastic/charts';
 
 export function useChartPointerEventContext() {
   const context = useContext(ChartPointerEventContext);
@@ -16,14 +20,36 @@ export function useChartPointerEventContext() {
     throw new Error('Missing ChartPointerEventContext provider');
   }
 
-  const { pointerEvent } = context;
+  const { pointerEventTargetRef } = context;
   const chartRef = React.createRef<Chart>();
+  const requestIdRef = useRef(0);
+  const updatePointerEventHandler = useCallback(
+    (event: Event) => {
+      cancelAnimationFrame(requestIdRef.current);
+      requestIdRef.current = requestAnimationFrame(() => {
+        const pointerEvent = (
+          event instanceof CustomEvent ? event.detail : null
+        ) as PointerEvent | null;
+        if (chartRef.current && pointerEvent) {
+          chartRef.current.dispatchExternalPointerEvent(pointerEvent);
+        }
+      });
+    },
+    [chartRef]
+  );
 
   useEffect(() => {
-    if (pointerEvent && chartRef.current) {
-      chartRef.current.dispatchExternalPointerEvent(pointerEvent);
-    }
-  }, [pointerEvent, chartRef]);
-
+    const pointerEventTarget = pointerEventTargetRef.current;
+    pointerEventTarget.addEventListener(
+      UPDATE_POINTER_EVENT,
+      updatePointerEventHandler
+    );
+    return () => {
+      pointerEventTarget.removeEventListener(
+        UPDATE_POINTER_EVENT,
+        updatePointerEventHandler
+      );
+    };
+  }, [updatePointerEventHandler]);
   return { ...context, chartRef };
 }

--- a/x-pack/plugins/apm/public/context/chart_pointer_event/use_chart_pointer_event_context.tsx
+++ b/x-pack/plugins/apm/public/context/chart_pointer_event/use_chart_pointer_event_context.tsx
@@ -7,11 +7,11 @@
 
 import React, { useContext, useEffect, useCallback, useRef } from 'react';
 import { Chart } from '@elastic/charts';
+import { PointerEvent } from '@elastic/charts';
 import {
   ChartPointerEventContext,
   UPDATE_POINTER_EVENT,
 } from './chart_pointer_event_context';
-import { PointerEvent } from '@elastic/charts';
 
 export function useChartPointerEventContext() {
   const context = useContext(ChartPointerEventContext);
@@ -50,6 +50,6 @@ export function useChartPointerEventContext() {
         updatePointerEventHandler
       );
     };
-  }, [updatePointerEventHandler]);
+  }, [updatePointerEventHandler, pointerEventTargetRef]);
   return { ...context, chartRef };
 }


### PR DESCRIPTION
Addresses #29169.

Improves the UX of shared chart pointer events by avoiding rerenders on each pointer event. Instead each chart subscribes to pointer events when the component mounts and unsubscribes on unmount. This improves responsiveness in the pointer events by almost 50%. There is still some improvements that can be made in the Elastic Charts component itself to avoid unnecessary re-renders, but this is out of scope for that.

Original:
![chart-pointer-event-perf-orig](https://user-images.githubusercontent.com/1967266/175564320-81f05d16-9be6-424f-bcea-43d30b2b160e.gif)

Improved:
![chart-pointer-event-perf-impr](https://user-images.githubusercontent.com/1967266/175564307-e4b0b1f2-a33a-47c9-9590-73a3f113f87e.gif)

#### Benchmark testing
To test the improved responsiveness, I loaded /app/apm/services/opbeans-java/transactions in my browser, and pasted the following script into the javascript console:
```javascript
((
  latencyTooltip,
  throughputTooltip
) => {
  window.tooltipLatencies = [];
  let startTime = 0;
  throughputTooltip.style.transitionProperty = "transform";
  throughputTooltip.style.transitionDuration = "1ms";
  throughputTooltip.ontransitionend = () => {
    startTime = new Date().getTime();
  };
  latencyTooltip.style.transitionProperty = "transform";
  latencyTooltip.style.transitionDuration = "1ms";
  latencyTooltip.ontransitionend = () => {
    if (startTime) {
        const endTime = new Date().getTime();
        tooltipLatencies.push(endTime - startTime);
    }
    startTime = 0;
  };
})(
  $("#echAnchorMainTooltip__latencyChart")[0],
  $("#echAnchorMainTooltip__throughput")[0]
 );
```
Then I slowly moved my cursor across the throughput chart. The script measures how long it takes in milliseconds for the tooltip of the latency chart to update it's position. Then I copied recorded times from global variable `tooltipLatencies` with the following results:
```javascript
const originalTimes = [ 200, 183, 167, 168, 182, 200, 180, 167, 167, 166, 184, 168, 201, 148, 165, 168, 165, 167, 152, 166, 166, 167, 151, 151, 156, 154 ]
avg(originalTimes) // 169.57692307692307 
const improvedTimes = [ 87, 118, 116, 166, 85, 82, 102, 81, 103, 103, 88, 104, 66, 102, 103, 84, 86, 82, 80, 66, 100, 100, 67, 104, 82, 84, 85, 83, 80, 86, 84, 68, 81 ]
avg(improvedTimes) // 91.15151515151516

// 46% increased responsiveness
```