### PR TITLE
[Fleet] Package verification API improvements

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -2011,6 +2011,22 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "sys_monitoring",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "force_install",
+            "required": false
           }
         ]
       }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1226,6 +1226,16 @@ paths:
       security: []
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+        - schema:
+            type: boolean
+          in: query
+          name: sys_monitoring
+          required: false
+        - schema:
+            type: boolean
+          in: query
+          name: force_install
+          required: false
   /agent_policies/{agentPolicyId}:
     parameters:
       - schema:

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
@@ -52,3 +52,14 @@ post:
   security: []
   parameters:
     - $ref: ../components/headers/kbn_xsrf.yaml
+    - schema:
+        type: boolean
+      in: query
+      name: sys_monitoring
+      required: false
+    - schema:
+        type: boolean
+      in: query
+      name: force_install
+      required: false
+

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent_policy.ts
@@ -31,6 +31,10 @@ export interface GetOneAgentPolicyResponse {
 
 export interface CreateAgentPolicyRequest {
   body: NewAgentPolicy;
+  params: {
+    sys_monitoring?: boolean;
+    force_install?: boolean;
+  };
 }
 
 export interface CreateAgentPolicyResponse {

--- a/x-pack/plugins/fleet/common/types/rest_spec/error.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/error.ts
@@ -7,10 +7,14 @@
 
 export type FleetErrorType = 'verification_failed';
 
-export interface FleetErrorResponse {
+export interface FleetPackageErrorResponse {
   message: string;
   statusCode: number;
   attributes?: {
     type?: FleetErrorType;
+    package?: {
+      name: string;
+      version: string;
+    };
   };
 }

--- a/x-pack/plugins/fleet/public/hooks/use_request/agent_policy.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/agent_policy.ts
@@ -76,13 +76,25 @@ export const sendGetOneAgentPolicy = (agentPolicyId: string) => {
 
 export const sendCreateAgentPolicy = (
   body: CreateAgentPolicyRequest['body'],
-  { withSysMonitoring }: { withSysMonitoring: boolean } = { withSysMonitoring: false }
+  { withSysMonitoring, forceInstall }: { withSysMonitoring?: boolean; forceInstall?: boolean } = {
+    withSysMonitoring: false,
+    forceInstall: false,
+  }
 ) => {
+  const query: CreateAgentPolicyRequest['params'] = {};
+
+  if (withSysMonitoring) {
+    query.sys_monitoring = true;
+  }
+  if (forceInstall) {
+    query.force_install = true;
+  }
+
   return sendRequest<CreateAgentPolicyResponse>({
     path: agentPolicyRouteService.getCreatePath(),
     method: 'post',
     body: JSON.stringify(body),
-    query: withSysMonitoring ? { sys_monitoring: true } : {},
+    query,
   });
 };
 

--- a/x-pack/plugins/fleet/public/hooks/use_request/epm.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/epm.ts
@@ -20,7 +20,7 @@ import type {
   UpdatePackageRequest,
   UpdatePackageResponse,
 } from '../../types';
-import type { GetStatsResponse } from '../../../common';
+import type { FleetPackageErrorResponse, GetStatsResponse } from '../../../common';
 
 import { getCustomIntegrations } from '../../services/custom_integrations';
 
@@ -102,10 +102,12 @@ export const sendGetFileByPath = (filePath: string) => {
   });
 };
 
-export const sendInstallPackage = (pkgName: string, pkgVersion: string) => {
-  return sendRequest<InstallPackageResponse>({
+export const sendInstallPackage = (pkgName: string, pkgVersion: string, force: boolean = false) => {
+  const body = force ? { force } : undefined;
+  return sendRequest<InstallPackageResponse, FleetPackageErrorResponse>({
     path: epmRouteService.getInstallPath(pkgName, pkgVersion),
     method: 'post',
+    body,
   });
 };
 

--- a/x-pack/plugins/fleet/public/services/package_verification.ts
+++ b/x-pack/plugins/fleet/public/services/package_verification.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { FleetPackageErrorResponse } from '../../common';
 import type { PackageInfo, PackageListItem } from '../types';
 
 import { ExperimentalFeaturesService } from '.';
@@ -24,3 +25,5 @@ export function isPackageUnverified(
     verificationStatus === 'unverified' || (verificationStatus === 'verified' && isKeyOutdated);
   return isPackageVerificationEnabled && isUnverified;
 }
+export const isVerificationError = (err?: FleetPackageErrorResponse) =>
+  err?.attributes?.type === 'verification_failed';

--- a/x-pack/plugins/fleet/server/errors/index.ts
+++ b/x-pack/plugins/fleet/server/errors/index.ts
@@ -16,7 +16,13 @@ export { defaultIngestErrorHandler, ingestErrorToResponseOptions } from './handl
 
 export { isESClientError } from './utils';
 export class IngestManagerError extends Error {
-  attributes?: { type?: FleetErrorType };
+  constructor(message?: string, public readonly meta?: unknown) {
+    super(message);
+    this.name = this.constructor.name; // for stack traces
+  }
+}
+export class IngestManagerPackageError extends IngestManagerError {
+  attributes?: { type: FleetErrorType; package: { name: string; version: string } };
   constructor(message?: string, public readonly meta?: unknown) {
     super(message);
     this.name = this.constructor.name; // for stack traces
@@ -33,11 +39,15 @@ export class RegistryResponseError extends RegistryError {
 export class PackageNotFoundError extends IngestManagerError {}
 export class PackageKeyInvalidError extends IngestManagerError {}
 export class PackageOutdatedError extends IngestManagerError {}
-export class PackageFailedVerificationError extends IngestManagerError {
-  constructor(pkgKey: string) {
-    super(`${pkgKey} failed signature verification.`);
+export class PackageFailedVerificationError extends IngestManagerPackageError {
+  constructor(pkgName: string, pkgVersion: string) {
+    super(`${pkgName}-${pkgVersion} failed signature verification.`);
     this.attributes = {
       type: 'verification_failed',
+      package: {
+        name: pkgName,
+        version: pkgVersion,
+      },
     };
   }
 }

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -116,6 +116,7 @@ export const createAgentPolicyHandler: FleetRequestHandler<
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = (await appContextService.getSecurity()?.authc.getCurrentUser(request)) || undefined;
   const withSysMonitoring = request.query.sys_monitoring ?? false;
+  const forceInstall = request.query.force_install ?? false;
   const monitoringEnabled = request.body.monitoring_enabled;
   const { has_fleet_server: hasFleetServer, ...newPolicy } = request.body;
   const spaceId = fleetContext.spaceId;
@@ -127,6 +128,7 @@ export const createAgentPolicyHandler: FleetRequestHandler<
         newPolicy,
         hasFleetServer,
         withSysMonitoring,
+        forceInstall,
         monitoringEnabled,
         spaceId,
         user,

--- a/x-pack/plugins/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_create.ts
@@ -79,6 +79,7 @@ interface CreateAgentPolicyParams {
   newPolicy: NewAgentPolicy;
   hasFleetServer?: boolean;
   withSysMonitoring: boolean;
+  forceInstall?: boolean;
   monitoringEnabled?: string[];
   spaceId: string;
   user?: AuthenticatedUser;
@@ -90,6 +91,7 @@ export async function createAgentPolicyWithPackages({
   newPolicy,
   hasFleetServer,
   withSysMonitoring,
+  forceInstall = false,
   monitoringEnabled,
   spaceId,
   user,
@@ -116,6 +118,7 @@ export async function createAgentPolicyWithPackages({
       savedObjectsClient: soClient,
       esClient,
       packagesToInstall,
+      force: forceInstall,
       spaceId,
     });
   }

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -151,7 +151,8 @@ export async function ensureInstalledPackage(options: {
               pkgVersion: pkgKeyProps.version,
             },
           });
-    throw new Error(`${errorPrefix}: ${installResult.error.message}`);
+    installResult.error.message = `${errorPrefix}: ${installResult.error.message}`;
+    throw installResult.error;
   }
 
   const installation = await getInstallation({ savedObjectsClient, pkgName });

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -310,7 +310,7 @@ export async function fetchArchiveBuffer({
     });
 
     if (verificationResult.verificationStatus === 'unverified' && !ignoreUnverified) {
-      throw new PackageFailedVerificationError(`${pkgName}-${pkgVersion}`);
+      throw new PackageFailedVerificationError(pkgName, pkgVersion);
     }
     return { archiveBuffer, archivePath, verificationResult };
   }

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -161,6 +161,7 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
             savedObjectsClient: soClient,
             pkgName: packagePolicy.package.name,
             pkgVersion: packagePolicy.package.version,
+            force: options?.force,
           }),
           pkgInfoPromise,
         ]);

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -148,6 +148,7 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
         savedObjectsClient: soClient,
         pkgName: packagePolicy.package.name,
         pkgVersion: packagePolicy.package.version,
+        skipArchive: true,
       });
 
       let pkgInfo: PackageInfo;

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -840,6 +840,7 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
       savedObjectsClient: soClient,
       pkgName,
       pkgVersion,
+      skipArchive: true,
     });
     if (packageInfo) {
       return packageToPackagePolicy(packageInfo, '', '');

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
@@ -27,6 +27,7 @@ export const CreateAgentPolicyRequestSchema = {
   body: NewAgentPolicySchema,
   query: schema.object({
     sys_monitoring: schema.maybe(schema.boolean()),
+    force_install: schema.maybe(schema.boolean()),
   }),
 };
 


### PR DESCRIPTION
A mixed bag of API changes that are needed now that package install can throw verification errors:

- add the force parameter to the client side types for the install package endpoint
- add force_install query parameter to the create agent policy API, allowing you to force install the system/elastic agent packages if needed
- the force parameter already existed for the create package policy endpoint, but it now also affects the package install. Before it only meant that you could add to a managed agent policy
- If there is a verification error, we now return attributes.package in the error response so the client knows which package failed verification. This is needed for situations like create agent policy, where we install 2 integrations (if sys_monitoring is true)