### PR TITLE
Stubbing out the UI for the new result component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result.scss
@@ -1,0 +1,52 @@
+.resultField:nth-child(odd) {
+  background-color: $euiColorLightestShade;
+}
+
+.resultField {
+  padding: $euiSizeXS $euiSizeS;
+}
+
+.resultCheckDragColumn {
+  border-right: $euiBorderThin;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-direction: column;
+  height: 100%;
+  padding: $euiSizeS;
+}
+
+.resultCheckDragColumn__emptySpacer {
+  display: inline-block;
+  width: $euiSizeXS;
+  flex-grow: 1;
+}
+
+.resultCheckDragColumn .euiCheckbox.euiCheckbox--noLabel {
+  margin: $euiSizeXS;
+}
+
+.resultExpandColumn {
+  border-left: $euiBorderThin;
+  align-items: flex-start;
+  justify-content: center;
+  height: 100%;
+  padding: $euiSizeS;
+}
+
+.resultActionButton .euiButtonContent > * + *{
+  margin-inline-start: $euiSizeXS;
+}
+
+.resultFieldList {
+  padding: $euiSizeXS $euiSizeS $euiSizeS $euiSizeS;
+}
+
+.resultHeader {
+  padding: $euiSizeS $euiSizeS 0 $euiSizeS;
+}
+
+.euiPanel.euiPanel--hasBorder.result__selected {
+  border: 1px solid $euiColorPrimary;
+  box-shadow:0 0 0 1px #07c, 0 6px 12px 1px rgba(0,0,0,.1), 0 4px 4px 1px rgba(0,0,0,.05), 0 2px 2px 0 rgba(0,0,0,.1); /* EUI Bottom Shadow with an added blue 1px spread inset */
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { EuiButtonIcon, EuiCheckbox, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiToolTip } from '@elastic/eui';
+// @ts-ignore
+import { htmlIdGenerator } from '@elastic/eui/lib/services';
+
+import { ActionProps, MetaDataProps, ResultFieldProps } from './types';
+import { ResultHeader } from './result_header';
+import { ResultFields } from './result_fields';
+
+interface ResultProps {
+  actions: ActionProps[];
+  metaData: MetaDataProps;
+  fields: ResultFieldProps[];
+  isCheckable?: boolean;
+  isDraggable?: boolean;
+}
+
+export const Result: React.FC<ResultProps> = ({
+  actions,
+  metaData,
+  fields,
+  isCheckable,
+  isDraggable,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+  const [showLeftColumn] = useState(isCheckable || isDraggable);
+
+  const toolTipContent = (
+    <>
+      {fields.length <= 3 ? (
+        'All fields are visible'
+      ) : (
+        `Show ${fields.length - 3} ${isExpanded ? 'fewer' : 'more'} fields`
+      )}
+    </>
+  )
+
+  return (
+    <EuiPanel hasBorder paddingSize="none" className={`${isChecked && 'result__selected'}`}>
+      <EuiFlexGroup gutterSize="none">
+        {showLeftColumn && (
+          <EuiFlexItem grow={false}>
+            <div className="resultCheckDragColumn">
+              {isCheckable ? (
+                <EuiCheckbox
+                  id={htmlIdGenerator()()}
+                  checked={isChecked}
+                  onChange={() => setIsChecked(!isChecked)}
+                />
+              ) : (
+                <div className="resultCheckDragColumn__emptySpace" />
+                )}
+              {isDraggable ? (
+                <EuiButtonIcon
+                  iconType="grab"
+                  color="text"
+                  onClick={() => console.log('Drag it')}
+                />
+              ) : (
+                <div className="resultCheckDragColumn__emptySpace" />
+              )}
+            </div>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="none">
+            <EuiFlexItem grow={false}>
+              <ResultHeader
+                title="A very well-written title"
+                actions={actions}
+                metaData={metaData}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <ResultFields fields={isExpanded ? fields : fields.slice(0, 3)} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <div className="resultExpandColumn">
+            <EuiToolTip
+              position="left"
+              content={toolTipContent}>
+              <EuiButtonIcon
+                disabled={fields.length <= 3}
+                iconType={isExpanded ? 'fold' : 'unfold'}
+                color="text"
+                onClick={() => setIsExpanded(!isExpanded)}/>
+            </EuiToolTip>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  )
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result_actions.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+} from '@elastic/eui';
+
+import { ActionProps } from './types';
+
+interface SingleAction {
+  action: ActionProps;
+}
+
+interface Props {
+  actions: ActionProps[];
+}
+
+const LinkAction: React.FC<SingleAction> = ({ action }) => (
+  <EuiButtonEmpty
+    className="resultActionButton"
+    flush="both" style={{ fontWeight: 700 }}
+    size="xs"
+    // @ts-ignore
+    color={action.color || 'primary'}
+    iconType={action.iconType}>
+    {action.label}
+  </EuiButtonEmpty>
+)
+
+// Maybe allow users to pass hrefs as well as an onClick and have the dom render either a button or a link
+const TextAction: React.FC<SingleAction> = ({ action }) => (
+  <EuiFlexGroup gutterSize="xs" alignItems="center">
+    {action.iconType && (
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={action.iconType} color={action.color || 'default'} />
+      </EuiFlexItem>
+    )}
+    <EuiFlexItem grow={false}>
+      <EuiText size="xs" color={action.color || 'default' }>
+        <strong>
+          {action.label}
+        </strong>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+)
+
+export const ResultActions: React.FC<Props> = ({
+  actions
+}) => {
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="s">
+      {actions.map((action: ActionProps) => (
+        <EuiFlexItem grow={false}>
+          {action.onClick ? (
+            <LinkAction action={action} />
+          ) : (
+            <TextAction action={action} />
+          )}
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  )
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result_field.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiToken } from '@elastic/eui';
+import { ResultFieldProps } from './types';
+
+export const ResultField: React.FC<ResultFieldProps> = ({
+  iconType = 'tokenString',
+  fieldName,
+  fieldValue,
+}) => {
+  return (
+    <EuiFlexItem className="resultField">
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiToken iconType={iconType} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="xs">{fieldName}</EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="sortRight" color="subdued" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={4}>
+          <EuiText size="xs">{fieldValue}</EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  )
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result_fields.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result_fields.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ResultField } from './result_field';
+import { ResultFieldProps } from './types';
+
+interface Props {
+  fields: ResultFieldProps[];
+}
+
+export const ResultFields: React.FC<Props> = ({
+  fields
+}) => {
+  return (
+    <div className="resultFieldList">
+      {fields.map((field) => (
+        <ResultField
+          iconType={field.iconType}
+          fieldName={field.fieldName}
+          fieldValue={field.fieldValue}
+        />
+      ))}
+    </div>
+  )
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result_header.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiPopover,
+  EuiPopoverFooter,
+  EuiPopoverTitle,
+  EuiText,
+  EuiTextColor,
+} from '@elastic/eui';
+import { ResultActions } from './result_actions';
+import { ActionProps } from './types';
+import { MetaDataProps } from './types';
+
+interface Props {
+  title: string;
+  metaData: MetaDataProps;
+  actions: ActionProps[];
+}
+
+interface TermDef {
+  label: string | number
+}
+
+const Term: React.FC<TermDef> = ({ label }) => (
+  <EuiFlexItem grow={false}>
+    <strong>
+      <EuiTextColor color="subdued">{label}:</EuiTextColor>
+    </strong>
+  </EuiFlexItem>
+)
+
+const Definition: React.FC<TermDef> = ({ label }) => (
+  <EuiFlexItem grow={false}>
+    <EuiTextColor color="subdued">{label}</EuiTextColor>
+  </EuiFlexItem>
+)
+
+export const ResultHeader: React.FC<Props> = ({
+  title,
+  actions,
+  metaData,
+}) => {
+  const [popoverIsOpen, setPopoverIsOpen] = useState(false);
+
+  const closePopover = () => setPopoverIsOpen(false);
+
+
+  const metaDataIcon = (
+    <EuiButtonIcon
+      display="empty"
+      size="xs"
+      iconType="iInCircle"
+      color="primary"
+      onClick={() => setPopoverIsOpen(!popoverIsOpen)}
+    />
+  )
+
+  const popover = (
+    <EuiPopover
+      button={metaDataIcon}
+      isOpen={popoverIsOpen}
+      closePopover={closePopover}
+    >
+      <EuiPopoverTitle>Document metadata</EuiPopoverTitle>
+      <EuiFlexGroup gutterSize="s" direction="column" style={{ width: '20rem' }}>
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <Term label="ID" />
+            <Definition label={metaData.id} />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <Term label="Last updated" />
+            <Definition label={metaData.lastUpdated} />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <Term label="Engine" />
+            <Definition label={metaData.engineId} />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <Term label="Clicks (7 days)" />
+            <Definition label={metaData.clickCount} />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiPopoverFooter>
+        <EuiButton
+          iconType="trash"
+          color="danger"
+          size="s"
+          onClick={closePopover}
+          fullWidth>
+          Delete document
+        </EuiButton>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  )
+  return (
+    <div className="resultHeader">
+      <EuiText size="s">
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem>
+            <EuiLink><strong>{title}</strong></EuiLink>
+          </EuiFlexItem>
+          {actions.length >= 1 && (
+            <EuiFlexItem grow={false}>
+              <ResultActions actions={actions} />
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false}>
+            {popover}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiText>
+    </div>
+  )
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/types.ts
@@ -1,0 +1,21 @@
+import { IconType } from "@elastic/eui";
+
+export interface ActionProps {
+  iconType?: IconType | string;
+  label: string;
+  onClick?: any;
+  color?: any;
+}
+
+export interface MetaDataProps {
+  id: string;
+  lastUpdated: string;
+  engineId: string;
+  clickCount: number;
+}
+
+export interface ResultFieldProps {
+  iconType: IconType;
+  fieldName: string;
+  fieldValue: string;
+}


### PR DESCRIPTION
## Summary

Stubs out the UI for the new result component in Enterprise Search.

Prototype available here: https://ent-search-result-component.vercel.app/


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
