### PR TITLE
[Cloud Posture] add sorting to resource findings table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -17,7 +17,7 @@ import { useCspBreadcrumbs } from '../../../../common/navigation/use_csp_breadcr
 import { findingsNavigation } from '../../../../common/navigation/constants';
 import { ResourceFindingsQuery, useResourceFindings } from './use_resource_findings';
 import { useUrlQuery } from '../../../../common/hooks/use_url_query';
-import type { FindingsBaseURLQuery, FindingsBaseProps } from '../../types';
+import type { FindingsBaseURLQuery, FindingsBaseProps, CspFinding } from '../../types';
 import {
   getFindingsPageSizeInfo,
   addFilter,
@@ -37,7 +37,7 @@ const getDefaultQuery = ({
 }: FindingsBaseURLQuery): FindingsBaseURLQuery & ResourceFindingsQuery => ({
   query,
   filters,
-  sort: { field: '@timestamp', direction: 'desc' },
+  sort: { field: 'result.evaluation' as keyof CspFinding, direction: 'asc' },
   pageIndex: 0,
   pageSize: 10,
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -37,6 +37,7 @@ const getDefaultQuery = ({
 }: FindingsBaseURLQuery): FindingsBaseURLQuery & ResourceFindingsQuery => ({
   query,
   filters,
+  sort: { field: '@timestamp', direction: 'desc' },
   pageIndex: 0,
   pageSize: 10,
 });
@@ -77,6 +78,7 @@ export const ResourceFindings = ({ dataView }: FindingsBaseProps) => {
       pageSize: urlQuery.pageSize,
       pageIndex: urlQuery.pageIndex,
     }),
+    sort: urlQuery.sort,
     query: baseEsQuery.query,
     resourceId: params.resourceId,
     enabled: !baseEsQuery.error,
@@ -138,8 +140,11 @@ export const ResourceFindings = ({ dataView }: FindingsBaseProps) => {
                 pageIndex: urlQuery.pageIndex,
                 totalItemCount: resourceFindings.data?.total || 0,
               })}
