### PR TITLE
[Actionable Observability] move ALERT_INSTANCE_ID to the technical field map

### DIFF
--- a/x-pack/plugins/rule_registry/common/assets/field_maps/experimental_rule_field_map.test.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/experimental_rule_field_map.test.ts
@@ -20,10 +20,6 @@ it('matches snapshot', () => {
         "scaling_factor": 100,
         "type": "scaled_float",
       },
-      "kibana.alert.instance.id": Object {
-        "required": true,
-        "type": "keyword",
-      },
     }
   `);
 });

--- a/x-pack/plugins/rule_registry/common/assets/field_maps/experimental_rule_field_map.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/experimental_rule_field_map.ts
@@ -8,7 +8,6 @@
 import * as Fields from '../../technical_rule_data_field_names';
 
 export const experimentalRuleFieldMap = {
-  [Fields.ALERT_INSTANCE_ID]: { type: 'keyword', required: true },
   [Fields.ALERT_EVALUATION_THRESHOLD]: { type: 'scaled_float', scaling_factor: 100 },
   [Fields.ALERT_EVALUATION_VALUE]: { type: 'scaled_float', scaling_factor: 100 },
 } as const;

--- a/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.test.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.test.ts
@@ -43,6 +43,10 @@ it('matches snapshot', () => {
       "kibana.alert.end": Object {
         "type": "date",
       },
+      "kibana.alert.instance.id": Object {
+        "required": true,
+        "type": "keyword",
+      },
       "kibana.alert.reason": Object {
         "array": false,
         "required": false,

--- a/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
@@ -23,6 +23,7 @@ export const technicalRuleFieldMap = {
   [Fields.ALERT_RULE_PRODUCER]: { type: 'keyword', required: true },
   [Fields.SPACE_IDS]: { type: 'keyword', array: true, required: true },
   [Fields.ALERT_UUID]: { type: 'keyword', required: true },
+  [Fields.ALERT_INSTANCE_ID]: { type: 'keyword', required: true },
   [Fields.ALERT_START]: { type: 'date' },
   [Fields.ALERT_END]: { type: 'date' },
   [Fields.ALERT_DURATION]: { type: 'long' },

--- a/x-pack/plugins/rule_registry/common/parse_technical_fields.test.ts
+++ b/x-pack/plugins/rule_registry/common/parse_technical_fields.test.ts
@@ -13,6 +13,7 @@ describe('parseTechnicalFields', () => {
       '@timestamp': ['2021-12-06T12:30:59.411Z'],
       'kibana.alert.status': ['active'],
       'kibana.alert.duration.us': ['488935266000'],
+      'kibana.alert.instance.id': ['My-MAC'],
       'kibana.alert.reason': ['host.uptime has reported no data over the past 1m for *'],
       'kibana.alert.workflow_status': ['open'],
       'kibana.alert.rule.uuid': ['c8ef4420-4604-11ec-b08c-c590e7b8c4cd'],
@@ -62,6 +63,7 @@ describe('parseTechnicalFields', () => {
   it('parses an alert with missing optional fields without error', () => {
     const ALERT_WITH_MISSING_OPTIONAL_FIELDS = {
       '@timestamp': ['2021-12-06T12:30:59.411Z'],
+      'kibana.alert.instance.id': ['My-MAC'],
       'kibana.alert.rule.uuid': ['c8ef4420-4604-11ec-b08c-c590e7b8c4cd'],
       'kibana.alert.status': ['active'],
       'kibana.alert.rule.producer': ['infrastructure'],


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/133993

### Summary

This PR moves `kibana.alert.instance.id` to the [technical field map](https://github.com/elastic/kibana/blob/main/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts) and removes it from the [experimental field map](https://github.com/elastic/kibana/blob/main/x-pack/plugins/rule_registry/common/assets/field_maps/experimental_rule_field_map.ts). Nothing should really break in the UI and alerts should keep working as before. 

### How to test
Experimental field is a field that exists in the solution specific component template (extended schema). In order to verify that `kibana.alert.instance.id` is not an experimental field anymore you could check following:
- Create an Inventory rule type (or any other RAC registered o11y rule type)
- Go to `Stack Management > Index Management`
- Select the `Component templates` tab
- In this example find `.alerts-observability.metrics.alerts-mappings`
- Open the flyout and verify that `kibana.alert.instance.id` doesn't appear in the `Mappings` tab. Only `kibana.alert.evaluation.threshold` and `kibana.alert.evaluation.value` should appear as shown in the screenshot.

<img width="1336" alt="Screenshot 2022-06-29 at 10 44 56" src="https://user-images.githubusercontent.com/2852703/176393558-f470d62d-bb91-455a-9bd0-c55fdb430790.png">

### Notes for the reviewer
Once rest experimental fields are removed `kibana.alert.evaluation.threshold` and `kibana.alert.evaluation.value` (not part of this PR), changes that were introduced as part of this [PR](https://github.com/elastic/kibana/pull/120904) should be removed as well 