### PR TITLE
[Synthetics] Monitor details panel style feedback

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/last_run_info.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/last_run_info.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import moment from 'moment';
 import { i18n } from '@kbn/i18n';
+import { useTheme } from '@kbn/observability-plugin/public';
 import { Ping } from '../../../../../common/runtime_types';
 import { useSelectedLocation } from './hooks/use_selected_location';
 
@@ -16,13 +17,19 @@ export const MonitorSummaryLastRunInfo = ({ ping }: { ping: Ping }) => {
   const selectedLocation = useSelectedLocation();
   const isBrowserType = ping.monitor.type === 'browser';
 
+  const theme = useTheme();
+
   return (
     <EuiFlexGroup gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
         {ping.monitor.status === 'up' ? (
-          <EuiBadge color="success">{isBrowserType ? SUCCESS_LABEL : UP_LABEL}</EuiBadge>
+          <EuiBadge color={theme.eui.euiColorVis0}>
+            {isBrowserType ? SUCCESS_LABEL : UP_LABEL}
+          </EuiBadge>
         ) : ping.monitor.status === 'up' ? (
-          <EuiBadge color="danger">{isBrowserType ? FAILED_LABEL : DOWN_LABEL}</EuiBadge>
+          <EuiBadge color={theme.eui.euiColorVis9}>
+            {isBrowserType ? FAILED_LABEL : DOWN_LABEL}
+          </EuiBadge>
         ) : (
           <EuiBadge color="default">{PENDING_LABEL}</EuiBadge>
         )}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/locations_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/locations_status.tsx
@@ -6,10 +6,13 @@
  */
 import React from 'react';
 import { EuiBadge, EuiBadgeGroup, EuiIcon, EuiLoadingSpinner } from '@elastic/eui';
+import { useTheme } from '@kbn/observability-plugin/public';
 import { useStatusByLocation } from '../hooks/use_status_by_location';
 
 export const LocationsStatus = () => {
   const { locations, loading } = useStatusByLocation();
+
+  const theme = useTheme();
 
   if (loading) {
     return <EuiLoadingSpinner />;
@@ -20,7 +23,11 @@ export const LocationsStatus = () => {
       {locations.map((loc) => (
         <EuiBadge
           iconType={() => (
-            <EuiIcon type="dot" color={(loc.summary?.down ?? 0) > 0 ? 'danger' : 'success'} />
+            <EuiIcon
+              size="s"
+              type="dot"
+              color={(loc.summary?.down ?? 0) > 0 ? theme.eui.euiColorVis9 : theme.eui.euiColorVis0}
+            />
           )}
           color="hollow"
         >

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/monitor_details_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/monitor_details_panel.tsx
@@ -19,6 +19,7 @@ import { capitalize } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { MonitorTags } from './monitor_tags';
 import { MonitorEnabled } from '../../monitors_page/management/monitor_list_table/monitor_enabled';
 import { LocationsStatus } from './locations_status';
@@ -43,9 +44,9 @@ export const MonitorDetailsPanel = () => {
   }
 
   return (
-    <>
-      <EuiSpacer />
-      <EuiDescriptionList type="responsiveColumn" style={{ maxWidth: '400px' }}>
+    <Wrapper>
+      <EuiSpacer size="s" />
+      <EuiDescriptionList type="responsiveColumn" compressed={true}>
         <EuiDescriptionListTitle>{ENABLED_LABEL}</EuiDescriptionListTitle>
         <EuiDescriptionListDescription>
           {monitor && (
@@ -80,9 +81,16 @@ export const MonitorDetailsPanel = () => {
           {monitor && <MonitorTags tags={monitor[ConfigKey.TAGS]} />}
         </EuiDescriptionListDescription>
       </EuiDescriptionList>
-    </>
+    </Wrapper>
   );
 };
+
+const Wrapper = euiStyled.div`
+  .euiDescriptionList.euiDescriptionList--column > *,
+  .euiDescriptionList.euiDescriptionList--responsiveColumn > * {
+    margin-top: ${(props) => props.theme.eui.euiSizeS};
+  }
+`;
 
 const FREQUENCY_LABEL = i18n.translate('xpack.synthetics.management.monitorList.frequency', {
   defaultMessage: 'Frequency',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/summary_tab_content.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_summary/tabs_content/summary_tab_content.tsx
@@ -6,19 +6,26 @@
  */
 
 import React from 'react';
-import { EuiTitle, EuiPanel } from '@elastic/eui';
+import { EuiTitle, EuiPanel, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { MonitorDetailsPanel } from './monitor_details_panel';
 
 export const SummaryTabContent = () => {
   return (
-    <EuiPanel>
-      <EuiTitle size="s">
-        <h3>{MONITOR_DETAILS_LABEL}</h3>
-      </EuiTitle>
-      <MonitorDetailsPanel />
-    </EuiPanel>
+    <EuiFlexGroup>
+      <EuiFlexItem grow={1}>
+        <EuiPanel>
+          <EuiTitle size="xs">
+            <h3>{MONITOR_DETAILS_LABEL}</h3>
+          </EuiTitle>
+          <MonitorDetailsPanel />
+        </EuiPanel>
+      </EuiFlexItem>
+      <EuiFlexItem grow={2}>
+        <EuiPanel />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_enabled.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_enabled.tsx
@@ -76,6 +76,7 @@ export const MonitorEnabled = ({ id, monitor, reloadPage, initialLoading }: Prop
         <EuiLoadingSpinner size="m" />
       ) : (
         <EuiSwitch
+          compressed={true}
           checked={enabled}
           disabled={isLoading || isDisabled}
           showLabel={false}


### PR DESCRIPTION
## Summary

Covered feedback by @hbharding for https://github.com/elastic/kibana/pull/134814 

- Decreased margin between rows
- Title size set to xs
- Enabled switch is compressed
- Use vizcolor 0 for success and 9 for danger
- Removed maxwidth set on the panel


<img width="1631" alt="image" src="https://user-images.githubusercontent.com/3505601/176164783-3ee9a486-b88d-45a1-9155-63f469872087.png">
