### PR TITLE
Add a gif module to be able to import gif files

### DIFF
--- a/packages/kbn-ambient-ui-types/index.d.ts
+++ b/packages/kbn-ambient-ui-types/index.d.ts
@@ -24,6 +24,12 @@ declare module '*.svg' {
   export default content;
 }
 
+declare module '*.gif' {
+  const content: string;
+  // eslint-disable-next-line import/no-default-export
+  export default content;
+}
+
 declare module '*.mdx' {
   let MDXComponent: (props: any) => JSX.Element;
   // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
## Summary
This PR adds a module declaration for gif files. 
When adding an [onboarding tour for Security](https://github.com/elastic/kibana/pull/132641), I noticed that importing a gif file throws a TS error. For example [here](https://github.com/elastic/kibana/blob/24a43e4df2773b163242e772ab66f25da6231dff/x-pack/plugins/security_solution/public/common/components/guided_onboarding/tour_config.ts#L10).
