### PR TITLE
[Lens] Add `fetch_event_annotation` expression

### DIFF
--- a/src/plugins/event_annotation/common/event_annotation_group/index.ts
+++ b/src/plugins/event_annotation/common/event_annotation_group/index.ts
@@ -8,15 +8,18 @@
 
 import type { ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { i18n } from '@kbn/i18n';
+import { IndexPatternExpressionType } from '@kbn/data-views-plugin/common';
 import type { EventAnnotationOutput } from '../manual_event_annotation/types';
 
 export interface EventAnnotationGroupOutput {
   type: 'event_annotation_group';
   annotations: EventAnnotationOutput[];
+  index?: IndexPatternExpressionType;
 }
 
 export interface EventAnnotationGroupArgs {
   annotations: EventAnnotationOutput[];
+  index?: IndexPatternExpressionType;
 }
 
 export function eventAnnotationGroup(): ExpressionFunctionDefinition<
@@ -34,6 +37,13 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
       defaultMessage: 'Event annotation group',
     }),
     args: {
+      index: {
+        types: ['index_pattern'],
+        required: false,
+        help: i18n.translate('eventAnnotation.group.args.annotationConfigs.index.help', {
+          defaultMessage: 'Data view retrieved with indexPatternLoad',
+        }),
+      },
       annotations: {
         types: ['manual_point_event_annotation', 'manual_range_event_annotation'],
         help: i18n.translate('eventAnnotation.group.args.annotationConfigs', {
@@ -46,6 +56,7 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
       return {
         type: 'event_annotation_group',
         annotations: args.annotations,
+        index: args.index,
       };
     },
   };

--- a/src/plugins/event_annotation/common/fetch_event_annotations/fetch_event_annotations.test.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/fetch_event_annotations.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ExpressionValueSearchContext } from '@kbn/data-plugin/common';
+import { FetchEventAnnotationsArgs, fetchEventAnnotations } from '.';
+
+const mockHandlers = {
+  abortSignal: jest.fn() as unknown as jest.Mocked<AbortSignal>,
+  getSearchContext: jest.fn(),
+  getSearchSessionId: jest.fn().mockReturnValue('abc123'),
+  getExecutionContext: jest.fn(),
+  inspectorAdapters: jest.fn(),
+  variables: {},
+  types: {},
+};
+
+const args = {
+  interval: '30m',
+  group: [
+    {
+      type: 'event_annotation_group',
+      annotations: [
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-07-05T11:12:00Z',
+        },
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-07-05T01:18:00Z',
+        },
+        {
+          type: 'manual_range_event_annotation',
+          time: '2022-07-03T05:00:00Z',
+          endTime: '2022-07-05T00:01:00Z',
+        },
+      ],
+    },
+    {
+      type: 'event_annotation_group',
+      annotations: [
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-07-05T04:34:00Z',
+          label: 'custom',
+          color: '#9170b8',
+          lineWidth: 3,
+          lineStyle: 'dotted',
+          icon: 'triangle',
+          textVisibility: true,
+        },
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-07-05T05:55:00Z',
+          isHidden: true,
+        },
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-08-05T12:48:10Z',
+        },
+        {
+          type: 'manual_point_event_annotation',
+          time: '2022-06-05T12:48:10Z',
+        },
+        {
+          type: 'manual_range_event_annotation',
+          time: '2022-06-03T05:00:00Z',
+          endTime: '2022-06-05T00:01:00Z',
+        },
+        {
+          type: 'manual_range_event_annotation',
+          time: '2022-08-03T05:00:00Z',
+          endTime: '2022-08-05T00:01:00Z',
+        },
+        {
+          type: 'manual_range_event_annotation',
+          time: '2022-06-03T05:00:00Z',
+          endTime: '2022-08-05T00:01:00Z',
+          label: 'Event range',
+          color: '#F04E981A',
+          outside: false,
+        },
+      ],
+    },
+  ],
+} as FetchEventAnnotationsArgs;
+
+const input = {
+  type: 'kibana_context',
+  query: [],
+  filters: [],
+  timeRange: {
+    type: 'timerange',
+    from: '2022-07-01T00:00:00Z',
+    to: '2022-07-31T00:00:00Z',
+  },
+} as ExpressionValueSearchContext;
+
+describe('fetchEventAnnotations', () => {
+  test('Sorts annotations by time, assigns correct timebuckets, filters out hidden and out of range annotations', async () => {
+    const result = await fetchEventAnnotations().fn(input, args, mockHandlers).toPromise();
+    expect(result!.rows).toEqual([
+      {
+        type: 'range',
+        time: '2022-06-03T05:00:00Z',
+        endTime: '2022-08-05T00:01:00Z',
+        label: 'Event range',
+        color: '#F04E981A',
+        outside: false,
+        timebucket: '2022-06-03T05:00:00.000Z',
+      },
+      {
+        type: 'range',
+        time: '2022-07-03T05:00:00Z',
+        endTime: '2022-07-05T00:01:00Z',
+        timebucket: '2022-07-03T05:00:00.000Z',
+      },
+      {
+        type: 'point',
+        time: '2022-07-05T01:18:00Z',
+        timebucket: '2022-07-05T01:00:00.000Z',
+      },
+      {
+        type: 'point',
+        time: '2022-07-05T04:34:00Z',
+        label: 'custom',
+        color: '#9170b8',
+        lineWidth: 3,
+        lineStyle: 'dotted',
+        icon: 'triangle',
+        textVisibility: true,
+        timebucket: '2022-07-05T04:30:00.000Z',
+      },
+      {
+        type: 'point',
+        time: '2022-07-05T11:12:00Z',
+        timebucket: '2022-07-05T11:00:00.000Z',
+      },
+    ]);
+  });
+});

