### PR TITLE
[ML] Replace a fixed Y-axis width with a max width setting for Anomaly Swim Lane Embeddable 

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
@@ -37,7 +37,7 @@ import { SeverityControl } from '../components/severity_control';
 import { AnomalyTimelineHelpPopover } from './anomaly_timeline_help_popover';
 import { isDefined } from '../../../common/types/guards';
 import { MlTooltipComponent } from '../components/chart_tooltip';
-import { SwimlaneAnnotationContainer } from './swimlane_annotation_container';
+import { SwimlaneAnnotationContainer, Y_AXIS_LABEL_WIDTH } from './swimlane_annotation_container';
 import { AnomalyTimelineService } from '../services/anomaly_timeline_service';
 import { useAnomalyExplorerContext } from './anomaly_explorer_context';
 import { useTimeBuckets } from '../components/custom_hooks/use_time_buckets';
@@ -348,6 +348,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
             }
             showTimeline={false}
             showLegend={false}
+            yAxisWidth={Y_AXIS_LABEL_WIDTH}
           />
 
           <EuiSpacer size="m" />
@@ -379,6 +380,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
                 }
               }}
               isLoading={loading || viewBySwimlaneDataLoading}
+              yAxisWidth={Y_AXIS_LABEL_WIDTH}
               noDataWarning={
                 <EuiText textAlign={'center'}>
                   <h5>

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -29,6 +29,7 @@ import {
   Position,
   ScaleType,
   PartialTheme,
+  HeatmapStyle,
 } from '@elastic/charts';
 import moment from 'moment';
 
@@ -155,6 +156,7 @@ export interface SwimlaneProps {
    */
   showTimeline?: boolean;
   showYAxis?: boolean;
+  yAxisWidth?: HeatmapStyle['yAxisLabel']['width'];
 }
 
 /**
@@ -180,6 +182,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
   showYAxis = true,
   showLegend = true,
   'data-test-subj': dataTestSubj,
+  yAxisWidth,
 }) => {
   const [chartWidth, setChartWidth] = useState<number>(0);
 
@@ -301,7 +304,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
         },
         yAxisLabel: {
           visible: showYAxis,
-          width: Y_AXIS_LABEL_WIDTH,
+          width: yAxisWidth,
           textColor: euiTheme.euiTextSubduedColor,
           padding: Y_AXIS_LABEL_PADDING,
           fontSize: parseInt(euiTheme.euiFontSizeXS, 10),

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
@@ -11,6 +11,7 @@ import { Observable } from 'rxjs';
 
 import { CoreStart } from '@kbn/core/public';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { Y_AXIS_LABEL_WIDTH } from '../../application/explorer/swimlane_annotation_container';
 import { useEmbeddableExecutionContext } from '../common/use_embeddable_execution_context';
 import { IAnomalySwimlaneEmbeddable } from './anomaly_swimlane_embeddable';
 import { useSwimlaneInputResolver } from './swimlane_input_resolver';
@@ -148,6 +149,7 @@ export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = (
           }
         }}
         isLoading={isLoading}
+        yAxisWidth={{ max: Y_AXIS_LABEL_WIDTH }}
         noDataWarning={
           <EuiEmptyPrompt
             titleSize="xxs"


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/123938

For the Anomaly detection swim lane embeddable sets the maximum allowed width instead of the hardcoded value. 

<img width="991" alt="image" src="https://user-images.githubusercontent.com/5236598/176456877-769665e2-260f-4c27-b85e-7578ef896f06.png">


For the Anomaly Explorer page the fixed width for Y-axis remains the same. 


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


