### PR TITLE
[Heatmap] Display Y-axis tick labels

### DIFF
--- a/src/plugins/vis_types/heatmap/public/to_ast.ts
+++ b/src/plugins/vis_types/heatmap/public/to_ast.ts
@@ -40,6 +40,7 @@ const prepareGrid = (params: HeatmapVisParams) => {
   const gridConfig = buildExpressionFunction('heatmap_grid', {
     isCellLabelVisible: params.valueAxes?.[0].labels.show ?? false,
     isXAxisLabelVisible: true,
+    isYAxisLabelVisible: true,
     isYAxisTitleVisible: true,
     isXAxisTitleVisible: true,
   });


### PR DESCRIPTION
## Summary

I noticed that on Visualize editor Heatmap the Y-axis tick labels were not displayed.

Before
<img width="1914" alt="image" src="https://user-images.githubusercontent.com/17003240/177936309-670f4ce3-a749-49d8-a475-3578cee9084b.png">

After
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/17003240/177936397-9057c96d-4476-4800-802f-689761e63468.png">

The fix is simple, we had forgotten to initialize the `isYAxisLabelVisible` on the ast file which is required for the tick labels to be shown