### PR TITLE
[ML] Data Visualizer: Remove import reference for users without import privileges

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/about_panel/about_panel.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/about_panel/about_panel.tsx
@@ -26,9 +26,10 @@ import { WelcomeContent } from './welcome_content';
 
 interface Props {
   onFilePickerChange(files: FileList | null): void;
+  hasPermissionToImport: boolean;
 }
 
-export const AboutPanel: FC<Props> = ({ onFilePickerChange }) => {
+export const AboutPanel: FC<Props> = ({ onFilePickerChange, hasPermissionToImport }) => {
   return (
     <EuiPageBody
       paddingSize="none"
@@ -39,7 +40,7 @@ export const AboutPanel: FC<Props> = ({ onFilePickerChange }) => {
       <EuiPageContent hasShadow={false} hasBorder>
         <EuiFlexGroup gutterSize="xl">
           <EuiFlexItem grow={true}>
-            <WelcomeContent />
+            <WelcomeContent hasPermissionToImport={hasPermissionToImport} />
 
             <EuiHorizontalRule margin="l" />
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/about_panel/welcome_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/about_panel/welcome_content.tsx
@@ -12,7 +12,11 @@ import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText, EuiTitle } from
 
 import { useDataVisualizerKibana } from '../../../kibana_context';
 
-export const WelcomeContent: FC = () => {
+interface Props {
+  hasPermissionToImport: boolean;
+}
+
+export const WelcomeContent: FC<Props> = ({ hasPermissionToImport }) => {
   const {
     services: {
       fileUpload: { getMaxBytesFormatted },
@@ -37,10 +41,17 @@ export const WelcomeContent: FC = () => {
         <EuiSpacer size="s" />
         <EuiText>
           <p>
-            <FormattedMessage
-              id="xpack.dataVisualizer.file.welcomeContent.visualizeDataFromLogFileDescription"
-              defaultMessage="Upload your file, analyze its data, and optionally import the data into an Elasticsearch index."
-            />
+            {hasPermissionToImport ? (
+              <FormattedMessage
+                id="xpack.dataVisualizer.file.welcomeContent.visualizeAndImportDataFromLogFileDescription"
+                defaultMessage="Upload your file, analyze its data, and optionally import the data into an Elasticsearch index."
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.dataVisualizer.file.welcomeContent.visualizeDataFromLogFileDescription"
+                defaultMessage="Upload your file and analyze its data."
+              />
+            )}
           </p>
         </EuiText>
         <EuiSpacer size="s" />

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
@@ -296,7 +296,12 @@ export class FileDataVisualizerView extends Component {
       <div>
         {mode === MODE.READ && (
           <>
-            {!loading && !loaded && <AboutPanel onFilePickerChange={this.onFilePickerChange} />}
+            {!loading && !loaded && (
+              <AboutPanel
+                onFilePickerChange={this.onFilePickerChange}
+                hasPermissionToImport={hasPermissionToImport}
+              />
+            )}
 
             {loading && <LoadingPanel />}
 


### PR DESCRIPTION
## Summary

Removes reference to `import the data into an Elasticsearch index` from the about screen in the file data visualizer for users without the necessary privileges to import data. Previously the inclusion of this text for all users, regardless of privileges, might have given an incorrect impression that they could import data into an index.

Part of #106617

Users without ability to import data:
![image](https://user-images.githubusercontent.com/7405507/177784426-d1a4bca2-2168-46c9-a9d3-1c04b7dd7c11.png)

Full text displayed for users with ability to import data:
![image](https://user-images.githubusercontent.com/7405507/177784536-d32aec58-cfad-4fe5-8afb-234b3217c1bf.png)


