### PR TITLE
[8.0] Remove cloud icon for xpack.reporting.queue.pollEnabled (#135771)

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -66,7 +66,7 @@ reports, you might need to change the following settings.
 `xpack.reporting.queue.indexInterval`::
 How often the index that stores reporting jobs rolls over to a new index. Valid values are `year`, `month`, `week`, `day`, and `hour`. Defaults to `week`.
 
-[[xpack-reportingQueue-pollEnabled]] `xpack.reporting.queue.pollEnabled` {ess-icon}::
+[[xpack-reportingQueue-pollEnabled]] `xpack.reporting.queue.pollEnabled` ::
 When `true`, enables the {kib} instance to poll {es} for pending jobs and claim them for
 execution. When `false`, allows the {kib} instance to only add new jobs to the reporting queue, list
 jobs, and provide the downloads to completed reports through the UI. This requires a deployment where at least


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [Remove cloud icon for xpack.reporting.queue.pollEnabled (#135771)](https://github.com/elastic/kibana/pull/135771)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kuniyasu Sen","email":"30574753+kunisen@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-07-06T23:26:52Z","message":"Remove cloud icon for xpack.reporting.queue.pollEnabled (#135771)\n\nRemove cloud icon for xpack.reporting.queue.pollEnabled per https://github.com/elastic/kibana/issues/126024#issuecomment-1155697765","sha":"1791d710377f2eb64d9ad6ba76046028c5410a39","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["v8.0.0","release_note:skip","backport missing","v8.1.0","v8.2.0","v8.3.0","v8.4.0"],"number":135771,"url":"https://github.com/elastic/kibana/pull/135771","mergeCommit":{"message":"Remove cloud icon for xpack.reporting.queue.pollEnabled (#135771)\n\nRemove cloud icon for xpack.reporting.queue.pollEnabled per https://github.com/elastic/kibana/issues/126024#issuecomment-1155697765","sha":"1791d710377f2eb64d9ad6ba76046028c5410a39"}},"sourceBranch":"main","suggestedTargetBranches":["8.0","8.1","8.2","8.3"],"targetPullRequestStates":[{"branch":"8.0","label":"v8.0.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.1","label":"v8.1.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.2","label":"v8.2.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.3","label":"v8.3.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/135771","number":135771,"mergeCommit":{"message":"Remove cloud icon for xpack.reporting.queue.pollEnabled (#135771)\n\nRemove cloud icon for xpack.reporting.queue.pollEnabled per https://github.com/elastic/kibana/issues/126024#issuecomment-1155697765","sha":"1791d710377f2eb64d9ad6ba76046028c5410a39"}}]}] BACKPORT-->