### PR TITLE
[Profiling] Update infrastructure for local containerized development

### DIFF
--- a/x-pack/plugins/profiling/DOCKER.md
+++ b/x-pack/plugins/profiling/DOCKER.md
@@ -21,16 +21,23 @@ You will first need to build the Docker image for the Kibana environment:
 make build
 ```
 
-This will create a Docker image with the tag `kibana-dev:8.1.x`.
+This will create a Docker image with the tag `kibana-dev:latest`.
 
 If you wish to change the image version, you can run this instead:
 
 ```
-make build KIBANA_VERSION=8.2
+make build KIBANA_VERSION=8.4
+```
+
+If you need to do a full refresh of the Docker image, you can rebuild from
+scratch using this:
+
+```
+make build-nocache
 ```
 
 Next, you can start the container using this (assumes Docker image is
-`kibana-dev:8.1.x` and Elasticsearch is running on the `apm-integration-testing`
+`kibana-dev:latest` and Elasticsearch is running on the `apm-integration-testing`
 Docker network):
 
 ```

--- a/x-pack/plugins/profiling/Dockerfile
+++ b/x-pack/plugins/profiling/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 

--- a/x-pack/plugins/profiling/Makefile
+++ b/x-pack/plugins/profiling/Makefile
@@ -1,16 +1,21 @@
-NODE_VERSION    = $(shell cat .node-version)
+KIBANA_REPO       = $(shell git rev-parse --show-toplevel)
+NODE_VERSION      = $(shell cat ${KIBANA_REPO}/.node-version)
 
-KIBANA_VERSION ?= 8.2.x
-NETWORK        ?= apm-integration-testing
-PORT           ?= 5601
+KIBANA_VERSION   ?= latest
+NETWORK          ?= apm-integration-testing
+PORT             ?= 5601
 
-DOCKER_IMAGE    = kibana-dev:${KIBANA_VERSION}
-DOCKER_RUN_ARGS = --rm -p ${PORT}:5601 -p 9229-9231:9229-9231/tcp -v $(shell pwd):/kibana/src -it ${DOCKER_IMAGE}
+DOCKER_IMAGE      = kibana-dev:${KIBANA_VERSION}
+DOCKER_BUILD_ARGS = --build-arg NODE_VERSION="${NODE_VERSION}" -t ${DOCKER_IMAGE} .
+DOCKER_RUN_ARGS   = --rm -p ${PORT}:5601 -p 9229-9231:9229-9231/tcp -v ${KIBANA_REPO}:/kibana/src -it ${DOCKER_IMAGE}
 
-.PHONY: build run run-networkless
+.PHONY: build build-nocache run run-networkless
 
 build:
-	docker build --build-arg NODE_VERSION="${NODE_VERSION}" -t ${DOCKER_IMAGE} .
+	docker build ${DOCKER_BUILD_ARGS}
+
+build-nocache:
+	docker build --no-cache ${DOCKER_BUILD_ARGS}
 
 run:
 	docker run --network ${NETWORK} ${DOCKER_RUN_ARGS}


### PR DESCRIPTION
## Summary

When running Kibana locally, we have the option to run it inside of container to make it easier to install and manage dependencies without the need to update the local environment. This also makes switching between different versions of the Elasticsearch stack a smoother process.

Given the recent efforts to integrate the profiling plugin into the Kibana ecosystem, this PR has a few updates that continue our support for a local containerized instance:

- optionally bypass caching when building an image
- build an image directly from `x-pack/plugins/profiling`
- simplify the build and run steps
- update the documentation
- upgrade base Ubuntu image