### PR TITLE
[ML] Functional tests - re-enable data frame analytics clone tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
@@ -135,8 +135,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     for (const testData of testDataList) {
-      // FLAKY: https://github.com/elastic/kibana/issues/134430
-      describe.skip(`${testData.suiteTitle}`, function () {
+      describe(`${testData.suiteTitle}`, function () {
         const cloneJobId = `${testData.job.id}_clone`;
         const cloneDestIndex = `${testData.job!.dest!.index}_clone`;
 


### PR DESCRIPTION
## Summary

This PR re-enables the data frame analytics clone tests.

### Details

After looking into this issue, we suspect that it was an issue with the port of the backend feature from the feature branch. Since the test failure came up and the tests were skipped, that feature branch also got merged and we couldn't reproduce this failure anymore in many local runs, so we think it might already be fixed.

Closes #134430
