### PR TITLE
[Security Solutions] Fix Inspect modal header should be in single linear of Host and User risk

### DIFF
--- a/x-pack/plugins/security_solution/public/hosts/components/host_risk_score_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/host_risk_score_table/index.tsx
@@ -9,6 +9,7 @@ import React, { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import styled from 'styled-components';
 import {
   Columns,
   Criteria,
@@ -45,6 +46,10 @@ export const rowItems: ItemsPerRow[] = [
     numberOfRow: 10,
   },
 ];
+
+const IconWrapper = styled.span`
+  margin-left: ${({ theme }) => theme.eui.euiSizeS};
+`;
 
 const tableType = hostsModel.HostsTableType.risk;
 
@@ -150,9 +155,9 @@ const HostRiskScoreTableComponent: React.FC<HostRiskScoreTableProps> = ({
   );
 
   const headerTitle = (
-    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-      <EuiFlexItem grow={false}>{i18nHosts.HOST_RISK_TITLE}</EuiFlexItem>
-      <EuiFlexItem grow={false}>
+    <>
+      {i18nHosts.HOST_RISK_TITLE}
+      <IconWrapper>
         <EuiIconTip
           color="subdued"
           content={i18nHosts.HOST_RISK_TABLE_TOOLTIP}
@@ -160,8 +165,8 @@ const HostRiskScoreTableComponent: React.FC<HostRiskScoreTableProps> = ({
           size="l"
           type="iInCircle"
         />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </IconWrapper>
+    </>
   );
 
   const getHostRiskScoreFilterQuerySelector = useMemo(

--- a/x-pack/plugins/security_solution/public/users/components/user_risk_score_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/user_risk_score_table/index.tsx
@@ -9,6 +9,7 @@ import React, { useMemo, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import styled from 'styled-components';
 import {
   Columns,
   Criteria,
@@ -36,6 +37,10 @@ import {
   RiskSeverity,
   UsersRiskScore,
 } from '../../../../common/search_strategy';
+
+const IconWrapper = styled.span`
+  margin-left: ${({ theme }) => theme.eui.euiSizeS};
+`;
 
 export const rowItems: ItemsPerRow[] = [
   {
@@ -154,9 +159,9 @@ const UserRiskScoreTableComponent: React.FC<UserRiskScoreTableProps> = ({
   );
 
   const headerTitle = (
-    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-      <EuiFlexItem grow={false}>{i18nUsers.NAVIGATION_RISK_TITLE}</EuiFlexItem>
-      <EuiFlexItem grow={false}>
+    <>
+      {i18nUsers.NAVIGATION_RISK_TITLE}
+      <IconWrapper>
         <EuiIconTip
           color="subdued"
           content={i18n.USER_RISK_TABLE_TOOLTIP}
@@ -164,8 +169,8 @@ const UserRiskScoreTableComponent: React.FC<UserRiskScoreTableProps> = ({
           size="l"
           type="iInCircle"
         />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </IconWrapper>
+    </>
   );
 
   const getUserRiskScoreFilterQuerySelector = useMemo(


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/134629

## Summary

Fix inspect User and Host risk Modal header to not break line.

<img width="770" alt="Screenshot 2022-07-05 at 14 44 23" src="https://user-images.githubusercontent.com/1490444/177334058-3cf6922d-bb3a-4d7c-836a-bb5f751c9d01.png">
<img width="771" alt="Screenshot 2022-07-05 at 15 02 06" src="https://user-images.githubusercontent.com/1490444/177334065-cb644ae5-a70e-4d33-8e89-7b7366826468.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

