### PR TITLE
[File storage] Public-side Client

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -131,3 +131,4 @@ pageLoadAssetSize:
   expressionXY: 34000
   kibanaUsageCollection: 16463
   kubernetesSecurity: 77234
+  files: 22673

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -32,7 +32,7 @@ interface HttpApiInterfaceEntryDefinition<P = unknown, Q = unknown, B = unknown,
   output: R;
 }
 
-type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
   unknown,
   {
@@ -44,7 +44,7 @@ type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { file: FileJSON }
 >;
 
-type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
   },
@@ -53,7 +53,7 @@ type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { ok: true }
 >;
 
-type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
     fileName?: string;
@@ -64,7 +64,7 @@ type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
   any
 >;
 
-type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
   },
@@ -73,21 +73,21 @@ type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { file: FileJSON }
 >;
 
-type ListHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type ListHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
   { page?: number; perPage?: number },
   unknown,
   { files: FileJSON[] }
 >;
 
-type UpdateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type UpdateHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
   unknown,
   { name?: string; alt?: string; meta?: Record<string, unknown> },
   { file: FileJSON }
 >;
 
-type UploadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type UploadHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { id: string },
   unknown,
   any,

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import * as qs from 'query-string';
 import { PLUGIN_ID } from './constants';
 import { FileJSON } from './types';
 
@@ -23,7 +24,26 @@ export const FILE_KIND_API_ROUTES = {
   getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
 };
 
-interface HttpApiInterfaceEntryDefinition<P = unknown, Q = unknown, B = unknown, R = unknown> {
+export const FILE_KIND_API_ROUTES_FILLED = {
+  getCreateFileRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}`,
+  getUploadRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}/blob`,
+  getDownloadRoute: (fileKind: string, id: string, fileName?: string) =>
+    `${FILES_API_BASE_PATH}/${fileKind}/${id}/blob/${fileName ? fileName : ''}`,
+  getUpdateRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}`,
+  getDeleteRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}`,
+  getListRoute: (fileKind: string, page?: number, perPage?: number) => {
+    const qParams = qs.stringify({ page, perPage });
+    return `${FILES_API_BASE_PATH}/${fileKind}/list${qParams ? `?${qParams}` : ''}`;
+  },
+  getByIdRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}`,
+};
+
+export interface HttpApiInterfaceEntryDefinition<
+  P = unknown,
+  Q = unknown,
+  B = unknown,
+  R = unknown
+> {
   inputs: {
     params: P;
     query: Q;
@@ -81,7 +101,7 @@ export type ListHttpEndpoint = HttpApiInterfaceEntryDefinition<
 >;
 
 export type UpdateHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
+  { id: string },
   unknown,
   { name?: string; alt?: string; meta?: Record<string, unknown> },
   { file: FileJSON }

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -13,7 +13,7 @@ const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
 const FILES_API_BASE_PATH = `${API_BASE_PATH}/files`;
 
-export const FILE_KIND_API_ROUTES = {
+export const FILE_KIND_API_ROUTES_SERVER = {
   getCreateFileRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}`,
   getUploadRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}/blob`,
   getDownloadRoute: (fileKind: string) =>
@@ -24,7 +24,7 @@ export const FILE_KIND_API_ROUTES = {
   getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
 };
 
-export const FILE_KIND_API_ROUTES_FILLED = {
+export const FILE_KIND_API_ROUTES_CLIENT = {
   getCreateFileRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}`,
   getUploadRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}/blob`,
   getDownloadRoute: (fileKind: string, id: string, fileName?: string) =>

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -113,16 +113,3 @@ export type UploadHttpEndpoint = HttpApiInterfaceEntryDefinition<
   any,
   { ok: true }
 >;
-
-/**
- * Types describing the full files public HTTP API interface
- */
-export interface HttpApiInterface {
-  create: CreateHttpEndpoint;
-  delete: DeleteHttpEndpoint;
-  download: DownloadHttpEndpoint;
-  getById: GetByIdHttpEndpoint;
-  list: ListHttpEndpoint;
-  update: UpdateHttpEndpoint;
-  upload: UploadHttpEndpoint;
-}

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -6,6 +6,7 @@
  */
 
 import { PLUGIN_ID } from './constants';
+import { FileJSON } from './types';
 
 const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
@@ -13,11 +14,95 @@ const FILES_API_BASE_PATH = `${API_BASE_PATH}/files`;
 
 export const FILE_KIND_API_ROUTES = {
   getCreateFileRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}`,
-  getUploadRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{fileId}/blob`,
+  getUploadRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}/blob`,
   getDownloadRoute: (fileKind: string) =>
