### PR TITLE
dataviews.clearCache cleanup

### DIFF
--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -267,7 +267,7 @@ export const IndexPatternTable = ({
             id={dataView.id}
             title={dataView.title}
             refresh={() => {
-              dataViews.clearCache(dataView.id);
+              dataViews.clearInstanceCache(dataView.id);
               loadDataViews();
             }}
           />

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -210,7 +210,7 @@ describe('IndexPatterns', () => {
 
     // Create a normal index patterns
     const pattern = await indexPatterns.get('foo');
-    indexPatterns.clearCache();
+    indexPatterns.clearInstanceCache();
 
     // Create the same one - we're going to handle concurrency
     const samePattern = await indexPatterns.get('foo');

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -123,10 +123,15 @@ export interface DataViewsServiceDeps {
  */
 export interface DataViewsServicePublicMethods {
   /**
-   * Clear the cache of data views.
-   * @param id
+   * Clear the cache of data view saved objects.
    */
-  clearCache: (id?: string | undefined) => void;
+  clearCache: () => void;
+
+  /**
+   * Clear the cache of data view instances.
+   */
+  clearInstanceCache: (id?: string) => void;
+
   /**
    * Create data view based on the provided spec.
    * @param spec - Data view spec.
@@ -396,11 +401,16 @@ export class DataViewsService {
   };
 
   /**
-   * Clear index pattern list cache.
-   * @param id optionally clear a single id
+   * Clear index pattern saved objects cache.
    */
-  clearCache = (id?: string) => {
+  clearCache = () => {
     this.savedObjectsCache = null;
+  };
+
+  /**
+   * Clear index pattern instance cache
+   */
+  clearInstanceCache = (id?: string) => {
     if (id) {
       this.dataViewCache.clear(id);
     } else {

--- a/src/plugins/discover/public/application/main/discover_main_route.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.tsx
@@ -102,7 +102,7 @@ export function DiscoverMainRoute(props: Props) {
 
         const ipList = ip.list as Array<SavedObject<DataViewAttributes>>;
         const indexPatternData = resolveIndexPattern(ip, searchSource, toastNotifications);
-
+        await data.dataViews.refreshFields(indexPatternData);
         setIndexPatternList(ipList);
 
         return indexPatternData;

--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
@@ -166,7 +166,9 @@ export function ChangeDataView({
     panelItems.push(
       <DataViewsList
         dataViewsList={dataViewsList}
-        onChangeDataView={(newId) => {
+        onChangeDataView={async (newId) => {
+          const dataView = await data.dataViews.get(newId);
+          await data.dataViews.refreshFields(dataView);
           onChangeDataView(newId);
           setPopoverIsOpen(false);
         }}


### PR DESCRIPTION
## Summary

`dataviews.clearCache(id?: string)` was cleaned up, before it cleaned the data view saved objects cache as well as data view instance cache. The method was split into two methods:
- clearCache() which clears data view saved object cache
- clearInstanceCache(id?: string): which clears the data view instance cache

for apps that used to clear whole instance cache (discover) unified search data view selector was updated to refresh the field list on data view change and discover also refreshes the field list of a data view on load to make sure user always gets the recent field list.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios