### PR TITLE
Optimize security entry bundle

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -52,13 +52,13 @@ pageLoadAssetSize:
   savedObjectsTagging: 59482
   savedObjectsTaggingOss: 20590
   searchprofiler: 67080
-  security: 115240
+  security: 65433
   snapshotRestore: 79032
   spaces: 57868
   telemetry: 51957
   telemetryManagementSection: 38586
   transform: 41007
-  triggersActionsUi: 119000 #This is temporary. Check https://github.com/elastic/kibana/pull/130710#issuecomment-1119843458 & https://github.com/elastic/kibana/issues/130728
+  triggersActionsUi: 119000
   upgradeAssistant: 81241
   urlForwarding: 32579
   usageCollection: 39762

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -58,7 +58,7 @@ pageLoadAssetSize:
   telemetry: 51957
   telemetryManagementSection: 38586
   transform: 41007
-  triggersActionsUi: 119000
+  triggersActionsUi: 119000 #This is temporary. Check https://github.com/elastic/kibana/pull/130710#issuecomment-1119843458 & https://github.com/elastic/kibana/issues/130728
   upgradeAssistant: 81241
   urlForwarding: 32579
   usageCollection: 39762

--- a/x-pack/plugins/security/public/account_management/account_management_app.test.tsx
+++ b/x-pack/plugins/security/public/account_management/account_management_app.test.tsx
@@ -16,7 +16,7 @@ import { UserAPIClient } from '../management';
 import { securityMock } from '../mocks';
 import { accountManagementApp } from './account_management_app';
 import * as AccountManagementPageImports from './account_management_page';
-import { UserProfileAPIClient } from './user_profile';
+import { UserProfileAPIClient } from './user_profile/user_profile_api_client';
 
 const AccountManagementPageMock = jest
   .spyOn(AccountManagementPageImports, 'AccountManagementPage')

--- a/x-pack/plugins/security/public/account_management/account_management_page.test.tsx
+++ b/x-pack/plugins/security/public/account_management/account_management_page.test.tsx
@@ -16,8 +16,8 @@ import { UserAPIClient } from '../management';
 import { securityMock } from '../mocks';
 import { Providers } from './account_management_app';
 import { AccountManagementPage } from './account_management_page';
-import { UserProfileAPIClient } from './user_profile';
 import * as UserProfileImports from './user_profile/user_profile';
+import { UserProfileAPIClient } from './user_profile/user_profile_api_client';
 
 const UserProfileMock = jest.spyOn(UserProfileImports, 'UserProfile');
 

--- a/x-pack/plugins/security/public/account_management/index.ts
+++ b/x-pack/plugins/security/public/account_management/index.ts
@@ -6,4 +6,4 @@
  */
 
 export { accountManagementApp } from './account_management_app';
-export { UserProfileAPIClient } from './user_profile';
+export { UserProfileAPIClient } from './user_profile/user_profile_api_client';

--- a/x-pack/plugins/security/public/account_management/user_profile/index.ts
+++ b/x-pack/plugins/security/public/account_management/user_profile/index.ts
@@ -8,4 +8,3 @@
 export { UserProfile } from './user_profile';
 
 export type { UserProfileProps, UserProfileFormValues } from './user_profile';
-export { UserProfileAPIClient } from './user_profile_api_client';


### PR DESCRIPTION
## Summary

Reduces the `security` entry bundle size by moving `formik` to an async chunk.

Resolves https://github.com/elastic/kibana/issues/133290

