### PR TITLE
[generate/package] exclude stories by default when building packages

### DIFF
--- a/packages/kbn-generate/templates/package/BUILD.bazel.ejs
+++ b/packages/kbn-generate/templates/package/BUILD.bazel.ejs
@@ -14,6 +14,7 @@ SOURCE_FILES = glob(
   ],
   exclude = [
     "**/*.test.*",
+    "**/*.story.*",
   ],
 )
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/135455

Stories are pretty common in packages now, we should avoid building them into the node_modules directory. @clintandrewhall are there patterns we should exclude for helpers or something?