### PR TITLE
[Fleet] support sorting agent list

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3337,7 +3337,7 @@
         "required": false,
         "schema": {
           "type": "integer",
-          "default": 50
+          "default": 20
         }
       },
       "page_index": {
@@ -3386,13 +3386,11 @@
         "in": "query",
         "required": false,
         "schema": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "asc",
-              "desc"
-            ]
-          }
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ]
         }
       }
     },

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1191,6 +1191,29 @@
           }
         },
         "operationId": "get-agents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page_size"
+          },
+          {
+            "$ref": "#/components/parameters/page_index"
+          },
+          {
+            "$ref": "#/components/parameters/kuery"
+          },
+          {
+            "$ref": "#/components/parameters/show_inactive"
+          },
+          {
+            "$ref": "#/components/parameters/show_upgradeable"
+          },
+          {
+            "$ref": "#/components/parameters/sort_field"
+          },
+          {
+            "$ref": "#/components/parameters/sort_order"
+          }
+        ],
         "security": [
           {
             "basicAuth": []
@@ -3332,6 +3355,44 @@
         "required": false,
         "schema": {
           "type": "string"
+        }
+      },
+      "show_inactive": {
+        "name": "showInactive",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "show_upgradeable": {
+        "name": "showUpgradeable",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "sort_field": {
+        "name": "sortField",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "sort_order": {
+        "name": "sortOrder",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
         }
       }
     },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2055,7 +2055,7 @@ components:
       required: false
       schema:
         type: integer
-        default: 50
+        default: 20
     page_index:
       name: page
       in: query
@@ -2092,11 +2092,10 @@ components:
       in: query
       required: false
       schema:
-        type:
-          type: string
-          enum:
-            - asc
-            - desc
+        type: string
+        enum:
+          - asc
+          - desc
   schemas:
     fleet_setup_response:
       title: Fleet Setup response

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -737,6 +737,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/get_agents_response'
       operationId: get-agents
+      parameters:
+        - $ref: '#/components/parameters/page_size'
+        - $ref: '#/components/parameters/page_index'
+        - $ref: '#/components/parameters/kuery'
+        - $ref: '#/components/parameters/show_inactive'
+        - $ref: '#/components/parameters/show_upgradeable'
+        - $ref: '#/components/parameters/sort_field'
+        - $ref: '#/components/parameters/sort_order'
       security:
         - basicAuth: []
   /agents/bulk_upgrade:
@@ -2061,6 +2069,34 @@ components:
       required: false
       schema:
         type: string
+    show_inactive:
+      name: showInactive
+      in: query
+      required: false
+      schema:
+        type: boolean
+    show_upgradeable:
+      name: showUpgradeable
+      in: query
+      required: false
+      schema:
+        type: boolean
+    sort_field:
+      name: sortField
+      in: query
+      required: false
+      schema:
+        type: string
+    sort_order:
+      name: sortOrder
+      in: query
+      required: false
+      schema:
+        type:
+          type: string
+          enum:
+            - asc
+            - desc
   schemas:
     fleet_setup_response:
       title: Fleet Setup response

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/page_size.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/page_size.yaml
@@ -4,4 +4,4 @@ description: The number of items to return
 required: false
 schema:
   type: integer
-  default: 50
+  default: 20

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/show_inactive.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/show_inactive.yaml
@@ -1,0 +1,5 @@
+name: showInactive
+in: query
+required: false
+schema:
+  type: boolean

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/show_upgradeable.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/show_upgradeable.yaml
@@ -1,0 +1,5 @@
+name: showUpgradeable
+in: query
+required: false
+schema:
+  type: boolean

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/sort_field.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/sort_field.yaml
@@ -1,0 +1,5 @@
+name: sortField
+in: query
+required: false
+schema:
+  type: string

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/sort_order.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/sort_order.yaml
@@ -2,6 +2,5 @@ name: sortOrder
 in: query
 required: false
 schema:
-  type:
-    type: string
-    enum: ['asc', 'desc']
+  type: string
+  enum: [asc, desc]

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/sort_order.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/sort_order.yaml
@@ -1,0 +1,7 @@
+name: sortOrder
+in: query
+required: false
+schema:
+  type:
+    type: string
+    enum: ['asc', 'desc']

--- a/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
@@ -9,5 +9,13 @@ get:
           schema:
             $ref: ../components/schemas/get_agents_response.yaml
   operationId: get-agents
+  parameters:
+    - $ref: ../components/parameters/page_size.yaml
+    - $ref: ../components/parameters/page_index.yaml
+    - $ref: ../components/parameters/kuery.yaml
+    - $ref: ../components/parameters/show_inactive.yaml
+    - $ref: ../components/parameters/show_upgradeable.yaml
+    - $ref: ../components/parameters/sort_field.yaml
+    - $ref: ../components/parameters/sort_order.yaml
   security:
     - basicAuth: []

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
@@ -156,4 +156,43 @@ describe('agent_list_page', () => {
 
     utils.getByText('4 agents selected');
   });
+
+  it('should pass sort parameters on table sort', () => {
+    act(() => {
+      fireEvent.click(utils.getByTitle('Last activity'));
+    });
+
+    expect(mockedSendGetAgents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortField: 'last_checkin',
+        sortOrder: 'asc',
+      })
+    );
+  });
+
+  it('should pass keyword field on table sort on version', () => {
+    act(() => {
+      fireEvent.click(utils.getByTitle('Version'));
+    });
+
+    expect(mockedSendGetAgents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortField: 'local_metadata.elastic.agent.version.keyword',
+        sortOrder: 'asc',
+      })
+    );
+  });
+
+  it('should pass keyword field on table sort on hostname', () => {
+    act(() => {
+      fireEvent.click(utils.getByTitle('Host'));
+    });
+
+    expect(mockedSendGetAgents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortField: 'local_metadata.host.hostname.keyword',
+        sortOrder: 'asc',
+      })
+    );
+  });
 });

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -128,6 +128,8 @@ export const getAgentsHandler: RequestHandler<
       showInactive: request.query.showInactive,
       showUpgradeable: request.query.showUpgradeable,
       kuery: request.query.kuery,
