### PR TITLE
[Lens] Dont let reference line fills on different axes collide

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line_layer.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line_layer.tsx
@@ -64,7 +64,10 @@ export const ReferenceLineLayer: FC<ReferenceLineLayerProps> = ({
       columnToLabelMap[decorationConfig.forAccessor] ??
       titles?.yTitles?.[decorationConfig.forAccessor];
     const value = row[decorationConfig.forAccessor];
-    const yDecorationsWithSameDirection = groupedByDirection[decorationConfig.fill!];
+    const yDecorationsWithSameDirection = groupedByDirection[decorationConfig.fill!].filter(
+      (yDecoration) =>
+        getAxisGroupForReferenceLine(axesConfiguration, yDecoration, isHorizontal) === axisGroup
+    );
     const indexFromSameType = yDecorationsWithSameDirection.findIndex(
       ({ forAccessor }) => forAccessor === decorationConfig.forAccessor
     );

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_lines.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_lines.test.tsx
@@ -385,7 +385,7 @@ describe('ReferenceLines', () => {
       ['above', { y0: 5, y1: 10 }, { y0: 10, y1: undefined }],
       ['below', { y0: undefined, y1: 5 }, { y0: 5, y1: 10 }],
     ] as Array<[Exclude<ExtendedReferenceLineDecorationConfig['fill'], undefined>, YCoords, YCoords]>)(
-      'should be robust and works also for different axes when on same direction: 1x Left + 1x Right both %s',
+      'should allow overlap for different axes when on same direction on different axes: 1x Left + 1x Right both %s',
       (fill, coordsA, coordsB) => {
         const wrapper = shallow(
           <ReferenceLines
@@ -416,7 +416,11 @@ describe('ReferenceLines', () => {
         ).toEqual(
           expect.arrayContaining([
             {
-              coordinates: { ...emptyCoords, ...coordsA },
+              coordinates: {
+                ...emptyCoords,
+                ...coordsA,
+                [fill === 'above' ? 'y1' : 'y0']: undefined,
+              },
               details: coordsA.y0 ?? coordsA.y1,
               header: undefined,
             },
@@ -427,7 +431,11 @@ describe('ReferenceLines', () => {
         ).toEqual(
           expect.arrayContaining([
             {
-              coordinates: { ...emptyCoords, ...coordsB },
+              coordinates: {
+                ...emptyCoords,
+                ...coordsB,
+                [fill === 'above' ? 'y1' : 'y0']: undefined,
+              },
               details: coordsB.y1 ?? coordsB.y0,
               header: undefined,
             },


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134803
Fixes https://github.com/elastic/kibana/issues/135024

This PR only considers other reference lines with a same direction fill for overlaps if they are on the same axis.

I'm not sure about the second bug (could you check that again @mbondyra ) but I couldn't reproduce this issue on this branch.

Maybe I misunderstood something about the repo.