### PR TITLE
[ML] Data Visualizer: Add timer for document count chart

### DIFF
--- a/x-pack/plugins/data_visualizer/common/constants.ts
+++ b/x-pack/plugins/data_visualizer/common/constants.ts
@@ -40,6 +40,7 @@ export const JOB_FIELD_TYPES = {
   TEXT: 'text',
   HISTOGRAM: 'histogram',
   UNKNOWN: 'unknown',
+  VERSION: 'version',
 } as const;
 
 export const OMIT_FIELDS: string[] = ['_source', '_type', '_index', '_id', '_version', '_score'];

--- a/x-pack/plugins/data_visualizer/common/types/field_request_config.ts
+++ b/x-pack/plugins/data_visualizer/common/types/field_request_config.ts
@@ -29,11 +29,6 @@ export interface DocumentCounts {
   interval?: number;
 }
 
-export interface LatLongExample {
-  lat: number;
-  lon: number;
-}
-
 export interface GeoPointExample {
   coordinates: number[];
   type?: string;

--- a/x-pack/plugins/data_visualizer/common/types/field_request_config.ts
+++ b/x-pack/plugins/data_visualizer/common/types/field_request_config.ts
@@ -29,6 +29,16 @@ export interface DocumentCounts {
   interval?: number;
 }
 
+export interface LatLongExample {
+  lat: number;
+  lon: number;
+}
+
+export interface GeoPointExample {
+  coordinates: number[];
+  type?: string;
+}
+
 export interface FieldVisStats {
   error?: Error;
   cardinality?: number;
@@ -56,7 +66,7 @@ export interface FieldVisStats {
   topValues?: Array<{ key: number | string; doc_count: number }>;
   topValuesSampleSize?: number;
   topValuesSamplerShardSize?: number;
-  examples?: Array<string | object>;
+  examples?: Array<string | GeoPointExample | object>;
   timeRangeEarliest?: number;
   timeRangeLatest?: number;
 }

--- a/x-pack/plugins/data_visualizer/common/types/field_stats.ts
+++ b/x-pack/plugins/data_visualizer/common/types/field_stats.ts
@@ -100,6 +100,7 @@ export interface DocumentCountStats {
   timeRangeEarliest?: number;
   timeRangeLatest?: number;
   totalCount: number;
+  took?: number;
 }
 
 export interface FieldExamples {

--- a/x-pack/plugins/data_visualizer/public/application/common/components/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/document_count_content/document_count_content.tsx
@@ -6,10 +6,10 @@
  */
 
 import React, { FC } from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
 import { DocumentCountChart, DocumentCountChartPoint } from './document_count_chart';
 import { TotalCountHeader } from './total_count_header';
 import { DocumentCountStats } from '../../../../../common/types/field_stats';
-
 export interface Props {
   documentCountStats?: DocumentCountStats;
   totalCount: number;
@@ -39,6 +39,7 @@ export const DocumentCountContent: FC<Props> = ({ documentCountStats, totalCount
         timeRangeLatest={timeRangeLatest}
         interval={documentCountStats.interval}
       />
+      <EuiCodeBlock>{`vanilla query took: ${documentCountStats.took}`}</EuiCodeBlock>
     </>
   );
 };

--- a/x-pack/plugins/data_visualizer/public/application/common/components/examples_list/examples_list.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/examples_list/examples_list.tsx
@@ -10,10 +10,11 @@ import React, { FC } from 'react';
 import { EuiListGroup, EuiListGroupItem } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
+import { GeoPointExample } from '../../../../../common/types/field_request_config';
 import { ExpandedRowFieldHeader } from '../stats_table/components/expanded_row_field_header';
 import { ExpandedRowPanel } from '../stats_table/components/field_data_expanded_row/expanded_row_panel';
 interface Props {
-  examples: Array<string | object>;
+  examples: Array<string | GeoPointExample | object>;
 }
 
 export const ExamplesList: FC<Props> = ({ examples }) => {

--- a/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/file_based_expanded_row.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/file_based_expanded_row.tsx
@@ -41,6 +41,7 @@ export const FileBasedDataVisualizerExpandedRow = ({ item }: { item: FileBasedFi
         return <IpContent config={config} />;
 
       case JOB_FIELD_TYPES.KEYWORD:
+      case JOB_FIELD_TYPES.VERSION:
         return <KeywordContent config={config} />;
 
       case JOB_FIELD_TYPES.TEXT:

--- a/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/geo_point_content_with_map/geo_point_content_with_map.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/geo_point_content_with_map/geo_point_content_with_map.tsx
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { ES_GEO_FIELD_TYPE, LayerDescriptor } from '@kbn/maps-plugin/common';
+import { getUniqCoordinates } from '../../../util/geo_utils';
 import { CombinedQuery } from '../../../../index_data_visualizer/types/combined_query';
 import { ExpandedRowContent } from '../../stats_table/components/field_data_expanded_row/expanded_row_content';
 import { DocumentStatsTable } from '../../stats_table/components/field_data_expanded_row/document_stats';
@@ -28,6 +28,8 @@ export const GeoPointContentWithMap: FC<{
   const {
     services: { maps: mapsPlugin, data },
   } = useDataVisualizerKibana();
+
+  const uniqueExamples = useMemo(() => getUniqCoordinates(stats?.examples), [stats?.examples]);
 
   // Update the layer list  with updated geo points upon refresh
   useEffect(() => {
@@ -64,7 +66,7 @@ export const GeoPointContentWithMap: FC<{
   return (
     <ExpandedRowContent dataTestSubj={'dataVisualizerIndexBasedMapContent'}>
       <DocumentStatsTable config={config} />
-      <ExamplesList examples={stats.examples} />
+      <ExamplesList examples={uniqueExamples} />
       <ExpandedRowPanel className={'dvPanel__wrapper dvMap__wrapper'} grow={true}>
         <EmbeddedMapComponent layerList={layerList} />
       </ExpandedRowPanel>

--- a/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/index_based_expanded_row.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/index_based_expanded_row.tsx
@@ -74,6 +74,7 @@ export const IndexBasedDataVisualizerExpandedRow = ({
         return <IpContent config={config} onAddFilter={onAddFilter} />;
 
       case JOB_FIELD_TYPES.KEYWORD:
+      case JOB_FIELD_TYPES.VERSION:
         return <KeywordContent config={config} onAddFilter={onAddFilter} />;
 
       case JOB_FIELD_TYPES.TEXT:

--- a/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/index_based_expanded_row.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/expanded_row/index_based_expanded_row.tsx
@@ -55,7 +55,7 @@ export const IndexBasedDataVisualizerExpandedRow = ({
         return <NumberContent config={config} onAddFilter={onAddFilter} />;
 
       case JOB_FIELD_TYPES.BOOLEAN:
-        return <BooleanContent config={config} />;
+        return <BooleanContent config={config} onAddFilter={onAddFilter} />;
 
       case JOB_FIELD_TYPES.DATE:
         return <DateContent config={config} />;

--- a/x-pack/plugins/data_visualizer/public/application/common/components/field_data_row/action_menu/lens_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/field_data_row/action_menu/lens_utils.ts
@@ -201,6 +201,7 @@ export function getCompatibleLensDataType(type: FieldVisConfig['type']): string 
   let lensType: string | undefined;
   switch (type) {
     case JOB_FIELD_TYPES.KEYWORD:
+    case JOB_FIELD_TYPES.VERSION:
       lensType = 'string';
       break;
     case JOB_FIELD_TYPES.DATE:
@@ -234,7 +235,11 @@ function getColumnsAndLayer(
   if (fieldType === JOB_FIELD_TYPES.NUMBER) {
     return getNumberSettings(item, defaultDataView);
   }
-  if (fieldType === JOB_FIELD_TYPES.IP || fieldType === JOB_FIELD_TYPES.KEYWORD) {
+  if (
+    fieldType === JOB_FIELD_TYPES.IP ||
+    fieldType === JOB_FIELD_TYPES.KEYWORD ||
+    fieldType === JOB_FIELD_TYPES.VERSION
+  ) {
     return getKeywordSettings(item);
   }
   if (fieldType === JOB_FIELD_TYPES.BOOLEAN) {

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/boolean_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/boolean_content.tsx
@@ -5,18 +5,13 @@
  * 2.0.
  */
 
-import React, { FC, ReactNode, useMemo } from 'react';
-import {
-  EuiBasicTable,
-  EuiSpacer,
-  RIGHT_ALIGNMENT,
-  LEFT_ALIGNMENT,
-  HorizontalAlignment,
-} from '@elastic/eui';
+import React, { FC, useMemo } from 'react';
+import { EuiSpacer } from '@elastic/eui';
 import { Axis, BarSeries, Chart, Settings, ScaleType } from '@elastic/charts';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { TopValues } from '../../../top_values';
 import type { FieldDataRowProps } from '../../types/field_data_row';
 import { ExpandedRowFieldHeader } from '../expanded_row_field_header';
 import { getTFPercentage } from '../../utils';
@@ -44,72 +39,42 @@ function getFormattedValue(value: number, totalCount: number): string {
 
 const BOOLEAN_DISTRIBUTION_CHART_HEIGHT = 70;
 
-export const BooleanContent: FC<FieldDataRowProps> = ({ config }) => {
+export const BooleanContent: FC<FieldDataRowProps> = ({ config, onAddFilter }) => {
   const fieldFormat = 'fieldFormat' in config ? config.fieldFormat : undefined;
   const formattedPercentages = useMemo(() => getTFPercentage(config), [config]);
   const theme = useDataVizChartTheme();
   if (!formattedPercentages) return null;
 
   const { trueCount, falseCount, count } = formattedPercentages;
-  const summaryTableItems = [
-    {
-      function: 'true',
-      display: (
-        <FormattedMessage
-          id="xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.trueCountLabel"
-          defaultMessage="true"
-        />
-      ),
-      value: getFormattedValue(trueCount, count),
-    },
-    {
-      function: 'false',
-      display: (
-        <FormattedMessage
-          id="xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.falseCountLabel"
-          defaultMessage="false"
-        />
-      ),
-      value: getFormattedValue(falseCount, count),
-    },
-  ];
-  const summaryTableColumns = [
-    {
-      field: 'function',
-      name: '',
-      render: (_: string, summaryItem: { display: ReactNode }) => summaryItem.display,
-      width: '25px',
-      align: LEFT_ALIGNMENT as HorizontalAlignment,
-    },
-    {
-      field: 'value',
-      name: '',
-      render: (v: string) => <strong>{v}</strong>,
-      align: RIGHT_ALIGNMENT as HorizontalAlignment,
-    },
-  ];
-
-  const summaryTableTitle = i18n.translate(
-    'xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.summaryTableTitle',
-    {
-      defaultMessage: 'Summary',
-    }
-  );
-
+  const stats = {
+    ...config.stats,
+    topValues: [
+      {
+        key: i18n.translate(
+          'xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.trueCountLabel',
+          { defaultMessage: 'true' }
+        ),
+        doc_count: trueCount ?? 0,
+      },
+      {
+        key: i18n.translate(
+          'xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.falseCountLabel',
+          { defaultMessage: 'false' }
+        ),
+        doc_count: falseCount ?? 0,
+      },
+    ],
+  };
   return (
     <ExpandedRowContent dataTestSubj={'dataVisualizerBooleanContent'}>
       <DocumentStatsTable config={config} />
 
-      <ExpandedRowPanel className={'dvSummaryTable__wrapper dvPanel__wrapper'}>
-        <ExpandedRowFieldHeader>{summaryTableTitle}</ExpandedRowFieldHeader>
-        <EuiBasicTable
-          className={'dvSummaryTable'}
-          compressed
-          items={summaryTableItems}
-          columns={summaryTableColumns}
-          tableCaption={summaryTableTitle}
-        />
-      </ExpandedRowPanel>
+      <TopValues
+        stats={stats}
+        fieldFormat={fieldFormat}
+        barColor="success"
+        onAddFilter={onAddFilter}
+      />
 
       <ExpandedRowPanel className={'dvPanel__wrapper dvPanel--uniform'}>
         <ExpandedRowFieldHeader>

--- a/x-pack/plugins/data_visualizer/public/application/common/util/field_types_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/util/field_types_utils.ts
@@ -54,6 +54,9 @@ export const jobTypeLabels = {
   [JOB_FIELD_TYPES.UNKNOWN]: i18n.translate('xpack.dataVisualizer.fieldTypeIcon.unknownTypeLabel', {
     defaultMessage: 'Unknown',
   }),
+  [JOB_FIELD_TYPES.VERSION]: i18n.translate('xpack.dataVisualizer.fieldTypeIcon.versionTypeLabel', {
+    defaultMessage: 'Version',
+  }),
 };
 
 // convert kibana types to ML Job types
@@ -62,9 +65,14 @@ export const jobTypeLabels = {
 export function kbnTypeToJobType(field: DataViewField) {
   // Return undefined if not one of the supported data visualizer field types.
   let type;
+
   switch (field.type) {
     case KBN_FIELD_TYPES.STRING:
       type = field.aggregatable ? JOB_FIELD_TYPES.KEYWORD : JOB_FIELD_TYPES.TEXT;
+
+      if (field.esTypes?.includes(JOB_FIELD_TYPES.VERSION)) {
+        type = JOB_FIELD_TYPES.VERSION;
+      }
       break;
     case KBN_FIELD_TYPES.NUMBER:
       type = JOB_FIELD_TYPES.NUMBER;

--- a/x-pack/plugins/data_visualizer/public/application/common/util/geo_utils.test.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/util/geo_utils.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getUniqCoordinates } from './geo_utils';
+
+describe('geo type utils', () => {
+  describe('getUniqCoordinates', () => {
+    test('should remove duplicated coordinates', () => {
+      expect(
+        getUniqCoordinates([
+          { coordinates: [0.0001, 2343], type: 'Point' },
+          { coordinates: [0.0001, 2343], type: 'Point' },
+          { coordinates: [0.0001, 2343], type: 'Point' },
+          { coordinates: [0.0001, 2343], type: 'Shape' },
+          { coordinates: [0.0001, 2343] },
+          { coordinates: [4321, 2343], type: 'Point' },
+          { coordinates: [4321, 2343], type: 'Point' },
+        ])
+      ).toMatchObject([
+        {
+          coordinates: [0.0001, 2343],
+          type: 'Point',
+        },
+        {
+          coordinates: [0.0001, 2343],
+          type: 'Shape',
+        },
+        {
+          coordinates: [0.0001, 2343],
+        },
+        {
+          coordinates: [4321, 2343],
+          type: 'Point',
+        },
+      ]);
+      expect(
+        getUniqCoordinates([
+          { coordinates: [1000, 2000, 3000], type: 'Point' },
+          { coordinates: [1000, 2000, 3000], type: 'Point' },
+          { coordinates: [1000, 2000, 3000], type: 'Point' },
+          { coordinates: [1000, 2000, 3000, 4000], type: 'Shape' },
+          { coordinates: [1000, 2000, 3000, 4000] },
+        ])
+      ).toMatchObject([
+        {
+          coordinates: [1000, 2000, 3000],
+          type: 'Point',
+        },
+        { coordinates: [1000, 2000, 3000, 4000], type: 'Shape' },
+        { coordinates: [1000, 2000, 3000, 4000] },
+      ]);
+    });
+  });
+});

--- a/x-pack/plugins/data_visualizer/public/application/common/util/geo_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/util/geo_utils.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isPopulatedObject } from '@kbn/ml-is-populated-object';
+import { GeoPointExample } from '../../../../common/types/field_request_config';
+import { isDefined } from './is_defined';
+
+export function isGeoPointExample(arg: unknown): arg is GeoPointExample {
+  return isPopulatedObject(arg, ['coordinates']);
+}
+
+export function getUniqCoordinates(
+  coordinates: Array<string | GeoPointExample | object> | undefined
+): GeoPointExample[] {
+  const uniqueCoordinates: GeoPointExample[] = [];
+  if (!isDefined(coordinates)) return uniqueCoordinates;
+
+  coordinates.forEach((ex) => {
+    if (
+      isGeoPointExample(ex) &&
+      uniqueCoordinates.findIndex(
+        (c) =>
+          c.type === ex.type && ex.coordinates.every((coord, idx) => coord === c.coordinates[idx])
+      ) === -1
+    ) {
+      uniqueCoordinates.push(ex);
+    }
+  });
+  return uniqueCoordinates;
+}

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/use_data_visualizer_grid_data.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/use_data_visualizer_grid_data.ts
@@ -394,7 +394,6 @@ export const useDataVisualizerGridData = (
 
     nonMetricFieldsToShow.forEach((field) => {
       const fieldData = nonMetricFieldData.find((f) => f.fieldName === field.spec.name);
-
       const nonMetricConfig: Partial<FieldVisConfig> = {
         ...(fieldData ? fieldData : {}),
         fieldFormat: currentDataView.getFormatterForField(field),

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_document_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_document_stats.ts
@@ -94,5 +94,6 @@ export const processDocumentCountStats = (
     timeRangeEarliest: params.earliest,
     timeRangeLatest: params.latest,
     totalCount,
+    took: body.took,
   };
 };

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_fields_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_fields_stats.ts
@@ -35,6 +35,7 @@ export const getFieldsStats = (
       return fetchNumericFieldsStats(dataSearch, params, fields, options);
     case JOB_FIELD_TYPES.KEYWORD:
     case JOB_FIELD_TYPES.IP:
+    case JOB_FIELD_TYPES.VERSION:
       return fetchStringFieldsStats(dataSearch, params, fields, options);
     case JOB_FIELD_TYPES.DATE:
       return fetchDateFieldsStats(dataSearch, params, fields, options);

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -10528,7 +10528,6 @@
     "xpack.dataVisualizer.dataGrid.field.topValues.calculatedFromSampleDescription": "Calculé à partir d'un échantillon de {topValuesSamplerShardSize} documents par partition",
     "xpack.dataVisualizer.dataGrid.field.topValuesLabel": "Valeurs les plus élevées",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.falseCountLabel": "faux",
-    "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.summaryTableTitle": "Résumé",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.trueCountLabel": "vrai",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.choroplethMapTopValues.calculatedFromSampleDescription": "Calculé à partir d'un échantillon de {topValuesSamplerShardSize} documents par partition",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.documentStatsTable.countLabel": "compte",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10520,7 +10520,6 @@
     "xpack.dataVisualizer.dataGrid.field.topValues.calculatedFromSampleDescription": "1 つのシャードにつき {topValuesSamplerShardSize} のドキュメントのサンプルで計算されています",
     "xpack.dataVisualizer.dataGrid.field.topValuesLabel": "トップの値",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.falseCountLabel": "false",
-    "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.summaryTableTitle": "まとめ",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.trueCountLabel": "true",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.choroplethMapTopValues.calculatedFromSampleDescription": "1 つのシャードにつき {topValuesSamplerShardSize} のドキュメントのサンプルで計算されています",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.documentStatsTable.countLabel": "カウント",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10534,7 +10534,6 @@
     "xpack.dataVisualizer.dataGrid.field.topValues.calculatedFromSampleDescription": "基于每个分片的 {topValuesSamplerShardSize} 文档样例计算",
     "xpack.dataVisualizer.dataGrid.field.topValuesLabel": "排名最前值",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.falseCountLabel": "false",
-    "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.summaryTableTitle": "摘要",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.booleanContent.trueCountLabel": "true",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.choroplethMapTopValues.calculatedFromSampleDescription": "基于每个分片的 {topValuesSamplerShardSize} 文档样例计算",
     "xpack.dataVisualizer.dataGrid.fieldExpandedRow.documentStatsTable.countLabel": "计数",


### PR DESCRIPTION
## Summary

This PR adds info for how long the query for the Data visualizer document count chart takes. This PR is used for benchmarking purposes only.
<img width="1710" alt="Screen Shot 2022-07-12 at 16 26 59" src="https://user-images.githubusercontent.com/43350163/178598459-b2bb23bb-6d24-4400-95d9-747c7de2e4c7.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
