### PR TITLE
Adds OpenAPI spec for get case status

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -2594,10 +2594,25 @@
             "content": {
               "application/json; charset=utf-8": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "count_closed_cases": {
+                      "type": "integer"
+                    },
+                    "count_in_progress_cases": {
+                      "type": "integer"
+                    },
+                    "count_open_cases": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "examples": {
+                  "getStatusResponse": {
+                    "$ref": "#/components/examples/get_status_response"
+                  }
                 }
-              },
-              "examples": {}
+              }
             }
           }
         },
@@ -6079,10 +6094,25 @@
             "content": {
               "application/json; charset=utf-8": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "count_closed_cases": {
+                      "type": "integer"
+                    },
+                    "count_in_progress_cases": {
+                      "type": "integer"
+                    },
+                    "count_open_cases": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "examples": {
+                  "getStatusResponse": {
+                    "$ref": "#/components/examples/get_status_response"
+                  }
                 }
-              },
-              "examples": {}
+              }
             }
           }
         },
@@ -7775,6 +7805,14 @@
             "email": "user2@elastic.co"
           }
         ]
+      },
+      "get_status_response": {
+        "summary": "Get the number of cases in each state.",
+        "value": {
+          "count_open_cases": 27,
+          "count_in_progress_cases": 50,
+          "count_closed_cases": 198
+        }
       },
       "get_tags_response": {
         "summary": "A list of tags that are used in cases",

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -2574,6 +2574,45 @@
         }
       ]
     },
+    "/api/cases/status": {
+      "get": {
+        "summary": "Returns the number of cases that are open, closed, and in progress.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "deprecated": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/owner"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "examples": {}
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
     "/api/cases/tags": {
       "get": {
         "summary": "Aggregates and returns a list of case tags.",
@@ -6002,6 +6041,48 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
+    "/s/{spaceId}/api/cases/status": {
+      "get": {
+        "summary": "Returns the number of cases that are open, closed, and in progress.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
+        "deprecated": true,
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/space_id"
+          },
+          {
+            "$ref": "#/components/parameters/owner"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "examples": {}
             }
           }
         },

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -2173,6 +2173,31 @@ paths:
         - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
+  /api/cases/status:
+    get:
+      summary: Returns the number of cases that are open, closed, and in progress.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're seeking.
+      tags:
+        - cases
+        - kibana
+      deprecated: true
+      parameters:
+        - $ref: '#/components/parameters/owner'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: string
+            examples: {}
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
   /api/cases/tags:
     get:
       summary: Aggregates and returns a list of case tags.
@@ -4996,6 +5021,32 @@ paths:
               examples:
                 getReportersResponse:
                   $ref: '#/components/examples/get_reporters_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+  /s/{spaceId}/api/cases/status:
+    get:
+      summary: Returns the number of cases that are open, closed, and in progress.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're seeking.
+      deprecated: true
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/space_id'
+        - $ref: '#/components/parameters/owner'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: string
+            examples: {}
       servers:
         - url: https://localhost:5601
     servers:

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -2192,8 +2192,17 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                type: string
-            examples: {}
+                type: object
+                properties:
+                  count_closed_cases:
+                    type: integer
+                  count_in_progress_cases:
+                    type: integer
+                  count_open_cases:
+                    type: integer
+              examples:
+                getStatusResponse:
+                  $ref: '#/components/examples/get_status_response'
       servers:
         - url: https://localhost:5601
     servers:
@@ -5045,8 +5054,17 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                type: string
-            examples: {}
+                type: object
+                properties:
+                  count_closed_cases:
+                    type: integer
+                  count_in_progress_cases:
+                    type: integer
+                  count_open_cases:
+                    type: integer
+              examples:
+                getStatusResponse:
+                  $ref: '#/components/examples/get_status_response'
       servers:
         - url: https://localhost:5601
     servers:
@@ -6365,6 +6383,12 @@ components:
         - username: user2
           full_name: User 2
           email: user2@elastic.co
+    get_status_response:
+      summary: Get the number of cases in each state.
+      value:
+        count_open_cases: 27
+        count_in_progress_cases: 50
+        count_closed_cases: 198
     get_tags_response:
       summary: A list of tags that are used in cases
       value:

--- a/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
@@ -31,8 +31,8 @@ paths:
     $ref: paths/api@cases@configure@connectors@_find.yaml
   '/api/cases/reporters':
     $ref: 'paths/api@cases@reporters.yaml'
-#  '/api/cases/status':
-#    $ref: 'paths/api@cases@status.yaml'
+  '/api/cases/status':
+    $ref: 'paths/api@cases@status.yaml'
   '/api/cases/tags':
     $ref: 'paths/api@cases@tags.yaml'
 #  '/api/cases/{caseId}':
@@ -62,8 +62,8 @@ paths:
     $ref: paths/s@{spaceid}@api@cases@configure@connectors@_find.yaml
   '/s/{spaceId}/api/cases/reporters':
     $ref: 'paths/s@{spaceid}@api@cases@reporters.yaml'
- # '/s/{spaceId}/api/cases/status':
- #   $ref: 'paths/s@{spaceid}@api@cases@status.yaml'
+  '/s/{spaceId}/api/cases/status':
+    $ref: 'paths/s@{spaceid}@api@cases@status.yaml'
   '/s/{spaceId}/api/cases/tags':
     $ref: 'paths/s@{spaceid}@api@cases@tags.yaml'
  # '/s/{spaceId}/api/cases/{caseId}':

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@status.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@status.yaml
@@ -16,8 +16,17 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
-        examples: {}
+            type: object
+            properties:
+              count_closed_cases:
+                type: integer
+              count_in_progress_cases:
+                type: integer
+              count_open_cases:
+                type: integer
+          examples:
+            getStatusResponse:
+              $ref: '../components/examples/get_status_response.yaml'
   servers:
     - url: https://localhost:5601
 servers:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@status.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@status.yaml
@@ -1,0 +1,24 @@
+get:
+  summary: Returns the number of cases that are open, closed, and in progress.
+  description: >
+    You must have `read` privileges for the **Cases** feature in the
+    **Management**, **Observability**, or **Security** section of the Kibana
+    feature privileges, depending on the owner of the cases you're seeking.
+  tags:
+    - cases
+    - kibana
+  deprecated: true
+  parameters:
+    - $ref: '../components/parameters/owner.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+servers:
+  - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@status.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@status.yaml
@@ -1,0 +1,25 @@
+get:
+  summary: Returns the number of cases that are open, closed, and in progress.
+  description: >
+    You must have `read` privileges for the **Cases** feature in the
+    **Management**, **Observability**, or **Security** section of the Kibana
+    feature privileges, depending on the owner of the cases you're seeking.
+  deprecated: true
+  tags:
+    - cases
+    - kibana
+  parameters:
+    - $ref: '../components/parameters/space_id.yaml'
+    - $ref: '../components/parameters/owner.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: string
+        examples: {}
+  servers:
+    - url: https://localhost:5601
+servers:
+  - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@status.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@status.yaml
@@ -17,8 +17,17 @@ get:
       content:
         application/json; charset=utf-8:
           schema:
-            type: string
-        examples: {}
+            type: object
+            properties:
+              count_closed_cases:
+                type: integer
+              count_in_progress_cases:
+                type: integer
+              count_open_cases:
+                type: integer
+          examples:
+            getStatusResponse:
+              $ref: '../components/examples/get_status_response.yaml'
   servers:
     - url: https://localhost:5601
 servers:


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/133345

This PR copies the layout used in https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/common/openapi to model the following API: https://www.elastic.co/guide/en/kibana/master/cases-api-get-status.html
