### PR TITLE
Add openAPI specifications for get comments API

### DIFF
--- a/docs/api/cases/cases-api-get-comments.asciidoc
+++ b/docs/api/cases/cases-api-get-comments.asciidoc
@@ -47,12 +47,12 @@ default space is used.
 
 === {api-examples-title}
 
-Retrieves comment ID `71ec1870-725b-11ea-a0b2-c51ea50a58e2` from case ID
-`a18b38a0-71b0-11ea-a0b2-c51ea50a58e2`:
+Retrieves comment ID `8048b460-fe2b-11ec-b15d-779a7c8bbcc3` from case ID
+`ecbf8a20-fe2a-11ec-b15d-779a7c8bbcc3`:
 
 [source,sh]
 --------------------------------------------------
-GET api/cases/a18b38a0-71b0-11ea-a0b2-c51ea50a58e2/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2
+GET api/cases/ecbf8a20-fe2a-11ec-b15d-779a7c8bbcc3/comments/8048b460-fe2b-11ec-b15d-779a7c8bbcc3
 --------------------------------------------------
 // KIBANA
 
@@ -61,20 +61,20 @@ The API returns the requested comment JSON object. For example:
 [source,json]
 --------------------------------------------------
 {
-  "id":"8acb3a80-ab0a-11ec-985f-97e55adae8b9",
-  "version":"Wzc5NzYsM10=",
-  "comment":"Start operation bubblegum immediately! And chew fast!",
+  "id":"8048b460-fe2b-11ec-b15d-779a7c8bbcc3",
+  "version":"WzIzLDFd",
   "type":"user",
   "owner":"cases",
-  "created_at":"2022-03-24T00:37:10.832Z",
-  "created_by": {
-    "email": "classified@hms.oo.gov.uk",
-    "full_name": "Classified",
-    "username": "M"
-    },
-  "pushed_at": null,
-  "pushed_by": null,
-  "updated_at": null,
-  "updated_by": null
+  "comment":"A new comment",
+  "created_at":"2022-07-07T19:32:13.104Z",
+  "created_by":{
+    "email":null,
+    "full_name":null,
+    "username":"elastic"
+  },
+  "pushed_at":null,
+  "pushed_by":null,
+  "updated_at":null,
+  "updated_by":null
 }
 --------------------------------------------------

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -3313,6 +3313,129 @@
           }
         ]
       },
+      "get": {
+        "summary": "Retrieves all the comments from a case.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "deprecated": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/alert_comment_response_properties"
+                      },
+                      {
+                        "$ref": "#/components/schemas/user_comment_response_properties"
+                      }
+                    ]
+                  }
+                }
+              },
+              "examples": {}
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
+    "/api/cases/{caseId}/comments/{commentId}": {
+      "delete": {
+        "summary": "Deletes a comment or alert from a case.",
+        "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/comment_id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Indicates a successful call."
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Retrieves a comment from a case.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/comment_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/alert_comment_response_properties"
+                    },
+                    {
+                      "$ref": "#/components/schemas/user_comment_response_properties"
+                    }
+                  ]
+                },
+                "examples": {
+                  "getCaseCommentResponse": {
+                    "$ref": "#/components/examples/get_comment_response"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
       "servers": [
         {
           "url": "https://localhost:5601"
@@ -6645,6 +6768,138 @@
           }
         ]
       },
+      "get": {
+        "summary": "Retrieves all the comments from a case.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
+        "deprecated": true,
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/space_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/alert_comment_response_properties"
+                      },
+                      {
+                        "$ref": "#/components/schemas/user_comment_response_properties"
+                      }
+                    ]
+                  }
+                }
+              },
+              "examples": {}
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
+    "/s/{spaceId}/api/cases/{caseId}/comments/{commentId}": {
+      "delete": {
+        "summary": "Deletes a comment or alert from a case.",
+        "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/comment_id"
+          },
+          {
+            "$ref": "#/components/parameters/space_id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Indicates a successful call."
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "get": {
+        "summary": "Retrieves a comment from a case.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security*** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/comment_id"
+          },
+          {
+            "$ref": "#/components/parameters/space_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/alert_comment_response_properties"
+                    },
+                    {
+                      "$ref": "#/components/schemas/user_comment_response_properties"
+                    }
+                  ]
+                },
+                "examples": {
+                  "getCaseCommentResponse": {
+                    "$ref": "#/components/examples/get_comment_response"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
       "servers": [
         {
           "url": "https://localhost:5601"
@@ -6734,6 +6989,16 @@
         "schema": {
           "type": "string",
           "example": "9c235210-6834-11ea-a78c-6ffb38a34414"
+        }
+      },
+      "comment_id": {
+        "in": "path",
+        "name": "commentId",
+        "description": "The identifier for the comment. To retrieve comment IDs, use the get case or find cases APIs.\n",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "71ec1870-725b-11ea-a0b2-c51ea50a58e2"
         }
       },
       "space_id": {
@@ -7580,6 +7845,26 @@
             "fields": null
           },
           "external_service": null
+        }
+      },
+      "get_comment_response": {
+        "summary": "A single user comment retrieved from a case",
+        "value": {
+          "id": "8048b460-fe2b-11ec-b15d-779a7c8bbcc3",
+          "version": "WzIzLDFd",
+          "type": "user",
+          "owner": "cases",
+          "comment": "A new comment",
+          "created_at": "2022-07-07T19:32:13.104Z",
+          "created_by": {
+            "email": null,
+            "full_name": null,
+            "username": "elastic"
+          },
+          "pushed_at": null,
+          "pushed_by": null,
+          "updated_at": null,
+          "updated_by": null
         }
       }
     }

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -2751,6 +2751,81 @@ paths:
                   $ref: '#/components/examples/update_comment_response'
       servers:
         - url: https://localhost:5601
