### PR TITLE
[KQL] Define KqlContext type

### DIFF
--- a/packages/kbn-es-query/src/kuery/ast/ast.ts
+++ b/packages/kbn-es-query/src/kuery/ast/ast.ts
@@ -10,7 +10,7 @@ import { JsonObject } from '@kbn/utility-types';
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { nodeTypes } from '../node_types';
 import { KQLSyntaxError } from '../kuery_syntax_error';
-import { KueryNode, KueryParseOptions, KueryQueryOptions } from '../types';
+import type { KqlContext, KueryNode, KueryParseOptions, KueryQueryOptions } from '../types';
 
 import { parse as parseKuery } from '../grammar';
 import { DataViewBase } from '../..';
@@ -68,7 +68,7 @@ export const toElasticsearchQuery = (
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context?: Record<string, any>
+  context?: KqlContext
 ): JsonObject => {
   if (!node || !node.type || !nodeTypes[node.type]) {
     return toElasticsearchQuery(nodeTypes.function.buildNode('and', []), indexPattern);

--- a/packages/kbn-es-query/src/kuery/functions/and.ts
+++ b/packages/kbn-es-query/src/kuery/functions/and.ts
@@ -7,7 +7,8 @@
  */
 
 import * as ast from '../ast';
-import { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(children: KueryNode[]) {
   return {
@@ -19,7 +20,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ) {
   const { filtersInMustClause } = config;
   const children = node.arguments || [];

--- a/packages/kbn-es-query/src/kuery/functions/exists.ts
+++ b/packages/kbn-es-query/src/kuery/functions/exists.ts
@@ -7,8 +7,9 @@
  */
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { DataViewFieldBase, DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { DataViewFieldBase, DataViewBase, KueryNode, KueryQueryOptions } from '../..';
 import * as literal from '../node_types/literal';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(fieldName: string) {
   return {
@@ -20,7 +21,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const {
     arguments: [fieldNameArg],

--- a/packages/kbn-es-query/src/kuery/functions/is.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.ts
@@ -12,10 +12,10 @@ import { getPhraseScript } from '../../filters';
 import { getFields } from './utils/get_fields';
 import { getTimeZoneFromSettings, getDataViewFieldSubtypeNested } from '../../utils';
 import { getFullFieldNameNode } from './utils/get_full_field_name_node';
-import { DataViewBase, KueryNode, DataViewFieldBase, KueryQueryOptions } from '../..';
+import type { DataViewBase, KueryNode, DataViewFieldBase, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 import * as ast from '../ast';
-
 import * as literal from '../node_types/literal';
 import * as wildcard from '../node_types/wildcard';
 
@@ -42,7 +42,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const {
     arguments: [fieldNameArg, valueArg, isPhraseArg],

--- a/packages/kbn-es-query/src/kuery/functions/nested.ts
+++ b/packages/kbn-es-query/src/kuery/functions/nested.ts
@@ -9,7 +9,8 @@
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import * as ast from '../ast';
 import * as literal from '../node_types/literal';
-import { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(path: any, child: any) {
   const pathNode =
@@ -23,7 +24,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const [path, child] = node.arguments;
   const stringPath = ast.toElasticsearchQuery(path) as unknown as string;

--- a/packages/kbn-es-query/src/kuery/functions/not.ts
+++ b/packages/kbn-es-query/src/kuery/functions/not.ts
@@ -8,7 +8,8 @@
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import * as ast from '../ast';
-import { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(child: KueryNode) {
   return {
@@ -20,7 +21,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const [argument] = node.arguments;
 

--- a/packages/kbn-es-query/src/kuery/functions/or.ts
+++ b/packages/kbn-es-query/src/kuery/functions/or.ts
@@ -8,7 +8,8 @@
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import * as ast from '../ast';
-import { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(children: KueryNode[]) {
   return {
@@ -20,7 +21,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const children = node.arguments || [];
 

--- a/packages/kbn-es-query/src/kuery/functions/range.ts
+++ b/packages/kbn-es-query/src/kuery/functions/range.ts
@@ -14,6 +14,7 @@ import { getFields } from './utils/get_fields';
 import { getDataViewFieldSubtypeNested, getTimeZoneFromSettings } from '../../utils';
 import { getFullFieldNameNode } from './utils/get_full_field_name_node';
 import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { KqlContext } from '../types';
 
 export function buildNodeParams(
   fieldName: string,
@@ -30,7 +31,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config: KueryQueryOptions = {},
-  context: Record<string, any> = {}
+  context: KqlContext = {}
 ): estypes.QueryDslQueryContainer {
   const [fieldNameArg, operatorArg, valueArg] = node.arguments;
   const fullFieldNameArg = getFullFieldNameNode(

--- a/packages/kbn-es-query/src/kuery/node_types/function.ts
+++ b/packages/kbn-es-query/src/kuery/node_types/function.ts
@@ -9,8 +9,9 @@
 import _ from 'lodash';
 
 import { functions } from '../functions';
-import { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
-import { FunctionName, FunctionTypeBuildNode } from './types';
+import type { DataViewBase, KueryNode, KueryQueryOptions } from '../..';
+import type { FunctionName, FunctionTypeBuildNode } from './types';
+import type { KqlContext } from '../types';
 
 export function buildNode(functionName: FunctionName, ...args: any[]) {
   const kueryFunction = functions[functionName];
@@ -47,7 +48,7 @@ export function toElasticsearchQuery(
   node: KueryNode,
   indexPattern?: DataViewBase,
   config?: KueryQueryOptions,
-  context?: Record<string, any>
+  context?: KqlContext
 ) {
   const kueryFunction = functions[node.function as FunctionName];
   return kueryFunction.toElasticsearchQuery(node, indexPattern, config, context);

--- a/packages/kbn-es-query/src/kuery/types.ts
+++ b/packages/kbn-es-query/src/kuery/types.ts
@@ -47,3 +47,13 @@ export interface KueryQueryOptions {
    */
   nestedIgnoreUnmapped?: boolean;
 }
+
+/** @public */
+export interface KqlContext {
+  nested?: {
+    /**
+     * For nested queries, we pass along the path to the nested document so we can properly craft the query DSL.
+     */
+    path: string;
+  };
+}


### PR DESCRIPTION
## Summary

When processing KQL DSL into ES query DSL, we make use of a helper object, `context`. This was introduced when we [added support for nested fields](https://github.com/elastic/kibana/pull/47070), but was never correctly typed. This PR simply introduces the correct type for this object.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
