### PR TITLE
[ci] prevent failures caused by excluding function configs

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -332,34 +332,36 @@ export async function pickTestGroupRunOrder() {
     { title: string; expectedDurationMin: number; names: string[] }
   > = {};
 
-  for (const { groups, queue } of getRunGroups(bk, types, FUNCTIONAL_TYPE)) {
-    for (const group of groups) {
-      if (!group.names.length) {
-        continue;
-      }
+  if (ftrConfigsByQueue.size) {
+    for (const { groups, queue } of getRunGroups(bk, types, FUNCTIONAL_TYPE)) {
+      for (const group of groups) {
+        if (!group.names.length) {
+          continue;
+        }
 
-      const key = `ftr_configs_${configCounter++}`;
-      let sortBy;
-      let title;
-      if (group.names.length === 1) {
-        title = group.names[0];
-        sortBy = title;
-      } else {
-        sortBy = ++groupCounter;
-        title = `FTR Configs #${sortBy}`;
-      }
+        const key = `ftr_configs_${configCounter++}`;
+        let sortBy;
+        let title;
+        if (group.names.length === 1) {
+          title = group.names[0];
+          sortBy = title;
+        } else {
+          sortBy = ++groupCounter;
+          title = `FTR Configs #${sortBy}`;
+        }
 
-      functionalGroups.push({
-        title,
-        key,
-        sortBy,
-        queue: queue ?? defaultQueue,
-      });
-      ftrRunOrder[key] = {
-        title,
-        expectedDurationMin: group.durationMin,
-        names: group.names,
-      };
+        functionalGroups.push({
+          title,
+          key,
+          sortBy,
+          queue: queue ?? defaultQueue,
+        });
+        ftrRunOrder[key] = {
+          title,
+          expectedDurationMin: group.durationMin,
+          names: group.names,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
In the `pick_test_group_run_order` ci step, if we try to call `getRunGroups()` for FTR test configs when functional configs are explicitly disabled (like they are for the code coverage jobs) then we throw and error because the run group can't be found. We shouldn't try to populate the "run group" maps unless we are working with ftr configs, so this PR adds a condition around that step to prevent the error.