### PR TITLE
[Dashboard] [Controls] Remove background colour from control group component

### DIFF
--- a/src/plugins/controls/public/control_group/component/control_group_component.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_component.tsx
@@ -91,7 +91,7 @@ export const ControlGroup = () => {
     return null;
   }
 
-  let panelBg: 'subdued' | 'plain' | 'success' = 'subdued';
+  let panelBg: 'transparent' | 'plain' | 'success' = 'transparent';
   if (emptyState) panelBg = 'plain';
   if (draggingId) panelBg = 'success';
 


### PR DESCRIPTION
## Summary
Before this change, there was a subtle difference in colour between the control group component background and the dashboard background:

![image](https://user-images.githubusercontent.com/8698078/179582238-254d070e-3918-4a85-bea6-73868a496695.png)

However, by changing the background colour of the control group component from `subdued` to `transparent`, this goes away as shown above.

Note that the `subdued` colour did not cause an issue in dark mode, so the control group container will look the exact same in dark mode both before and after this change:
![image](https://user-images.githubusercontent.com/8698078/179583429-8cdc4f6d-0688-4348-b9c6-2eaa2f78552e.png)


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
