### PR TITLE
[Fleet] bulk update agent tags ui

### DIFF
--- a/x-pack/plugins/fleet/common/services/routes.ts
+++ b/x-pack/plugins/fleet/common/services/routes.ts
@@ -179,6 +179,7 @@ export const fleetSetupRouteService = {
 export const agentRouteService = {
   getInfoPath: (agentId: string) => AGENT_API_ROUTES.INFO_PATTERN.replace('{agentId}', agentId),
   getUpdatePath: (agentId: string) => AGENT_API_ROUTES.UPDATE_PATTERN.replace('{agentId}', agentId),
+  getBulkUpdateTagsPath: () => AGENT_API_ROUTES.BULK_UPDATE_AGENT_TAGS_PATTERN,
   getUnenrollPath: (agentId: string) =>
     AGENT_API_ROUTES.UNENROLL_PATTERN.replace('{agentId}', agentId),
   getBulkUnenrollPath: () => AGENT_API_ROUTES.BULK_UNENROLL_PATTERN,

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -156,6 +156,14 @@ export interface UpdateAgentRequest {
   };
 }
 
+export interface PostBulkUpdateAgentTagsRequest {
+  body: {
+    agents: string[] | string;
+    tagsToAdd?: string[];
+    tagsToRemove?: string[];
+  };
+}
+
 export interface GetAgentStatusRequest {
   query: {
     kuery?: string;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
@@ -53,7 +53,7 @@ describe('AgentBulkActions', () => {
       currentQuery: '',
       selectedAgents,
       refreshAgents: () => undefined,
-      allAgents: [],
+      visibleAgents: [],
       allTags: [],
     };
     const testBed = registerTestBed(TestComponent)(props);
@@ -82,7 +82,7 @@ describe('AgentBulkActions', () => {
       currentQuery: '',
       selectedAgents,
       refreshAgents: () => undefined,
-      allAgents: [],
+      visibleAgents: [],
       allTags: [],
     };
     const testBed = registerTestBed(TestComponent)(props);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
@@ -53,6 +53,8 @@ describe('AgentBulkActions', () => {
       currentQuery: '',
       selectedAgents,
       refreshAgents: () => undefined,
+      allAgents: [],
+      allTags: [],
     };
     const testBed = registerTestBed(TestComponent)(props);
     const { exists } = testBed;
@@ -80,6 +82,8 @@ describe('AgentBulkActions', () => {
       currentQuery: '',
       selectedAgents,
       refreshAgents: () => undefined,
+      allAgents: [],
+      allTags: [],
     };
     const testBed = registerTestBed(TestComponent)(props);
     const { exists } = testBed;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -41,7 +41,7 @@ export interface Props {
   selectionMode: SelectionMode;
   currentQuery: string;
   selectedAgents: Agent[];
-  allAgents: Agent[];
+  visibleAgents: Agent[];
   refreshAgents: (args?: { refreshTags?: boolean }) => void;
   allTags: string[];
 }
@@ -52,7 +52,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   selectionMode,
   currentQuery,
   selectedAgents,
-  allAgents,
+  visibleAgents,
   refreshAgents,
   allTags,
 }) => {
@@ -173,8 +173,8 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   ];
 
   const getSelectedTagsFromAgents = useMemo(
-    () => getCommonTags(agents, allAgents),
-    [agents, allAgents]
+    () => getCommonTags(agents, visibleAgents),
+    [agents, visibleAgents]
   );
 
   return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -94,7 +94,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
           ),
           icon: <EuiIcon type="tag" size="m" />,
           disabled: !atLeastOneActiveAgentSelected,
-          onClick: (event) => {
+          onClick: (event: any) => {
             setTagsPopoverButton((event.target as Element).closest('button')!);
             setIsTagAddVisible(!isTagAddVisible);
           },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { intersection } from 'lodash';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -27,6 +26,8 @@ import {
 } from '../../components';
 import { useLicense } from '../../../../hooks';
 import { LICENSE_FOR_SCHEDULE_UPGRADE } from '../../../../../../../common';
+
+import { getCommonTags } from '../utils';
 
 import type { SelectionMode } from './types';
 import { TagsAddRemove } from './tags_add_remove';
@@ -93,7 +94,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
           ),
           icon: <EuiIcon type="tag" size="m" />,
           disabled: !atLeastOneActiveAgentSelected,
-          onClick: (event: MouseEvent) => {
+          onClick: (event) => {
             setTagsPopoverButton((event.target as Element).closest('button')!);
             setIsTagAddVisible(!isTagAddVisible);
           },
@@ -171,27 +172,10 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
     },
   ];
 
-  const getSelectedTagsFromAgents = useMemo(() => {
-    const commonSelectedTags = (agentList: Agent[]) =>
-      agentList.reduce(
-        (acc: string[], curr: Agent) =>
-          acc.length > 0 ? intersection(curr.tags ?? [], acc) : curr.tags ?? [],
-        []
-      );
-
-    if (!Array.isArray(agents)) {
-      // in query mode, returning common tags of all agents in current page
-      // this is a simplification to avoid querying all agents from backend to determine common tags
-      return commonSelectedTags(allAgents ?? []);
-    }
-    // taking latest tags from freshly loaded agents data, as selected agents array does not contain the latest tags of agents
-    const freshSelectedAgentsData =
-      allAgents?.filter((newAgent) =>
-        agents.find((existingAgent) => existingAgent.id === newAgent.id)
-      ) ?? agents;
-
-    return commonSelectedTags(freshSelectedAgentsData);
-  }, [agents, allAgents]);
+  const getSelectedTagsFromAgents = useMemo(
+    () => getCommonTags(agents, allAgents),
+    [agents, allAgents]
+  );
 
   return (
     <>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -89,6 +89,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents: Agent[];
   refreshAgents: (args?: { refreshTags?: boolean }) => void;
   onClickAddAgent: () => void;
+  allAgents: Agent[];
 }> = ({
   agentPolicies,
   draftKuery,
@@ -110,6 +111,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents,
   refreshAgents,
   onClickAddAgent,
+  allAgents,
 }) => {
   // Policies state for filtering
   const [isAgentPoliciesFilterOpen, setIsAgentPoliciesFilterOpen] = useState<boolean>(false);
@@ -336,7 +338,9 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                 selectionMode={selectionMode}
                 currentQuery={currentQuery}
                 selectedAgents={selectedAgents}
+                allAgents={allAgents}
                 refreshAgents={refreshAgents}
+                allTags={tags}
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -89,7 +89,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents: Agent[];
   refreshAgents: (args?: { refreshTags?: boolean }) => void;
   onClickAddAgent: () => void;
-  allAgents: Agent[];
+  visibleAgents: Agent[];
 }> = ({
   agentPolicies,
   draftKuery,
@@ -111,7 +111,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents,
   refreshAgents,
   onClickAddAgent,
-  allAgents,
+  visibleAgents,
 }) => {
   // Policies state for filtering
   const [isAgentPoliciesFilterOpen, setIsAgentPoliciesFilterOpen] = useState<boolean>(false);
@@ -338,7 +338,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                 selectionMode={selectionMode}
                 currentQuery={currentQuery}
                 selectedAgents={selectedAgents}
-                allAgents={allAgents}
+                visibleAgents={visibleAgents}
                 refreshAgents={refreshAgents}
                 allTags={tags}
               />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
@@ -8,7 +8,11 @@
 import { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import { sendPutAgentTagsUpdate, useStartServices } from '../../../../hooks';
+import {
+  sendPostBulkAgentTagsUpdate,
+  sendPutAgentTagsUpdate,
+  useStartServices,
+} from '../../../../hooks';
 
 export const useUpdateTags = () => {
   const { notifications } = useStartServices();
@@ -40,5 +44,37 @@ export const useUpdateTags = () => {
     [notifications.toasts]
   );
 
-  return { updateTags };
+  const bulkUpdateTags = useCallback(
+    async (
+      agents: string[] | string,
+      tagsToAdd: string[],
+      tagsToRemove: string[],
+      onSuccess: () => void
+    ) => {
+      try {
+        const res = await sendPostBulkAgentTagsUpdate({ agents, tagsToAdd, tagsToRemove });
+
+        if (res.error) {
+          throw res.error;
+        }
+        const successMessage = i18n.translate(
+          'xpack.fleet.updateAgentTags.successNotificationTitle',
+          {
+            defaultMessage: 'Tags updated',
+          }
+        );
+        notifications.toasts.addSuccess(successMessage);
+
+        onSuccess();
+      } catch (error) {
+        const errorMessage = i18n.translate('xpack.fleet.updateAgentTags.errorNotificationTitle', {
+          defaultMessage: 'Tags update failed',
+        });
+        notifications.toasts.addError(error, { title: errorMessage });
+      }
+    },
+    [notifications.toasts]
+  );
+
+  return { updateTags, bulkUpdateTags };
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -632,7 +632,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           Promise.all([fetchData({ refreshTags }), refreshUpgrades()])
         }
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
-        allAgents={agents}
+        visibleAgents={agents}
       />
       <EuiSpacer size="m" />
       {/* Agent total, bulk actions and status bar */}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -632,6 +632,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           Promise.all([fetchData({ refreshTags }), refreshUpgrades()])
         }
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
+        allAgents={agents}
       />
       <EuiSpacer size="m" />
       {/* Agent total, bulk actions and status bar */}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Agent } from '../../../../types';
+
+import { getCommonTags } from './get_common_tags';
+
+describe('getCommonTags', () => {
+  it('should return common tags from allAgents if agents is empty string', () => {
+    const result = getCommonTags('', [{ tags: ['tag1'] }, { tags: ['tag1', 'tag2'] }] as Agent[]);
+
+    expect(result).toEqual(['tag1']);
+  });
+
+  it('should return common tags from allAgents if agents is query', () => {
+    const result = getCommonTags('query', [
+      { tags: ['tag1'] },
+      { tags: ['tag1', 'tag2'] },
+    ] as Agent[]);
+
+    expect(result).toEqual(['tag1']);
+  });
+
+  it('should return empty common tags if allAgents not set', () => {
+    const result = getCommonTags('');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return common tags from fresh data if agents is selected agent list', () => {
+    const result = getCommonTags(
+      [
+        { id: 'agent1', tags: ['oldTag'] },
+        { id: 'agent2', tags: ['oldTag'] },
+      ] as Agent[],
+      [
+        { id: 'agent1', tags: ['oldTag', 'tag1'] },
+        { id: 'agent2', tags: ['oldTag', 'tag1'] },
+      ] as Agent[]
+    );
+
+    expect(result).toEqual(['oldTag', 'tag1']);
+  });
+
+  it('should return common tags from old data if allAgents not set', () => {
+    const result = getCommonTags([
+      { id: 'agent1', tags: ['oldTag'] },
+      { id: 'agent2', tags: ['oldTag'] },
+    ] as Agent[]);
+
+    expect(result).toEqual(['oldTag']);
+  });
+
+  it('should return empty common tags if one agent has no tags set', () => {
+    const result = getCommonTags([{ id: 'agent1', tags: ['oldTag'] }, { id: 'agent2' }] as Agent[]);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.test.ts
@@ -10,13 +10,13 @@ import type { Agent } from '../../../../types';
 import { getCommonTags } from './get_common_tags';
 
 describe('getCommonTags', () => {
-  it('should return common tags from allAgents if agents is empty string', () => {
+  it('should return common tags from visibleAgents if agents is empty string', () => {
     const result = getCommonTags('', [{ tags: ['tag1'] }, { tags: ['tag1', 'tag2'] }] as Agent[]);
 
     expect(result).toEqual(['tag1']);
   });
 
-  it('should return common tags from allAgents if agents is query', () => {
+  it('should return common tags from visibleAgents if agents is query', () => {
     const result = getCommonTags('query', [
       { tags: ['tag1'] },
       { tags: ['tag1', 'tag2'] },
@@ -25,7 +25,7 @@ describe('getCommonTags', () => {
     expect(result).toEqual(['tag1']);
   });
 
-  it('should return empty common tags if allAgents not set', () => {
+  it('should return empty common tags if visibleAgents not set', () => {
     const result = getCommonTags('');
 
     expect(result).toEqual([]);
@@ -46,7 +46,7 @@ describe('getCommonTags', () => {
     expect(result).toEqual(['oldTag', 'tag1']);
   });
 
-  it('should return common tags from old data if allAgents not set', () => {
+  it('should return common tags from old data if visibleAgents not set', () => {
     const result = getCommonTags([
       { id: 'agent1', tags: ['oldTag'] },
       { id: 'agent2', tags: ['oldTag'] },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
@@ -9,7 +9,7 @@ import { intersection } from 'lodash';
 
 import type { Agent } from '../../../../types';
 
-export const getCommonTags = (agents: string | Agent[], allAgents?: Agent[]): string[] => {
+export const getCommonTags = (agents: string | Agent[], visibleAgents?: Agent[]): string[] => {
   const commonSelectedTags = (agentList: Agent[]) =>
     agentList.reduce(
       (acc: string[], curr: Agent) =>
@@ -20,11 +20,11 @@ export const getCommonTags = (agents: string | Agent[], allAgents?: Agent[]): st
   if (!Array.isArray(agents)) {
     // in query mode, returning common tags of all agents in current page
     // this is a simplification to avoid querying all agents from backend to determine common tags
-    return commonSelectedTags(allAgents ?? []);
+    return commonSelectedTags(visibleAgents ?? []);
   }
   // taking latest tags from freshly loaded agents data, as selected agents array does not contain the latest tags of agents
   const freshSelectedAgentsData =
-    allAgents?.filter((newAgent) =>
+    visibleAgents?.filter((newAgent) =>
       agents.find((existingAgent) => existingAgent.id === newAgent.id)
     ) ?? agents;
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { intersection } from 'lodash';
+
+import type { Agent } from '../../../../types';
+
+export const getCommonTags = (agents: string | Agent[], allAgents: Agent[]): string[] => {
+  const commonSelectedTags = (agentList: Agent[]) =>
+    agentList.reduce(
+      (acc: string[], curr: Agent) =>
+        acc.length > 0 ? intersection(curr.tags ?? [], acc) : curr.tags ?? [],
+      []
+    );
+
+  if (!Array.isArray(agents)) {
+    // in query mode, returning common tags of all agents in current page
+    // this is a simplification to avoid querying all agents from backend to determine common tags
+    return commonSelectedTags(allAgents ?? []);
+  }
+  // taking latest tags from freshly loaded agents data, as selected agents array does not contain the latest tags of agents
+  const freshSelectedAgentsData =
+    allAgents?.filter((newAgent) =>
+      agents.find((existingAgent) => existingAgent.id === newAgent.id)
+    ) ?? agents;
+
+  return commonSelectedTags(freshSelectedAgentsData);
+};

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_common_tags.ts
@@ -9,7 +9,7 @@ import { intersection } from 'lodash';
 
 import type { Agent } from '../../../../types';
 
-export const getCommonTags = (agents: string | Agent[], allAgents: Agent[]): string[] => {
+export const getCommonTags = (agents: string | Agent[], allAgents?: Agent[]): string[] => {
   const commonSelectedTags = (agentList: Agent[]) =>
     agentList.reduce(
       (acc: string[], curr: Agent) =>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/index.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './truncate_tag';
+export * from './get_common_tags';

--- a/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { UpdateAgentRequest } from '../../../common';
+import type { PostBulkUpdateAgentTagsRequest, UpdateAgentRequest } from '../../../common';
 
 import { agentRouteService } from '../../services';
 
@@ -203,6 +203,18 @@ export function sendPutAgentTagsUpdate(
   return sendRequest<GetOneAgentResponse>({
     method: 'put',
     path: agentRouteService.getUpdatePath(agentId),
+    body,
+    ...options,
+  });
+}
+
+export function sendPostBulkAgentTagsUpdate(
+  body: PostBulkUpdateAgentTagsRequest['body'],
+  options?: RequestOptions
+) {
+  return sendRequest<GetOneAgentResponse>({
+    method: 'post',
+    path: agentRouteService.getBulkUpdateTagsPath(),
     body,
     ...options,
   });


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/133307

Added bulk action to Add / Remove tags on Agents.
- Selected tags are those that are common for all selected agents.
- Implemented for query selection as well, for those, selected tags are the ones which are common for agents in current page as we don't have the info about all agents' common tags. This could be improved by returning the common tags of all agents from backend.

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/90178898/177166283-d70a7f85-19f3-4312-8739-1b80e6440070.png">
<img width="1777" alt="image" src="https://user-images.githubusercontent.com/90178898/177166555-36f693d4-b152-4f8e-933f-4ba67c8a8454.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
