### PR TITLE
[Fleet] Remove licence restrictions for bulk reassign and bulk unenroll

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -29,7 +29,6 @@ import type {
   PostBulkUpdateAgentTagsRequestSchema,
 } from '../../types';
 import { defaultIngestErrorHandler } from '../../errors';
-import { licenseService } from '../../services';
 import * as AgentService from '../../services/agents';
 
 export const getAgentHandler: RequestHandler<
@@ -214,13 +213,6 @@ export const postBulkAgentsReassignHandler: RequestHandler<
   undefined,
   TypeOf<typeof PostBulkAgentReassignRequestSchema.body>
 > = async (context, request, response) => {
-  if (!licenseService.isGoldPlus()) {
-    return response.customError({
-      statusCode: 403,
-      body: { message: 'Requires Gold license' },
-    });
-  }
-
   const coreContext = await context.core;
   const soClient = coreContext.savedObjects.client;
   const esClient = coreContext.elasticsearch.client.asInternalUser;

--- a/x-pack/plugins/fleet/server/routes/agent/unenroll_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/unenroll_handler.ts
@@ -16,7 +16,6 @@ import type {
   PostAgentUnenrollRequestSchema,
   PostBulkAgentUnenrollRequestSchema,
 } from '../../types';
-import { licenseService } from '../../services';
 import * as AgentService from '../../services/agents';
 import { defaultIngestErrorHandler } from '../../errors';
 
@@ -46,13 +45,6 @@ export const postBulkAgentsUnenrollHandler: RequestHandler<
   undefined,
   TypeOf<typeof PostBulkAgentUnenrollRequestSchema.body>
 > = async (context, request, response) => {
-  if (!licenseService.isGoldPlus()) {
-    return response.customError({
-      statusCode: 403,
-      body: { message: 'Requires Gold license' },
-    });
-  }
-
   const coreContext = await context.core;
   const soClient = coreContext.savedObjects.client;
   const esClient = coreContext.elasticsearch.client.asInternalUser;


### PR DESCRIPTION
## Summary

While implementing rolling upgrade we implemented we removed licence restrictions from the UI but we keep these restricitons in the Fleet APIs, that PR remove these restriction there too.

@nimarezainia it's my assumption correct here that we do not want licence restrictions for agent bulk action? (expect special case like scheduled upgrade, ...)

This bug was found by a user here https://discuss.elastic.co/t/unenrolling-multiple-agents-requires-gold-license/309518 

## Release note

Allow agent bulk actions without specific licence restrictions.