### PR TITLE
[8.3] Add separate buttons for add agent/add fleet server (#135747)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -89,6 +89,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents: Agent[];
   refreshAgents: (args?: { refreshTags?: boolean }) => void;
   onClickAddAgent: () => void;
+  onClickAddFleetServer: () => void;
 }> = ({
   agentPolicies,
   draftKuery,
@@ -110,6 +111,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   selectedAgents,
   refreshAgents,
   onClickAddAgent,
+  onClickAddFleetServer,
 }) => {
   // Policies state for filtering
   const [isAgentPoliciesFilterOpen, setIsAgentPoliciesFilterOpen] = useState<boolean>(false);
@@ -320,14 +322,38 @@ export const SearchAndFilterBar: React.FunctionComponent<{
               </EuiFilterGroup>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiButton
-                fill
-                iconType="plusInCircle"
-                onClick={() => onClickAddAgent()}
-                data-test-subj="addAgentButton"
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addFleetServerButton.tooltip"
+                    defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
+                  />
+                }
               >
-                <FormattedMessage id="xpack.fleet.agentList.addButton" defaultMessage="Add agent" />
-              </EuiButton>
+                <EuiButton onClick={onClickAddFleetServer} data-test-subj="addFleetServerButton">
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addFleetServerButton"
+                    defaultMessage="Add Fleet Server"
+                  />
+                </EuiButton>
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addAgentButton.tooltip"
+                    defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
+                  />
+                }
+              >
+                <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.addButton"
+                    defaultMessage="Add agent"
+                  />
+                </EuiButton>
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <AgentBulkActions

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -576,6 +576,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           Promise.all([fetchData({ refreshTags }), refreshUpgrades()])
         }
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
+        onClickAddFleetServer={onClickAddFleetServer}
       />
       <EuiSpacer size="m" />
       {/* Agent total, bulk actions and status bar */}

--- a/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_agent_enrollment_flyout_data.ts
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 
 import type { AgentPolicy } from '../types';
 import { SO_SEARCH_LIMIT } from '../constants';
+import { policyHasFleetServer } from '../services';
 
 import { useGetAgentPolicies } from './use_request';
 
@@ -33,7 +34,7 @@ export function useAgentEnrollmentFlyoutData(): AgentEnrollmentFlyoutData {
 
   const agentPolicies = useMemo(() => {
     if (!isLoadingAgentPolicies) {
-      return agentPoliciesData?.items ?? [];
+      return (agentPoliciesData?.items ?? []).filter((policy) => !policyHasFleetServer(policy));
     }
     return [];
   }, [isLoadingAgentPolicies, agentPoliciesData?.items]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add separate buttons for add agent/add fleet server (#135747)](https://github.com/elastic/kibana/pull/135747)

<!--- Backport version: 8.5.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)