### PR TITLE
[ML] Explain log rate spikes: Use DualBrush component to select WindowParameters for analysis.

### DIFF
--- a/x-pack/plugins/aiops/public/application/services/timefilter_refresh_service.ts
+++ b/x-pack/plugins/aiops/public/application/services/timefilter_refresh_service.ts
@@ -12,4 +12,4 @@ export interface Refresh {
   timeRange?: { start: string; end: string };
 }
 
-export const aiOpsRefresh$ = new Subject<Refresh>();
+export const aiopsRefresh$ = new Subject<Refresh>();

--- a/x-pack/plugins/aiops/public/components/date_picker_wrapper/date_picker_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/date_picker_wrapper/date_picker_wrapper.tsx
@@ -15,7 +15,7 @@ import { TimeHistoryContract, UI_SETTINGS } from '@kbn/data-plugin/public';
 
 import { useUrlState } from '../../hooks/url_state';
 import { useAiOpsKibana } from '../../kibana_context';
-import { aiOpsRefresh$ } from '../../application/services/timefilter_refresh_service';
+import { aiopsRefresh$ } from '../../application/services/timefilter_refresh_service';
 
 interface TimePickerQuickRange {
   from: string;
@@ -47,7 +47,7 @@ function getRecentlyUsedRangesFactory(timeHistory: TimeHistoryContract) {
 }
 
 function updateLastRefresh(timeRange: OnRefreshProps) {
-  aiOpsRefresh$.next({ lastRefresh: Date.now(), timeRange });
+  aiopsRefresh$.next({ lastRefresh: Date.now(), timeRange });
 }
 
 export const DatePickerWrapper: FC = () => {

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -142,7 +142,11 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
         windowParameters === undefined &&
         adjustedChartPoints !== undefined
       ) {
-        const wp = getWindowParameters(startRange, xDomain.min, xDomain.max + interval);
+        const wp = getWindowParameters(
+          startRange + interval / 2,
+          xDomain.min,
+          xDomain.max + interval
+        );
         setOriginalWindowParameters(wp);
         setWindowParameters(wp);
         brushSelectionUpdateHandler(wp);
@@ -231,12 +235,12 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
               <DualBrushAnnotation
                 id="baseline"
                 min={windowParameters.baselineMin}
-                max={windowParameters.baselineMax}
+                max={windowParameters.baselineMax - interval}
               />
               <DualBrushAnnotation
                 id="deviation"
                 min={windowParameters.deviationMin}
-                max={windowParameters.deviationMax}
+                max={windowParameters.deviationMax - interval}
               />
             </>
           )}

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -234,12 +234,12 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
           {windowParameters && (
             <>
               <DualBrushAnnotation
-                id="baseline"
+                id="aiopsBaseline"
                 min={windowParameters.baselineMin}
                 max={windowParameters.baselineMax - interval}
               />
               <DualBrushAnnotation
-                id="deviation"
+                id="aiopsDeviation"
                 min={windowParameters.deviationMin}
                 max={windowParameters.deviationMax - interval}
               />

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -83,7 +83,8 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
     defaultMessage: 'document count',
   });
 
