### PR TITLE
[Reporting] Make browser zoom configurable

### DIFF
--- a/x-pack/plugins/screenshotting/server/layouts/create_layout.ts
+++ b/x-pack/plugins/screenshotting/server/layouts/create_layout.ts
@@ -40,7 +40,7 @@ export function createLayout({ id, dimensions, selectors, ...config }: LayoutPar
 
   if (dimensions) {
     if (layoutId === 'preserve_layout') {
-      return new PreserveLayout(sanitizeLayout(dimensions), selectors);
+      return new PreserveLayout(sanitizeLayout(dimensions), selectors, config.zoom);
     }
 
     if (layoutId === 'canvas') {

--- a/x-pack/plugins/screenshotting/server/layouts/preserve_layout.ts
+++ b/x-pack/plugins/screenshotting/server/layouts/preserve_layout.ts
@@ -23,12 +23,16 @@ export class PreserveLayout extends BaseLayout implements Layout {
   private readonly scaledHeight: number;
   private readonly scaledWidth: number;
 
-  constructor(size: Size, selectors?: Partial<LayoutSelectorDictionary>) {
+  constructor(
+    size: Size,
+    selectors?: Partial<LayoutSelectorDictionary>,
+    private readonly zoom: number = ZOOM
+  ) {
     super('preserve_layout');
     this.height = size.height;
     this.width = size.width;
-    this.scaledHeight = size.height * ZOOM;
-    this.scaledWidth = size.width * ZOOM;
+    this.scaledHeight = size.height * this.zoom;
+    this.scaledWidth = size.width * this.zoom;
 
     this.selectors = { ...DEFAULT_SELECTORS, ...selectors };
   }
@@ -46,14 +50,14 @@ export class PreserveLayout extends BaseLayout implements Layout {
   }
 
   public getBrowserZoom() {
-    return ZOOM;
+    return this.zoom;
   }
 
   public getViewport() {
     return {
       height: this.height,
       width: this.width,
-      zoom: ZOOM,
+      zoom: this.zoom,
     };
   }
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/89659

Intended as an investigation that can be upgraded to an implementation since it looks fairly straightforward to complete this effort.

Adds a new toggle-able field for adjusting the zoom level as part of the "advanced settings" area of the reporting generation UI.

<img width="368" alt="Screenshot 2022-06-27 at 13 02 05" src="https://user-images.githubusercontent.com/8155004/175931568-c14dc8c4-3c3f-432a-b374-6d295a6ed7e4.png">
<img width="341" alt="Screenshot 2022-06-27 at 13 02 41" src="https://user-images.githubusercontent.com/8155004/175931577-f53b5aff-3cf9-43e4-841a-fbd5e9f1e821.png">

## Notes

* We will have to make sure that this value is passed through to all layout types
* Zoom level passed through as 1 [[Logs] Web Traffic (5) zoom level 1.pdf](https://github.com/elastic/kibana/files/8991531/Logs.Web.Traffic.5.zoom.level.1.pdf)
* Zoom level pass through as 3 [[Logs] Web Traffic (5) zoom level3.pdf](https://github.com/elastic/kibana/files/8991533/Logs.Web.Traffic.5.zoom.level3.pdf)
* Current UI changes are proposal, they need a design review to ensure that a divergent form field pattern is not being introduced
* Also redesigned how the Copy POST URL button looks to make it similar to the zoom form field and also to de-emphasise it slightly.

## TODO

- [ ] Pass through zoom level setting for canvas layouts
- [ ] Pass through zoom level setting for print optimized layouts
- [ ] Should we be sanity checking the zoom levels? Are there values that would be too big? Current minimum is 1.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