+    get:
+      summary: Retrieves all the comments from a case.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases with the
+        comments you're seeking.
+      tags:
+        - cases
+        - kibana
+      deprecated: true
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/alert_comment_response_properties'
+                    - $ref: '#/components/schemas/user_comment_response_properties'
+            examples: {}
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+  /api/cases/{caseId}/comments/{commentId}:
+    delete:
+      summary: Deletes a comment or alert from a case.
+      description: >
+        You must have `all` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're deleting.
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/comment_id'
+      responses:
+        '204':
+          description: Indicates a successful call.
+      servers:
+        - url: https://localhost:5601
+    get:
+      summary: Retrieves a comment from a case.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases with the
+        comments you're seeking.
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/comment_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/alert_comment_response_properties'
+                  - $ref: '#/components/schemas/user_comment_response_properties'
+              examples:
+                getCaseCommentResponse:
+                  $ref: '#/components/examples/get_comment_response'
+      servers:
+        - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
   /s/{spaceId}/api/cases:
@@ -5507,6 +5582,84 @@ paths:
                   $ref: '#/components/examples/update_comment_response'
       servers:
         - url: https://localhost:5601
+    get:
+      summary: Retrieves all the comments from a case.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases with the
+        comments you're seeking.
+      deprecated: true
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/space_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/alert_comment_response_properties'
+                    - $ref: '#/components/schemas/user_comment_response_properties'
+            examples: {}
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+  /s/{spaceId}/api/cases/{caseId}/comments/{commentId}:
+    delete:
+      summary: Deletes a comment or alert from a case.
+      description: >
+        You must have `all` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're deleting.
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/comment_id'
+        - $ref: '#/components/parameters/space_id'
+      responses:
+        '204':
+          description: Indicates a successful call.
+      servers:
+        - url: https://localhost:5601
+    get:
+      summary: Retrieves a comment from a case.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security*** section of the
+        Kibana feature privileges, depending on the owner of the cases with the
+        comments you're seeking.
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/comment_id'
+        - $ref: '#/components/parameters/space_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/alert_comment_response_properties'
+                  - $ref: '#/components/schemas/user_comment_response_properties'
+              examples:
+                getCaseCommentResponse:
+                  $ref: '#/components/examples/get_comment_response'
+      servers:
+        - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
 components:
@@ -5576,6 +5729,16 @@ components:
       schema:
         type: string
         example: 9c235210-6834-11ea-a78c-6ffb38a34414
+    comment_id:
+      in: path
+      name: commentId
+      description: >
+        The identifier for the comment. To retrieve comment IDs, use the get
+        case or find cases APIs.
+      required: true
+      schema:
+        type: string
+        example: 71ec1870-725b-11ea-a0b2-c51ea50a58e2
     space_id:
       in: path
       name: spaceId
