### PR TITLE
[Embeddable] Provide a Redux `store` adapter for the embeddable input

### DIFF
--- a/dev_docs/key_concepts/embeddables.mdx
+++ b/dev_docs/key_concepts/embeddables.mdx
@@ -14,6 +14,7 @@ If you are planning to integrate with the plugin, please get in touch with the A
 ## Capabilities
 - Framework-agnostic API.
 - Out-of-the-box React support.
+- Integration with Redux.
 - Integration with the [UI Actions](https://github.com/elastic/kibana/tree/HEAD/src/plugins/ui_actions) plugin.
 - Hierarchical structure to enclose multiple widgets.
 - Error handling.

--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -94,6 +94,9 @@
         },
         {
           "id": "kibDevKeyConceptsNavigation"
+        },
+        {
+          "id": "kibDevDocsEmbeddables"
         }
       ]
     },

--- a/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
+++ b/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
@@ -24,7 +24,7 @@ import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core-theme-browser';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 
-import { CONTEXT_MENU_TRIGGER, EmbeddablePanel, PANEL_BADGE_TRIGGER, ViewMode } from '..';
+import { actions, CONTEXT_MENU_TRIGGER, EmbeddablePanel, PANEL_BADGE_TRIGGER, ViewMode } from '..';
 import { HelloWorldEmbeddable } from './hello_world_embeddable';
 
 const layout: DecoratorFn = (story) => {
@@ -91,17 +91,13 @@ const HelloWorldEmbeddablePanel = forwardRef<
     const embeddable = useMemo(() => new HelloWorldEmbeddable({ id: `${Math.random()}` }, {}), []);
     const theme$ = useMemo(() => new ReplaySubject<CoreTheme>(1), []);
     const theme = useContext(ThemeContext) as CoreTheme;
+    const store = useMemo(() => embeddable.getStore(), [embeddable]);
 
     useEffect(() => theme$.next(theme), [theme$, theme]);
-    useEffect(
-      () =>
-        embeddable.updateInput({
-          title,
-          viewMode: viewMode ? ViewMode.VIEW : ViewMode.EDIT,
-          lastReloadRequestTime: new Date().getMilliseconds(),
-        }),
-      [embeddable, title, viewMode]
-    );
+    useEffect(() => {
+      store.dispatch(actions.setTitle(title));
+      store.dispatch(actions.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT));
+    }, [store, title, viewMode]);
     useEffect(
       () =>
         embeddable.updateOutput({
@@ -162,7 +158,9 @@ export function DefaultWithBadges({ badges, ...props }: DefaultWithBadgesProps) 
 
   useEffect(
     () =>
-      ref.current?.embeddable.updateInput({ lastReloadRequestTime: new Date().getMilliseconds() }),
+      void ref.current?.embeddable
+        .getStore()
+        .dispatch(actions.setLastReloadRequestTime(new Date().getMilliseconds())),
     [getActions]
   );
 
@@ -207,7 +205,9 @@ export function DefaultWithContextMenu({ items, ...props }: DefaultWithContextMe
 
   useEffect(
     () =>
-      ref.current?.embeddable.updateInput({ lastReloadRequestTime: new Date().getMilliseconds() }),
+      void ref.current?.embeddable
+        .getStore()
+        .dispatch(actions.setLastReloadRequestTime(new Date().getMilliseconds())),
     [getActions]
   );
 

--- a/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
+++ b/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
@@ -96,10 +96,12 @@ const HelloWorldEmbeddablePanel = forwardRef<
     useEffect(() => theme$.next(theme), [theme$, theme]);
     useEffect(() => {
       embeddable.store.dispatch(actions.input.setTitle(title));
+    }, [embeddable.store, title]);
+    useEffect(() => {
       embeddable.store.dispatch(
         actions.input.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT)
       );
-    }, [embeddable.store, title, viewMode]);
+    }, [embeddable.store, viewMode]);
     useEffect(
       () => void embeddable.store.dispatch(actions.output.setLoading(loading)),
       [embeddable, loading]

--- a/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
+++ b/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
@@ -101,10 +101,7 @@ const HelloWorldEmbeddablePanel = forwardRef<
       );
     }, [embeddable.store, title, viewMode]);
     useEffect(
-      () =>
-        embeddable.updateOutput({
-          loading,
-        }),
+      () => void embeddable.store.dispatch(actions.output.setLoading(loading)),
       [embeddable, loading]
     );
     useImperativeHandle(ref, () => ({ embeddable }));
@@ -232,7 +229,10 @@ interface DefaultWithErrorProps extends HelloWorldEmbeddablePanelProps {
 export function DefaultWithError({ message, ...props }: DefaultWithErrorProps) {
   const ref = useRef<React.ComponentRef<typeof HelloWorldEmbeddablePanel>>(null);
 
-  useEffect(() => ref.current?.embeddable.updateOutput({ error: new Error(message) }), [message]);
+  useEffect(
+    () => void ref.current?.embeddable.store.dispatch(actions.output.setError(new Error(message))),
+    [message]
+  );
 
   return <HelloWorldEmbeddablePanel ref={ref} {...props} />;
 }
@@ -258,7 +258,10 @@ export function DefaultWithCustomError({ message, ...props }: DefaultWithErrorPr
       }),
     []
   );
-  useEffect(() => ref.current?.embeddable.updateOutput({ error: new Error(message) }), [message]);
+  useEffect(
+    () => void ref.current?.embeddable.store.dispatch(actions.output.setError(new Error(message))),
+    [message]
+  );
 
   return <HelloWorldEmbeddablePanel ref={ref} {...props} />;
 }

--- a/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
+++ b/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
@@ -95,8 +95,10 @@ const HelloWorldEmbeddablePanel = forwardRef<
 
     useEffect(() => theme$.next(theme), [theme$, theme]);
     useEffect(() => {
-      embeddable.store.dispatch(actions.setTitle(title));
-      embeddable.store.dispatch(actions.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT));
+      embeddable.store.dispatch(actions.input.setTitle(title));
+      embeddable.store.dispatch(
+        actions.input.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT)
+      );
     }, [embeddable.store, title, viewMode]);
     useEffect(
       () =>
@@ -159,7 +161,7 @@ export function DefaultWithBadges({ badges, ...props }: DefaultWithBadgesProps) 
   useEffect(
     () =>
       void ref.current?.embeddable.store.dispatch(
-        actions.setLastReloadRequestTime(new Date().getMilliseconds())
+        actions.input.setLastReloadRequestTime(new Date().getMilliseconds())
       ),
     [getActions]
   );
@@ -206,7 +208,7 @@ export function DefaultWithContextMenu({ items, ...props }: DefaultWithContextMe
   useEffect(
     () =>
       void ref.current?.embeddable.store.dispatch(
-        actions.setLastReloadRequestTime(new Date().getMilliseconds())
+        actions.input.setLastReloadRequestTime(new Date().getMilliseconds())
       ),
     [getActions]
   );

--- a/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
+++ b/src/plugins/embeddable/public/__stories__/embeddable_panel.stories.tsx
@@ -24,7 +24,8 @@ import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core-theme-browser';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 
-import { actions, CONTEXT_MENU_TRIGGER, EmbeddablePanel, PANEL_BADGE_TRIGGER, ViewMode } from '..';
+import { CONTEXT_MENU_TRIGGER, EmbeddablePanel, PANEL_BADGE_TRIGGER, ViewMode } from '..';
+import { actions } from '../store';
 import { HelloWorldEmbeddable } from './hello_world_embeddable';
 
 const layout: DecoratorFn = (story) => {
@@ -91,13 +92,12 @@ const HelloWorldEmbeddablePanel = forwardRef<
     const embeddable = useMemo(() => new HelloWorldEmbeddable({ id: `${Math.random()}` }, {}), []);
     const theme$ = useMemo(() => new ReplaySubject<CoreTheme>(1), []);
     const theme = useContext(ThemeContext) as CoreTheme;
-    const store = useMemo(() => embeddable.getStore(), [embeddable]);
 
     useEffect(() => theme$.next(theme), [theme$, theme]);
     useEffect(() => {
-      store.dispatch(actions.setTitle(title));
-      store.dispatch(actions.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT));
-    }, [store, title, viewMode]);
+      embeddable.store.dispatch(actions.setTitle(title));
+      embeddable.store.dispatch(actions.setViewMode(viewMode ? ViewMode.VIEW : ViewMode.EDIT));
+    }, [embeddable.store, title, viewMode]);
     useEffect(
       () =>
         embeddable.updateOutput({
@@ -158,9 +158,9 @@ export function DefaultWithBadges({ badges, ...props }: DefaultWithBadgesProps) 
 
   useEffect(
     () =>
-      void ref.current?.embeddable
-        .getStore()
-        .dispatch(actions.setLastReloadRequestTime(new Date().getMilliseconds())),
+      void ref.current?.embeddable.store.dispatch(
+        actions.setLastReloadRequestTime(new Date().getMilliseconds())
+      ),
     [getActions]
   );
 
@@ -205,9 +205,9 @@ export function DefaultWithContextMenu({ items, ...props }: DefaultWithContextMe
 
   useEffect(
     () =>
-      void ref.current?.embeddable
-        .getStore()
-        .dispatch(actions.setLastReloadRequestTime(new Date().getMilliseconds())),
+      void ref.current?.embeddable.store.dispatch(
+        actions.setLastReloadRequestTime(new Date().getMilliseconds())
+      ),
     [getActions]
   );
 

--- a/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
+++ b/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
@@ -8,8 +8,9 @@
 
 import React from 'react';
 import { render } from 'react-dom';
+import { connect, Provider } from 'react-redux';
 import { EuiEmptyPrompt } from '@elastic/eui';
-import { Embeddable, IEmbeddable } from '..';
+import { Embeddable, EmbeddableInput, IEmbeddable } from '..';
 
 export class HelloWorldEmbeddable extends Embeddable {
   readonly type = 'hello-world';
@@ -19,9 +20,14 @@ export class HelloWorldEmbeddable extends Embeddable {
   reload() {}
 
   render(node: HTMLElement) {
-    render(<EuiEmptyPrompt body={this.getTitle()} />, node);
+    const App = connect((state: EmbeddableInput) => ({ body: state.title }))(EuiEmptyPrompt);
 
-    this.reload = this.render.bind(this, node);
+    render(
+      <Provider store={this.getStore()}>
+        <App />
+      </Provider>,
+      node
+    );
   }
 
   setErrorRenderer(renderer: IEmbeddable['renderError']) {

--- a/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
+++ b/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { render } from 'react-dom';
 import { connect, Provider } from 'react-redux';
 import { EuiEmptyPrompt } from '@elastic/eui';
-import { Embeddable, EmbeddableInput, IEmbeddable } from '..';
-import { createStore } from '../store';
+import { Embeddable, IEmbeddable } from '..';
+import { createStore, State } from '../store';
 
 export class HelloWorldEmbeddable extends Embeddable {
   // eslint-disable-next-line @kbn/eslint/no_this_in_property_initializers
@@ -24,7 +24,7 @@ export class HelloWorldEmbeddable extends Embeddable {
   reload() {}
 
   render(node: HTMLElement) {
-    const App = connect((state: EmbeddableInput) => ({ body: state.title }))(EuiEmptyPrompt);
+    const App = connect((state: State) => ({ body: state.input.title }))(EuiEmptyPrompt);
 
     render(
       <Provider store={this.store}>

--- a/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
+++ b/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
@@ -37,8 +37,4 @@ export class HelloWorldEmbeddable extends Embeddable {
   setErrorRenderer(renderer: IEmbeddable['renderError']) {
     this.renderError = renderer;
   }
-
-  updateOutput(...args: Parameters<Embeddable['updateOutput']>): void {
-    return super.updateOutput(...args);
-  }
 }

--- a/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
+++ b/src/plugins/embeddable/public/__stories__/hello_world_embeddable.tsx
@@ -11,8 +11,12 @@ import { render } from 'react-dom';
 import { connect, Provider } from 'react-redux';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import { Embeddable, EmbeddableInput, IEmbeddable } from '..';
+import { createStore } from '../store';
 
 export class HelloWorldEmbeddable extends Embeddable {
+  // eslint-disable-next-line @kbn/eslint/no_this_in_property_initializers
+  readonly store = createStore(this);
+
   readonly type = 'hello-world';
 
   renderError: IEmbeddable['renderError'];
@@ -23,7 +27,7 @@ export class HelloWorldEmbeddable extends Embeddable {
     const App = connect((state: EmbeddableInput) => ({ body: state.title }))(EuiEmptyPrompt);
 
     render(
-      <Provider store={this.getStore()}>
+      <Provider store={this.store}>
         <App />
       </Provider>,
       node

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -43,6 +43,7 @@ export type {
   EmbeddableContainerSettings,
 } from './lib';
 export {
+  actions,
   ACTION_ADD_PANEL,
   ACTION_EDIT_PANEL,
   AddPanelAction,

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -43,7 +43,6 @@ export type {
   EmbeddableContainerSettings,
 } from './lib';
 export {
-  actions,
   ACTION_ADD_PANEL,
   ACTION_EDIT_PANEL,
   AddPanelAction,

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
@@ -41,8 +41,10 @@ export abstract class Embeddable<
   protected output: TEmbeddableOutput;
   protected input: TEmbeddableInput;
 
-  private readonly input$: Rx.BehaviorSubject<TEmbeddableInput>;
-  private readonly output$: Rx.BehaviorSubject<TEmbeddableOutput>;
+  private readonly inputSubject = new Rx.ReplaySubject<TEmbeddableInput>(1);
+  private readonly outputSubject = new Rx.ReplaySubject<TEmbeddableOutput>(1);
+  private readonly input$ = this.inputSubject.asObservable();
+  private readonly output$ = this.outputSubject.asObservable();
 
   protected renderComplete = new RenderCompleteDispatcher();
 
@@ -71,8 +73,8 @@ export abstract class Embeddable<
     };
     this.parent = parent;
 
-    this.input$ = new Rx.BehaviorSubject<TEmbeddableInput>(this.input);
-    this.output$ = new Rx.BehaviorSubject<TEmbeddableOutput>(this.output);
+    this.inputSubject.next(this.input);
+    this.outputSubject.next(this.output);
 
     if (parent) {
       this.parentSubscription = Rx.merge(parent.getInput$(), parent.getOutput$()).subscribe(() => {
@@ -89,12 +91,7 @@ export abstract class Embeddable<
         map(({ title }) => title || ''),
         distinctUntilChanged()
       )
-      .subscribe(
-        (title) => {
-          this.renderComplete.setTitle(title);
-        },
-        () => {}
-      );
+      .subscribe((title) => this.renderComplete.setTitle(title));
   }
 
   public reportsEmbeddableLoad() {
@@ -142,11 +139,11 @@ export abstract class Embeddable<
   }
 
   public getInput$(): Readonly<Rx.Observable<TEmbeddableInput>> {
-    return this.input$.asObservable();
+    return this.input$;
   }
 
   public getOutput$(): Readonly<Rx.Observable<TEmbeddableOutput>> {
-    return this.output$.asObservable();
+    return this.output$;
   }
 
   public getOutput(): Readonly<TEmbeddableOutput> {
@@ -238,8 +235,8 @@ export abstract class Embeddable<
   public destroy(): void {
     this.destroyed = true;
 
-    this.input$.complete();
-    this.output$.complete();
+    this.inputSubject.complete();
+    this.outputSubject.complete();
 
     if (this.parentSubscription) {
       this.parentSubscription.unsubscribe();
@@ -264,13 +261,13 @@ export abstract class Embeddable<
     };
     if (!fastIsEqual(this.output, newOutput)) {
       this.output = newOutput;
-      this.output$.next(this.output);
+      this.outputSubject.next(this.output);
     }
   }
 
   protected onFatalError(e: Error) {
     this.fatalError = e;
-    this.output$.error(e);
+    this.outputSubject.error(e);
     // if the container is waiting for this embeddable to complete loading,
     // a fatal error counts as complete.
     if (this.deferEmbeddableLoad && this.parent?.isContainer) {
@@ -282,7 +279,7 @@ export abstract class Embeddable<
     if (!fastIsEqual(this.input, newInput)) {
       const oldLastReloadRequestTime = this.input.lastReloadRequestTime;
       this.input = newInput;
-      this.input$.next(newInput);
+      this.inputSubject.next(newInput);
       this.updateOutput({
         title: getPanelTitle(this.input, this.output),
       } as Partial<TEmbeddableOutput>);

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
@@ -254,7 +254,7 @@ export abstract class Embeddable<
     }
   }
 
-  protected updateOutput(outputChanges: Partial<TEmbeddableOutput>): void {
+  public updateOutput(outputChanges: Partial<TEmbeddableOutput>): void {
     const newOutput = {
       ...this.output,
       ...outputChanges,

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
@@ -12,11 +12,9 @@ import * as Rx from 'rxjs';
 import { merge } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, skip } from 'rxjs/operators';
 import { RenderCompleteDispatcher } from '@kbn/kibana-utils-plugin/public';
-import type { Reducer, Store } from 'redux';
 import { Adapters } from '../types';
 import { IContainer } from '../containers';
 import { EmbeddableOutput, IEmbeddable } from './i_embeddable';
-import { createStore, slice } from './embeddable_store';
 import { EmbeddableInput, ViewMode } from '../../../common/types';
 import { genericEmbeddableInputIsEqual, omitGenericEmbeddableInput } from './diff_embeddable_input';
 
@@ -53,8 +51,6 @@ export abstract class Embeddable<
   private parentSubscription?: Rx.Subscription;
 
   protected destroyed: boolean = false;
-
-  private cachedStore = new WeakMap<Reducer, Store<TEmbeddableInput>>();
 
   constructor(input: TEmbeddableInput, output: TEmbeddableOutput, parent?: IContainer) {
     this.id = input.id;
@@ -202,16 +198,6 @@ export abstract class Embeddable<
       root = root.parent;
     }
     return root;
-  }
-
-  public getStore(
-    reducer: Reducer<TEmbeddableInput> = slice.reducer as Reducer
-  ): Store<TEmbeddableInput> {
-    if (!this.cachedStore.has(reducer)) {
-      this.cachedStore.set(reducer, createStore(this, reducer as Reducer) as Store);
-    }
-
-    return this.cachedStore.get(reducer)!;
   }
 
   public updateInput(changes: Partial<TEmbeddableInput>): void {

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_store.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_store.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { debounce } from 'lodash';
+import type { Reducer, Store } from 'redux';
+import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { EmbeddableInput, IEmbeddable } from './i_embeddable';
+
+export const slice = createSlice({
+  name: 'embeddable',
+  initialState: {} as EmbeddableInput,
+  reducers: {
+    setDisabledActions(state, action: PayloadAction<EmbeddableInput['disabledActions']>) {
+      state.disabledActions = action.payload;
+    },
+    setDisableTriggers(state, action: PayloadAction<EmbeddableInput['disableTriggers']>) {
+      state.disableTriggers = action.payload;
+    },
+    setEnhancements(state, action: PayloadAction<EmbeddableInput['enhancements']>) {
+      state.enhancements = action.payload;
+    },
+    setExecutionContext(state, action: PayloadAction<EmbeddableInput['executionContext']>) {
+      state.executionContext = action.payload;
+    },
+    setHidePanelTitles(state, action: PayloadAction<EmbeddableInput['hidePanelTitles']>) {
+      state.hidePanelTitles = action.payload;
+    },
+    setLastReloadRequestTime(
+      state,
+      action: PayloadAction<EmbeddableInput['lastReloadRequestTime']>
+    ) {
+      state.lastReloadRequestTime = action.payload;
+    },
+    setSearchSessionId(state, action: PayloadAction<EmbeddableInput['searchSessionId']>) {
+      state.searchSessionId = action.payload;
+    },
+    setSyncColors(state, action: PayloadAction<EmbeddableInput['syncColors']>) {
+      state.syncColors = action.payload;
+    },
+    setSyncTooltips(state, action: PayloadAction<EmbeddableInput['syncTooltips']>) {
+      state.syncTooltips = action.payload;
+    },
+    setTitle(state, action: PayloadAction<EmbeddableInput['title']>) {
+      state.title = action.payload;
+    },
+    setViewMode(state, action: PayloadAction<EmbeddableInput['viewMode']>) {
+      state.viewMode = action.payload;
+    },
+    set(state, action: PayloadAction<EmbeddableInput>) {
+      return action.payload;
+    },
+    update(state, action: PayloadAction<EmbeddableInput>) {
+      return { ...state, ...action.payload };
+    },
+  },
+});
+
+export const { actions } = slice;
+
+export function createStore(
+  embeddable: IEmbeddable,
+  reducer: Reducer<EmbeddableInput>
+): Store<EmbeddableInput> {
+  const store = configureStore({
+    reducer,
+    preloadedState: embeddable.getInput(),
+  });
+
+  const onUpdate = debounce(() => embeddable.updateInput(store.getState()));
+  const unsubscribe = store.subscribe(onUpdate);
+
+  embeddable.getInput$().subscribe({ complete: unsubscribe });
+
+  return store;
+}

--- a/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
@@ -8,6 +8,7 @@
 
 import { Observable } from 'rxjs';
 import { ErrorLike } from '@kbn/expressions-plugin/common';
+import type { Reducer, Store } from 'redux';
 import { Adapters } from '../types';
 import { IContainer } from '../containers/i_container';
 import { EmbeddableInput } from '../../../common/types';
@@ -135,6 +136,12 @@ export interface IEmbeddable<
    *   last name, your output state could be greeting.
    **/
   getOutput(): Readonly<O>;
+
+  /**
+   * Returns a Redux state for the embeddable instance.
+   * @param reducer A reducer to use. If not provided, a default reducer will be used.
+   */
+  getStore(reducer?: Reducer<I>): Store<I>;
 
   /**
    * Updates input state with the given changes.

--- a/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
@@ -143,6 +143,12 @@ export interface IEmbeddable<
   updateInput(changes: Partial<I>): void;
 
   /**
+   * Updates output state with the given changes.
+   * @param changes
+   */
+  updateOutput(changes: Partial<O>): void;
+
+  /**
    * Returns an observable which will be notified when input state changes.
    */
   getInput$(): Readonly<Observable<I>>;

--- a/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
@@ -8,7 +8,6 @@
 
 import { Observable } from 'rxjs';
 import { ErrorLike } from '@kbn/expressions-plugin/common';
-import type { Reducer, Store } from 'redux';
 import { Adapters } from '../types';
 import { IContainer } from '../containers/i_container';
 import { EmbeddableInput } from '../../../common/types';
@@ -136,12 +135,6 @@ export interface IEmbeddable<
    *   last name, your output state could be greeting.
    **/
   getOutput(): Readonly<O>;
-
-  /**
-   * Returns a Redux state for the embeddable instance.
-   * @param reducer A reducer to use. If not provided, a default reducer will be used.
-   */
-  getStore(reducer?: Reducer<I>): Store<I>;
 
   /**
    * Updates input state with the given changes.

--- a/src/plugins/embeddable/public/lib/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/index.ts
@@ -11,6 +11,7 @@ export { isEmbeddable } from './is_embeddable';
 export { Embeddable } from './embeddable';
 export * from './embeddable_factory';
 export * from './embeddable_factory_definition';
+export { actions } from './embeddable_store';
 export * from './default_embeddable_factory_provider';
 export { ErrorEmbeddable, isErrorEmbeddable } from './error_embeddable';
 export { withEmbeddableSubscription } from './with_subscription';

--- a/src/plugins/embeddable/public/lib/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/index.ts
@@ -11,7 +11,6 @@ export { isEmbeddable } from './is_embeddable';
 export { Embeddable } from './embeddable';
 export * from './embeddable_factory';
 export * from './embeddable_factory_definition';
-export { actions } from './embeddable_store';
 export * from './default_embeddable_factory_provider';
 export { ErrorEmbeddable, isErrorEmbeddable } from './error_embeddable';
 export { withEmbeddableSubscription } from './with_subscription';

--- a/src/plugins/embeddable/public/store.ts
+++ b/src/plugins/embeddable/public/store.ts
@@ -9,7 +9,7 @@
 import { debounce } from 'lodash';
 import type { Reducer, Store } from 'redux';
 import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { EmbeddableInput, IEmbeddable } from './i_embeddable';
+import type { EmbeddableInput, IEmbeddable } from './lib';
 
 export const slice = createSlice({
   name: 'embeddable',
@@ -64,7 +64,7 @@ export const { actions } = slice;
 
 export function createStore(
   embeddable: IEmbeddable,
-  reducer: Reducer<EmbeddableInput>
+  reducer: Reducer<EmbeddableInput> = slice.reducer
 ): Store<EmbeddableInput> {
   let isUpstreamUpdate = false;
   let isDownstreamUpdate = false;

--- a/src/plugins/embeddable/public/store/create_store.test.ts
+++ b/src/plugins/embeddable/public/store/create_store.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createAction, createReducer, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { Store } from 'redux';
+import { Embeddable, EmbeddableInput, EmbeddableOutput } from '../lib';
+import { createStore, State } from './create_store';
+import { input } from './input_slice';
+import { output } from './output_slice';
+
+interface TestEmbeddableInput extends EmbeddableInput {
+  custom?: string;
+}
+
+interface TestEmbeddableOutput extends EmbeddableOutput {
+  custom?: string;
+}
+
+class TestEmbeddable extends Embeddable<TestEmbeddableInput, TestEmbeddableOutput> {
+  type = 'test';
+  reload = jest.fn();
+  render = jest.fn();
+}
+
+describe('createStore', () => {
+  let embeddable: TestEmbeddable;
+  let store: Store<State<TestEmbeddable>>;
+
+  beforeEach(() => {
+    embeddable = new TestEmbeddable({ id: '12345' }, { title: 'Test' });
+    store = createStore(embeddable);
+  });
+
+  it('should populate the state with the embeddable input', () => {
+    expect(store.getState()).toHaveProperty('input', expect.objectContaining({ id: '12345' }));
+  });
+
+  it('should populate the state with the embeddable output', () => {
+    expect(store.getState()).toHaveProperty('output', expect.objectContaining({ title: 'Test' }));
+  });
+
+  it('should update the embeddable input on action dispatch', () => {
+    store.dispatch(input.actions.setTitle('Something'));
+
+    expect(store.getState()).toHaveProperty('input.title', 'Something');
+  });
+
+  it('should update the embeddable output on action dispatch', () => {
+    store.dispatch(output.actions.setTitle('Something'));
+
+    expect(store.getState()).toHaveProperty('output.title', 'Something');
+  });
+
+  it('should group input updates on multiple dispatch calls', async () => {
+    jest.spyOn(embeddable, 'updateInput');
+    store.dispatch(input.actions.setTitle('Something'));
+    store.dispatch(input.actions.setHidePanelTitles(true));
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(embeddable.updateInput).toHaveBeenCalledTimes(1);
+    expect(embeddable.updateInput).nthCalledWith(
+      1,
+      expect.objectContaining({ title: 'Something', hidePanelTitles: true })
+    );
+  });
+
+  it('should group output updates on multiple dispatch calls', async () => {
+    jest.spyOn(embeddable, 'updateOutput');
+    store.dispatch(output.actions.setTitle('Something'));
+    store.dispatch(output.actions.setLoading(true));
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(embeddable.updateOutput).toHaveBeenCalledTimes(1);
+    expect(embeddable.updateOutput).nthCalledWith(
+      1,
+      expect.objectContaining({ title: 'Something', loading: true })
+    );
+  });
+
+  it('should not update input on output changes', async () => {
+    jest.spyOn(embeddable, 'updateInput');
+    store.dispatch(output.actions.setTitle('Something'));
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(embeddable.updateInput).not.toHaveBeenCalled();
+  });
+
+  it('should sync input changes', () => {
+    jest.spyOn(embeddable, 'updateInput');
+    embeddable.updateInput({ title: 'Something' });
+
+    expect(embeddable.updateInput).toHaveBeenCalledTimes(1);
+    expect(store.getState()).toHaveProperty('input.title', 'Something');
+  });
+
+  it('should sync output changes', () => {
+    jest.spyOn(embeddable, 'updateOutput');
+    embeddable.updateOutput({ title: 'Something' });
+
+    expect(embeddable.updateOutput).toHaveBeenCalledTimes(1);
+    expect(store.getState()).toHaveProperty('output.title', 'Something');
+  });
+
+  it('should provide a way to use a custom reducer', async () => {
+    const setCustom = createAction<string>('custom');
+    const customStore = createStore(embeddable, {
+      reducer: {
+        input: createReducer({} as TestEmbeddableInput, (builder) =>
+          builder.addCase(setCustom, (state, action) => ({ ...state, custom: action.payload }))
+        ),
+      },
+    });
+
+    jest.spyOn(embeddable, 'updateInput');
+    customStore.dispatch(input.actions.setTitle('Something'));
+    customStore.dispatch(setCustom('Something else'));
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(embeddable.updateInput).toHaveBeenCalledWith(
+      expect.objectContaining({ custom: 'Something else', title: 'Something' })
+    );
+  });
+
+  it('should provide a way to use a custom slice', async () => {
+    const slice = createSlice({
+      name: 'test',
+      initialState: {} as State<TestEmbeddable>,
+      reducers: {
+        setCustom(state, action: PayloadAction<TestEmbeddableInput['custom']>) {
+          state.input.custom = action.payload;
+          state.output.custom = action.payload;
+        },
+      },
+    });
+    const customStore = createStore(embeddable, { reducer: slice.reducer });
+
+    jest.spyOn(embeddable, 'updateInput');
+    jest.spyOn(embeddable, 'updateOutput');
+    customStore.dispatch(input.actions.setTitle('Something'));
+    customStore.dispatch(slice.actions.setCustom('Something else'));
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(embeddable.updateInput).toHaveBeenCalledWith(
+      expect.objectContaining({ custom: 'Something else', title: 'Something' })
+    );
+    expect(embeddable.updateOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ custom: 'Something else' })
+    );
+  });
+});

--- a/src/plugins/embeddable/public/store/create_store.ts
+++ b/src/plugins/embeddable/public/store/create_store.ts
@@ -99,7 +99,7 @@ export function createStore<E extends IEmbeddable = IEmbeddable, S extends State
       distinctUntilChanged(),
       map((value) => diff(embeddable.getInput(), value)),
       filter((patch) => !isEmpty(patch)),
-      debounceTime(0),
+      debounceTime(0)
     )
     .subscribe((patch) => embeddable.updateInput(patch));
 
@@ -110,21 +110,21 @@ export function createStore<E extends IEmbeddable = IEmbeddable, S extends State
       distinctUntilChanged(),
       map((value) => diff(embeddable.getOutput(), value)),
       filter((patch) => !isEmpty(patch)),
-      debounceTime(0),
+      debounceTime(0)
     )
     .subscribe((patch) => embeddable.updateOutput(patch));
 
   input$
     .pipe(
       map((value) => diff(store.getState().input, value)),
-      filter((patch) => !isEmpty(patch)),
+      filter((patch) => !isEmpty(patch))
     )
     .subscribe((patch) => store.dispatch(input.actions.update(patch)));
 
   output$
     .pipe(
       map((value) => diff(store.getState().output, value)),
-      filter((patch) => !isEmpty(patch)),
+      filter((patch) => !isEmpty(patch))
     )
     .subscribe((patch) => store.dispatch(output.actions.update(patch)));
 

--- a/src/plugins/embeddable/public/store/create_store.ts
+++ b/src/plugins/embeddable/public/store/create_store.ts
@@ -67,9 +67,9 @@ export function createStore<E extends IEmbeddable = IEmbeddable, S extends State
   state$
     .pipe(
       takeUntil(input$.pipe(last())),
-      filter(() => !isUpstreamUpdate),
       pluck('input'),
       distinctUntilChanged(),
+      filter(() => !isUpstreamUpdate),
       debounceTime(0)
     )
     .subscribe((value) => {
@@ -81,9 +81,9 @@ export function createStore<E extends IEmbeddable = IEmbeddable, S extends State
   state$
     .pipe(
       takeUntil(output$.pipe(last())),
-      filter(() => !isUpstreamUpdate),
       pluck('output'),
       distinctUntilChanged(),
+      filter(() => !isUpstreamUpdate),
       debounceTime(0)
     )
     .subscribe((value) => {

--- a/src/plugins/embeddable/public/store/create_store.ts
+++ b/src/plugins/embeddable/public/store/create_store.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { debounce } from 'lodash';
+import { combineReducers, Reducer, Store } from 'redux';
+import { configureStore, ConfigureStoreOptions } from '@reduxjs/toolkit';
+import { filter } from 'rxjs';
+import reduceReducers from 'reduce-reducers';
+import type { EmbeddableInput, IEmbeddable } from '../lib';
+import { input } from './input_slice';
+
+export interface State {
+  input: EmbeddableInput;
+}
+
+const GENERIC_REDUCER = combineReducers({ input: input.reducer }) as Reducer<State>;
+
+function createReducer(reducer?: ConfigureStoreOptions<State>['reducer']) {
+  if (!reducer) {
+    return GENERIC_REDUCER;
+  }
+
+  return reduceReducers(
+    GENERIC_REDUCER,
+    reducer instanceof Function ? reducer : combineReducers(reducer)
+  ) as Reducer<State>;
+}
+
+export function createStore(
+  embeddable: IEmbeddable,
+  { reducer, ...options }: Partial<ConfigureStoreOptions<State>> = {}
+): Store<State> {
+  let isUpstreamUpdate = false;
+  let isDownstreamUpdate = false;
+
+  const store = configureStore({ ...options, reducer: createReducer(reducer) });
+  const onUpdate = debounce(() => {
+    isDownstreamUpdate = true;
+    embeddable.updateInput(store.getState().input);
+    isDownstreamUpdate = false;
+  });
+  const unsubscribe = store.subscribe(() => !isUpstreamUpdate && onUpdate());
+
+  embeddable
+    .getInput$()
+    .pipe(filter(() => !isDownstreamUpdate))
+    .subscribe({
+      next: () => {
+        isUpstreamUpdate = true;
+        store.dispatch(input.actions.set(embeddable.getInput()));
+        isUpstreamUpdate = false;
+      },
+      complete: unsubscribe,
+    });
+
+  return store;
+}

--- a/src/plugins/embeddable/public/store/index.ts
+++ b/src/plugins/embeddable/public/store/index.ts
@@ -7,8 +7,10 @@
  */
 
 import { input } from './input_slice';
+import { output } from './output_slice';
 
 export { createStore, State } from './create_store';
 export const actions = {
   input: input.actions,
+  output: output.actions,
 };

--- a/src/plugins/embeddable/public/store/index.ts
+++ b/src/plugins/embeddable/public/store/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { input } from './input_slice';
+
+export { createStore, State } from './create_store';
+export const actions = {
+  input: input.actions,
+};

--- a/src/plugins/embeddable/public/store/index.ts
+++ b/src/plugins/embeddable/public/store/index.ts
@@ -9,7 +9,8 @@
 import { input } from './input_slice';
 import { output } from './output_slice';
 
-export { createStore, State } from './create_store';
+export type { CreateStoreOptions, State } from './create_store';
+export { createStore } from './create_store';
 export const actions = {
   input: input.actions,
   output: output.actions,

--- a/src/plugins/embeddable/public/store/input_slice.ts
+++ b/src/plugins/embeddable/public/store/input_slice.ts
@@ -49,9 +49,6 @@ export const input = createSlice({
     setViewMode(state, action: PayloadAction<EmbeddableInput['viewMode']>) {
       state.viewMode = action.payload;
     },
-    set(state, action: PayloadAction<EmbeddableInput>) {
-      return action.payload;
-    },
     update(state, action: PayloadAction<Partial<EmbeddableInput>>) {
       return { ...state, ...action.payload };
     },

--- a/src/plugins/embeddable/public/store/input_slice.ts
+++ b/src/plugins/embeddable/public/store/input_slice.ts
@@ -10,7 +10,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { EmbeddableInput } from '../lib';
 
 export const input = createSlice({
-  name: 'embeddable',
+  name: 'input',
   initialState: {} as EmbeddableInput,
   reducers: {
     setDisabledActions(state, action: PayloadAction<EmbeddableInput['disabledActions']>) {
@@ -52,7 +52,7 @@ export const input = createSlice({
     set(state, action: PayloadAction<EmbeddableInput>) {
       return action.payload;
     },
-    update(state, action: PayloadAction<EmbeddableInput>) {
+    update(state, action: PayloadAction<Partial<EmbeddableInput>>) {
       return { ...state, ...action.payload };
     },
   },

--- a/src/plugins/embeddable/public/store/output_slice.ts
+++ b/src/plugins/embeddable/public/store/output_slice.ts
@@ -43,9 +43,6 @@ export const output = createSlice({
     setSavedObjectId(state, action: PayloadAction<EmbeddableOutput['savedObjectId']>) {
       state.savedObjectId = action.payload;
     },
-    set(state, action: PayloadAction<EmbeddableOutput>) {
-      return action.payload;
-    },
     update(state, action: PayloadAction<Partial<EmbeddableOutput>>) {
       return { ...state, ...action.payload };
     },

--- a/src/plugins/embeddable/public/store/output_slice.ts
+++ b/src/plugins/embeddable/public/store/output_slice.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { EmbeddableOutput } from '../lib';
+
+export const output = createSlice({
+  name: 'output',
+  initialState: {} as EmbeddableOutput,
+  reducers: {
+    setLoading(state, action: PayloadAction<EmbeddableOutput['loading']>) {
+      state.loading = action.payload;
+    },
+    setRendered(state, action: PayloadAction<EmbeddableOutput['rendered']>) {
+      state.rendered = action.payload;
+    },
+    setError(state, action: PayloadAction<EmbeddableOutput['error']>) {
+      state.error = action.payload;
+    },
+    setEditUrl(state, action: PayloadAction<EmbeddableOutput['editUrl']>) {
+      state.editUrl = action.payload;
+    },
+    setEditApp(state, action: PayloadAction<EmbeddableOutput['editApp']>) {
+      state.editApp = action.payload;
+    },
+    setEditPath(state, action: PayloadAction<EmbeddableOutput['editPath']>) {
+      state.editPath = action.payload;
+    },
+    setDefaultTitle(state, action: PayloadAction<EmbeddableOutput['defaultTitle']>) {
+      state.defaultTitle = action.payload;
+    },
+    setTitle(state, action: PayloadAction<EmbeddableOutput['title']>) {
+      state.title = action.payload;
+    },
+    setEditable(state, action: PayloadAction<EmbeddableOutput['editable']>) {
+      state.editable = action.payload;
+    },
+    setSavedObjectId(state, action: PayloadAction<EmbeddableOutput['savedObjectId']>) {
+      state.savedObjectId = action.payload;
+    },
+    set(state, action: PayloadAction<EmbeddableOutput>) {
+      return action.payload;
+    },
+    update(state, action: PayloadAction<Partial<EmbeddableOutput>>) {
+      return { ...state, ...action.payload };
+    },
+  },
+});


### PR DESCRIPTION
## Summary

This PR brings a bi-directional adapter exposing a Redux `store` over an embeddable instance:
- The store can be used in the `render` hook to provide reactive updates of the Virtual DOM.
- Also, the store can be used to manipulate the data if an embeddable is used inside another React component.
- The storybook examples have been updated accordingly to demonstrate both cases.
- The store factory provides a way to override `configureStore` options, including correct reducers merging.
- The store factory doesn't perform any serialization of the data. That should be done via custom middleware as described in the Redux Toolkit [documentation](https://redux-toolkit.js.org/api/serializabilityMiddleware).
- The store synchronization seamlessly supports the inherited state.
- The synchronization is well optimized and does not perform state updates or embeddable updates if there are no changes.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
