### PR TITLE
[Enterprise Search] Clear fallback flag when snippet is disabled

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
@@ -680,10 +680,10 @@ describe('ResultSettingsLogic', () => {
         );
       });
 
-      it('should remove rawSize value when toggling off', () => {
+      it('should remove rawSize and snippetFallback value when toggling off', () => {
         mount({
           resultFields: {
-            bar: { raw: false, snippet: true, snippetSize: 5 },
+            bar: { raw: false, snippet: true, snippetSize: 5, snippetFallback: true },
           },
         });
         jest.spyOn(ResultSettingsLogic.actions, 'updateField');
@@ -696,6 +696,7 @@ describe('ResultSettingsLogic', () => {
           {
             raw: false,
             snippet: false,
+            snippetFallback: false,
           }
         );
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
@@ -272,7 +272,7 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
       actions.updateField(fieldName, {
         ...omit(field, ['snippetSize']),
         snippet,
-        ...(snippet ? { snippetSize: DEFAULT_SNIPPET_SIZE } : {}),
+        ...(snippet ? { snippetSize: DEFAULT_SNIPPET_SIZE } : { snippetFallback: false }),
       });
     },
     toggleSnippetFallbackForField: ({ fieldName }) => {


### PR DESCRIPTION
## Summary

In App Search results settings, disabling the snippet flag does not disable the fallback flag:
<img width="187" alt="Screenshot 2022-07-11 at 16 29 49" src="https://user-images.githubusercontent.com/16032709/178461031-d1f1e985-f8db-4eb1-94de-daa3c31d9976.png">

This should fix it.