### PR TITLE
[Security Solution][Endpoint] Turn off Responder's command input history functionality

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.test.tsx
@@ -92,14 +92,16 @@ describe('When entering data into the Console input', () => {
     expect(getFooterText()).toEqual('Unknown command abc');
   });
 
-  it('should display the input history popover when UP key is pressed', async () => {
+  // FIXME:PT uncomment once task OLM task #4384 is implemented
+  it.skip('should display the input history popover when UP key is pressed', async () => {
     render();
     await showInputHistoryPopover();
 
     expect(renderResult.getByTestId('test-inputHistorySelector')).not.toBeNull();
   });
 
-  describe('and when the command input history popover is opened', () => {
+  // FIXME:PT uncomment once task OLM task #4384 is implemented
+  describe.skip('and when the command input history popover is opened', () => {
     const renderWithInputHistory = async (inputText: string = '') => {
       render();
       enterCommand('help');
@@ -237,7 +239,8 @@ describe('When entering data into the Console input', () => {
       expect(getFooterText()).toEqual('cmd1 ');
     });
 
-    it('should return original cursor position if input history is closed with no selection', async () => {
+    // FIXME:PT uncomment once task OLM task #4384 is implemented
+    it.skip('should return original cursor position if input history is closed with no selection', async () => {
       typeKeyboardKey('{Enter}'); // add `isolate` to the input history
 
       typeKeyboardKey('release');
@@ -262,7 +265,8 @@ describe('When entering data into the Console input', () => {
       expect(getRightOfCursorText()).toEqual('elease');
     });
 
-    it('should reset cursor position to default (at end) if a selection is done from input history', async () => {
+    // FIXME:PT uncomment once task OLM task #4384 is implemented
+    it.skip('should reset cursor position to default (at end) if a selection is done from input history', async () => {
       typeKeyboardKey('{Enter}'); // add `isolate` to the input history
 
       typeKeyboardKey('release');

--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.tsx
@@ -131,12 +131,13 @@ export const CommandInput = memo<CommandInputProps>(({ prompt = '', focusRef, ..
       const keyCode = eventDetails.keyCode;
 
       // UP arrow key
-      if (keyCode === 38) {
-        dispatch({ type: 'removeFocusFromKeyCapture' });
-        dispatch({ type: 'updateInputPopoverState', payload: { show: 'input-history' } });
-
-        return;
-      }
+      // FIXME:PT to be addressed via OLM task #4384
+      // if (keyCode === 38) {
+      //   dispatch({ type: 'removeFocusFromKeyCapture' });
+      //   dispatch({ type: 'updateInputPopoverState', payload: { show: 'input-history' } });
+      //
+      //   return;
+      // }
 
       // Update the store with the updated text that was entered
       dispatch({


### PR DESCRIPTION
## Summary

Comments out Responder's command input history and defers this functionality to a future release.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



