### PR TITLE
Switched _handle_alias and _scripted_fields to use UI settings to change date and time instead of time picker.

### DIFF
--- a/test/functional/apps/management/_scripted_fields.ts
+++ b/test/functional/apps/management/_scripted_fields.ts
@@ -256,7 +256,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should see scripted field value in Discover', async function () {
         await PageObjects.common.navigateToApp('discover');
-        // await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
 
         await PageObjects.discover.clickFieldListItem(scriptedPainlessFieldName2);
         await retry.try(async function () {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/113998

This PR migrates the management OSS tests `_handle_alias.ts` and `_scripted_fields.ts` to use UI Settings rather than time picker to set the date and time. 