### PR TITLE
replace switchMap with concatMap in event log indexer

### DIFF
--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import { Subject } from 'rxjs';
-import { bufferTime, filter as rxFilter, switchMap } from 'rxjs/operators';
+import { bufferTime, filter as rxFilter, concatMap } from 'rxjs/operators';
 import { reject, isUndefined, isNumber, pick } from 'lodash';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
@@ -87,7 +87,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
       .pipe(
         bufferTime(EVENT_BUFFER_TIME, null, EVENT_BUFFER_LENGTH),
         rxFilter((docs) => docs.length > 0),
-        switchMap(async (docs) => await this.indexDocuments(docs))
+        concatMap(async (docs) => await this.indexDocuments(docs))
       )
       .toPromise();
   }


### PR DESCRIPTION
Fixes: #134730 

`switchMap` drops the results of an existing observable if a new observable is added while the previous one is still running.
Since we don't expect or evaluate results of buffered docs execution, swithMap does not break anything yet.
Nevertheless, this PR intends to replace `switchMap` with `concatMap` in event log indexer to make it ready for future developments.
