### PR TITLE
[Fleet] replace number with boolean for conditional rendering 

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -172,7 +172,7 @@ export const PackagePolicyInputStreamConfig: React.FunctionComponent<{
               );
             })}
             {/* Advanced section */}
-            {(isPackagePolicyEdit || advancedVars.length) && (
+            {(isPackagePolicyEdit || !!advancedVars.length) && (
               <Fragment>
                 <EuiFlexItem>
                   <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">


### PR DESCRIPTION
this PR fixes an issue where the char `0` sneaks up into the DOM 

### before 
![Screen Shot 2022-07-11 at 11 39 24](https://user-images.githubusercontent.com/20814186/178517373-30ce6120-a37a-44ee-9cd9-39b5f115cce9.png)


### after 

![Screen Shot 2022-07-12 at 17 39 57](https://user-images.githubusercontent.com/20814186/178520100-780da372-fc11-4977-b5fc-bcb2f855d4ea.png)


came up while working on our (CSP) integration 