### PR TITLE
[Wizard] Fixes the shadows problem

### DIFF
--- a/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.scss
+++ b/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.scss
@@ -1,3 +1,0 @@
-.aggBasedDialog__card {
-  background-color: $euiColorEmptyShade;
-}

--- a/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
@@ -28,7 +28,6 @@ import { memoizeLast } from '../../legacy/memoize';
 import { VisGroups } from '../../vis_types/vis_groups_enum';
 import type { BaseVisType, TypesStart } from '../../vis_types';
 import { DialogNavigation } from '../dialog_navigation';
-import './agg_based_selection.scss';
 
 interface VisTypeListEntry {
   type: BaseVisType;
@@ -139,6 +138,7 @@ class AggBasedSelection extends React.Component<AggBasedSelectionProps, AggBased
           isDisabled={isDisabled}
           icon={<EuiIcon type={visType.type.icon || 'empty'} size="l" color="success" />}
           className="aggBasedDialog__card"
+          hasBorder={true}
         />
       </EuiFlexItem>
     );

--- a/src/plugins/visualizations/public/wizard/dialog.scss
+++ b/src/plugins/visualizations/public/wizard/dialog.scss
@@ -34,11 +34,6 @@ $modalHeight: $euiSizeL * 30;
   background-color: transparent;
 }
 
-.visNewVisDialog__groupsCard {
-  background-color: transparent;
-  box-shadow: none;
-}
-
 .visNewVisDialog__groupsCardWrapper {
   position: relative;
 

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -112,7 +112,6 @@ function GroupSelection(props: GroupSelectionProps) {
                     }
                   )}
                   icon={<EuiIcon type="heatmap" size="xl" color="success" />}
-                  className="visNewVisDialog__groupsCard"
                 >
                   <EuiLink
                     data-test-subj="visGroupAggBasedExploreLink"
@@ -205,7 +204,6 @@ const VisGroup = ({ visType, onVisTypeSelected }: VisCardProps) => {
         }
         layout="horizontal"
         icon={<EuiIcon type={visType.icon || 'empty'} size="xl" color="success" />}
-        className="visNewVisDialog__groupsCard"
       />
     </EuiFlexItem>
   );

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -95,6 +95,7 @@ function GroupSelection(props: GroupSelectionProps) {
                 <EuiCard
                   titleSize="xs"
                   layout="horizontal"
+                  display="transparent"
                   onClick={() => props.toggleGroups(false)}
                   title={
                     <span data-test-subj="visGroupAggBasedTitle">
@@ -185,6 +186,7 @@ const VisGroup = ({ visType, onVisTypeSelected }: VisCardProps) => {
     <EuiFlexItem className="visNewVisDialog__groupsCardWrapper">
       <EuiCard
         titleSize="xs"
+        hasBorder={true}
         title={
           <span data-test-subj="visTypeTitle">
             {'titleInWizard' in visType && visType.titleInWizard


### PR DESCRIPTION
## Summary

Removes an unnecessary class from the wizard cards. Before the emotion changes, this class was never applied. (I dont remember why I had added this back then)
<img width="484" alt="image" src="https://user-images.githubusercontent.com/17003240/176427774-88bca480-b705-4ee0-94e2-b106997cce61.png">

(screenshot from 8.2)

But with EUI changes, now this className was getting higher priority and was applied.
<img width="785" alt="image (20)" src="https://user-images.githubusercontent.com/17003240/176427552-5f4ae06f-04a2-42cd-8a2e-f868017d5dbd.png">

With my changes:
<img width="893" alt="image" src="https://user-images.githubusercontent.com/17003240/176428513-2c671be7-fd8a-495b-824f-4f8bb91f3e37.png">