--- a/src/plugins/event_annotation/common/fetch_event_annotations/index.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/index.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { defer, switchMap, Observable } from 'rxjs';
+import { i18n } from '@kbn/i18n';
+import { ExpressionValueSearchContext, parseEsInterval } from '@kbn/data-plugin/common';
+import type { ExpressionFunctionDefinition, Datatable } from '@kbn/expressions-plugin/common';
+import moment from 'moment';
+import { ESCalendarInterval, ESFixedInterval, roundDateToESInterval } from '@elastic/charts';
+import { EventAnnotationGroupOutput } from '../event_annotation_group';
+import { annotationColumns, EventAnnotationOutput } from '../manual_event_annotation/types';
+import { filterOutOfTimeRange, isManualPointAnnotation, sortByTime } from './utils';
+
+export interface FetchEventAnnotationsDatatable {
+  annotations: EventAnnotationOutput[];
+  type: 'fetch_event_annotations';
+}
+
+export type FetchEventAnnotationsOutput = Observable<Datatable>;
+
+export interface FetchEventAnnotationsArgs {
+  group: EventAnnotationGroupOutput[];
+  interval: string;
+}
+
+export type FetchEventAnnotationsExpressionFunctionDefinition = ExpressionFunctionDefinition<
+  'fetch_event_annotations',
+  ExpressionValueSearchContext | null,
+  FetchEventAnnotationsArgs,
+  FetchEventAnnotationsOutput
+>;
+
+export function fetchEventAnnotations(): FetchEventAnnotationsExpressionFunctionDefinition {
+  return {
+    name: 'fetch_event_annotations',
+    aliases: [],
+    type: 'datatable',
+    inputTypes: ['kibana_context', 'null'],
+    help: i18n.translate('eventAnnotation.fetchEventAnnotations.description', {
+      defaultMessage: 'Fetch event annotations',
+    }),
+    args: {
+      group: {
+        types: ['event_annotation_group'],
+        help: i18n.translate('eventAnnotation.fetchEventAnnotations.args.annotationConfigs', {
+          defaultMessage: 'Annotation configs',
+        }),
+        multi: true,
+      },
+      interval: {
+        required: true,
+        types: ['string'],
+        help: i18n.translate('eventAnnotation.fetchEventAnnotations.args.interval.help', {
+          defaultMessage: 'Interval to use for this aggregation',
+        }),
+      },
+    },
+    fn: (input, args) => {
+      return defer(async () => {
+        const annotations = args.group
+          .flatMap((group) => group.annotations)
+          .filter(
+            (annotation) =>
+              !annotation.isHidden && filterOutOfTimeRange(annotation, input?.timeRange)
+          );
+        // TODO: fetching for Query annotations goes here
+
+        return { annotations };
+      }).pipe(
+        switchMap(({ annotations }) => {
+          const datatable: Datatable = {
+            type: 'datatable',
+            columns: annotationColumns,
+            rows: annotations.sort(sortByTime).map((annotation) => {
+              const initialDate = moment(annotation.time).valueOf();
+              const snappedDate = roundDateToESInterval(
+                initialDate,
+                parseEsInterval(args.interval) as ESCalendarInterval | ESFixedInterval,
+                'start',
+                'UTC'
+              );
+              return {
+                ...annotation,
+                type: isManualPointAnnotation(annotation) ? 'point' : 'range',
+                timebucket: moment(snappedDate).toISOString(),
+              };
+            }),
+          };
+
+          return new Observable<Datatable>((subscriber) => {
+            subscriber.next(datatable);
+            subscriber.complete();
+          });
+        })
+      );
+    },
+  };
+}

