### PR TITLE
[Fleet] prevent adding tags to hosted agents

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -122,12 +122,14 @@ export const bulkUpdateAgentTagsHandler: RequestHandler<
 > = async (context, request, response) => {
   const coreContext = await context.core;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
+  const soClient = coreContext.savedObjects.client;
   const agentOptions = Array.isArray(request.body.agents)
     ? { agentIds: request.body.agents }
     : { kuery: request.body.agents };
 
   try {
     const results = await AgentService.updateAgentTags(
+      soClient,
       esClient,
       { ...agentOptions, batchSize: request.body.batchSize },
       request.body.tagsToAdd ?? [],

--- a/x-pack/plugins/fleet/server/services/agents/filter_hosted_agents.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/filter_hosted_agents.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
+import type { Agent } from '../../types';
+
+import { filterHostedPolicies } from './filter_hosted_agents';
+
+jest.mock('./hosted_agent', () => ({
+  ...jest.requireActual('./hosted_agent'),
+  getHostedPolicies: jest.fn().mockResolvedValue({ hosted: true }),
+}));
+
+describe('filterHostedPolicies', () => {
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+  });
+
+  it('should filter out agents with hosted policies', async () => {
+    const outgoingErrors = {};
+    const agents = await filterHostedPolicies(
+      soClient,
+      [
+        { id: 'agent1', policy_id: 'hosted' },
+        { id: 'agent2', policy_id: 'other' },
+      ] as Agent[],
+      outgoingErrors,
+      'error'
+    );
+
+    expect(agents).toEqual([{ id: 'agent2', policy_id: 'other' }]);
+    expect(outgoingErrors).toEqual({
+      agent1: new HostedAgentPolicyRestrictionRelatedError('error'),
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/agents/filter_hosted_agents.ts
+++ b/x-pack/plugins/fleet/server/services/agents/filter_hosted_agents.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+
+import type { Agent } from '../../types';
+import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
+
+import { getHostedPolicies, isHostedAgent } from './hosted_agent';
+
+export async function filterHostedPolicies(
+  soClient: SavedObjectsClientContract,
+  givenAgents: Agent[],
+  outgoingErrors: Record<Agent['id'], Error>,
+  errorMessage: string
+): Promise<Agent[]> {
+  const hostedPolicies = await getHostedPolicies(soClient, givenAgents);
+
+  return givenAgents.reduce<Agent[]>((agents, agent, index) => {
+    if (isHostedAgent(hostedPolicies, agent)) {
+      const id = givenAgents[index].id;
+      outgoingErrors[id] = new HostedAgentPolicyRestrictionRelatedError(errorMessage);
+    } else {
+      agents.push(agent);
+    }
+    return agents;
+  }, []);
+}

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
@@ -10,6 +10,12 @@ import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/serv
 
 import { updateAgentTags } from './update_agent_tags';
 
+jest.mock('./filter_hosted_agents', () => ({
+  filterHostedPolicies: jest
+    .fn()
+    .mockImplementation((soClient, givenAgents) => Promise.resolve(givenAgents)),
+}));
+
 describe('update_agent_tags', () => {
   let esClient: ElasticsearchClientMock;
   let soClient: jest.Mocked<SavedObjectsClientContract>;

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
@@ -4,17 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
-import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 
 import { updateAgentTags } from './update_agent_tags';
 
 describe('update_agent_tags', () => {
   let esClient: ElasticsearchClientMock;
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
 
   beforeEach(() => {
     esClient = elasticsearchServiceMock.createInternalClient();
+    soClient = savedObjectsClientMock.create();
     esClient.mget.mockResolvedValue({
       docs: [
         {
@@ -46,19 +48,19 @@ describe('update_agent_tags', () => {
   }
 
   it('should replace tag in middle place when one add and one remove tag', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['two']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], ['two']);
 
     expectTagsInEsBulk(['one', 'newName', 'three']);
   });
 
   it('should replace tag in first place when one add and one remove tag', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['one']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], ['one']);
 
     expectTagsInEsBulk(['newName', 'two', 'three']);
   });
 
   it('should replace tag in last place when one add and one remove tag', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['three']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], ['three']);
 
     expectTagsInEsBulk(['one', 'two', 'newName']);
   });
@@ -72,31 +74,37 @@ describe('update_agent_tags', () => {
         } as any,
       ],
     });
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['three']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], ['three']);
 
     expectTagsInEsBulk(['newName']);
   });
 
   it('should remove duplicate tags', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['one'], ['two']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['one'], ['two']);
 
     expectTagsInEsBulk(['one', 'three']);
   });
 
   it('should add tag at the end when no tagsToRemove', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], []);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], []);
 
     expectTagsInEsBulk(['one', 'two', 'three', 'newName']);
   });
 
   it('should add tag at the end when tagsToRemove not in existing tags', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['dummy']);
