### PR TITLE
[Files] Refactor File metadata

### DIFF
--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -130,10 +130,7 @@ export interface FileJSON<Meta = unknown> {
 
 export type FileSavedObject<Meta = unknown> = SavedObject<FileSavedObjectAttributes<Meta>>;
 
-export type UpdatableFileAttributes<Meta = unknown> = Pick<
-  FileSavedObjectAttributes<Meta>,
-  'Meta' | 'Alt' | 'name'
->;
+export type UpdatableFileAttributes<Meta = unknown> = Pick<FileJSON<Meta>, 'meta' | 'alt' | 'name'>;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type FileShareSavedObjectAttributes = {

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -11,70 +11,128 @@ import type { ES_FIXED_SIZE_INDEX_BLOB_STORE } from './constants';
 
 export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'UPLOAD_ERROR' | 'DELETED';
 
+export type FileCompression = 'br' | 'gzip' | 'deflate' | 'none';
+
+/**
+ * File metadata fields are defined per the ECS specification:
+ *
+ * https://www.elastic.co/guide/en/ecs/current/ecs-file.html
+ *
+ * Custom fields are named according to the custom field convention: "CustomFieldName".
+ *
+ * TODO: Consider moving this to a commonly shareable package
+ */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type FileSavedObjectAttributes<Meta = unknown> = {
-  created_at: string;
-
-  updated_at: string;
-
+export type FileMetadata = {
   /**
-   * User-friendly name given to the file
-   */
-  name: string;
-
-  /**
-   * Unique identifier of the kind of file. Kibana applications can register
-   * these at runtime.
-   */
-  file_kind: string;
-
-  status: FileStatus;
-
-  /**
-   * An alternate even more human-friendly name for the contents. This should be
-   * usable by, for example, the alt attribute in image tags if the content is an
-   * image.
-   */
-  alt?: string;
-
-  /**
-   * A unique ID for file content that enables retrieval from a blob store.
+   * Name of the file
    *
-   * May not be available at the time this object is created
+   * @note This field is recommended since it will provide a better UX
    */
-  content_ref?: string;
+  name?: string;
 
   /**
-   * MIME type of the file content, e.g.: image/png.
+   * MIME type of the file contents
    */
-  mime?: string;
+  mime_type?: string;
 
   /**
-   * Extension that should match the full mime type
+   * ISO string representing the file creation date
    */
-  extension?: string;
+  created?: string;
 
   /**
-   * Size of the contents in bytes.
+   * Size of the file
    */
   size?: number;
 
   /**
-   * User-defined metadata
+   * Hash of the file's contents
    */
-  meta?: Meta;
+  hash?: {
+    md5?: string;
+    sha1?: string;
+    sha256?: string;
+    sha384?: string;
+    sha512?: string;
+    ssdeep?: string;
+    tlsh?: string;
+    [hashName: string]: string | undefined;
+  };
+
+  /**
+   * Alternate text that can be used used to describe the contents of the file
+   * in human-friendly language
+   */
+  Alt?: string;
+
+  /**
+   * The file extension, for example "jpg", "png", "svg" and so forth
+   */
+  Extension?: string;
+
+  /**
+   * ISO string representing when the file was last updated
+   */
+  Updated?: string;
+
+  /**
+   * The file's current status
+   */
+  Status?: FileStatus;
+
+  /**
+   * The maximum number of bytes per file chunk
+   */
+  ChunkSize?: number;
+
+  /**
+   * Compression algorithm used to transform chunks before they were stored.
+   */
+  Compression?: FileCompression;
 };
+
+export type FileSavedObjectAttributes<Meta = unknown> = Required<
+  Pick<FileMetadata, 'created' | 'name' | 'Status' | 'Updated'>
+> &
+  FileMetadata & {
+    /**
+     * Unique identifier of the kind of file. Kibana applications can register
+     * these at runtime.
+     */
+    FileKind: string;
+
+    /**
+     * User-defined metadata
+     */
+    Meta?: Meta;
+  };
 
 /**
  * Attributes of a file that represent a serialised version of the file.
  */
-export type FileJSON = FileSavedObjectAttributes & { id: string };
+export interface FileJSON<Meta = unknown> {
+  id: string;
+  created: FileSavedObjectAttributes['created'];
+  updated: FileSavedObjectAttributes['Updated'];
+  name: FileSavedObjectAttributes['name'];
+  mimeType: FileSavedObjectAttributes['mime_type'];
+  size: FileSavedObjectAttributes['size'];
+
+  meta: FileSavedObjectAttributes<Meta>['Meta'];
+  extension: FileSavedObjectAttributes['Extension'];
+  alt: FileSavedObjectAttributes['Alt'];
+  chunkSize: FileSavedObjectAttributes['ChunkSize'];
+  fileKind: FileSavedObjectAttributes['FileKind'];
+  compression: FileSavedObjectAttributes['Compression'];
+  status: FileSavedObjectAttributes['Status'];
+}
 
 export type FileSavedObject<Meta = unknown> = SavedObject<FileSavedObjectAttributes<Meta>>;
 
 export type UpdatableFileAttributes<Meta = unknown> = Pick<
   FileSavedObjectAttributes<Meta>,
-  'meta' | 'alt' | 'name'
+  'Meta' | 'Alt' | 'name'
 >;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -105,37 +163,10 @@ export type FileShareJSON = FileShareSavedObjectAttributes & { id: string; fileI
 export type UpdatableFileShareAttributes = Pick<FileSavedObjectAttributes, 'name'>;
 
 /**
- * The set of properties and behaviors of the "smart" file object. This is built
- * directly from the set of saved object attributes
+ * The set of properties and behaviors of the "smart" file object and adds
+ * behaviours for interacting with files on top of the pure data.
  */
-export interface File<Meta = unknown> {
-  id: string;
-
-  /**
-   * The ID of a {@link FileKind}.
-   */
-  fileKind: string;
-
-  /**
-   * The user-facing file name.
-   */
-  name: string;
-
-  status: FileStatus;
-  /**
-   * User provided metadata
-   */
-  meta: Meta;
-
-  alt: undefined | string;
-
-  /**
-   * MIME type of the file content, e.g.: image/png.
-   */
-  mime: undefined | string;
-
-  extension: undefined | string;
-
+export interface File<Meta = unknown> extends FileJSON<Meta> {
   update(attr: Partial<UpdatableFileAttributes<Meta>>): Promise<File<Meta>>;
 
   uploadContent(content: Readable): Promise<void>;
@@ -155,7 +186,7 @@ export interface File<Meta = unknown> {
     shareId: string;
   }): Promise<void>;
 
-  toJSON(): FileJSON;
+  toJSON(): FileJSON<Meta>;
 }
 
 /**

--- a/x-pack/plugins/files/server/file/file_attributes_reducer.ts
+++ b/x-pack/plugins/files/server/file/file_attributes_reducer.ts
@@ -50,8 +50,8 @@ export function fileAttributesReducer(
       return {
         ...state,
         name: payload.name ?? state.name,
-        Alt: payload.Alt ?? state.Alt,
-        Meta: payload.Meta ?? state.Meta,
+        Alt: payload.alt ?? state.Alt,
+        Meta: payload.meta ?? state.Meta,
         Updated: d.toISOString(),
       };
     default:

--- a/x-pack/plugins/files/server/file/file_attributes_reducer.ts
+++ b/x-pack/plugins/files/server/file/file_attributes_reducer.ts
@@ -22,13 +22,13 @@ export type Action =
 
 export function createDefaultFileAttributes(): Pick<
   FileSavedObjectAttributes,
-  'created_at' | 'updated_at' | 'status'
+  'created' | 'Updated' | 'Status'
 > {
   const dateString = new Date().toISOString();
   return {
-    created_at: dateString,
-    updated_at: dateString,
-    status: 'AWAITING_UPLOAD',
+    created: dateString,
+    Updated: dateString,
+    Status: 'AWAITING_UPLOAD',
   };
 }
 
@@ -38,21 +38,21 @@ export function fileAttributesReducer(
 ): FileSavedObjectAttributes {
   switch (action) {
     case 'delete':
-      return { ...state, status: 'DELETED' };
+      return { ...state, Status: 'DELETED' };
     case 'uploading':
-      return { ...state, content_ref: undefined, status: 'UPLOADING' };
+      return { ...state, Status: 'UPLOADING' };
     case 'uploaded':
-      return { ...state, ...payload, status: 'READY' };
+      return { ...state, ...payload, Status: 'READY' };
     case 'uploadError':
-      return { ...state, status: 'UPLOAD_ERROR', content_ref: undefined };
+      return { ...state, Status: 'UPLOAD_ERROR' };
     case 'updateFile':
       const d = new Date();
       return {
         ...state,
         name: payload.name ?? state.name,
-        alt: payload.alt ?? state.alt,
-        meta: payload.meta ?? state.meta,
-        updated_at: d.toISOString(),
+        Alt: payload.Alt ?? state.Alt,
+        Meta: payload.Meta ?? state.Meta,
+        Updated: d.toISOString(),
       };
     default:
       return state;

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -100,11 +100,11 @@ export class InternalFileService {
   public async find({ fileKind, id }: FindFileArgs): Promise<IFile> {
     try {
       const result = await this.soClient.get<FileSavedObjectAttributes>(this.savedObjectType, id);
-      const { file_kind: actualFileKind, status } = result.attributes;
+      const { FileKind: actualFileKind, Status } = result.attributes;
       if (actualFileKind !== fileKind) {
         throw new Error(`Unexpected file kind "${actualFileKind}", expected "${fileKind}".`);
       }
-      if (status === 'DELETED') {
+      if (Status === 'DELETED') {
         throw new FileNotFoundError('File has been deleted');
       }
       return this.toFile(result, this.getFileKind(fileKind));
@@ -125,7 +125,7 @@ export class InternalFileService {
     const fileKind = this.getFileKind(fileKindId);
     const result = await this.soClient.find<FileSavedObjectAttributes>({
       type: this.savedObjectType,
-      filter: `${this.savedObjectType}.attributes.file_kind: ${fileKindId} AND NOT ${this.savedObjectType}.attributes.status: DELETED`,
+      filter: `${this.savedObjectType}.attributes.FileKind: ${fileKindId} AND NOT ${this.savedObjectType}.attributes.Status: DELETED`,
       page,
       perPage,
     });

--- a/x-pack/plugins/files/server/file_share_service/internal_file_share_service.ts
+++ b/x-pack/plugins/files/server/file_share_service/internal_file_share_service.ts
@@ -11,7 +11,6 @@ import type {
   ISavedObjectsRepository,
 } from '@kbn/core/server';
 import type {
-  FileSavedObjectAttributes,
   FileShareJSON,
   FileShareSavedObjectAttributes,
   UpdatableFileShareAttributes,
@@ -116,13 +115,13 @@ export class InternalFileShareService implements FileShareServiceStart {
   public async update({
     id,
     attributes,
-  }: UpdateArgs): Promise<FileSavedObjectAttributes & { id: string }> {
+  }: UpdateArgs): Promise<FileShareSavedObjectAttributes & { id: string }> {
     const result = await this.savedObjects.update<FileShareSavedObjectAttributes>(
       this.savedObjectsType,
       id,
       attributes
     );
-    return { id, ...(result.attributes as FileSavedObjectAttributes) };
+    return { id, ...(result.attributes as FileShareSavedObjectAttributes) };
   }
 
   public async list({ file, page, perPage }: ListArgs): Promise<FileShareJSON[]> {

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -155,7 +155,7 @@ describe('FileService', () => {
     const updatedFile2 = await fileService.find<CustomMeta>({ fileKind, id: file.id });
     expect(updatedFile2.meta).toEqual(expect.objectContaining(updatableFields.meta));
     // Below also tests that our meta type is work as expected by using `some` field.
-    expect(updatedFile2.meta.some).toBe(updatableFields.meta.some);
+    expect(updatedFile2.meta?.some).toBe(updatableFields.meta.some);
     expect(updatedFile2.name).toBe(updatableFields.name);
     expect(updatedFile2.alt).toBe(updatableFields.alt);
   });

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -29,7 +29,7 @@ type Response = Readable;
 function getDownloadedFileName(file: File): string {
   // When creating a file we also calculate the extension so the `file.extension`
   // check is not really necessary except for type checking.
-  if (file.mime && file.extension) {
+  if (file.mimeType && file.extension) {
     return `${file.name}.${file.extension}`;
   }
   return file.name;
@@ -50,7 +50,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   return res.ok({
     body,
     headers: {
-      'content-type': file.mime ?? 'application/octet-stream',
+      'content-type': file.mimeType ?? 'application/octet-stream',
       // note, this name can be overridden by the client if set via a "download" attribute.
       'content-disposition': `attachment; filename="${fileName || getDownloadedFileName(file)}"`,
     },

--- a/x-pack/plugins/files/server/saved_objects/file.ts
+++ b/x-pack/plugins/files/server/saved_objects/file.ts
@@ -12,38 +12,44 @@ import type { FileSavedObjectAttributes } from '../../common';
 type Properties = Record<keyof FileSavedObjectAttributes, SavedObjectsFieldMapping>;
 
 const properties: Properties = {
-  created_at: {
+  created: {
     type: 'date',
   },
-  updated_at: {
+  Updated: {
     type: 'date',
   },
   name: {
     type: 'text',
   },
-  alt: {
+  Alt: {
     type: 'text',
   },
-  status: {
+  Status: {
     type: 'keyword',
   },
-  content_ref: {
+  mime_type: {
     type: 'keyword',
   },
-  mime: {
-    type: 'keyword',
-  },
-  extension: {
+  Extension: {
     type: 'keyword',
   },
   size: {
     type: 'long',
   },
-  meta: {
+  Meta: {
     type: 'object',
   },
-  file_kind: {
+  FileKind: {
     type: 'keyword',
+  },
+  ChunkSize: {
+    type: 'long',
+  },
+  Compression: {
+    type: 'keyword',
+  },
+  hash: {
+    type: 'object',
   },
 };
 


### PR DESCRIPTION
## Summary

We are migrating stored file metadata to be based on the ECS specification: 

https://www.elastic.co/guide/en/ecs/current/ecs-file.html

This way we have a predefined spec and naming convention to draw from. Changes in this PR are focussed on refactoring to the ECS naming conventions and add a few new optional fields we may use in future. It should be straight-forward to add others in future.