+      sortField: request.query.sortField,
+      sortOrder: request.query.sortOrder,
     });
     const totalInactive = request.query.showInactive
       ? await AgentService.countInactiveAgents(esClient, {

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -203,6 +203,8 @@ export async function getAgentsByKuery(
   esClient: ElasticsearchClient,
   options: ListWithKuery & {
     showInactive: boolean;
+    sortField?: string;
+    sortOrder?: 'asc' | 'desc';
   }
 ): Promise<{
   agents: Agent[];
@@ -213,8 +215,8 @@ export async function getAgentsByKuery(
   const {
     page = 1,
     perPage = 20,
-    sortField = 'enrolled_at',
-    sortOrder = 'desc',
+    sortField = options.sortField ?? 'enrolled_at',
+    sortOrder = options.sortOrder ?? 'desc',
     kuery,
     showInactive = false,
     showUpgradeable,

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -18,6 +18,8 @@ export const GetAgentsRequestSchema = {
     kuery: schema.maybe(schema.string()),
     showInactive: schema.boolean({ defaultValue: false }),
     showUpgradeable: schema.boolean({ defaultValue: false }),
+    sortField: schema.maybe(schema.string()),
+    sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
   }),
 };
 

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -71,5 +71,17 @@ export default function ({ getService }: FtrProviderContext) {
       const agent = apiResponse.items[0];
       expect(agent.access_api_key_id).to.eql('api-key-2');
     });
+
+    it('should return a 200 when given sort options', async () => {
+      const { body: apiResponse } = await supertest
+        .get(`/api/fleet/agents?sortField=last_checkin&sortOrder=desc`)
+        .expect(200);
+      expect(apiResponse.items.map((agent: { id: string }) => agent.id)).to.eql([
+        'agent4',
+        'agent3',
+        'agent2',
+        'agent1',
+      ]);
+    });
   });
 }

--- a/x-pack/test/functional/es_archives/fleet/agents/data.json
+++ b/x-pack/test/functional/es_archives/fleet/agents/data.json
@@ -10,7 +10,8 @@
       "type": "PERMANENT",
       "local_metadata": {},
       "user_provided_metadata": {},
-      "enrolled_at": "2022-06-21T12:14:25Z"
+      "enrolled_at": "2022-06-21T12:14:25Z",
+      "last_checkin": "2022-06-27T12:26:29Z"
     }
   }
 }
@@ -27,7 +28,8 @@
       "type": "PERMANENT",
       "local_metadata": {},
       "user_provided_metadata": {},
-      "enrolled_at": "2022-06-21T12:15:25Z"
+      "enrolled_at": "2022-06-21T12:15:25Z",
+      "last_checkin": "2022-06-27T12:27:29Z"
     }
   }
 }
@@ -44,7 +46,8 @@
       "type": "PERMANENT",
       "local_metadata": {},
       "user_provided_metadata": {},
-      "enrolled_at": "2022-06-21T12:16:25Z"
+      "enrolled_at": "2022-06-21T12:16:25Z",
+      "last_checkin": "2022-06-27T12:28:29Z"
     }
   }
 }
@@ -61,7 +64,8 @@
       "type": "PERMANENT",
       "local_metadata": {},
       "user_provided_metadata": {},
-      "enrolled_at": "2022-06-21T12:17:25Z"
+      "enrolled_at": "2022-06-21T12:17:25Z",
+      "last_checkin": "2022-06-27T12:29:29Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/133148

Enabled sorting in agent list for columns: Host, Agent policy, Version, Last activity.
For host and version, passing the keyword field to sort.

Did not enable for Status because status is a calculated value, so the sorting would be complex to implement and might not reflect the order of the status labels.
Did not enable sorting on tags either, as that is a multi value field.

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/90178898/175949608-a2dc8511-a2f8-432b-a280-03be70ae5ca3.png">
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/90178898/175949832-c4ed56a0-e29d-4b90-9472-94a69751f7ae.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