-    `${FILES_API_BASE_PATH}/${fileKind}/{fileId}/blob/{fileName?}`,
-  getUpdateRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{fileId}`,
-  getDeleteRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{fileId}`,
+    `${FILES_API_BASE_PATH}/${fileKind}/{id}/blob/{fileName?}`,
+  getUpdateRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
+  getDeleteRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
   getListRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/list`,
-  getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{fileId}`,
+  getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
 };
+
+interface HttpApiInterfaceEntryDefinition<P = unknown, Q = unknown, B = unknown, R = unknown> {
+  inputs: {
+    params: P;
+    query: Q;
+    body: B;
+  };
+  output: R;
+}
+
+type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  unknown,
+  unknown,
+  {
+    name: string;
+    alt?: string;
+    meta?: Record<string, unknown>;
+    mime?: string;
+  },
+  { file: FileJSON }
+>;
+
+type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  {
+    id: string;
+  },
+  unknown,
+  unknown,
+  { ok: true }
+>;
+
+type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  {
+    id: string;
+    fileName?: string;
+  },
+  unknown,
+  unknown,
+  // Should be a readable stream
+  any
+>;
+
+type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  {
+    id: string;
+  },
+  unknown,
+  unknown,
+  { file: FileJSON }
+>;
+
+type ListHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  unknown,
+  { page?: number; perPage?: number },
+  unknown,
+  { files: FileJSON[] }
+>;
+
+type UpdateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  unknown,
+  unknown,
+  { name?: string; alt?: string; meta?: Record<string, unknown> },
+  { file: FileJSON }
+>;
+
+type UploadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  { id: string },
+  unknown,
+  any,
+  { ok: true }
+>;
+
+/**
+ * Types describing the full files public HTTP API interface
+ */
+export interface HttpApiInterface {
+  create: CreateHttpEndpoint;
+  delete: DeleteHttpEndpoint;
+  download: DownloadHttpEndpoint;
+  getById: GetByIdHttpEndpoint;
+  list: ListHttpEndpoint;
+  update: UpdateHttpEndpoint;
+  upload: UploadHttpEndpoint;
+}

--- a/x-pack/plugins/files/common/constants.ts
+++ b/x-pack/plugins/files/common/constants.ts
@@ -13,4 +13,4 @@ export const PLUGIN_NAME = 'files' as const;
  */
 export const FILE_SO_TYPE = 'file';
 
-export const ES_SINGLE_INDEX_BLOB_STORE = 'esSingleIndex' as const;
+export const ES_FIXED_SIZE_INDEX_BLOB_STORE = 'esFixedSizeIndex' as const;

