### PR TITLE
Fix Pinned filters should be visible on new maps without user having to do any action on layers

### DIFF
--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -193,6 +193,8 @@ export class MapApp extends React.Component<Props, State> {
   };
 
   async _updateIndexPatterns() {
+    const { nextIndexPatternIds } = this.props;
+    
     if (_.isEqual(nextIndexPatternIds, this._prevIndexPatternIds)) {
       return;
     }

--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -194,7 +194,7 @@ export class MapApp extends React.Component<Props, State> {
 
   async _updateIndexPatterns() {
     const { nextIndexPatternIds } = this.props;
-    
+
     if (_.isEqual(nextIndexPatternIds, this._prevIndexPatternIds)) {
       return;
     }
@@ -205,7 +205,7 @@ export class MapApp extends React.Component<Props, State> {
     if (nextIndexPatternIds.length === 0) {
       // Use default data view to always show filter bar when filters are present
       // Example scenario, global state has pinned filters and new map is created
-      const defaultDataView = getIndexPatternService().getDefaultDataView();
+      const defaultDataView = await getIndexPatternService().getDefaultDataView();
       if (defaultDataView) {
         indexPatterns = [indexPatterns];
       }

--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -207,7 +207,7 @@ export class MapApp extends React.Component<Props, State> {
       // Example scenario, global state has pinned filters and new map is created
       const defaultDataView = await getIndexPatternService().getDefaultDataView();
       if (defaultDataView) {
-        indexPatterns = [indexPatterns];
+        indexPatterns = [defaultDataView];
       }
     } else {
       indexPatterns = await getIndexPatternsFromIds(nextIndexPatternIds);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/106170

`TopNavMenu` component does not render filter pills when `indexPatterns` is an empty array. To resolve the issue, the default data view is supplied when there are no data views supplied by layers.

The redesigned search bar removed any issues with showing an empty row when there are no filters. Notice in the screen shot below of the old search bar and how the empty filter pills wasted a whole row. This is not a problem in the new search bar as  the filter pill row is only displayed when there are filter pills. This wasted space was why default data view was not supplied in the past but now its a none issue.

<img width="600" alt="Screen Shot 2022-06-29 at 11 37 00 AM" src="https://user-images.githubusercontent.com/373691/176502562-0dddca4a-7cd4-4974-acd1-3abd5f0ca087.png">
