### PR TITLE
[DOCS] Removes tag from 8.3.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,8 +34,6 @@ Review important information about the {kib} 8.3.x releases.
 [[release-notes-8.3.2]]
 == {kib} 8.3.2
 
-coming::[8.3.2]
-
 Review the following information about the {kib} 8.3.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 8.3.2 release notes.