### PR TITLE
Add ability to allow a license for a particular package

### DIFF
--- a/src/dev/license_checker/valid.test.ts
+++ b/src/dev/license_checker/valid.test.ts
@@ -41,6 +41,30 @@ describe('tasks/lib/licenses', () => {
       }).toThrow(PACKAGE.name);
     });
 
+    it('throw an error when the packages license is invalid and not overriden', () => {
+      expect(() => {
+        assertLicensesValid({
+          packages: [PACKAGE],
+          validLicenses: [`not ${PACKAGE.licenses[0]}`],
+          perPackageOverrides: {
+            [`${PACKAGE.name}-${PACKAGE.version}`]: [`also not ${PACKAGE.licenses[0]}`],
+          },
+        });
+      }).toThrow(PACKAGE.name);
+    });
+
+    it('should return undefined if the package license is invalid but has an ovveride', () => {
+      expect(
+        assertLicensesValid({
+          packages: [PACKAGE],
+          validLicenses: [`not ${PACKAGE.licenses[0]}`],
+          perPackageOverrides: {
+            [`${PACKAGE.name}-${PACKAGE.version}`]: PACKAGE.licenses,
+          },
+        })
+      ).toEqual(undefined);
+    });
+
     it('throws an error when the package has no licenses', () => {
       expect(() => {
         assertLicensesValid({

--- a/src/dev/license_checker/valid.ts
+++ b/src/dev/license_checker/valid.ts
@@ -17,6 +17,7 @@ interface Options {
     licenses: string[];
   }>;
   validLicenses: string[];
+  perPackageOverrides?: Record<string, string[]>;
 }
 
 /**
@@ -24,9 +25,19 @@ interface Options {
  *  options, either throws an error with details about
  *  violations or returns undefined.
  */
-export function assertLicensesValid({ packages, validLicenses }: Options) {
+export function assertLicensesValid({
+  packages,
+  validLicenses,
+  perPackageOverrides = {},
+}: Options) {
   const invalidMsgs = packages.reduce((acc, pkg) => {
-    const invalidLicenses = pkg.licenses.filter((license) => !validLicenses.includes(license));
+    const isValidLicense = (license: string) => validLicenses.includes(license);
+    const isValidLicenseForPackage = (license: string) =>
+      (perPackageOverrides[`${pkg.name}-${pkg.version}`] || []).includes(license);
+
+    const invalidLicenses = pkg.licenses.filter(
+      (license) => !isValidLicense(license) && !isValidLicenseForPackage(license)
+    );
 
     if (pkg.licenses.length && !invalidLicenses.length) {
       return acc;


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/133822.

Allow named packages to have licenses that are not in the allowed list of licenses.

In https://github.com/elastic/kibana/pull/135223 we will be adding an LGPLv3 licensed module, my only option was to add this to the global allow list. However @jbudz raised thta we should only allow this license on a per-package basis, which this PR addresses.

