### PR TITLE
Keep timeframe when editing a map from a dashboard

### DIFF
--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -262,6 +262,7 @@ export class MapApp extends React.Component<Props, State> {
       filters: [..._.get(globalState, 'filters', []), ...appFilters, ...savedObjectFilters],
       query,
       time: getInitialTimeFilters({
+        hasSaveAndReturnConfig: this.props.savedMap.hasSaveAndReturnConfig(),
         serializedMapState,
         globalState,
       }),

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_time_filters.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_time_filters.ts
@@ -10,13 +10,15 @@ import { getUiSettings } from '../../../kibana_services';
 import { SerializedMapState } from './types';
 
 export function getInitialTimeFilters({
+  hasSaveAndReturnConfig,
   serializedMapState,
   globalState,
 }: {
+  hasSaveAndReturnConfig: boolean;
   serializedMapState?: SerializedMapState;
   globalState: GlobalQueryStateFromUrl;
 }) {
-  if (serializedMapState?.timeFilters) {
+  if (!hasSaveAndReturnConfig && serializedMapState?.timeFilters) {
     return serializedMapState.timeFilters;
   }
 

--- a/x-pack/test/functional/apps/maps/group2/embeddable/save_and_return.js
+++ b/x-pack/test/functional/apps/maps/group2/embeddable/save_and_return.js
@@ -8,7 +8,14 @@
 import expect from '@kbn/expect';
 
 export default function ({ getPageObjects, getService }) {
-  const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'maps', 'timePicker', 'visualize']);
+  const PageObjects = getPageObjects([
+    'common',
+    'dashboard',
+    'header',
+    'maps',
+    'timePicker',
+    'visualize',
+  ]);
   const dashboardAddPanel = getService('dashboardAddPanel');
   const dashboardPanelActions = getService('dashboardPanelActions');
   const testSubjects = getService('testSubjects');

--- a/x-pack/test/functional/apps/maps/group2/embeddable/save_and_return.js
+++ b/x-pack/test/functional/apps/maps/group2/embeddable/save_and_return.js
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 
 export default function ({ getPageObjects, getService }) {
-  const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'maps', 'visualize']);
+  const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'maps', 'timePicker', 'visualize']);
   const dashboardAddPanel = getService('dashboardAddPanel');
   const dashboardPanelActions = getService('dashboardPanelActions');
   const testSubjects = getService('testSubjects');
@@ -75,6 +75,14 @@ export default function ({ getPageObjects, getService }) {
       });
 
       describe('save and return', () => {
+        it('should use dashboard instead of time stored in map state', async () => {
+          // join example map's time is "last 17 minutes"
+          // ensure map has dashboard time
+          const timeConfig = await PageObjects.timePicker.getTimeConfig();
+          expect(timeConfig.start).to.equal('Sep 20, 2015 @ 00:00:00.000');
+          expect(timeConfig.end).to.equal('Sep 20, 2015 @ 01:00:00.000');
+        });
+
         it('should return to dashboard', async () => {
           await PageObjects.maps.clickSaveAndReturnButton();
           await PageObjects.dashboard.waitForRenderComplete();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/134064

PR updates MapApp to use global state time when map is opened from originating application such as dashboard