### PR TITLE
[Actionable Observability] Add actionable-observability as owner of rule_details page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@
 /x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/rule_details  @elastic/actionable-observability
 
 # Infra Monitoring
 /x-pack/plugins/infra/ @elastic/infra-monitoring-ui


### PR DESCRIPTION
# Summary

Add `actionable-observability` as owner of `rule_details` page

