### PR TITLE
[Cloud Posture] use benchmark id in rule config updates

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule_metadata.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule_metadata.ts
@@ -6,11 +6,13 @@
  */
 import { schema as rt, TypeOf } from '@kbn/config-schema';
 
+export const benchmarkIdSchema = rt.oneOf([rt.literal('cis_k8s'), rt.literal('cis_eks')]);
+
 export const cspRuleMetadataSchema = rt.object({
   audit: rt.string(),
   benchmark: rt.object({
     name: rt.string(),
-    id: rt.oneOf([rt.literal('cis_k8s'), rt.literal('cis_eks')]),
+    id: benchmarkIdSchema,
     version: rt.string(),
   }),
   default_value: rt.maybe(rt.string()),

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_rules_configuration.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 import { schema as rt, TypeOf } from '@kbn/config-schema';
+import { benchmarkIdSchema } from './csp_rule_metadata';
 
 // cspRulesConfigSchema has to match the 'DataYaml' struct in https://github.com/elastic/cloudbeat/blob/main/config/config.go#L45-L51
 export const cspRulesConfigSchema = rt.object({
   data_yaml: rt.object({
-    activated_rules: rt.object({
-      cis_k8s: rt.arrayOf(rt.string()),
-    }),
+    activated_rules: rt.recordOf(benchmarkIdSchema, rt.arrayOf(rt.string())),
   }),
 });
 

--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PackagePolicy, GetAgentPoliciesResponseItem } from '@kbn/fleet-plugin/common';
+import type { CspRuleMetadata } from './schemas/csp_rule_metadata';
 
 export type Evaluation = 'passed' | 'failed' | 'NA';
 /** number between 1-100 */
@@ -95,3 +96,5 @@ export interface Benchmark {
   agent_policy: Pick<GetAgentPoliciesResponseItem, 'id' | 'name' | 'agents'>;
   rules: CspRulesStatus;
 }
+
+export type BenchmarkId = CspRuleMetadata['benchmark']['id'];

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -24,10 +24,10 @@ import {
   CSP_RULE_SAVED_OBJECT_TYPE,
   CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE,
 } from '../../common/constants';
-import type { CspRule, CspRuleMetadata, CspRuleTemplate } from '../../common/schemas';
+import type { CspRule, CspRuleTemplate } from '../../common/schemas';
+import type { BenchmarkId } from '../../common/types';
 
 type CloudbeatInputType = keyof typeof CIS_INTEGRATION_INPUTS_MAP;
-export type BenchmarkId = CspRuleMetadata['benchmark']['id'];
 
 const getBenchmarkTypeFilter = (type: BenchmarkId): string =>
   `${CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE}.attributes.metadata.benchmark.id: "${type}"`;

--- a/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/fleet_integration/fleet_integration.ts
@@ -27,7 +27,7 @@ import {
 import type { CspRule, CspRuleMetadata, CspRuleTemplate } from '../../common/schemas';
 
 type CloudbeatInputType = keyof typeof CIS_INTEGRATION_INPUTS_MAP;
-type BenchmarkId = CspRuleMetadata['benchmark']['id'];
+export type BenchmarkId = CspRuleMetadata['benchmark']['id'];
 
 const getBenchmarkTypeFilter = (type: BenchmarkId): string =>
   `${CSP_RULE_TEMPLATE_SAVED_OBJECT_TYPE}.attributes.metadata.benchmark.id: "${type}"`;

--- a/x-pack/plugins/cloud_security_posture/server/plugin.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.test.ts
@@ -82,9 +82,20 @@ describe('Cloud Security Posture Plugin', () => {
     const findMock = mockRouteContext.core.savedObjects.client.find as jest.Mock;
     findMock.mockReturnValue(
       Promise.resolve({
-        saved_objects: [],
-        total: 0,
-        per_page: 0,
+        saved_objects: [
+          {
+            type: 'csp_rule',
+            attributes: {
+              enabled: false,
+              metadata: {
+                rego_rule_id: 'cis_1_1_1',
+                benchmark: { id: 'cis_k8s' },
+              },
+            },
+          },
+        ],
+        total: 1,
+        per_page: 10,
         page: 1,
       })
     );
@@ -295,6 +306,9 @@ describe('Cloud Security Posture Plugin', () => {
             {
               type: 'csp-rule-template',
               id: 'csp_rule_template-41308bcdaaf665761478bb6f0d745a5c',
+              benchmark: {
+                id: 'cis_k8s',
+              },
             },
           ],
         })

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -140,6 +140,7 @@ describe('Update rules configuration API', () => {
             enabled: true,
             metadata: {
               rego_rule_id: 'cis_1_1_1',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -149,6 +150,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_2',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -158,6 +160,7 @@ describe('Update rules configuration API', () => {
             enabled: true,
             metadata: {
               rego_rule_id: 'cis_1_1_3',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -181,6 +184,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_1',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -190,6 +194,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_2',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -199,6 +204,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_3',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -253,6 +259,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_1',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -262,6 +269,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_2',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -271,6 +279,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_3',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -315,6 +324,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_1',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -324,6 +334,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_2',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -333,6 +344,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_3',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },
@@ -389,6 +401,7 @@ describe('Update rules configuration API', () => {
             enabled: false,
             metadata: {
               rego_rule_id: 'cis_1_1_1',
+              benchmark: { id: 'cis_k8s' },
             },
           },
         },

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -66,15 +66,17 @@ export const getCspRules = (
 };
 
 const getEnabledRulesByBenchmark = (rules: SavedObjectsFindResponse<CspRule>['saved_objects']) =>
-  rules.reduce((benchmarks, rule) => {
-    const benchmarkId = rule.attributes.metadata.benchmark.id;
-    if (!rule.attributes.enabled || !benchmarkId) return benchmarks;
+  rules.reduce<CspRulesConfiguration['data_yaml']['activated_rules']>(
+    (benchmarks, rule) => {
+      const benchmark = benchmarks[rule.attributes.metadata.benchmark.id];
+      if (!rule.attributes.enabled || !benchmark) return benchmarks;
 
-    benchmarks[benchmarkId] = benchmarks[benchmarkId] || [];
-    benchmarks[benchmarkId].push(rule.attributes.metadata.rego_rule_id);
+      benchmark.push(rule.attributes.metadata.rego_rule_id);
 
-    return benchmarks;
-  }, {} as CspRulesConfiguration['data_yaml']['activated_rules']);
+      return benchmarks;
+    },
+    { cis_k8s: [], cis_eks: [] }
+  );
 
 export const createRulesConfig = (
   cspRules: SavedObjectsFindResponse<CspRule>


### PR DESCRIPTION
## Summary

in https://github.com/elastic/kibana/pull/135798 we added support for another benchmark type

this PR updates the active rules configuration we pass to cloudbeat (using the [dataYaml](https://github.com/elastic/integrations/blob/main/packages/cloud_security_posture/manifest.yml#L53) var) to use the benchmark id instead of the default one. 

### How to test locally? 

#### test new revision of `dataYml` is updated correctly
- [checkout the PR locally](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
- add CIS integration 
- view agent policy and note the value of dataYml 
- disable a rule and save 
- view agent policy and note the new value of dataYml (from new revision of the agent policy)
- compare the diff. the disabled rule ID should not be in the new value. 

#### test rule changes in kibana affect findings (big thanks to @ofiriro3 👑 ) 
- follow @CohenIdo's [guide](https://github.com/elastic/security-team/blob/main/docs/cloud-security-posture-team/kibana/Local_Setup_Using_Elastic_Package.mdx) on how to setup a local env with `kibana` from source and `elasticsearch`, `fleet-server` and `agent` using `elastic-package` 

- [checkout the PR locally](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
- add CIS integration (`cloudbeat/vanilla`) is easier to test as it doesn't require a cloud env (also doable, consult with @ofiriro3)
- edit the period cloudbeat sends data to `1m` (see guide)
- disable a rule
- in discover, filter on the latest cycle id AND the rule tag/name, it should not exist
- enable a rule 
- in discover, filter on the latest cycle id (new cycle) AND the rule tag/name, it should exist

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


