### PR TITLE
Restoring snoozeEndTime to AlertAttributesExcludedFromAAD

### DIFF
--- a/x-pack/plugins/alerting/server/saved_objects/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/index.ts
@@ -22,9 +22,9 @@ import { isRuleExportable } from './is_rule_exportable';
 import { RuleTypeRegistry } from '../rule_type_registry';
 export { partiallyUpdateAlert } from './partially_update_alert';
 
-// Use caution when removing items from this array! If the field
-// exists in the rule SO, it needs to be included in this array to
-// prevent decryption failures during migration.
+// Use caution when removing items from this array! Any field which has
+// ever existed in the rule SO must be included in this array to prevent
+// decryption failures during migration.
 export const AlertAttributesExcludedFromAAD = [
   'scheduledTaskId',
   'muteAll',
@@ -33,7 +33,7 @@ export const AlertAttributesExcludedFromAAD = [
   'updatedAt',
   'executionStatus',
   'monitoring',
-  'snoozeEndTime',
+  'snoozeEndTime', // field removed in 8.2, but must be retained in case an rule created/updated in 8.2 is being migrated
   'snoozeSchedule',
   'isSnoozedUntil',
 ];

--- a/x-pack/plugins/alerting/server/saved_objects/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/index.ts
@@ -22,6 +22,9 @@ import { isRuleExportable } from './is_rule_exportable';
 import { RuleTypeRegistry } from '../rule_type_registry';
 export { partiallyUpdateAlert } from './partially_update_alert';
 
+// Use caution when removing items from this array! If the field
+// exists in the rule SO, it needs to be included in this array to
+// prevent decryption failures during migration.
 export const AlertAttributesExcludedFromAAD = [
   'scheduledTaskId',
   'muteAll',
@@ -30,6 +33,7 @@ export const AlertAttributesExcludedFromAAD = [
   'updatedAt',
   'executionStatus',
   'monitoring',
+  'snoozeEndTime',
   'snoozeSchedule',
   'isSnoozedUntil',
 ];
@@ -46,6 +50,7 @@ export type AlertAttributesExcludedFromAADType =
   | 'updatedAt'
   | 'executionStatus'
   | 'monitoring'
+  | 'snoozeEndTime'
   | 'snoozeSchedule'
   | 'isSnoozedUntil';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/migrations.ts
@@ -443,5 +443,22 @@ export default function createGetTests({ getService }: FtrProviderContext) {
       expect(response.statusCode).to.equal(200);
       expect(response.body._source?.alert?.tags).to.eql(['test-tag-1', 'foo-tag']);
     });
+
+    it('8.3.0 removes snoozeEndTime in favor of snoozeSchedule', async () => {
+      const response = await es.get<{ alert: RawRule }>(
+        {
+          index: '.kibana',
+          id: 'alert:734def70-f8b1-11ec-b8e0-c99fab63aaae',
+        },
+        { meta: true }
+      );
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.body._source?.alert?.snoozeEndTime).to.be(undefined);
+      expect(response.body._source?.alert?.snoozeSchedule).not.to.be(undefined);
+
+      const snoozeSchedule = response.body._source?.alert.snoozeSchedule!;
+      expect(snoozeSchedule.length).to.eql(1);
+    });
   });
 }

--- a/x-pack/test/functional/es_archives/alerts/data.json
+++ b/x-pack/test/functional/es_archives/alerts/data.json
@@ -1041,3 +1041,63 @@
      }
   }
 }
+
+{
+  "type":"doc",
+  "value":{
+     "id":"alert:734def70-f8b1-11ec-b8e0-c99fab63aaae",
+     "index":".kibana_1",
+     "source":{
+        "alert":{
+           "name":"Test rule with snoozeEndTime",
+           "alertTypeId":".index-threshold",
+           "consumer":"alerts",
+           "params" : {
+             "aggType" : "count",
+             "termSize" : 5,
+             "thresholdComparator" : ">",
+             "timeWindowSize" : 5,
+             "timeWindowUnit" : "d",
+             "groupBy" : "all",
+             "threshold" : [
+               0
+             ],
+             "index" : [
+               ".test-test-test"
+             ],
+             "timeField" : "@timestamp"
+           },
+           "schedule":{
+              "interval":"1m"
+           },
+           "enabled":true,
+           "actions":[
+              
+           ],
+           "throttle":null,
+           "notifyWhen" : "onActiveAlert",
+           "apiKeyOwner" : "elastic",
+           "apiKey" : "y86eFOuG06GNd4p/90Zh4V4C+4wF8rFHiLcOeNqHQFFAbagYCXIuggq/N/AB0HBncCsWrh5PsCs4RiX53+LP2o+oLtoQkdTK9m+iv0BnzP6aavoypIudKtnElN3SotI3XpIRm7c3MEdM/C/zZXHgCmn4UMExhkulOO1S/Q//FwvIr2/SKw/mp8Vx5qP41hqDX4YFfSMoFkPSLw==",
+           "createdBy":"elastic",
+           "updatedBy":"elastic",
+           "createdAt":"2021-07-27T20:42:55.896Z",
+           "muteAll":false,
+           "mutedInstanceIds":[
+              
+           ],
+           "snoozeEndTime" : "2022-06-30T23:18:17.740Z",
+           "scheduledTaskId":"734def70-f8b1-11ec-b8e0-c99fab63aaae",
+           "tags":[
+           ]
+        },
+        "type":"alert",
+        "migrationVersion":{
+           "alert":"8.2.0"
+        },
+        "updated_at":"2021-08-13T23:00:11.985Z",
+        "references":[
+           
+        ]
+     }
+  }
+}

--- a/x-pack/test/functional/es_archives/alerts/mappings.json
+++ b/x-pack/test/functional/es_archives/alerts/mappings.json
@@ -150,6 +150,9 @@
               },
               "type": "text"
             },
+            "notifyWhen": {
+              "type": "keyword"
+            },
             "params": {
               "enabled": false,
               "type": "object"
@@ -162,6 +165,9 @@
               }
             },
             "scheduledTaskId": {
+              "type": "keyword"
+            },
+            "snoozeEndTime": {
               "type": "keyword"
             },
             "tags": {


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in `8.3.0` which causes any rule created or updated by an `8.2.x` cluster to fail on migration on upgrade to `8.3.0` or `8.3.1`.

The root cause of the bug is that the `snoozeEndTime` field which was added in `8.2.0` and subsequently removed in `8.3.0` was omitted from the `AlertAttributesExcludedFromAAD` list, which meant they could no longer be decrypted.
As a result, any `rule` Saved Object which was created or updated in `8.2.x` would try to use the `snoozeEndTime` field to decrypt the rule as part of the `8.3.0` migration - which consistently fails as the SO uses the field (even if empty) as part of AAD.

When this migration fails for such a rule the following error message is visible in the server log:
```
Failed to decrypt "apiKey" attribute: Unsupported state or unable to authenticate data
```

Once Kibana runs it might still try to run these failed rules, which should result in an error such as this:
```
<rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
```

## Remediation for customers who have already upgraded to 8.3.0 or 8.3.1

If a customer upgrades to 8.3.0 or 8.3.1 and their alerting rules have stopped running with an error similar to the example above, they will need to use the **Update API key** operation in `Stack Management > Rules and Connectors` to restore the alerting rule to a functional state. It should be noted that the **Update API Key** operation causes the alerting rule to run as the user that performed the operation.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
