### PR TITLE
[Fleet] Hide add agent/fleet server buttons when actions is shown

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -323,40 +323,47 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                 </EuiFilterButton>
               </EuiFilterGroup>
             </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiToolTip
-                content={
-                  <FormattedMessage
-                    id="xpack.fleet.agentList.addFleetServerButton.tooltip"
-                    defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
-                  />
-                }
-              >
-                <EuiButton onClick={onClickAddFleetServer} data-test-subj="addFleetServerButton">
-                  <FormattedMessage
-                    id="xpack.fleet.agentList.addFleetServerButton"
-                    defaultMessage="Add Fleet Server"
-                  />
-                </EuiButton>
-              </EuiToolTip>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiToolTip
-                content={
-                  <FormattedMessage
-                    id="xpack.fleet.agentList.addAgentButton.tooltip"
-                    defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
-                  />
-                }
-              >
-                <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
-                  <FormattedMessage
-                    id="xpack.fleet.agentList.addButton"
-                    defaultMessage="Add agent"
-                  />
-                </EuiButton>
-              </EuiToolTip>
-            </EuiFlexItem>
+            {selectedAgents.length === 0 && (
+              <>
+                <EuiFlexItem>
+                  <EuiToolTip
+                    content={
+                      <FormattedMessage
+                        id="xpack.fleet.agentList.addFleetServerButton.tooltip"
+                        defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
+                      />
+                    }
+                  >
+                    <EuiButton
+                      onClick={onClickAddFleetServer}
+                      data-test-subj="addFleetServerButton"
+                    >
+                      <FormattedMessage
+                        id="xpack.fleet.agentList.addFleetServerButton"
+                        defaultMessage="Add Fleet Server"
+                      />
+                    </EuiButton>
+                  </EuiToolTip>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiToolTip
+                    content={
+                      <FormattedMessage
+                        id="xpack.fleet.agentList.addAgentButton.tooltip"
+                        defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
+                      />
+                    }
+                  >
+                    <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
+                      <FormattedMessage
+                        id="xpack.fleet.agentList.addButton"
+                        defaultMessage="Add agent"
+                      />
+                    </EuiButton>
+                  </EuiToolTip>
+                </EuiFlexItem>
+              </>
+            )}
             <EuiFlexItem grow={false}>
               <AgentBulkActions
                 totalAgents={totalAgents}


### PR DESCRIPTION
## Summary

Since we added the separate Add Agent/Add Fleet Server buttons, the Actions button crowds the search/filter bar in the agents table when agents are selected. This PR toggles the "add" buttons and the "actions" button so only one set of buttons is shown at a time. This prevents line wrapping issues and overall crowding of the UI.

### Before

https://user-images.githubusercontent.com/6766512/177580572-bb58d06c-f60f-47c6-81c3-0cbcd6f9abcd.mov

### After

https://user-images.githubusercontent.com/6766512/177580613-bc0ce3f6-8165-4924-9e63-1e322d08a254.mov

I'm open to a better solution here, since the amount of layout shifting is still not great.