@@ -6278,6 +6441,23 @@ components:
           type: .none
           fields: null
         external_service: null
+    get_comment_response:
+      summary: A single user comment retrieved from a case
+      value:
+        id: 8048b460-fe2b-11ec-b15d-779a7c8bbcc3
+        version: WzIzLDFd
+        type: user
+        owner: cases
+        comment: A new comment
+        created_at: '2022-07-07T19:32:13.104Z'
+        created_by:
+          email: null
+          full_name: null
+          username: elastic
+        pushed_at: null
+        pushed_by: null
+        updated_at: null
+        updated_by: null
 security:
   - basicAuth: []
   - apiKeyAuth: []

--- a/x-pack/plugins/cases/docs/openapi/components/examples/get_comment_response.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/examples/get_comment_response.yaml
@@ -1,0 +1,19 @@
+summary: A single user comment retrieved from a case
+value: 
+  {
+    "id":"8048b460-fe2b-11ec-b15d-779a7c8bbcc3",
+    "version":"WzIzLDFd",
+    "type":"user",
+    "owner":"cases",
+    "comment":"A new comment",
+    "created_at":"2022-07-07T19:32:13.104Z",
+    "created_by":{
+      "email":null,
+      "full_name":null,
+      "username":"elastic"
+    },
+    "pushed_at":null,
+    "pushed_by":null,
+    "updated_at":null,
+    "updated_by":null
+  }

--- a/x-pack/plugins/cases/docs/openapi/components/parameters/comment_id.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/parameters/comment_id.yaml
@@ -1,7 +1,9 @@
 in: path
 name: commentId
-description: The identifier for the comment. To retrieve comment IDs, use the get case or find cases APIs. If it is not specified, all comments are deleted.
-required: false 
+description: >
+  The identifier for the comment. To retrieve comment IDs, use the get case or
+  find cases APIs.
+required: true 
 schema:
   type: string
   example: '71ec1870-725b-11ea-a0b2-c51ea50a58e2'

--- a/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
@@ -41,8 +41,8 @@ paths:
 #    $ref: 'paths/api@cases@{caseid}@alerts.yaml'
   '/api/cases/{caseId}/comments':
     $ref: 'paths/api@cases@{caseid}@comments.yaml'
-#  '/api/cases/{caseId}/comments/{commentId}':
-#    $ref: 'paths/api@cases@{caseid}@comments@{commentid}.yaml'
+  '/api/cases/{caseId}/comments/{commentId}':
+    $ref: 'paths/api@cases@{caseid}@comments@{commentid}.yaml'
 #  '/api/cases/{caseId}/connector/{connectorId}/_push':
 #    $ref: 'paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml'
 #  '/api/cases/{caseId}/user_actions':
@@ -72,8 +72,8 @@ paths:
  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml'
   '/s/{spaceId}/api/cases/{caseId}/comments':
     $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments.yaml'
-#  '/s/{spaceId}/api/cases/{caseId}/comments/{commentId}':
-#    $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml'
+  '/s/{spaceId}/api/cases/{caseId}/comments/{commentId}':
+    $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml'
  # '/s/{spaceId}/api/cases/{caseId}/connector/{connectorId}/_push':
  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@connector@{connectorid}@_push.yaml'
  # '/s/{spaceId}/api/cases/{caseId}/user_actions':

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
@@ -92,9 +92,14 @@ patch:
         - url: https://localhost:5601
 
 get:
+  summary: Retrieves all the comments from a case.
   description: >
-    Retrieves all the comments from a case.
-    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+    You must have `read` privileges for the **Cases** feature in the **Management**,
+    **Observability**, or **Security** section of the Kibana feature privileges,
+    depending on the owner of the cases with the comments you're seeking.
+  tags:
+    - cases
+    - kibana
   deprecated: true
   parameters:
     - $ref: ../components/parameters/case_id.yaml
@@ -104,7 +109,11 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
+            type: array
+            items:
+              anyOf:
+                - $ref: '../components/schemas/alert_comment_response_properties.yaml'
+                - $ref: '../components/schemas/user_comment_response_properties.yaml'
         examples: {}
   servers:
     - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
@@ -91,5 +91,23 @@ patch:
   servers:
         - url: https://localhost:5601
 
+get:
+  description: >
+    Retrieves all the comments from a case.
+    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+  deprecated: true
+  parameters:
+    - $ref: ../components/parameters/case_id.yaml
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+
 servers:
       - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
