### PR TITLE
Use enable/disable instead of update api key

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -93,9 +93,10 @@ Alerting users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
 Both 8.3.0 and 8.3.1 have a bug where alerting rules that were created or edited
 in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
-example, you will need to use the *Update API key* operation in
-*{stack-manage-app} > {rules-ui}* to restore the alerting rule to a functional
-state. It should be noted that the *Update API Key* operation causes the
+example, you will need to go to *Stack Management* > *Rules and Connectors*, 
+multi-select the failed rules that need to be fixed, click on *Manage rules* > *Disable*, 
+then click on *Manage rules* > *Enable* to restore the alerting rule to a functional
+state. It should be noted that the disable-enable operation causes the 
 alerting rule to run as the user that performed the operation. For more details
 about API key authorization, refer to <<alerting-authorization>>.
 
@@ -162,9 +163,10 @@ Alerting users who are running 8.2 should not upgrade to either 8.3.0 or 8.3.1.
 Both 8.3.0 and 8.3.1 have a bug where alerting rules that were created or edited
 in 8.2 will stop running on upgrade. If you have upgraded to 8.3.0 or 8.3.1 and
 your alerting rules have stopped running with an error similar to the following
-example, you will need to use the *Update API key* operation in
-*{stack-manage-app} > {rules-ui}* to restore the alerting rule to a functional
-state. It should be noted that the *Update API Key* operation causes the
+example, you will need to go to *Stack Management* > *Rules and Connectors*, 
+multi-select the failed rules that need to be fixed, click on *Manage rules* > *Disable*, 
+then click on *Manage rules* > *Enable* to restore the alerting rule to a functional
+state. It should be noted that the disable-enable operation causes the 
 alerting rule to run as the user that performed the operation. For more details
 about API key authorization, refer to <<alerting-authorization>>.
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -97,7 +97,7 @@ example, you will need to go to *Stack Management* > *Rules and Connectors*,
 multi-select the failed rules that need to be fixed, click on *Manage rules* > *Disable*, 
 then click on *Manage rules* > *Enable* to restore the alerting rule to a functional
 state. It should be noted that the disable-enable operation causes the 
-alerting rule to run as the user that performed the operation. For more details
+alerting rule to run as the user that performed the operation and reset the rule state. For more details
 about API key authorization, refer to <<alerting-authorization>>.
 
 Example error message::
@@ -167,7 +167,7 @@ example, you will need to go to *Stack Management* > *Rules and Connectors*,
 multi-select the failed rules that need to be fixed, click on *Manage rules* > *Disable*, 
 then click on *Manage rules* > *Enable* to restore the alerting rule to a functional
 state. It should be noted that the disable-enable operation causes the 
-alerting rule to run as the user that performed the operation. For more details
+alerting rule to run as the user that performed the operation and reset the rule state. For more details
 about API key authorization, refer to <<alerting-authorization>>.
 
 Example error message::


### PR DESCRIPTION
Updating release notes instructions to use enable/disable instead of update api key.  This allows users to batch update rules instead of having to click into the rule to perform the update api key one by one.
