### PR TITLE
[Security Solution][Alerts] Implement saved query preview

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/preview_rules_route.ts
@@ -46,6 +46,7 @@ import {
   createIndicatorMatchAlertType,
   createMlAlertType,
   createQueryAlertType,
+  createSavedQueryAlertType,
   createThresholdAlertType,
 } from '../../rule_types';
 import { createSecurityRuleTypeWrapper } from '../../rule_types/create_security_rule_type_wrapper';
@@ -287,6 +288,19 @@ export const previewRulesRoute = async (
               queryAlertType.executor,
               queryAlertType.id,
               queryAlertType.name,
+              previewRuleParams,
+              () => true,
+              { create: alertInstanceFactoryStub, done: () => ({ getRecoveredAlerts: () => [] }) }
+            );
+            break;
+          case 'saved_query':
+            const savedQueryAlertType = previewRuleTypeWrapper(
+              createSavedQueryAlertType(ruleOptions)
+            );
+            await runExecutors(
+              savedQueryAlertType.executor,
+              savedQueryAlertType.id,
+              savedQueryAlertType.name,
               previewRuleParams,
               () => true,
               { create: alertInstanceFactoryStub, done: () => ({ getRecoveredAlerts: () => [] }) }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136093

When we implemented rule preview, it was thought that there was no longer a way to create a saved_query rule through the UI because there's no rule type card for it. However, if you load a saved query in the query bar then the UI will treat the rule as type `saved_query`. This PR adds the `saved_query` case to the preview rules route so the rule will work with preview.
