### PR TITLE
[Dashboard] Fix `z-index` of `embPanel__header--floater` 

### DIFF
--- a/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
+++ b/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
@@ -85,7 +85,9 @@
   right: 0;
   top: 0;
   left: 0;
-  z-index: $euiZLevel1;
+  * {
+    z-index: $euiZLevel1; // apply high z-index to all children
+  }
 }
 
 // OPTIONS MENU

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -154,7 +154,7 @@ export function PanelHeader({
 
   if (!showPanelBar) {
     return (
-      <div data-test-subj="dashboardPanelTitle__wrapper" className={classes}>
+      <>
         <PanelOptionsMenu
           getActionContextMenuPanel={getActionContextMenuPanel}
           isViewMode={isViewMode}
@@ -163,7 +163,7 @@ export function PanelHeader({
           index={index}
         />
         <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
-      </div>
+      </>
     );
   }
 
@@ -214,25 +214,23 @@ export function PanelHeader({
   };
 
   return (
-    <span data-test-subj="dashboardPanelTitle__wrapper">
-      <figcaption
-        className={classes}
-        data-test-subj={`embeddablePanelHeading-${(title || '').replace(/\s/g, '')}`}
-      >
-        <h2 data-test-subj="dashboardPanelTitle" className="embPanel__title embPanel__dragger">
-          <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
-          {renderTitle()}
-          {renderBadges(badges, embeddable)}
-        </h2>
-        {renderNotifications(notifications, embeddable)}
-        <PanelOptionsMenu
-          isViewMode={isViewMode}
-          getActionContextMenuPanel={getActionContextMenuPanel}
-          closeContextMenu={closeContextMenu}
-          title={title}
-          index={index}
-        />
-      </figcaption>
-    </span>
+    <figcaption
+      className={classes}
+      data-test-subj={`embeddablePanelHeading-${(title || '').replace(/\s/g, '')}`}
+    >
+      <h2 data-test-subj="dashboardPanelTitle" className="embPanel__title embPanel__dragger">
+        <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
+        {renderTitle()}
+        {renderBadges(badges, embeddable)}
+      </h2>
+      {renderNotifications(notifications, embeddable)}
+      <PanelOptionsMenu
+        isViewMode={isViewMode}
+        getActionContextMenuPanel={getActionContextMenuPanel}
+        closeContextMenu={closeContextMenu}
+        title={title}
+        index={index}
+      />
+    </figcaption>
   );
 }

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -154,7 +154,7 @@ export function PanelHeader({
 
   if (!showPanelBar) {
     return (
-      <>
+      <div className={classes}>
         <PanelOptionsMenu
           getActionContextMenuPanel={getActionContextMenuPanel}
           isViewMode={isViewMode}
@@ -163,7 +163,7 @@ export function PanelHeader({
           index={index}
         />
         <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
-      </>
+      </div>
     );
   }
 

--- a/test/functional/apps/dashboard_elements/controls/controls_callout.ts
+++ b/test/functional/apps/dashboard_elements/controls/controls_callout.ts
@@ -39,7 +39,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         before(async () => {
           const panelCount = await dashboard.getPanelCount();
           if (panelCount > 0) {
-            const panels = await dashboard.getAllPanels();
+            const panels = await dashboard.getDashboardPanels();
             for (const panel of panels) {
               await dashboardPanelActions.removePanel(panel);
             }

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -611,11 +611,6 @@ export class DashboardPageObject extends FtrService {
     return panels.length;
   }
 
-  public async getAllPanels() {
-    this.log.debug('getAllPanels');
-    return await this.testSubjects.findAll('embeddablePanel');
-  }
-
   public getTestVisualizations() {
     return [
       { name: PIE_CHART_VIS_NAME, description: 'PieChart' },

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -566,7 +566,9 @@ export class DashboardPageObject extends FtrService {
     return await Promise.all(titleObjects.map(async (title) => await title.getVisibleText()));
   }
 
-  // returns an array of Boolean values - true if the panel title is visible in view mode, false if it is not
+  /**
+   * @return An array of boolean values - true if the panel title is visible in view mode, false if it is not
+   */
   public async getVisibilityOfPanelTitles() {
     this.log.debug('in getVisibilityOfPanels');
     // only works if the dashboard is in view mode
@@ -575,9 +577,12 @@ export class DashboardPageObject extends FtrService {
       await this.clickCancelOutOfEditMode();
     }
     const visibilities: boolean[] = [];
-    const titleObjects = await this.testSubjects.findAll('dashboardPanelTitle__wrapper');
-    for (const titleObject of titleObjects) {
-      const exists = !(await titleObject.elementHasClass('embPanel__header--floater'));
+    const panels = await this.getDashboardPanels();
+    for (const panel of panels) {
+      const exists = await this.find.descendantExistsByCssSelector(
+        'figcaption.embPanel__header',
+        panel
+      );
       visibilities.push(exists);
     }
     // return to edit mode if a switch to view mode above was necessary

--- a/x-pack/test/functional/apps/dashboard/group2/panel_titles.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/panel_titles.ts
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const LIBRARY_TITLE_FOR_CUSTOM_TESTS = 'Library Title for Custom Title Tests';
   const LIBRARY_TITLE_FOR_EMPTY_TESTS = 'Library Title for Empty Title Tests';
 
-  describe('panel titles', () => {
+  describe.only('panel titles', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
@@ -41,7 +41,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.dashboard.saveDashboard(DASHBOARD_NAME);
     });
 
-    describe('panel titles - by value', () => {
+    describe('by value', () => {
       it('new panel by value has empty title', async () => {
         await PageObjects.lens.createAndAddLensFromDashboard({});
         const newPanelTitle = (await PageObjects.dashboard.getPanelTitles())[0];
@@ -103,7 +103,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('panel titles - by reference', () => {
+    describe('by reference', () => {
       it('linking a by value panel with a custom title to the library will overwrite the custom title with the library title', async () => {
         await dashboardPanelActions.setCustomPanelTitle(CUSTOM_TITLE);
         await dashboardPanelActions.saveToLibrary(LIBRARY_TITLE_FOR_CUSTOM_TESTS);

--- a/x-pack/test/functional/apps/dashboard/group2/panel_titles.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/panel_titles.ts
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const LIBRARY_TITLE_FOR_CUSTOM_TESTS = 'Library Title for Custom Title Tests';
   const LIBRARY_TITLE_FOR_EMPTY_TESTS = 'Library Title for Empty Title Tests';
 
-  describe.only('panel titles', () => {
+  describe('panel titles', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/131969

## Summary

As outlined in the attached issue, it was originally thought that the `dashboardPanelTitle__wrapper` element was causing an issue where certain parts of a chart were inaccessible underneath it because of its high z-index. To address this, I removed the `dashboardPanelTitle__wrapper` entirely (since it was used **explicitly** for testing purposes) and restructured the `getVisibilityOfPanelTitles` function in the Dashboard page object to work without this wrapper.

However, upon further investigation, the `dashboardPanelTitle__wrapper` element was **not** what was causing the bug - it was actually the `embPanel__header--floater` class, which is required so that the panel options menu floats on the right corner of a panel when hovering in view mode:

![image](https://user-images.githubusercontent.com/8698078/179570465-965d87ef-f4bf-4e71-a8fa-b3b20453b6cf.png)

Therefore, this PR makes the following changes:
1. It removes the `dashboardPanelTitle__wrapper` and restructures the  `getVisibilityOfPanelTitles` function to work without it - while this is not required to fix the actual bug, as noted above, it results in slightly cleaner code so I decided to keep these changes regardless.
2. It applies the higher z-index to the **children** elements of the `embPanel__header--floater` class rather than the parent - this means that only the `PanelOptionsMenu` component has a high z-index, and the rest of the panel header does not, which fixes the original bug.

### Video of Fix

https://user-images.githubusercontent.com/8698078/179572516-b41e7104-4775-4f28-9e4d-092f674efad0.mov


Note that the high `z-index` for the children means that the `PanelOptionsMenu` can overlap the charts underneath it when necessary so the panel options are still accessible:

https://user-images.githubusercontent.com/8698078/179573250-4a9849b9-9c0a-4ceb-b1b4-6e9392d26abc.mov


### How to Test

1. Create a TSVB markdown visualization 
2. Include a link in the first line
3. Hide the panel title
4. Go in to view mode
5. The link should be clickable

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
