### PR TITLE
[doc] enclose custom drilldown URLs in single quotes

### DIFF
--- a/docs/user/graph/index.asciidoc
+++ b/docs/user/graph/index.asciidoc
@@ -179,6 +179,9 @@ in the graph toolbar to show the drilldown buttons for the selected vertices.
 To configure drilldowns, go to *Settings > Drilldowns*. See also
 <<disable-drill-down, Disabling drilldown configuration>>.
 
+
+NOTE: when creating custom drilldowns, make sure to enclose the referenced index pattern in single quotes (`'`) to avoid rison decoding errors.
+
 [float]
 [[graph-run-layout]]
 ==== Run and pause the layout

--- a/docs/user/graph/index.asciidoc
+++ b/docs/user/graph/index.asciidoc
@@ -180,7 +180,7 @@ To configure drilldowns, go to *Settings > Drilldowns*. See also
 <<disable-drill-down, Disabling drilldown configuration>>.
 
 
-NOTE: when creating custom drilldowns, make sure to enclose the referenced index pattern in single quotes (`'`) to avoid rison decoding errors.
+NOTE: When creating custom drilldowns to Kibana applications, enclose the referenced data view in single quotes (`'`) to avoid decoding errors.
 
 [float]
 [[graph-run-layout]]


### PR DESCRIPTION
Based on https://github.com/elastic/kibana/issues/134781 index patterns in custom drill-down should be enclosed into single quotes (`'`) to avoid prison decoding errors. This happens when the index pattern starts with a number instead of a letter but it is generally best practice to do it for all index patterns. This should be reflected in the documentation and should ideally be backported to all 7.x and 8.x docs as this affects all versions.