### PR TITLE
[eslint] use --quiet by default

### DIFF
--- a/src/dev/run_eslint.js
+++ b/src/dev/run_eslint.js
@@ -8,6 +8,13 @@
 
 import { parse } from 'eslint/lib/options';
 
+let quiet = true;
+if (process.argv.includes('--no-quiet')) {
+  quiet = false;
+} else {
+  process.argv.push('--quiet');
+}
+
 const options = parse(process.argv);
 process.env.KIBANA_RESOLVER_HARD_CACHE = 'true';
 
@@ -25,3 +32,11 @@ if (!process.argv.includes('--ext')) {
 
 // common-js is required so that logic before this executes before loading eslint
 require('eslint/bin/eslint');
+
+if (quiet) {
+  process.on('exit', (code) => {
+    if (!code) {
+      console.log('✅ no eslint errors found');
+    }
+  });
+}


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/135070 added 5688 warnings to ESLint. Warnings weren't very useful in the past, but VSCode actually makes them pretty useful in editors now, so I'm of the opinion that we should let teams use them, and instead just ignore them on CI. All these warnings make the output of the ESLint job useless as it's just full of warnings that nobody will ever read, and likely won't fix, so I'm going to ignore them by default in the eslint script. Users can enable them by passing the `--no-quiet` flag, the inverse of the `--quiet` flag that we are passing to ESLint by default.