### PR TITLE
Add state when navigating between Lens and Visualize

### DIFF
--- a/src/plugins/visualizations/public/visualize_app/app.tsx
+++ b/src/plugins/visualizations/public/visualize_app/app.tsx
@@ -8,7 +8,7 @@
 
 import './app.scss';
 import React, { useEffect, useCallback, useState } from 'react';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { AppMountParameters, CoreStart } from '@kbn/core/public';
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
@@ -30,6 +30,7 @@ import { VisualizeConstants } from '../../common/constants';
 
 export interface VisualizeAppProps {
   onAppLeave: AppMountParameters['onAppLeave'];
+  preserveFilters?: boolean;
 }
 
 interface NoDataComponentProps {
@@ -66,7 +67,8 @@ export const VisualizeApp = ({ onAppLeave }: VisualizeAppProps) => {
       dataViewEditor,
     },
   } = useKibana<VisualizeServices>();
-  const { pathname } = useLocation();
+  const { pathname, state } = useLocation();
+  const history = useHistory();
   const [showNoDataPage, setShowNoDataPage] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -134,7 +136,7 @@ export const VisualizeApp = ({ onAppLeave }: VisualizeAppProps) => {
         <VisualizeByValueEditor onAppLeave={onAppLeave} />
       </Route>
       <Route path={[VisualizeConstants.CREATE_PATH, `${VisualizeConstants.EDIT_PATH}/:id`]}>
-        <VisualizeEditor onAppLeave={onAppLeave} />
+        <VisualizeEditor onAppLeave={onAppLeave} preserveFilters={true} />
       </Route>
       <Route
         exact

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_editor.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_editor.tsx
@@ -25,7 +25,7 @@ import { VisualizeEditorCommon } from './visualize_editor_common';
 import { VisualizeAppProps } from '../app';
 import { VisualizeConstants } from '../../../common/constants';
 
-export const VisualizeEditor = ({ onAppLeave }: VisualizeAppProps) => {
+export const VisualizeEditor = ({ onAppLeave, preserveFilters }: VisualizeAppProps) => {
   const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
   const [originatingApp, setOriginatingApp] = useState<string>();
   const [originatingPath, setOriginatingPath] = useState<string>();
@@ -53,7 +53,8 @@ export const VisualizeEditor = ({ onAppLeave }: VisualizeAppProps) => {
   const { appState, hasUnappliedChanges } = useVisualizeAppState(
     services,
     eventEmitter,
-    savedVisInstance
+    savedVisInstance,
+    preserveFilters
   );
   const { isEmbeddableRendered, currentAppState } = useEditorUpdates(
     services,

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiBreadcrumb, EuiConfirmModal } from '@elastic/eui';
 import { useExecutionContext, useKibana } from '@kbn/kibana-react-plugin/public';
 import { OnSaveProps } from '@kbn/saved-objects-plugin/public';
+import { cloneDeep } from 'lodash';
 import { LensAppProps, LensAppServices } from './types';
 import { LensTopNavMenu } from './lens_top_nav';
 import { LensByReferenceInput } from '../embeddable';
@@ -29,7 +30,7 @@ import {
 import { SaveModalContainer, runSaveLensVisualization } from './save_modal_container';
 import { LensInspector } from '../lens_inspector_service';
 import { getEditPath } from '../../common';
-import { isLensEqual } from './lens_document_equality';
+import { areFiltersEqual, isLensEqual } from './lens_document_equality';
 
 export type SaveProps = Omit<OnSaveProps, 'onTitleDuplicate' | 'newDescription'> & {
   returnToOrigin: boolean;
@@ -322,22 +323,30 @@ export function App({
         datasourceMap
       );
       if (!initialDocFromContextHasChanged) {
+        if (
+          !areFiltersEqual(initialDocFromContext, lastKnownDoc, data.query.filterManager.inject)
+        ) {
+          data.query.filterManager.setAppFilters(cloneDeep(lastKnownDoc?.state?.filters || []));
+        }
         onAppLeave((actions) => {
           return actions.default();
         });
-        application.navigateToApp('visualize', { path: initialContext.vizEditorOriginatingAppUrl });
+        application.navigateToApp('visualize', {
+          path: initialContext.vizEditorOriginatingAppUrl,
+          state: { preserveFilters: 'true' },
+        });
       } else {
         setIsGoBackToVizEditorModalVisible(true);
       }
     }
   }, [
     application,
-    data.query.filterManager.inject,
     datasourceMap,
     initialContext,
     initialDocFromContext,
     lastKnownDoc,
     onAppLeave,
+    data.query.filterManager,
   ]);
 
   const navigateToVizEditor = useCallback(() => {

--- a/x-pack/plugins/lens/public/app_plugin/lens_document_equality.ts
+++ b/x-pack/plugins/lens/public/app_plugin/lens_document_equality.ts
@@ -66,14 +66,25 @@ export const isLensEqual = (
     return false;
   }
 
+  return true;
+};
+
+export const areFiltersEqual = (
+  doc1In: Document | undefined,
+  doc2In: Document | undefined,
+  injectFilterReferences: FilterManager['inject']
+) => {
+  if (doc1In === undefined || doc2In === undefined) {
+    return doc1In === doc2In;
+  }
+
+  // we do this so that undefined props are the same as non-existant props
+  const doc1 = removeNonSerializable(doc1In);
+  const doc2 = removeNonSerializable(doc2In);
   const [filtersInjected1, filtersInjected2] = [doc1, doc2].map((doc) =>
     removePinnedFilters(injectDocFilterReferences(injectFilterReferences, doc))
   );
-  if (!isEqual(filtersInjected1?.state.filters, filtersInjected2?.state.filters)) {
-    return false;
-  }
-
-  return true;
+  return isEqual(filtersInjected1?.state.filters, filtersInjected2?.state.filters);
 };
 
 function injectDocFilterReferences(


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
