### PR TITLE
[ci] fix ftr script when called with parallelism

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -133,7 +133,7 @@ for (const testSuite of testSuites) {
       env: {
         FTR_CONFIG: testSuite.ftrConfig,
       },
-      label: `FTR Config: ${testSuite.ftrConfig}`,
+      label: `${testSuite.ftrConfig}`,
       parallelism: testSuite.count,
       concurrency,
       concurrency_group: process.env.UUID,

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
-BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-0}
+BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-}
 FTR_CONFIG_GROUP_KEY=${FTR_CONFIG_GROUP_KEY:-}
 if [ "$FTR_CONFIG_GROUP_KEY" == "" ] && [ "$BUILDKITE_PARALLEL_JOB" == "" ]; then
   echo "Missing FTR_CONFIG_GROUP_KEY env var"


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/135349 I changed the FTR script to stop expecting the use of BK `parallelism: x` but we still using this option in the flaky test runner. Additionally, in the flaky test runner we specify the config file via the ENV rather than the artifacts. This PR updates the `ftr_configs.sh` script to handle this scenario so that when `parallelism: x` is used the `FTR_CONFIG_GROUP_KEY` env var is not required, and then if the `$configs` list can't be populated an error is logged.