-  const viewMode = VIEW_MODE.BRUSH;
+  // TODO Let user choose between ZOOM and BRUSH mode.
+  const [viewMode] = useState<VIEW_MODE>(VIEW_MODE.BRUSH);
 
   const xDomain = {
     min: timeRangeEarliest,

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
@@ -4,7 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { FC } from 'react';
+import React, { useState, FC } from 'react';
+
+import { WindowParameters } from '@kbn/aiops-utils';
+
 import { DocumentCountChart, DocumentCountChartPoint } from '../document_count_chart';
 import { TotalCountHeader } from '../total_count_header';
 import { DocumentCountStats } from '../../../get_document_stats';
@@ -15,6 +18,8 @@ export interface Props {
 }
 
 export const DocumentCountContent: FC<Props> = ({ documentCountStats, totalCount }) => {
+  const [spikeSelection, setSpikeSelection] = useState<WindowParameters | undefined>();
+
   if (documentCountStats === undefined) {
     return totalCount !== undefined ? <TotalCountHeader totalCount={totalCount} /> : null;
   }
@@ -32,12 +37,15 @@ export const DocumentCountContent: FC<Props> = ({ documentCountStats, totalCount
   return (
     <>
       <TotalCountHeader totalCount={totalCount} />
-      <DocumentCountChart
-        chartPoints={chartPoints}
-        timeRangeEarliest={timeRangeEarliest}
-        timeRangeLatest={timeRangeLatest}
-        interval={documentCountStats.interval}
-      />
+      {documentCountStats.interval !== undefined && (
+        <DocumentCountChart
+          brushSelectionUpdateHandler={setSpikeSelection}
+          chartPoints={chartPoints}
+          timeRangeEarliest={timeRangeEarliest}
+          timeRangeLatest={timeRangeLatest}
+          interval={documentCountStats.interval}
+        />
+      )}
     </>
   );
 };

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState, FC } from 'react';
+import React, { FC } from 'react';
 
 import { WindowParameters } from '@kbn/aiops-utils';
 
@@ -12,14 +12,17 @@ import { DocumentCountChart, DocumentCountChartPoint } from '../document_count_c
 import { TotalCountHeader } from '../total_count_header';
 import { DocumentCountStats } from '../../../get_document_stats';
 
-export interface Props {
+export interface DocumentCountContentProps {
+  brushSelectionUpdateHandler: (d: WindowParameters) => void;
   documentCountStats?: DocumentCountStats;
   totalCount: number;
 }
 
-export const DocumentCountContent: FC<Props> = ({ documentCountStats, totalCount }) => {
-  const [spikeSelection, setSpikeSelection] = useState<WindowParameters | undefined>();
-
+export const DocumentCountContent: FC<DocumentCountContentProps> = ({
+  brushSelectionUpdateHandler,
+  documentCountStats,
+  totalCount,
+}) => {
   if (documentCountStats === undefined) {
     return totalCount !== undefined ? <TotalCountHeader totalCount={totalCount} /> : null;
   }
@@ -39,7 +42,7 @@ export const DocumentCountContent: FC<Props> = ({ documentCountStats, totalCount
       <TotalCountHeader totalCount={totalCount} />
       {documentCountStats.interval !== undefined && (
         <DocumentCountChart
-          brushSelectionUpdateHandler={setSpikeSelection}
+          brushSelectionUpdateHandler={brushSelectionUpdateHandler}
           chartPoints={chartPoints}
           timeRangeEarliest={timeRangeEarliest}
           timeRangeLatest={timeRangeLatest}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes.tsx
@@ -7,18 +7,6 @@
 
 import React, { useEffect, FC } from 'react';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiPageBody,
-  EuiPageContentBody,
-  EuiPageContentHeader,
-  EuiPageContentHeaderSection,
-  EuiSpacer,
-  EuiTitle,
-} from '@elastic/eui';
-
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { ProgressControls } from '@kbn/aiops-components';
 import { useFetchStream } from '@kbn/aiops-utils';
@@ -28,11 +16,6 @@ import { useAiOpsKibana } from '../../kibana_context';
 import { initialState, streamReducer } from '../../../common/api/stream_reducer';
 import type { ApiExplainLogRateSpikes } from '../../../common/api';
 import { SpikeAnalysisTable } from '../spike_analysis_table';
-import { FullTimeRangeSelector } from '../full_time_range_selector';
-import { DocumentCountContent } from '../document_count_content/document_count_content';
-import { DatePickerWrapper } from '../date_picker_wrapper';
-import { useData } from '../../hooks/use_data';
-import { useUrlState } from '../../hooks/url_state';
 
 /**
  * ExplainLogRateSpikes props require a data view.
@@ -40,20 +23,22 @@ import { useUrlState } from '../../hooks/url_state';
 export interface ExplainLogRateSpikesProps {
   /** The data view to analyze. */
   dataView: DataView;
+  /** Start timestamp filter */
+  earliest: number;
+  /** End timestamp filter */
+  latest: number;
   /** Window parameters for the analysis */
   windowParameters: WindowParameters;
 }
 
 export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesProps> = ({
   dataView,
+  earliest,
+  latest,
   windowParameters,
 }) => {
   const { services } = useAiOpsKibana();
   const basePath = services.http?.basePath.get() ?? '';
-
-  const [globalState, setGlobalState] = useUrlState('_g');
-
-  const { docStats, timefilter } = useData(dataView, setGlobalState);
 
   const { cancel, start, data, isRunning, error } = useFetchStream<
     ApiExplainLogRateSpikes,
@@ -61,11 +46,8 @@ export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesProps> = ({
   >(
     `${basePath}/internal/aiops/explain_log_rate_spikes`,
     {
-      // TODO Consider actual user selected time ranges.
-      // Since we already receive window parameters here,
-      // we just set a maximum time range of 1970-2038 here.
-      start: 0,
-      end: 2147483647000,
+      start: earliest,
+      end: latest,
       // TODO Consider an optional Kuery.
       kuery: '',
       // TODO Handle data view without time fields.
@@ -77,99 +59,22 @@ export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesProps> = ({
   );
 
   useEffect(() => {
-    if (globalState?.time !== undefined) {
-      timefilter.setTime({
-        from: globalState.time.from,
-        to: globalState.time.to,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(globalState?.time), timefilter]);
-
-  useEffect(() => {
-    if (globalState?.refreshInterval !== undefined) {
-      timefilter.setRefreshInterval(globalState.refreshInterval);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(globalState?.refreshInterval), timefilter]);
-
-  useEffect(() => {
     start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!dataView || !timefilter) return null;
-
   return (
     <>
-      <EuiPageBody data-test-subj="aiOpsIndexPage" paddingSize="none" panelled={false}>
-        <EuiFlexGroup gutterSize="m">
-          <EuiFlexItem>
-            <EuiPageContentHeader className="aiOpsPageHeader">
-              <EuiPageContentHeaderSection>
-                <div className="aiOpsTitleHeader">
-                  <EuiTitle size={'s'}>
-                    <h2>{dataView.title}</h2>
-                  </EuiTitle>
-                </div>
-              </EuiPageContentHeaderSection>
-
-              <EuiFlexGroup
-                alignItems="center"
-                justifyContent="flexEnd"
-                gutterSize="s"
-                data-test-subj="aiOpsTimeRangeSelectorSection"
-              >
-                {dataView.timeFieldName !== undefined && (
-                  <EuiFlexItem grow={false}>
-                    <FullTimeRangeSelector
-                      dataView={dataView}
-                      query={undefined}
-                      disabled={false}
-                      timefilter={timefilter}
-                    />
-                  </EuiFlexItem>
-                )}
-                <EuiFlexItem grow={false}>
-                  <DatePickerWrapper />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPageContentHeader>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="m" />
-        <EuiHorizontalRule />
-        <EuiPageContentBody>
-          <EuiFlexGroup direction="column">
-            {docStats?.totalCount !== undefined && (
-              <EuiFlexItem>
-                <DocumentCountContent
-                  documentCountStats={docStats.documentCountStats}
-                  totalCount={docStats.totalCount}
-                />
-              </EuiFlexItem>
-            )}
-            <EuiFlexItem>
-              <ProgressControls
-                progress={data.loaded}
-                progressMessage={data.loadingState ?? ''}
-                isRunning={isRunning}
-                onRefresh={start}
-                onCancel={cancel}
-              />
-            </EuiFlexItem>
-            {data?.changePoints ? (
-              <EuiFlexItem>
-                <SpikeAnalysisTable
-                  changePointData={data.changePoints}
-                  loading={isRunning}
-                  error={error}
-                />
-              </EuiFlexItem>
-            ) : null}
-          </EuiFlexGroup>
-        </EuiPageContentBody>
-      </EuiPageBody>
+      <ProgressControls
+        progress={data.loaded}
+        progressMessage={data.loadingState ?? ''}
+        isRunning={isRunning}
+        onRefresh={start}
+        onCancel={cancel}
+      />
+      {data?.changePoints ? (
+        <SpikeAnalysisTable changePointData={data.changePoints} loading={isRunning} error={error} />
+      ) : null}
     </>
   );
 };

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes.tsx
@@ -20,7 +20,7 @@ import { SpikeAnalysisTable } from '../spike_analysis_table';
 /**
  * ExplainLogRateSpikes props require a data view.
  */
-export interface ExplainLogRateSpikesProps {
+interface ExplainLogRateSpikesProps {
   /** The data view to analyze. */
   dataView: DataView;
   /** Start timestamp filter */

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_wrapper.tsx
@@ -149,12 +149,12 @@ export const ExplainLogRateSpikesWrapper: FC<ExplainLogRateSpikesWrapperProps> =
 
   return (
     <UrlStateContextProvider value={{ searchString: urlSearchString, setUrlState }}>
-      <EuiPageBody data-test-subj="aiOpsIndexPage" paddingSize="none" panelled={false}>
+      <EuiPageBody data-test-subj="aiopsIndexPage" paddingSize="none" panelled={false}>
         <EuiFlexGroup gutterSize="m">
           <EuiFlexItem>
-            <EuiPageContentHeader className="aiOpsPageHeader">
+            <EuiPageContentHeader className="aiopsPageHeader">
               <EuiPageContentHeaderSection>
-                <div className="aiOpsTitleHeader">
+                <div className="aiopsTitleHeader">
                   <EuiTitle size={'s'}>
                     <h2>{dataView.title}</h2>
                   </EuiTitle>
@@ -165,7 +165,7 @@ export const ExplainLogRateSpikesWrapper: FC<ExplainLogRateSpikesWrapperProps> =
                 alignItems="center"
                 justifyContent="flexEnd"
                 gutterSize="s"
-                data-test-subj="aiOpsTimeRangeSelectorSection"
+                data-test-subj="aiopsTimeRangeSelectorSection"
               >
                 {dataView.timeFieldName !== undefined && (
                   <EuiFlexItem grow={false}>

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/index.ts
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export type { ExplainLogRateSpikesProps } from './explain_log_rate_spikes';
+export type { ExplainLogRateSpikesWrapperProps } from './explain_log_rate_spikes_wrapper';
 import { ExplainLogRateSpikesWrapper } from './explain_log_rate_spikes_wrapper';
 
 // required for dynamic import using React.lazy()

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -117,6 +117,7 @@ export const SpikeAnalysisTable: FC<Props> = ({ changePointData, error, loading 
 
   return (
     <EuiBasicTable
+      compressed
       columns={columns}
       items={pageOfItems ?? []}
       noItemsMessage={noDataText}

--- a/x-pack/plugins/aiops/public/hooks/url_state.ts
+++ b/x-pack/plugins/aiops/public/hooks/url_state.ts
@@ -80,15 +80,15 @@ export function parseUrlState(search: string): Dictionary<any> {
 // This uses a context to be able to maintain only one instance
 // of the url state. It gets passed down with `UrlStateProvider`
 // and can be used via `useUrlState`.
-export const aiOpsUrlStateStore = createContext<UrlState>({
+export const aiopsUrlStateStore = createContext<UrlState>({
   searchString: '',
   setUrlState: () => {},
 });
 
-export const { Provider } = aiOpsUrlStateStore;
+export const { Provider } = aiopsUrlStateStore;
 
 export const useUrlState = (accessor: Accessor) => {
-  const { searchString, setUrlState: setUrlStateContext } = useContext(aiOpsUrlStateStore);
+  const { searchString, setUrlState: setUrlStateContext } = useContext(aiopsUrlStateStore);
 
   const urlState = useMemo(() => {
     const fullUrlState = parseUrlState(searchString);

--- a/x-pack/plugins/aiops/public/hooks/use_data.ts
+++ b/x-pack/plugins/aiops/public/hooks/use_data.ts
@@ -11,7 +11,7 @@ import { merge } from 'rxjs';
 import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { useAiOpsKibana } from '../kibana_context';
 import { useTimefilter } from './use_time_filter';
-import { aiOpsRefresh$ } from '../application/services/timefilter_refresh_service';
+import { aiopsRefresh$ } from '../application/services/timefilter_refresh_service';
 import { TimeBuckets } from '../../common/time_buckets';
 import { useDocumentCountStats } from './use_document_count_stats';
 import { Dictionary } from './url_state';
@@ -80,7 +80,7 @@ export const useData = (
     const timeUpdateSubscription = merge(
       timefilter.getTimeUpdate$(),
       timefilter.getAutoRefreshFetch$(),
-      aiOpsRefresh$
+      aiopsRefresh$
     ).subscribe(() => {
       if (onUpdate) {
         onUpdate({

--- a/x-pack/plugins/aiops/public/hooks/use_storage.ts
+++ b/x-pack/plugins/aiops/public/hooks/use_storage.ts
@@ -8,7 +8,7 @@
 import { useCallback, useState } from 'react';
 import { useAiOpsKibana } from '../kibana_context';
 
-export const AIOPS_FROZEN_TIER_PREFERENCE = 'aiOps.frozenDataTierPreference';
+export const AIOPS_FROZEN_TIER_PREFERENCE = 'aiop.frozenDataTierPreference';
 
 export type AiOps = Partial<{
   [AIOPS_FROZEN_TIER_PREFERENCE]: 'exclude_frozen' | 'include_frozen';

--- a/x-pack/plugins/aiops/public/index.ts
+++ b/x-pack/plugins/aiops/public/index.ts
@@ -13,6 +13,5 @@ export function plugin() {
   return new AiopsPlugin();
 }
 
-export type { ExplainLogRateSpikesProps } from './components/explain_log_rate_spikes';
 export { ExplainLogRateSpikes } from './shared_lazy_components';
 export type { AiopsPluginSetup, AiopsPluginStart } from './types';

--- a/x-pack/plugins/aiops/public/shared_lazy_components.tsx
+++ b/x-pack/plugins/aiops/public/shared_lazy_components.tsx
@@ -9,7 +9,7 @@ import React, { FC, Suspense } from 'react';
 
 import { EuiErrorBoundary, EuiLoadingContent } from '@elastic/eui';
 
-import type { ExplainLogRateSpikesProps } from './components/explain_log_rate_spikes';
+import type { ExplainLogRateSpikesWrapperProps } from './components/explain_log_rate_spikes';
 
 const ExplainLogRateSpikesWrapperLazy = React.lazy(
   () => import('./components/explain_log_rate_spikes')
@@ -22,10 +22,10 @@ const LazyWrapper: FC = ({ children }) => (
 );
 
 /**
- * Lazy-wrapped ExplainLogRateSpikes React component
- * @param {ExplainLogRateSpikesProps}  props - properties specifying the data on which to run the analysis.
+ * Lazy-wrapped ExplainLogRateSpikesWrapper React component
+ * @param {ExplainLogRateSpikesWrapperProps}  props - properties specifying the data on which to run the analysis.
  */
-export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesProps> = (props) => (
+export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesWrapperProps> = (props) => (
   <LazyWrapper>
     <ExplainLogRateSpikesWrapperLazy {...props} />
   </LazyWrapper>

--- a/x-pack/plugins/ml/public/application/aiops/explain_log_rate_spikes.tsx
+++ b/x-pack/plugins/ml/public/application/aiops/explain_log_rate_spikes.tsx
@@ -5,18 +5,14 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, FC } from 'react';
+import React, { FC } from 'react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ExplainLogRateSpikes } from '@kbn/aiops-plugin/public';
-import { getWindowParameters } from '@kbn/aiops-utils';
-import type { WindowParameters } from '@kbn/aiops-utils';
-import { KBN_FIELD_TYPES } from '@kbn/data-plugin/public';
 
 import { useMlContext } from '../contexts/ml';
 import { useMlKibana } from '../contexts/kibana';
 import { HelpMenu } from '../components/help_menu';
-import { ml } from '../services/ml_api_service';
 
 import { MlPageHeader } from '../components/page_header';
 
@@ -28,36 +24,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
   const context = useMlContext();
   const dataView = context.currentDataView;
 
-  const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
-
-  useEffect(() => {
-    async function fetchWindowParameters() {
-      if (dataView.timeFieldName) {
-        const stats: Array<{
-          data: Array<{ doc_count: number; key: number }>;
-          stats: [number, number];
-        }> = await ml.getVisualizerFieldHistograms({
-          indexPattern: dataView.title,
-          fields: [{ fieldName: dataView.timeFieldName, type: KBN_FIELD_TYPES.DATE }],
-          query: { match_all: {} },
-          samplerShardSize: -1,
-        });
-
-        const peak = stats[0].data.reduce((p, c) => (c.doc_count >= p.doc_count ? c : p), {
-          doc_count: 0,
-          key: 0,
-        });
-        const peakTimestamp = Math.round(peak.key);
-
-        setWindowParameters(
-          getWindowParameters(peakTimestamp, stats[0].stats[0], stats[0].stats[1])
-        );
-      }
-    }
-
-    fetchWindowParameters();
-  }, []);
-
   return (
     <>
       <MlPageHeader>
@@ -66,9 +32,7 @@ export const ExplainLogRateSpikesPage: FC = () => {
           defaultMessage="Explain log rate spikes"
         />
       </MlPageHeader>
-      {dataView.timeFieldName && windowParameters && (
-        <ExplainLogRateSpikes dataView={dataView} windowParameters={windowParameters} />
-      )}
+      {dataView.timeFieldName && <ExplainLogRateSpikes dataView={dataView} />}
       <HelpMenu docLink={docLinks.links.ml.guide} />
     </>
   );


### PR DESCRIPTION
## Summary

Part of #136265.

- Adds the `DualBrush` component to `DocumentCountChart` to allow the user to select `WindowParameters` for the explain log rate spikes analysis.
- `VIEW_MODE` is for now hard coded to `brush`. In a follow up we will allow a user to switch between `zoom` mode for navigation and `brush` mode for selection of `WindowParameters`.
- The auto-generation of `WindowParameters` has been removed from the wrapping code in the ML plugin.
- `urlState` related code has been moved from `ExplainLogRateSpikes` to `ExplainLogRateSpikesWrapper`.
- The analysis results table style has been changed to `compressed`.

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/230104/178730638-45d3fbe8-87ba-412a-b68d-44c9dc81ba2f.png">


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
