### PR TITLE
[Security Solution] Unblocking main

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/bulk_edit_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/bulk_edit_rules.spec.ts
@@ -12,6 +12,7 @@ import {
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
   LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN,
   RULES_TAGS_FILTER_BTN,
+  RULES_TABLE_REFRESH_INDICATOR,
 } from '../../screens/alerts_detection_rules';
 
 import {
@@ -119,6 +120,8 @@ describe('Detection rules, bulk edit', () => {
 
     // check if rule has been updated
     cy.get(CUSTOM_RULES_BTN).click();
+    cy.get(RULES_TABLE_REFRESH_INDICATOR).should('exist');
+    cy.get(RULES_TABLE_REFRESH_INDICATOR).should('not.exist');
     goToTheRuleDetailsOf(RULE_NAME);
     hasIndexPatterns([...DEFAULT_INDEX_PATTERNS, CUSTOM_INDEX_PATTERN_1].join(''));
   });


### PR DESCRIPTION
## Summary

After investigating why the test should be failing, looks like the page the test is interacting with is slower than expected, hence, we are trying to find an element that is not displayed on the page yet.

In this PR we are fixing the issue by waiting for the loading spinner to first appear and then disappear before continuing with any action.

Take into consideration this is a quick fix in order to unblock main without losing coverage, but further investigation by the team would be nice in order to check the performance of the page.