### PR TITLE
not reusing references on spec when creating dataview

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -44,7 +44,7 @@ const runtimeField = {
 fieldFormatsMock.getInstance = jest.fn().mockImplementation(() => new MockFieldFormatter()) as any;
 
 // helper function to create index patterns
-function create(id: string) {
+function create(id: string, spec?: object) {
   const {
     type,
     version,
@@ -61,6 +61,7 @@ function create(id: string) {
       title,
       name,
       runtimeFieldMap,
+      ...spec,
     },
     fieldFormats: fieldFormatsMock,
     shortDotsEnable: false,
@@ -411,6 +412,14 @@ describe('IndexPattern', () => {
       expect(restoredPattern.title).toEqual(indexPattern.title);
       expect(restoredPattern.timeFieldName).toEqual(indexPattern.timeFieldName);
       expect(restoredPattern.fields.length).toEqual(indexPattern.fields.length);
+    });
+
+    test('creating from spec does not contain references to spec', () => {
+      const sourceFilters = ['test'];
+      const spec = { sourceFilters };
+      const dataView1 = create('test1', spec);
+      const dataView2 = create('test2', spec);
+      expect(dataView1.sourceFilters).not.toBe(dataView2.sourceFilters);
     });
   });
 });

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -145,7 +145,7 @@ export class DataView implements DataViewBase {
     const { spec = {}, fieldFormats, shortDotsEnable = false, metaFields = [] } = config;
 
     // set dependencies
-    this.fieldFormats = fieldFormats;
+    this.fieldFormats = { ...fieldFormats };
     // set config
     this.shortDotsEnable = shortDotsEnable;
     this.metaFields = metaFields;
@@ -162,13 +162,13 @@ export class DataView implements DataViewBase {
 
     this.title = spec.title || '';
     this.timeFieldName = spec.timeFieldName;
-    this.sourceFilters = spec.sourceFilters;
+    this.sourceFilters = [...(spec.sourceFilters || [])];
     this.fields.replaceAll(Object.values(spec.fields || {}));
     this.type = spec.type;
     this.typeMeta = spec.typeMeta;
-    this.fieldAttrs = spec.fieldAttrs || {};
+    this.fieldAttrs = cloneDeep(spec.fieldAttrs) || {};
     this.allowNoIndex = spec.allowNoIndex || false;
-    this.runtimeFieldMap = spec.runtimeFieldMap || {};
+    this.runtimeFieldMap = cloneDeep(spec.runtimeFieldMap) || {};
     this.namespaces = spec.namespaces || [];
     this.name = spec.name || '';
   }


### PR DESCRIPTION
## Summary

When dataview gets created the passed in spec contains objects which dataview instance reuses (does not copy).

This PR addresses this by making sure this passed in structures are copied onto the instance.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios