### PR TITLE
[Flaky tests] Click a more explicit button

### DIFF
--- a/test/analytics/tests/instrumented_events/from_the_browser/click.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/click.ts
@@ -16,8 +16,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('General "click"', () => {
     beforeEach(async () => {
       await common.navigateToApp('home');
-      // Just click on the top div and expect it's still there... we're just testing the click event generation
-      await common.clickAndValidate('kibanaChrome', 'kibanaChrome');
+      // Just clicking the top-nav-button and expecting it's still there... we're just testing the click event generation
+      await common.clickAndValidate('toggleNavButton', 'toggleNavButton');
     });
 
     it('should emit a "click" event', async () => {
@@ -28,6 +28,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(targets.includes('DIV')).to.be(true);
       expect(targets.includes('id=kibana-body')).to.be(true);
       expect(targets.includes('data-test-subj=kibanaChrome')).to.be(true);
+      expect(targets.includes('BUTTON')).to.be(true);
+      expect(targets.includes('data-test-subj=toggleNavButton')).to.be(true);
     });
   });
 }


### PR DESCRIPTION
## Summary

Resolves #133800.

Clicking on the top div was failing once a month because it randomly selected a place where it could also click another component and the browser driver threw an error because of it. This PR now clicks an explicit button (the top nav hamburger toggle) because our intention is to test the click event generation, not the action of the button itself.

Flaky test runner (x100): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/866

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