--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { FILE_SO_TYPE, PLUGIN_ID, PLUGIN_NAME, ES_SINGLE_INDEX_BLOB_STORE } from './constants';
+export { FILE_SO_TYPE, PLUGIN_ID, PLUGIN_NAME, ES_FIXED_SIZE_INDEX_BLOB_STORE } from './constants';
 
 export type {
   FileSavedObjectAttributes,

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -7,7 +7,7 @@
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import type { SavedObject } from '@kbn/core/server';
 import type { Readable } from 'stream';
-import type { ES_SINGLE_INDEX_BLOB_STORE } from './constants';
+import type { ES_FIXED_SIZE_INDEX_BLOB_STORE } from './constants';
 
 export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'UPLOAD_ERROR' | 'DELETED';
 
@@ -127,7 +127,7 @@ export interface BlobStorageSettings {
   /**
    * Single index that supports up to 50GB of blobs
    */
-  [ES_SINGLE_INDEX_BLOB_STORE]?: {
+  [ES_FIXED_SIZE_INDEX_BLOB_STORE]?: {
     index: string;
   };
   // Other blob store settings will go here once available

--- a/x-pack/plugins/files/kibana.json
+++ b/x-pack/plugins/files/kibana.json
@@ -8,7 +8,7 @@
   },
   "description": "Bringing blob storage to Kibana",
   "server": true,
-  "ui": false,
+  "ui": true,
   "requiredPlugins": [],
   "optionalPlugins": ["security"]
 }

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -18,6 +18,9 @@ export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
   return {
     create(args) {
       return http.post(FILE_KIND_API_ROUTES_FILLED.getCreateFileRoute(fileKind), {
+        headers: {
+          'content-type': 'application/json',
+        },
         body: JSON.stringify(args),
       });
     },
@@ -37,6 +40,9 @@ export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
     },
     update({ id, ...body }) {
       return http.patch(FILE_KIND_API_ROUTES_FILLED.getUpdateRoute(fileKind, id), {
+        headers: {
+          'content-type': 'application/json',
+        },
         body: JSON.stringify(body),
       });
     },

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -7,7 +7,7 @@
 
 import type { HttpStart } from '@kbn/core/public';
 import type { FilesClient } from '../types';
-import { FILE_KIND_API_ROUTES_FILLED } from '../../common/api_routes';
+import { FILE_KIND_API_ROUTES_CLIENT } from '../../common/api_routes';
 
 interface Args {
   fileKind: string;
@@ -17,7 +17,7 @@ interface Args {
 export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
   return {
     create(args) {
-      return http.post(FILE_KIND_API_ROUTES_FILLED.getCreateFileRoute(fileKind), {
+      return http.post(FILE_KIND_API_ROUTES_CLIENT.getCreateFileRoute(fileKind), {
         headers: {
           'content-type': 'application/json',
         },
@@ -25,21 +25,21 @@ export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
       });
     },
     delete(args) {
-      return http.delete(FILE_KIND_API_ROUTES_FILLED.getDeleteRoute(fileKind, args.id));
+      return http.delete(FILE_KIND_API_ROUTES_CLIENT.getDeleteRoute(fileKind, args.id));
     },
     download(args) {
       return http.get(
-        FILE_KIND_API_ROUTES_FILLED.getDownloadRoute(fileKind, args.id, args.fileName)
+        FILE_KIND_API_ROUTES_CLIENT.getDownloadRoute(fileKind, args.id, args.fileName)
       );
     },
     getById(args) {
-      return http.get(FILE_KIND_API_ROUTES_FILLED.getByIdRoute(fileKind, args.id));
+      return http.get(FILE_KIND_API_ROUTES_CLIENT.getByIdRoute(fileKind, args.id));
     },
     list(args) {
-      return http.get(FILE_KIND_API_ROUTES_FILLED.getListRoute(fileKind, args.page, args.perPage));
+      return http.get(FILE_KIND_API_ROUTES_CLIENT.getListRoute(fileKind, args.page, args.perPage));
     },
     update({ id, ...body }) {
-      return http.patch(FILE_KIND_API_ROUTES_FILLED.getUpdateRoute(fileKind, id), {
+      return http.patch(FILE_KIND_API_ROUTES_CLIENT.getUpdateRoute(fileKind, id), {
         headers: {
           'content-type': 'application/json',
         },
@@ -47,7 +47,7 @@ export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
       });
     },
     upload(args) {
-      return http.put(FILE_KIND_API_ROUTES_FILLED.getUploadRoute(fileKind, args.id), {
+      return http.put(FILE_KIND_API_ROUTES_CLIENT.getUploadRoute(fileKind, args.id), {
         body: args.body,
       });
     },

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -6,7 +6,7 @@
  */
 
 import type { HttpStart } from '@kbn/core/public';
-import type { FilesClient as IFilesClient } from '../types';
+import type { FilesClient } from '../types';
 import { FILE_KIND_API_ROUTES_FILLED } from '../../common/api_routes';
 
 interface Args {
@@ -14,7 +14,7 @@ interface Args {
   http: HttpStart;
 }
 
-export const createFilesClient = ({ http, fileKind }: Args): IFilesClient => {
+export const createFilesClient = ({ http, fileKind }: Args): FilesClient => {
   return {
     create(args) {
       return http.post(FILE_KIND_API_ROUTES_FILLED.getCreateFileRoute(fileKind), {

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -4,3 +4,46 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import type { HttpStart } from '@kbn/core/public';
+import type { FilesClient as IFilesClient } from '../types';
+import { FILE_KIND_API_ROUTES_FILLED } from '../../common/api_routes';
+
+interface Args {
+  fileKind: string;
+  http: HttpStart;
+}
+
+export const createFilesClient = ({ http, fileKind }: Args): IFilesClient => {
+  return {
+    create(args) {
+      return http.post(FILE_KIND_API_ROUTES_FILLED.getCreateFileRoute(fileKind), {
+        body: JSON.stringify(args),
+      });
+    },
+    delete(args) {
+      return http.delete(FILE_KIND_API_ROUTES_FILLED.getDeleteRoute(fileKind, args.id));
+    },
+    download(args) {
+      return http.get(
+        FILE_KIND_API_ROUTES_FILLED.getDownloadRoute(fileKind, args.id, args.fileName)
+      );
+    },
+    getById(args) {
+      return http.get(FILE_KIND_API_ROUTES_FILLED.getByIdRoute(fileKind, args.id));
+    },
+    list(args) {
+      return http.get(FILE_KIND_API_ROUTES_FILLED.getListRoute(fileKind, args.page, args.perPage));
+    },
+    update({ id, ...body }) {
+      return http.patch(FILE_KIND_API_ROUTES_FILLED.getUpdateRoute(fileKind, id), {
+        body: JSON.stringify(body),
+      });
+    },
+    upload(args) {
+      return http.put(FILE_KIND_API_ROUTES_FILLED.getUploadRoute(fileKind, args.id), {
+        body: args.body,
+      });
+    },
+  };
+};

--- a/x-pack/plugins/files/public/files_client/index.ts
+++ b/x-pack/plugins/files/public/files_client/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */

--- a/x-pack/plugins/files/public/files_client/index.ts
+++ b/x-pack/plugins/files/public/files_client/index.ts
@@ -4,3 +4,5 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+export { createFilesClient } from './files_client';

--- a/x-pack/plugins/files/public/index.ts
+++ b/x-pack/plugins/files/public/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginInitializerContext } from '@kbn/core/public';
+import { FilesPlugin } from './plugin';
+
+export function plugin(ctx: PluginInitializerContext) {
+  return new FilesPlugin(ctx);
+}

--- a/x-pack/plugins/files/public/index.ts
+++ b/x-pack/plugins/files/public/index.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { PluginInitializerContext } from '@kbn/core/public';
 import { FilesPlugin } from './plugin';
 
-export function plugin(ctx: PluginInitializerContext) {
-  return new FilesPlugin(ctx);
+export type { FilesClient, FilesClientFactory } from './types';
+
+export function plugin() {
+  return new FilesPlugin();
 }

--- a/x-pack/plugins/files/public/plugin.ts
+++ b/x-pack/plugins/files/public/plugin.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+
+export class FilesPlugin implements Plugin {
+  constructor(private readonly ctx: PluginInitializerContext) {}
+  setup(core: CoreSetup, plugins: object): void {}
+  start(core: CoreStart, plugins: object): void {}
+}

--- a/x-pack/plugins/files/public/plugin.ts
+++ b/x-pack/plugins/files/public/plugin.ts
@@ -5,10 +5,31 @@
  * 2.0.
  */
 
-import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import type { FilesClientFactory } from './types';
+import { createFilesClient } from './files_client';
 
-export class FilesPlugin implements Plugin {
-  constructor(private readonly ctx: PluginInitializerContext) {}
-  setup(core: CoreSetup, plugins: object): void {}
-  start(core: CoreStart, plugins: object): void {}
+export interface FilesSetup {
+  filesClientFactory: FilesClientFactory;
+}
+
+export type FilesStart = FilesSetup;
+
+export class FilesPlugin implements Plugin<FilesSetup, FilesStart> {
+  private api: undefined | FilesSetup;
+
+  setup(core: CoreSetup): FilesSetup {
+    this.api = {
+      filesClientFactory: {
+        asScoped(fileKind: string) {
+          return createFilesClient({ fileKind, http: core.http });
+        },
+      },
+    };
+    return this.api;
+  }
+
+  start(core: CoreStart): FilesStart {
+    return this.api!;
+  }
 }

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -5,12 +5,27 @@
  * 2.0.
  */
 
-import type { HttpApiInterface } from '../common/api_routes';
+import type {
+  HttpApiInterfaceEntryDefinition,
+  CreateHttpEndpoint,
+  DeleteHttpEndpoint,
+  DownloadHttpEndpoint,
+  GetByIdHttpEndpoint,
+  ListHttpEndpoint,
+  UpdateHttpEndpoint,
+  UploadHttpEndpoint,
+} from '../common/api_routes';
 
-export type FilesClient = {
-  [method in keyof HttpApiInterface]: (
-    args: HttpApiInterface[method]['inputs']['body'] &
-      HttpApiInterface[method]['inputs']['params'] &
-      HttpApiInterface[method]['inputs']['query']
-  ) => Promise<HttpApiInterface[method]['output']>;
-};
+type ClientMethodFrom<E extends HttpApiInterfaceEntryDefinition> = (
+  args: E['inputs']['body'] & E['inputs']['params'] & E['inputs']['query']
+) => Promise<E['output']>;
+
+export interface FilesClient {
+  create: ClientMethodFrom<CreateHttpEndpoint>;
+  delete: ClientMethodFrom<DeleteHttpEndpoint>;
+  download: ClientMethodFrom<DownloadHttpEndpoint>;
+  getById: ClientMethodFrom<GetByIdHttpEndpoint>;
+  list: ClientMethodFrom<ListHttpEndpoint>;
+  update: ClientMethodFrom<UpdateHttpEndpoint>;
+  upload: ClientMethodFrom<UploadHttpEndpoint>;
+}

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpApiInterface } from '../common/api_routes';
+
+export type FilesClient = {
+  [method in keyof HttpApiInterface]: (
+    args: HttpApiInterface[method]['inputs']['body'] &
+      HttpApiInterface[method]['inputs']['params'] &
+      HttpApiInterface[method]['inputs']['query']
+  ) => Promise<HttpApiInterface[method]['output']>;
+};

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -29,3 +29,7 @@ export interface FilesClient {
   update: ClientMethodFrom<UpdateHttpEndpoint>;
   upload: ClientMethodFrom<UploadHttpEndpoint>;
 }
+
+export interface FilesClientFactory {
+  asScoped(fileKind: string): FilesClient;
+}

--- a/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
@@ -28,6 +28,6 @@ export class BlobStorageService {
   }
 
   public createBlobStore(args?: BlobStorageSettings) {
-    return this.createESBlobStorage({ ...args?.esSingleIndex });
+    return this.createESBlobStorage({ ...args?.esFixedSizeIndex });
   }
 }

--- a/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/file_service/integration_tests/file_service.test.ts
@@ -50,7 +50,7 @@ describe('FileService', () => {
     fileKindsRegistry.register({
       id: fileKindNonDefault,
       http: {},
-      blobStoreSettings: { esSingleIndex: { index: nonDefaultIndex } },
+      blobStoreSettings: { esFixedSizeIndex: { index: nonDefaultIndex } },
     });
     fileKindsRegistry.register({
       id: fileKindTinyFiles,

--- a/x-pack/plugins/files/server/index.ts
+++ b/x-pack/plugins/files/server/index.ts
@@ -8,6 +8,8 @@
 import type { PluginInitializerContext } from '@kbn/core/server';
 import { FilesPlugin } from './plugin';
 
+export type { FilesSetup, FilesStart } from './types';
+
 export function plugin(initializerContext: PluginInitializerContext) {
   return new FilesPlugin(initializerContext);
 }

--- a/x-pack/plugins/files/server/plugin.ts
+++ b/x-pack/plugins/files/server/plugin.ts
@@ -17,14 +17,12 @@ import { PLUGIN_ID } from '../common/constants';
 
 import { BlobStorageService } from './blob_storage_service';
 import { FileServiceFactory } from './file_service';
-import type { FilesPluginSetupDependencies, FilesPluginSetup, FilesPluginStart } from './types';
+import type { FilesPluginSetupDependencies, FilesSetup, FilesStart } from './types';
 import { fileKindsRegistry } from './file_kinds_registry';
 import type { FilesRequestHandlerContext, FilesRouter } from './routes/types';
 import { registerRoutes } from './routes';
 
-export class FilesPlugin
-  implements Plugin<FilesPluginSetup, FilesPluginStart, FilesPluginSetupDependencies>
-{
+export class FilesPlugin implements Plugin<FilesSetup, FilesStart, FilesPluginSetupDependencies> {
   private readonly logger: Logger;
   private fileServiceFactory: undefined | FileServiceFactory;
   private securitySetup: FilesPluginSetupDependencies['security'];
@@ -33,7 +31,7 @@ export class FilesPlugin
     this.logger = initializerContext.logger.get();
   }
 
-  public setup(core: CoreSetup, deps: FilesPluginSetupDependencies): FilesPluginSetup {
+  public setup(core: CoreSetup, deps: FilesPluginSetupDependencies): FilesSetup {
     FileServiceFactory.setup(core.savedObjects);
     this.securitySetup = deps.security;
 
@@ -70,7 +68,7 @@ export class FilesPlugin
     };
   }
 
-  public start(coreStart: CoreStart): FilesPluginStart {
+  public start(coreStart: CoreStart): FilesStart {
     const { savedObjects } = coreStart;
     const esClient = coreStart.elasticsearch.client.asInternalUser;
     const blobStorageService = new BlobStorageService(

--- a/x-pack/plugins/files/server/routes/file_kind/common_schemas.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/common_schemas.ts
@@ -21,10 +21,12 @@ export const fileName = schema.string({
   validate: alphanumericValidation,
 });
 
-export const fileAlt = schema.string({
-  minLength: 1,
-  maxLength: 256,
-  validate: alphanumericValidation,
-});
+export const fileAlt = schema.maybe(
+  schema.string({
+    minLength: 1,
+    maxLength: 256,
+    validate: alphanumericValidation,
+  })
+);
 
 export const fileMeta = schema.maybe(schema.object({}, { unknowns: 'allow' }));

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import { Ensure } from '@kbn/utility-types';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { CreateHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import * as commonSchemas from './common_schemas';
 
@@ -20,11 +20,9 @@ export const bodySchema = schema.object({
   mime: schema.maybe(schema.string()),
 });
 
-type CreateInterface = HttpApiInterface['create'];
+type Body = Ensure<CreateHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
 
-type Body = Ensure<CreateInterface['inputs']['body'], TypeOf<typeof bodySchema>>;
-
-type Response = CreateInterface['output'];
+type Response = CreateHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
   { fileKind, files },

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
-import { FileJSON } from '../../../common';
+import { Ensure } from '@kbn/utility-types';
+import type { HttpApiInterface } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import * as commonSchemas from './common_schemas';
 
@@ -19,11 +20,11 @@ export const bodySchema = schema.object({
   mime: schema.maybe(schema.string()),
 });
 
-type Body = TypeOf<typeof bodySchema>;
+type CreateInterface = HttpApiInterface['create'];
 
-interface Response {
-  file: FileJSON;
-}
+type Body = Ensure<CreateInterface['inputs']['body'], TypeOf<typeof bodySchema>>;
+
+type Response = CreateInterface['output'];
 
 export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
   { fileKind, files },

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { DeleteHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 import { getById } from './helpers';
@@ -18,11 +18,9 @@ export const paramsSchema = schema.object({
   id: schema.string(),
 });
 
-type DeleteInterface = HttpApiInterface['delete'];
+type Params = Ensure<DeleteHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-type Params = Ensure<DeleteInterface['inputs']['params'], TypeOf<typeof paramsSchema>>;
-
-type Response = DeleteInterface['output'];
+type Response = DeleteHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const {

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -6,6 +6,8 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
+import type { Ensure } from '@kbn/utility-types';
+import type { HttpApiInterface } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 import { getById } from './helpers';
@@ -13,17 +15,18 @@ import { getById } from './helpers';
 export const method = 'delete' as const;
 
 export const paramsSchema = schema.object({
-  fileId: schema.string(),
+  id: schema.string(),
 });
-type Params = TypeOf<typeof paramsSchema>;
 
-interface Response {
-  ok: true;
-}
+type DeleteInterface = HttpApiInterface['delete'];
+
+type Params = Ensure<DeleteInterface['inputs']['params'], TypeOf<typeof paramsSchema>>;
+
+type Response = DeleteInterface['output'];
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const {
-    params: { fileId: id },
+    params: { id },
   } = req;
   const { fileService } = await files;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -10,7 +10,7 @@ import { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 
 import type { File } from '../../../common';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { DownloadHttpEndpoint } from '../../../common/api_routes';
 
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
@@ -22,9 +22,7 @@ export const paramsSchema = schema.object({
   fileName: schema.maybe(schema.string()),
 });
 
-type DownloadInterface = HttpApiInterface['download'];
-
-type Params = Ensure<DownloadInterface['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<DownloadHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 type Response = Readable;
 

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -6,9 +6,11 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
+import { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 
 import type { File } from '../../../common';
+import type { HttpApiInterface } from '../../../common/api_routes';
 
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
@@ -16,10 +18,13 @@ import type { FileKindsRequestHandler } from './types';
 export const method = 'get' as const;
 
 export const paramsSchema = schema.object({
-  fileId: schema.string(),
+  id: schema.string(),
   fileName: schema.maybe(schema.string()),
 });
-type Params = TypeOf<typeof paramsSchema>;
+
+type DownloadInterface = HttpApiInterface['download'];
+
+type Params = Ensure<DownloadInterface['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 type Response = Readable;
 
@@ -39,7 +44,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
 ) => {
   const { fileService } = await files;
   const {
-    params: { fileId: id, fileName },
+    params: { id, fileName },
   } = req;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);
   if (error) return error;

--- a/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
@@ -7,20 +7,18 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { GetByIdHttpEndpoint } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
-type GetByIdEndpoint = HttpApiInterface['getById'];
-
-type Response = GetByIdEndpoint['output'];
+type Response = GetByIdHttpEndpoint['output'];
 
 export const method = 'get' as const;
 
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
-type Params = Ensure<GetByIdEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<GetByIdHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;

--- a/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
@@ -6,25 +6,26 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
-import { FileJSON } from '../../../common/types';
+import type { Ensure } from '@kbn/utility-types';
+import type { HttpApiInterface } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
-interface Response {
-  file: FileJSON;
-}
+type GetByIdEndpoint = HttpApiInterface['getById'];
+
+type Response = GetByIdEndpoint['output'];
 
 export const method = 'get' as const;
 
 export const paramsSchema = schema.object({
-  fileId: schema.string(),
+  id: schema.string(),
 });
-type Params = TypeOf<typeof paramsSchema>;
+type Params = Ensure<GetByIdEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;
   const {
-    params: { fileId: id },
+    params: { id },
   } = req;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);
   if (error) return error;

--- a/x-pack/plugins/files/server/routes/file_kind/index.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FILE_KIND_API_ROUTES } from '../../../common/api_routes';
+import { FILE_KIND_API_ROUTES_SERVER } from '../../../common/api_routes';
 import { fileKindsRegistry } from '../../file_kinds_registry';
 
 import { FilesRouter } from '../types';
@@ -25,7 +25,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.create) {
       fileKindRouter[create.method](
         {
-          path: FILE_KIND_API_ROUTES.getCreateFileRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getCreateFileRoute(fileKind.id),
           validate: {
             body: create.bodySchema,
           },
@@ -38,7 +38,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
 
       fileKindRouter[upload.method](
         {
-          path: FILE_KIND_API_ROUTES.getUploadRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getUploadRoute(fileKind.id),
           validate: {
             body: upload.bodySchema,
             params: upload.paramsSchema,
@@ -58,7 +58,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.update) {
       fileKindRouter[update.method](
         {
-          path: FILE_KIND_API_ROUTES.getUpdateRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getUpdateRoute(fileKind.id),
           validate: {
             body: update.bodySchema,
             params: update.paramsSchema,
@@ -73,7 +73,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.delete) {
       fileKindRouter[deleteEndpoint.method](
         {
-          path: FILE_KIND_API_ROUTES.getDeleteRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getDeleteRoute(fileKind.id),
           validate: {
             params: deleteEndpoint.paramsSchema,
           },
@@ -87,7 +87,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.list) {
       fileKindRouter[list.method](
         {
-          path: FILE_KIND_API_ROUTES.getListRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getListRoute(fileKind.id),
           validate: {
             query: list.querySchema,
           },
@@ -101,7 +101,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.download) {
       fileKindRouter[download.method](
         {
-          path: FILE_KIND_API_ROUTES.getDownloadRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getDownloadRoute(fileKind.id),
           validate: {
             params: download.paramsSchema,
           },
@@ -115,7 +115,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
     if (fileKind.http.getById) {
       fileKindRouter[getById.method](
         {
-          path: FILE_KIND_API_ROUTES.getByIdRoute(fileKind.id),
+          path: FILE_KIND_API_ROUTES_SERVER.getByIdRoute(fileKind.id),
           validate: {
             params: getById.paramsSchema,
           },

--- a/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
@@ -36,7 +36,7 @@ describe('File kind HTTP API', () => {
     fileKindsRegistry.register({
       id: fileKind,
       blobStoreSettings: {
-        esSingleIndex: { index: testIndex },
+        esFixedSizeIndex: { index: testIndex },
       },
       http: {
         create: { tags: ['access:myapp'] },

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -5,20 +5,23 @@
  * 2.0.
  */
 import { schema, TypeOf } from '@kbn/config-schema';
-import { FileJSON } from '../../../common/types';
+import type { Ensure } from '@kbn/utility-types';
+import type { FileJSON } from '../../../common';
+import type { HttpApiInterface } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 export const method = 'get' as const;
 
-export const querySchema = schema.object({
-  page: schema.number({ defaultValue: 1 }),
-  perPage: schema.number({ defaultValue: 100 }),
-});
-type Query = TypeOf<typeof querySchema>;
+type ListEndpoint = HttpApiInterface['list'];
 
-interface Response {
-  files: FileJSON[];
-}
+export const querySchema = schema.object({
+  page: schema.maybe(schema.number({ defaultValue: 1 })),
+  perPage: schema.maybe(schema.number({ defaultValue: 100 })),
+});
+
+type Query = Ensure<ListEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+
+type Response = ListEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<unknown, Query> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -7,21 +7,19 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import type { FileJSON } from '../../../common';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { ListHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 export const method = 'get' as const;
-
-type ListEndpoint = HttpApiInterface['list'];
 
 export const querySchema = schema.object({
   page: schema.maybe(schema.number({ defaultValue: 1 })),
   perPage: schema.maybe(schema.number({ defaultValue: 100 })),
 });
 
-type Query = Ensure<ListEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+type Query = Ensure<ListHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
 
-type Response = ListEndpoint['output'];
+type Response = ListHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<unknown, Query> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { UpdateHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import { getById } from './helpers';
 
@@ -15,15 +15,13 @@ import * as commonSchemas from './common_schemas';
 
 export const method = 'patch' as const;
 
-type UpdateEndpoint = HttpApiInterface['update'];
-
 export const bodySchema = schema.object({
   name: schema.maybe(commonSchemas.fileName),
   alt: schema.maybe(commonSchemas.fileAlt),
   meta: schema.maybe(commonSchemas.fileMeta),
 });
 
-type Body = Ensure<UpdateEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
+type Body = Ensure<UpdateHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
 
 export const paramsSchema = schema.object({
   id: schema.string(),
@@ -31,7 +29,7 @@ export const paramsSchema = schema.object({
 
 type Params = TypeOf<typeof paramsSchema>;
 
-type Response = UpdateEndpoint['output'];
+type Response = UpdateHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -27,7 +27,7 @@ export const paramsSchema = schema.object({
   id: schema.string(),
 });
 
-type Params = TypeOf<typeof paramsSchema>;
+type Params = Ensure<UpdateHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 type Response = UpdateHttpEndpoint['output'];
 

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -6,7 +6,8 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
-import type { FileJSON } from '../../../common/types';
+import type { Ensure } from '@kbn/utility-types';
+import type { HttpApiInterface } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import { getById } from './helpers';
 
@@ -14,22 +15,23 @@ import * as commonSchemas from './common_schemas';
 
 export const method = 'patch' as const;
 
+type UpdateEndpoint = HttpApiInterface['update'];
+
 export const bodySchema = schema.object({
   name: schema.maybe(commonSchemas.fileName),
   alt: schema.maybe(commonSchemas.fileAlt),
   meta: schema.maybe(commonSchemas.fileMeta),
 });
 
-type Body = TypeOf<typeof bodySchema>;
+type Body = Ensure<UpdateEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
 
 export const paramsSchema = schema.object({
-  fileId: schema.string(),
+  id: schema.string(),
 });
+
 type Params = TypeOf<typeof paramsSchema>;
 
-interface Response {
-  file: FileJSON;
-}
+type Response = UpdateEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },
@@ -38,7 +40,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
 ) => {
   const { fileService } = await files;
   const {
-    params: { fileId: id },
+    params: { id },
     body: attrs,
   } = req;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -8,13 +8,11 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
-import type { HttpApiInterface } from '../../../common/api_routes';
+import type { UploadHttpEndpoint } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
 export const method = 'put' as const;
-
-type UploadEndpoint = HttpApiInterface['upload'];
 
 export const bodySchema = schema.stream();
 type Body = TypeOf<typeof bodySchema>;
@@ -22,9 +20,9 @@ type Body = TypeOf<typeof bodySchema>;
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
-type Params = Ensure<UploadEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<UploadHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-type Response = UploadEndpoint['output'];
+type Response = UploadHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -6,24 +6,25 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
+import type { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
-
+import type { HttpApiInterface } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
 export const method = 'put' as const;
 
+type UploadEndpoint = HttpApiInterface['upload'];
+
 export const bodySchema = schema.stream();
 type Body = TypeOf<typeof bodySchema>;
 
 export const paramsSchema = schema.object({
-  fileId: schema.string(),
+  id: schema.string(),
 });
-type Params = TypeOf<typeof paramsSchema>;
+type Params = Ensure<UploadEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-interface Response {
-  ok: true;
-}
+type Response = UploadEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },
@@ -33,7 +34,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   const { fileService } = await files;
   const {
     body: stream,
-    params: { fileId: id },
+    params: { id },
   } = req;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);
   if (error) return error;

--- a/x-pack/plugins/files/server/types.ts
+++ b/x-pack/plugins/files/server/types.ts
@@ -8,14 +8,14 @@ import { SecurityPluginSetup } from '@kbn/security-plugin/server';
 import { FileKind } from '../common';
 import { FileServiceFactory } from './file_service';
 
-export interface FilesPluginSetup {
+export interface FilesSetup {
   registerFileKind(fileKind: FileKind): void;
-}
-
-export interface FilesPluginStart {
-  fileServiceFactory: FileServiceFactory;
 }
 
 export interface FilesPluginSetupDependencies {
   security?: SecurityPluginSetup;
+}
+
+export interface FilesStart {
+  fileServiceFactory: FileServiceFactory;
 }


### PR DESCRIPTION
## Summary

Create and expose a simple public side client of the file service. This can be used by UI components or plugins that want to interact with Files HTTP API endpoints with a JS interface.

Includes a refactor of TS types so they are shared between public and client.