### PR TITLE
[Fleet] added tags to agent details page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -25,6 +25,7 @@ import { useKibanaVersion } from '../../../../../hooks';
 import { isAgentUpgradeable } from '../../../../../services';
 import { AgentPolicySummaryLine } from '../../../../../components';
 import { AgentHealth } from '../../../components';
+import { Tags } from '../../../agent_list_page/components/tags';
 
 // Allows child text to be truncated
 const FlexItemWithMinWidth = styled(EuiFlexItem)`
@@ -173,6 +174,12 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                   defaultMessage="Disabled"
                 />
               ),
+          },
+          {
+            title: i18n.translate('xpack.fleet.agentDetails.tagsLabel', {
+              defaultMessage: 'Tags',
+            }),
+            description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
           },
         ].map(({ title, description }) => {
           return (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/134482

Showing tags on agent details page, using the same `Tags` component that includes truncate logic with tooltip.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/90178898/177761944-e39484ac-38cc-4c5c-96d3-09f9fa775c99.png">
<img width="553" alt="image" src="https://user-images.githubusercontent.com/90178898/177762514-f5009896-467c-46d5-a313-9aff43ebf7a8.png">
<img width="545" alt="image" src="https://user-images.githubusercontent.com/90178898/177762655-8d73f3b4-db40-4a60-8ddb-fc8abdd6184b.png">
