### PR TITLE
[Security Solution][Rules] Allow related_integrations to be set in some cases

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/schemas/rule_converters.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/schemas/rule_converters.ts
@@ -36,7 +36,12 @@ import {
   InternalRuleUpdate,
 } from './rule_schemas';
 import { assertUnreachable } from '../../../../common/utility_types';
-import { RuleExecutionSummary } from '../../../../common/detection_engine/schemas/common';
+import {
+  RelatedIntegrationArray,
+  RequiredFieldArray,
+  RuleExecutionSummary,
+  SetupGuide,
+} from '../../../../common/detection_engine/schemas/common';
 import {
   CreateRulesSchema,
   CreateTypeSpecific,
@@ -340,7 +345,11 @@ const shouldUpdateVersion = (params: PatchRulesSchema): boolean => {
 
 // eslint-disable-next-line complexity
 export const convertPatchAPIToInternalSchema = (
-  params: PatchRulesSchema,
+  params: PatchRulesSchema & {
+    related_integrations?: RelatedIntegrationArray;
+    required_fields?: RequiredFieldArray;
+    setup?: SetupGuide;
+  },
   existingRule: SanitizedRule<RuleParams>
 ): InternalRuleUpdate => {
   const typeSpecificParams = patchTypeSpecificSnakeToCamel(params, existingRule.params);
@@ -362,12 +371,12 @@ export const convertPatchAPIToInternalSchema = (
       timelineTitle: params.timeline_title ?? existingParams.timelineTitle,
       meta: params.meta ?? existingParams.meta,
       maxSignals: params.max_signals ?? existingParams.maxSignals,
-      relatedIntegrations: existingParams.relatedIntegrations,
-      requiredFields: existingParams.requiredFields,
+      relatedIntegrations: params.related_integrations ?? existingParams.relatedIntegrations,
+      requiredFields: params.required_fields ?? existingParams.requiredFields,
       riskScore: params.risk_score ?? existingParams.riskScore,
       riskScoreMapping: params.risk_score_mapping ?? existingParams.riskScoreMapping,
       ruleNameOverride: params.rule_name_override ?? existingParams.ruleNameOverride,
-      setup: existingParams.setup,
+      setup: params.setup ?? existingParams.setup,
       severity: params.severity ?? existingParams.severity,
       severityMapping: params.severity_mapping ?? existingParams.severityMapping,
       threat: params.threat ?? existingParams.threat,
@@ -395,7 +404,11 @@ export const convertPatchAPIToInternalSchema = (
 };
 
 export const convertCreateAPIToInternalSchema = (
-  input: CreateRulesSchema,
+  input: CreateRulesSchema & {
+    related_integrations?: RelatedIntegrationArray;
+    required_fields?: RequiredFieldArray;
+    setup?: SetupGuide;
+  },
   immutable = false,
   defaultEnabled = true
 ): InternalRuleCreate => {
@@ -433,9 +446,9 @@ export const convertCreateAPIToInternalSchema = (
       note: input.note,
       version: input.version ?? 1,
       exceptionsList: input.exceptions_list ?? [],
-      relatedIntegrations: [],
-      requiredFields: [],
-      setup: '',
+      relatedIntegrations: input.related_integrations ?? [],
+      requiredFields: input.required_fields ?? [],
+      setup: input.setup ?? '',
       ...typeSpecificParams,
     },
     schedule: { interval: input.interval ?? '5m' },


### PR DESCRIPTION
## Summary

The [schema refactor PR](https://github.com/elastic/kibana/pull/135479) switched all detection rules routes that create rules over to use the `createRules` function, and internally switched `createRules` to use `convertCreateAPIToInternalSchema` for the conversion. However, `convertCreateAPIToInternalSchema` did not allow `relatedIntegrations`, `requiredFields`, or `setup` to be set since it's based on `CreateRulesSchema`. This broke the add prepackaged and import rules behavior that allowed those fields to be set previously.

This PR adds the 3 fields to `convertCreateAPIToInternalSchema` without adding them to `CreateRulesSchema` to preserve the ability to have those fields on imported or prepackaged rules but not regular custom rules. It also adds those fields to the `convertPatchAPIToInternalSchema` function so that imported and prepackaged rules can update those fields.
