### PR TITLE
[Discover] Fix filter in / filter out buttons for empty values 

### DIFF
--- a/src/plugins/discover/public/__mocks__/es_hits.ts
+++ b/src/plugins/discover/public/__mocks__/es_hits.ts
@@ -40,6 +40,12 @@ export const esHits = [
     _id: '5',
     _score: 1,
     _type: '_doc',
-    _source: { date: '2020-20-01T12:12:12.128', name: 'test5', extension: 'doc', bytes: 50 },
+    _source: {
+      date: '2020-20-01T12:12:12.128',
+      name: 'test5',
+      extension: 'doc',
+      bytes: 50,
+      message: '',
+    },
   },
 ];

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -164,7 +164,7 @@ export function DiscoverLayout({
   });
 
   const onAddFilter = useCallback(
-    (field: DataViewField | string, values: string, operation: '+' | '-') => {
+    (field: DataViewField | string, values: string | undefined, operation: '+' | '-') => {
       const fieldName = typeof field === 'string' ? field : field.name;
       popularizeField(indexPattern, fieldName, indexPatterns, capabilities);
       const newFilters = generateFilters(filterManager, field, values, operation, indexPattern);

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -164,7 +164,7 @@ export function DiscoverLayout({
   });
 
   const onAddFilter = useCallback(
-    (field: DataViewField | string, values: string | undefined, operation: '+' | '-') => {
+    (field: DataViewField | string, values: unknown, operation: '+' | '-') => {
       const fieldName = typeof field === 'string' ? field : field.name;
       popularizeField(indexPattern, fieldName, indexPatterns, capabilities);
       const newFilters = generateFilters(filterManager, field, values, operation, indexPattern);

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -62,6 +62,48 @@ describe('Discover cell actions ', function () {
       '+'
     );
   });
+  it('triggers filter function when FilterInBtn is clicked for a non-provided value', async () => {
+    const component = mountWithIntl(
+      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+        <FilterInBtn
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Component={(props: any) => <EuiButton {...props} />}
+          rowIndex={0}
+          colIndex={1}
+          columnId="extension"
+          isExpanded={false}
+        />
+      </DiscoverGridContext.Provider>
+    );
+    const button = findTestSubject(component, 'filterForButton');
+    await button.simulate('click');
+    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
+      discoverGridContextMock.indexPattern.fields.getByName('extension'),
+      undefined,
+      '+'
+    );
+  });
+  it('triggers filter function when FilterInBtn is clicked for an empty string value', async () => {
+    const component = mountWithIntl(
+      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+        <FilterInBtn
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Component={(props: any) => <EuiButton {...props} />}
+          rowIndex={4}
+          colIndex={1}
+          columnId="message"
+          isExpanded={false}
+        />
+      </DiscoverGridContext.Provider>
+    );
+    const button = findTestSubject(component, 'filterForButton');
+    await button.simulate('click');
+    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
+      discoverGridContextMock.indexPattern.fields.getByName('message'),
+      '',
+      '+'
+    );
+  });
   it('triggers filter function when FilterOutBtn is clicked', async () => {
     const component = mountWithIntl(
       <DiscoverGridContext.Provider value={discoverGridContextMock}>

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -25,7 +25,7 @@ function onFilterCell(
   const field = context.indexPattern.fields.getByName(columnId);
 
   if (field) {
-    context.onFilter(field, typeof value === 'undefined' ? undefined : String(value), mode);
+    context.onFilter(field, value, mode);
   }
 }
 

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -21,11 +21,11 @@ function onFilterCell(
   mode: '+' | '-'
 ) {
   const row = context.rows[rowIndex];
-  const value = String(row.flattened[columnId]);
+  const value = row.flattened[columnId];
   const field = context.indexPattern.fields.getByName(columnId);
 
-  if (value && field) {
-    context.onFilter(field, value, mode);
+  if (field) {
+    context.onFilter(field, typeof value === 'undefined' ? undefined : String(value), mode);
   }
 }
 

--- a/src/plugins/discover/public/components/doc_table/components/table_row.test.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_row.test.tsx
@@ -101,6 +101,21 @@ describe('Doc table row component', () => {
     expect(fields.length).toBe(3);
   });
 
+  it('should apply filter when pressed', () => {
+    const component = mountComponent({ ...defaultProps, columns: ['bytes'] });
+
+    const fields = findTestSubject(component, 'docTableField');
+    expect(fields.first().text()).toBe('20');
+
+    const filterInButton = findTestSubject(component, 'docTableCellFilter');
+    filterInButton.simulate('click');
+    expect(mockInlineFilter).toHaveBeenCalledWith(
+      indexPatternWithTimefieldMock.getFieldByName('bytes'),
+      20,
+      '+'
+    );
+  });
+
   describe('details row', () => {
     it('should be empty by default', () => {
       const component = mountComponent(defaultProps);

--- a/src/plugins/discover/public/components/doc_table/components/table_row.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_row.tsx
@@ -93,7 +93,7 @@ export const TableRow = ({
   const inlineFilter = useCallback(
     (column: string, type: '+' | '-') => {
       const field = indexPattern.fields.getByName(column);
-      filter(field!, row.flattened, type);
+      filter(field!, row.flattened[column], type);
     },
     [filter, indexPattern.fields, row.flattened]
   );


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/135912

## Summary

This PR fixes issues with how Filter In / Filter Out buttons are handled for empty values in cells.

- [x] In the new grid
- [x] In the legacy table

![Jul-07-2022 17-25-39](https://user-images.githubusercontent.com/1415710/177813344-49d9ee1e-737e-4941-adec-8686d3ea684c.gif)
![Jul-07-2022 17-56-52](https://user-images.githubusercontent.com/1415710/177819029-5ff1ac11-f865-4d68-ae0b-c386dda3903b.gif)



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
