### PR TITLE
[Lens] Add confirmation modal when removing the layer

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.test.tsx
@@ -158,7 +158,7 @@ describe('ConfigPanel', () => {
       });
       instance.update();
       act(() => {
-        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+        instance.find('[data-test-subj="lnsLayerRemoveConfirmButton"]').first().simulate('click');
       });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(firstLayerFocusable);
@@ -185,7 +185,7 @@ describe('ConfigPanel', () => {
       });
       instance.update();
       act(() => {
-        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+        instance.find('[data-test-subj="lnsLayerRemoveConfirmButton"]').first().simulate('click');
       });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(secondLayerFocusable);
@@ -211,7 +211,7 @@ describe('ConfigPanel', () => {
       });
       instance.update();
       act(() => {
-        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+        instance.find('[data-test-subj="lnsLayerRemoveConfirmButton"]').first().simulate('click');
       });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(firstLayerFocusable);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.test.tsx
@@ -156,6 +156,10 @@ describe('ConfigPanel', () => {
       act(() => {
         instance.find('[data-test-subj="lnsLayerRemove"]').first().simulate('click');
       });
+      instance.update();
+      act(() => {
+        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+      });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(firstLayerFocusable);
     });
@@ -179,6 +183,10 @@ describe('ConfigPanel', () => {
       act(() => {
         instance.find('[data-test-subj="lnsLayerRemove"]').at(0).simulate('click');
       });
+      instance.update();
+      act(() => {
+        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+      });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(secondLayerFocusable);
     });
@@ -200,6 +208,10 @@ describe('ConfigPanel', () => {
         .instance();
       act(() => {
         instance.find('[data-test-subj="lnsLayerRemove"]').at(2).simulate('click');
+      });
+      instance.update();
+      act(() => {
+        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
       });
       const focusedEl = document.activeElement;
       expect(focusedEl).toEqual(firstLayerFocusable);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -166,7 +166,7 @@ describe('LayerPanel', () => {
       });
       instance.update();
       act(() => {
-        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+        instance.find('[data-test-subj="lnsLayerRemoveConfirmButton"]').first().simulate('click');
       });
       expect(cb).toHaveBeenCalled();
     });

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -164,6 +164,10 @@ describe('LayerPanel', () => {
       act(() => {
         instance.find('[data-test-subj="lnsLayerRemove"]').first().simulate('click');
       });
+      instance.update();
+      act(() => {
+        instance.find('[data-test-subj="confirmModalConfirmButton"]').first().simulate('click');
+      });
       expect(cb).toHaveBeenCalled();
     });
   });

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -315,6 +315,7 @@ export function LayerPanel(
                   layerIndex={layerIndex}
                   isOnlyLayer={isOnlyLayer}
                   activeVisualization={activeVisualization}
+                  layerType={activeVisualization.getLayerType(layerId, visualizationState)}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
@@ -60,14 +60,14 @@ const getButtonCopy = (
           defaultMessage: 'reference lines',
         });
 