--- a/src/plugins/event_annotation/common/fetch_event_annotations/utils.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { TimeRange } from '@kbn/data-plugin/common';
+
+import {
+  EventAnnotationOutput,
+  ManualPointEventAnnotationOutput,
+  ManualRangeEventAnnotationOutput,
+} from '../manual_event_annotation/types';
+
+export const isRangeAnnotation = (
+  annotation: EventAnnotationOutput
+): annotation is ManualRangeEventAnnotationOutput => {
+  return 'endTime' in annotation;
+};
+
+export const isManualPointAnnotation = (
+  annotation: EventAnnotationOutput
+): annotation is ManualPointEventAnnotationOutput => {
+  return 'time' in annotation && !('endTime' in annotation);
+};
+
+export const filterOutOfTimeRange = (annotation: EventAnnotationOutput, timerange?: TimeRange) => {
+  if (!timerange) {
+    return false;
+  }
+  if (isRangeAnnotation(annotation)) {
+    return !(annotation.time >= timerange.to || annotation.endTime < timerange.from);
+  }
+  if (isManualPointAnnotation(annotation)) {
+    return annotation.time >= timerange.from && annotation.time <= timerange.to;
+  }
+};
+
+export const sortByTime = (a: EventAnnotationOutput, b: EventAnnotationOutput) => {
+  return a.time.localeCompare(b.time);
+};

