### PR TITLE
[APM] Rename xpack.apm.maxServiceSelections to xpack.apm.maxServiceSelection

### DIFF
--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -99,7 +99,7 @@ export const config: PluginConfigDescriptor<APMConfig> = {
       { level: 'warning' }
     ),
     renameFromRoot(
-      'xpack.apm.maxServiceSelections',
+      'xpack.apm.maxServiceSelection',
       `uiSettings.overrides[${maxSuggestions}]`,
       { level: 'warning' }
     ),


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/130975
