### PR TITLE
Add operationId to cases openAPI specs

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -31,7 +31,8 @@
   "paths": {
     "/api/cases": {
       "post": {
-        "summary": "Creates a case.",
+        "summary": "Creates a case in the default space.",
+        "operationId": "createCaseDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're creating.\n",
         "tags": [
           "cases",
@@ -484,7 +485,8 @@
         ]
       },
       "delete": {
-        "summary": "Deletes one or more cases.",
+        "summary": "Deletes one or more cases from the default space.",
+        "operationId": "deleteCaseDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -517,7 +519,8 @@
         ]
       },
       "patch": {
-        "summary": "Updates one or more cases.",
+        "summary": "Updates one or more cases in the default space.",
+        "operationId": "updateCaseDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're updating.\n",
         "tags": [
           "cases",
@@ -989,7 +992,8 @@
     },
     "/api/cases/_find": {
       "get": {
-        "summary": "Retrieves a paginated subset of cases.",
+        "summary": "Retrieves a paginated subset of cases from the default space.",
+        "operationId": "getCasesDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "tags": [
           "cases",
@@ -1494,7 +1498,8 @@
     },
     "/api/cases/alerts/{alertId}": {
       "get": {
-        "summary": "Returns the cases associated with a specific alert.",
+        "summary": "Returns the cases associated with a specific alert in the default space.",
+        "operationId": "getCasesByAlertDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "x-technical-preview": true,
         "tags": [
@@ -1554,7 +1559,8 @@
     },
     "/api/cases/configure": {
       "get": {
-        "summary": "Retrieves external connection details, such as the closure type and default connector for cases.",
+        "summary": "Retrieves external connection details, such as the closure type and default connector for cases in the default space.",
+        "operationId": "getCaseConfigurationDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration.\n",
         "tags": [
           "cases",
@@ -1762,7 +1768,8 @@
         ]
       },
       "post": {
-        "summary": "Sets external connection details, such as the closure type and default connector for cases.",
+        "summary": "Sets external connection details, such as the closure type and default connector for cases in the default space.",
+        "operationId": "setCaseConfigurationDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration. Connectors are used to interface with external systems. You must create a connector before you can use it in your cases. Refer to the add connectors API. If you set a default connector, it is automatically selected when you create cases in Kibana. If you use the create case API, however, you must still specify all of the connector details.\n",
         "tags": [
           "cases",
@@ -2109,7 +2116,8 @@
     },
     "/api/cases/configure/{configurationId}": {
       "patch": {
-        "summary": "Updates external connection details, such as the closure type and default connector for cases.",
+        "summary": "Updates external connection details, such as the closure type and default connector for cases in the default space.",
+        "operationId": "updateCaseConfigurationDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration. Connectors are used to interface with external systems. You must create a connector before you can use it in your cases. Refer to the add connectors API.\n",
         "tags": [
           "cases",
@@ -2445,7 +2453,8 @@
     },
     "/api/cases/configure/connectors/_find": {
       "get": {
-        "summary": "Retrieves information about connectors.",
+        "summary": "Retrieves information about connectors for cases in the default space.",
+        "operationId": "getCaseConnectorsDefaultSpace",
         "description": "In particular, only the connectors that are supported for use in cases are  returned. You must have `read` privileges for the **Actions and Connectors** feature in the **Management** section of the Kibana feature privileges.\n",
         "tags": [
           "cases",
@@ -2520,7 +2529,8 @@
     },
     "/api/cases/reporters": {
       "get": {
-        "summary": "Returns information about the users who opened cases.",
+        "summary": "Returns information about the users who opened cases in the default space.",
+        "operationId": "getCaseReportersDefaultCase",
         "description": "You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases. The API returns information about the users as they existed at the time of the case creation, including their name, full name, and email address. If any of those details change thereafter or if a user is deleted, the information returned by this API is unchanged.\n",
         "tags": [
           "cases",
@@ -2576,7 +2586,8 @@
     },
     "/api/cases/tags": {
       "get": {
-        "summary": "Aggregates and returns a list of case tags.",
+        "summary": "Aggregates and returns a list of case tags in the default space.",
+        "operationId": "getCaseTagsDefaultSpace",
         "description": "You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "tags": [
           "cases",
@@ -2636,7 +2647,8 @@
     },
     "/api/cases/{caseId}/comments": {
       "post": {
-        "summary": "Adds a comment or alert to a case.",
+        "summary": "Adds a comment or alert to a case in the default space.",
+        "operationId": "addCaseCommentDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're creating.\n",
         "tags": [
           "cases",
@@ -2962,7 +2974,8 @@
         ]
       },
       "delete": {
-        "summary": "Deletes all comments and alerts from a case.",
+        "summary": "Deletes all comments and alerts from a case in the default space.",
+        "operationId": "deleteCaseCommentsDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -2988,7 +3001,8 @@
         ]
       },
       "patch": {
-        "summary": "Updates a comment or alert in a case.",
+        "summary": "Updates a comment or alert in a case in the default space.",
+        "operationId": "updateCaseCommentDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're updating. NOTE: You cannot change the comment type or the owner of a comment.\n",
         "tags": [
           "cases",
@@ -3314,7 +3328,8 @@
         ]
       },
       "get": {
-        "summary": "Retrieves all the comments from a case.",
+        "summary": "Retrieves all the comments from a case in the default space.",
+        "operationId": "getAllCaseCommentsDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
         "tags": [
           "cases",
@@ -3363,7 +3378,8 @@
     },
     "/api/cases/{caseId}/comments/{commentId}": {
       "delete": {
-        "summary": "Deletes a comment or alert from a case.",
+        "summary": "Deletes a comment or alert from a case in the default space.",
+        "operationId": "deleteCaseCommentDefaultSpace",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -3392,7 +3408,8 @@
         ]
       },
       "get": {
-        "summary": "Retrieves a comment from a case.",
+        "summary": "Retrieves a comment from a case in the default space.",
+        "operationId": "getCaseCommentDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
         "tags": [
           "cases",
@@ -3445,6 +3462,7 @@
     "/s/{spaceId}/api/cases": {
       "post": {
         "summary": "Creates a case.",
+        "operationId": "createCase",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're creating.\n",
         "tags": [
           "cases",
@@ -3901,6 +3919,7 @@
       },
       "delete": {
         "summary": "Deletes one or more cases.",
+        "operationId": "deleteCase",
         "description": "You must have `all` privileges for the **Cases** feature in the  **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -3937,6 +3956,7 @@
       },
       "patch": {
         "summary": "Updates one or more cases.",
+        "operationId": "updateCase",
         "description": "You must have `all` privileges for the **Cases** feature in the  **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're updating.\n",
         "tags": [
           "cases",
@@ -4412,6 +4432,7 @@
     "/s/{spaceId}/api/cases/_find": {
       "get": {
         "summary": "Retrieves a paginated subset of cases.",
+        "operationId": "getCases",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "tags": [
           "cases",
@@ -4918,6 +4939,7 @@
     "/s/{spaceId}/api/cases/alerts/{alertId}": {
       "get": {
         "summary": "Returns the cases associated with a specific alert.",
+        "operationId": "getCasesByAlert",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "x-technical-preview": true,
         "tags": [
@@ -4981,6 +5003,7 @@
     "/s/{spaceId}/api/cases/configure": {
       "get": {
         "summary": "Retrieves external connection details, such as the closure type and default connector for cases.",
+        "operationId": "getCaseConfiguration",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration.\n",
         "tags": [
           "cases",
@@ -5192,6 +5215,7 @@
       },
       "post": {
         "summary": "Sets external connection details, such as the closure type and default connector for cases.",
+        "operationId": "setCaseConfiguration",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration. Connectors are used to interface with external systems. You must create a connector before you can use it in your cases. Refer to the add connectors API. If you set a default connector, it is automatically selected when you create cases in Kibana. If you use the create case API, however, you must still specify all of the connector details.\n",
         "tags": [
           "cases",
@@ -5542,6 +5566,7 @@
     "/s/{spaceId}/api/cases/configure/{configurationId}": {
       "patch": {
         "summary": "Updates external connection details, such as the closure type and default connector for cases.",
+        "operationId": "updateCaseConfiguration",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case configuration. Connectors are used to interface with external systems. You must create a connector before you can use it in your cases. Refer to the add connectors API.\n",
         "tags": [
           "cases",
@@ -5881,6 +5906,7 @@
     "/s/{spaceId}/api/cases/configure/connectors/_find": {
       "get": {
         "summary": "Retrieves information about connectors.",
+        "operationId": "getCaseConnectors",
         "description": "In particular, only the connectors that are supported for use in cases are returned. You must have `read` privileges for the **Actions and Connectors** feature in the **Management** section of the Kibana feature privileges.\n",
         "tags": [
           "cases",
@@ -5961,6 +5987,7 @@
     "/s/{spaceId}/api/cases/reporters": {
       "get": {
         "summary": "Returns information about the users who opened cases.",
+        "operationId": "getCaseReporters",
         "description": "You must have read privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases. The API returns information about the users as they existed at the time of the case creation, including their name, full name, and email address. If any of those details change thereafter or if a user is deleted, the information returned by this API is unchanged.\n",
         "tags": [
           "cases",
@@ -6020,6 +6047,7 @@
     "/s/{spaceId}/api/cases/tags": {
       "get": {
         "summary": "Aggregates and returns a list of case tags.",
+        "operationId": "getCaseTags",
         "description": "You must have read privileges for the **Cases*** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
         "tags": [
           "cases",
@@ -6083,6 +6111,7 @@
     "/s/{spaceId}/api/cases/{caseId}/comments": {
       "post": {
         "summary": "Adds a comment or alert to a case.",
+        "operationId": "addCaseComment",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're creating.\n",
         "tags": [
           "cases",
@@ -6412,6 +6441,7 @@
       },
       "delete": {
         "summary": "Deletes all comments and alerts from a case.",
+        "operationId": "deleteCaseComments",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -6441,6 +6471,7 @@
       },
       "patch": {
         "summary": "Updates a comment or alert in a case.",
+        "operationId": "updateCaseComment",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're updating. NOTE: You cannot change the comment type or the owner of a comment.\n",
         "tags": [
           "cases",
@@ -6770,6 +6801,7 @@
       },
       "get": {
         "summary": "Retrieves all the comments from a case.",
+        "operationId": "getAllCaseComments",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
         "deprecated": true,
         "tags": [
@@ -6822,6 +6854,7 @@
     "/s/{spaceId}/api/cases/{caseId}/comments/{commentId}": {
       "delete": {
         "summary": "Deletes a comment or alert from a case.",
+        "operationId": "deleteCaseComment",
         "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
         "tags": [
           "cases",
@@ -6854,6 +6887,7 @@
       },
       "get": {
         "summary": "Retrieves a comment from a case.",
+        "operationId": "getCaseComment",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security*** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.\n",
         "tags": [
           "cases",

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -19,7 +19,8 @@ servers:
 paths:
   /api/cases:
     post:
-      summary: Creates a case.
+      summary: Creates a case in the default space.
+      operationId: createCaseDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -411,7 +412,8 @@ paths:
       servers:
         - url: https://localhost:5601
     delete:
-      summary: Deletes one or more cases.
+      summary: Deletes one or more cases from the default space.
+      operationId: deleteCaseDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -436,7 +438,8 @@ paths:
       servers:
         - url: https://localhost:5601
     patch:
-      summary: Updates one or more cases.
+      summary: Updates one or more cases in the default space.
+      operationId: updateCaseDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -839,7 +842,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/_find:
     get:
-      summary: Retrieves a paginated subset of cases.
+      summary: Retrieves a paginated subset of cases from the default space.
+      operationId: getCasesDefaultSpace
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -1230,7 +1234,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/alerts/{alertId}:
     get:
-      summary: Returns the cases associated with a specific alert.
+      summary: Returns the cases associated with a specific alert in the default space.
+      operationId: getCasesByAlertDefaultSpace
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -1269,7 +1274,8 @@ paths:
     get:
       summary: >-
         Retrieves external connection details, such as the closure type and
-        default connector for cases.
+        default connector for cases in the default space.
+      operationId: getCaseConfigurationDefaultSpace
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -1455,7 +1461,8 @@ paths:
     post:
       summary: >-
         Sets external connection details, such as the closure type and default
-        connector for cases.
+        connector for cases in the default space.
+      operationId: setCaseConfigurationDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -1776,7 +1783,8 @@ paths:
     patch:
       summary: >-
         Updates external connection details, such as the closure type and
-        default connector for cases.
+        default connector for cases in the default space.
+      operationId: updateCaseConfigurationDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2086,7 +2094,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/configure/connectors/_find:
     get:
-      summary: Retrieves information about connectors.
+      summary: Retrieves information about connectors for cases in the default space.
+      operationId: getCaseConnectorsDefaultSpace
       description: >
         In particular, only the connectors that are supported for use in cases
         are  returned. You must have `read` privileges for the **Actions and
@@ -2136,7 +2145,10 @@ paths:
       - url: https://localhost:5601
   /api/cases/reporters:
     get:
-      summary: Returns information about the users who opened cases.
+      summary: >-
+        Returns information about the users who opened cases in the default
+        space.
+      operationId: getCaseReportersDefaultCase
       description: >
         You must have read privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2175,7 +2187,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/tags:
     get:
-      summary: Aggregates and returns a list of case tags.
+      summary: Aggregates and returns a list of case tags in the default space.
+      operationId: getCaseTagsDefaultSpace
       description: >
         You must have read privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2214,7 +2227,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/{caseId}/comments:
     post:
-      summary: Adds a comment or alert to a case.
+      summary: Adds a comment or alert to a case in the default space.
+      operationId: addCaseCommentDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2474,7 +2488,8 @@ paths:
       servers:
         - url: https://localhost:5601
     delete:
-      summary: Deletes all comments and alerts from a case.
+      summary: Deletes all comments and alerts from a case in the default space.
+      operationId: deleteCaseCommentsDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2491,7 +2506,8 @@ paths:
       servers:
         - url: https://localhost:5601
     patch:
-      summary: Updates a comment or alert in a case.
+      summary: Updates a comment or alert in a case in the default space.
+      operationId: updateCaseCommentDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2752,7 +2768,8 @@ paths:
       servers:
         - url: https://localhost:5601
     get:
-      summary: Retrieves all the comments from a case.
+      summary: Retrieves all the comments from a case in the default space.
+      operationId: getAllCaseCommentsDefaultSpace
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2782,7 +2799,8 @@ paths:
       - url: https://localhost:5601
   /api/cases/{caseId}/comments/{commentId}:
     delete:
-      summary: Deletes a comment or alert from a case.
+      summary: Deletes a comment or alert from a case in the default space.
+      operationId: deleteCaseCommentDefaultSpace
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2800,7 +2818,8 @@ paths:
       servers:
         - url: https://localhost:5601
     get:
-      summary: Retrieves a comment from a case.
+      summary: Retrieves a comment from a case in the default space.
+      operationId: getCaseCommentDefaultSpace
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -2831,6 +2850,7 @@ paths:
   /s/{spaceId}/api/cases:
     post:
       summary: Creates a case.
+      operationId: createCase
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the
@@ -3225,6 +3245,7 @@ paths:
         - url: https://localhost:5601
     delete:
       summary: Deletes one or more cases.
+      operationId: deleteCase
       description: >
         You must have `all` privileges for the **Cases** feature in the 
         **Management**, **Observability**, or **Security** section of the
@@ -3252,6 +3273,7 @@ paths:
         - url: https://localhost:5601
     patch:
       summary: Updates one or more cases.
+      operationId: updateCase
       description: >
         You must have `all` privileges for the **Cases** feature in the 
         **Management**, **Observability**, or **Security** section of the
@@ -3657,6 +3679,7 @@ paths:
   /s/{spaceId}/api/cases/_find:
     get:
       summary: Retrieves a paginated subset of cases.
+      operationId: getCases
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -4051,6 +4074,7 @@ paths:
   /s/{spaceId}/api/cases/alerts/{alertId}:
     get:
       summary: Returns the cases associated with a specific alert.
+      operationId: getCasesByAlert
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -4091,6 +4115,7 @@ paths:
       summary: >-
         Retrieves external connection details, such as the closure type and
         default connector for cases.
+      operationId: getCaseConfiguration
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -4278,6 +4303,7 @@ paths:
       summary: >-
         Sets external connection details, such as the closure type and default
         connector for cases.
+      operationId: setCaseConfiguration
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -4600,6 +4626,7 @@ paths:
       summary: >-
         Updates external connection details, such as the closure type and
         default connector for cases.
+      operationId: updateCaseConfiguration
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -4911,6 +4938,7 @@ paths:
   /s/{spaceId}/api/cases/configure/connectors/_find:
     get:
       summary: Retrieves information about connectors.
+      operationId: getCaseConnectors
       description: >
         In particular, only the connectors that are supported for use in cases
         are returned. You must have `read` privileges for the **Actions and
@@ -4963,6 +4991,7 @@ paths:
   /s/{spaceId}/api/cases/reporters:
     get:
       summary: Returns information about the users who opened cases.
+      operationId: getCaseReporters
       description: >
         You must have read privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5003,6 +5032,7 @@ paths:
   /s/{spaceId}/api/cases/tags:
     get:
       summary: Aggregates and returns a list of case tags.
+      operationId: getCaseTags
       description: >
         You must have read privileges for the **Cases*** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5043,6 +5073,7 @@ paths:
   /s/{spaceId}/api/cases/{caseId}/comments:
     post:
       summary: Adds a comment or alert to a case.
+      operationId: addCaseComment
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5304,6 +5335,7 @@ paths:
         - url: https://localhost:5601
     delete:
       summary: Deletes all comments and alerts from a case.
+      operationId: deleteCaseComments
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5322,6 +5354,7 @@ paths:
         - url: https://localhost:5601
     patch:
       summary: Updates a comment or alert in a case.
+      operationId: updateCaseComment
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5584,6 +5617,7 @@ paths:
         - url: https://localhost:5601
     get:
       summary: Retrieves all the comments from a case.
+      operationId: getAllCaseComments
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5615,6 +5649,7 @@ paths:
   /s/{spaceId}/api/cases/{caseId}/comments/{commentId}:
     delete:
       summary: Deletes a comment or alert from a case.
+      operationId: deleteCaseComment
       description: >
         You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the Kibana
@@ -5634,6 +5669,7 @@ paths:
         - url: https://localhost:5601
     get:
       summary: Retrieves a comment from a case.
+      operationId: getCaseComment
       description: >
         You must have `read` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security*** section of the

--- a/x-pack/plugins/cases/docs/openapi/components/examples/get_status.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/examples/get_status.yaml
@@ -1,0 +1,7 @@
+summary: Get the number of cases in each state.
+value: 
+  {
+    "count_open_cases": 27,
+    "count_in_progress_cases": 50,
+    "count_closed_cases": 198
+  }

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases.yaml
@@ -1,5 +1,6 @@
 post:
-  summary: Creates a case.
+  summary: Creates a case in the default space.
+  operationId: createCaseDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -73,7 +74,8 @@ post:
      - url: https://localhost:5601
 
 delete:
-  summary: Deletes one or more cases.
+  summary: Deletes one or more cases from the default space.
+  operationId: deleteCaseDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -97,7 +99,8 @@ delete:
     - url: https://localhost:5601
 
 patch:
-  summary: Updates one or more cases.
+  summary: Updates one or more cases in the default space.
+  operationId: updateCaseDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@_find.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Retrieves a paginated subset of cases.
+  summary: Retrieves a paginated subset of cases from the default space.
+  operationId: getCasesDefaultSpace
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Returns the cases associated with a specific alert.
+  summary: Returns the cases associated with a specific alert in the default space.
+  operationId: getCasesByAlertDefaultSpace
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Retrieves external connection details, such as the closure type and default connector for cases.
+  summary: Retrieves external connection details, such as the closure type and default connector for cases in the default space.
+  operationId: getCaseConfigurationDefaultSpace
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -24,7 +25,8 @@ get:
         - url: https://localhost:5601
 
 post:
-  summary: Sets external connection details, such as the closure type and default connector for cases.
+  summary: Sets external connection details, such as the closure type and default connector for cases in the default space.
+  operationId: setCaseConfigurationDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure@connectors@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure@connectors@_find.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Retrieves information about connectors. 
+  summary: Retrieves information about connectors for cases in the default space.
+  operationId: getCaseConnectorsDefaultSpace
   description: >
     In particular, only the connectors that are supported for use in cases are 
     returned. You must have `read` privileges for the **Actions and Connectors**

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure@{configurationid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@configure@{configurationid}.yaml
@@ -1,5 +1,6 @@
 patch:
-  summary: Updates external connection details, such as the closure type and default connector for cases.
+  summary: Updates external connection details, such as the closure type and default connector for cases in the default space.
+  operationId: updateCaseConfigurationDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@reporters.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@reporters.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Returns information about the users who opened cases. 
+  summary: Returns information about the users who opened cases in the default space. 
+  operationId: getCaseReportersDefaultCase
   description: >
     You must have read privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security** section of the Kibana feature privileges,

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@tags.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@tags.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Aggregates and returns a list of case tags.
+  summary: Aggregates and returns a list of case tags in the default space.
+  operationId: getCaseTagsDefaultSpace
   description: >
     You must have read privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
@@ -1,5 +1,6 @@
 post:
-  summary: Adds a comment or alert to a case.
+  summary: Adds a comment or alert to a case in the default space.
+  operationId: addCaseCommentDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -36,7 +37,8 @@ post:
      - url: https://localhost:5601
 
 delete:
-  summary: Deletes all comments and alerts from a case.
+  summary: Deletes all comments and alerts from a case in the default space.
+  operationId: deleteCaseCommentsDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -54,7 +56,8 @@ delete:
     - url: https://localhost:5601
 
 patch:
-  summary: Updates a comment or alert in a case.
+  summary: Updates a comment or alert in a case in the default space.
+  operationId: updateCaseCommentDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -92,7 +95,8 @@ patch:
         - url: https://localhost:5601
 
 get:
-  summary: Retrieves all the comments from a case.
+  summary: Retrieves all the comments from a case in the default space.
+  operationId: getAllCaseCommentsDefaultSpace
   description: >
     You must have `read` privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security** section of the Kibana feature privileges,

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
@@ -1,5 +1,6 @@
 delete:
-  summary: Deletes a comment or alert from a case.
+  summary: Deletes a comment or alert from a case in the default space.
+  operationId: deleteCaseCommentDefaultSpace
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -18,7 +19,8 @@ delete:
     - url: https://localhost:5601
 
 get:
-  summary: Retrieves a comment from a case.
+  summary: Retrieves a comment from a case in the default space.
+  operationId: getCaseCommentDefaultSpace
   description: >
     You must have `read` privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security** section of the Kibana feature privileges,

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases.yaml
@@ -1,5 +1,6 @@
 post:
   summary: Creates a case.
+  operationId: createCase
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana 
@@ -75,6 +76,7 @@ post:
 
 delete:
   summary: Deletes one or more cases.
+  operationId: deleteCase
   description: >
     You must have `all` privileges for the **Cases** feature in the 
     **Management**, **Observability**, or **Security** section of the Kibana 
@@ -100,6 +102,7 @@ delete:
 
 patch:
   summary: Updates one or more cases.
+  operationId: updateCase
   description: >
     You must have `all` privileges for the **Cases** feature in the 
     **Management**, **Observability**, or **Security** section of the Kibana 

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@_find.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Retrieves a paginated subset of cases.
+  operationId: getCases
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@alerts@{alertid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@alerts@{alertid}.yaml
@@ -1,5 +1,6 @@
 get:
   summary:  Returns the cases associated with a specific alert.
+  operationId: getCasesByAlert
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Retrieves external connection details, such as the closure type and default connector for cases.
+  operationId: getCaseConfiguration
   description: >
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -26,6 +27,7 @@ get:
 
 post:
   summary: Sets external connection details, such as the closure type and default connector for cases. 
+  operationId: setCaseConfiguration
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure@connectors@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure@connectors@_find.yaml
@@ -1,5 +1,6 @@
 get:
-  summary: Retrieves information about connectors. 
+  summary: Retrieves information about connectors.
+  operationId: getCaseConnectors
   description: >
     In particular, only the connectors that are supported for use in cases are
     returned. You must have `read` privileges for the **Actions and Connectors**

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure@{configurationid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@configure@{configurationid}.yaml
@@ -1,5 +1,6 @@
 patch:
   summary: Updates external connection details, such as the closure type and default connector for cases.
+  operationId: updateCaseConfiguration
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@reporters.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@reporters.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Returns information about the users who opened cases.
+  operationId: getCaseReporters
   description: >
     You must have read privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security** section of the Kibana feature privileges,

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@tags.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@tags.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Aggregates and returns a list of case tags.
+  operationId: getCaseTags
   description: >
     You must have read privileges for the **Cases*** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments.yaml
@@ -1,5 +1,6 @@
 post:
   summary: Adds a comment or alert to a case.
+  operationId: addCaseComment
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -38,6 +39,7 @@ post:
 
 delete:
   summary: Deletes all comments and alerts from a case.
+  operationId: deleteCaseComments
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -57,6 +59,7 @@ delete:
 
 patch:
   summary: Updates a comment or alert in a case.
+  operationId: updateCaseComment
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -96,6 +99,7 @@ patch:
 
 get:
   summary: Retrieves all the comments from a case.
+  operationId: getAllCaseComments
   description: >
     You must have `read` privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security** section of the Kibana feature privileges,

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml
@@ -1,5 +1,6 @@
 delete:
   summary: Deletes a comment or alert from a case.
+  operationId: deleteCaseComment
   description: >
     You must have `all` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
@@ -20,6 +21,7 @@ delete:
 
 get:
   summary: Retrieves a comment from a case.
+  operationId: getCaseComment
   description: >
     You must have `read` privileges for the **Cases** feature in the **Management**,
     **Observability**, or **Security*** section of the Kibana feature privileges,


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/133345

This PR adds `operationId` properties to all the open API specifications for the case APIs. Per https://swagger.io/docs/specification/paths-and-operations/, "operationId is an optional unique string used to identify an operation. If provided, these IDs must be unique among all operations described in your API...Some code generators use this value to name the corresponding methods in code." In the absence of this property, some tools I was testing generate quite long and unwieldy identifiers.

It also adds an example for the get case status API, which was accidentally omitted from https://github.com/elastic/kibana/pull/136128