### PR TITLE
[Security Solution] bubble up macos system extension errors

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -341,6 +341,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       blocklist: `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/blocklist.html`,
       policyResponseTroubleshooting: {
         full_disk_access: `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/deploy-elastic-endpoint.html#enable-fda-endpoint`,
+        macos_system_ext: `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/deploy-elastic-endpoint.html#system-extension-endpoint`,
       },
     },
     query: {

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -247,6 +247,7 @@ export interface DocLinks {
     readonly blocklist: string;
     readonly policyResponseTroubleshooting: {
       full_disk_access: string;
+      macos_system_ext: string;
     };
   };
   readonly query: {

--- a/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response.tsx
@@ -8,7 +8,6 @@
 import React, { memo, useCallback } from 'react';
 import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { DocLinksStart } from '@kbn/core/public';
 import { EuiHealth, EuiText, EuiTreeView, EuiNotificationBadge } from '@elastic/eui';
 import { useKibana } from '../../../common/lib/kibana';
 import type {
@@ -47,6 +46,7 @@ const StyledEuiTreeView = styled(EuiTreeView)`
 `;
 
 interface PolicyResponseProps {
+  hostOs: string;
   policyResponseConfig: Immutable<HostPolicyResponseConfiguration>;
   policyResponseActions: Immutable<HostPolicyResponseAppliedAction[]>;
   policyResponseAttentionCount: Map<string, number>;
@@ -57,6 +57,7 @@ interface PolicyResponseProps {
  */
 export const PolicyResponse = memo(
   ({
+    hostOs,
     policyResponseConfig,
     policyResponseActions,
     policyResponseAttentionCount,
@@ -93,9 +94,8 @@ export const PolicyResponse = memo(
 
           const policyResponseActionFormatter = new PolicyResponseActionFormatter(
             action || {},
-            docLinks.links.securitySolution.policyResponseTroubleshooting[
-              action.name as keyof DocLinksStart['links']['securitySolution']['policyResponseTroubleshooting']
-            ]
+            docLinks.links.securitySolution.policyResponseTroubleshooting,
+            hostOs
           );
           return {
             label: (
@@ -144,6 +144,7 @@ export const PolicyResponse = memo(
         docLinks.links.securitySolution.policyResponseTroubleshooting,
         getEntryIcon,
         policyResponseActions,
+        hostOs,
       ]
     );
 

--- a/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response_action_item.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response_action_item.tsx
@@ -38,7 +38,7 @@ export const PolicyResponseActionItem = memo(
           {policyResponseActionFormatter.linkText && policyResponseActionFormatter.linkUrl && (
             <EuiLink
               target="_blank"
-              href={`${policyResponseActionFormatter.linkUrl}`}
+              href={policyResponseActionFormatter.linkUrl}
               data-test-subj="endpointPolicyResponseErrorCallOutLink"
             >
               {policyResponseActionFormatter.linkText}


### PR DESCRIPTION
## Summary

Bubble up MacOS system extension errors.
<img width="1025" alt="Screen Shot 2022-07-08 at 2 12 58 PM" src="https://user-images.githubusercontent.com/11009772/178056062-1d8514a3-6f23-434b-a636-f912181150b9.png">


### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
