### PR TITLE
[Fleet] Validate integer in package policy variables

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -10,7 +10,11 @@ import { safeLoad } from 'js-yaml';
 import { installationStatuses } from '../constants';
 import type { PackageInfo, NewPackagePolicy, RegistryPolicyTemplate } from '../types';
 
-import { validatePackagePolicy, validationHasErrors } from './validate_package_policy';
+import {
+  validatePackagePolicy,
+  validatePackagePolicyConfig,
+  validationHasErrors,
+} from './validate_package_policy';
 import { AWS_PACKAGE, INVALID_AWS_POLICY, VALID_AWS_POLICY } from './fixtures/aws_package';
 
 describe('Fleet - validatePackagePolicy()', () => {
@@ -868,5 +872,79 @@ describe('Fleet - validationHasErrors()', () => {
         },
       })
     ).toBe(false);
+  });
+});
+
+describe('Fleet - validatePackagePolicyConfig', () => {
+  describe('Integer', () => {
+    it('should return an error message for invalid integer', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'integer',
+          value: 'test',
+        },
+        {
+          name: 'myvariable',
+          type: 'integer',
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Invalid integer']);
+    });
+
+    it('should accept valid integer', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'integer',
+          value: '12',
+        },
+        {
+          name: 'myvariable',
+          type: 'integer',
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('should return an error message for invalid multi integers', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'integer',
+          value: ['test'],
+        },
+        {
+          name: 'myvariable',
+          type: 'integer',
+          multi: true,
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Invalid integer']);
+    });
+
+    it('should accept valid multi integer', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'integer',
+          value: ['12'],
+        },
+        {
+          name: 'myvariable',
+          type: 'integer',
+          multi: true,
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toBeNull();
+    });
   });
 });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -250,6 +250,7 @@ export const validatePackagePolicyConfig = (
           defaultMessage: 'Invalid format',
         })
       );
+      return errors;
     }
     if (varDef.required && Array.isArray(parsedValue) && parsedValue.length === 0) {
       errors.push(
@@ -261,8 +262,8 @@ export const validatePackagePolicyConfig = (
         })
       );
     }
-    if (varDef.type === 'text' && parsedValue && Array.isArray(parsedValue)) {
-      const invalidStrings = parsedValue.filter((cand) => /^[*&]/.test(cand));
+    if (varDef.type === 'text' && parsedValue) {
+      const invalidStrings = parsedValue.filter((cand: any) => /^[*&]/.test(cand));
       // only show one error if multiple strings in array are invalid
       if (invalidStrings.length > 0) {
         errors.push(
@@ -273,6 +274,20 @@ export const validatePackagePolicyConfig = (
         );
       }
     }
+
+    if (varDef.type === 'integer' && parsedValue) {
+      const invalidIntegers = parsedValue.filter((val: any) => !Number.isInteger(Number(val)));
+      // only show one error if multiple strings in array are invalid
+      if (invalidIntegers.length > 0) {
+        errors.push(
+          i18n.translate('xpack.fleet.packagePolicyValidation.invalidIntegerMultiErrorMessage', {
+            defaultMessage: 'Invalid integer',
+          })
+        );
+      }
+    }
+
+    return errors.length ? errors : null;
   }
 
   if (varDef.type === 'text' && parsedValue && !Array.isArray(parsedValue)) {
@@ -296,6 +311,16 @@ export const validatePackagePolicyConfig = (
         defaultMessage: 'Boolean values must be either true or false',
       })
     );
+  }
+
+  if (varDef.type === 'integer' && parsedValue && !Array.isArray(parsedValue)) {
+    if (!Number.isInteger(Number(parsedValue))) {
+      errors.push(
+        i18n.translate('xpack.fleet.packagePolicyValidation.invalidIntegerErrorMessage', {
+          defaultMessage: 'Invalid integer',
+        })
+      );
+    }
   }
 
   return errors.length ? errors : null;


### PR DESCRIPTION
## Summary

Resolve #135233 

We should validate correctly integer in package policy variables that PR fix that.

## Tests

It's covered by a unit test, and you can test that both UI and API use that validation 

#### UI

<img width="453" alt="Screen Shot 2022-06-27 at 4 23 17 PM" src="https://user-images.githubusercontent.com/1336873/176030693-7075791b-2c3f-492e-8a71-1e2056c77279.png">


#### API response 
```
{"statusCode":400,"error":"Bad Request","message":"Package policy is invalid: inputs.fleet-server.vars.max_agents: Invalid integer"}%
```