### PR TITLE
[Fleet] Verification status Saved Object migration

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -40,6 +40,7 @@ import { migrateInstallationToV7160, migratePackagePolicyToV7160 } from './migra
 import { migrateInstallationToV800, migrateOutputToV800 } from './migrations/to_v8_0_0';
 import { migratePackagePolicyToV820 } from './migrations/to_v8_2_0';
 import { migrateInstallationToV830, migratePackagePolicyToV830 } from './migrations/to_v8_3_0';
+import { migrateInstallationToV840 } from './migrations/to_v8_4_0';
 
 /*
  * Saved object types and mappings
@@ -268,6 +269,7 @@ const getSavedObjectTypes = (
       '7.16.0': migrateInstallationToV7160,
       '8.0.0': migrateInstallationToV800,
       '8.3.0': migrateInstallationToV830,
+      '8.4.0': migrateInstallationToV840,
     },
   },
   [ASSETS_SAVED_OBJECT_TYPE]: {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_4_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_4_0.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectMigrationFn } from '@kbn/core/server';
+
+import type { Installation } from '../../../common';
+
+export const migrateInstallationToV840: SavedObjectMigrationFn<Installation, Installation> = (
+  installationDoc
+) => {
+  installationDoc.attributes.verification_status = 'unknown';
+
+  return installationDoc;
+};


### PR DESCRIPTION
## Summary

Part of #133822

As part of the new verification feature, verification_status is a mandatory field. Setting the field to unknown does not have any effect visually.

Test steps:

- start an 8.3.0 kibana locally and install a package
- switch to this branch and restart elastic & kibana 
- run a query to see the install saved objects and see that they now all have `verification_status: "unknown"`:

```
GET /.kibana/_search?q=type:epm-packages
```
