### PR TITLE
[7.17] revert package policy validation that caused issue with input groups (#125657)

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -556,7 +556,8 @@ describe('Fleet - validatePackagePolicy()', () => {
       });
     });
 
-    it('returns package policy validation error if input var does not exist', () => {
+    // TODO enable when https://github.com/elastic/kibana/issues/125655 is fixed
+    it.skip('returns package policy validation error if input var does not exist', () => {
       expect(
         validatePackagePolicy(
           {

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -210,15 +210,11 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef === undefined) {
-    errors.push(
-      i18n.translate('xpack.fleet.packagePolicyValidation.nonExistentVarMessage', {
-        defaultMessage: '{varName} var definition does not exist',
-        values: {
-          varName,
-        },
-      })
-    );
-    return errors;
+    // TODO return validation error here once https://github.com/elastic/kibana/issues/125655 is fixed
+    // eslint-disable-next-line no-console
+    console.debug(`No variable definition for ${varName} found`);
+
+    return null;
   }
 
   if (varDef.required) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [revert package policy validation that caused issue with input groups (#125657)](https://github.com/elastic/kibana/pull/125657)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Bardi","email":"90178898+juliaElastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-02-15T15:46:05Z","message":"revert package policy validation that caused issue with input groups (#125657)","sha":"35f4ba536262d37946a48922d30997e98ff74620","branchLabelMapping":{"^v8.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","auto-backport","v8.1.0","v8.2.0","v8.0.1","v7.17.1"],"number":125657,"url":"https://github.com/elastic/kibana/pull/125657","mergeCommit":{"message":"revert package policy validation that caused issue with input groups (#125657)","sha":"35f4ba536262d37946a48922d30997e98ff74620"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"8.1","label":"v8.1.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/125678","number":125678,"state":"MERGED","mergeCommit":{"sha":"f2930490c5a5f1c88f46325bd161d074e9614018","message":"revert package policy validation that caused issue with input groups (#125657) (#125678)\n\n(cherry picked from commit 35f4ba536262d37946a48922d30997e98ff74620)\n\nCo-authored-by: Julia Bardi <90178898+juliaElastic@users.noreply.github.com>"}},{"branch":"main","label":"v8.2.0","labelRegex":"^v8.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/125657","number":125657,"mergeCommit":{"message":"revert package policy validation that caused issue with input groups (#125657)","sha":"35f4ba536262d37946a48922d30997e98ff74620"}},{"branch":"8.0","label":"v8.0.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/125679","number":125679,"state":"MERGED","mergeCommit":{"sha":"bc031b47df1854bb54823e0121179b510314e72e","message":"revert package policy validation that caused issue with input groups (#125657) (#125679)\n\n(cherry picked from commit 35f4ba536262d37946a48922d30997e98ff74620)\n\nCo-authored-by: Julia Bardi <90178898+juliaElastic@users.noreply.github.com>"}},{"branch":"7.17","label":"v7.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->