### PR TITLE
[Synthetics]  fix delete action

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/actions.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/actions.tsx
@@ -44,6 +44,9 @@ export const Actions = ({ euiTheme, id, name, reloadPage, canEditSynthetics }: P
 
   // TODO: Move deletion logic to redux state
   useEffect(() => {
+    if (!isDeleting) {
+      return;
+    }
     if (
       monitorDeleteStatus === FETCH_STATUS.SUCCESS ||
       monitorDeleteStatus === FETCH_STATUS.FAILURE
@@ -71,7 +74,7 @@ export const Actions = ({ euiTheme, id, name, reloadPage, canEditSynthetics }: P
         { toastLifeTimeMs: 3000 }
       );
     }
-  }, [setIsDeleting, reloadPage, monitorDeleteStatus]);
+  }, [setIsDeleting, isDeleting, reloadPage, monitorDeleteStatus]);
 
   const openPopover = () => {
     setIsPopoverOpen(true);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135814

Resolves an issue where deleting monitors from the Synthetics App was crashing the page.

Testing
--
1. Navigate to the Synthetics app
2. Add a monitor
3. Navigate to Synthetics app monitors page
4. Delete the monitor
5. Monitor should be deleted successfully without crashing the page