### PR TITLE
[Cloud Posture] create rules by benchmark type

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -38,3 +38,14 @@ export const INTERNAL_FEATURE_FLAGS = {
 
 export const CSP_RULE_SAVED_OBJECT_TYPE = 'csp_rule';
 export const CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE = 'csp-rule-template';
+
+export const CLOUDBEAT_VANILLA = 'cloudbeat/vanilla'; // Integration input
+export const INTEGRATION_CIS_K8S = 'cis_k8s'; // rule template benchmark id
+
+export const CLOUDBEAT_EKS = 'cloudbeat/eks'; // Integration input
+export const INTEGRATION_CIS_EKS = 'cis_eks'; // rule template benchmark id
+
+export const CIS_INTEGRATION_INPUTS_MAP = {
+  [CLOUDBEAT_VANILLA]: INTEGRATION_CIS_K8S,
+  [CLOUDBEAT_EKS]: INTEGRATION_CIS_EKS,
+} as const;

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule_metadata.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule_metadata.ts
@@ -8,7 +8,11 @@ import { schema as rt, TypeOf } from '@kbn/config-schema';
 
 export const cspRuleMetadataSchema = rt.object({
   audit: rt.string(),
-  benchmark: rt.object({ name: rt.string(), version: rt.string() }),
+  benchmark: rt.object({
+    name: rt.string(),
+    id: rt.oneOf([rt.literal('cis_k8s'), rt.literal('cis_eks')]),
+    version: rt.string(),
+  }),
   default_value: rt.maybe(rt.string()),
   description: rt.string(),
   id: rt.string(),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.test.tsx
@@ -13,7 +13,6 @@ import type { PropsOf } from '@elastic/eui';
 import Chance from 'chance';
 import type { CspFinding } from '../types';
 import { TestProvider } from '../../../test/test_provider';
-import { CIS_INTEGRATION_INPUTS_MAP } from '../../../../common/constants';
 
 const chance = new Chance();
 
@@ -33,7 +32,7 @@ const getFakeFindings = (name: string): CspFinding & { id: string } => ({
     benchmark: {
       name: 'CIS Kubernetes',
       version: '1.6.0',
-      id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'],
+      id: 'cis_k8s',
     },
     default_value: chance.sentence(),
     description: chance.paragraph(),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.test.tsx
@@ -13,6 +13,7 @@ import type { PropsOf } from '@elastic/eui';
 import Chance from 'chance';
 import type { CspFinding } from '../types';
 import { TestProvider } from '../../../test/test_provider';
+import { CIS_INTEGRATION_INPUTS_MAP } from '../../../../common/constants';
 
 const chance = new Chance();
 
@@ -32,6 +33,7 @@ const getFakeFindings = (name: string): CspFinding & { id: string } => ({
     benchmark: {
       name: 'CIS Kubernetes',
       version: '1.6.0',
+      id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'],
     },
     default_value: chance.sentence(),
     description: chance.paragraph(),

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
@@ -16,8 +16,12 @@ import {
   SavedObjectsFindResponse,
 } from '@kbn/core/server';
 import { createPackagePolicyMock, deletePackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
-import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../common/constants';
 import {
+  CIS_INTEGRATION_INPUTS_MAP,
+  CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
+} from '../../common/constants';
+import {
+  getBenchmarkInputType,
   onPackagePolicyPostCreateCallback,
   removeCspRulesInstancesCallback,
 } from './fleet_integration';
@@ -41,6 +45,7 @@ describe('create CSP rules with post package create callback', () => {
     benchmark: {
       name: 'CIS Kubernetes V1.20',
       version: 'v1.0.0',
+      id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'],
     },
     enabled: true,
     rego_rule_id: 'cis_1_2_2',
@@ -116,5 +121,49 @@ describe('create CSP rules with post package create callback', () => {
     );
 
     expect(savedObjectRepositoryMock.find.mock.calls[0][0]).toMatchObject({ perPage: 10000 });
+  });
+
+  it('get default integration type from inputs with multiple enabled types', () => {
+    const mockPackagePolicy = createPackagePolicyMock();
+
+    // Both enabled falls back to default
+    mockPackagePolicy.inputs = [
+      { type: 'cloudbeat/vanilla', enabled: true, streams: [] },
+      { type: 'cloudbeat/eks', enabled: true, streams: [] },
+    ];
+    const type = getBenchmarkInputType(mockPackagePolicy.inputs);
+    expect(type).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
+  });
+
+  it('get default integration type from inputs without any enabled types', () => {
+    const mockPackagePolicy = createPackagePolicyMock();
+
+    // None enabled falls back to default
+    mockPackagePolicy.inputs = [
+      { type: 'cloudbeat/vanilla', enabled: false, streams: [] },
+      { type: 'cloudbeat/eks', enabled: false, streams: [] },
+    ];
+    const type = getBenchmarkInputType(mockPackagePolicy.inputs);
+    expect(type).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
+  });
+
+  it('get selected integration type from inputs with a single enabled type', () => {
+    const mockPackagePolicy = createPackagePolicyMock();
+
+    // Single EKS selected
+    mockPackagePolicy.inputs = [
+      { type: 'cloudbeat/eks', enabled: true, streams: [] },
+      { type: 'cloudbeat/vanilla', enabled: false, streams: [] },
+    ];
+    const typeEks = getBenchmarkInputType(mockPackagePolicy.inputs);
+    expect(typeEks).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/eks']);
+
+    // Single k8s selected
+    mockPackagePolicy.inputs = [
+      { type: 'cloudbeat/eks', enabled: false, streams: [] },
+      { type: 'cloudbeat/vanilla', enabled: true, streams: [] },
+    ];
+    const typeK8s = getBenchmarkInputType(mockPackagePolicy.inputs);
+    expect(typeK8s).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
   });
 });

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.test.ts
@@ -16,10 +16,7 @@ import {
   SavedObjectsFindResponse,
 } from '@kbn/core/server';
 import { createPackagePolicyMock, deletePackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
-import {
-  CIS_INTEGRATION_INPUTS_MAP,
-  CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
-} from '../../common/constants';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../common/constants';
 import {
   getBenchmarkInputType,
   onPackagePolicyPostCreateCallback,
@@ -45,7 +42,7 @@ describe('create CSP rules with post package create callback', () => {
     benchmark: {
       name: 'CIS Kubernetes V1.20',
       version: 'v1.0.0',
-      id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'],
+      id: 'cis_k8s',
     },
     enabled: true,
     rego_rule_id: 'cis_1_2_2',
@@ -132,7 +129,7 @@ describe('create CSP rules with post package create callback', () => {
       { type: 'cloudbeat/eks', enabled: true, streams: [] },
     ];
     const type = getBenchmarkInputType(mockPackagePolicy.inputs);
-    expect(type).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
+    expect(type).toMatch('cis_k8s');
   });
 
   it('get default integration type from inputs without any enabled types', () => {
@@ -144,10 +141,10 @@ describe('create CSP rules with post package create callback', () => {
       { type: 'cloudbeat/eks', enabled: false, streams: [] },
     ];
     const type = getBenchmarkInputType(mockPackagePolicy.inputs);
-    expect(type).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
+    expect(type).toMatch('cis_k8s');
   });
 
-  it('get selected integration type from inputs with a single enabled type', () => {
+  it('get EKS integration type', () => {
     const mockPackagePolicy = createPackagePolicyMock();
 
     // Single EKS selected
@@ -156,7 +153,11 @@ describe('create CSP rules with post package create callback', () => {
       { type: 'cloudbeat/vanilla', enabled: false, streams: [] },
     ];
     const typeEks = getBenchmarkInputType(mockPackagePolicy.inputs);
-    expect(typeEks).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/eks']);
+    expect(typeEks).toMatch('cis_eks');
+  });
+
+  it('get Vanilla K8S integration type', () => {
+    const mockPackagePolicy = createPackagePolicyMock();
 
     // Single k8s selected
     mockPackagePolicy.inputs = [
@@ -164,6 +165,6 @@ describe('create CSP rules with post package create callback', () => {
       { type: 'cloudbeat/vanilla', enabled: true, streams: [] },
     ];
     const typeK8s = getBenchmarkInputType(mockPackagePolicy.inputs);
-    expect(typeK8s).toMatch(CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla']);
+    expect(typeK8s).toMatch('cis_k8s');
   });
 });

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -24,25 +24,23 @@ import {
   CSP_RULE_SAVED_OBJECT_TYPE,
   CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE,
 } from '../../common/constants';
-import type { CspRule, CspRuleTemplate } from '../../common/schemas';
+import type { CspRule, CspRuleMetadata, CspRuleTemplate } from '../../common/schemas';
 
-type InputsMap = typeof CIS_INTEGRATION_INPUTS_MAP;
-type Input = {
-  [K in keyof InputsMap]: { key: K; value: InputsMap[K] };
-}[keyof InputsMap];
+type CloudbeatInputType = keyof typeof CIS_INTEGRATION_INPUTS_MAP;
+type BenchmarkId = CspRuleMetadata['benchmark']['id'];
 
-const getBenchmarkTypeFilter = (type: Input['value']): string =>
+const getBenchmarkTypeFilter = (type: BenchmarkId): string =>
   `${CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE}.attributes.metadata.benchmark.id: "${type}"`;
 
 const isEnabledBenchmarkInputType = (input: PackagePolicyInput) =>
   input.type in CIS_INTEGRATION_INPUTS_MAP && !!input.enabled;
 
-export const getBenchmarkInputType = (inputs: PackagePolicy['inputs']): Input['value'] => {
+export const getBenchmarkInputType = (inputs: PackagePolicy['inputs']): BenchmarkId => {
   const enabledInputs = inputs.filter(isEnabledBenchmarkInputType);
 
   // Use the only enabled input
   if (enabledInputs.length === 1)
-    return CIS_INTEGRATION_INPUTS_MAP[enabledInputs[0].type as Input['key']];
+    return CIS_INTEGRATION_INPUTS_MAP[enabledInputs[0].type as CloudbeatInputType];
 
   // Use the the default input for multiple/none selected
   return CIS_INTEGRATION_INPUTS_MAP[CLOUDBEAT_VANILLA];

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -12,19 +12,41 @@ import type {
   SavedObjectsClientContract,
   Logger,
 } from '@kbn/core/server';
-import { PackagePolicy, DeletePackagePoliciesResponse } from '@kbn/fleet-plugin/common';
+import {
+  PackagePolicy,
+  DeletePackagePoliciesResponse,
+  PackagePolicyInput,
+} from '@kbn/fleet-plugin/common';
 import { createCspRuleSearchFilterByPackagePolicy } from '../../common/utils/helpers';
 import {
+  CLOUDBEAT_VANILLA,
+  CIS_INTEGRATION_INPUTS_MAP,
   CSP_RULE_SAVED_OBJECT_TYPE,
   CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE,
 } from '../../common/constants';
 import type { CspRule, CspRuleTemplate } from '../../common/schemas';
 
-type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends ReadonlyArray<
-  infer ElementType
->
-  ? ElementType
-  : never;
+type InputsMap = typeof CIS_INTEGRATION_INPUTS_MAP;
+type Input = {
+  [K in keyof InputsMap]: { key: K; value: InputsMap[K] };
+}[keyof InputsMap];
+
+const getBenchmarkTypeFilter = (type: Input['value']): string =>
+  `${CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE}.attributes.metadata.benchmark.id: "${type}"`;
+
+const isEnabledBenchmarkInputType = (input: PackagePolicyInput) =>
+  input.type in CIS_INTEGRATION_INPUTS_MAP && !!input.enabled;
+
+export const getBenchmarkInputType = (inputs: PackagePolicy['inputs']): Input['value'] => {
+  const enabledInputs = inputs.filter(isEnabledBenchmarkInputType);
+
+  // Use the only enabled input
+  if (enabledInputs.length === 1)
+    return CIS_INTEGRATION_INPUTS_MAP[enabledInputs[0].type as Input['key']];
+
+  // Use the the default input for multiple/none selected
+  return CIS_INTEGRATION_INPUTS_MAP[CLOUDBEAT_VANILLA];
+};
 
 /**
  * Callback to handle creation of PackagePolicies in Fleet
@@ -34,14 +56,18 @@ export const onPackagePolicyPostCreateCallback = async (
   packagePolicy: PackagePolicy,
   savedObjectsClient: SavedObjectsClientContract
 ): Promise<void> => {
+  const benchmarkType = getBenchmarkInputType(packagePolicy.inputs);
+
   // Create csp-rules from the generic asset
   const existingRuleTemplates: SavedObjectsFindResponse<CspRuleTemplate> =
     await savedObjectsClient.find({
       type: CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE,
       perPage: 10000,
+      filter: getBenchmarkTypeFilter(benchmarkType),
     });
 
   if (existingRuleTemplates.total === 0) {
+    logger.warn(`expected CSP rule templates to exists for type: ${benchmarkType}`);
     return;
   }
 
@@ -64,7 +90,7 @@ export const onPackagePolicyPostCreateCallback = async (
  * Callback to handle deletion of PackagePolicies in Fleet
  */
 export const removeCspRulesInstancesCallback = async (
-  deletedPackagePolicy: ArrayElement<DeletePackagePoliciesResponse>,
+  deletedPackagePolicy: DeletePackagePoliciesResponse[number],
   soClient: ISavedObjectsRepository,
   logger: Logger
 ): Promise<void> => {

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/mappings.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/mappings.ts
@@ -42,5 +42,20 @@ export const cspRuleSavedObjectMapping: SavedObjectsTypeMappingDefinition = {
 
 export const cspRuleTemplateSavedObjectMapping: SavedObjectsTypeMappingDefinition = {
   dynamic: false,
-  properties: {},
+  properties: {
+    metadata: {
+      type: 'object',
+      properties: {
+        benchmark: {
+          type: 'object',
+          properties: {
+            id: {
+              // Needed for filtering rule templates by benchmark.id
+              type: 'keyword',
+            },
+          },
+        },
+      },
+    },
+  },
 };

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule.ts
@@ -11,7 +11,6 @@ import {
   SavedObjectMigrationContext,
 } from '@kbn/core/server';
 import { CspRuleV830, CspRuleV840 } from '../../../common/schemas/csp_rule';
-import { CIS_INTEGRATION_INPUTS_MAP } from '../../../common/constants';
 
 function migrateCspRuleMetadata(
   doc: SavedObjectUnsanitizedDoc<CspRuleV830>,
@@ -29,7 +28,7 @@ function migrateCspRuleMetadata(
       policy_id,
       metadata: {
         ...metadata,
-        benchmark: { ...benchmark, id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'] },
+        benchmark: { ...benchmark, id: 'cis_k8s' },
         impact: metadata.impact || undefined,
         default_value: metadata.default_value || undefined,
         references: metadata.references || undefined,

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule.ts
@@ -11,13 +11,14 @@ import {
   SavedObjectMigrationContext,
 } from '@kbn/core/server';
 import { CspRuleV830, CspRuleV840 } from '../../../common/schemas/csp_rule';
+import { CIS_INTEGRATION_INPUTS_MAP } from '../../../common/constants';
 
 function migrateCspRuleMetadata(
   doc: SavedObjectUnsanitizedDoc<CspRuleV830>,
   context: SavedObjectMigrationContext
 ): SavedObjectUnsanitizedDoc<CspRuleV840> {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { enabled, muted, package_policy_id, policy_id, ...metadata } = doc.attributes;
+  const { enabled, muted, package_policy_id, policy_id, benchmark, ...metadata } = doc.attributes;
 
   return {
     ...doc,
@@ -28,6 +29,7 @@ function migrateCspRuleMetadata(
       policy_id,
       metadata: {
         ...metadata,
+        benchmark: { ...benchmark, id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'] },
         impact: metadata.impact || undefined,
         default_value: metadata.default_value || undefined,
         references: metadata.references || undefined,

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule_template.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule_template.ts
@@ -10,7 +10,6 @@ import {
   SavedObjectUnsanitizedDoc,
   SavedObjectMigrationContext,
 } from '@kbn/core/server';
-import { CIS_INTEGRATION_INPUTS_MAP } from '../../../common/constants';
 import {
   CspRuleTemplateV830,
   CspRuleTemplateV840,
@@ -28,7 +27,7 @@ function migrateCspRuleMetadata(
       muted,
       metadata: {
         ...metadata,
-        benchmark: { ...benchmark, id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'] },
+        benchmark: { ...benchmark, id: 'cis_k8s' },
         impact: metadata.impact || undefined,
         default_value: metadata.default_value || undefined,
         references: metadata.references || undefined,

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule_template.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/migrations/csp_rule_template.ts
@@ -10,6 +10,7 @@ import {
   SavedObjectUnsanitizedDoc,
   SavedObjectMigrationContext,
 } from '@kbn/core/server';
+import { CIS_INTEGRATION_INPUTS_MAP } from '../../../common/constants';
 import {
   CspRuleTemplateV830,
   CspRuleTemplateV840,
@@ -19,7 +20,7 @@ function migrateCspRuleMetadata(
   doc: SavedObjectUnsanitizedDoc<CspRuleTemplateV830>,
   context: SavedObjectMigrationContext
 ): SavedObjectUnsanitizedDoc<CspRuleTemplateV840> {
-  const { enabled, muted, ...metadata } = doc.attributes;
+  const { enabled, muted, benchmark, ...metadata } = doc.attributes;
   return {
     ...doc,
     attributes: {
@@ -27,6 +28,7 @@ function migrateCspRuleMetadata(
       muted,
       metadata: {
         ...metadata,
+        benchmark: { ...benchmark, id: CIS_INTEGRATION_INPUTS_MAP['cloudbeat/vanilla'] },
         impact: metadata.impact || undefined,
         default_value: metadata.default_value || undefined,
         references: metadata.references || undefined,


### PR DESCRIPTION
## Summary

this PR:
1. adds `benchmark.id` field (`"cis_k8s" | "cis_eks"`) to latest rule schema 
2. updates rule saved-object migration to use `cis_k8s` for existing templates and concrete rules. 
3. updates the rule templates query to filter by `benchmark.id` when creating rules, defaults to `cis_k8s` for any invalid selection 

### How to test this? 

1. use local package registry
   - setup `xpack.fleet.registryUrl: 'http://localhost:8080'` in `kibana.dev.yml` 
   - pull the [integrations PR](https://github.com/elastic/integrations/pull/3654) 
   - add an `eks` 
      - copy-paste a `cis_k8s` rule
      - change its `id` so it's unique (replace a single char)
      - change the `benchmark.id` to `cis_eks` 
   - run `elastic-package build && elastic-package stack up -v -s package-registry`
2. add a CIS integration per benchmark and verify the number of rules is `92` for `cis_k8s` and `1` for `cis_eks` 
  
 example:
![Screen Shot 2022-07-11 at 16 06 55](https://user-images.githubusercontent.com/20814186/178271181-e0acfd22-7c73-4765-aff1-0a8b671f1caf.png)

### Note 

- there is a known UX issue regarding Fleet UI going out-of-sync once we extract a single benchmark type from user selection which may include multiple benchmark types or none at all. the current approach to somewhat mitigtae this for now is to include a note: 

![Screen Shot 2022-07-11 at 15 21 33](https://user-images.githubusercontent.com/20814186/178270231-a41b7053-82e5-4070-8471-fd5181eccd7a.png)

handling this properly probably requires owning the UI using `registerExtension` which is out of scope for this PR.

- ### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


