### PR TITLE
[Cloud Posture] Add latest-findings index link

### DIFF
--- a/x-pack/plugins/cloud_security_posture/kibana.json
+++ b/x-pack/plugins/cloud_security_posture/kibana.json
@@ -10,6 +10,6 @@
   "description": "The cloud security posture plugin",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["navigation", "data", "fleet", "unifiedSearch", "taskManager", "security", "charts"],
+  "requiredPlugins": ["navigation", "data", "fleet", "unifiedSearch", "taskManager", "security", "charts", "discover"],
   "requiredBundles": ["kibanaReact"]
 }

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
@@ -23,7 +23,7 @@ import type { DataView } from '@kbn/data-plugin/common';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import { discoverPluginMock } from '@kbn/discover-plugin/public/mocks';
-import { DiscoverStart } from '@kbn/discover-plugin/public';
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
 
 jest.mock('../../common/api/use_latest_findings_data_view');
 jest.mock('../../common/api/use_cis_kubernetes_integration');

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
@@ -22,6 +22,8 @@ import { useCisKubernetesIntegration } from '../../common/api/use_cis_kubernetes
 import type { DataView } from '@kbn/data-plugin/common';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import { discoverPluginMock } from '@kbn/discover-plugin/public/mocks';
+import { DiscoverStart } from '@kbn/discover-plugin/public';
 
 jest.mock('../../common/api/use_latest_findings_data_view');
 jest.mock('../../common/api/use_cis_kubernetes_integration');
@@ -34,12 +36,14 @@ const Wrapper = ({
   data = dataPluginMock.createStartContract(),
   unifiedSearch = unifiedSearchPluginMock.createStartContract(),
   charts = chartPluginMock.createStartContract(),
+  discover = discoverPluginMock.createStartContract(),
 }: {
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   charts: ChartsPluginStart;
+  discover: DiscoverStart;
 }) => (
-  <TestProvider deps={{ data, unifiedSearch, charts }}>
+  <TestProvider deps={{ data, unifiedSearch, charts, discover }}>
     <Findings />
   </TestProvider>
 );
