### PR TITLE
[Fleet] Add separate buttons for add agent/add fleet server to prevent "stuck" states

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -89,6 +89,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents: Agent[];
   refreshAgents: (args?: { refreshTags?: boolean }) => void;
   onClickAddAgent: () => void;
+  onClickAddFleetServer: () => void;
   visibleAgents: Agent[];
 }> = ({
   agentPolicies,
@@ -111,6 +112,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents,
   refreshAgents,
   onClickAddAgent,
+  onClickAddFleetServer,
   visibleAgents,
 }) => {
   // Policies state for filtering
@@ -322,14 +324,38 @@ export const SearchAndFilterBar: React.FunctionComponent<{
               </EuiFilterGroup>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiButton
-                fill
-                iconType="plusInCircle"
-                onClick={() => onClickAddAgent()}
-                data-test-subj="addAgentButton"
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addFleetServerButton.tooltip"
+                    defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
+                  />
+                }
               >
-                <FormattedMessage id="xpack.fleet.agentList.addButton" defaultMessage="Add agent" />
-              </EuiButton>
+                <EuiButton onClick={onClickAddFleetServer} data-test-subj="addFleetServerButton">
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addFleetServerButton"
+                    defaultMessage="Add Fleet Server"
+                  />
+                </EuiButton>
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addAgentButton.tooltip"
+                    defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
+                  />
+                }
+              >
+                <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addButton"
+                    defaultMessage="Add agent"
+                  />
+                </EuiButton>
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <AgentBulkActions

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -632,6 +632,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           Promise.all([fetchData({ refreshTags }), refreshUpgrades()])
         }
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
+        onClickAddFleetServer={onClickAddFleetServer}
         visibleAgents={agents}
       />
       <EuiSpacer size="m" />

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 
 import type { AgentPolicy } from '../types';
 import { SO_SEARCH_LIMIT } from '../constants';
+import { policyHasFleetServer } from '../services';
 
 import { useGetAgentPolicies } from './use_request';
 
@@ -33,7 +34,7 @@ export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
 
   const agentPolicies = useMemo(() => {
     if (!isLoadingAgentPolicies) {
-      return agentPoliciesData?.items ?? [];
+      return (agentPoliciesData?.items ?? []).filter((policy) => !policyHasFleetServer(policy));
     }
     return [];
   }, [isLoadingAgentPolicies, agentPoliciesData?.items]);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/130892
Blocked by https://github.com/elastic/kibana/pull/135734

I've added separate "Add agent" and "Add Fleet Server" buttons as designed (see linked issue) as well as tooltips using text from elsewhere in Fleet UI or the docs. I felt the tooltips were helpful in differentiating why you might want to use each button compared to the other. I know the whole "Fleet Server" concept can be a sticking point in onboarding.

The enrollment flyout now excludes Fleet Server policies, and the Fleet Server flyout still only includes Fleet Server policies as it has always done.

## Screen recording

https://user-images.githubusercontent.com/6766512/177402922-9d8b9f0a-92ef-4f2d-98c0-3e8189e494b3.mov

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
