### PR TITLE
[Enterprise Search] API to create an API Key for use with an API Index

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
@@ -5,18 +5,17 @@
  * 2.0.
  */
 
-import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { KibanaRequest } from '@kbn/core/server';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
 
 import { createApiKey } from './create_api_key';
-
 
 describe('createApiKey lib function', () => {
   const security = securityMock.createStart();
   const request = {} as KibanaRequest;
 
   const indexName = 'my-index';
-  const keyName = `{indexName}-key`;
+  const keyName = '{indexName}-key';
 
   const createResponse = {
     api_key: 'ui2lp2axTNmsyakw9tvNnw',
@@ -32,20 +31,23 @@ describe('createApiKey lib function', () => {
   });
 
   it('should create an api key via the security plugin', async () => {
-    await expect(
-      createApiKey(request, security, indexName, keyName)
-    ).resolves.toEqual(createResponse);
+    await expect(createApiKey(request, security, indexName, keyName)).resolves.toEqual(
+      createResponse
+    );
 
-    expect(security.authc.apiKeys.create).toHaveBeenCalledWith(request, {name: keyName, role_descriptors: {
-      [`${indexName}-key-role`]: {
-        cluster: [],
-        index: [
-          {
-            names: [indexName],
-            privileges: ['all'],
-          },
-        ],
+    expect(security.authc.apiKeys.create).toHaveBeenCalledWith(request, {
+      name: keyName,
+      role_descriptors: {
+        [`${indexName}-key-role`]: {
+          cluster: [],
+          index: [
+            {
+              names: [indexName],
+              privileges: ['all'],
+            },
+          ],
+        },
       },
-    }});
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { KibanaRequest } from '@kbn/core/server';
+
+import { createApiKey } from './create_api_key';
+
+
+describe('createApiKey lib function', () => {
+  const security = securityMock.createStart();
+  const request = {} as KibanaRequest;
+
+  const indexName = 'my-index';
+  const keyName = `{indexName}-key`;
+
+  const createResponse = {
+    id: 'VuaCfGcBCdbkQm-e5aOx',
+    name: keyName,
+    api_key: 'ui2lp2axTNmsyakw9tvNnw',
+    encoded: 'VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==',
+  };
+
+  security.authc.apiKeys.create = jest.fn().mockReturnValue(createResponse);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create an api key via the security plugin', async () => {
+    await expect(
+      createApiKey(request, security, indexName, keyName)
+    ).resolves.toEqual(createResponse);
+
+    expect(security.authc.apiKeys.create).toHaveBeenCalledWith(request, {name: keyName, role_descriptors: {
+      [`${indexName}-key-role`]: {
+        cluster: [],
+        index: [
+          {
+            names: [indexName],
+            privileges: ['all'],
+          },
+        ],
+      },
+    }});
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
@@ -19,10 +19,10 @@ describe('createApiKey lib function', () => {
   const keyName = `{indexName}-key`;
 
   const createResponse = {
-    id: 'VuaCfGcBCdbkQm-e5aOx',
-    name: keyName,
     api_key: 'ui2lp2axTNmsyakw9tvNnw',
     encoded: 'VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==',
+    id: 'VuaCfGcBCdbkQm-e5aOx',
+    name: keyName,
   };
 
   security.authc.apiKeys.create = jest.fn().mockReturnValue(createResponse);

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
@@ -5,19 +5,27 @@
  * 2.0.
  */
 
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { KibanaRequest } from '@kbn/core/server';
+import { SecurityPluginStart } from '@kbn/security-plugin/server';
 
-export const createApiKey = async (request: KibanaRequest, security: SecurityPluginStart, indexName: string, keyName: string) => {
-  return await security.authc.apiKeys.create(request, {name: keyName, role_descriptors: {
-    [`${indexName}-key-role`]: {
-      cluster: [],
-      index: [
-        {
-          names: [indexName],
-          privileges: ['all'],
-        },
-      ],
+export const createApiKey = async (
+  request: KibanaRequest,
+  security: SecurityPluginStart,
+  indexName: string,
+  keyName: string
+) => {
+  return await security.authc.apiKeys.create(request, {
+    name: keyName,
+    role_descriptors: {
+      [`${indexName}-key-role`]: {
+        cluster: [],
+        index: [
+          {
+            names: [indexName],
+            privileges: ['all'],
+          },
+        ],
+      },
     },
-  }});
+  });
 };

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { KibanaRequest } from '@kbn/core/server';
+
+export const createApiKey = async (request: KibanaRequest, security: SecurityPluginStart, indexName: string, keyName: string) => {
+  return await security.authc.apiKeys.create(request, {name: keyName, role_descriptors: {
+    [`${indexName}-key-role`]: {
+      cluster: [],
+      index: [
+        {
+          names: [indexName],
+          privileges: ['all'],
+        },
+      ],
+    },
+  }});
+};

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -169,8 +169,8 @@ export class EnterpriseSearchPlugin implements Plugin {
     registerConnectorRoutes(dependencies);
     registerCrawlerRoutes(dependencies);
 
-    getStartServices().then(([, { security }]) => {
-      registerCreateAPIKeyRoute(dependencies, security);
+    getStartServices().then(([, { security:securityStart }]) => {
+      registerCreateAPIKeyRoute(dependencies, securityStart);
     });
 
     /**

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -18,7 +18,7 @@ import {
 import { CustomIntegrationsPluginSetup } from '@kbn/custom-integrations-plugin/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import { InfraPluginSetup } from '@kbn/infra-plugin/server';
-import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/server';
 import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
@@ -49,6 +49,7 @@ import { registerEnterpriseSearchRoutes } from './routes/enterprise_search';
 import { registerConfigDataRoute } from './routes/enterprise_search/config_data';
 import { registerConnectorRoutes } from './routes/enterprise_search/connectors';
 import { registerCrawlerRoutes } from './routes/enterprise_search/crawler';
+import { registerCreateAPIKeyRoute } from './routes/enterprise_search/create_api_key';
 import { registerTelemetryRoute } from './routes/enterprise_search/telemetry';
 import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
 
@@ -68,6 +69,7 @@ interface PluginsSetup {
 
 interface PluginsStart {
   spaces: SpacesPluginStart;
+  security: SecurityPluginStart;
 }
 
 export interface RouteDependencies {
@@ -166,6 +168,11 @@ export class EnterpriseSearchPlugin implements Plugin {
     // Enterprise Search Routes
     registerConnectorRoutes(dependencies);
     registerCrawlerRoutes(dependencies);
+
+    getStartServices().then(([, { security }]) => {
+
+      registerCreateAPIKeyRoute(dependencies, security);
+    });
 
     /**
      * Bootstrap the routes, saved objects, and collector for telemetry

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -169,7 +169,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     registerConnectorRoutes(dependencies);
     registerCrawlerRoutes(dependencies);
 
-    getStartServices().then(([, { security:securityStart }]) => {
+    getStartServices().then(([, { security: securityStart }]) => {
       registerCreateAPIKeyRoute(dependencies, securityStart);
     });
 

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -170,7 +170,6 @@ export class EnterpriseSearchPlugin implements Plugin {
     registerCrawlerRoutes(dependencies);
 
     getStartServices().then(([, { security }]) => {
-
       registerCreateAPIKeyRoute(dependencies, security);
     });
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
@@ -17,11 +17,11 @@ export function registerCreateAPIKeyRoute({ router }: RouteDependencies, securit
     {
       path: '/internal/enterprise_search/{indexName}/api_keys',
       validate: {
-        params: schema.object({
-          indexName: schema.string(),
-        }),
         body: schema.object({
           keyName: schema.string(),
+        }),
+        params: schema.object({
+          indexName: schema.string(),
         }),
     } },
     async (context, request, response) => {
@@ -30,7 +30,7 @@ export function registerCreateAPIKeyRoute({ router }: RouteDependencies, securit
       try {
         const createResponse = await createApiKey(request, security, indexName, keyName);
         if (!createResponse) {
-          throw 'Unable to create API Key';
+          throw new Error('Unable to create API Key');
         }
         return response.ok({
           body: { apiKey: createResponse },
@@ -38,8 +38,8 @@ export function registerCreateAPIKeyRoute({ router }: RouteDependencies, securit
         });
       } catch (error) {
         return response.customError({
-          statusCode: 502,
           body: 'Error creating API Key',
+          statusCode: 502,
         });
       }
     }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { RouteDependencies } from '../../plugin';
+
+export function registerCreateAPIKeyRoute({ router }: RouteDependencies, security: SecurityPluginStart) {
+  router.get(
+    { path: '/internal/enterprise_search/create_api_key', validate: false },
+    async (context, request, response) => {
+      try {
+        const createResponse = await security.authc.apiKeys.create(request, {name: 'test-jgr-1', role_descriptors: {}});
+        if (!createResponse) {
+          throw "whoopsie";
+        }
+        return response.ok({
+          body: { apiKey: createResponse },
+          headers: { 'content-type': 'application/json' },
+        });
+      } catch (error) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Error creating API Key',
+        });
+      }
+    }
+  );
+}

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
@@ -10,10 +10,12 @@ import { schema } from '@kbn/config-schema';
 import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { RouteDependencies } from '../../plugin';
 
+import { createApiKey } from '../../lib/indices/create_api_key';
+
 export function registerCreateAPIKeyRoute({ router }: RouteDependencies, security: SecurityPluginStart) {
   router.post(
     {
-      path: '/internal/enterprise_search/{indexName}/api_keys}',
+      path: '/internal/enterprise_search/{indexName}/api_keys',
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -26,17 +28,7 @@ export function registerCreateAPIKeyRoute({ router }: RouteDependencies, securit
       const { indexName } = request.params;
       const { keyName } = request.body;
       try {
-        const createResponse = await security.authc.apiKeys.create(request, {name: keyName, role_descriptors: {
-          [`${indexName}-key-role`]: {
-            cluster: [],
-            index: [
-              {
-                names: [indexName],
-                privileges: ['all'],
-              },
-            ],
-          },
-        }});
+        const createResponse = await createApiKey(request, security, indexName, keyName);
         if (!createResponse) {
           throw 'Unable to create API Key';
         }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
@@ -8,11 +8,14 @@
 import { schema } from '@kbn/config-schema';
 
 import { SecurityPluginStart } from '@kbn/security-plugin/server';
-import { RouteDependencies } from '../../plugin';
 
 import { createApiKey } from '../../lib/indices/create_api_key';
+import { RouteDependencies } from '../../plugin';
 
-export function registerCreateAPIKeyRoute({ router }: RouteDependencies, security: SecurityPluginStart) {
+export function registerCreateAPIKeyRoute(
+  { router }: RouteDependencies,
+  security: SecurityPluginStart
+) {
   router.post(
     {
       path: '/internal/enterprise_search/{indexName}/api_keys',
@@ -23,7 +26,8 @@ export function registerCreateAPIKeyRoute({ router }: RouteDependencies, securit
         params: schema.object({
           indexName: schema.string(),
         }),
-    } },
+      },
+    },
     async (context, request, response) => {
       const { indexName } = request.params;
       const { keyName } = request.body;


### PR DESCRIPTION
## Summary

This adds an API that uses the Security Plugin to generate an API Key for use with a specific index. This API will be used by the API Index empty state described in https://github.com/elastic/enterprise-search-team/issues/2099.

closes https://github.com/elastic/enterprise-search-team/issues/2119

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