--- a/src/plugins/event_annotation/common/index.ts
+++ b/src/plugins/event_annotation/common/index.ts
@@ -17,6 +17,8 @@ export type {
 export { manualPointEventAnnotation, manualRangeEventAnnotation } from './manual_event_annotation';
 export { eventAnnotationGroup } from './event_annotation_group';
 export type { EventAnnotationGroupArgs } from './event_annotation_group';
+export { fetchEventAnnotations } from './fetch_event_annotations';
+export type { FetchEventAnnotationsArgs } from './fetch_event_annotations';
 export type {
   EventAnnotationConfig,
   RangeEventAnnotationConfig,

--- a/src/plugins/event_annotation/common/manual_event_annotation/types.ts
+++ b/src/plugins/event_annotation/common/manual_event_annotation/types.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { DatatableColumn } from '@kbn/expressions-plugin';
 import { PointStyleProps, RangeStyleProps } from '../types';
 
 export type ManualPointEventAnnotationArgs = {
@@ -29,3 +30,18 @@ export type EventAnnotationArgs = ManualPointEventAnnotationArgs | ManualRangeEv
 export type EventAnnotationOutput =
   | ManualPointEventAnnotationOutput
   | ManualRangeEventAnnotationOutput;
+
+export const annotationColumns: DatatableColumn[] = [
+  { id: 'time', name: 'time', meta: { type: 'string' } },
+  { id: 'endTime', name: 'endTime', meta: { type: 'string' } },
+  { id: 'timebucket', name: 'timebucket', meta: { type: 'string' } },
+  { id: 'type', name: 'type', meta: { type: 'string' } },
+  { id: 'label', name: 'label', meta: { type: 'string' } },
+  { id: 'color', name: 'color', meta: { type: 'string' } },
+  { id: 'lineStyle', name: 'lineStyle', meta: { type: 'string' } },
+  { id: 'lineWidth', name: 'lineWidth', meta: { type: 'number' } },
+  { id: 'icon', name: 'icon', meta: { type: 'string' } },
+  { id: 'textVisibility', name: 'textVisibility', meta: { type: 'boolean' } },
+  { id: 'outside', name: 'outside', meta: { type: 'number' } },
+  { id: 'skippedAnnotationsCount', name: 'skippedAnnotationsCount', meta: { type: 'number' } },
+];

--- a/src/plugins/event_annotation/jest.config.js
+++ b/src/plugins/event_annotation/jest.config.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../..',
+  roots: ['<rootDir>/src/plugins/event_annotation'],
+  coverageDirectory: '<rootDir>/target/kibana-coverage/jest/src/plugins/event_ann',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: ['<rootDir>/src/plugins/event_ann/{common,public,server}/**/*.{ts,tsx}'],
+};

--- a/src/plugins/event_annotation/kibana.json
+++ b/src/plugins/event_annotation/kibana.json
@@ -8,7 +8,8 @@
     "common"
   ],
   "requiredPlugins": [
-    "expressions"
+    "expressions",
+    "data"
   ],
   "owner": {
     "name": "Vis Editors",

--- a/src/plugins/event_annotation/public/plugin.ts
+++ b/src/plugins/event_annotation/public/plugin.ts
@@ -12,6 +12,7 @@ import {
   manualPointEventAnnotation,
   manualRangeEventAnnotation,
   eventAnnotationGroup,
+  fetchEventAnnotations,
 } from '../common';
 import { EventAnnotationService } from './event_annotation_service';
 
@@ -35,6 +36,7 @@ export class EventAnnotationPlugin
     dependencies.expressions.registerFunction(manualPointEventAnnotation);
     dependencies.expressions.registerFunction(manualRangeEventAnnotation);
     dependencies.expressions.registerFunction(eventAnnotationGroup);
+    dependencies.expressions.registerFunction(fetchEventAnnotations);
     return this.eventAnnotationService;
   }
 

--- a/src/plugins/event_annotation/tsconfig.json
+++ b/src/plugins/event_annotation/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../expressions/tsconfig.json"
-    }
+    },
+    {
+      "path": "../data/tsconfig.json"
+    },
   ]
 }


### PR DESCRIPTION
## Summary

Adds `fetch_event_annotation` expression that does couple of things:
- takes annotation groups, 
- filters them to only get the ones that are visible and in timerange 
- returns the datatable of annotations sorted, 
- with extra `timebucket` field 

To test in Canvas:
```
kibana 
|  kibana_context timeRange={timerange from='2022-06-21T00:00:00Z' to='2022-07-06T00:00:00Z'} savedSearchId=null 
| fetch_event_annotations interval='30m'
  group={event_annotation_group 
    annotations={manual_range_event_annotation endTime="2022-07-05T00:01:00Z" time="2022-07-03T05:00:00Z"} 
    annotations={manual_point_event_annotation time="2022-07-05T00:12:00Z"} 
    annotations={manual_point_event_annotation time="2022-07-05T00:15:00Z"}}
    group={event_annotation_group annotations={manual_point_event_annotation time="2022-07-05T04:34:00Z"} annotations={manual_point_event_annotation time="2022-06-22 12:34"} annotations={manual_point_event_annotation time="2022-06-22 12:34"}}
  | render as="debug"

```
All the chrono files will be removed once https://github.com/elastic/elastic-charts/pull/1754 is published and new EC version is merged to Kibana.  https://github.com/elastic/kibana/pull/136250/files