### PR TITLE
[ML] Add a link to ML trained models list from ID in Stack Management app table

### DIFF
--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/space_management/columns.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/space_management/columns.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBasicTableColumn } from '@elastic/eui';
+import { TrainedModelLink } from '../../../../../trained_models/models_management';
 import type { MlSavedObjectType } from '../../../../../../../common/types/saved_objects';
 import type {
   AnalyticsManagementItems,
@@ -146,6 +147,7 @@ const trainedModelColumns: Array<EuiBasicTableColumn<TrainedModelsManagementItem
     truncateText: true,
     'data-test-subj': 'mlSpaceManagementTableColumnId',
     scope: 'row',
+    render: (id: string) => <TrainedModelLink id={id} />,
   },
   {
     field: 'description',

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/index.ts
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/index.ts
@@ -14,3 +14,5 @@ export const ModelsTableToConfigMapping = {
   type: 'type',
   modelType: 'model_type',
 } as const;
+
+export { TrainedModelLink } from './model_link';

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/model_link.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/model_link.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLink } from '@elastic/eui';
+import React, { FC } from 'react';
+import { useMlLink } from '../../contexts/kibana';
+import { ML_PAGES } from '../../../../common/constants/locator';
+
+export interface TrainedModelLinkProps {
+  id: string;
+}
+
+export const TrainedModelLink: FC<TrainedModelLinkProps> = ({ id }) => {
+  const href = useMlLink({
+    page: ML_PAGES.TRAINED_MODELS_MANAGE,
+    pageState: { modelId: id },
+  });
+
+  return <EuiLink href={href}>{id}</EuiLink>;
+};

--- a/x-pack/plugins/ml/public/locator/formatters/trained_models.ts
+++ b/x-pack/plugins/ml/public/locator/formatters/trained_models.ts
@@ -17,7 +17,28 @@ export function formatTrainedModelsManagementUrl(
   appBasePath: string,
   mlUrlGeneratorState: TrainedModelsUrlState['pageState']
 ): string {
-  return `${appBasePath}/${ML_PAGES.TRAINED_MODELS_MANAGE}`;
+  let url = `${appBasePath}/${ML_PAGES.TRAINED_MODELS_MANAGE}`;
+  if (mlUrlGeneratorState) {
+    const { modelId } = mlUrlGeneratorState;
+
+    if (modelId) {
+      const modelsListState: Partial<ListingPageUrlState> = {
+        queryText: `model_id:(${modelId})`,
+      };
+
+      const queryState: AppPageState<ListingPageUrlState> = {
+        [ML_PAGES.TRAINED_MODELS_MANAGE]: modelsListState,
+      };
+
+      url = setStateToKbnUrl<AppPageState<ListingPageUrlState>>(
+        '_a',
+        queryState,
+        { useHash: false, storeInHashQuery: false },
+        url
+      );
+    }
+  }
+  return url;
 }
 
 export function formatTrainedModelsNodesManagementUrl(

--- a/x-pack/plugins/ml/public/locator/ml_locator.test.ts
+++ b/x-pack/plugins/ml/public/locator/ml_locator.test.ts
@@ -323,5 +323,22 @@ describe('ML locator', () => {
         });
       });
     });
+
+    describe('Trained Models', () => {
+      it('should generate valid URL for the Trained Models page with model id', async () => {
+        const location = await definition.getLocation({
+          page: ML_PAGES.TRAINED_MODELS_MANAGE,
+          pageState: {
+            modelId: 'my_model_01',
+          },
+        });
+
+        expect(location).toMatchObject({
+          app: 'ml',
+          path: "/trained_models?_a=(trained_models:(queryText:'model_id:(my_model_01)'))",
+          state: {},
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/135229

Adds a link to ML trained models list from ID in Stack Management app table.

![Jul-05-2022 13-31-30](https://user-images.githubusercontent.com/5236598/177318174-5af7b77e-651f-4b81-aa2d-4ae577417e23.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
