### PR TITLE
[Lens] Show badge for read-only

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -139,6 +139,17 @@ export async function mountApp(
   const embeddableEditorIncomingState = stateTransfer?.getIncomingEditorState(APP_ID);
 
   addHelpMenuToAppChrome(coreStart.chrome, coreStart.docLinks);
+  if (!lensServices.application.capabilities.visualize.save) {
+    coreStart.chrome.setBadge({
+      text: i18n.translate('xpack.lens.badge.readOnly.text', {
+        defaultMessage: 'Read only',
+      }),
+      tooltip: i18n.translate('xpack.lens.badge.readOnly.tooltip', {
+        defaultMessage: 'Unable to save visualizations to the library',
+      }),
+      iconType: 'glasses',
+    });
+  }
   coreStart.chrome.docTitle.change(
     i18n.translate('xpack.lens.pageTitle', { defaultMessage: 'Lens' })
   );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134754

By adding the read only badge in case the visualize save capability is not available.