### PR TITLE
[Exploratory View] Allow parent to specify legend position

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { Position } from '@elastic/charts';
 import React, { useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
 import styled from 'styled-components';
@@ -34,6 +35,7 @@ export interface ExploratoryEmbeddableProps {
   dataTypesIndexPatterns?: Partial<Record<AppDataType, string>>;
   isSingleMetric?: boolean;
   legendIsVisible?: boolean;
+  legendPosition?: Position;
   onBrushEnd?: (param: { range: number[] }) => void;
   caseOwner?: string;
   reportConfigMap?: ReportConfigMap;
@@ -61,6 +63,7 @@ export default function Embeddable({
   indexPatterns,
   isSingleMetric = false,
   legendIsVisible,
+  legendPosition,
   lens,
   onBrushEnd,
   caseOwner = observabilityFeatureId,
@@ -105,6 +108,9 @@ export default function Embeddable({
 
   if (typeof legendIsVisible !== 'undefined') {
     (attributesJSON.state.visualization as XYState).legend.isVisible = legendIsVisible;
+  }
+  if (typeof legendPosition !== 'undefined') {
+    (attributesJSON.state.visualization as XYState).legend.position = legendPosition;
   }
 
   const actions = useActions({


### PR DESCRIPTION
## Summary

This PR adds a prop to the `ExploratoryViewEmbeddable` that allows the parent to specify where Lens should render the legend in the chart.

## Testing this PR

You can test this by finding any exploratory view embeddable we already use in the UI, whether it's in the UX dashboard or elsewhere, and pass the `legendPosition` prop to the embeddable component. Verify that the default behavior is overridden and the legend shows up on a different side of the chart than before. Example:


```
<ExploratoryViewEmbeddable ... />
```

<img width="732" alt="image" src="https://user-images.githubusercontent.com/18429259/178333569-7634263c-7dd8-4d03-8536-8425f4167a5f.png">


vs.

```
<ExploratoryViewEmbeddable
  legendPosition="top"
  ...
/>
```

<img width="716" alt="image" src="https://user-images.githubusercontent.com/18429259/178333446-0ef9c70d-5bff-4b66-a3a2-2792ee183fc1.png">
