### PR TITLE
[Fleet] Display package verification status

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -4082,6 +4082,9 @@
                 "encrypted_saved_object_encryption_key_required"
               ]
             }
+          },
+          "package_verification_key_id": {
+            "type": "string"
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2557,6 +2557,8 @@ components:
             type: string
             enum:
               - encrypted_saved_object_encryption_key_required
+        package_verification_key_id:
+          type: string
       required:
         - isReady
         - missing_requirements

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_status_response.yaml
@@ -18,6 +18,8 @@ properties:
       type: string
       enum:
         - 'encrypted_saved_object_encryption_key_required'
+  package_verification_key_id: 
+    type: string
 required:
   - isReady
   - missing_requirements

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -406,7 +406,8 @@ export interface IntegrationCardItem {
   id: string;
   categories: string[];
   fromIntegrations?: string;
-  isUnverified: boolean;
+  isUnverified?: boolean;
+  showLabels?: boolean;
 }
 
 export type PackageVerificationStatus = 'verified' | 'unverified' | 'unknown';

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -406,6 +406,7 @@ export interface IntegrationCardItem {
   id: string;
   categories: string[];
   fromIntegrations?: string;
+  isUnverified: boolean;
 }
 
 export type PackageVerificationStatus = 'verified' | 'unverified' | 'unknown';

--- a/x-pack/plugins/fleet/common/types/rest_spec/error.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/error.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type FleetErrorType = 'verification_failed';
+
+export interface FleetErrorResponse {
+  message: string;
+  statusCode: number;
+  attributes?: {
+    type?: FleetErrorType;
+  };
+}

--- a/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/fleet_setup.ts
@@ -16,4 +16,5 @@ export interface GetFleetStatusResponse {
     'security_required' | 'tls_required' | 'api_keys' | 'fleet_admin_user' | 'fleet_server'
   >;
   missing_optional_features: Array<'encrypted_saved_object_encryption_key_required'>;
+  package_verification_key_id?: string;
 }

--- a/x-pack/plugins/fleet/common/types/rest_spec/index.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/index.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-export * from './common';
-export * from './package_policy';
-export * from './data_stream';
-export * from './agent';
 export * from './agent_policy';
-export * from './fleet_setup';
-export * from './epm';
-export * from './enrollment_api_key';
-export * from './output';
-export * from './settings';
+export * from './agent';
 export * from './app';
+export * from './common';
+export * from './data_stream';
 export * from './download_sources';
+export * from './enrollment_api_key';
+export * from './epm';
+export * from './error';
+export * from './fleet_setup';
+export * from './output';
+export * from './package_policy';
+export * from './settings';

--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -20,83 +20,83 @@ const TabBadge = styled(EuiBadge)`
   margin-left: 4px;
 `;
 
-const TabTitle: React.FC<{ title: JSX.Element; hasWarning: boolean }> = ({ title, hasWarning }) => {
-  return (
-    <>
-      {title}
-      {hasWarning && <TabBadge color="warning" iconType="alert" />}
-    </>
-  );
-};
+const TabTitle: React.FC<{ title: JSX.Element; hasWarning: boolean }> = memo(
+  ({ title, hasWarning }) => {
+    return (
+      <>
+        {title}
+        {hasWarning && <TabBadge color="warning" iconType="alert" />}
+      </>
+    );
+  }
+);
 interface Props {
   section?: Section;
   children?: React.ReactNode;
   sectionsWithWarning?: Section[];
 }
 
-export const DefaultLayout: React.FunctionComponent<Props> = memo(
-  ({ section, children, sectionsWithWarning }) => {
-    const { getHref } = useLink();
-    const tabs = [
-      {
-        name: (
-          <FormattedMessage
-            id="xpack.fleet.appNavigation.integrationsAllLinkText"
-            defaultMessage="Browse integrations"
-          />
-        ),
-        section: 'browse' as Section,
-        href: getHref('integrations_all'),
-      },
-      {
-        name: (
-          <FormattedMessage
-            id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
-            defaultMessage="Installed integrations"
-          />
-        ),
-        section: 'manage' as Section,
-        href: getHref('integrations_installed'),
-      },
-    ];
+export const DefaultLayout: React.FC<Props> = memo(({ section, children, sectionsWithWarning }) => {
+  const { getHref } = useLink();
+  const tabs = [
+    {
+      name: (
+        <FormattedMessage
+          id="xpack.fleet.appNavigation.integrationsAllLinkText"
+          defaultMessage="Browse integrations"
+        />
+      ),
+      section: 'browse' as Section,
+      href: getHref('integrations_all'),
+    },
+    {
+      name: (
+        <FormattedMessage
+          id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
+          defaultMessage="Installed integrations"
+        />
+      ),
+      section: 'manage' as Section,
+      href: getHref('integrations_installed'),
+    },
+  ];
 
-    return (
-      <WithHeaderLayout
-        leftColumn={
-          <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
-            <EuiText>
-              <h1>
+  return (
+    <WithHeaderLayout
+      leftColumn={
+        <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
+          <EuiText>
+            <h1>
+              <FormattedMessage
+                id="xpack.fleet.integrationsHeaderTitle"
+                defaultMessage="Integrations"
+              />
+            </h1>
+          </EuiText>
+
+          <EuiSpacer size="s" />
+
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" color="subdued">
+              <p>
                 <FormattedMessage
-                  id="xpack.fleet.integrationsHeaderTitle"
-                  defaultMessage="Integrations"
+                  id="xpack.fleet.epm.pageSubtitle"
+                  defaultMessage="Choose an integration to start collecting and analyzing your data."
                 />
-              </h1>
+              </p>
             </EuiText>
-
-            <EuiSpacer size="s" />
-
-            <EuiFlexItem grow={false}>
-              <EuiText size="s" color="subdued">
-                <p>
-                  <FormattedMessage
-                    id="xpack.fleet.epm.pageSubtitle"
-                    defaultMessage="Choose an integration to start collecting and analyzing your data."
-                  />
-                </p>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
-        tabs={tabs.map((tab) => ({
-          name: (
-            <TabTitle title={tab.name} hasWarning={!!sectionsWithWarning?.includes(tab.section)} />
-          ),
-          href: tab.href,
-          isSelected: section === tab.section,
-        }))}
-      >
-        {children}
-      </WithHeaderLayout>
-    );
-  }
-);
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+      tabs={tabs.map((tab) => ({
+        name: (
+          <TabTitle title={tab.name} hasWarning={!!sectionsWithWarning?.includes(tab.section)} />
+        ),
+        href: tab.href,
+        isSelected: section === tab.section,
+      }))}
+    >
+      {children}
+    </WithHeaderLayout>
+  );
+});

--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -5,73 +5,98 @@
  * 2.0.
  */
 import React, { memo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiBadge, EuiSpacer, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+
+import styled from 'styled-components';
 
 import { useLink } from '../../../hooks';
 import type { Section } from '../sections';
 
 import { WithHeaderLayout } from '.';
 
+const TabBadge = styled(EuiBadge)`
+  padding: 0 1px;
+  margin-left: 4px;
+`;
+
+const TabTitle: React.FC<{ title: JSX.Element; hasWarning: boolean }> = ({ title, hasWarning }) => {
+  return (
+    <>
+      {title}
+      {hasWarning && <TabBadge color="warning" iconType="alert" />}
+    </>
+  );
+};
 interface Props {
   section?: Section;
   children?: React.ReactNode;
+  sectionsWithWarning?: Section[];
 }
 
-export const DefaultLayout: React.FunctionComponent<Props> = memo(({ section, children }) => {
-  const { getHref } = useLink();
+export const DefaultLayout: React.FunctionComponent<Props> = memo(
+  ({ section, children, sectionsWithWarning }) => {
+    const { getHref } = useLink();
+    const tabs = [
+      {
+        name: (
+          <FormattedMessage
+            id="xpack.fleet.appNavigation.integrationsAllLinkText"
+            defaultMessage="Browse integrations"
+          />
+        ),
+        section: 'browse' as Section,
+        href: getHref('integrations_all'),
+      },
+      {
+        name: (
+          <FormattedMessage
+            id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
+            defaultMessage="Installed integrations"
+          />
+        ),
+        section: 'manage' as Section,
+        href: getHref('integrations_installed'),
+      },
+    ];
 
-  return (
-    <WithHeaderLayout
-      leftColumn={
-        <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
-          <EuiText>
-            <h1>
-              <FormattedMessage
-                id="xpack.fleet.integrationsHeaderTitle"
-                defaultMessage="Integrations"
-              />
-            </h1>
-          </EuiText>
-
-          <EuiSpacer size="s" />
-
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              <p>
+    return (
+      <WithHeaderLayout
+        leftColumn={
+          <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
+            <EuiText>
+              <h1>
                 <FormattedMessage
-                  id="xpack.fleet.epm.pageSubtitle"
-                  defaultMessage="Choose an integration to start collecting and analyzing your data."
+                  id="xpack.fleet.integrationsHeaderTitle"
+                  defaultMessage="Integrations"
                 />
-              </p>
+              </h1>
             </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      tabs={[
-        {
+
+            <EuiSpacer size="s" />
+
+            <EuiFlexItem grow={false}>
+              <EuiText size="s" color="subdued">
+                <p>
+                  <FormattedMessage
+                    id="xpack.fleet.epm.pageSubtitle"
+                    defaultMessage="Choose an integration to start collecting and analyzing your data."
+                  />
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        tabs={tabs.map((tab) => ({
           name: (
-            <FormattedMessage
-              id="xpack.fleet.appNavigation.integrationsAllLinkText"
-              defaultMessage="Browse integrations"
-            />
+            <TabTitle title={tab.name} hasWarning={!!sectionsWithWarning?.includes(tab.section)} />
           ),
-          isSelected: section === 'browse',
-          href: getHref('integrations_all'),
-        },
-        {
-          name: (
-            <FormattedMessage
-              id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
-              defaultMessage="Installed integrations"
-            />
-          ),
-          isSelected: section === 'manage',
-          href: getHref('integrations_installed'),
-        },
-      ]}
-    >
-      {children}
-    </WithHeaderLayout>
-  );
-});
+          href: tab.href,
+          isSelected: section === tab.section,
+        }))}
+      >
+        {children}
+      </WithHeaderLayout>
+    );
+  }
+);

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.stories.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.stories.tsx
@@ -7,10 +7,6 @@
 
 import React from 'react';
 
-import type { SavedObject } from '@kbn/core/public';
-
-import type { Installation } from '../../../../../../common';
-
 import type { PackageCardProps } from './package_card';
 import { PackageCard } from './package_card';
 
@@ -19,7 +15,7 @@ export default {
   description: 'A card representing a package available in Fleet',
 };
 
-type Args = Omit<PackageCardProps, 'status'> & { width: number };
+type Args = PackageCardProps & { width: number };
 
 const args: Args = {
   width: 280,
@@ -33,6 +29,7 @@ const args: Args = {
   icons: [],
   integration: '',
   categories: ['foobar'],
+  isUnverified: false,
 };
 
 const argTypes = {
@@ -42,48 +39,23 @@ const argTypes = {
       options: ['ga', 'beta', 'experimental'],
     },
   },
+  isUnverified: {
+    control: 'boolean',
+  },
 };
 
-export const NotInstalled = ({ width, ...props }: Args) => (
+export const AvailablePackage = ({ width, ...props }: Args) => (
   <div style={{ width }}>
-    {/*
- // @ts-ignore */}
-    <PackageCard {...props} status="not_installed" />
+    <PackageCard {...props} showLabels={false} />
   </div>
 );
+AvailablePackage.args = args;
+AvailablePackage.argTypes = argTypes;
 
-export const Installed = ({ width, ...props }: Args) => {
-  const savedObject: SavedObject<Installation> = {
-    id: props.id,
-    // @ts-expect-error
-    type: props.type || '',
-    attributes: {
-      name: props.name,
-      version: props.version,
-      install_version: props.version,
-      es_index_patterns: {},
-      installed_kibana: [],
-      installed_kibana_space_id: 'default',
-      installed_es: [],
-      install_status: 'installed',
-      install_source: 'registry',
-      install_started_at: '2020-01-01T00:00:00.000Z',
-      keep_policies_up_to_date: false,
-      verification_status: 'unknown',
-    },
-    references: [],
-  };
-
-  return (
-    <div style={{ width }}>
-      {/*
- // @ts-ignore */}
-      <PackageCard {...props} status="installed" savedObject={savedObject} />
-    </div>
-  );
-};
-
-NotInstalled.args = args;
-NotInstalled.argTypes = argTypes;
-Installed.args = args;
-Installed.argTypes = argTypes;
+export const InstalledPackage = ({ width, ...props }: Args) => (
+  <div style={{ width }}>
+    <PackageCard {...props} showLabels={true} />
+  </div>
+);
+InstalledPackage.args = args;
+InstalledPackage.argTypes = argTypes;

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { EuiBadge, EuiCard, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiBadge, EuiCard, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
@@ -56,8 +56,10 @@ export function PackageCard({
     );
   }
 
+  let verifiedBadge: React.ReactNode | null = null;
+
   if (isUnverified && showLabels) {
-    releaseBadge = (
+    verifiedBadge = (
       <EuiFlexItem grow={false}>
         <EuiSpacer size="xs" />
         <span>
@@ -105,7 +107,10 @@ export function PackageCard({
         }
         onClick={onCardClick}
       >
-        {releaseBadge}
+        <EuiFlexGroup gutterSize="xs">
+          {verifiedBadge}
+          {releaseBadge}
+        </EuiFlexGroup>
       </Card>
     </TrackApplicationView>
   );

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -41,6 +41,7 @@ export function PackageCard({
   id,
   fromIntegrations,
   isUnverified,
+  showLabels = true,
 }: PackageCardProps) {
   let releaseBadge: React.ReactNode | null = null;
 
@@ -55,7 +56,7 @@ export function PackageCard({
     );
   }
 
-  if (isUnverified) {
+  if (isUnverified && showLabels) {
     releaseBadge = (
       <EuiFlexItem grow={false}>
         <EuiSpacer size="xs" />

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -7,9 +7,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { EuiCard, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiBadge, EuiCard, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
+
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { CardIcon } from '../../../../../components/package_icon';
 import type { IntegrationCardItem } from '../../../../../../common/types/models/epm';
@@ -38,6 +40,7 @@ export function PackageCard({
   release,
   id,
   fromIntegrations,
+  isUnverified,
 }: PackageCardProps) {
   let releaseBadge: React.ReactNode | null = null;
 
@@ -47,6 +50,19 @@ export function PackageCard({
         <EuiSpacer size="xs" />
         <span>
           <CardReleaseBadge release={release} />
+        </span>
+      </EuiFlexItem>
+    );
+  }
+
+  if (isUnverified) {
+    releaseBadge = (
+      <EuiFlexItem grow={false}>
+        <EuiSpacer size="xs" />
+        <span>
+          <EuiBadge color="warning">
+            <FormattedMessage id="packageCard.unverifiedLabel" defaultMessage="Unverified" />
+          </EuiBadge>
         </span>
       </EuiFlexItem>
     );

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -64,7 +64,10 @@ export function PackageCard({
         <EuiSpacer size="xs" />
         <span>
           <EuiBadge color="warning">
-            <FormattedMessage id="packageCard.unverifiedLabel" defaultMessage="Unverified" />
+            <FormattedMessage
+              id="xpack.fleet.packageCard.unverifiedLabel"
+              defaultMessage="Unverified"
+            />
           </EuiBadge>
         </span>
       </EuiFlexItem>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
@@ -39,6 +39,7 @@ export interface Props {
   onSearchChange: (search: string) => void;
   showMissingIntegrationMessage?: boolean;
   callout?: JSX.Element | null;
+  showCardLabels?: boolean;
 }
 
 export const PackageListGrid: FunctionComponent<Props> = ({
@@ -52,6 +53,7 @@ export const PackageListGrid: FunctionComponent<Props> = ({
   showMissingIntegrationMessage = false,
   featuredList = null,
   callout,
+  showCardLabels = true,
 }) => {
   const [searchTerm, setSearchTerm] = useState(initialSearch || '');
   const localSearchRef = useLocalSearch(list);
@@ -104,6 +106,7 @@ export const PackageListGrid: FunctionComponent<Props> = ({
       <GridColumn
         list={filteredList}
         showMissingIntegrationMessage={showMissingIntegrationMessage}
+        showCardLabels={showCardLabels}
       />
     );
   }
@@ -180,16 +183,21 @@ function ControlsColumn({ controls, title, sticky }: ControlsColumnProps) {
 interface GridColumnProps {
   list: IntegrationCardItem[];
   showMissingIntegrationMessage?: boolean;
+  showCardLabels?: boolean;
 }
 
-function GridColumn({ list, showMissingIntegrationMessage = false }: GridColumnProps) {
+function GridColumn({
+  list,
+  showMissingIntegrationMessage = false,
+  showCardLabels = false,
+}: GridColumnProps) {
   return (
     <EuiFlexGrid gutterSize="l" columns={3}>
       {list.length ? (
         list.map((item) => {
           return (
             <EuiFlexItem key={item.id}>
-              <PackageCard {...item} />
+              <PackageCard {...item} showLabels={showCardLabels} />
             </EuiFlexItem>
           );
         })

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -7,15 +7,11 @@
 import React, { memo, useMemo } from 'react';
 import styled from 'styled-components';
 import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-
 import { i18n } from '@kbn/i18n';
-
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useFleetStatus } from '../../../../../../../hooks';
-
 import { isPackageUnverified } from '../../../../../../../services';
-
 import type { PackageInfo, RegistryPolicyTemplate } from '../../../../../types';
 
 import { Screenshots } from './screenshots';

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -6,7 +6,15 @@
  */
 import React, { memo, useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { useFleetStatus } from '../../../../../../../hooks';
+
+import { isPackageUnverified } from '../../../../../../../services';
 
 import type { PackageInfo, RegistryPolicyTemplate } from '../../../../../types';
 
@@ -26,16 +34,39 @@ const LeftColumn = styled(EuiFlexItem)`
   }
 `;
 
+const UnverifiedCallout = () => (
+  <>
+    <EuiCallOut
+      title={i18n.translate('xpack.fleet.epm.verificationWarningCalloutTitle', {
+        defaultMessage: 'This integration is not verified',
+      })}
+      iconType="alert"
+      color="warning"
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.fleet.epm.verificationWarningCalloutIntroText"
+          defaultMessage="One or more of the installed integrations contains an unsigned package with unknown authenticity."
+          // TODO: add documentation link
+        />
+      </p>
+    </EuiCallOut>
+    <EuiSpacer size="l" />
+  </>
+);
+
 export const OverviewPage: React.FC<Props> = memo(({ packageInfo, integrationInfo }) => {
   const screenshots = useMemo(
     () => integrationInfo?.screenshots || packageInfo.screenshots || [],
     [integrationInfo, packageInfo.screenshots]
   );
-
+  const { packageVerificationKeyId } = useFleetStatus();
+  const isUnverified = isPackageUnverified(packageInfo, packageVerificationKeyId);
   return (
     <EuiFlexGroup alignItems="flexStart">
       <LeftColumn grow={2} />
       <EuiFlexItem grow={9} className="eui-textBreakWord">
+        {isUnverified && <UnverifiedCallout />}
         {packageInfo.readme ? (
           <Readme
             readmePath={integrationInfo?.readme || packageInfo.readme}

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FunctionComponent } from 'react';
-import React, { memo, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useLocation, useHistory, useParams } from 'react-router-dom';
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
@@ -38,7 +38,7 @@ import {
   useLink,
 } from '../../../../hooks';
 import { doesPackageHaveIntegrations } from '../../../../services';
-import type { PackageList } from '../../../../types';
+import type { GetPackagesResponse, PackageList } from '../../../../types';
 import { PackageListGrid } from '../../components/package_list_grid';
 
 import type { PackageListItem } from '../../../../types';
@@ -180,7 +180,10 @@ const packageListToIntegrationsList = (packages: PackageList): PackageList => {
 
 // TODO: clintandrewhall - this component is hard to test due to the hooks, particularly those that use `http`
 // or `location` to load data.  Ideally, we'll split this into "connected" and "pure" components.
-export const AvailablePackages: React.FC = memo(() => {
+export const AvailablePackages: React.FC<{
+  allPackages?: GetPackagesResponse | null;
+  isLoading: boolean;
+}> = ({ allPackages, isLoading }) => {
   const [preference, setPreference] = useState<IntegrationPreferenceType>('recommended');
   useBreadcrumbs('integrations_all');
 
@@ -384,4 +387,4 @@ export const AvailablePackages: React.FC = memo(() => {
       callout={noEprCallout}
     />
   );
-});
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -238,7 +238,7 @@ export const AvailablePackages: React.FC = memo(() => {
   ];
 
   const cards: IntegrationCardItem[] = eprAndCustomPackages.map((item) => {
-    return mapToCard(getAbsolutePath, getHref, item);
+    return mapToCard({ getAbsolutePath, getHref, item });
   });
 
   cards.sort((a, b) => {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -385,6 +385,7 @@ export const AvailablePackages: React.FC<{
       onSearchChange={setSearchTerm}
       showMissingIntegrationMessage
       callout={noEprCallout}
+      showCardLabels={false}
     />
   );
 };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -17,11 +17,11 @@ import { installationStatuses } from '../../../../../../../common/constants';
 import type { DynamicPage, DynamicPagePathValues, StaticPage } from '../../../../constants';
 import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_SEARCH_QUERYPARAM } from '../../../../constants';
 import { DefaultLayout } from '../../../../layouts';
-import { ExperimentalFeaturesService } from '../../../../services';
+import { isPackageUnverified } from '../../../../services';
 
 import type { PackageListItem } from '../../../../types';
 
-import type { Installation, IntegrationCardItem } from '../../../../../../../common/types/models';
+import type { IntegrationCardItem } from '../../../../../../../common/types/models';
 
 import { useGetPackages } from '../../../../hooks';
 
@@ -50,22 +50,6 @@ export const categoryExists = (category: string, categories: CategoryFacet[]) =>
   return categories.some((c) => c.id === category);
 };
 
-function showPackageUnverified(
-  installation: Installation,
-  packageVerificationKeyId?: string
-): boolean {
-  const verificationStatus = installation.verification_status;
-  const verificationKeyId = installation.verification_key_id;
-
-  const { packageVerification: isPackageVerificationEnabled } = ExperimentalFeaturesService.get();
-  const isStatusUnverified = verificationStatus === 'unverified';
-  const isKeyOutdated =
-    verificationStatus === 'verified' &&
-    !!verificationKeyId &&
-    verificationKeyId !== packageVerificationKeyId;
-  return isPackageVerificationEnabled && (isStatusUnverified || isKeyOutdated);
-}
-
 export const mapToCard = ({
   getAbsolutePath,
   getHref,
@@ -88,8 +72,7 @@ export const mapToCard = ({
     let urlVersion = item.version;
     if ('savedObject' in item) {
       urlVersion = item.savedObject.attributes.version || item.version;
-
-      isUnverified = showPackageUnverified(item.savedObject.attributes, packageVerificationKeyId);
+      isUnverified = isPackageUnverified(item, packageVerificationKeyId);
     }
 
     const url = getHref('integration_details_overview', {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -117,13 +117,8 @@ export const EPMHomePage: React.FC = () => {
     [allPackages?.response]
   );
 
-  const atLeastOneUnverifiedPackageInstalled = useMemo(
-    () =>
-      installedPackages.some(
-        (pkg) =>
-          'savedObject' in pkg && pkg.savedObject.attributes.verification_status === 'unverified'
-      ),
-    [installedPackages]
+  const atLeastOneUnverifiedPackageInstalled = installedPackages.some(
+    (pkg) => 'savedObject' in pkg && pkg.savedObject.attributes.verification_status === 'unverified'
   );
 
   const sectionsWithWarning = (atLeastOneUnverifiedPackageInstalled ? ['manage'] : []) as Section[];

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -15,10 +15,11 @@ import type { CustomIntegration } from '@kbn/custom-integrations-plugin/common';
 import type { DynamicPage, DynamicPagePathValues, StaticPage } from '../../../../constants';
 import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_SEARCH_QUERYPARAM } from '../../../../constants';
 import { DefaultLayout } from '../../../../layouts';
+import { ExperimentalFeaturesService } from '../../../../services';
 
 import type { PackageListItem } from '../../../../types';
 
-import type { IntegrationCardItem } from '../../../../../../../common/types/models';
+import type { Installation, IntegrationCardItem } from '../../../../../../../common/types/models';
 
 import type { CategoryFacet } from './category_facets';
 import { InstalledPackages } from './installed_packages';
@@ -43,21 +44,46 @@ export const categoryExists = (category: string, categories: CategoryFacet[]) =>
   return categories.some((c) => c.id === category);
 };
 
-export const mapToCard = (
-  getAbsolutePath: (p: string) => string,
-  getHref: (page: StaticPage | DynamicPage, values?: DynamicPagePathValues) => string,
-  item: CustomIntegration | PackageListItem,
-  selectedCategory?: string
-): IntegrationCardItem => {
+function showPackageUnverified(
+  installation: Installation,
+  packageVerificationKeyId?: string
+): boolean {
+  const verificationStatus = installation.verification_status;
+  const verificationKeyId = installation.verification_key_id;
+
+  const { packageVerification: isPackageVerificationEnabled } = ExperimentalFeaturesService.get();
+  const isStatusUnverified = verificationStatus === 'unverified';
+  const isKeyOutdated =
+    verificationStatus === 'verified' &&
+    !!verificationKeyId &&
+    verificationKeyId !== packageVerificationKeyId;
+  return isPackageVerificationEnabled && (isStatusUnverified || isKeyOutdated);
+}
+
+export const mapToCard = ({
+  getAbsolutePath,
+  getHref,
+  item,
+  packageVerificationKeyId,
+  selectedCategory,
+}: {
+  getAbsolutePath: (p: string) => string;
+  getHref: (page: StaticPage | DynamicPage, values?: DynamicPagePathValues) => string;
+  item: CustomIntegration | PackageListItem;
+  packageVerificationKeyId?: string;
+  selectedCategory?: string;
+}): IntegrationCardItem => {
   let uiInternalPathUrl;
 
+  let isUnverified = false;
   if (item.type === 'ui_link') {
     uiInternalPathUrl = item.uiExternalLink || getAbsolutePath(item.uiInternalPath);
   } else {
     let urlVersion = item.version;
-
     if ('savedObject' in item) {
       urlVersion = item.savedObject.attributes.version || item.version;
+
+      isUnverified = showPackageUnverified(item.savedObject.attributes, packageVerificationKeyId);
     }
 
     const url = getHref('integration_details_overview', {
@@ -87,6 +113,7 @@ export const mapToCard = (
     version: 'version' in item ? item.version || '' : '',
     release,
     categories: ((item.categories || []) as string[]).filter((c: string) => !!c),
+    isUnverified,
   };
 };
 

--- a/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_status.tsx
@@ -19,6 +19,7 @@ interface FleetStatusState {
   error?: Error;
   missingRequirements?: GetFleetStatusResponse['missing_requirements'];
   missingOptionalFeatures?: GetFleetStatusResponse['missing_optional_features'];
+  packageVerificationKeyId?: GetFleetStatusResponse['package_verification_key_id'];
 }
 
 interface FleetStatus extends FleetStatusState {
@@ -58,6 +59,7 @@ export const FleetStatusProvider: React.FC = ({ children }) => {
           isReady: res.data?.isReady ?? false,
           missingRequirements: res.data?.missing_requirements,
           missingOptionalFeatures: res.data?.missing_optional_features,
+          packageVerificationKeyId: res.data?.package_verification_key_id,
         }));
       } catch (error) {
         setState((s) => ({ ...s, isLoading: false, error }));

--- a/x-pack/plugins/fleet/public/services/index.ts
+++ b/x-pack/plugins/fleet/public/services/index.ts
@@ -41,7 +41,7 @@ export {
   countValidationErrors,
   getStreamsForInputType,
 } from '../../common';
-
+export * from './package_verification';
 export * from './pkg_key_from_package_info';
 export * from './ui_extensions';
 export * from './increment_policy_name';

--- a/x-pack/plugins/fleet/public/services/package_verification.test.ts
+++ b/x-pack/plugins/fleet/public/services/package_verification.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackageVerificationStatus } from '../../common';
+import type { PackageInfo } from '../types';
+
+import { ExperimentalFeaturesService, isPackageUnverified } from '.';
+
+const mockGet = jest.spyOn(ExperimentalFeaturesService, 'get');
+
+const createPackage = ({
+  verificationStatus = 'unknown',
+  verificationKeyId,
+}: {
+  verificationStatus?: PackageVerificationStatus;
+  verificationKeyId?: string;
+} = {}): PackageInfo => ({
+  name: 'test-package',
+  description: 'Test Package',
+  title: 'Test Package',
+  version: '0.0.1',
+  latestVersion: '0.0.1',
+  release: 'experimental',
+  format_version: '1.0.0',
+  owner: { github: 'elastic/fleet' },
+  policy_templates: [],
+  // @ts-ignore
+  assets: {},
+  savedObject: {
+    id: '1234',
+    type: 'epm-package',
+    references: [],
+    attributes: {
+      installed_kibana: [],
+      installed_es: [],
+      es_index_patterns: {},
+      name: 'test-package',
+      version: '0.0.1',
+      install_status: 'installed',
+      install_version: '0.0.1',
+      install_started_at: new Date().toString(),
+      install_source: 'registry',
+      verification_status: verificationStatus,
+      ...(verificationKeyId && { verification_key_id: verificationKeyId }),
+    },
+  },
+});
+
+describe('isPackageUnverified', () => {
+  describe('When experimental feature is disabled', () => {
+    beforeEach(() => {
+      mockGet.mockReturnValue({
+        packageVerification: false,
+      } as ReturnType<typeof ExperimentalFeaturesService['get']>);
+    });
+
+    it('Should return false for a package with no saved object', () => {
+      const noSoPkg = createPackage();
+      // @ts-ignore we know pkg has savedObject but ts doesn't
+      delete noSoPkg.savedObject;
+      expect(isPackageUnverified(noSoPkg)).toEqual(false);
+    });
+    it('Should return false for an unverified package', () => {
+      const unverifiedPkg = createPackage({ verificationStatus: 'unverified' });
+      expect(isPackageUnverified(unverifiedPkg)).toEqual(false);
+    });
+    it('Should return false for a verified package', () => {
+      const verifiedPkg = createPackage({ verificationStatus: 'verified' });
+      expect(isPackageUnverified(verifiedPkg)).toEqual(false);
+    });
+    it('Should return false for a verified package with correct key', () => {
+      const unverifiedPkg = createPackage({
+        verificationStatus: 'verified',
+        verificationKeyId: '1234',
+      });
+      expect(isPackageUnverified(unverifiedPkg, '1234')).toEqual(false);
+    });
+    it('Should return false for a verified package with out of date key', () => {
+      const unverifiedPkg = createPackage({
+        verificationStatus: 'verified',
+        verificationKeyId: '1234',
+      });
+      expect(isPackageUnverified(unverifiedPkg, 'not_1234')).toEqual(false);
+    });
+    it('Should return false for an unknown verification package', () => {
+      const unknownPkg = createPackage({ verificationStatus: 'unknown' });
+      expect(isPackageUnverified(unknownPkg)).toEqual(false);
+    });
+  });
+  describe('When experimental feature is enabled', () => {
+    beforeEach(() => {
+      mockGet.mockReturnValue({
+        packageVerification: true,
+      } as ReturnType<typeof ExperimentalFeaturesService['get']>);
+    });
+    it('Should return false for a package with no saved object', () => {
+      const noSoPkg = createPackage();
+      // @ts-ignore we know pkg has savedObject but ts doesn't
+      delete noSoPkg.savedObject;
+      expect(isPackageUnverified(noSoPkg)).toEqual(false);
+    });
+    it('Should return false for a verified package', () => {
+      const unverifiedPkg = createPackage({ verificationStatus: 'verified' });
+      expect(isPackageUnverified(unverifiedPkg)).toEqual(false);
+    });
+    it('Should return false for an unknown verification package', () => {
+      const unverifiedPkg = createPackage({ verificationStatus: 'unknown' });
+      expect(isPackageUnverified(unverifiedPkg)).toEqual(false);
+    });
+    it('Should return false for a verified package with correct key', () => {
+      const unverifiedPkg = createPackage({
+        verificationStatus: 'verified',
+        verificationKeyId: '1234',
+      });
+      expect(isPackageUnverified(unverifiedPkg, '1234')).toEqual(false);
+    });
+
+    it('Should return true for an unverified package', () => {
+      const unverifiedPkg = createPackage({ verificationStatus: 'unverified' });
+      expect(isPackageUnverified(unverifiedPkg)).toEqual(true);
+    });
+
+    it('Should return true for a verified package with out of date key', () => {
+      const unverifiedPkg = createPackage({
+        verificationStatus: 'verified',
+        verificationKeyId: '1234',
+      });
+      expect(isPackageUnverified(unverifiedPkg, 'not_1234')).toEqual(true);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/services/package_verification.ts
+++ b/x-pack/plugins/fleet/public/services/package_verification.ts
@@ -19,11 +19,8 @@ export function isPackageUnverified(
     pkg.savedObject.attributes;
 
   const { packageVerification: isPackageVerificationEnabled } = ExperimentalFeaturesService.get();
-  const isStatusUnverified = verificationStatus === 'unverified';
-  const isKeyOutdated =
-    verificationStatus === 'verified' &&
-    !!verificationKeyId &&
-    verificationKeyId !== packageVerificationKeyId;
-
-  return isPackageVerificationEnabled && (isStatusUnverified || isKeyOutdated);
+  const isKeyOutdated = !!verificationKeyId && verificationKeyId !== packageVerificationKeyId;
+  const isUnverified =
+    verificationStatus === 'unverified' || (verificationStatus === 'verified' && isKeyOutdated);
+  return isPackageVerificationEnabled && isUnverified;
 }

--- a/x-pack/plugins/fleet/public/services/package_verification.ts
+++ b/x-pack/plugins/fleet/public/services/package_verification.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PackageInfo, PackageListItem } from '../types';
+
+import { ExperimentalFeaturesService } from '.';
+
+export function isPackageUnverified(
+  pkg: PackageInfo | PackageListItem,
+  packageVerificationKeyId?: string
+) {
+  if (!('savedObject' in pkg)) return false;
+
+  const { verification_status: verificationStatus, verification_key_id: verificationKeyId } =
+    pkg.savedObject.attributes;
+
+  const { packageVerification: isPackageVerificationEnabled } = ExperimentalFeaturesService.get();
+  const isStatusUnverified = verificationStatus === 'unverified';
+  const isKeyOutdated =
+    verificationStatus === 'verified' &&
+    !!verificationKeyId &&
+    verificationKeyId !== packageVerificationKeyId;
+
+  return isPackageVerificationEnabled && (isStatusUnverified || isKeyOutdated);
+}

--- a/x-pack/plugins/fleet/server/errors/handlers.ts
+++ b/x-pack/plugins/fleet/server/errors/handlers.ts
@@ -84,7 +84,7 @@ export function ingestErrorToResponseOptions(error: IngestErrorHandlerParams['er
     logger.error(error.message);
     return {
       statusCode: getHTTPResponseCode(error),
-      body: { message: error.message },
+      body: { message: error.message, attributes: error.attributes },
     };
   }
 

--- a/x-pack/plugins/fleet/server/errors/index.ts
+++ b/x-pack/plugins/fleet/server/errors/index.ts
@@ -8,13 +8,15 @@
 /* eslint-disable max-classes-per-file */
 import type { ElasticsearchErrorDetails } from '@kbn/es-errors';
 
+import type { FleetErrorType } from '../../common';
+
 import { isESClientError } from './utils';
 
 export { defaultIngestErrorHandler, ingestErrorToResponseOptions } from './handlers';
 
 export { isESClientError } from './utils';
-
 export class IngestManagerError extends Error {
+  attributes?: { type?: FleetErrorType };
   constructor(message?: string, public readonly meta?: unknown) {
     super(message);
     this.name = this.constructor.name; // for stack traces
@@ -34,6 +36,9 @@ export class PackageOutdatedError extends IngestManagerError {}
 export class PackageFailedVerificationError extends IngestManagerError {
   constructor(pkgKey: string) {
     super(`${pkgKey} failed signature verification.`);
+    this.attributes = {
+      type: 'verification_failed',
+    };
   }
 }
 export class AgentPolicyError extends IngestManagerError {}

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -11,6 +11,7 @@ import { formatNonFatalErrors, setupFleet } from '../../services/setup';
 import { hasFleetServers } from '../../services/fleet_server';
 import { defaultIngestErrorHandler } from '../../errors';
 import type { FleetRequestHandler } from '../../types';
+import { getGpgKeyIdOrUndefined } from '../../services/epm/packages/package_verification';
 
 export const getFleetStatusHandler: FleetRequestHandler = async (context, request, response) => {
   try {
@@ -42,6 +43,12 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       missing_requirements: missingRequirements,
       missing_optional_features: missingOptionalFeatures,
     };
+
+    const packageVerificationKeyId = await getGpgKeyIdOrUndefined();
+
+    if (packageVerificationKeyId) {
+      body.package_verification_key_id = packageVerificationKeyId;
+    }
 
     return response.ok({
       body,

--- a/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/package_verification.ts
@@ -24,6 +24,14 @@ interface VerificationResult {
 
 let cachedKey: openpgp.Key | undefined | null = null;
 
+export async function getGpgKeyIdOrUndefined(): Promise<string | undefined> {
+  const key = await getGpgKeyOrUndefined();
+
+  if (!key) return undefined;
+
+  return key.getKeyID().toHex();
+}
+
 export async function getGpgKeyOrUndefined(): Promise<openpgp.Key | undefined> {
   if (cachedKey !== null) return cachedKey;
 


### PR DESCRIPTION
## Summary

Part of #133822

if the package verification feature flag is enabled, show which packages are unverified in the UI: 

- show unverified label on the package card in installed integrations (this is not shown in the browse view)
- show a callout in the installed integrations view if any packages are unverified
- show a warning icon on the installed integrations tab if any packages are unverified
- show a callout on the integration overview page if a package is unverified

Additional changes:

- add error.attributes.type to the error response when verification fails so that verification error can be distinguished
- add `package_verification_key_id` to the fleet status response

NOTE: there are a few TODOs in the code where I will need to add a documentation link when its available, I don't know what other people do when a link isn't ready yet?

### Screenshots

Installed integrations: new labels, callout and icon on tab
<img width="1217" alt="Screenshot 2022-07-07 at 20 17 24" src="https://user-images.githubusercontent.com/3315046/177854427-a923e574-a32b-40de-9257-b038a02a400e.png">

Tab icon still visible when not on tab:
<img width="1256" alt="Screenshot 2022-07-07 at 20 17 51" src="https://user-images.githubusercontent.com/3315046/177854437-21c89b9b-111d-4fd9-b2ea-6cff55b4e1a5.png">

Callout also displayed on integrations overview:
<img width="1257" alt="Screenshot 2022-07-07 at 20 17 59" src="https://user-images.githubusercontent.com/3315046/177854432-b6e046a7-ccef-43a1-9ca8-48757bdc11dc.png">

### Testing steps

- 1. Run the version of the EPR with package signatures locally:

```docker run -p 8080:8080 docker.elastic.co/observability-ci/package-registry/distribution:PR-463```
- 2. set `xpack.fleet.registryUrl: http://localhost:8080`
- 3. download this public key which will cause all verifications to fail [NOT_THE_ELASTIC_KEY](https://github.com/elastic/kibana/files/9021435/NOT_THE_ELASTIC_KEY.txt)
- 4. set `xpack.fleet.packageVerification.gpgKeyPath: /tmp/NOT_THE_ELASTIC_KEY.txt`
- 5. Enable the feature by setting:

```
xpack.fleet.enableExperimental: 
    - packageVerification
```

- 6. force install some packages (force is required to override the verification failing)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
