### PR TITLE
[8.2] [CI] Install global npm modules with a retry and failsafe (#135437)

### DIFF
--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
 echo "--- Setup Node"
 
 NODE_VERSION="$(cat "$KIBANA_DIR/.node-version")"
@@ -61,14 +65,7 @@ YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yar
 export YARN_VERSION
 
 if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
-  rm -rf "$(npm root -g)/yarn" # in case the directory is in a bad state
-  if [[ ! $(npm install -g "yarn@^${YARN_VERSION}") ]]; then
-    # If this command is terminated early, e.g. because the build was cancelled in buildkite,
-    # a yarn directory is left behind in a bad state that can cause all subsequent installs to fail
-    rm -rf "$(npm root -g)/yarn"
-    echo "Trying again to install yarn..."
-    npm install -g "yarn@^${YARN_VERSION}"
-  fi
+  npm_install_global yarn "^$YARN_VERSION"
 fi
 
 yarn config set yarn-offline-mirror "$YARN_OFFLINE_CACHE"

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -7,7 +7,17 @@ source .buildkite/scripts/common/util.sh
 BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
 export BUILDKITE_TOKEN
 
-echo '--- Install buildkite dependencies'
+echo '--- Install/build buildkite dependencies'
+
+# `rm -rf <ts-node node_modules dir>; npm install -g ts-node` will cause ts-node bin files to be messed up
+# but literally just calling `npm install -g ts-node` a second time fixes it
+# this is only on newer versions of npm
+npm_install_global ts-node
+if ! ts-node --version; then
+  npm_install_global ts-node
+  ts-node --version;
+fi
+
 cd '.buildkite'
 retry 5 15 npm ci
 cd ..


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[CI] Install global npm modules with a retry and failsafe (#135437)](https://github.com/elastic/kibana/pull/135437)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Brian Seeders","email":"brian.seeders@elastic.co"},"sourceCommit":{"committedDate":"2022-06-30T14:46:47Z","message":"[CI] Install global npm modules with a retry and failsafe (#135437)","sha":"82b5d8e120c9eeb5c589966ade1beeebd1fa22ab","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","Feature:CI","v8.4.0","v8.3.1","backport:prev-minor"],"number":135437,"url":"https://github.com/elastic/kibana/pull/135437","mergeCommit":{"message":"[CI] Install global npm modules with a retry and failsafe (#135437)","sha":"82b5d8e120c9eeb5c589966ade1beeebd1fa22ab"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/135437","number":135437,"mergeCommit":{"message":"[CI] Install global npm modules with a retry and failsafe (#135437)","sha":"82b5d8e120c9eeb5c589966ade1beeebd1fa22ab"}},{"branch":"8.3","label":"v8.3.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/135563","number":135563,"state":"MERGED","mergeCommit":{"sha":"e6f38c7b2473bad12e70a584408469bfa1d4f2ef","message":"[CI] Install global npm modules with a retry and failsafe (#135437) (#135563)\n\n(cherry picked from commit 82b5d8e120c9eeb5c589966ade1beeebd1fa22ab)\n\nCo-authored-by: Brian Seeders <brian.seeders@elastic.co>"}}]}] BACKPORT-->