-              setTableOptions={({ page }) =>
-                setUrlQuery({ pageIndex: page.index, pageSize: page.size })
+              sorting={{
+                sort: { field: urlQuery.sort.field, direction: urlQuery.sort.direction },
+              }}
+              setTableOptions={({ page, sort }) =>
+                setUrlQuery({ pageIndex: page.index, pageSize: page.size, sort })
               }
               onAddFilter={(field, value, negate) =>
                 setUrlQuery({

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
@@ -8,10 +8,11 @@ import React, { useMemo, useState } from 'react';
 import {
   EuiEmptyPrompt,
   EuiBasicTable,
-  CriteriaWithPagination,
-  Pagination,
-  EuiBasicTableColumn,
-  EuiTableActionsColumnType,
+  type CriteriaWithPagination,
+  type Pagination,
+  type EuiBasicTableColumn,
+  type EuiTableActionsColumnType,
+  type EuiBasicTableProps,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -27,6 +28,7 @@ interface Props {
   items: CspFinding[];
   loading: boolean;
   pagination: Pagination;
+  sorting: Required<EuiBasicTableProps<CspFinding>>['sorting'];
   setTableOptions(options: CriteriaWithPagination<CspFinding>): void;
   onAddFilter: OnAddFilter;
 }
@@ -35,6 +37,7 @@ const ResourceFindingsTableComponent = ({
   items,
   loading,
   pagination,
+  sorting,
   setTableOptions,
   onAddFilter,
 }: Props) => {
@@ -48,8 +51,14 @@ const ResourceFindingsTableComponent = ({
       getExpandColumn<CspFinding>({ onClick: setSelectedFinding }),
       baseFindingsColumns['resource.id'],
       createColumnWithFilters(baseFindingsColumns['result.evaluation'], { onAddFilter }),
-      createColumnWithFilters(baseFindingsColumns['resource.sub_type'], { onAddFilter }),
-      createColumnWithFilters(baseFindingsColumns['resource.name'], { onAddFilter }),
+      createColumnWithFilters(
+        { ...baseFindingsColumns['resource.sub_type'], sortable: false },
+        { onAddFilter }
+      ),
+      createColumnWithFilters(
+        { ...baseFindingsColumns['resource.name'], sortable: false },
+        { onAddFilter }
+      ),
       createColumnWithFilters(baseFindingsColumns['rule.name'], { onAddFilter }),
       baseFindingsColumns['rule.section'],
       createColumnWithFilters(baseFindingsColumns.cluster_id, { onAddFilter }),
@@ -80,6 +89,7 @@ const ResourceFindingsTableComponent = ({
         columns={columns}
         onChange={setTableOptions}
         pagination={pagination}
+        sorting={sorting}
       />
       {selectedFinding && (
         <FindingsRuleFlyout

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/use_resource_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/use_resource_findings.ts
@@ -15,19 +15,21 @@ import { FindingsEsPitContext } from '../../es_pit/findings_es_pit_context';
 import { FINDINGS_REFETCH_INTERVAL_MS } from '../../constants';
 import { useKibana } from '../../../../common/hooks/use_kibana';
 import { showErrorToast } from '../../latest_findings/use_latest_findings';
-import type { CspFinding, FindingsBaseEsQuery } from '../../types';
-import { getAggregationCount, getFindingsCountAggQuery } from '../../utils';
+import type { CspFinding, FindingsBaseEsQuery, Sort } from '../../types';
+import { getAggregationCount, getFindingsCountAggQuery, getSortKey } from '../../utils';
 
 interface UseResourceFindingsOptions extends FindingsBaseEsQuery {
   resourceId: string;
   from: NonNullable<estypes.SearchRequest['from']>;
   size: NonNullable<estypes.SearchRequest['size']>;
+  sort: Sort<CspFinding>;
   enabled: boolean;
 }
 
 export interface ResourceFindingsQuery {
   pageIndex: Pagination['pageIndex'];
   pageSize: Pagination['pageSize'];
+  sort: Sort<CspFinding>;
 }
 
 type ResourceFindingsRequest = IKibanaSearchRequest<estypes.SearchRequest>;
@@ -43,6 +45,7 @@ const getResourceFindingsQuery = ({
   from,
   size,
   pitId,
+  sort,
 }: UseResourceFindingsOptions & { pitId: string }): estypes.SearchRequest => ({
   from,
   size,
@@ -54,6 +57,7 @@ const getResourceFindingsQuery = ({
         filter: [...(query?.bool?.filter || []), { term: { 'resource.id': resourceId } }],
       },
     },
+    sort: [{ [getSortKey(sort.field)]: sort.direction }],
     pit: { id: pitId },
     aggs: getFindingsCountAggQuery(),
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/types.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { Criteria } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { BoolQuery, Filter, Query } from '@kbn/es-query';
 import type { CspRuleMetadata } from '../../../common/schemas';
@@ -86,3 +87,5 @@ export interface CspFindingsQueryData {
   page: CspFinding[];
   total: number;
 }
+
+export type Sort<T> = NonNullable<Criteria<T>['sort']>;

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/utils.ts
@@ -161,3 +161,15 @@ export const addFilter = ({
 
   return [...filters, filter].filter(isNonNullable);
 };
+
+const FIELDS_WITHOUT_KEYWORD_MAPPING = new Set([
+  '@timestamp',
+  'resource.sub_type',
+  'resource.name',
+  'resource.id',
+  'rule.name',
+]);
+
+// NOTE: .keyword comes from the mapping we defined for the Findings index
+export const getSortKey = (key: string): string =>
+  FIELDS_WITHOUT_KEYWORD_MAPPING.has(key) ? key : `${key}.keyword`;


### PR DESCRIPTION
## Summary

this PR adds sorting for the following fields:  `resource.id`, `result.evaluation`, `rule.name`, `result.section`, `@timestamp` 



https://user-images.githubusercontent.com/20814186/178431299-8df34b50-2277-4f0a-9aaf-f31de7401b53.mov


also note this view is currently in the works (Product-wise) and will be updated soon. changes will include improvements such as dealing with columns that can't be sorted. (which are sorted in this PR) 