### PR TITLE
[Files] Remove attributes from blobstore

### DIFF
--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -15,8 +15,6 @@ import {
 } from '@kbn/core/test_helpers/kbn_server';
 
 import { ElasticsearchBlobStorage, BLOB_STORAGE_SYSTEM_INDEX_NAME } from '../es';
-import { BlobAttributes } from '../../../types';
-import { FileChunkDocument } from '../mappings';
 
 describe('Elasticsearch blob storage', () => {
   let manageES: TestElasticsearchUtils;
@@ -133,35 +131,5 @@ describe('Elasticsearch blob storage', () => {
       chunks.push(chunk);
     }
     expect(chunks.join('')).toBe(fileString2);
-  });
-
-  it('sets attributes on a blob', async () => {
-    const attributes: BlobAttributes = [
-      ['foo', 'bar'],
-      ['myObject', { foo: 'bar' }],
-    ];
-    const { id } = await esBlobStorage.upload(Readable.from(['upload this']), { attributes });
-    const attrsResponse = await esBlobStorage.getAttributes(id);
-    expect(attrsResponse).toEqual(
-      expect.objectContaining({
-        foo: 'bar',
-        myObject: { foo: 'bar' },
-      })
-    );
-
-    const unsearchableAttributePath = 'app_metadata.foo';
-
-    // We cannot search by metadata
-    const {
-      hits: { hits: hits2 },
-    } = await esClient.search<FileChunkDocument>({
-      index: BLOB_STORAGE_SYSTEM_INDEX_NAME,
-      query: {
-        match: {
-          [unsearchableAttributePath]: 'bar',
-        },
-      },
-    });
-    expect(hits2).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/files/server/blob_storage_service/types.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/types.ts
@@ -10,22 +10,7 @@ import type { Readable, Transform } from 'stream';
 
 export type BlobAttribute = [key: string, value: JsonValue];
 
-/**
- * An array of {@link BlobAttribute}.
- *
- * @note Each key value must be unique.
- */
-export type BlobAttributes = BlobAttribute[];
-
-export interface BlobAttributesResponse {
-  [key: string]: JsonValue;
-}
-
 interface UploadOptions {
-  /**
-   * Optionally provide attributes to store on with the blob directly
-   */
-  attributes?: BlobAttributes;
   /**
    * Optionally provide any transforms to run on the readable source stream
    * as it is being uploaded.
@@ -61,11 +46,6 @@ export interface BlobStorage {
    * stream.
    */
   download(args: { id: string; size?: number }): Promise<Readable>;
-
-  /**
-   * Get attributes of a blob.
-   */
-  getAttributes(id: string): Promise<BlobAttributesResponse>;
 
   /**
    * Delete a file given a unique ID.


### PR DESCRIPTION
## Summary

Remove "attributes" from the blob store layer. This will always be handled by a metadata layer.