### PR TITLE
[8.3] Fix Failing test: X-Pack CCS Tests.x-pack/test/functional/apps/lens/roup1/smokescreen·ts - lens app - group 1 lens smokescreen tests should allow to change index pattern (#133015)

### DIFF
--- a/src/plugins/unified_search/public/dataview_picker/dataview_list.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/dataview_list.tsx
@@ -56,6 +56,7 @@ export function DataViewsList({
         placeholder: i18n.translate('unifiedSearch.query.queryBar.indexPattern.findDataView', {
           defaultMessage: 'Find a data view',
         }),
+        'data-test-subj': 'indexPattern-switcher--input',
         ...(selectableProps ? selectableProps.searchProps : undefined),
       }}
     >

--- a/test/functional/page_objects/unified_search_page.ts
+++ b/test/functional/page_objects/unified_search_page.ts
@@ -10,6 +10,7 @@ import { FtrService } from '../ftr_provider_context';
 
 export class UnifiedSearchPageObject extends FtrService {
   private readonly browser = this.ctx.getService('browser');
+  private readonly retry = this.ctx.getService('retry');
   private readonly testSubjects = this.ctx.getService('testSubjects');
 
   public async closeTour() {
@@ -22,5 +23,18 @@ export class UnifiedSearchPageObject extends FtrService {
   public async closeTourPopoverByLocalStorage() {
     await this.browser.setLocalStorageItem('data.newDataViewMenu', 'true');
     await this.browser.refresh();
+  }
+
+  public async switchDataView(switchButtonSelector: string, dataViewTitle: string) {
+    await this.testSubjects.click(switchButtonSelector);
+
+    const indexPatternSwitcher = await this.testSubjects.find('indexPattern-switcher', 500);
+    await this.testSubjects.setValue('indexPattern-switcher--input', dataViewTitle);
+    await (await indexPatternSwitcher.findByCssSelector(`[title="${dataViewTitle}"]`)).click();
+
+    await this.retry.waitFor(
+      'wait for updating switcher',
+      async () => (await this.testSubjects.getVisibleText(switchButtonSelector)) === dataViewTitle
+    );
   }
 }

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -841,18 +841,16 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     /**
      * Changes the index pattern in the data panel
      */
-    async switchDataPanelIndexPattern(name: string) {
-      await testSubjects.click('lns-dataView-switch-link');
-      await find.clickByCssSelector(`[title="${name}"]`);
+    async switchDataPanelIndexPattern(dataViewTitle: string) {
+      await PageObjects.unifiedSearch.switchDataView('lns-dataView-switch-link', dataViewTitle);
       await PageObjects.header.waitUntilLoadingHasFinished();
     },
 
     /**
      * Changes the index pattern for the first layer
      */
-    async switchFirstLayerIndexPattern(name: string) {
-      await testSubjects.click('lns_layerIndexPatternLabel');
-      await find.clickByCssSelector(`.lnsChangeIndexPatternPopover [title="${name}"]`);
+    async switchFirstLayerIndexPattern(dataViewTitle: string) {
+      await PageObjects.unifiedSearch.switchDataView('lns_layerIndexPatternLabel', dataViewTitle);
       await PageObjects.header.waitUntilLoadingHasFinished();
     },
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Fix Failing test: X-Pack CCS Tests.x-pack/test/functional/apps/lens/roup1/smokescreen·ts - lens app - group 1 lens smokescreen tests should allow to change index pattern (#133015)](https://github.com/elastic/kibana/pull/133015)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)