-  let modalTitle = i18n.translate('xpack.lens.modalTitle.title', {
+  let modalTitle = i18n.translate('xpack.lens.modalTitle.title.delete', {
     defaultMessage: 'Delete {layerType} layer?',
     values: { layerType: layerTypeCopy },
   });
   let modalDesc = modalDescVis;
 
   if (!canBeRemoved || isOnlyLayer) {
-    modalTitle = i18n.translate('xpack.lens.modalTitle.title', {
+    modalTitle = i18n.translate('xpack.lens.modalTitle.title.clear', {
       defaultMessage: 'Clear {layerType} layer?',
       values: { layerType: layerTypeCopy },
     });
@@ -237,6 +237,7 @@ const RemoveConfirmModal = ({
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButton
+                  data-test-subj="lnsLayerRemoveConfirmButton"
                   onClick={() => {
                     closeModal();
                     removeLayer();

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
@@ -227,7 +227,7 @@ const RemoveConfirmModal = ({
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexGroup alignItems="center" justifyContent="flexEnd" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty onClick={closeModal}>
                   {i18n.translate('xpack.lens.layer.cancelDelete', {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import React, { useState } from 'react';
+import { EuiButtonIcon, EuiCheckbox, EuiConfirmModal } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { Visualization } from '../../../types';
+import { LocalStorageLens, LOCAL_STORAGE_LENS_KEY } from '../../../settings_storage';
 
 export function RemoveLayerButton({
   onRemoveLayer,
@@ -22,6 +24,20 @@ export function RemoveLayerButton({
   activeVisualization: Visualization;
 }) {
   let ariaLabel;
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [lensLocalStorage, setLensLocalStorage] = useLocalStorage<LocalStorageLens>(
+    LOCAL_STORAGE_LENS_KEY,
+    {}
+  );
+
+  const onChangeShouldShowModal = () =>
+    setLensLocalStorage({
+      ...lensLocalStorage,
+      skipDeleteModal: !lensLocalStorage?.skipDeleteModal,
+    });
+
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
 
   if (!activeVisualization.removeLayer) {
     ariaLabel = i18n.translate('xpack.lens.resetVisualizationAriaLabel', {
@@ -39,27 +55,73 @@ export function RemoveLayerButton({
     });
   }
 
+  const removeLayer = () => {
+    // If we don't blur the remove / clear button, it remains focused
+    // which is a strange UX in this case. e.target.blur doesn't work
+    // due to who knows what, but probably event re-writing. Additionally,
+    // activeElement does not have blur so, we need to do some casting + safeguards.
+    const el = document.activeElement as unknown as { blur: () => void };
+
+    if (el?.blur) {
+      el.blur();
+    }
+
+    onRemoveLayer();
+  };
+
   return (
-    <EuiButtonIcon
-      size="xs"
-      iconType={isOnlyLayer ? 'eraser' : 'trash'}
-      color="danger"
-      data-test-subj="lnsLayerRemove"
-      aria-label={ariaLabel}
-      title={ariaLabel}
-      onClick={() => {
-        // If we don't blur the remove / clear button, it remains focused
-        // which is a strange UX in this case. e.target.blur doesn't work
-        // due to who knows what, but probably event re-writing. Additionally,
-        // activeElement does not have blur so, we need to do some casting + safeguards.
-        const el = document.activeElement as unknown as { blur: () => void };
-
-        if (el?.blur) {
-          el.blur();
-        }
-
-        onRemoveLayer();
-      }}
-    />
+    <>
+      <EuiButtonIcon
+        size="xs"
+        iconType={isOnlyLayer ? 'eraser' : 'trash'}
+        color="danger"
+        data-test-subj="lnsLayerRemove"
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        onClick={() => {
+          if (lensLocalStorage?.skipDeleteModal) {
+            return removeLayer();
+          }
+          return showModal();
+        }}
+      />
+      {isModalVisible ? (
+        <EuiConfirmModal
+          data-test-subj="lnsLayerRemoveModal"
+          title={ariaLabel}
+          onCancel={closeModal}
+          onConfirm={() => {
+            closeModal();
+            removeLayer();
+          }}
+          cancelButtonText={i18n.translate('xpack.lens.layer.cancelDelete', {
+            defaultMessage: `No, don't remove`,
+          })}
+          confirmButtonText={i18n.translate('xpack.lens.layer.confirmDelete', {
+            defaultMessage: `Yes, remove the layer`,
+          })}
+          defaultFocusedButton="confirm"
+        >
+          <p>
+            {i18n.translate('xpack.lens.layer.confirmModal', {
+              defaultMessage: `You're about to remove the layer content.`,
+            })}
+          </p>
+          <p>
+            {i18n.translate('xpack.lens.layer.confirmModal2', {
+              defaultMessage: `Are you sure you want to do this?`,
+            })}
+          </p>
+          <EuiCheckbox
+            id={'lnsLayerRemoveModalCheckbox'}
+            label={i18n.translate('xpack.lens.layer.confirmModal.dontAskAgain', {
+              defaultMessage: `Never ask again`,
+            })}
+            indeterminate={lensLocalStorage?.skipDeleteModal}
+            onChange={onChangeShouldShowModal}
+          />
+        </EuiConfirmModal>
+      ) : null}
+    </>
   );
 }

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/remove_layer_button.tsx
@@ -215,7 +215,7 @@ const RemoveConfirmModal = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
           <EuiFlexItem>
             <EuiCheckbox
               id={'lnsLayerRemoveModalCheckbox'}

--- a/x-pack/plugins/lens/public/settings_storage.tsx
+++ b/x-pack/plugins/lens/public/settings_storage.tsx
@@ -7,12 +7,17 @@
 
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 
-const STORAGE_KEY = 'lens-settings';
+export interface LocalStorageLens {
+  indexPatternId?: string;
+  skipDeleteModal?: boolean;
+}
+
+export const LOCAL_STORAGE_LENS_KEY = 'lens-settings';
 
 export const readFromStorage = (storage: IStorageWrapper, key: string) => {
-  const data = storage.get(STORAGE_KEY);
+  const data = storage.get(LOCAL_STORAGE_LENS_KEY);
   return data && data[key];
 };
 export const writeToStorage = (storage: IStorageWrapper, key: string, value: string) => {
-  storage.set(STORAGE_KEY, { ...storage.get(STORAGE_KEY), [key]: value });
+  storage.set(LOCAL_STORAGE_LENS_KEY, { ...storage.get(LOCAL_STORAGE_LENS_KEY), [key]: value });
 };

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1215,7 +1215,13 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
 
     /** resets visualization/layer or removes a layer */
     async removeLayer() {
-      await testSubjects.click('lnsLayerRemove');
+      await retry.try(async () => {
+        await testSubjects.click('lnsLayerRemove');
+        if (await testSubjects.exists('lnsLayerRemoveModal')) {
+          await testSubjects.exists('confirmModalConfirmButton');
+          await testSubjects.click('confirmModalConfirmButton');
+        }
+      });
     },
 
     /**

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1218,8 +1218,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       await retry.try(async () => {
         await testSubjects.click('lnsLayerRemove');
         if (await testSubjects.exists('lnsLayerRemoveModal')) {
-          await testSubjects.exists('confirmModalConfirmButton');
-          await testSubjects.click('confirmModalConfirmButton');
+          await testSubjects.exists('lnsLayerRemoveConfirmButton');
+          await testSubjects.click('lnsLayerRemoveConfirmButton');
         }
       });
     },


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135253
The 'don't show this again state' is kept in local storage. 

Updated copy:
<img width="375" alt="Screenshot 2022-07-06 at 14 48 37" src="https://user-images.githubusercontent.com/4283304/177553773-e693fd10-75ac-4d36-84f2-506fa67f850e.png">
<img width="358" alt="Screenshot 2022-07-06 at 14 48 26" src="https://user-images.githubusercontent.com/4283304/177553779-a04b24ff-c174-4bc2-9953-94c9de4300ff.png">
<img width="380" alt="Screenshot 2022-07-06 at 14 48 16" src="https://user-images.githubusercontent.com/4283304/177553782-00f03d46-c333-447f-9112-51334289562d.png">
<img width="384" alt="Screenshot 2022-07-06 at 14 48 08" src="https://user-images.githubusercontent.com/4283304/177553784-ec855c6a-392c-452d-aa37-0e460b596d5e.png">


