### PR TITLE
[checks] disable spinners in CI to cut-down on log sizes

### DIFF
--- a/packages/kbn-telemetry-tools/src/cli/run_telemetry_check.ts
+++ b/packages/kbn-telemetry-tools/src/cli/run_telemetry_check.ts
@@ -48,64 +48,70 @@ export function runTelemetryCheck() {
         );
       }
 
-      const list = new Listr([
-        {
-          title: 'Checking .telemetryrc.json files',
-          task: () => new Listr(parseConfigsTask(), { exitOnError: true }),
-        },
-        {
-          title: 'Extracting Collectors',
-          task: (context) => new Listr(extractCollectorsTask(context, path), { exitOnError: true }),
-        },
-        {
-          enabled: () => typeof path !== 'undefined',
-          title: 'Checking collectors in --path are not excluded',
-          task: ({ roots }: TaskContext) => {
-            const totalCollections = roots.reduce((acc, root) => {
-              return acc + (root.parsedCollections?.length || 0);
-            }, 0);
-            const collectorsInPath = Array.isArray(path) ? path.length : 1;
+      const list = new Listr(
+        [
+          {
+            title: 'Checking .telemetryrc.json files',
+            task: () => new Listr(parseConfigsTask(), { exitOnError: true }),
+          },
+          {
+            title: 'Extracting Collectors',
+            task: (context) =>
+              new Listr(extractCollectorsTask(context, path), { exitOnError: true }),
+          },
+          {
+            enabled: () => typeof path !== 'undefined',
+            title: 'Checking collectors in --path are not excluded',
+            task: ({ roots }: TaskContext) => {
+              const totalCollections = roots.reduce((acc, root) => {
+                return acc + (root.parsedCollections?.length || 0);
+              }, 0);
+              const collectorsInPath = Array.isArray(path) ? path.length : 1;
 
-            if (totalCollections !== collectorsInPath) {
-              throw new Error(
-                'Collector specified in `path` is excluded; Check the telemetryrc.json files.'
+              if (totalCollections !== collectorsInPath) {
+                throw new Error(
+                  'Collector specified in `path` is excluded; Check the telemetryrc.json files.'
+                );
+              }
+            },
+          },
+          {
+            title: 'Checking Compatible collector.schema with collector.fetch type',
+            task: (context) => new Listr(checkCompatibleTypesTask(context), { exitOnError: true }),
+          },
+          {
+            enabled: (_) => fix || !ignoreStoredJson,
+            title: 'Checking Matching collector.schema against stored json files',
+            task: (context) =>
+              new Listr(checkMatchingSchemasTask(context, !fix), { exitOnError: true }),
+          },
+          {
+            enabled: (_) => fix,
+            skip: ({ roots }: TaskContext) => {
+              const noDiffs = roots.every(
+                ({ esMappingDiffs }) => !esMappingDiffs || !esMappingDiffs.length
               );
-            }
+              return noDiffs && 'No changes needed.';
+            },
+            title: 'Generating new telemetry mappings',
+            task: (context) => new Listr(generateSchemasTask(context), { exitOnError: true }),
           },
-        },
-        {
-          title: 'Checking Compatible collector.schema with collector.fetch type',
-          task: (context) => new Listr(checkCompatibleTypesTask(context), { exitOnError: true }),
-        },
-        {
-          enabled: (_) => fix || !ignoreStoredJson,
-          title: 'Checking Matching collector.schema against stored json files',
-          task: (context) =>
-            new Listr(checkMatchingSchemasTask(context, !fix), { exitOnError: true }),
-        },
-        {
-          enabled: (_) => fix,
-          skip: ({ roots }: TaskContext) => {
-            const noDiffs = roots.every(
-              ({ esMappingDiffs }) => !esMappingDiffs || !esMappingDiffs.length
-            );
-            return noDiffs && 'No changes needed.';
+          {
+            enabled: (_) => fix,
+            skip: ({ roots }: TaskContext) => {
+              const noDiffs = roots.every(
+                ({ esMappingDiffs }) => !esMappingDiffs || !esMappingDiffs.length
+              );
+              return noDiffs && 'No changes needed.';
+            },
+            title: 'Updating telemetry mapping files',
+            task: (context) => new Listr(writeToFileTask(context), { exitOnError: true }),
           },
-          title: 'Generating new telemetry mappings',
-          task: (context) => new Listr(generateSchemasTask(context), { exitOnError: true }),
-        },
+        ],
         {
-          enabled: (_) => fix,
-          skip: ({ roots }: TaskContext) => {
-            const noDiffs = roots.every(
-              ({ esMappingDiffs }) => !esMappingDiffs || !esMappingDiffs.length
-            );
-            return noDiffs && 'No changes needed.';
-          },
-          title: 'Updating telemetry mapping files',
-          task: (context) => new Listr(writeToFileTask(context), { exitOnError: true }),
-        },
-      ]);
+          renderer: process.env.CI ? 'verbose' : 'default',
+        }
+      );
 
       try {
         const context = createTaskContext();

--- a/packages/kbn-telemetry-tools/src/cli/run_telemetry_extract.ts
+++ b/packages/kbn-telemetry-tools/src/cli/run_telemetry_extract.ts
@@ -21,24 +21,29 @@ import {
 export function runTelemetryExtract() {
   run(
     async ({ flags: {}, log }) => {
-      const list = new Listr([
+      const list = new Listr(
+        [
+          {
+            title: 'Parsing .telemetryrc.json files',
+            task: () => new Listr(parseConfigsTask(), { exitOnError: true }),
+          },
+          {
+            title: 'Extracting Telemetry Collectors',
+            task: (context) => new Listr(extractCollectorsTask(context), { exitOnError: true }),
+          },
+          {
+            title: 'Generating Schema files',
+            task: (context) => new Listr(generateSchemasTask(context), { exitOnError: true }),
+          },
+          {
+            title: 'Writing to file',
+            task: (context) => new Listr(writeToFileTask(context), { exitOnError: true }),
+          },
+        ],
         {
-          title: 'Parsing .telemetryrc.json files',
-          task: () => new Listr(parseConfigsTask(), { exitOnError: true }),
-        },
-        {
-          title: 'Extracting Telemetry Collectors',
-          task: (context) => new Listr(extractCollectorsTask(context), { exitOnError: true }),
-        },
-        {
-          title: 'Generating Schema files',
-          task: (context) => new Listr(generateSchemasTask(context), { exitOnError: true }),
-        },
-        {
-          title: 'Writing to file',
-          task: (context) => new Listr(writeToFileTask(context), { exitOnError: true }),
-        },
-      ]);
+          renderer: process.env.CI ? 'verbose' : 'default',
+        }
+      );
 
       try {
         const context = createTaskContext();

--- a/src/dev/run_i18n_check.ts
+++ b/src/dev/run_i18n_check.ts
@@ -120,6 +120,7 @@ run(
       {
         concurrent: false,
         exitOnError: true,
+        renderer: process.env.CI ? 'verbose' : 'default',
       }
     );
 

--- a/src/dev/run_i18n_extract.ts
+++ b/src/dev/run_i18n_extract.ts
@@ -38,32 +38,37 @@ run(
     }
     const srcPaths = Array().concat(path || ['./src', './packages', './x-pack']);
 
-    const list = new Listr([
-      {
-        title: 'Merging .i18nrc.json files',
-        task: () => new Listr(mergeConfigs(includeConfig), { exitOnError: true }),
-      },
-      {
-        title: 'Extracting Default Messages',
-        task: ({ config }) =>
-          new Listr(extractDefaultMessages(config, srcPaths), { exitOnError: true }),
-      },
-      {
-        title: 'Writing to file',
-        enabled: (ctx) => outputDir && ctx.messages.size,
-        task: async (ctx) => {
-          const sortedMessages = [...ctx.messages].sort(([key1], [key2]) =>
-            key1.localeCompare(key2)
-          );
-          await writeFileAsync(
-            resolve(outputDir, 'en.json'),
-            outputFormat === 'json5'
-              ? serializeToJson5(sortedMessages)
-              : serializeToJson(sortedMessages)
-          );
+    const list = new Listr(
+      [
+        {
+          title: 'Merging .i18nrc.json files',
+          task: () => new Listr(mergeConfigs(includeConfig), { exitOnError: true }),
         },
-      },
-    ]);
+        {
+          title: 'Extracting Default Messages',
+          task: ({ config }) =>
+            new Listr(extractDefaultMessages(config, srcPaths), { exitOnError: true }),
+        },
+        {
+          title: 'Writing to file',
+          enabled: (ctx) => outputDir && ctx.messages.size,
+          task: async (ctx) => {
+            const sortedMessages = [...ctx.messages].sort(([key1], [key2]) =>
+              key1.localeCompare(key2)
+            );
+            await writeFileAsync(
+              resolve(outputDir, 'en.json'),
+              outputFormat === 'json5'
+                ? serializeToJson5(sortedMessages)
+                : serializeToJson(sortedMessages)
+            );
+          },
+        },
+      ],
+      {
+        renderer: process.env.CI ? 'verbose' : 'default',
+      }
+    );
 
     try {
       const reporter = new ErrorReporter();

--- a/src/dev/run_i18n_integrate.ts
+++ b/src/dev/run_i18n_integrate.ts
@@ -69,33 +69,38 @@ run(
 
     const srcPaths = Array().concat(path || ['./src', './packages', './x-pack']);
 
-    const list = new Listr([
-      {
-        title: 'Merging .i18nrc.json files',
-        task: () => new Listr(mergeConfigs(includeConfig), { exitOnError: true }),
-      },
-      {
-        title: 'Extracting Default Messages',
-        task: ({ config }) =>
-          new Listr(extractDefaultMessages(config, srcPaths), { exitOnError: true }),
-      },
-      {
-        title: 'Integrating Locale File',
-        task: async ({ messages, config }) => {
-          await integrateLocaleFiles(messages, {
-            sourceFileName: source,
-            targetFileName: target,
-            dryRun,
-            ignoreIncompatible,
-            ignoreUnused,
-            ignoreMissing,
-            ignoreMalformed,
-            config,
-            log,
-          });
+    const list = new Listr(
+      [
+        {
+          title: 'Merging .i18nrc.json files',
+          task: () => new Listr(mergeConfigs(includeConfig), { exitOnError: true }),
         },
-      },
-    ]);
+        {
+          title: 'Extracting Default Messages',
+          task: ({ config }) =>
+            new Listr(extractDefaultMessages(config, srcPaths), { exitOnError: true }),
+        },
+        {
+          title: 'Integrating Locale File',
+          task: async ({ messages, config }) => {
+            await integrateLocaleFiles(messages, {
+              sourceFileName: source,
+              targetFileName: target,
+              dryRun,
+              ignoreIncompatible,
+              ignoreUnused,
+              ignoreMissing,
+              ignoreMalformed,
+              config,
+              log,
+            });
+          },
+        },
+      ],
+      {
+        renderer: process.env.CI ? 'verbose' : 'default',
+      }
+    );
 
     try {
       const reporter = new ErrorReporter();

--- a/x-pack/plugins/apm/scripts/precommit.js
+++ b/x-pack/plugins/apm/scripts/precommit.js
@@ -80,7 +80,11 @@ const tasks = new Listr(
         ),
     },
   ],
-  { exitOnError: true, concurrent: false }
+  {
+    exitOnError: true,
+    concurrent: false,
+    renderer: process.env.CI ? 'verbose' : 'default',
+  }
 );
 
 tasks.run().catch((error) => {


### PR DESCRIPTION
The "Checks" step on CI runs a handful of scripts and several of them use "listr" to produce pretty log output. This is unnecessary on CI and causes a lot of log data to be written to buildkite (each update is stored and counts towards the 1MB limit) leading to logging truncation, even though the result still looks a lot like this:

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/1329312/178826239-54ba7ceb-282c-4d3c-8c43-41feda77bc7e.png">


# Reviewers
The changes are very small but lead to prettier changing indentation in more places, you probably want to hide whitespace only changes
<img width="688" alt="image" src="https://user-images.githubusercontent.com/1329312/178829378-cc69bcaf-7b7f-40f7-a5c1-745261e503ae.png">


<!--ONMERGE {"backportTargets":["7.17","8.3"]} ONMERGE-->