### PR TITLE
[Visualize] Exclude some aggregations from the Orderby custom metric dropdown

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/_terms_order_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_order_helper.ts
@@ -12,6 +12,12 @@ import { IBucketAggConfig, BucketAggParam } from './bucket_agg_type';
 export const termsAggFilter = [
   '!top_hits',
   '!percentiles',
+  '!percentile_ranks',
+  '!filtered_metric',
+  '!percentile',
+  '!percentile_rank',
+  '!geo_bounds',
+  '!geo_centroid',
   '!std_dev',
   '!derivative',
   '!moving_avg',


### PR DESCRIPTION
## Summary

When we are excluding new aggregations from the aggbased visualizations we should also take care of the order by custom metric dropdown. There were some aggregations on the list that were not compatible with the agg based visualizations or with the order by custom metric functionality. This PR updates the allowed termsAggs array.

For example the filtered metric is an agg used in Lens and should not be available in this dropdown
<img width="346" alt="Screenshot 2022-07-05 at 1 14 51 PM" src="https://user-images.githubusercontent.com/17003240/177307884-e9cbbac8-f429-49dd-8df7-7947f2834955.png">