### PR TITLE
Remove spawn-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1096,7 +1096,6 @@
     "sinon": "^7.4.2",
     "sort-package-json": "^1.53.1",
     "source-map": "^0.7.3",
-    "spawn-sync": "^1.0.15",
     "string-replace-loader": "^2.2.0",
     "strong-log-transformer": "^2.1.0",
     "style-loader": "^1.1.3",

--- a/packages/kbn-pm/webpack.config.js
+++ b/packages/kbn-pm/webpack.config.js
@@ -37,22 +37,6 @@ module.exports = {
         ],
         exclude: /node_modules/,
       },
-      // Removing an unnecessary require from
-      // https://github.com/ForbesLindesay/spawn-sync/blob/8ba6d1bd032917ff5f0cf68508b91bb628d16336/index.js#L3
-      //
-      // This require would cause warnings when building with Webpack, and it's
-      // only required for Node <= 0.12.
-      {
-        test: /spawn-sync\/index\.js$/,
-        use: {
-          loader: 'string-replace-loader',
-          options: {
-            search: ` || require('./lib/spawn-sync')`,
-            replace: '',
-            strict: true,
-          },
-        },
-      },
       // In order to make it work with Node 10 we had the need to upgrade
       // the package cpy to a version >= 7.0.0. In this version cpy is
       // using the new globby that relies in the fast-glob which relies

--- a/yarn.lock
+++ b/yarn.lock
@@ -22192,11 +22192,6 @@ os-name@^3.0.0, os-name@^3.1.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
-
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -26832,14 +26827,6 @@ sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
   integrity sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=
-
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
 
 spawn-wrap@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
spawnSync is included in our node version now, we no longer need this
package.