### PR TITLE
[Fleet] useHistoryBlock should preserve url search on confirm

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act } from '@testing-library/react-hooks';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import { useHistoryBlock } from '.';
+
+describe('useHistoryBlock', () => {
+  describe('without search params', () => {
+    it('should not block if not edited', () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.renderHook(() => useHistoryBlock(false));
+
+      act(() => renderer.mountHistory.push('/test'));
+
+      const { location } = renderer.mountHistory;
+      expect(location.pathname).toBe('/test');
+      expect(location.search).toBe('');
+      expect(renderer.startServices.overlays.openConfirm).not.toBeCalled();
+    });
+
+    it('should block if edited', async () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.startServices.overlays.openConfirm.mockResolvedValue(true);
+      renderer.renderHook(() => useHistoryBlock(true));
+
+      act(() => renderer.mountHistory.push('/test'));
+      // needed because we have an async useEffect
+      await act(() => new Promise((resolve) => resolve()));
+
+      expect(renderer.startServices.overlays.openConfirm).toBeCalled();
+      expect(renderer.startServices.application.navigateToUrl).toBeCalledWith(
+        '/mock/test',
+        expect.anything()
+      );
+    });
+
+    it('should block if edited and not navigate on cancel', async () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.startServices.overlays.openConfirm.mockResolvedValue(false);
+      renderer.renderHook(() => useHistoryBlock(true));
+
+      act(() => renderer.mountHistory.push('/test'));
+      // needed because we have an async useEffect
+      await act(() => new Promise((resolve) => resolve()));
+
+      expect(renderer.startServices.overlays.openConfirm).toBeCalled();
+      expect(renderer.startServices.application.navigateToUrl).not.toBeCalled();
+    });
+  });
+  describe('with search params', () => {
+    it('should not block if not edited', () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.renderHook(() => useHistoryBlock(false));
+
+      act(() => renderer.mountHistory.push('/test?param=test'));
+
+      const { location } = renderer.mountHistory;
+      expect(location.pathname).toBe('/test');
+      expect(location.search).toBe('?param=test');
+      expect(renderer.startServices.overlays.openConfirm).not.toBeCalled();
+    });
+
+    it('should block if edited and navigate on confirm', async () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.startServices.overlays.openConfirm.mockResolvedValue(true);
+      renderer.renderHook(() => useHistoryBlock(true));
+
+      act(() => renderer.mountHistory.push('/test?param=test'));
+      // needed because we have an async useEffect
+      await act(() => new Promise((resolve) => resolve()));
+
+      expect(renderer.startServices.overlays.openConfirm).toBeCalled();
+      expect(renderer.startServices.application.navigateToUrl).toBeCalledWith(
+        '/mock/test?param=test',
+        expect.anything()
+      );
+    });
+
+    it('should block if edited and not navigate on cancel', async () => {
+      const renderer = createFleetTestRendererMock();
+
+      renderer.startServices.overlays.openConfirm.mockResolvedValue(false);
+      renderer.renderHook(() => useHistoryBlock(true));
+
+      act(() => renderer.mountHistory.push('/test?param=test'));
+      // needed because we have an async useEffect
+      await act(() => new Promise((resolve) => resolve()));
+
+      expect(renderer.startServices.overlays.openConfirm).toBeCalled();
+      expect(renderer.startServices.application.navigateToUrl).not.toBeCalled();
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.tsx
@@ -35,7 +35,7 @@ export function useHistoryBlock(isEdited: boolean) {
 
         if (confirmRes) {
           unblock();
-          application.navigateToUrl(state.pathname, { state: state.state });
+          application.navigateToUrl(state.pathname + state.search, { state: state.state });
         }
       }
       confirmAsync();

--- a/x-pack/plugins/fleet/public/mock/create_test_renderer.tsx
+++ b/x-pack/plugins/fleet/public/mock/create_test_renderer.tsx
@@ -12,6 +12,7 @@ import type { RenderOptions, RenderResult } from '@testing-library/react';
 import { render as reactRender, act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import type { RenderHookResult } from '@testing-library/react-hooks';
+import { Router } from 'react-router-dom';
 
 import { themeServiceMock } from '@kbn/core/public/mocks';
 
@@ -27,6 +28,7 @@ import { createConfigurationMock } from './plugin_configuration';
 import { createStartMock } from './plugin_interfaces';
 import { createStartServices } from './fleet_start_services';
 import type { MockedFleetStart, MockedFleetStartServices } from './types';
+
 type UiRender = (ui: React.ReactElement, options?: RenderOptions) => RenderResult;
 
 /**
@@ -58,18 +60,21 @@ export const createFleetTestRendererMock = (): TestRenderer => {
   const extensions: UIExtensionsStorage = {};
   const startServices = createStartServices(basePath);
   const history = createMemoryHistory({ initialEntries: [basePath] });
+  const mountHistory = new ScopedHistory(history, basePath);
 
   const HookWrapper = memo(({ children }) => {
     return (
       <startServices.i18n.Context>
-        <KibanaContextProvider services={{ ...startServices }}>{children}</KibanaContextProvider>
+        <Router history={mountHistory}>
+          <KibanaContextProvider services={{ ...startServices }}>{children}</KibanaContextProvider>
+        </Router>
       </startServices.i18n.Context>
     );
   });
 
   const testRendererMocks: TestRenderer = {
     history,
-    mountHistory: new ScopedHistory(history, basePath),
+    mountHistory,
     startServices,
     config: createConfigurationMock(),
     startInterface: createStartMock(extensions),


### PR DESCRIPTION
## Summary

Resolve #136131

The `useHistoryBlock` hook we introduced to show a confirm dialog when quitting the package policy editor without should preserve url search on confirm.

That PR fix that, I added some unit test to that hook too.
