### PR TITLE
Fix stack alerts codeowners so response ops team gets pinged

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -363,7 +363,7 @@
 /x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/response-ops
 /docs/user/alerting/ @elastic/response-ops @elastic/mlr-docs
 /docs/management/connectors/ @elastic/response-ops @elastic/mlr-docs
-#CC# /x-pack/plugins/stack_alerts @elastic/response-ops
+#CC# /x-pack/plugins/stack_alerts/ @elastic/response-ops
 /x-pack/plugins/cases/ @elastic/response-ops
 /x-pack/test/cases_api_integration/ @elastic/response-ops
 /x-pack/test/functional/services/cases/ @elastic/response-ops


### PR DESCRIPTION
A repeat of https://github.com/elastic/kibana/pull/86148 from 2020. Not sure how the slash got removed..