### PR TITLE
[APM] On week:  Service map as transform

### DIFF
--- a/x-pack/plugins/apm/server/routes/service_map/route.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/route.ts
@@ -23,7 +23,7 @@ import { getServiceMapTracePathsPreview } from './trace_path_preview';
 import { getServiceMapTracePathsPreviewOriginal } from './trace_path_preview_original';
 
 const serviceMapTracePathsOriginalRoute = createApmServerRoute({
-  endpoint: 'GET /internal/apm/service-map/trace_path_preview_original',
+  endpoint: 'GET /internal/apm/service-map/trace_paths_original',
   params: t.type({
     query: rangeRt,
   }),
@@ -47,7 +47,7 @@ const serviceMapTracePathsOriginalRoute = createApmServerRoute({
 });
 
 const serviceMapTracePathsRoute = createApmServerRoute({
-  endpoint: 'GET /internal/apm/service-map/trace_path_preview',
+  endpoint: 'GET /internal/apm/service-map/trace_paths',
   params: t.type({
     query: rangeRt,
   }),

--- a/x-pack/plugins/apm/server/routes/service_map/route.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/route.ts
@@ -19,6 +19,56 @@ import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { environmentRt, rangeRt } from '../default_api_types';
 import { getServiceGroup } from '../service_groups/get_service_group';
 import { offsetRt } from '../../../common/comparison_rt';
+import { getServiceMapTracePathsPreview } from './trace_path_preview';
+import { getServiceMapTracePathsPreviewOriginal } from './trace_path_preview_original';
+
+const serviceMapTracePathsOriginalRoute = createApmServerRoute({
+  endpoint: 'GET /internal/apm/service-map/trace_path_preview_original',
+  params: t.type({
+    query: rangeRt,
+  }),
+  options: { tags: ['access:apm'] },
+  handler: async (resources): Promise<any> => {
+    const { params } = resources;
+    const setup = await setupRequest(resources);
+
+    const {
+      query: { start, end },
+    } = params;
+
+    const res = await getServiceMapTracePathsPreviewOriginal({
+      setup,
+      start,
+      end,
+    });
+
+    return res;
+  },
+});
+
+const serviceMapTracePathsRoute = createApmServerRoute({
+  endpoint: 'GET /internal/apm/service-map/trace_path_preview',
+  params: t.type({
+    query: rangeRt,
+  }),
+  options: { tags: ['access:apm'] },
+  handler: async (resources): Promise<any> => {
+    const { params } = resources;
+    const setup = await setupRequest(resources);
+
+    const {
+      query: { start, end },
+    } = params;
+
+    const tracePaths = await getServiceMapTracePathsPreview({
+      setup,
+      start,
+      end,
+    });
+
+    return { tracePaths };
+  },
+});
 
 const serviceMapRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/service-map',
@@ -254,6 +304,8 @@ const serviceMapBackendNodeRoute = createApmServerRoute({
 });
 
 export const serviceMapRouteRepository = {
+  ...serviceMapTracePathsOriginalRoute,
+  ...serviceMapTracePathsRoute,
   ...serviceMapRoute,
   ...serviceMapServiceNodeRoute,
   ...serviceMapBackendNodeRoute,

--- a/x-pack/plugins/apm/server/routes/service_map/trace_path_create_transform.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/trace_path_create_transform.ts
@@ -9,7 +9,7 @@ import {
   TRACE_ID,
   PROCESSOR_EVENT,
 } from '../../../common/elasticsearch_fieldnames';
-import { tracePathsAggs } from './trace_path_preview';
+import { tracePathsAggs } from './trace_path';
 
 // client.transform.putTransform(...)
 // client.transform.startTransform(...)

--- a/x-pack/plugins/apm/server/routes/service_map/trace_path_create_transform.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/trace_path_create_transform.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  TRACE_ID,
+  PROCESSOR_EVENT,
+} from '../../../common/elasticsearch_fieldnames';
+import { tracePathsAggs } from './trace_path_preview';
+
+// client.transform.putTransform(...)
+// client.transform.startTransform(...)
+
+const transform = {
+  dest: {
+    index: 'apm_trace_paths',
+  },
+  source: {
+    index: 'traces-apm*',
+    query: {
+      bool: {
+        filter: [
+          {
+            prefix: {
+              'trace.id': '1',
+            },
+          },
+          {
+            terms: {
+              [PROCESSOR_EVENT]: ['span', 'transaction'],
+            },
+          },
+        ],
+      },
+    },
+  },
+  pivot: {
+    group_by: {
+      trace_id: {
+        terms: {
+          field: TRACE_ID,
+        },
+      },
+    },
+    aggs: tracePathsAggs,
+  },
+  description: 'APM trace paths',
+  frequency: '10m',
+  sync: {
+    time: {
+      field: '@timestamp',
+      delay: '60s',
+    },
+  },
+  retention_policy: {
+    time: {
+      field: '@timestamp',
+      max_age: '30d',
+    },
+  },
+};

--- a/x-pack/plugins/apm/server/routes/service_map/trace_path_preview.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/trace_path_preview.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import { PROCESSOR_EVENT } from '../../../common/elasticsearch_fieldnames';
+import { Setup } from '../../lib/helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
+
+export async function getServiceMapTracePathsPreview({
+  setup,
+  start,
+  end,
+}: {
+  setup: Setup;
+  start: number;
+  end: number;
+}) {
+  const params = {
+    apm: {
+      events: [ProcessorEvent.transaction, ProcessorEvent.span],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            ...rangeQuery(start, end),
+            {
+              terms: {
+                [PROCESSOR_EVENT]: ['span', 'transaction'],
+              },
+            },
+          ],
+        },
+      },
+      aggs: tracePathsAggs,
+    },
+  };
+
+  const { apmEventClient } = setup;
+  const response = await apmEventClient.search('get_trace_paths', params);
+  return response.aggregations?.service_map.value;
+}
+
+export const tracePathsAggs = {
+  service_map: {
+    scripted_metric: {
+      init_script: {
+        lang: 'painless',
+        source: `
+          state.eventsById = new HashMap();
+          state.parentIds = new ArrayList();
+          state.traceIds = new HashSet();
+
+          String[] fieldsToCopy = new String[] {
+            'parent.id',
+            'service.name',
+            'service.environment',
+            'span.destination.service.resource',
+            'trace.id',
+            'processor.event',
+            'span.type',
+            'span.subtype',
+            'agent.name',
+            'transaction.type'
+          };
+          state.fieldsToCopy = fieldsToCopy;`,
+      },
+      map_script: {
+        lang: 'painless',
+        source: `
+          //  limit to 1000 traces
+          def MAX_NUM_TRACES = 1000;
+        
+          def traceId = doc['trace.id'].value;
+          if (state.traceIds.size() >= MAX_NUM_TRACES && !state.traceIds.contains(traceId)) {
+            return;
+          }
+          state.traceIds.add(traceId);
+        
+          def id;
+          if (!doc['span.id'].empty) {
+            id = doc['span.id'].value;
+          } else {
+            id = doc['transaction.id'].value;
+          }
+
+          def copy = new HashMap();
+          copy.id = id;
+
+          for(key in state.fieldsToCopy ) {
+            if (!doc[key].empty) {
+              copy[key] = doc[key].value;
+            }
+          }
+          
+          if(!doc['parent.id'].empty) {
+            state.parentIds.add(doc['parent.id'].value);
+          }
+
+          state.eventsById[id] = copy`,
+      },
+      combine_script: {
+        lang: 'painless',
+        source: `
+          return [
+            'eventsById': state.eventsById, 
+            'parentIds': state.parentIds
+          ];
+        `,
+      },
+      reduce_script: {
+        lang: 'painless',
+        source: `
+
+        def getLeafNode ( def event, def hash ) {
+          def leafNode = new HashMap();
+          leafNode['span.destination.service.resource'] = event['span.destination.service.resource'];
+          leafNode['span.type'] = event['span.type'];
+          leafNode['span.subtype'] = event['span.subtype'];
+          leafNode['upstream.hash'] = hash;
+          leafNode['trace.id'] = event['trace.id'];
+          leafNode['parent.id'] = event['parent.id'];
+          leafNode['id'] = event['id'];
+          leafNode['leafNode'] = true;
+          
+          return leafNode;
+        }
+        
+        def getNode(def event) {
+          return [ 
+            '@timestamp': event['@timestamp'], 
+            'service.name': event['service.name'], 
+            'service.environment': event['service_environment'], 
+            'agent.name': event['agent.name'], 
+            'processor.event': event['processor.event'],
+            'parent.id': event['parent.id'],
+            'id': event['id'],
+            'trace.id': event['trace.id'],
+            'leafNode': false
+          ];
+          
+        }
+
+        def processAndReturnEvent(def context, def eventId) {
+          if (context.processedEvents[eventId] != null) {
+            return context.processedEvents[eventId];
+          }
+          
+          def event = context.eventsById[eventId];
+          if (event == null) {
+            return null;
+          }
+          
+          def node = getNode(event);
+          context.processedEvents[eventId] = node;
+          
+          def tracePath = [];
+          def parentId = event['parent.id'];
+          def parent;
+          def upstreamHash = '';
+          def hash = '';
+          
+          if (parentId != null && parentId != event['id']) {
+            parent = processAndReturnEvent(context, parentId);
+            if (parent != null) {
+              /* copy the path from the parent */
+              tracePath.addAll(parent.path);
+              
+              if (parent['downstream.hash'] != null) {
+                upstreamHash = parent['downstream.hash'];
+                hash = [ 
+                  'service.name': node['service.name'], 
+                  'service.environment': node['service.environment'], 
+                  'upstreamHash': upstreamHash 
+                ].hashCode().toString();
+              } else {
+                hash = parent.hash;
+              }
+            }
+          }
+          
+          node['upstream.hash'] = upstreamHash;
+          node.hash = hash;
+          
+          if (event['span.destination.service.resource'] != null) {
+            node['downstream.hash'] = [ 
+              'service.name': node['service.name'], 
+              'service.environment': node['service.environment'], 
+              'upstreamHash': upstreamHash, 
+              'hash': hash, 
+              'span.destination.service.resource': event['span.destination.service.resource'] 
+            ].hashCode().toString();
+
+            node['span.destination.service.resource'] = event['span.destination.service.resource'];
+          }
+          
+          if(event['span.type'] != null) {
+            node['span.type'] = event['span.type'];
+          }
+          
+          if (event['transaction.type'] != null) {
+            node['transaction.type'] = event['transaction.type'];
+          }
+
+
+          /* only add the current location to the path if it's different from the last one*/
+          if (
+            parent == null
+              || parent['service.name'] != node['service.name']
+              || parent['service.environment'] != node['service.environment']
+              || event['span.destination.service.resource'] != null
+          ) {
+            // node.id = eventId;
+            // node['parent.id'] = parentId;
+            def clone = node.clone();
+            node.remove('path');
+            tracePath.add(clone);
+          }
+
+          /* if there is an outgoing span, create a new path */
+          if (event['span.destination.service.resource'] != null
+            && event['span.destination.service.resource'] != '') {
+            
+            def leafNode = getLeafNode(event, node['downstream.hash']);
+            def fullTracePath = new ArrayList(tracePath);
+            fullTracePath.add(leafNode);
+            
+            // Only add if leafNode is not a parent (in which case it's not a leaf node)
+            def isParent = context.parentIds.contains(leafNode.id);
+            if(!isParent) {
+              def leafNodeHash = leafNode['upstream.hash'];
+              context.paths[leafNodeHash] = fullTracePath;
+            }
+          }
+
+          node.path = tracePath;
+
+          return node;
+        }
+
+
+        def context = new HashMap();
+        context.parentIds = new ArrayList();
+        context.processedEvents = new HashMap();
+        context.eventsById = new HashMap();
+        context.paths = new HashMap();
+
+        for (state in states) {
+          context.parentIds.addAll(state['parentIds']);
+          context.eventsById.putAll(state['eventsById']);
+        }
+        
+        for (eventId in context.eventsById.keySet()) {
+          processAndReturnEvent(context, eventId);
+        }
+        
+        def tracePaths = new HashSet();
+        tracePaths.addAll(context.paths.values());
+                
+        def output = new HashMap();                
+        output.pathCount = tracePaths.size();
+        output.tracePaths = tracePaths;
+        return output;          
+        `,
+      },
+    },
+  },
+};

--- a/x-pack/plugins/apm/server/routes/service_map/trace_path_preview_original.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/trace_path_preview_original.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import {
+  PROCESSOR_EVENT,
+  TRACE_ID,
+} from '../../../common/elasticsearch_fieldnames';
+import { Setup } from '../../lib/helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
+
+export async function getServiceMapTracePathsPreviewOriginal({
+  setup,
+  start,
+  end,
+}: {
+  setup: Setup;
+  start: number;
+  end: number;
+}) {
+  const params = {
+    apm: {
+      events: [ProcessorEvent.transaction, ProcessorEvent.span],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            ...rangeQuery(start, end),
+            {
+              // pseudo random sampling
+              prefix: { [TRACE_ID]: 'a' },
+            },
+            {
+              terms: {
+                [PROCESSOR_EVENT]: ['span', 'transaction'],
+              },
+            },
+          ],
+        },
+      },
+      aggs: tracePathsAggs,
+    },
+  };
+
+  const { apmEventClient } = setup;
+  const response = await apmEventClient.search('get_trace_paths', params);
+  return response.aggregations?.service_map.value;
+}
+
+const tracePathsAggs = {
+  service_map: {
+    scripted_metric: {
+      init_script: {
+        lang: 'painless',
+        source: `state.eventsById = new HashMap();
+
+        String[] fieldsToCopy = new String[] {
+            'parent.id',
+            'service.name',
+            'service.environment',
+            'span.destination.service.resource',
+            'trace.id',
+            'processor.event',
+            'span.type',
+            'span.subtype',
+            'agent.name'
+          };
+          state.fieldsToCopy = fieldsToCopy;`,
+      },
+      map_script: {
+        lang: 'painless',
+        source: `def id;
+          if (!doc['span.id'].empty) {
+            id = doc['span.id'].value;
+          } else {
+            id = doc['transaction.id'].value;
+          }
+
+          def copy = new HashMap();
+          copy.id = id;
+
+          for(key in state.fieldsToCopy) {
+            if (!doc[key].empty) {
+              copy[key] = doc[key].value;
+            }
+          }
+
+          state.eventsById[id] = copy`,
+      },
+      combine_script: {
+        lang: 'painless',
+        source: `return state.eventsById;`,
+      },
+      reduce_script: {
+        lang: 'painless',
+        source: `
+        def getDestination ( def event ) {
+          def destination = new HashMap();
+          destination['span.destination.service.resource'] = event['span.destination.service.resource'];
+          destination['span.type'] = event['span.type'];
+          destination['span.subtype'] = event['span.subtype'];
+          return destination;
+        }
+
+        def processAndReturnEvent(def context, def eventId) {
+          if (context.processedEvents[eventId] != null) {
+            return context.processedEvents[eventId];
+          }
+
+          def event = context.eventsById[eventId];
+
+          if (event == null) {
+            return null;
+          }
+
+          def service = new HashMap();
+          service['service.name'] = event['service.name'];
+          service['service.environment'] = event['service.environment'];
+          service['agent.name'] = event['agent.name'];
+          service['trace.id'] = event['trace.id'];
+
+          def basePath = new ArrayList();
+
+          def parentId = event['parent.id'];
+          def parent;
+
+          if (parentId != null && parentId != event['id']) {
+            parent = processAndReturnEvent(context, parentId);
+            if (parent != null) {
+              /* copy the path from the parent */
+              basePath.addAll(parent.path);
+              /* flag parent path for removal, as it has children */
+              context.locationsToRemove.add(parent.path);
+
+              /* if the parent has 'span.destination.service.resource' set, and the service is different,
+              we've discovered a service */
+
+              if (parent['span.destination.service.resource'] != null
+                && parent['span.destination.service.resource'] != ""
+                && (parent['service.name'] != event['service.name']
+                  || parent['service.environment'] != event['service.environment']
+                )
+              ) {
+                def parentDestination = getDestination(parent);
+                context.externalToServiceMap.put(parentDestination, service);
+              }
+            }
+          }
+
+          def lastLocation = basePath.size() > 0 ? basePath[basePath.size() - 1] : null;
+
+          def currentLocation = service;
+
+          /* only add the current location to the path if it's different from the last one*/
+          if (lastLocation == null || !lastLocation.equals(currentLocation)) {
+            basePath.add(currentLocation);
+          }
+
+          /* if there is an outgoing span, create a new path */
+          if (event['span.destination.service.resource'] != null
+            && event['span.destination.service.resource'] != '') {
+            def outgoingLocation = getDestination(event);
+            def outgoingPath = new ArrayList(basePath);
+            outgoingPath.add(outgoingLocation);
+            context.paths.add(outgoingPath);
+          }
+
+          event.path = basePath;
+
+          context.processedEvents[eventId] = event;
+          return event;
+        }
+
+        def context = new HashMap();
+
+        context.processedEvents = new HashMap();
+        context.eventsById = new HashMap();
+
+        context.paths = new HashSet();
+        context.externalToServiceMap = new HashMap();
+        context.locationsToRemove = new HashSet();
+
+        for (state in states) {
+          context.eventsById.putAll(state);
+        }
+
+        for (entry in context.eventsById.entrySet()) {
+          processAndReturnEvent(context, entry.getKey());
+        }
+
+        def paths = new HashSet();
+
+        for(foundPath in context.paths) {
+          if (!context.locationsToRemove.contains(foundPath)) {
+            paths.add(foundPath);
+          }
+        }
+
+        def response = new HashMap();
+        response.paths = paths;
+
+        def discoveredServices = new HashSet();
+
+        for(entry in context.externalToServiceMap.entrySet()) {
+          def map = new HashMap();
+          map.from = entry.getKey();
+          map.to = entry.getValue();
+          discoveredServices.add(map);
+        }
+        response.discoveredServices = discoveredServices;
+
+        return response;`,
+      },
+    },
+  } as const,
+};


