### PR TITLE
[XY] Removes extra space from the legend when it is positioned on top/bottom

### DIFF
--- a/src/plugins/vis_types/xy/public/__snapshots__/to_ast.test.ts.snap
+++ b/src/plugins/vis_types/xy/public/__snapshots__/to_ast.test.ts.snap
@@ -33,7 +33,7 @@ Object {
       "top",
     ],
     "legendSize": Array [
-      "small",
+      "auto",
     ],
     "maxLegendLines": Array [
       1,

--- a/src/plugins/vis_types/xy/public/to_ast.ts
+++ b/src/plugins/vis_types/xy/public/to_ast.ts
@@ -7,12 +7,13 @@
  */
 
 import moment from 'moment';
-
+import { Position } from '@elastic/charts';
 import {
   VisToExpressionAst,
   getVisSchemas,
   DateHistogramParams,
   HistogramParams,
+  LegendSize,
 } from '@kbn/visualizations-plugin/public';
 import { buildExpression, buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { BUCKET_TYPES } from '@kbn/data-plugin/public';
@@ -202,6 +203,11 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = async (vis, params
       }
     }
   });
+  let legendSize = vis.params.legendSize;
+
+  if (vis.params.legendPosition === Position.Top || vis.params.legendPosition === Position.Bottom) {
+    legendSize = LegendSize.AUTO;
+  }
 
   const visTypeXy = buildExpressionFunction<VisTypeXyExpressionFunctionDefinition>(visName, {
     type: vis.type.name as XyVisType,
@@ -209,7 +215,7 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = async (vis, params
     addTimeMarker: vis.params.addTimeMarker,
     truncateLegend: vis.params.truncateLegend,
     maxLegendLines: vis.params.maxLegendLines,
-    legendSize: vis.params.legendSize,
+    legendSize,
     addLegend: vis.params.addLegend,
     addTooltip: vis.params.addTooltip,
     legendPosition: vis.params.legendPosition,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/135979

There is an extra space when rendering and agg based visualization with the legend positioned on top/bottom.
Exactly as done here for Lens https://github.com/elastic/kibana/pull/133851, this PR defaults the legendSize always to AUTO when the position is top / bottom

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/17003240/177951261-0f3c551c-9903-4c3e-9fbb-d7d13476b653.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios