### PR TITLE
[precommit] log warnings even on success

### DIFF
--- a/src/dev/eslint/lint_files.ts
+++ b/src/dev/eslint/lint_files.ts
@@ -39,10 +39,9 @@ export function lintFiles(log: ToolingLog, files: File[], { fix }: { fix?: boole
     log[report.errorCount ? 'error' : 'warning'](cli.getFormatter()(report.results));
   }
 
-  if (!report.errorCount) {
-    log.success('[eslint] %d files linted successfully', files.length);
-    return;
+  if (report.errorCount) {
+    throw createFailError(`[eslint] errors`);
   }
 
-  throw createFailError(`[eslint] errors`);
+  log.success('[eslint] %d files linted successfully', files.length);
 }

--- a/src/dev/eslint/lint_files.ts
+++ b/src/dev/eslint/lint_files.ts
@@ -35,14 +35,14 @@ export function lintFiles(log: ToolingLog, files: File[], { fix }: { fix?: boole
     CLIEngine.outputFixes(report);
   }
 
-  const failTypes = [];
-  if (report.errorCount > 0) failTypes.push('errors');
+  if (report.errorCount || report.warningCount) {
+    log[report.errorCount ? 'error' : 'warning'](cli.getFormatter()(report.results));
+  }
 
-  if (!failTypes.length) {
+  if (!report.errorCount) {
     log.success('[eslint] %d files linted successfully', files.length);
     return;
   }
 
-  log.error(cli.getFormatter()(report.results));
-  throw createFailError(`[eslint] ${failTypes.join(' & ')}`);
+  throw createFailError(`[eslint] errors`);
 }


### PR DESCRIPTION
I've been defeated my long standing desire to prevent using ESLint warnings has now been stopped. We can now use warnings but we had to stop failing the pre-commit hook on warnings too. This PR extends https://github.com/elastic/kibana/commit/d4d3fe3997eef6d62faf8133268be80960b2d1c8 (which was an emergency push to main to unblock folks) and adds logging for warnings discovered in the pre-commit hook.