### PR DESCRIPTION
Related to: https://github.com/elastic/apm-dev/issues/782

# Goal
The aim is to transform trace data (transaction and span documents) into trace paths (a new type of document) that can be used to build the service map among other things.

The way we build trace paths for the service map today:
 1. [Retrieve 10.000 random](https://github.com/elastic/kibana/blob/8fc1c9297cf59a0ed72651300402734a1f67d074/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts) (hopefully representative) trace ids
 2. [Fetch trace documents](https://github.com/elastic/kibana/blob/8fc1c9297cf59a0ed72651300402734a1f67d074/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts) (transactions and spans) for selected trace ids (it is important that we retrieve all trace documents for each trace id and not just some of them)
 3. Find the trace path for each trace by traversing from the child document up to the upper-most parent (each document has a parent.id). This will produce paths like service A -> Service B -> Service D ; Service B -> Service C -> Service D   etc.
 4. Service map can now be rendered based on the trace paths

My mental model of how this should happen in a background job is this:
 - Retrieve traces
 - Perform scripted metric aggregations to transform trace documents to trace paths
 - Write a single trace path document to ES


## What this PR includes

Currently two debug endpoints have been added : 
- `GET /internal/apm/service-map/trace_paths_original` returns the trace paths using the existing implementation. 
- `GET /internal/apm/service-map/trace_paths` returns trace paths using the new implementation made for transforms


## Limitations with transforms
Neither `pivot` or `latest` are adequate solutions and they both seem quite constraining for our use case. It seems like we lack a more unbounded transform type, that takes an input, and then writes whatever output the user wants to one or more documents.

**Identified problems**
   - `pivot`: Pivotting (`group_by`) on `trace.id` is equivalent of doing a terms agg on `trace.id` with `size` set to infinity. It will page through all trace.id buckets which is TERRIBLY inefficient since we only need a small sample of ~ 10.000 traces.
   - It's not trivial to get a representative sample of traces, since the sampler aggregation is not supported in transforms.

## Debug queries

### Preview Transform
<details>
  <summary>Show query</summary>
  
```jsonc
# Start transform
# POST _transform/apm_trace_paths_transform/_start
# Create transform
# PUT _transform/apm_trace_paths_transform

GET _transform/_preview
{
  "dest": {
    "index": "apm_trace_paths"
  },
  "source": {
    "index": "remote_cluster:traces-apm*",
    "query": {
      "bool": {
        "filter": [
          {  
            "terms": {
              "processor.event": [
                "span",
                "transaction"
                ]
            }
          }
          ]
      }
    }
  },
  "pivot": {
    "aggs": {
      "trace_paths": {
        "scripted_metric": {
          "init_script": {
            "lang": "painless",
            "source": """
            state.eventsById = new HashMap();
            state.parentIds = new ArrayList();
            
            String[] fieldsToCopy = new String[] {
              'parent.id',
              'service.name',
              'service.environment',
              'span.destination.service.resource',
              'trace.id',
              'processor.event',
              'span.type',
              'span.subtype',
              'agent.name',
              'transaction.type',
              '@timestamp'
            };
            state.fieldsToCopy = fieldsToCopy;            
            """
          },
          "map_script": {
            "lang": "painless",
            "source": """
            
            def id;
            if (!doc['span.id'].empty) {
              id = doc['span.id'].value;
            } else {
              id = doc['transaction.id'].value;
            }
            def copy = new HashMap();
            copy.id = id;
            for(key in state.fieldsToCopy ) {
              if (!doc[key].empty) {
                copy[key] = doc[key].value;
              }
            }
            
            if(!doc['parent.id'].empty) {
              state.parentIds.add(doc['parent.id'].value);
            }
            state.eventsById[id] = copy
            """
          },
          "combine_script": {
            "lang": "painless",
            "source": "\n          return [\n            'eventsById': state.eventsById, \n            'parentIds': state.parentIds\n          ];\n        "
          },
          "reduce_script": {
            "lang": "painless",
            "source": """
            def getLeafNode ( def event, def hash ) {
              def leafNode = new HashMap();
              leafNode['span.destination.service.resource'] = event['span.destination.service.resource'];
              leafNode['span.type'] = event['span.type'];
              leafNode['span.subtype'] = event['span.subtype'];
              leafNode['upstream.hash'] = hash;
              leafNode['trace.id'] = event['trace.id'];
              leafNode['parent.id'] = event['parent.id'];
              leafNode['id'] = event['id'];
              leafNode['leafNode'] = true;
              
              return leafNode;
            }
            
            def getNode(def event) {
              return [ 
                '@timestamp': event['@timestamp'], 
                'service.name': event['service.name'], 
                'service.environment': event['service_environment'], 
                'agent.name': event['agent.name'], 
                'processor.event': event['processor.event'],
                'parent.id': event['parent.id'],
                'id': event['id'],
                'trace.id': event['trace.id'],
                'leafNode': false
                ];          
            }
            
            def isParent(def context, def eventId) {
              return context.parentIds.contains(eventId);
            }
            
            def processAndReturnEvent(def context, def eventId) {
              if (context.processedEvents[eventId] != null) {
                return context.processedEvents[eventId];
              }
              
              def event = context.eventsById[eventId];
              if (event == null) {
                return null;
              }
              
              def node = getNode(event);
              context.processedEvents[eventId] = node;
              
              def tracePath = [];
              def parentId = event['parent.id'];
              def parent;
              def upstreamHash = '';
              def hash = '';
              
              if (parentId != null && parentId != event['id']) {
                parent = processAndReturnEvent(context, parentId);
                if (parent != null) {
                  /* copy the path from the parent */
                  tracePath.addAll(parent.path);
                  
                  if (parent['downstream.hash'] != null) {
                    upstreamHash = parent['downstream.hash'];
                    hash = [ 
                      'service.name': node['service.name'], 
                      'service.environment': node['service.environment'], 
                      'upstreamHash': upstreamHash 
                      ].hashCode().toString();
                  } else {
                    hash = parent.hash;
                  }
                }
              }
              
              node['upstream.hash'] = upstreamHash;
              node.hash = hash;
              
              if (event['span.destination.service.resource'] != null) {
                node['downstream.hash'] = [ 
                  'service.name': node['service.name'], 
                  'service.environment': node['service.environment'], 
                  'upstreamHash': upstreamHash, 
                  'hash': hash, 
                  'span.destination.service.resource': event['span.destination.service.resource'] 
                  ].hashCode().toString();
                  
                  node['span.destination.service.resource'] = event['span.destination.service.resource'];
              }
              
              if(event['span.type'] != null) {
                node['span.type'] = event['span.type'];
              }
              
              if (event['transaction.type'] != null) {
                node['transaction.type'] = event['transaction.type'];
              }
              
              
              /* only add the current location to the path if it's different from the last one*/
              if (
              parent == null
              || parent['service.name'] != node['service.name']
              || parent['service.environment'] != node['service.environment']
              || event['span.destination.service.resource'] != null
              ) {
                // node.id = eventId;
                // node['parent.id'] = parentId;
                def clone = node.clone();
                node.remove('path');
                tracePath.add(clone);
              }
              
              /* if there is an outgoing span, create a new path */
              if (event['span.destination.service.resource'] != null
              && event['span.destination.service.resource'] != '') {
                
                def leafNode = getLeafNode(event, node['downstream.hash']);
                def fullTracePath = new ArrayList(tracePath);
                fullTracePath.add(leafNode);
                
                // Only add if leafNode is not a parent (in which case it's not a leaf node)            
                if(!isParent(context, leafNode.id)) {
                  def leafNodeHash = leafNode['upstream.hash'];
                  context.paths[leafNodeHash] = fullTracePath;
                }
              }
              
              node.path = tracePath;
              
              return node;
            }
            
            
            def context = new HashMap();
            context.parentIds = new ArrayList();
            context.processedEvents = new HashMap();
            context.eventsById = new HashMap();
            context.paths = new HashMap();
            
            for (state in states) {
              context.parentIds.addAll(state['parentIds']);
              context.eventsById.putAll(state['eventsById']);
            }
            
            for (eventId in context.eventsById.keySet()) {
              // only traverse leaf nodes (which are not parents to anything)
              if (!isParent(context, eventId)) {
                processAndReturnEvent(context, eventId);
              }
            }
            
            def tracePaths = new HashSet();
            tracePaths.addAll(context.paths.values());
            return tracePaths;          
            
            """
          }
        }
      }
    },
    "group_by": {
      "trace_id": {
        "terms": {
          "field": "trace.id"
        }
      }
    }
  },
  "description": "Service Map for APM",
  "frequency": "1s",
  "sync": {
    "time": {
      "field": "@timestamp",
      "delay": "60s"
    }
  }
}  
```

</details>


### Query for imitating transform
<details>
  <summary>Show query</summary>
  
```jsonc
GET remote_cluster:apm-*,remote_cluster:traces-apm*,apm-*,traces-apm*/_search
{
  "size": 0,
  "query": {
    "bool": {
      "filter": [
        {
          "range": {
            "@timestamp": {
              "gte": "2022-06-26T11:00:00.000Z",
              "lte": "2022-06-27T12:00:00.000Z"
            }
          }
        },
        {
          "terms": {
            "processor.event": [
              "transaction",
              "span"
              ]
          }
        }
        ]
    }
  },
  "aggs": {
    "traces": {
      "terms": {
        "field": "trace.id",
        "size": 1000,
        "execution_hint": "map",
        "order": {
          "_key": "desc"
        }
      },
      "aggs": {
        "trace_paths": {
          "scripted_metric": {
            "init_script": {
              "lang": "painless",
              "source": """
              state.eventsById = new HashMap();
              state.parentIds = new ArrayList();
              
              String[] fieldsToCopy = new String[] {
                'parent.id',
                'service.name',
                'service.environment',
                'span.destination.service.resource',
                'trace.id',
                'processor.event',
                'span.type',
                'span.subtype',
                'agent.name',
                'transaction.type',
              '@timestamp'
              };
              state.fieldsToCopy = fieldsToCopy;            
              """
            },
            "map_script": {
              "lang": "painless",
              "source": """            
              
              def id;
              if (!doc['span.id'].empty) {
                id = doc['span.id'].value;
              } else {
                id = doc['transaction.id'].value;
              }
              
              def copy = new HashMap();
              copy.id = id;
              
              for(key in state.fieldsToCopy ) {
                if (!doc[key].empty) {
                  copy[key] = doc[key].value;
                }
              }
              
              if(!doc['parent.id'].empty) {
                state.parentIds.add(doc['parent.id'].value);
              }
              
              state.eventsById[id] = copy
              """
            },
            "combine_script": {
              "lang": "painless",
              "source": "\n          return [\n            'eventsById': state.eventsById, \n            'parentIds': state.parentIds\n          ];\n        "
            },
            "reduce_script": {
              "lang": "painless",
              "source": """
              def getLeafNode ( def event, def hash ) {
                def leafNode = new HashMap();
                leafNode['span.destination.service.resource'] = event['span.destination.service.resource'];
                leafNode['span.type'] = event['span.type'];
                leafNode['span.subtype'] = event['span.subtype'];
                leafNode['upstream.hash'] = hash;
                leafNode['trace.id'] = event['trace.id'];
                leafNode['parent.id'] = event['parent.id'];
                leafNode['id'] = event['id'];
                leafNode['leafNode'] = true;
                
                return leafNode;
              }
              
              def getNode(def event) {
                return [ 
                  '@timestamp': event['@timestamp'], 
                  'service.name': event['service.name'], 
                  'service.environment': event['service_environment'], 
                  'agent.name': event['agent.name'], 
                  'processor.event': event['processor.event'],
                  'parent.id': event['parent.id'],
                  'id': event['id'],
                  'trace.id': event['trace.id'],
                  'leafNode': false
                  ];          
              }
              
              def isParent(def context, def eventId) {
                return context.parentIds.contains(eventId);
              }
              
              def processAndReturnEvent(def context, def eventId) {
                if (context.processedEvents[eventId] != null) {
                  return context.processedEvents[eventId];
                }
                
                def event = context.eventsById[eventId];
                if (event == null) {
                  return null;
                }
                
                def node = getNode(event);
                context.processedEvents[eventId] = node;
                
                def tracePath = [];
                def parentId = event['parent.id'];
                def parent;
                def upstreamHash = '';
                def hash = '';
                
                if (parentId != null && parentId != event['id']) {
                  parent = processAndReturnEvent(context, parentId);
                  if (parent != null) {
                    /* copy the path from the parent */
                    tracePath.addAll(parent.path);
                    
                    if (parent['downstream.hash'] != null) {
                      upstreamHash = parent['downstream.hash'];
                      hash = [ 
                        'service.name': node['service.name'], 
                        'service.environment': node['service.environment'], 
                        'upstreamHash': upstreamHash 
                        ].hashCode().toString();
                    } else {
                      hash = parent.hash;
                    }
                  }
                }
                
                node['upstream.hash'] = upstreamHash;
                node.hash = hash;
                
                if (event['span.destination.service.resource'] != null) {
                  node['downstream.hash'] = [ 
                    'service.name': node['service.name'], 
                    'service.environment': node['service.environment'], 
                    'upstreamHash': upstreamHash, 
                    'hash': hash, 
                    'span.destination.service.resource': event['span.destination.service.resource'] 
                    ].hashCode().toString();
                    
                    node['span.destination.service.resource'] = event['span.destination.service.resource'];
                }
                
                if(event['span.type'] != null) {
                  node['span.type'] = event['span.type'];
                }
                
                if (event['transaction.type'] != null) {
                  node['transaction.type'] = event['transaction.type'];
                }
                
                
                /* only add the current location to the path if it's different from the last one*/
                if (
                parent == null
                || parent['service.name'] != node['service.name']
                || parent['service.environment'] != node['service.environment']
                || event['span.destination.service.resource'] != null
                ) {
                  // node.id = eventId;
                  // node['parent.id'] = parentId;
                  def clone = node.clone();
                  node.remove('path');
                  tracePath.add(clone);
                }
                
                /* if there is an outgoing span, create a new path */
                if (event['span.destination.service.resource'] != null
                && event['span.destination.service.resource'] != '') {
                  
                  def leafNode = getLeafNode(event, node['downstream.hash']);
                  def fullTracePath = new ArrayList(tracePath);
                  fullTracePath.add(leafNode);
                  
                  // Only add if leafNode is not a parent (in which case it's not a leaf node)            
                  if(!isParent(context, leafNode.id)) {
                    def leafNodeHash = leafNode['upstream.hash'];
                    context.paths[leafNodeHash] = fullTracePath;
                  }
                }
                
                node.path = tracePath;
                
                return node;
              }
              
              
              def context = new HashMap();
              context.parentIds = new ArrayList();
              context.processedEvents = new HashMap();
              context.eventsById = new HashMap();
              context.paths = new HashMap();
              
              for (state in states) {
                context.parentIds.addAll(state['parentIds']);
                context.eventsById.putAll(state['eventsById']);
              }
              
              for (eventId in context.eventsById.keySet()) {
                // only traverse leaf nodes (which are not parents to anything)
                if (!isParent(context, eventId)) {
                  processAndReturnEvent(context, eventId);
                }
              }
              
              def tracePaths = new HashSet();
              tracePaths.addAll(context.paths.values());
              return tracePaths;
              
              """
            }
          }
        }
      }         
    }
  }
}
```
</details>