### PR TITLE
[fleet] Add escape_string and to_json helpers

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -224,8 +224,11 @@ text_var: {{escape_string text_var}}
 
     it('should respect new lines and literal escapes', () => {
       const vars = {
-        text_var: { type: 'text', value: `This is a text with
-New lines and \\n escaped values.` },
+        text_var: {
+          type: 'text',
+          value: `This is a text with
+New lines and \\n escaped values.`,
+        },
       };
 
       const output = compileTemplate(vars, streamTemplateWithNewlinesAndEscapes);
@@ -264,7 +267,9 @@ yaml_var: {{to_json yaml_var}}
 
     it('should parse a yaml string into a json object', () => {
       const vars = {
-        yaml_var: { type: 'yaml', value: `foo:
+        yaml_var: {
+          type: 'yaml',
+          value: `foo:
   bar:
     - a
     - b`,

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -224,8 +224,11 @@ text_var: {{escape_string text_var}}
 
     it('should respect new lines and literal escapes', () => {
       const vars = {
-        password: { type: 'text_var', value: `This is a text with
-        New lines and \n escaped values.` },
+        password: {
+          type: 'text_var',
+          value: `This is a text with
+        New lines and \n escaped values.`,
+        },
       };
 
       const output = compileTemplate(vars, streamTemplateWithNewlinesAndEscapes);
@@ -257,17 +260,20 @@ yaml_var: {{to_json yaml_var}}
       expect(output).toEqual({
         input: 'log',
         json_var: {
-          foo: ["bar", "bazz"],
+          foo: ['bar', 'bazz'],
         },
       });
     });
 
     it('should parse a yaml string into a json object', () => {
       const vars = {
-        password: { type: 'yaml_var', value: `foo:
+        password: {
+          type: 'yaml_var',
+          value: `foo:
   bar:
     - a
-    - b` },
+    - b`,
+        },
       };
 
       const output = compileTemplate(vars, streamTemplateWithNewYaml);
@@ -275,7 +281,7 @@ yaml_var: {{to_json yaml_var}}
         input: 'log',
         yaml_var: {
           foo: {
-            bar: ["a", "b"],
+            bar: ['a', 'b'],
           },
         },
       });

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -212,30 +212,27 @@ text_var: {{escape_string text_var}}
 
     it('should wrap in single quotes and escape any single quotes in the string', () => {
       const vars = {
-        password: { type: 'password', value: `abc"'"'!@#$%^&*()_-+=}{][|\\/?>.<,~\`:;]}123` },
+        password: { type: 'password', value: "ab'c'" },
       };
 
       const output = compileTemplate(vars, streamTemplate);
       expect(output).toEqual({
         input: 'log',
-        password: `'abc"''"''!@#$%^&*()_-+=}{][|\\/?>.<,~\`:;]}123'`,
+        password: "ab'c'",
       });
     });
 
     it('should respect new lines and literal escapes', () => {
       const vars = {
-        password: {
-          type: 'text_var',
-          value: `This is a text with
-        New lines and \n escaped values.`,
-        },
+        text_var: { type: 'text', value: `This is a text with
+New lines and \\n escaped values.` },
       };
 
       const output = compileTemplate(vars, streamTemplateWithNewlinesAndEscapes);
       expect(output).toEqual({
         input: 'log',
-        password: `This is a text with
-        New lines and \n escaped values.`,
+        text_var: `This is a text with
+New lines and \\n escaped values.`,
       });
     });
   });
@@ -253,7 +250,7 @@ yaml_var: {{to_json yaml_var}}
 
     it('should parse a json string into a json object', () => {
       const vars = {
-        password: { type: 'json_var', value: `{"foo":["bar","bazz"]}` },
+        json_var: { type: 'text', value: `{"foo":["bar","bazz"]}` },
       };
 
       const output = compileTemplate(vars, streamTemplate);
@@ -267,9 +264,7 @@ yaml_var: {{to_json yaml_var}}
 
     it('should parse a yaml string into a json object', () => {
       const vars = {
-        password: {
-          type: 'yaml_var',
-          value: `foo:
+        yaml_var: { type: 'yaml', value: `foo:
   bar:
     - a
     - b`,

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -199,6 +199,89 @@ pcap: false
     });
   });
 
+  describe('escape_string helper', () => {
+    const streamTemplate = `
+input: log
+password: {{escape_string password}}
+      `;
+
+    const streamTemplateWithNewlinesAndEscapes = `
+input: log
+text_var: {{escape_string text_var}}
+      `;
+
+    it('should wrap in single quotes and escape any single quotes in the string', () => {
+      const vars = {
+        password: { type: 'password', value: `abc"'"'!@#$%^&*()_-+=}{][|\\/?>.<,~\`:;]}123` },
+      };
+
+      const output = compileTemplate(vars, streamTemplate);
+      expect(output).toEqual({
+        input: 'log',
+        password: `'abc"''"''!@#$%^&*()_-+=}{][|\\/?>.<,~\`:;]}123'`,
+      });
+    });
+
+    it('should respect new lines and literal escapes', () => {
+      const vars = {
+        password: { type: 'text_var', value: `This is a text with
+        New lines and \n escaped values.` },
+      };
+
+      const output = compileTemplate(vars, streamTemplateWithNewlinesAndEscapes);
+      expect(output).toEqual({
+        input: 'log',
+        password: `This is a text with
+        New lines and \n escaped values.`,
+      });
+    });
+  });
+
+  describe('to_json helper', () => {
+    const streamTemplate = `
+input: log
+json_var: {{to_json json_var}}
+      `;
+
+    const streamTemplateWithNewYaml = `
+input: log
+yaml_var: {{to_json yaml_var}}
+      `;
+
+    it('should parse a json string into a json object', () => {
+      const vars = {
+        password: { type: 'json_var', value: `{"foo":["bar","bazz"]}` },
+      };
+
+      const output = compileTemplate(vars, streamTemplate);
+      expect(output).toEqual({
+        input: 'log',
+        json_var: {
+          foo: ["bar", "bazz"],
+        },
+      });
+    });
+
+    it('should parse a yaml string into a json object', () => {
+      const vars = {
+        password: { type: 'yaml_var', value: `foo:
+  bar:
+    - a
+    - b` },
+      };
+
+      const output = compileTemplate(vars, streamTemplateWithNewYaml);
+      expect(output).toEqual({
+        input: 'log',
+        yaml_var: {
+          foo: {
+            bar: ["a", "b"],
+          },
+        },
+      });
+    });
+  });
+
   it('should support optional yaml values at root level', () => {
     const streamTemplate = `
 input: logs

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -115,7 +115,7 @@ handlebars.registerHelper('contains', containsHelper);
 // and to respect any incoming newline we also need to double them, otherwise
 // they will be replaced with a space.
 function escapeStringHelper(str: string) {
-  return "'" + str.replace( /\'/g, "''").replace(/\n/g, "\n\n") + "'";
+  return "'" + str.replace(/\'/g, "''").replace(/\n/g, '\n\n') + "'";
 }
 handlebars.registerHelper('escape_string', escapeStringHelper);
 

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -110,17 +110,20 @@ function containsHelper(this: any, item: string, check: string | string[], optio
 }
 handlebars.registerHelper('contains', containsHelper);
 
+// escapeStringHelper will wrap the provided string with single quotes.
+// Single quoted strings in yaml need to escape single quotes by doubling them
+// and to respect any incoming newline we also need to double them, otherwise
+// they will be replaced with a space.
 function escapeStringHelper(str: string) {
-  const regex = /\'/;
-  return "'" + str.replace(regex, "''") + "'";
+  return "'" + str.replace( /\'/g, "''").replace(/\n/g, "\n\n") + "'";
 }
 handlebars.registerHelper('escape_string', escapeStringHelper);
 
+// toJsonHelper will convert any object to a Json string.
 function toJsonHelper(value: any) {
   if (typeof value === 'string') {
-    // if we get a string we assume it is a yaml or json serialized object
-    const yaml = safeLoad(value, {});
-    return JSON.stringify(yaml);
+    // if we get a string we assume is an already serialized json
+    return value;
   }
   return JSON.stringify(value);
 }

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -110,6 +110,22 @@ function containsHelper(this: any, item: string, check: string | string[], optio
 }
 handlebars.registerHelper('contains', containsHelper);
 
+function escapeStringHelper(str: string) {
+  const regex = /\'/;
+  return "'" + str.replace(regex, "''") + "'";
+}
+handlebars.registerHelper('escape_string', escapeStringHelper);
+
+function toJsonHelper(value: any) {
+  if (typeof value === 'string') {
+    // if we get a string we assume it is a yaml or json serialized object
+    const yaml = safeLoad(value, {});
+    return JSON.stringify(yaml);
+  }
+  return JSON.stringify(value);
+}
+handlebars.registerHelper('to_json', toJsonHelper);
+
 function replaceRootLevelYamlVariables(yamlVariables: { [k: string]: any }, yamlTemplate: string) {
   if (Object.keys(yamlVariables).length === 0 || !yamlTemplate) {
     return yamlTemplate;


### PR DESCRIPTION
## Summary

Adds to_json and escape_string helpers to handlebars for fleet server.

Closes https://github.com/elastic/kibana/issues/127268
Related https://github.com/elastic/kibana/pull/133070

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
