### PR TITLE
[Fleet] keep all agents selected in query selection mode

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
@@ -147,6 +147,14 @@ describe('agent_list_page', () => {
     });
 
     utils.getByText('All agents selected');
+
+    expect(
+      utils
+        .getByText('agent6')
+        .closest('tr')!
+        .getAttribute('class')!
+        .includes('euiTableRow-isSelected')
+    ).toBeTruthy();
   });
 
   it('should set selection mode when agent selection changed manually', async () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -353,6 +353,11 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         selectedAgents.length > 0 && differenceBy(selectedAgents, agents, 'id').length === 0;
       if (areSelectedAgentsStillVisible) {
         setSelectionMode('manual');
+      } else {
+        // force selecting all agents on current page if staying in query mode
+        if (tableRef?.current) {
+          tableRef.current.setSelection(agents);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary

Fix for https://github.com/elastic/kibana/issues/133523#issuecomment-1170157358

To verify:
- enroll 20+ agents with horde
- select all agents on agent list view by clicking `Select everything on all pages`
- wait for agent refresh, eventually the agents on current page will change
- expected: all agents should continue to be selected (all checkboxes checked). `All agents selected` label is still visible (query mode).

<img width="930" alt="image" src="https://user-images.githubusercontent.com/90178898/176661879-180b2625-356e-4166-b398-abcebc72b81f.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
