### PR TITLE
Update `@kbn/monaco` code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,7 @@
 /examples/search_examples/ @elastic/kibana-app-services
 /packages/kbn-datemath/ @elastic/kibana-app-services
 /packages/kbn-interpreter/ @elastic/kibana-app-services
+/packages/kbn-monaco/ @elastic/kibana-app-services
 /packages/kbn-react-field/ @elastic/kibana-app-services
 /packages/kbn-es-query/ @elastic/kibana-app-services
 /packages/kbn-field-types/ @elastic/kibana-app-services
@@ -394,7 +395,6 @@
 /x-pack/plugins/watcher/  @elastic/platform-deployment-management
 /x-pack/plugins/ingest_pipelines/  @elastic/platform-deployment-management
 /packages/kbn-ace/ @elastic/platform-deployment-management
-/packages/kbn-monaco/ @elastic/platform-deployment-management
 #CC# /x-pack/plugins/cross_cluster_replication/ @elastic/platform-deployment-management
 
 # Security Solution


### PR DESCRIPTION
## Summary

Updating `@kbn/monaco` code owners as the ownership has been transferred to the @elastic/kibana-app-services team.

