### PR TITLE
Add known issue to 8.3.0 for Dev Tools

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -57,8 +57,8 @@ To review the breaking changes in previous versions, refer to the following:
 [discrete]
 === Known issues
 
-* Elasticsearch API commands will fail if you add any URL arguments (e.g. `?v`, `?pretty`) to the call. 
-This only impacts the Kibana Dev Tools.  All other sources of API calls are not affected (e.g. curl, Elastic Cloud API console) {kibana-issue}133965[#133965]
+* API requests will fail if you add any URL arguments (e.g. `?v`, `?pretty`) to the request. 
+This only impacts the Kibana Dev Tools.  All other sources of API requests are not affected (e.g. curl, Elastic Cloud API console) {kibana-issue}133965[#133965]
 
 [float]
 [[enhancement-v8.3.1]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -54,6 +54,12 @@ To review the breaking changes in previous versions, refer to the following:
 
 {kibana-ref-all}/8.2/release-notes-8.2.0.html#breaking-changes-8.2.0[8.2.0] | {kibana-ref-all}/8.1/release-notes-8.1.0.html#breaking-changes-8.1.0[8.1.0] | {kibana-ref-all}/8.0/release-notes-8.0.0.html#breaking-changes-8.0.0[8.0.0] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc2.html#breaking-changes-8.0.0-rc2[8.0.0-rc2] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc1.html#breaking-changes-8.0.0-rc1[8.0.0-rc1] | {kibana-ref-all}/8.0/release-notes-8.0.0-beta1.html#breaking-changes-8.0.0-beta1[8.0.0-beta1] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha2.html#breaking-changes-8.0.0-alpha2[8.0.0-alpha2] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha1.html#breaking-changes-8.0.0-alpha1[8.0.0-alpha1]
 
+[discrete]
+=== Known issues
+
+* Elasticsearch API commands will fail if you add any URL arguments (e.g. `?v`, `?pretty`) to the call. 
+This only impacts the Kibana Dev Tools.  All other sources of API calls are not affected (e.g. curl, Elastic Cloud API console) {kibana-issue}133965[#133965]
+
 [float]
 [[enhancement-v8.3.1]]
 === Enhancements


### PR DESCRIPTION
This adds https://github.com/elastic/kibana/issues/133965 to the known issues in 8.3.0 release notes.

Please backport to 8.3.0.