### PR TITLE
Users still have to fix existing rules after upgrading to 8.3.2

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -59,6 +59,15 @@ To review the breaking changes in previous versions, refer to the following:
 Alerting::
 Fixes an issue where alerting rules that were created or edited in 8.2.0 stopped running when you upgraded {kib} to 8.3.0 or 8.3.1 {kibana-pull}135663[#135663]
 
+====
+[IMPORTANT]
+If you already upgraded to 8.3.0 or 8.3.1 and noticed that rules created or updated in 8.2.x were failing with an error similar to the message below, complete the appropriate steps to restore your rules after you upgrade to 8.3.2. Refer to the <<known-issue-8.3.1, known issue section>> of the 8.3.1 release notes for more information.
+[source,text]
+----
+<rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""
+----
+====
+
 Discover::
 * Hide Alerts menu item when user does not have access to Stack Rules {kibana-pull}135655[#135655]
 * Fixes loading of a single doc JSON when using index alias based data views {kibana-pull}135446[#135446]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -61,7 +61,7 @@ Fixes an issue where alerting rules that were created or edited in 8.2.0 stopped
 
 ====
 [IMPORTANT]
-If you already upgraded to 8.3.0 or 8.3.1 and noticed that rules created or updated in 8.2.x were failing with an error similar to the message below, complete the appropriate steps to restore your rules after you upgrade to 8.3.2. Refer to the <<known-issue-8.3.1, known issue section>> of the 8.3.1 release notes for more information.
+If you already upgraded to 8.3.0 or 8.3.1 and noticed that rules created or updated in 8.2.x were failing with an error similar to the message below, complete the appropriate steps to restore your rules after you upgrade to 8.3.2. Refer to the <<known-issues-8.3.1, known issue section>> of the 8.3.1 release notes for more information.
 [source,text]
 ----
 <rule-type>:<UUID>: execution failed - security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: ""


### PR DESCRIPTION
Users who have already upgraded to 8.3.0 or 8.3.1 and have failing rules due to the known issue will still have to apply the workaround; the upgrade only prevents the issue from affecting future rules.