+    await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['newName'], ['dummy']);
 
     expectTagsInEsBulk(['one', 'two', 'three', 'newName']);
   });
 
   it('should add tag at the end when multiple tagsToRemove', async () => {
-    await updateAgentTags(esClient, { agentIds: ['agent1'] }, ['newName'], ['one', 'two']);
+    await updateAgentTags(
+      soClient,
+      esClient,
+      { agentIds: ['agent1'] },
+      ['newName'],
+      ['one', 'two']
+    );
 
     expectTagsInEsBulk(['three', 'newName']);
   });

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.ts
@@ -95,7 +95,7 @@ async function updateTagsBatch(
   const filteredAgents = await filterHostedPolicies(
     soClient,
     givenAgents,
-    outgoingErrors,
+    errors,
     `Cannot modify tags on a hosted agent`
   );
 

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.ts
@@ -7,7 +7,7 @@
 
 import { difference, uniq } from 'lodash';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
 import type { Agent, BulkActionResult } from '../../types';
 import { AgentReassignmentError } from '../../errors';
@@ -20,12 +20,14 @@ import {
 } from './crud';
 import type { GetAgentsOptions } from '.';
 import { searchHitToAgent } from './helpers';
+import { filterHostedPolicies } from './filter_hosted_agents';
 
 function isMgetDoc(doc?: estypes.MgetResponseItem<unknown>): doc is estypes.GetGetResult {
   return Boolean(doc && 'found' in doc);
 }
 
 export async function updateAgentTags(
+  soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient,
   options: ({ agents: Agent[] } | GetAgentsOptions) & { batchSize?: number },
   tagsToAdd: string[],
@@ -55,6 +57,7 @@ export async function updateAgentTags(
       },
       async (agents: Agent[], skipSuccess: boolean) =>
         await updateTagsBatch(
+          soClient,
           esClient,
           agents,
           outgoingErrors,
@@ -67,6 +70,7 @@ export async function updateAgentTags(
   }
 
   return await updateTagsBatch(
+    soClient,
     esClient,
     givenAgents,
     outgoingErrors,
@@ -77,6 +81,7 @@ export async function updateAgentTags(
 }
 
 async function updateTagsBatch(
+  soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient,
   givenAgents: Agent[],
   outgoingErrors: Record<Agent['id'], Error>,
@@ -86,6 +91,13 @@ async function updateTagsBatch(
   skipSuccess?: boolean
 ): Promise<{ items: BulkActionResult[] }> {
   const errors: Record<Agent['id'], Error> = { ...outgoingErrors };
+
+  const filteredAgents = await filterHostedPolicies(
+    soClient,
+    givenAgents,
+    outgoingErrors,
+    `Cannot modify tags on a hosted agent`
+  );
 
   const getNewTags = (agent: Agent): string[] => {
     const existingTags = agent.tags ?? [];
@@ -106,7 +118,7 @@ async function updateTagsBatch(
 
   await bulkUpdateAgents(
     esClient,
-    givenAgents.map((agent) => ({
+    filteredAgents.map((agent) => ({
       agentId: agent.id,
       data: {
         tags: getNewTags(agent),
@@ -114,5 +126,5 @@ async function updateTagsBatch(
     }))
   );
 
-  return { items: errorsToResults(givenAgents, errors, agentIds, skipSuccess) };
+  return { items: errorsToResults(filteredAgents, errors, agentIds, skipSuccess) };
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135975

Filtering out hosted agents when executing bulk add tags action.

To verify:
- create a managed policy with preconfig / test in cloud
- add agent to managed policy
- action `Add / remove tags` on bulk selection including agent with managed policy
- verify that the tags are not added to hosted agent

<img width="1778" alt="image" src="https://user-images.githubusercontent.com/90178898/179514038-36d8ff8d-a944-442e-809d-09ffd6b02c5c.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios