### PR TITLE
[Console] Handle encoded characters in API requests

### DIFF
--- a/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
+++ b/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
@@ -80,7 +80,10 @@ export const NetworkRequestStatusBar: FunctionComponent<Props> = ({
               }`}</EuiText>
             }
           >
-            <EuiBadge color={mapStatusCodeToBadgeColor(statusCode)}>
+            <EuiBadge
+              data-test-subj="consoleRequestStatusBadge"
+              color={mapStatusCodeToBadgeColor(statusCode)}
+            >
               {/*  Use &nbsp; to ensure that no matter the width we don't allow line breaks */}
               {statusCode}&nbsp;-&nbsp;{statusText}
             </EuiBadge>

--- a/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
+++ b/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
@@ -81,7 +81,7 @@ export const NetworkRequestStatusBar: FunctionComponent<Props> = ({
             }
           >
             <EuiBadge
-              data-test-subj="consoleRequestStatusBadge"
+              data-test-subj="consoleResponseStatusBadge"
               color={mapStatusCodeToBadgeColor(statusCode)}
             >
               {/*  Use &nbsp; to ensure that no matter the width we don't allow line breaks */}

--- a/src/plugins/console/server/lib/proxy_request.test.ts
+++ b/src/plugins/console/server/lib/proxy_request.test.ts
@@ -46,7 +46,7 @@ describe(`Console's send request`, () => {
       method: 'get',
       payload: null as any,
       uri,
-      timeout, // immediately timeout
+      timeout,
       requestPath,
     });
   };
@@ -58,7 +58,7 @@ describe(`Console's send request`, () => {
       once() {},
     } as any;
     try {
-      await sendProxyRequest({ timeout: 0 });
+      await sendProxyRequest({ timeout: 0 }); // immediately timeout
       fail('Should not reach here!');
     } catch (e) {
       expect(e.message).toEqual('Client request timeout');

--- a/src/plugins/console/server/lib/utils/encode_path.test.ts
+++ b/src/plugins/console/server/lib/utils/encode_path.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { encodePath } from '.';
+import { encodePath } from './encode_path';
 
 describe('encodePath', () => {
   const tests = [

--- a/src/plugins/console/server/lib/utils/encode_path.ts
+++ b/src/plugins/console/server/lib/utils/encode_path.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { URLSearchParams } from 'url';
+import { trimStart } from 'lodash';
+
+export const encodePath = (path: string) => {
+  const decodedPath = new URLSearchParams(`path=${path}`).get('path') ?? '';
+  // Take the initial path and compare it with the decoded path.
+  // If the result is not the same, the path is encoded.
+  const isEncoded = trimStart(path, '/') !== trimStart(decodedPath, '/');
+
+  // Return the initial path if it is already encoded
+  if (isEncoded) {
+    return path;
+  }
+
+  // Encode every component except slashes
+  return path
+    .split('/')
+    .map((component) => encodeURIComponent(component))
+    .join('/');
+};

--- a/src/plugins/console/server/lib/utils/index.ts
+++ b/src/plugins/console/server/lib/utils/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { URLSearchParams } from 'url';
+import { trimStart } from 'lodash';
+
+export const encodePath = (path: string) => {
+  const decodedPath = new URLSearchParams(`path=${path}`).get('path') ?? '';
+  // Take the initial path and compare it with the decoded path.
+  // If the result is not the same, the path is encoded.
+  const isEncoded = trimStart(path, '/') !== trimStart(decodedPath, '/');
+
+  // Return the initial path if it is already encoded
+  if (isEncoded) {
+    return path;
+  }
+
+  // Encode every component except slashes
+  return path
+    .split('/')
+    .map((component) => encodeURIComponent(component))
+    .join('/');
+};

--- a/src/plugins/console/server/lib/utils/index.ts
+++ b/src/plugins/console/server/lib/utils/index.ts
@@ -6,23 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { URLSearchParams } from 'url';
-import { trimStart } from 'lodash';
-
-export const encodePath = (path: string) => {
-  const decodedPath = new URLSearchParams(`path=${path}`).get('path') ?? '';
-  // Take the initial path and compare it with the decoded path.
-  // If the result is not the same, the path is encoded.
-  const isEncoded = trimStart(path, '/') !== trimStart(decodedPath, '/');
-
-  // Return the initial path if it is already encoded
-  if (isEncoded) {
-    return path;
-  }
-
-  // Encode every component except slashes
-  return path
-    .split('/')
-    .map((component) => encodeURIComponent(component))
-    .join('/');
-};
+export { encodePath } from './encode_path';

--- a/src/plugins/console/server/lib/utils/utils.test.ts
+++ b/src/plugins/console/server/lib/utils/utils.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { encodePath } from '.';
+
+describe('encodePath', () => {
+  const tests = [
+    {
+      description: 'encodes invalid URL characters',
+      source: '/%{[@metadata][beat]}-%{[@metadata][version]}-2020.08.23',
+      assert:
+        '/%25%7B%5B%40metadata%5D%5Bbeat%5D%7D-%25%7B%5B%40metadata%5D%5Bversion%5D%7D-2020.08.23',
+    },
+    {
+      description: 'ignores encoded characters',
+      source: '/my-index/_doc/this%2Fis%2Fa%2Fdoc',
+      assert: '/my-index/_doc/this%2Fis%2Fa%2Fdoc',
+    },
+    {
+      description: 'ignores slashes between',
+      source: '_index/test/.test',
+      assert: '_index/test/.test',
+    },
+  ];
+
+  tests.forEach(({ description, source, assert }) => {
+    test(description, () => {
+      const result = encodePath(source);
+      expect(result).toEqual(assert);
+    });
+  });
+});

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -146,6 +146,10 @@ export const createHandler =
       const host = hosts[idx];
       try {
         const uri = toURL(host, path);
+        // Invalid URL characters included in uri pathname will be percent-encoded by Node URL method, and results in a faulty request in some cases.
+        // To fix this issue, we need to extract the original request path and supply it to proxyRequest function to encode it correctly with encodeURIComponent.
+        // We ignore the search params here, since we are extracting them from the uri constructed by Node URL method.
+        const [requestPath] = path.split('?');
 
         // Because this can technically be provided by a settings-defined proxy config, we need to
         // preserve these property names to maintain BWC.
@@ -175,6 +179,7 @@ export const createHandler =
           payload: body,
           rejectUnauthorized,
           agent,
+          requestPath,
         });
 
         break;

--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -124,6 +124,22 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    describe('with query params', () => {
+      it('should issue a successful request', async () => {
+        await PageObjects.console.clearTextArea();
+        await PageObjects.console.enterRequest(
+          '\n GET _cat/aliases?format=json&v=true&pretty=true'
+        );
+        await PageObjects.console.clickPlay();
+        await PageObjects.header.waitUntilLoadingHasFinished();
+
+        await retry.try(async () => {
+          const status = await PageObjects.console.getResponseStatus();
+          expect(status).to.eql(200);
+        });
+      });
+    });
+
     describe('multiple requests output', () => {
       const sendMultipleRequests = async (requests: string[]) => {
         await asyncForEach(requests, async (request) => {

--- a/test/functional/page_objects/console_page.ts
+++ b/test/functional/page_objects/console_page.ts
@@ -221,7 +221,7 @@ export class ConsolePageObject extends FtrService {
       return false;
     }
   }
-  
+
   public async getResponseStatus() {
     const statusBadge = await this.testSubjects.find('consoleResponseStatusBadge');
     const text = await statusBadge.getVisibleText();

--- a/test/functional/page_objects/console_page.ts
+++ b/test/functional/page_objects/console_page.ts
@@ -223,7 +223,7 @@ export class ConsolePageObject extends FtrService {
   }
   
   public async getResponseStatus() {
-    const statusBadge = await this.testSubjects.find('consoleRequestStatusBadge');
+    const statusBadge = await this.testSubjects.find('consoleResponseStatusBadge');
     const text = await statusBadge.getVisibleText();
     return text.replace(/[^\d.]+/, '');
   }

--- a/test/functional/page_objects/console_page.ts
+++ b/test/functional/page_objects/console_page.ts
@@ -221,4 +221,10 @@ export class ConsolePageObject extends FtrService {
       return false;
     }
   }
+  
+  public async getResponseStatus() {
+    const statusBadge = await this.testSubjects.find('consoleRequestStatusBadge');
+    const text = await statusBadge.getVisibleText();
+    return text.replace(/[^\d.]+/, '');
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/131798
Replaces https://github.com/elastic/kibana/pull/132191
Related to https://github.com/elastic/kibana/issues/76585
Related to https://github.com/elastic/kibana/issues/128701

## Summary

Fixes sending API requests with encoded characters in request URLs. 
Fixes the issue when using `_cat` commands with parameters.

### Testing
To test this out, send any of the following requests in Console


```
POST _bulk
{ "index" : { "_index" : "my-index", "_id" : "this/is/a/doc" } }
{ "title" : "a doc" }

GET my-index/_doc/this%2Fis%2Fa%2Fdoc
```
<img width="1118" alt="Screen Shot 2022-06-29 at 19 39 10" src="https://user-images.githubusercontent.com/53621505/176464908-8a715787-b94a-423b-a700-7d6e1690ca1f.png">

```
GET _cat/indices/.kibana?v
```
<img width="1118" alt="Screen Shot 2022-06-29 at 19 40 00" src="https://user-images.githubusercontent.com/53621505/176464969-d0cd942c-939d-4eb2-b849-829d9879e425.png">

```
PUT %{[@metadata][beat]}-%{[@metadata][version]}-2020.08.23
```
<img width="1118" alt="Screen Shot 2022-06-29 at 19 39 33" src="https://user-images.githubusercontent.com/53621505/176465022-66c957b1-66b3-4c2a-8835-fa497bd1ebb7.png">

```
PUT /%3Cmy-index-%7Bnow%2Fd%7D%3E
```
<img width="1118" alt="Screen Shot 2022-06-29 at 19 39 51" src="https://user-images.githubusercontent.com/53621505/176465066-6ec44234-5169-4092-a4cd-acbb14b8821c.png">

### Release note

Fixed a bug in Console when sending a request with encoded characters resulted in an error 