### PR TITLE
[Flaky Tests] Event Loop Delays collector

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -56,8 +56,7 @@ const outdatedRawEventLoopDelaysDaily = [
   createRawObject(moment().subtract(7, 'days')),
 ];
 
-// FLAKY https://github.com/elastic/kibana/issues/111821
-describe.skip('daily rollups integration test', () => {
+describe('daily rollups integration test', () => {
   let esServer: TestElasticsearchUtils;
   let root: TestKibanaUtils['root'];
   let internalRepository: ISavedObjectsRepository;
@@ -70,7 +69,7 @@ describe.skip('daily rollups integration test', () => {
     await root.preboot();
     await root.setup();
     const start = await root.start();
-    logger = root.logger.get('test dailt rollups');
+    logger = root.logger.get('test daily rollups');
     internalRepository = start.savedObjects.createInternalRepository([SAVED_OBJECTS_DAILY_TYPE]);
 
     await internalRepository.bulkCreate<EventLoopDelaysDaily>(


### PR DESCRIPTION
## Summary

Resolves #111821

Flaky test runner (x100): Our flaky test runner does not support Jest Integration tests yet. I ran [a build](https://buildkite.com/elastic/kibana-pull-request/builds/55663) with a loop in the test to run it 100 times. The relevant [CI step](https://buildkite.com/elastic/kibana-pull-request/builds/55663#0181d40d-596a-40db-a613-8d9fb2149e57/6-6099) shows all 100 executions were successful.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
