### PR TITLE
[CI] Install global npm modules with a retry and failsafe

### DIFF
--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
 echo "--- Setup Node"
 
 NODE_VERSION="$(cat "$KIBANA_DIR/.node-version")"
@@ -62,13 +66,7 @@ export YARN_VERSION
 
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
   rm -rf "$(npm root -g)/yarn" # in case the directory is in a bad state
-  if [[ ! $(npm install -g "yarn@^${YARN_VERSION}") ]]; then
-    # If this command is terminated early, e.g. because the build was cancelled in buildkite,
-    # a yarn directory is left behind in a bad state that can cause all subsequent installs to fail
-    rm -rf "$(npm root -g)/yarn"
-    echo "Trying again to install yarn..."
-    npm install -g "yarn@^${YARN_VERSION}"
-  fi
+  npm_install_global yarn "^$YARN_VERSION"
 fi
 
 yarn config set yarn-offline-mirror "$YARN_OFFLINE_CACHE"

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -65,7 +65,6 @@ YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yar
 export YARN_VERSION
 
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
-  rm -rf "$(npm root -g)/yarn" # in case the directory is in a bad state
   npm_install_global yarn "^$YARN_VERSION"
 fi
 

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -167,6 +167,4 @@ npm_install_global() {
     echo "Trying again to install $toInstall..."
     npm install -g "$toInstall" && touch "$successFlag"
   fi
-
-  ls -alh "$packageRoot"
 }

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -151,6 +151,9 @@ npm_install_global() {
 
   npmRoot=$(npm root -g)
   packageRoot="${npmRoot:?}/$package"
+
+  # The success flag file exists just to try to make sure we know that the full install was done
+  # For example, if a job terminates in the middle of npm install, a directory could be left behind that we don't know the state of
   successFlag="${packageRoot:?}/.install-success"
 
   toInstall="$package"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -142,8 +142,9 @@ set_git_merge_base() {
   export GITHUB_PR_MERGE_BASE
 }
 
-# If this command is terminated early, e.g. because the build was cancelled in buildkite,
+# If npm install is terminated early, e.g. because the build was cancelled in buildkite,
 # a package directory is left behind in a bad state that can cause all subsequent installs to fail
+# So this function contains some cleanup/retry logic to try to recover from this kind of situation
 npm_install_global() {
   package="$1"
   version="${2:-}"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -147,7 +147,8 @@ set_git_merge_base() {
 # So this function contains some cleanup/retry logic to try to recover from this kind of situation
 npm_install_global() {
   package="$1"
-  version="${2:-}"
+  version="${2:-latest}"
+  toInstall="$package@$version"
 
   npmRoot=$(npm root -g)
   packageRoot="${npmRoot:?}/$package"
@@ -155,11 +156,6 @@ npm_install_global() {
   # The success flag file exists just to try to make sure we know that the full install was done
   # For example, if a job terminates in the middle of npm install, a directory could be left behind that we don't know the state of
   successFlag="${packageRoot:?}/.install-success"
-
-  toInstall="$package"
-  if [[ "$version" ]]; then
-    toInstall="$package@$version"
-  fi
 
   if [[ -d "$packageRoot" && ! -f "$successFlag" ]]; then
     echo "Removing existing package directory $packageRoot before install, seems previous installation was not successful"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -163,9 +163,10 @@ npm_install_global() {
   fi
 
   if [[ ! $(npm install -g "$toInstall" && touch "$successFlag") ]]; then
-    npmRoot=$(npm root -g)
     rm -rf "$packageRoot"
     echo "Trying again to install $toInstall..."
     npm install -g "$toInstall" && touch "$successFlag"
   fi
+
+  ls -alh "$packageRoot"
 }

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -141,3 +141,22 @@ set_git_merge_base() {
 
   export GITHUB_PR_MERGE_BASE
 }
+
+# If this command is terminated early, e.g. because the build was cancelled in buildkite,
+# a package directory is left behind in a bad state that can cause all subsequent installs to fail
+npm_install_global() {
+  package="$1"
+  version="${2:-}"
+
+  toInstall="$package"
+  if [[ "$version" ]]; then
+    toInstall="$package@$version"
+  fi
+
+  if [[ ! $(npm install -g "$toInstall") ]]; then
+    npmRoot=$(npm root -g)
+    rm -rf "${npmRoot:?}/$package"
+    echo "Trying again to install $toInstall..."
+    npm install -g "$toInstall"
+  fi
+}

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -12,7 +12,7 @@ BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/k
 export BUILDKITE_TOKEN
 
 echo '--- Install/build buildkite dependencies'
-npm install -g ts-node
+npm_install_global ts-node
 cd '.buildkite'
 retry 5 15 npm ci
 cd ..

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -16,7 +16,16 @@ mkdir -p "$(npm root -g)/pnpm/test"
 npm_install_global pnpm
 
 echo '--- Install/build buildkite dependencies'
+
+# `rm -rf <ts-node node_modules dir>; npm install -g ts-node` will cause ts-node bin files to be messed up
+# but literally just calling `npm install -g ts-node` a second time fixes it
+# this is only on newer versions of npm
 npm_install_global ts-node
+if ! ts-node --version; then
+  npm_install_global ts-node
+  ts-node --version;
+fi
+
 cd '.buildkite'
 retry 5 15 npm ci
 cd ..

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -11,6 +11,10 @@ source .buildkite/scripts/common/setup_node.sh
 BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
 export BUILDKITE_TOKEN
 
+# TODO remove after testing
+mkdir -p "$(npm root -g)/pnpm/test"
+npm_install_global pnpm
+
 echo '--- Install/build buildkite dependencies'
 npm_install_global ts-node
 cd '.buildkite'

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -11,10 +11,6 @@ source .buildkite/scripts/common/setup_node.sh
 BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
 export BUILDKITE_TOKEN
 
-# TODO remove after testing
-mkdir -p "$(npm root -g)/pnpm/test"
-npm_install_global pnpm
-
 echo '--- Install/build buildkite dependencies'
 
 # `rm -rf <ts-node node_modules dir>; npm install -g ts-node` will cause ts-node bin files to be messed up


### PR DESCRIPTION
[A job](https://buildkite.com/elastic/kibana-pull-request/builds/54196#0181af05-32b5-4e28-9991-8d11956c2129) was cancelled during `ts-node` installation, and it left behind a broken `ts-node` directory. So, I'm generalizing the retry/cleanup logic we have for yarn and applying it to ts-node as well.