### PR TITLE
Update the 8.3 alerting upgrade known issue to recommend enable/disable

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -43,11 +43,12 @@ Alerting users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
 Both 8.3.0 and 8.3.1 have a bug where alerting rules that were created or edited
 in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
-example, you will need to use the *Update API key* operation in
-*{stack-manage-app} > {rules-ui}* to restore the alerting rule to a functional
-state. It should be noted that the *Update API Key* operation causes the
-alerting rule to run as the user that performed the operation. For more details
-about API key authorization, refer to <<alerting-authorization>>.
+example, you will need to go to *{stack-manage-app} > {rules-ui}*, multi-select
+the failed rules, click on **Manage rules > Disable** and then click on **Manage
+rules > Enable**. Disabling and re-enabling the rule will generate a new API Key
+using the credentials of the user performing these actions and reset the rule
+state. For more details about API Key authorization, refer to 
+<<alerting-authorization>>.
 
 Example error message::
 
@@ -116,11 +117,12 @@ Alerting users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
 Both 8.3.0 and 8.3.1 have a bug where alerting rules that were created or edited
 in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
-example, you will need to use the *Update API key* operation in
-*{stack-manage-app} > {rules-ui}* to restore the alerting rule to a functional
-state. It should be noted that the *Update API Key* operation causes the
-alerting rule to run as the user that performed the operation. For more details
-about API key authorization, refer to <<alerting-authorization>>.
+example, you will need to go to *{stack-manage-app} > {rules-ui}*, multi-select
+the failed rules, click on **Manage rules > Disable** and then click on **Manage
+rules > Enable**. Disabling and re-enabling the rule will generate a new API Key
+using the credentials of the user performing these actions and reset the rule
+state. For more details about API Key authorization, refer to 
+<<alerting-authorization>>.
 
 Example error message::
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,9 +45,9 @@ in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
 example, you will need to go to *{stack-manage-app} > {rules-ui}*, multi-select
 the failed rules, click on **Manage rules > Disable** and then click on **Manage
-rules > Enable**. Disabling and re-enabling the rule will generate a new API Key
+rules > Enable**. Disabling and re-enabling the rule will generate a new API key
 using the credentials of the user performing these actions and reset the rule
-state. For more details about API Key authorization, refer to 
+state. For more details about API key authorization, refer to 
 <<alerting-authorization>>.
 
 Example error message::
@@ -119,9 +119,9 @@ in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
 example, you will need to go to *{stack-manage-app} > {rules-ui}*, multi-select
 the failed rules, click on **Manage rules > Disable** and then click on **Manage
-rules > Enable**. Disabling and re-enabling the rule will generate a new API Key
+rules > Enable**. Disabling and re-enabling the rule will generate a new API key
 using the credentials of the user performing these actions and reset the rule
-state. For more details about API Key authorization, refer to 
+state. For more details about API key authorization, refer to 
 <<alerting-authorization>>.
 
 Example error message::


### PR DESCRIPTION
Changing the 8.3 alerting upgrade known issue to now recommend disable and then enable instead of update API Key. The enable/disable feature works with many alerting rules, while using update API Key required the user to perform this action for every single failed alerting rule.