@@ -49,6 +53,7 @@ describe.skip('<Findings />', () => {
     const data = dataPluginMock.createStartContract();
     const unifiedSearch = unifiedSearchPluginMock.createStartContract();
     const charts = chartPluginMock.createStartContract();
+    const discover = discoverPluginMock.createStartContract();
     const source = await data.search.searchSource.create();
 
     (useCisKubernetesIntegration as jest.Mock).mockImplementation(() => ({
@@ -65,7 +70,9 @@ describe.skip('<Findings />', () => {
       }),
     } as UseQueryResult<DataView>);
 
-    render(<Wrapper data={data} unifiedSearch={unifiedSearch} charts={charts} />);
+    render(
+      <Wrapper data={data} unifiedSearch={unifiedSearch} charts={charts} discover={discover} />
+    );
 
     expect(await screen.findByTestId(TEST_SUBJECTS.FINDINGS_CONTAINER)).toBeInTheDocument();
   });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -131,11 +131,6 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
 
       await discover.locator.navigate({
         indexPatternId: latestFindingsDataView.data.id,
-        timeRange: {
-          to: 'now',
-          from: 'now-15m',
-          mode: 'relative',
-        },
       });
     } catch (err) {
       toasts.danger({

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -25,6 +25,8 @@ import { CisKubernetesIcons, Markdown, CodeBlock } from './findings_flyout';
 type Accordion = Pick<EuiAccordionProps, 'title' | 'id' | 'initialIsOpen'> &
   Pick<EuiDescriptionListProps, 'listItems'>;
 
+const INDEX_LINK_NAME = 'logs-cloud_security_posture.findings_latest-default';
+
 const getDetailsList = (data: CspFinding, navigateToIndex: any) => [
   {
     title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.ruleNameTitle', {
@@ -60,11 +62,7 @@ const getDetailsList = (data: CspFinding, navigateToIndex: any) => [
     title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexTitle', {
       defaultMessage: 'Index',
     }),
-    description: (
-      <EuiLink onClick={navigateToIndex}>
-        {'logs-cloud_security_posture.findings_latest-default'}
-      </EuiLink>
-    ),
+    description: <EuiLink onClick={navigateToIndex}>{INDEX_LINK_NAME}</EuiLink>,
   },
 ];
 
@@ -131,7 +129,7 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
         throw new Error();
       }
 
-      return await discover.locator.navigate({
+      await discover.locator.navigate({
         indexPatternId: latestFindingsDataView.data.id,
         timeRange: {
           to: 'now',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -62,7 +62,7 @@ const getDetailsList = (data: CspFinding, navigateToIndex: any) => [
     }),
     description: (
       <EuiLink onClick={navigateToIndex}>
-        {'logs - cloud_security_posture.findings_latest-default'}
+        {'logs-cloud_security_posture.findings_latest-default'}
       </EuiLink>
     ),
   },
@@ -122,13 +122,12 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
     services: { discover },
     notifications: { toasts },
   } = useKibana();
-  console.log(useKibana());
   const latestFindingsDataView = useLatestFindingsDataView();
 
   const navigateToIndex = useCallback(async () => {
     try {
       // both cases should not happen, data view is loaded beforehand on findings page, this is mainly to discriminate and as a precaution
-      if (!discover.locator || !latestFindingsDataView.data || true) {
+      if (!discover.locator || !latestFindingsDataView.data) {
         throw new Error(
           i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorMessage', {
             defaultMessage: "Index link wasn't found",

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -127,7 +127,7 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
   const navigateToIndex = useCallback(async () => {
     try {
       // both cases should not happen, data view is loaded beforehand on findings page, this is mainly to discriminate and as a precaution
-      if (!discover.locator || !latestFindingsDataView.data || true) {
+      if (!discover.locator || !latestFindingsDataView.data) {
         throw new Error(
           i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorMessage', {
             defaultMessage: 'Index link not found',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -127,10 +127,10 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
   const navigateToIndex = useCallback(async () => {
     try {
       // both cases should not happen, data view is loaded beforehand on findings page, this is mainly to discriminate and as a precaution
-      if (!discover.locator || !latestFindingsDataView.data) {
+      if (!discover.locator || !latestFindingsDataView.data || true) {
         throw new Error(
           i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorMessage', {
-            defaultMessage: "Index link wasn't found",
+            defaultMessage: 'Index link not found',
           })
         );
       }
@@ -146,7 +146,7 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
     } catch (err) {
       toasts.danger({
         title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorTitle', {
-          defaultMessage: 'Index link error',
+          defaultMessage: 'Error',
         }),
         body: err.message,
       });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -128,11 +128,7 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
     try {
       // both cases should not happen, data view is loaded beforehand on findings page, this is mainly to discriminate and as a precaution
       if (!discover.locator || !latestFindingsDataView.data) {
-        throw new Error(
-          i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorMessage', {
-            defaultMessage: 'Index link not found',
-          })
-        );
+        throw new Error();
       }
 
       return await discover.locator.navigate({
@@ -148,7 +144,10 @@ export const OverviewTab = ({ data }: { data: CspFinding }) => {
         title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorTitle', {
           defaultMessage: 'Error',
         }),
-        body: err.message,
+        body: i18n.translate(
+          'xpack.csp.findings.findingsFlyout.overviewTab.indexLinkErrorMessage',
+          { defaultMessage: 'Index link not found' }
+        ),
       });
     }
   }, [discover.locator, latestFindingsDataView.data, toasts]);

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.test.tsx
@@ -22,6 +22,7 @@ import { buildEsQuery } from '@kbn/es-query';
 import { getPaginationQuery } from '../utils';
 import { FindingsEsPitContext } from '../es_pit/findings_es_pit_context';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
+import { discoverPluginMock } from '@kbn/discover-plugin/public/mocks';
 
 jest.mock('../../../common/api/use_latest_findings_data_view');
 jest.mock('../../../common/api/use_cis_kubernetes_integration');
@@ -66,6 +67,7 @@ describe('<LatestFindingsContainer />', () => {
           data: dataMock,
           unifiedSearch: unifiedSearchPluginMock.createStartContract(),
           charts: chartPluginMock.createStartContract(),
+          discover: discoverPluginMock.createStartContract(),
         }}
       >
         <FindingsEsPitContext.Provider value={{ setPitId, pitIdRef, pitQuery }}>

--- a/x-pack/plugins/cloud_security_posture/public/test/test_provider.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/test/test_provider.tsx
@@ -14,6 +14,7 @@ import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
+import { discoverPluginMock } from '@kbn/discover-plugin/public/mocks';
 import type { CspAppDeps } from '../application/app';
 
 export const TestProvider: React.FC<Partial<CspAppDeps>> = ({
@@ -22,6 +23,7 @@ export const TestProvider: React.FC<Partial<CspAppDeps>> = ({
     data: dataPluginMock.createStartContract(),
     unifiedSearch: unifiedSearchPluginMock.createStartContract(),
     charts: chartPluginMock.createStartContract(),
+    discover: discoverPluginMock.createStartContract(),
   },
   params = coreMock.createAppMountParameters(),
   children,

--- a/x-pack/plugins/cloud_security_posture/public/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/types.ts
@@ -8,6 +8,7 @@
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { DataPublicPluginSetup, DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CspClientPluginSetup {}
@@ -26,5 +27,6 @@ export interface CspClientPluginStartDeps {
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   charts: ChartsPluginStart;
+  discover: DiscoverStart;
   // optional
 }


### PR DESCRIPTION
## Summary

- Added `discover` to plugin deps
- Used `discover.locator` function to navigate to discover page
- Used `useLatestFindingsDataView().data.id` to navigate to `latest-findings` index in discover page 

https://user-images.githubusercontent.com/51442161/178265193-485359c5-d3db-45da-8b7f-ba37ae0dbd49.mov

- Added error case

`discover.locater` and `useLatestFindingsDataView().data.id` can potentially be `undefined`. Rare case since if discover services are not working we won't get to this stage, also `getLatestFindingsDataView()` is getting called by the findings page before the flyout is opened. rather than asserting and after a discussion with @orouz, in the rare case of error, and we cant generate the link to discover, the index name will be displayed as plain text and will not be clickable:

![image](https://user-images.githubusercontent.com/51442161/178726953-863d4ef6-3604-4ccd-be9a-6004283963c5.png)
