### PR TITLE
[Security Solution][Detections] fixes timeline template selection when templates have same name

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/pick_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/pick_timeline/index.tsx
@@ -36,23 +36,21 @@ export const PickTimeline = ({
 
   useEffect(() => {
     const { id, title } = field.value as FieldValueTimeline;
-    if (timelineTitle !== title && timelineId !== id) {
+    if (timelineId !== id) {
       setTimelineId(id);
       setTimelineTitle(title);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [field.value]);
+  }, [field.value, timelineId]);
 
   const handleOnTimelineChange = useCallback(
     (title: string, id: string | null) => {
       if (id === null) {
         field.setValue({ id, title: null });
-      } else if (timelineTitle !== title && timelineId !== id) {
+      } else if (timelineId !== id) {
         field.setValue({ id, title });
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [field]
+    [field, timelineId]
   );
 
   return (


### PR DESCRIPTION
## Summary

- addresses https://github.com/elastic/kibana/issues/130366
- instead of checking title and id when changing selection, only id will be checked

### Before

Impossible to select timeline template, if previously selected one has the same name

https://user-images.githubusercontent.com/92328789/177312907-bdc588c6-2811-430d-855a-6c957a65a8f8.mov


### After
Possible to select timeline template, if previously selected one has the same name

https://user-images.githubusercontent.com/92328789/177313210-81519771-10c5-4959-bcd2-db46c8d4a41f.mov


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Release note
fixes issue when users were not able to select timeline template on rules edit/create page and bulk actions if templates have the same name