### PR TITLE
Refactoring network top N flow to use useSearchStrategy

### DIFF
--- a/x-pack/plugins/security_solution/public/network/containers/network_top_n_flow/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/containers/network_top_n_flow/index.test.tsx
@@ -8,27 +8,76 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { TestProviders } from '../../../common/mock';
 import { ID, useNetworkTopNFlow } from '.';
-import { NetworkType } from '../../store/model';
+import { useSearchStrategy } from '../../../common/containers/use_search_strategy';
+import { networkModel } from '../../store';
 import { FlowTargetSourceDest } from '../../../../common/search_strategy';
 
+jest.mock('../../../common/containers/use_search_strategy', () => ({
+  useSearchStrategy: jest.fn(),
+}));
+const mockUseSearchStrategy = useSearchStrategy as jest.Mock;
+const mockSearch = jest.fn();
+
+const props = {
+  endDate: '2020-07-08T08:20:18.966Z',
+  flowTarget: FlowTargetSourceDest.source,
+  id: ID,
+  indexNames: ['auditbeat-*'],
+  skip: false,
+  startDate: '2020-07-07T08:20:18.966Z',
+  type: networkModel.NetworkType.page,
+};
+
 describe('useNetworkTopNFlow', () => {
-  it('skip = true will cancel any running request', () => {
-    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSearchStrategy.mockReturnValue({
+      loading: false,
+      result: {
+        edges: [],
+        totalCount: -1,
+        pageInfo: {
+          activePage: 0,
+          fakeTotalCount: 0,
+          showMorePagesIndicator: false,
+        },
+      },
+      search: mockSearch,
+      refetch: jest.fn(),
+      inspect: {},
+    });
+  });
+
+  it('runs search', () => {
+    renderHook(() => useNetworkTopNFlow(props), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).toHaveBeenCalled();
+  });
+
+  it('does not run search when skip = true', () => {
     const localProps = {
-      docValueFields: [],
-      flowTarget: FlowTargetSourceDest.source,
-      startDate: '2020-07-07T08:20:18.966Z',
-      endDate: '2020-07-08T08:20:18.966Z',
-      id: `${ID}-${NetworkType.page}`,
-      indexNames: ['cool'],
-      type: NetworkType.page,
-      skip: false,
+      ...props,
+      skip: true,
+    };
+    renderHook(() => useNetworkTopNFlow(localProps), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('skip = true will cancel any running request', () => {
+    const localProps = {
+      ...props,
     };
     const { rerender } = renderHook(() => useNetworkTopNFlow(localProps), {
       wrapper: TestProviders,
     });
     localProps.skip = true;
     act(() => rerender());
-    expect(abortSpy).toHaveBeenCalledTimes(4);
+    expect(mockUseSearchStrategy).toHaveBeenCalledTimes(3);
+    expect(mockUseSearchStrategy.mock.calls[2][0].abort).toEqual(true);
   });
 });

--- a/x-pack/plugins/security_solution/public/network/containers/network_top_n_flow/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/containers/network_top_n_flow/index.tsx
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import { noop } from 'lodash/fp';
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import deepEqual from 'fast-deep-equal';
-import { Subscription } from 'rxjs';
 
-import { isCompleteResponse, isErrorResponse } from '@kbn/data-plugin/common';
 import type { ESTermQuery } from '../../../../common/typed_json';
 import type { inputsModel } from '../../../common/store';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { useKibana } from '../../../common/lib/kibana';
 import { createFilter } from '../../../common/containers/helpers';
 import { generateTablePaginationOptions } from '../../../common/components/paginated_table/helpers';
 import type { networkModel } from '../../store';
@@ -23,14 +19,12 @@ import type {
   FlowTargetSourceDest,
   NetworkTopNFlowEdges,
   NetworkTopNFlowRequestOptions,
-  NetworkTopNFlowStrategyResponse,
   PageInfoPaginated,
 } from '../../../../common/search_strategy';
 import { NetworkQueries } from '../../../../common/search_strategy';
-import { getInspectResponse } from '../../../helpers';
 import type { InspectResponse } from '../../../types';
 import * as i18n from './translations';
-import { useAppToasts } from '../../../common/hooks/use_app_toasts';
+import { useSearchStrategy } from '../../../common/containers/use_search_strategy';
 
 export const ID = 'networkTopNFlowQuery';
 
@@ -72,11 +66,6 @@ export const useNetworkTopNFlow = ({
   const { activePage, limit, sort } = useDeepEqualSelector((state) =>
     getTopNFlowSelector(state, type, flowTarget)
   );
-  const { data } = useKibana().services;
-  const refetch = useRef<inputsModel.Refetch>(noop);
-  const abortCtrl = useRef(new AbortController());
-  const searchSubscription$ = useRef(new Subscription());
-  const [loading, setLoading] = useState(false);
 
   const [networkTopNFlowRequest, setTopNFlowRequest] =
     useState<NetworkTopNFlowRequestOptions | null>(null);
@@ -97,74 +86,51 @@ export const useNetworkTopNFlow = ({
     [limit]
   );
 
-  const [networkTopNFlowResponse, setNetworkTopNFlowResponse] = useState<NetworkTopNFlowArgs>({
-    networkTopNFlow: [],
-    id,
-    inspect: {
-      dsl: [],
-      response: [],
+  const {
+    loading,
+    result: response,
+    search,
+    refetch,
+    inspect,
+  } = useSearchStrategy<NetworkQueries.topNFlow>({
+    factoryQueryType: NetworkQueries.topNFlow,
+    initialResult: {
+      edges: [],
+      totalCount: -1,
+      pageInfo: {
+        activePage: 0,
+        fakeTotalCount: 0,
+        showMorePagesIndicator: false,
+      },
     },
-    isInspected: false,
-    loadPage: wrappedLoadMore,
-    pageInfo: {
-      activePage: 0,
-      fakeTotalCount: 0,
-      showMorePagesIndicator: false,
-    },
-    refetch: refetch.current,
-    totalCount: -1,
+    errorMessage: i18n.FAIL_NETWORK_TOP_N_FLOW,
+    abort: skip,
   });
-  const { addError, addWarning } = useAppToasts();
 
-  const networkTopNFlowSearch = useCallback(
-    (request: NetworkTopNFlowRequestOptions | null) => {
-      if (request == null || skip) {
-        return;
-      }
-
-      const asyncSearch = async () => {
-        abortCtrl.current = new AbortController();
-        setLoading(true);
-
-        searchSubscription$.current = data.search
-          .search<NetworkTopNFlowRequestOptions, NetworkTopNFlowStrategyResponse>(request, {
-            strategy: 'securitySolutionSearchStrategy',
-            abortSignal: abortCtrl.current.signal,
-          })
-          .subscribe({
-            next: (response) => {
-              if (isCompleteResponse(response)) {
-                setLoading(false);
-                setNetworkTopNFlowResponse((prevResponse) => ({
-                  ...prevResponse,
-                  networkTopNFlow: response.edges,
-                  inspect: getInspectResponse(response, prevResponse.inspect),
-                  pageInfo: response.pageInfo,
-                  refetch: refetch.current,
-                  totalCount: response.totalCount,
-                }));
-                searchSubscription$.current.unsubscribe();
-              } else if (isErrorResponse(response)) {
-                setLoading(false);
-                addWarning(i18n.ERROR_NETWORK_TOP_N_FLOW);
-                searchSubscription$.current.unsubscribe();
-              }
-            },
-            error: (msg) => {
-              setLoading(false);
-              addError(msg, {
-                title: i18n.FAIL_NETWORK_TOP_N_FLOW,
-              });
-              searchSubscription$.current.unsubscribe();
-            },
-          });
-      };
-      searchSubscription$.current.unsubscribe();
-      abortCtrl.current.abort();
-      asyncSearch();
-      refetch.current = asyncSearch;
-    },
-    [data.search, addError, addWarning, skip]
+  const networkTopNFlowResponse = useMemo(
+    () => ({
+      endDate,
+      networkTopNFlow: response.edges,
+      id,
+      inspect,
+      isInspected: false,
+      loadPage: wrappedLoadMore,
+      pageInfo: response.pageInfo,
+      refetch,
+      startDate,
+      totalCount: response.totalCount,
+    }),
+    [
+      endDate,
+      id,
+      inspect,
+      refetch,
+      response.edges,
+      response.pageInfo,
+      response.totalCount,
+      startDate,
+      wrappedLoadMore,
+    ]
   );
 
   useEffect(() => {
@@ -192,20 +158,10 @@ export const useNetworkTopNFlow = ({
   }, [activePage, endDate, filterQuery, indexNames, ip, limit, startDate, sort, flowTarget]);
 
   useEffect(() => {
-    networkTopNFlowSearch(networkTopNFlowRequest);
-    return () => {
-      searchSubscription$.current.unsubscribe();
-      abortCtrl.current.abort();
-    };
-  }, [networkTopNFlowRequest, networkTopNFlowSearch]);
-
-  useEffect(() => {
-    if (skip) {
-      setLoading(false);
-      searchSubscription$.current.unsubscribe();
-      abortCtrl.current.abort();
+    if (!skip && networkTopNFlowRequest) {
+      search(networkTopNFlowRequest);
     }
-  }, [skip]);
+  }, [networkTopNFlowRequest, search, skip]);
 
   return [loading, networkTopNFlowResponse];
 };

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.test.tsx
@@ -24,6 +24,24 @@ import { createStore } from '../../../common/store';
 import { NetworkDetails } from '.';
 import { FlowTargetSourceDest } from '../../../../common/search_strategy';
 
+jest.mock('../../../common/containers/use_search_strategy', () => ({
+  useSearchStrategy: jest.fn().mockReturnValue({
+    loading: false,
+    result: {
+      edges: [],
+      pageInfo: {
+        activePage: 0,
+        fakeTotalCount: 0,
+        showMorePagesIndicator: false,
+      },
+      totalCount: -1,
+    },
+    search: jest.fn(),
+    refetch: jest.fn(),
+    inspect: {},
+  }),
+}));
+
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
   return {


### PR DESCRIPTION
## Summary


https://user-images.githubusercontent.com/6295984/178342417-9b223b12-4568-4998-aac8-0144c8754f70.mov



Steps to verify:

1. Index a sample data

```
POST filebeat-7.16.2-2022.07.11-000001-MyTest/_doc
{
  "agent": {
    "build_date": "2022-04-01 13:13:45 +0000 UTC",
    "name": "bastion00",
    "commit": "58327465d29b69f55dde92715cd06968311a15ab",
    "id": "7a25ee1d-0b43-435e-afcc-891ae418eb1d",
    "type": "filebeat",
    "ephemeral_id": "b33f49bc-326d-4588-a74d-b0637b268c05",
    "version": "8.2.0"
  },
  "log": {
    "file": {
      "path": "/var/log/traefik/access.log.json"
    },
    "offset": 2460703619
  },
  "traefik": {
    "access": {
      "OriginContentSize": 18,
      "entryPointName": "web",
      "ClientAddr": "139.177.197.217:47834",
      "RequestScheme": "http",
      "OriginStatus": 307,
      "RouterName": "redirector@file",
      "Overhead": 212185,
      "OriginDuration": 171531,
      "RequestCount": 407821598,
      "RetryAttempts": 0
    }
  },
  "destination": {
    "geo": {
      "continent_name": "Europe",
      "country_iso_code": "DE",
      "country_name": "Germany",
      "location": {
        "lon": 9.491,
        "lat": 51.2993
      }
    },
    "as": {
      "number": 44486,
      "organization": {
        "name": "SYNLINQ"
      }
    },
    "address": "45.85.219.239",
    "port": 4444,
    "ip": "45.85.219.239"
  },
  "source": {
    "geo": {
      "continent_name": "North America",
      "region_iso_code": "CA-ON",
      "city_name": "Toronto",
      "country_iso_code": "CA",
      "country_name": "Canada",
      "region_name": "Ontario",
      "location": {
        "lon": -79.3623,
        "lat": 43.6547
      }
    },
    "as": {
      "number": 63949,
      "organization": {
        "name": "Linode, LLC"
      }
    },
    "address": "139.177.197.217",
    "port": 47834,
    "ip": "139.177.197.217"
  },
  "message": """{"ClientAddr":"139.177.197.217:47834","ClientHost":"139.177.197.217","ClientPort":"47834","ClientUsername":"-","DownstreamContentSize":18,"DownstreamStatus":307,"Duration":383716,"OriginContentSize":18,"OriginDuration":171531,"OriginStatus":307,"Overhead":212185,"RequestAddr":"45.85.219.239:4444","RequestContentSize":0,"RequestCount":407821598,"RequestHost":"45.85.219.239","RequestMethod":"CONNECT","RequestPath":"","RequestPort":"4444","RequestProtocol":"HTTP/1.1","RequestScheme":"http","RetryAttempts":0,"RouterName":"redirector@file","StartLocal":"2022-07-11T15:58:20.660776429Z","StartUTC":"2022-07-11T15:58:20.660776429Z","entryPointName":"web","level":"info","msg":"","time":"2022-07-11T15:58:20Z"}""",
  "url": {
    "path": "",
    "domain": "45.85.219.239:4444"
  },
  "network": {
    "community_id": "1:WMjixKW/TOQZLDN+gfxg0TRBOvA=",
    "transport": "tcp"
  },
  "input": {
    "type": "log"
  },
  "@timestamp": "2022-07-12T15:58:20.660Z",
  "related": {
    "ip": [
      "139.177.197.217",
      "45.85.219.239"
    ]
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "bastion00"
  },
  "http": {
    "request": {
      "method": "CONNECT",
      "body": {
        "bytes": 0
      }
    },
    "response": {
      "status_code": 307,
      "body": {
        "size": 18
      }
    },
    "version": "1.1"
  },
  "event": {
    "duration": 383716,
    "created": "2022-07-11T15:58:21.115Z",
    "module": "traefik",
    "start": "2022-07-11T15:58:20.660776429Z",
    "end": "2022-07-11T15:58:20.661Z",
    "dataset": "traefik.access"
  },
  "user": {
    "name": "-"
  }
}
}
```
2. Navigate to network page, and make sure filebeat-* is selected
3. Check the network top N flow tables are rendered.

### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
