### PR TITLE
[8.3] [Discover] Fix filter in / filter out buttons for empty values  (#135919)

### DIFF
--- a/src/plugins/discover/public/__mocks__/es_hits.ts
+++ b/src/plugins/discover/public/__mocks__/es_hits.ts
@@ -40,6 +40,12 @@ export const esHits = [
     _id: '5',
     _score: 1,
     _type: '_doc',
-    _source: { date: '2020-20-01T12:12:12.128', name: 'test5', extension: 'doc', bytes: 50 },
+    _source: {
+      date: '2020-20-01T12:12:12.128',
+      name: 'test5',
+      extension: 'doc',
+      bytes: 50,
+      message: '',
+    },
   },
 ];

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -169,7 +169,7 @@ export function DiscoverLayout({
   });
 
   const onAddFilter = useCallback(
-    (field: DataViewField | string, values: string, operation: '+' | '-') => {
+    (field: DataViewField | string, values: unknown, operation: '+' | '-') => {
       const fieldName = typeof field === 'string' ? field : field.name;
       popularizeField(indexPattern, fieldName, indexPatterns, capabilities);
       const newFilters = generateFilters(

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -76,6 +76,48 @@ describe('Discover cell actions ', function () {
       '+'
     );
   });
+  it('triggers filter function when FilterInBtn is clicked for a non-provided value', async () => {
+    const component = mountWithIntl(
+      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+        <FilterInBtn
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Component={(props: any) => <EuiButton {...props} />}
+          rowIndex={0}
+          colIndex={1}
+          columnId="extension"
+          isExpanded={false}
+        />
+      </DiscoverGridContext.Provider>
+    );
+    const button = findTestSubject(component, 'filterForButton');
+    await button.simulate('click');
+    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
+      discoverGridContextMock.indexPattern.fields.getByName('extension'),
+      undefined,
+      '+'
+    );
+  });
+  it('triggers filter function when FilterInBtn is clicked for an empty string value', async () => {
+    const component = mountWithIntl(
+      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+        <FilterInBtn
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Component={(props: any) => <EuiButton {...props} />}
+          rowIndex={4}
+          colIndex={1}
+          columnId="message"
+          isExpanded={false}
+        />
+      </DiscoverGridContext.Provider>
+    );
+    const button = findTestSubject(component, 'filterForButton');
+    await button.simulate('click');
+    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
+      discoverGridContextMock.indexPattern.fields.getByName('message'),
+      '',
+      '+'
+    );
+  });
   it('triggers filter function when FilterOutBtn is clicked', async () => {
     const component = mountWithIntl(
       <DiscoverGridContext.Provider value={contextMock}>

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -78,7 +78,7 @@ describe('Discover cell actions ', function () {
   });
   it('triggers filter function when FilterInBtn is clicked for a non-provided value', async () => {
     const component = mountWithIntl(
-      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+      <DiscoverGridContext.Provider value={contextMock}>
         <FilterInBtn
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           Component={(props: any) => <EuiButton {...props} />}
@@ -91,15 +91,15 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterForButton');
     await button.simulate('click');
-    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
-      discoverGridContextMock.indexPattern.fields.getByName('extension'),
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      contextMock.indexPattern.fields.getByName('extension'),
       undefined,
       '+'
     );
   });
   it('triggers filter function when FilterInBtn is clicked for an empty string value', async () => {
     const component = mountWithIntl(
-      <DiscoverGridContext.Provider value={discoverGridContextMock}>
+      <DiscoverGridContext.Provider value={contextMock}>
         <FilterInBtn
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           Component={(props: any) => <EuiButton {...props} />}
@@ -112,8 +112,8 @@ describe('Discover cell actions ', function () {
     );
     const button = findTestSubject(component, 'filterForButton');
     await button.simulate('click');
-    expect(discoverGridContextMock.onFilter).toHaveBeenCalledWith(
-      discoverGridContextMock.indexPattern.fields.getByName('message'),
+    expect(contextMock.onFilter).toHaveBeenCalledWith(
+      contextMock.indexPattern.fields.getByName('message'),
       '',
       '+'
     );

--- a/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid_cell_actions.tsx
@@ -21,10 +21,10 @@ function onFilterCell(
   mode: '+' | '-'
 ) {
   const row = context.rowsFlattened[rowIndex];
-  const value = String(row[columnId]);
+  const value = row[columnId];
   const field = context.indexPattern.fields.getByName(columnId);
 
-  if (value && field) {
+  if (field) {
     context.onFilter(field, value, mode);
   }
 }

--- a/src/plugins/discover/public/components/doc_table/components/table_row.test.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_row.test.tsx
@@ -99,6 +99,21 @@ describe('Doc table row component', () => {
     expect(fields.length).toBe(3);
   });
 
+  it('should apply filter when pressed', () => {
+    const component = mountComponent({ ...defaultProps, columns: ['bytes'] });
+
+    const fields = findTestSubject(component, 'docTableField');
+    expect(fields.first().text()).toBe('20');
+
+    const filterInButton = findTestSubject(component, 'docTableCellFilter');
+    filterInButton.simulate('click');
+    expect(mockInlineFilter).toHaveBeenCalledWith(
+      indexPatternWithTimefieldMock.getFieldByName('bytes'),
+      20,
+      '+'
+    );
+  });
+
   describe('details row', () => {
     it('should be empty by default', () => {
       const component = mountComponent(defaultProps);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Discover] Fix filter in / filter out buttons for empty values  (#135919)](https://github.com/elastic/kibana/pull/135919)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2022-07-08T07:02:02Z","message":"[Discover] Fix filter in / filter out buttons for empty values  (#135919)\n\n* [Discover] Fix filter in / filter out buttons for empty values in the new grid\r\n\r\n* [Discover] Fix filter in / filter out buttons in the legacy table\r\n\r\n* [Discover] Simplify the code\r\n\r\n* [Discover] Add a test for legacy table","sha":"cead7b48184698b0d34ae4a08986b09cedeae14c","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:fix","Team:DataDiscovery","v8.4.0","backport:prev-minor","v8.3.3"],"number":135919,"url":"https://github.com/elastic/kibana/pull/135919","mergeCommit":{"message":"[Discover] Fix filter in / filter out buttons for empty values  (#135919)\n\n* [Discover] Fix filter in / filter out buttons for empty values in the new grid\r\n\r\n* [Discover] Fix filter in / filter out buttons in the legacy table\r\n\r\n* [Discover] Simplify the code\r\n\r\n* [Discover] Add a test for legacy table","sha":"cead7b48184698b0d34ae4a08986b09cedeae14c"}},"sourceBranch":"main","suggestedTargetBranches":["8.3"],"targetPullRequestStates":[{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/135919","number":135919,"mergeCommit":{"message":"[Discover] Fix filter in / filter out buttons for empty values  (#135919)\n\n* [Discover] Fix filter in / filter out buttons for empty values in the new grid\r\n\r\n* [Discover] Fix filter in / filter out buttons in the legacy table\r\n\r\n* [Discover] Simplify the code\r\n\r\n* [Discover] Add a test for legacy table","sha":"cead7b48184698b0d34ae4a08986b09cedeae14c"}},{"branch":"8.3","label":"v8.3.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->