### PR TITLE
allow editing adhoc dataview

### DIFF
--- a/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
@@ -32,7 +32,9 @@ const IndexPatternFlyoutContentContainer = ({
         editData.title = title;
         editData.name = name;
         editData.timeFieldName = timeFieldName;
-        saveResponse = await dataViews.updateSavedObject(editData);
+        saveResponse = editData.isPersisted()
+          ? await dataViews.updateSavedObject(editData)
+          : editData;
       } else {
         saveResponse = await dataViews.createAndSave(dataViewSpec);
       }

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -67,7 +67,7 @@ export const IndexHeader: React.FC<IndexHeaderProps> = ({
             {editTooltip}
           </EuiButton>
         ),
-        defaultIndex !== indexPattern.id && setDefault && canSave && (
+        defaultIndex !== indexPattern.id && setDefault && canSave && indexPattern.isPersisted() && (
           <EuiButton
             onClick={setDefault}
             iconType="starFilled"
@@ -77,7 +77,7 @@ export const IndexHeader: React.FC<IndexHeaderProps> = ({
             {setDefaultTooltip}
           </EuiButton>
         ),
-        canSave && (
+        canSave && indexPattern.isPersisted() && (
           <EuiButtonEmpty
             color="danger"
             onClick={deleteIndexPatternClick}

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -156,7 +156,7 @@ export class DataView implements DataViewBase {
 
     // set values
     this.id = spec.id;
-    this.fieldFormatMap = spec.fieldFormats || {};
+    this.fieldFormatMap = { ...spec.fieldFormats };
 
     this.version = spec.version;
 


### PR DESCRIPTION
## Summary

Allows managing and editing ad-hoc dataviews:

- runtime fields can be added to a local dataview
- field properties can be adjusted on adhoc dataview (format, custom label, ...)
- main properties can be adjusted on adhoc dataview (name, timefield, ...)
- its not possible to delete adhoc dataview from the management page
- its not possible to set adhoc dataview as default dataview
