### PR TITLE
[Monaco] Fix painless lexer to handle divisions and regular expressions correctly

### DIFF
--- a/packages/kbn-monaco/src/painless/README.md
+++ b/packages/kbn-monaco/src/painless/README.md
@@ -120,5 +120,3 @@ npm run build:antlr4ts
 ```
 
 *Note:* This script should only need to be run if a change has been made to `painless_lexer.g4` or `painless_parser.g4`.
-
-*Note:* There is a manual change made to the `sempred()` method in the generated `painless_lexer.ts`. This needs further investigation, but it appears there is an offset between the rule index and the token value. Without this manual change, ANTLR incorrectly reports an error when using a `/` or regex in a script. There is a comment in the generated code to this effect.

--- a/packages/kbn-monaco/src/painless/antlr/painless_lexer.ts
+++ b/packages/kbn-monaco/src/painless/antlr/painless_lexer.ts
@@ -185,14 +185,10 @@ export class painless_lexer extends Lexer {
 	// @Override
 	public sempred(_localctx: RuleContext, ruleIndex: number, predIndex: number): boolean {
 		switch (ruleIndex) {
-    // DO NOT CHANGE
-    // This is a manual fix to handle slashes appropriately, DIV: 32
-		case 32:
+		case 31:
 			return this.DIV_sempred(_localctx, predIndex);
 
-    // DO NOT CHANGE
-    // This is a manual fix to handle regexes appropriately, REGEX: 78
-		case 78:
+		case 77:
 			return this.REGEX_sempred(_localctx, predIndex);
 		}
 		return true;

--- a/packages/kbn-monaco/src/painless/worker/lib/lexer.ts
+++ b/packages/kbn-monaco/src/painless/worker/lib/lexer.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { CharStream } from 'antlr4ts';
+import type { Token } from 'antlr4ts';
 import { painless_lexer as PainlessLexer } from '../../antlr/painless_lexer';
 
 /*
@@ -15,19 +15,16 @@ import { painless_lexer as PainlessLexer } from '../../antlr/painless_lexer';
  * Based on the Java implementation: https://github.com/elastic/elasticsearch/blob/feab123ba400b150f3dcd04dd27cf57474b70d5a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/EnhancedPainlessLexer.java#L73
  */
 export class PainlessLexerEnhanced extends PainlessLexer {
-  constructor(input: CharStream) {
-    super(input);
+  private lastToken?: Token;
+
+  nextToken(): Token {
+    this.lastToken = super.nextToken();
+
+    return this.lastToken;
   }
 
   isSlashRegex(): boolean {
-    const lastToken = super.nextToken();
-
-    if (lastToken == null) {
-      return true;
-    }
-
-    // @ts-ignore
-    switch (lastToken._type) {
+    switch (this.lastToken?.type) {
       case PainlessLexer.RBRACE:
       case PainlessLexer.RP:
       case PainlessLexer.OCTAL:


### PR DESCRIPTION
## Summary

Resolves #131226.

The problem was in the incorrect workaround for the generated semantic predicates. According to the ANTLR source code, it passes a rule index, not the rule id, to the generated method. Therefore, the fix had to be reverted.

Reverting the workaround brought back the problem with parsing regular expressions. That was due to the `nextToken` call in the `isSlashRegex` predicate. In case when the interpreter tried to differentiate between division and regular expression, it was doing unnecessary iteration. That was returning the token after instead of the previous one, so we were getting an unexpected token error.

The higher-level problem in the original issue is the lexer was treating divisions as a regular expression if there are a few `/` on the same line. As a workaround, we can change the code in a way where we have only a single `/` per line:

```java
if (!doc['@timestamp'].empty ) {
   emit ( (( new Date().getTime() - ( doc['@timestamp'].value.getMillis()) / 1000
      / 60
      / 60
      / 24 )) * -1 )
} else emit (-1)
```

### Checklist
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Release Notes
Fixed a bug in the Painless code editor that was incorrectly handling expressions with multiple division operators.
