### PR TITLE
[ML] Disable/Subdue AIOps sidenav item when not enough permissions.

### DIFF
--- a/x-pack/plugins/ml/public/application/components/ml_page/side_nav.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/side_nav.tsx
@@ -227,6 +227,7 @@ export function useSideNavItems(activeRoute: MlRoute | undefined) {
         name: i18n.translate('xpack.ml.navMenu.aiopsTabLinkText', {
           defaultMessage: 'AIOps',
         }),
+        disabled: disableLinks,
         items: [
           {
             id: 'explainlogratespikes',


### PR DESCRIPTION
## Summary

Part of #136265.

Disable/Subdue AIOps sidenav item when not enough permissions.

Before:

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/230104/177194756-516068a2-0ddf-4ef4-b8f8-6cbf6af31469.png">


After:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/230104/177194700-d917e43a-06ec-4e9e-934f-224f0437bdb4.png">


### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
