### PR TITLE
Fix/no alert status popover 125354

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/overview/status_popover_button.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/overview/status_popover_button.tsx
@@ -44,6 +44,8 @@ export const StatusPopoverButton = React.memo<StatusPopoverButtonProps>(
       alertStatus: enrichedFieldInfo.values[0] as Status,
     });
 
+    const statusPopoverVisible = useMemo(() => actionItems.length > 0, [actionItems]);
+
     const button = useMemo(
       () => (
         <FormattedFieldValue
@@ -56,13 +58,17 @@ export const StatusPopoverButton = React.memo<StatusPopoverButtonProps>(
           fieldFormat={enrichedFieldInfo.data.format}
           isDraggable={false}
           truncate={false}
-          isButton={true}
-          onClick={togglePopover}
+          isButton={statusPopoverVisible}
+          onClick={statusPopoverVisible ? togglePopover : undefined}
           onClickAriaLabel={CLICK_TO_CHANGE_ALERT_STATUS}
         />
       ),
-      [contextId, eventId, enrichedFieldInfo, togglePopover]
+      [contextId, eventId, enrichedFieldInfo, togglePopover, statusPopoverVisible]
     );
+
+    if (!statusPopoverVisible) {
+      return button;
+    }
 
     return (
       <EuiPopover

--- a/x-pack/plugins/security_solution/public/common/components/event_details/overview/status_popover_button.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/overview/status_popover_button.tsx
@@ -44,6 +44,8 @@ export const StatusPopoverButton = React.memo<StatusPopoverButtonProps>(
       alertStatus: enrichedFieldInfo.values[0] as Status,
     });
 
+    // statusPopoverVisible includes the logic for the visibility of the popover in
+    // case actionItems is an empty array ( ex, when user has read access ).
     const statusPopoverVisible = useMemo(() => actionItems.length > 0, [actionItems]);
 
     const button = useMemo(
@@ -66,6 +68,7 @@ export const StatusPopoverButton = React.memo<StatusPopoverButtonProps>(
       [contextId, eventId, enrichedFieldInfo, togglePopover, statusPopoverVisible]
     );
 
+    // EuiPopover is not needed if statusPopoverVisible is false
     if (!statusPopoverVisible) {
       return button;
     }


### PR DESCRIPTION
## Summary

This PR fixes #125354 .


### Issue

When user has only read access, user could click the status to display the popover as show in the screenshot below:
![image](https://user-images.githubusercontent.com/7485038/178736430-fd11ab5f-1e15-444e-bfca-ad3b17e01e01.png)


### Solution
1. Ideally, the field should be a simple text batch and not a popover.
2. Changes include to conditionally change the display of status batch as simple `text` ( in case of only read access ) and `popover`( in case of write access as well )
![image](https://user-images.githubusercontent.com/7485038/178736775-702dc8e0-325a-4409-898a-23e0752a5193.png)






### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
