### PR TITLE
[Console] Close autocomplete popup when navigating away from Console

### DIFF
--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -233,6 +233,8 @@ function EditorUI({ initialTextValue, setEditorInstance }: EditorProps) {
       autocompleteInfo.clearSubscriptions();
       window.removeEventListener('hashchange', onHashChange);
       if (editorInstanceRef.current) {
+        // Close autocomplete popup on unmount
+        editorInstanceRef.current?.getCoreEditor().editor.completer.detach();
         editorInstanceRef.current.getCoreEditor().destroy();
       }
     };

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -234,7 +234,7 @@ function EditorUI({ initialTextValue, setEditorInstance }: EditorProps) {
       window.removeEventListener('hashchange', onHashChange);
       if (editorInstanceRef.current) {
         // Close autocomplete popup on unmount
-        editorInstanceRef.current?.getCoreEditor().editor.completer.detach();
+        editorInstanceRef.current?.getCoreEditor().detachCompleter();
         editorInstanceRef.current.getCoreEditor().destroy();
       }
     };

--- a/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
@@ -228,6 +228,10 @@ export class LegacyCoreEditor implements CoreEditor {
     );
   }
 
+  detachCompleter() {
+    return (this.editor as unknown as { completer: { detach(): void } }).completer.detach();
+  }
+
   private forceRetokenize() {
     const session = this.editor.getSession();
     return new Promise<void>((resolve) => {

--- a/src/plugins/console/public/types/core_editor.ts
+++ b/src/plugins/console/public/types/core_editor.ts
@@ -289,10 +289,8 @@ export interface CoreEditor {
    */
   addFoldsAtRanges(foldRanges: Range[]): void;
 
-  /** Entry point into the Ace functionality. See for more details https://ace.c9.io/#nav=api&api=editor */
-  editor: {
-    completer: {
-      detach(): void;
-    };
-  };
+  /**
+   * Detach autocomplete
+   */
+  detachCompleter(): void;
 }

--- a/src/plugins/console/public/types/core_editor.ts
+++ b/src/plugins/console/public/types/core_editor.ts
@@ -288,4 +288,11 @@ export interface CoreEditor {
    * Add folds at given ranges
    */
   addFoldsAtRanges(foldRanges: Range[]): void;
+
+  /** Entry point into the Ace functionality. See for more details https://ace.c9.io/#nav=api&api=editor */
+  editor: {
+    completer: {
+      detach(): void;
+    };
+  };
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/133972

### Summary
Fixes the bug where the autocomplete popup remains open when navigating away from Console

https://user-images.githubusercontent.com/53621505/178713342-15301f25-a8a4-4a6b-9427-173ee9e2e2ce.mov


#### Release note
Fixed a bug where the autocomplete popup remains open when navigating away from Console