### PR TITLE
[Enterprise Search] Fix path of internal endpoint for Content app crawler domain validation

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.test.ts
@@ -430,7 +430,7 @@ describe('crawler routes', () => {
 
     it('creates a request to enterprise search', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/ent/v1/internal/crawler/validate_url',
+        path: '/api/ent/v1/internal/crawler2/validate_url',
       });
     });
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
@@ -42,7 +42,7 @@ export function registerCrawlerRoutes(routeDependencies: RouteDependencies) {
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/ent/v1/internal/crawler/validate_url',
+      path: '/api/ent/v1/internal/crawler2/validate_url',
     })
   );
 


### PR DESCRIPTION
## Summary

I broke this during code review of https://github.com/elastic/kibana/pull/135719 😅 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
