### PR TITLE
[8.3] [testGroupRunOrder] allow defining a queue name for each ftr config (#135349)

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -54,6 +54,7 @@ disabled:
   - x-pack/test/plugin_api_perf/config.js
   - x-pack/test/screenshot_creation/config.ts
 
+defaultQueue: 'n2-4-spot'
 enabled:
   - test/accessibility/config.ts
   - test/analytics/config.ts

--- a/.buildkite/pipeline-utils/ci-stats/client.ts
+++ b/.buildkite/pipeline-utils/ci-stats/client.ts
@@ -43,6 +43,7 @@ export interface TestGroupRunOrderResponse {
   types: Array<{
     type: string;
     count: number;
+    queue?: string;
     groups: Array<{
       durationMin: number;
       names: string[];
@@ -159,6 +160,7 @@ export class CiStatsClient {
     >;
     groups: Array<{
       type: string;
+      queue?: string;
       defaultMin?: number;
       maxMin: number;
       minimumIsolationMin?: number;

--- a/packages/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
@@ -14,10 +14,28 @@ import JsYaml from 'js-yaml';
 
 export const FTR_CONFIGS_MANIFEST_REL = '.buildkite/ftr_configs.yml';
 
-const ftrConfigsManifest = JsYaml.safeLoad(
+interface FtrConfigWithOptions {
+  [configPath: string]: {
+    queue: string;
+  };
+}
+
+interface FtrConfigsManifest {
+  defaultQueue: string;
+  disabled: string[];
+  enabled: Array<string | FtrConfigWithOptions>;
+}
+
+const ftrConfigsManifest: FtrConfigsManifest = JsYaml.safeLoad(
   Fs.readFileSync(Path.resolve(REPO_ROOT, FTR_CONFIGS_MANIFEST_REL), 'utf8')
 );
 
-export const FTR_CONFIGS_MANIFEST_PATHS = (Object.values(ftrConfigsManifest) as string[][])
+export const FTR_CONFIGS_MANIFEST_PATHS = [
+  Object.values(ftrConfigsManifest.enabled),
+  Object.values(ftrConfigsManifest.disabled),
+]
   .flat()
-  .map((rel) => Path.resolve(REPO_ROOT, rel));
+  .map((config) => {
+    const rel = typeof config === 'string' ? config : Object.keys(config)[0];
+    return Path.resolve(REPO_ROOT, rel);
+  });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[testGroupRunOrder] allow defining a queue name for each ftr config (#135349)](https://github.com/elastic/kibana/pull/135349)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)