### PR TITLE
[ftr] use correct script path when running outside of repo root

### DIFF
--- a/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
@@ -68,7 +68,7 @@ export async function runKibanaServer({
   };
 
   const prefixArgs = devMode
-    ? [Path.relative(process.cwd(), Path.resolve(REPO_ROOT, 'scripts/kibana'))]
+    ? [Path.relative(procRunnerOpts.cwd, Path.resolve(REPO_ROOT, 'scripts/kibana'))]
     : [];
 
   const buildArgs: string[] = config.get('kbnTestServer.buildArgs') || [];


### PR DESCRIPTION
In #135875 I made the cwd of the Kibana process more explicit, but I didn't notice the use of `process.cwd()` for creating a relative path to `scripts/kibana` in development. This updates the logic to use the cwd of the eventual process as the `from` value for the relative path.