### PR TITLE
[Alerting][Discover] Hide Alerts menu item when user does not have access to Stack Rules

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -196,7 +196,10 @@ export const getTopNavLinks = ({
     ...(services.capabilities.advancedSettings.save ? [options] : []),
     newSearch,
     openSearch,
-    ...(services.triggersActionsUi ? [alerts] : []),
+    ...(services.triggersActionsUi &&
+    services.capabilities.management?.insightsAndAlerting?.triggersActions
+      ? [alerts]
+      : []),
     shareSearch,
     inspectSearch,
     ...(services.capabilities.discover.save ? [saveSearch] : []),


### PR DESCRIPTION
Addresses: https://github.com/elastic/kibana/issues/135642

## Summary

This PR hides "Alerts" menu item if user's role does not include Management > Stack Rules privilege.
This PR does not remove Create rule action from the Alerts popover as it requires more complex checks for certain rule types.

Fore testing:
- Create a custom user role which has access to Discover but not to Stack Rules
- Create a new user with this role and login
- Check that "Alerts" is not present on Discover page but it's available there if access to Stack Rules is granted to the user.

