### PR TITLE
[Security Solution][Endpoint] Enables policyResponseInFleetEnabled by default

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -21,7 +21,7 @@ export const allowedExperimentalValues = Object.freeze({
   riskyUsersEnabled: false,
   pendingActionResponsesWithAck: true,
   policyListEnabled: true,
-  policyResponseInFleetEnabled: false,
+  policyResponseInFleetEnabled: true,
   groupedNavigation: true,
 
   /**


### PR DESCRIPTION
## Summary

Enables `policyResponseInFleetEnabled` by default.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
