### PR TITLE
[App Search][Nested Fields / Object fields]Use field capabilities

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.test.ts
@@ -20,14 +20,14 @@ describe('buildSearchUIConfig', () => {
         capabilities: {
           snippet: true,
           facet: true,
-        }
+        },
       },
       bar: {
         type: SchemaType.Number,
         capabilities: {
           snippet: false,
           facet: false,
-        }
+        },
       },
     };
     const fields = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.test.ts
@@ -15,11 +15,23 @@ describe('buildSearchUIConfig', () => {
   it('builds a configuration object for Search UI', () => {
     const connector = {};
     const schema = {
-      foo: SchemaType.Text,
-      bar: SchemaType.Number,
+      foo: {
+        type: SchemaType.Text,
+        capabilities: {
+          snippet: true,
+          facet: true,
+        }
+      },
+      bar: {
+        type: SchemaType.Number,
+        capabilities: {
+          snippet: false,
+          facet: false,
+        }
+      },
     };
     const fields = {
-      filterFields: ['fieldA', 'fieldB'],
+      filterFields: ['foo', 'bar'],
       sortFields: [],
     };
 
@@ -32,13 +44,9 @@ describe('buildSearchUIConfig', () => {
         sortField: 'id',
       },
       searchQuery: {
-        disjunctiveFacets: ['fieldA', 'fieldB'],
+        disjunctiveFacets: ['foo'],
         facets: {
-          fieldA: {
-            size: 30,
-            type: 'value',
-          },
-          fieldB: {
+          foo: {
             size: 30,
             type: 'value',
           },
@@ -50,7 +58,6 @@ describe('buildSearchUIConfig', () => {
           foo: {
             raw: {},
             snippet: {
-              fallback: true,
               size: 300,
             },
           },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -7,26 +7,34 @@
 
 import type { APIConnector, SortDirection } from '@elastic/search-ui';
 
-import { Schema } from '../../../../shared/schema/types';
+import { SchemaType, AdvancedSchema } from '../../../../shared/schema/types';
 
 import { Fields } from './types';
 
 export const buildSearchUIConfig = (
   apiConnector: APIConnector,
-  schema: Schema,
+  schema: AdvancedSchema,
   fields: Fields,
   initialState = { sortDirection: 'desc' as SortDirection, sortField: 'id' }
 ) => {
-  const facets = fields.filterFields.reduce((facetsConfig, fieldName) => {
-    // Geolocation fields do not support value facets https://www.elastic.co/guide/en/app-search/current/facets.html
-    if (schema[fieldName] === 'geolocation') {
-      return facetsConfig;
-    }
-    return {
-      ...facetsConfig,
-      [fieldName]: { type: 'value', size: 30 },
-    };
-  }, {});
+  const facets = fields.filterFields
+    .filter(fieldName => schema[fieldName].type !== SchemaType.Geolocation)
+    .filter(fieldName => !!schema[fieldName].capabilities.facet)
+    .reduce((facetsConfig, fieldName) => {
+      return {
+        ...facetsConfig,
+        [fieldName]: { type: 'value', size: 30 },
+      };
+    }, {});
+
+  const resultFields = Object.entries(schema)
+    .filter(([_, schemaField]) => schemaField.type !== SchemaType.Nested)
+    .reduce((acc, [fieldName, schemaField]) => {
+      if (schemaField.capabilities.snippet) {
+        return {  ...acc,  [fieldName]: {  raw: {},  snippet: { size: 300 } } };
+      }
+      return {  ...acc,  [fieldName]: {  raw: {} } };
+    }, {});
 
   return {
     alwaysSearchOnInitialLoad: true,
@@ -34,25 +42,9 @@ export const buildSearchUIConfig = (
     trackUrlState: false,
     initialState,
     searchQuery: {
-      disjunctiveFacets: fields.filterFields,
+      disjunctiveFacets: Object.keys(facets),
       facets,
-      result_fields: Object.keys(schema).reduce((acc: { [key: string]: object }, key: string) => {
-        if (schema[key] === 'text') {
-          // Only text fields support snippets
-          acc[key] = {
-            snippet: {
-              size: 300,
-              fallback: true,
-            },
-            raw: {},
-          };
-        } else {
-          acc[key] = {
-            raw: {},
-          };
-        }
-        return acc;
-      }, {}),
+      result_fields: resultFields,
     },
   };
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -18,8 +18,8 @@ export const buildSearchUIConfig = (
   initialState = { sortDirection: 'desc' as SortDirection, sortField: 'id' }
 ) => {
   const facets = fields.filterFields
-    .filter(fieldName =>  !!schema[fieldName] && schema[fieldName].type !== SchemaType.Geolocation)
-    .filter(fieldName => !!schema[fieldName].capabilities.facet)
+    .filter((fieldName) => !!schema[fieldName] && schema[fieldName].type !== SchemaType.Geolocation)
+    .filter((fieldName) => !!schema[fieldName].capabilities.facet)
     .reduce((facetsConfig, fieldName) => {
       return {
         ...facetsConfig,
@@ -31,9 +31,9 @@ export const buildSearchUIConfig = (
     .filter(([, schemaField]) => schemaField.type !== SchemaType.Nested)
     .reduce((acc, [fieldName, schemaField]) => {
       if (schemaField.capabilities.snippet) {
-        return {  ...acc,  [fieldName]: {  raw: {},  snippet: { size: 300 } } };
+        return { ...acc, [fieldName]: { raw: {}, snippet: { size: 300 } } };
       }
-      return {  ...acc,  [fieldName]: {  raw: {} } };
+      return { ...acc, [fieldName]: { raw: {} } };
     }, {});
 
   return {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -28,7 +28,7 @@ export const buildSearchUIConfig = (
     }, {});
 
   const resultFields = Object.entries(schema)
-    .filter(([_, schemaField]) => schemaField.type !== SchemaType.Nested)
+    .filter(([, schemaField]) => schemaField.type !== SchemaType.Nested)
     .reduce((acc, [fieldName, schemaField]) => {
       if (schemaField.capabilities.snippet) {
         return {  ...acc,  [fieldName]: {  raw: {},  snippet: { size: 300 } } };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -18,7 +18,7 @@ export const buildSearchUIConfig = (
   initialState = { sortDirection: 'desc' as SortDirection, sortField: 'id' }
 ) => {
   const facets = fields.filterFields
-    .filter(fieldName => schema[fieldName].type !== SchemaType.Geolocation)
+    .filter(fieldName =>  !!schema[fieldName] && schema[fieldName].type !== SchemaType.Geolocation)
     .filter(fieldName => !!schema[fieldName].capabilities.facet)
     .reduce((facetsConfig, fieldName) => {
       return {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
@@ -54,15 +54,17 @@ export const CustomizationModal: React.FC<Props> = ({
 
   const schema = engine.advancedSchema || {};
   const selectableFilterFields = useMemo(
-    () => Object.keys(schema)
-      .filter(fieldName => schema[fieldName].capabilities.filter)
-      .map(fieldNameToComboBoxOption),
+    () =>
+      Object.keys(schema)
+        .filter((fieldName) => schema[fieldName].capabilities.filter)
+        .map(fieldNameToComboBoxOption),
     [schema]
   );
   const selectableSortFields = useMemo(
-    () => Object.keys(schema)
-      .filter(fieldName => schema[fieldName].capabilities.sort)
-      .map(fieldNameToComboBoxOption),
+    () =>
+      Object.keys(schema)
+        .filter((fieldName) => schema[fieldName].capabilities.sort)
+        .map(fieldNameToComboBoxOption),
     [schema]
   );
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
@@ -52,14 +52,18 @@ export const CustomizationModal: React.FC<Props> = ({
     sortFields.map(fieldNameToComboBoxOption)
   );
 
-  const engineSchema = engine.schema || {};
+  const schema = engine.advancedSchema || {};
   const selectableFilterFields = useMemo(
-    () => Object.keys(engineSchema).map(fieldNameToComboBoxOption),
-    [engineSchema]
+    () => Object.keys(schema)
+      .filter(fieldName => schema[fieldName].capabilities.filter)
+      .map(fieldNameToComboBoxOption),
+    [schema]
   );
   const selectableSortFields = useMemo(
-    () => Object.keys(engineSchema).map(fieldNameToComboBoxOption),
-    [engineSchema]
+    () => Object.keys(schema)
+      .filter(fieldName => schema[fieldName].capabilities.sort)
+      .map(fieldNameToComboBoxOption),
+    [schema]
   );
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -100,7 +100,7 @@ export const SearchExperience: React.FC = () => {
 
   const searchProviderConfig = buildSearchUIConfig(
     connector,
-    engine.schema || {},
+    engine.advancedSchema || {},
     fields,
     initialState
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -41,6 +41,19 @@ describe('EngineLogic', () => {
     isMeta: false,
     invalidBoosts: false,
     schema: { test: SchemaType.Text },
+    advanceSchema: {
+      test: {
+        type: SchemaType.Text,
+        capabilities: {
+          fulltext: true,
+          filter: true,
+          facet: true,
+          sort: true,
+          snippet: true,
+          boost: true,
+        }
+      }
+    },
     apiTokens: [],
     apiKey: 'some-key',
     adaptive_relevance_suggestions_active: true,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -51,8 +51,8 @@ describe('EngineLogic', () => {
           sort: true,
           snippet: true,
           boost: true,
-        }
-      }
+        },
+      },
     },
     apiTokens: [],
     apiKey: 'some-key',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -41,7 +41,7 @@ describe('EngineLogic', () => {
     isMeta: false,
     invalidBoosts: false,
     schema: { test: SchemaType.Text },
-    advanceSchema: {
+    advancedSchema: {
       test: {
         type: SchemaType.Text,
         capabilities: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Schema, SchemaConflicts, IIndexingStatus } from '../../../shared/schema/types';
+import { Schema, SchemaConflicts, IIndexingStatus, AdvancedSchema } from '../../../shared/schema/types';
 import { ApiToken } from '../credentials/types';
 
 export enum EngineTypes {
@@ -47,6 +47,7 @@ export interface EngineDetails extends Engine {
   apiKey: string;
   elasticsearchIndexName?: string;
   schema: Schema;
+  advancedSchema: AdvancedSchema;
   schemaConflicts?: SchemaConflicts;
   unconfirmedFields?: string[];
   activeReindexJob?: IIndexingStatus;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { Schema, SchemaConflicts, IIndexingStatus, AdvancedSchema } from '../../../shared/schema/types';
+import {
+  Schema,
+  SchemaConflicts,
+  IIndexingStatus,
+  AdvancedSchema,
+} from '../../../shared/schema/types';
 import { ApiToken } from '../credentials/types';
 
 export enum EngineTypes {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_token.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_token.tsx
@@ -26,6 +26,7 @@ const fieldTypeToTokenMap = {
   [InternalSchemaType.Location]: 'tokenGeo',
   [SchemaType.Date]: 'tokenDate',
   [InternalSchemaType.Date]: 'tokenDate',
+  [InternalSchemaType.Nested]: 'tokenNested',
 };
 
 export const ResultToken: React.FC<Props> = ({ fieldType }) => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
@@ -14,6 +14,7 @@ export enum SchemaType {
   Number = 'number',
   Geolocation = 'geolocation',
   Date = 'date',
+  Nested = 'nested',
 }
 // Certain API endpoints will use these internal type names, which map to the external names above
 export enum InternalSchemaType {
@@ -21,6 +22,7 @@ export enum InternalSchemaType {
   Float = 'float',
   Location = 'location',
   Date = 'date',
+  Nested = 'nested',
 }
 
 export type Schema = Record<string, SchemaType>;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/types.ts
@@ -64,3 +64,20 @@ export interface FieldCoercionError {
   error: string;
 }
 export type FieldCoercionErrors = Record<string, FieldCoercionError[]>;
+
+export interface SchemaFieldCapabilities {
+  fulltext?: boolean;
+  filter?: boolean;
+  facet?: boolean;
+  sort?: boolean;
+  snippet?: boolean;
+  boost?: boolean;
+}
+
+export interface AdvancedSchemaField {
+  type: SchemaType;
+  nestedPath?: string;
+  capabilities: SchemaFieldCapabilities;
+}
+
+export type AdvancedSchema = Record<string, AdvancedSchemaField>;


### PR DESCRIPTION
## Summary

With the introduction of more complex fields, the field type is insufficient to determine if a field can be used as a facet, filter, ... 
These field capabilities are now exposed in the engine details endpoint, so it is possible to use them directly (and avoid duplication in the frontend).

This PR adds an `advancedSchema` field to the `EngineDetails` interface.

Also, it is using these new capabilities to fix issues in the SearchExperience components (document list).


### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


