### PR TITLE
Marking the node.roles kibana.yml setting as technical preview

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -312,7 +312,7 @@ system for the {kib} UI notification center. Set to `false` to disable the
 newsfeed system. *Default: `true`*
 
 `node.roles`::
-Indicates which roles to configure the {kib} process with, which will effectively
+experimental[] Indicates which roles to configure the {kib} process with, which will effectively
 run {kib} in different modes. Valid options are `background_tasks` and `ui`,
 or `*` to select all roles. *Default: `*`*
 


### PR DESCRIPTION
The recently added `node.roles` setting is being used to trigger various conditional behavior in task-manager. While this implementation is being vetted and fully tested, it should be marked as experimental.