### PR TITLE
[Discover] Improve alerts popover accessibility and semantics

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { findTestSubject } from '@elastic/eui/lib/test';
+import { createSearchSourceMock } from '@kbn/data-plugin/public/mocks';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { AlertsPopover } from './open_alerts_popover';
+import { discoverServiceMock } from '../../../../__mocks__/services';
+import { indexPatternWithTimefieldMock } from '../../../../__mocks__/index_pattern_with_timefield';
+import { indexPatternMock } from '../../../../__mocks__/index_pattern';
+
+const mount = (dataView = indexPatternMock) =>
+  mountWithIntl(
+    <KibanaContextProvider services={discoverServiceMock}>
+      <AlertsPopover
+        searchSource={createSearchSourceMock({ index: dataView })}
+        anchorElement={document.createElement('div')}
+        savedQueryId={undefined}
+        onClose={() => {}}
+      />
+    </KibanaContextProvider>
+  );
+
+describe('OpenAlertsPopover', () => {
+  it('should render with the create search threshold rule button disabled if the data view has no time field', () => {
+    const component = mount();
+    expect(findTestSubject(component, 'discoverCreateAlertButton').prop('disabled')).toBeTruthy();
+  });
+
+  it('should render with the create search threshold rule button enabled if the data view has a time field', () => {
+    const component = mount(indexPatternWithTimefieldMock);
+    expect(findTestSubject(component, 'discoverCreateAlertButton').prop('disabled')).toBeFalsy();
+  });
+
+  it('should render the manage rules and connectors link', () => {
+    const component = mount();
+    expect(findTestSubject(component, 'discoverManageAlertsButton').exists()).toBeTruthy();
+  });
+});

--- a/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/open_alerts_popover.tsx
@@ -9,7 +9,7 @@
 import React, { useCallback, useState, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { I18nStart } from '@kbn/core/public';
-import { EuiWrappingPopover, EuiLink, EuiContextMenu, EuiToolTip } from '@elastic/eui';
+import { EuiWrappingPopover, EuiContextMenu } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ISearchSource } from '@kbn/data-plugin/common';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -79,58 +79,41 @@ export function AlertsPopover({
   }, [getParams, onClose, triggersActionsUi, alertFlyoutVisible]);
 
   const hasTimeFieldName = dataView.timeFieldName;
-  let createSearchThresholdRuleLink = (
-    <EuiLink
-      data-test-subj="discoverCreateAlertButton"
-      onClick={() => setAlertFlyoutVisibility(true)}
-      disabled={!hasTimeFieldName}
-    >
-      <FormattedMessage
-        id="discover.alerts.createSearchThreshold"
-        defaultMessage="Create search threshold rule"
-      />
-    </EuiLink>
-  );
-
-  if (!hasTimeFieldName) {
-    const toolTipContent = (
-      <FormattedMessage
-        id="discover.alerts.missedTimeFieldToolTip"
-        defaultMessage="Data view does not have a time field."
-      />
-    );
-    createSearchThresholdRuleLink = (
-      <EuiToolTip position="top" content={toolTipContent}>
-        {createSearchThresholdRuleLink}
-      </EuiToolTip>
-    );
-  }
-
   const panels = [
     {
       id: 'mainPanel',
       name: 'Alerting',
       items: [
         {
-          name: <>{createSearchThresholdRuleLink}</>,
+          name: (
+            <FormattedMessage
+              id="discover.alerts.createSearchThreshold"
+              defaultMessage="Create search threshold rule"
+            />
+          ),
           icon: 'bell',
+          onClick: () => setAlertFlyoutVisibility(true),
           disabled: !hasTimeFieldName,
+          toolTipContent: hasTimeFieldName ? undefined : (
+            <FormattedMessage
+              id="discover.alerts.missedTimeFieldToolTip"
+              defaultMessage="Data view does not have a time field."
+            />
+          ),
+          ['data-test-subj']: 'discoverCreateAlertButton',
         },
         {
           name: (
-            <EuiLink
-              color="text"
-              href={services?.application?.getUrlForApp(
-                'management/insightsAndAlerting/triggersActions/alerts'
-              )}
-            >
-              <FormattedMessage
-                id="discover.alerts.manageRulesAndConnectors"
-                defaultMessage="Manage rules and connectors"
-              />
-            </EuiLink>
+            <FormattedMessage
+              id="discover.alerts.manageRulesAndConnectors"
+              defaultMessage="Manage rules and connectors"
+            />
           ),
           icon: 'tableOfContents',
+          href: services?.application?.getUrlForApp(
+            'management/insightsAndAlerting/triggersActions/alerts'
+          ),
+          ['data-test-subj']: 'discoverManageAlertsButton',
         },
       ],
     },

--- a/test/functional/apps/discover/_discover_accessibility.ts
+++ b/test/functional/apps/discover/_discover_accessibility.ts
@@ -86,6 +86,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await focusAndPressButton('discoverAlertsButton');
         expect(await hasFocus('discoverAlertsButton')).to.be(false);
         await focusAndPressButton('discoverCreateAlertButton');
+        await retry.waitFor(
+          'Create Rule flyout is visible',
+          async () => await testSubjects.exists('addRuleFlyoutTitle')
+        );
         expect(await hasFocus('discoverCreateAlertButton')).to.be(false);
         await retry.try(async () => {
           await browser.pressKeys(browser.keys.ESCAPE);


### PR DESCRIPTION
## Summary

This PR improves the keyboard navigation for the Discover alerts popover, and fixes the HTML output so there aren't buttons and anchors nested within other buttons.

Original:
![original_alerts_popover](https://user-images.githubusercontent.com/25592674/176045809-cdcf6176-a627-416f-8a40-1d51e5535f85.gif)

Updated:
![updated_alerts_popover](https://user-images.githubusercontent.com/25592674/176045824-3692498c-6b5d-4bb8-ac5f-873373ab3f29.gif)

Fixes #134982.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)