### PR TITLE
[8.3] [Security Solution] Fix FieldBrowser dataView selector 

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
@@ -19,7 +19,7 @@ const renderUseCreateFieldButton = (props: Partial<UseCreateFieldButtonProps> = 
   renderHook<UseCreateFieldButtonProps, ReturnType<UseCreateFieldButton>>(
     () =>
       useCreateFieldButton({
-        hasFieldEditPermission: true,
+        isAllowed: true,
         loading: false,
         openFieldEditor: mockOpenFieldEditor,
         ...props,
@@ -40,7 +40,7 @@ describe('useCreateFieldButton', () => {
   });
 
   it('should return the undefined when user do not has edit permissions', async () => {
-    const { result } = renderUseCreateFieldButton({ hasFieldEditPermission: false });
+    const { result } = renderUseCreateFieldButton({ isAllowed: false });
     expect(result.current).toBeUndefined();
   });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.tsx
@@ -18,7 +18,7 @@ const StyledButton = styled(EuiButton)`
 `;
 
 export interface UseCreateFieldButtonProps {
-  hasFieldEditPermission: boolean;
+  isAllowed: boolean;
   loading: boolean;
   openFieldEditor: OpenFieldEditor;
 }
@@ -30,7 +30,7 @@ export type UseCreateFieldButton = (
  * Returns a memoised 'CreateFieldButton' with only an 'onClick' property.
  */
 export const useCreateFieldButton: UseCreateFieldButton = ({
-  hasFieldEditPermission,
+  isAllowed,
   loading,
   openFieldEditor,
 }) => {
@@ -52,5 +52,5 @@ export const useCreateFieldButton: UseCreateFieldButton = ({
     [loading, openFieldEditor]
   );
 
-  return hasFieldEditPermission ? createFieldButton : undefined;
+  return isAllowed ? createFieldButton : undefined;
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -34,6 +34,22 @@ let mockIndexPatternFieldEditor: Start;
 jest.mock('../../../common/lib/kibana');
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
+const defaultDataviewState: {
+  missingPatterns: string[];
+  selectedDataViewId: string | null;
+} = {
+  missingPatterns: [],
+  selectedDataViewId: 'security-solution',
+};
+const mockScopeIdSelector = jest.fn(() => defaultDataviewState);
+jest.mock('../../../common/store', () => {
+  const original = jest.requireActual('../../../common/store');
+  return {
+    ...original,
+    sourcererSelectors: { scopeIdSelector: () => mockScopeIdSelector },
+  };
+});
+
 const mockIndexFieldsSearch = jest.fn();
 jest.mock('../../../common/containers/source/use_data_view', () => ({
   useDataView: () => ({
@@ -100,6 +116,7 @@ describe('useFieldBrowserOptions', () => {
       ...useKibanaMock().services.application.capabilities,
       indexPatterns: { save: true },
     };
+    mockScopeIdSelector.mockReturnValue(defaultDataviewState);
     jest.clearAllMocks();
   });
 
@@ -121,6 +138,22 @@ describe('useFieldBrowserOptions', () => {
     expect(result.current.getFieldTableColumns({ highlight: '', onHide: mockOnHide })).toHaveLength(
       4
     );
+  });
+
+  it('should return the button when a dataView is selected', async () => {
+    const { result } = renderUseFieldBrowserOptions();
+
+    expect(result.current.createFieldButton).toBeDefined();
+    expect(result.current.getFieldTableColumns({ highlight: '', onHide: mockOnHide })).toHaveLength(
+      5
+    );
+  });
+
+  it('should not return the button when a dataView is not selected', () => {
+    mockScopeIdSelector.mockReturnValue({ missingPatterns: [], selectedDataViewId: null });
+    const { result } = renderUseFieldBrowserOptions();
+
+    expect(result.current.createFieldButton).toBeUndefined();
   });
 
   it('should call onHide when button is pressed', async () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
@@ -155,7 +155,7 @@ export const useFieldBrowserOptions: UseFieldBrowserOptions = ({
   );
 
   const createFieldButton = useCreateFieldButton({
-    hasFieldEditPermission,
+    isAllowed: hasFieldEditPermission && !!selectedDataViewId,
     loading: !dataView,
     openFieldEditor,
   });

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.test.tsx
@@ -9,13 +9,9 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { TestProviders, mockBrowserFields, defaultHeaders } from '../../../../mock';
-import { mockGlobalState } from '../../../../mock/global_state';
 import { tGridActions } from '../../../../store/t_grid';
 
 import { FieldsBrowser, FieldsBrowserComponentProps } from './field_browser';
-
-import { createStore, State } from '../../../../types';
-import { createSecuritySolutionStorageMock } from '../../../../mock/mock_local_storage';
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -42,7 +38,6 @@ const testProps: FieldsBrowserComponentProps = {
   filterSelectedEnabled: false,
   onFilterSelectedChange: jest.fn(),
 };
-const { storage } = createSecuritySolutionStorageMock();
 
 describe('FieldsBrowser', () => {
   beforeEach(() => {
@@ -173,40 +168,11 @@ describe('FieldsBrowser', () => {
     expect(onSearchInputChange).toBeCalledWith(inputText);
   });
 
-  test('does not render the CreateFieldButton when it is provided but does not have a dataViewId', () => {
+  test('it renders the CreateFieldButton when it is provided', () => {
     const MyTestComponent = () => <div>{'test'}</div>;
 
     const wrapper = mount(
       <TestProviders>
-        <FieldsBrowser
-          {...testProps}
-          options={{
-            createFieldButton: MyTestComponent,
-          }}
-        />
-      </TestProviders>
-    );
-
-    expect(wrapper.find(MyTestComponent).exists()).toBeFalsy();
-  });
-
-  test('it renders the CreateFieldButton when it is provided and have a dataViewId', () => {
-    const state: State = {
-      ...mockGlobalState,
-      timelineById: {
-        ...mockGlobalState.timelineById,
-        test: {
-          ...mockGlobalState.timelineById.test,
-          dataViewId: 'security-solution-default',
-        },
-      },
-    };
-    const store = createStore(state, storage);
-
-    const MyTestComponent = () => <div>{'test'}</div>;
-
-    const wrapper = mount(
-      <TestProviders store={store}>
         <FieldsBrowser
           {...testProps}
           options={{

--- a/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/toolbar/fields_browser/field_browser.tsx
@@ -123,9 +123,7 @@ const FieldsBrowserComponent: React.FC<FieldsBrowserComponentProps> = ({
   }, [onHide, restoreFocusTo]);
 
   const getManageTimeline = useMemo(() => tGridSelectors.getManageTimelineById(), []);
-  const { dataViewId, defaultColumns } = useDeepEqualSelector((state) =>
-    getManageTimeline(state, timelineId)
-  );
+  const { defaultColumns } = useDeepEqualSelector((state) => getManageTimeline(state, timelineId));
 
   const onResetColumns = useCallback(() => {
     onUpdateColumns(defaultColumns);
@@ -173,9 +171,7 @@ const FieldsBrowserComponent: React.FC<FieldsBrowserComponentProps> = ({
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {CreateFieldButton && dataViewId != null && dataViewId.length > 0 && (
-                <CreateFieldButton onHide={onHide} />
-              )}
+              {CreateFieldButton && <CreateFieldButton onHide={onHide} />}
             </EuiFlexItem>
           </EuiFlexGroup>
 


### PR DESCRIPTION
## Summary

fixes: https://github.com/elastic/kibana/issues/135827

The bug was caused by the `dataViewId` in the timeline selector being `null` when opened using "Open in timeline" button on the Alerts page.

Since the `CreateFieldButton` component is an optional prop passed to the timeline's FieldBrowser from outside, it should always render the component if it is passed, it should not have to know that the button should be rendered only if there's a dataView selected. 

To decouple the logic, the dataView conditional has been moved to the SecuritySolution's `CreateFieldButton`, the same way it has been done for 8.4. 

The SecuritySolution's sourcerer selector works correctly, and the button is displayed when the timeline is opened using "Open in timeline".


https://user-images.githubusercontent.com/17747913/177607527-ed098035-1c4f-4852-93c8-22a9ed30671c.mov