@@ -17,5 +17,23 @@ delete:
   servers:
     - url: https://localhost:5601
 
+get:
+  description: >
+    Retrieves a comment from a case.
+    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+  parameters:
+    - $ref: '../components/parameters/case_id.yaml'
+    - $ref: '../components/parameters/comment_id.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+
 servers:
       - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
@@ -18,9 +18,14 @@ delete:
     - url: https://localhost:5601
 
 get:
+  summary: Retrieves a comment from a case.
   description: >
-    Retrieves a comment from a case.
-    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+    You must have `read` privileges for the **Cases** feature in the **Management**,
+    **Observability**, or **Security** section of the Kibana feature privileges,
+    depending on the owner of the cases with the comments you're seeking.
+  tags:
+    - cases
+    - kibana
   parameters:
     - $ref: '../components/parameters/case_id.yaml'
     - $ref: '../components/parameters/comment_id.yaml'
@@ -30,8 +35,12 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
-        examples: {}
+            oneOf:
+              - $ref: '../components/schemas/alert_comment_response_properties.yaml'
+              - $ref: '../components/schemas/user_comment_response_properties.yaml'
+          examples:
+           getCaseCommentResponse:
+              $ref: '../components/examples/get_comment_response.yaml'
   servers:
     - url: https://localhost:5601
 

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
@@ -94,5 +94,24 @@ patch:
   servers:
         - url: https://localhost:5601
 
+get:
+  description: >
+    Retrieves all the comments from a case.
+    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+  deprecated: true
+  parameters:
+    - $ref: '../components/parameters/case_id.yaml'
+    - $ref: '../components/parameters/space_id.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+
 servers:
       - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
@@ -95,10 +95,15 @@ patch:
         - url: https://localhost:5601
 
 get:
+  summary: Retrieves all the comments from a case.
   description: >
-    Retrieves all the comments from a case.
-    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+    You must have `read` privileges for the **Cases** feature in the **Management**,
+    **Observability**, or **Security** section of the Kibana feature privileges,
+    depending on the owner of the cases with the comments you're seeking.
   deprecated: true
+  tags:
+    - cases
+    - kibana
   parameters:
     - $ref: '../components/parameters/case_id.yaml'
     - $ref: '../components/parameters/space_id.yaml'
@@ -108,7 +113,11 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
+            type: array
+            items:
+              anyOf:
+                - $ref: '../components/schemas/alert_comment_response_properties.yaml'
+                - $ref: '../components/schemas/user_comment_response_properties.yaml'
         examples: {}
   servers:
     - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
@@ -18,5 +18,24 @@ delete:
   servers:
     - url: https://localhost:5601
 
+get:
+  description: >
+    Retrieves a comment from a case.
+    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security*** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+  parameters:
+    - $ref: '../components/parameters/case_id.yaml'
+    - $ref: '../components/parameters/comment_id.yaml'
+    - $ref: '../components/parameters/space_id.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+
 servers:
       - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
@@ -19,9 +19,14 @@ delete:
     - url: https://localhost:5601
 
 get:
+  summary: Retrieves a comment from a case.
   description: >
-    Retrieves a comment from a case.
-    You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security*** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
+    You must have `read` privileges for the **Cases** feature in the **Management**,
+    **Observability**, or **Security*** section of the Kibana feature privileges,
+    depending on the owner of the cases with the comments you're seeking.
+  tags:
+    - cases
+    - kibana
   parameters:
     - $ref: '../components/parameters/case_id.yaml'
     - $ref: '../components/parameters/comment_id.yaml'
@@ -32,8 +37,12 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
-        examples: {}
+            oneOf:
+              - $ref: '../components/schemas/alert_comment_response_properties.yaml'
+              - $ref: '../components/schemas/user_comment_response_properties.yaml'
+          examples:
+            getCaseCommentResponse:
+              $ref: '../components/examples/get_comment_response.yaml'
   servers:
     - url: https://localhost:5601
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/133345, https://github.com/elastic/kibana/issues/132473

This PR copies the layout used in https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/common/openapi to model the following API: https://www.elastic.co/guide/en/kibana/master/cases-api-get-comments.html

It also removes pop culture references from the API example.

### Preview

https://kibana_135921.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-get-comments.html