### PR TITLE
Correct version number text in https://www.elastic.co/guide/en/kibana/7.17/upgrade-assistant.html

### DIFF
--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -10,7 +10,7 @@ The assistant identifies deprecated settings in your configuration,
 enables you to see if you are using deprecated features,
 and guides you through the process of resolving issues.
 
-IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to {prev-major-last}**.
+IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to 7.17**.
 
 If you have indices that were created prior to 7.0,
 you can use the assistant to reindex them so they can be accessed from 8.0. 


### PR DESCRIPTION
[On this page](https://www.elastic.co/guide/en/kibana/7.17/upgrade-assistant.html), looks {prev-major-last} is a placeholder but it's not working properly. So suggest to change actual version number as 7.17.

Screenshot:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/622436/177717217-ce210753-e3aa-4c9c-bf05-30d42ff9a320.png">

(I couldn't find where is the place to define placeholders...)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
