### PR TITLE
[Files] Find endpoint

### DIFF
--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -39,6 +39,10 @@ export const FILE_KIND_API_ROUTES_CLIENT = {
   getByIdRoute: (fileKind: string, id: string) => `${FILES_API_BASE_PATH}/${fileKind}/${id}`,
 };
 
+export const FILES_API_ROUTES = {
+  find: `${FILES_API_BASE_PATH}/find`,
+};
+
 export interface HttpApiInterfaceEntryDefinition<
   P = unknown,
   Q = unknown,
@@ -60,7 +64,7 @@ export type CreateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
     name: string;
     alt?: string;
     meta?: Record<string, unknown>;
-    mime?: string;
+    mimeType?: string;
   },
   { file: FileJSON }
 >;
@@ -142,7 +146,12 @@ export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<
     /**
      * Filter for match on extensions
      */
-    extensions?: string[];
+    extension?: string[];
+
+    /**
+     * Filter for match on extensions
+     */
+    status?: string[];
   },
   { files: FileJSON[] }
 >;

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -22,7 +22,6 @@ export const FILE_KIND_API_ROUTES_SERVER = {
   getDeleteRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
   getListRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/list`,
   getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
-  getFindRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/find`,
 };
 
 export const FILE_KIND_API_ROUTES_CLIENT = {

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -22,6 +22,7 @@ export const FILE_KIND_API_ROUTES_SERVER = {
   getDeleteRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
   getListRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/list`,
   getByIdRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/{id}`,
+  getFindRoute: (fileKind: string) => `${FILES_API_BASE_PATH}/${fileKind}/find`,
 };
 
 export const FILE_KIND_API_ROUTES_CLIENT = {
@@ -52,7 +53,7 @@ export interface HttpApiInterfaceEntryDefinition<
   output: R;
 }
 
-export type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type CreateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
   unknown,
   {
@@ -64,7 +65,7 @@ export type CreateHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { file: FileJSON }
 >;
 
-export type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type DeleteFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
   },
@@ -73,7 +74,7 @@ export type DeleteHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { ok: true }
 >;
 
-export type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type DownloadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
     fileName?: string;
@@ -84,7 +85,7 @@ export type DownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
   any
 >;
 
-export type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type GetByIdFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {
     id: string;
   },
@@ -93,23 +94,30 @@ export type GetByIdHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { file: FileJSON }
 >;
 
-export type ListHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type ListFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
   { page?: number; perPage?: number },
   unknown,
   { files: FileJSON[] }
 >;
 
-export type UpdateHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type UpdateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { id: string },
   unknown,
   { name?: string; alt?: string; meta?: Record<string, unknown> },
   { file: FileJSON }
 >;
 
-export type UploadHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type UploadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { id: string },
   unknown,
   any,
   { ok: true }
+>;
+
+export type FindFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  unknown,
+  unknown,
+  {},
+  { files: FileJSON[] }
 >;

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -115,9 +115,34 @@ export type UploadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { ok: true }
 >;
 
-export type FindFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
+export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,
-  unknown,
-  {},
+  { perPage?: number; page?: number },
+  {
+    /**
+     * Filter for set of file-kinds
+     */
+    kind?: string[];
+
+    /**
+     * Filter for match on names
+     */
+    name?: string[];
+
+    /**
+     * Filter for set of meta attributes matching this object
+     */
+    meta: {};
+
+    /**
+     * Filter for exact match on MIME types
+     */
+    mimeType?: string[];
+
+    /**
+     * Filter for match on extensions
+     */
+    extensions?: string[];
+  },
   { files: FileJSON[] }
 >;

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -122,9 +122,7 @@ export interface FileJSON<Meta = unknown> {
   meta: FileSavedObjectAttributes<Meta>['Meta'];
   extension: FileSavedObjectAttributes['Extension'];
   alt: FileSavedObjectAttributes['Alt'];
-  chunkSize: FileSavedObjectAttributes['ChunkSize'];
   fileKind: FileSavedObjectAttributes['FileKind'];
-  compression: FileSavedObjectAttributes['Compression'];
   status: FileSavedObjectAttributes['Status'];
 }
 

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -61,15 +61,15 @@ export type FileMetadata = {
   };
 
   /**
+   * The file extension, for example "jpg", "png", "svg" and so forth
+   */
+  extension?: string;
+
+  /**
    * Alternate text that can be used used to describe the contents of the file
    * in human-friendly language
    */
   Alt?: string;
-
-  /**
-   * The file extension, for example "jpg", "png", "svg" and so forth
-   */
-  Extension?: string;
 
   /**
    * ISO string representing when the file was last updated
@@ -118,9 +118,9 @@ export interface FileJSON<Meta = unknown> {
   name: FileSavedObjectAttributes['name'];
   mimeType: FileSavedObjectAttributes['mime_type'];
   size: FileSavedObjectAttributes['size'];
+  extension: FileSavedObjectAttributes['extension'];
 
   meta: FileSavedObjectAttributes<Meta>['Meta'];
-  extension: FileSavedObjectAttributes['Extension'];
   alt: FileSavedObjectAttributes['Alt'];
   fileKind: FileSavedObjectAttributes['FileKind'];
   status: FileSavedObjectAttributes['Status'];

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -7,13 +7,13 @@
 
 import type {
   HttpApiInterfaceEntryDefinition,
-  CreateHttpEndpoint,
-  DeleteHttpEndpoint,
-  DownloadHttpEndpoint,
-  GetByIdHttpEndpoint,
-  ListHttpEndpoint,
-  UpdateHttpEndpoint,
-  UploadHttpEndpoint,
+  CreateFileKindHttpEndpoint,
+  DeleteFileKindHttpEndpoint,
+  DownloadFileKindHttpEndpoint,
+  GetByIdFileKindHttpEndpoint,
+  ListFileKindHttpEndpoint,
+  UpdateFileKindHttpEndpoint,
+  UploadFileKindHttpEndpoint,
 } from '../common/api_routes';
 
 type ClientMethodFrom<E extends HttpApiInterfaceEntryDefinition> = (
@@ -21,13 +21,13 @@ type ClientMethodFrom<E extends HttpApiInterfaceEntryDefinition> = (
 ) => Promise<E['output']>;
 
 export interface FilesClient {
-  create: ClientMethodFrom<CreateHttpEndpoint>;
-  delete: ClientMethodFrom<DeleteHttpEndpoint>;
-  download: ClientMethodFrom<DownloadHttpEndpoint>;
-  getById: ClientMethodFrom<GetByIdHttpEndpoint>;
-  list: ClientMethodFrom<ListHttpEndpoint>;
-  update: ClientMethodFrom<UpdateHttpEndpoint>;
-  upload: ClientMethodFrom<UploadHttpEndpoint>;
+  create: ClientMethodFrom<CreateFileKindHttpEndpoint>;
+  delete: ClientMethodFrom<DeleteFileKindHttpEndpoint>;
+  download: ClientMethodFrom<DownloadFileKindHttpEndpoint>;
+  getById: ClientMethodFrom<GetByIdFileKindHttpEndpoint>;
+  list: ClientMethodFrom<ListFileKindHttpEndpoint>;
+  update: ClientMethodFrom<UpdateFileKindHttpEndpoint>;
+  upload: ClientMethodFrom<UploadFileKindHttpEndpoint>;
 }
 
 export interface FilesClientFactory {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -60,6 +60,7 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     } catch (e) {
       if (e instanceof errors.ResponseError && e.statusCode === 400) {
         this.logger.warn('Unable to create blob storage index, it may have been created already.');
+        return;
       }
       throw e;
     }

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -30,6 +30,7 @@ import { InternalFileService } from '../file_service/internal_file_service';
 import { InternalFileShareService } from '../file_share_service';
 import { BlobStorage } from '../blob_storage_service/types';
 import { enforceMaxByteSizeTransform } from './stream_transforms';
+import { toJSON } from './to_json';
 
 /**
  * Public class that provides all data and functionality consumers will need at the
@@ -166,21 +167,7 @@ export class File<M = unknown> implements IFile {
   }
 
   public toJSON(): FileJSON<M> {
-    return {
-      id: this.id,
-      alt: this.alt,
-      chunkSize: this.attributes.ChunkSize,
-      extension: this.extension,
-      meta: this.meta,
-      mimeType: this.mimeType,
-      size: this.size,
-      compression: this.compression,
-      created: this.created,
-      updated: this.updated,
-      fileKind: this.fileKind,
-      name: this.name,
-      status: this.status,
-    };
+    return toJSON<M>(this.id, this.attributes);
   }
 
   private get attributes(): FileSavedObjectAttributes {

--- a/x-pack/plugins/files/server/file/file.ts
+++ b/x-pack/plugins/files/server/file/file.ts
@@ -223,7 +223,7 @@ export class File<M = unknown> implements IFile {
   }
 
   public get extension(): undefined | string {
-    return this.attributes.Extension;
+    return this.attributes.extension;
   }
 
   /**
@@ -247,7 +247,7 @@ export class File<M = unknown> implements IFile {
       Alt: alt,
       Meta: meta,
       FileKind: fileKind.id,
-      Extension: (mime && mimeType.getExtension(mime)) ?? undefined,
+      extension: (mime && mimeType.getExtension(mime)) ?? undefined,
     });
 
     const file = internalFileService.toFile(fileSO, fileKind);

--- a/x-pack/plugins/files/server/file/index.ts
+++ b/x-pack/plugins/files/server/file/index.ts
@@ -7,5 +7,7 @@
 
 export { File } from './file';
 
+export { toJSON } from './to_json';
+
 export { createDefaultFileAttributes, fileAttributesReducer } from './file_attributes_reducer';
 export type { Action } from './file_attributes_reducer';

--- a/x-pack/plugins/files/server/file/to_json.ts
+++ b/x-pack/plugins/files/server/file/to_json.ts
@@ -17,8 +17,6 @@ export function toJSON<M = unknown>(id: string, attrs: FileSavedObjectAttributes
     FileKind,
     Status,
     Alt,
-    ChunkSize,
-    Compression,
     Extension,
     Meta,
   } = attrs;
@@ -31,8 +29,6 @@ export function toJSON<M = unknown>(id: string, attrs: FileSavedObjectAttributes
     updated: Updated,
     fileKind: FileKind,
     alt: Alt,
-    chunkSize: ChunkSize,
-    compression: Compression,
     extension: Extension,
     status: Status,
     meta: Meta as M,

--- a/x-pack/plugins/files/server/file/to_json.ts
+++ b/x-pack/plugins/files/server/file/to_json.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FileSavedObjectAttributes, FileJSON } from '../../common/types';
+
+export function toJSON<M = unknown>(id: string, attrs: FileSavedObjectAttributes): FileJSON<M> {
+  const {
+    name,
+    mime_type: mimeType,
+    size,
+    created,
+    Updated,
+    FileKind,
+    Status,
+    Alt,
+    ChunkSize,
+    Compression,
+    Extension,
+    Meta,
+  } = attrs;
+  return {
+    id,
+    name,
+    mimeType,
+    size,
+    created,
+    updated: Updated,
+    fileKind: FileKind,
+    alt: Alt,
+    chunkSize: ChunkSize,
+    compression: Compression,
+    extension: Extension,
+    status: Status,
+    meta: Meta as M,
+  };
+}

--- a/x-pack/plugins/files/server/file/to_json.ts
+++ b/x-pack/plugins/files/server/file/to_json.ts
@@ -17,7 +17,7 @@ export function toJSON<M = unknown>(id: string, attrs: FileSavedObjectAttributes
     FileKind,
     Status,
     Alt,
-    Extension,
+    extension,
     Meta,
   } = attrs;
   return {
@@ -26,11 +26,11 @@ export function toJSON<M = unknown>(id: string, attrs: FileSavedObjectAttributes
     mimeType,
     size,
     created,
-    updated: Updated,
-    fileKind: FileKind,
+    extension,
     alt: Alt,
-    extension: Extension,
     status: Status,
     meta: Meta as M,
+    updated: Updated,
+    fileKind: FileKind,
   };
 }

--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -5,14 +5,15 @@
  * 2.0.
  */
 
-import { File } from '../../common';
+import { File, FileJSON } from '../../common';
 import { FileShareServiceStart } from '../file_share_service/types';
 import {
   CreateFileArgs,
   UpdateFileArgs,
   DeleteFileArgs,
-  FindFileArgs,
+  GetByIdArgs,
   ListFilesArgs,
+  FindFileArgs,
 } from './internal_file_service';
 
 /**
@@ -37,9 +38,14 @@ export interface FileServiceStart {
   delete(args: DeleteFileArgs): Promise<void>;
 
   /**
-   * Find a file. Will throw if file cannot be found.
+   * Get a file by ID. Will throw if file cannot be found.
    */
-  find<M>(args: FindFileArgs): Promise<File<M>>;
+  getById<M>(args: GetByIdArgs): Promise<File<M>>;
+
+  /**
+   * Find files given a set of parameters.
+   */
+  find<M>(args: FindFileArgs): Promise<Array<FileJSON<M>>>;
 
   /**
    * List all files of specific file kind.

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -13,13 +13,14 @@ import {
 } from '@kbn/core/server';
 import { SecurityPluginSetup } from '@kbn/security-plugin/server';
 
-import type { File, FileSavedObjectAttributes } from '../../common';
+import type { File, FileJSON, FileSavedObjectAttributes } from '../../common';
 import { fileObjectType, fileShareObjectType } from '../saved_objects';
 import { BlobStorageService } from '../blob_storage_service';
 import { InternalFileShareService } from '../file_share_service';
 import {
   CreateFileArgs,
   FindFileArgs,
+  GetByIdArgs,
   InternalFileService,
   ListFilesArgs,
   UpdateFileArgs,
@@ -70,8 +71,11 @@ export class FileServiceFactory {
       async delete(args) {
         return internalFileService.deleteFile(args);
       },
+      async getById<M>(args: GetByIdArgs) {
+        return internalFileService.getById(args) as Promise<File<M>>;
+      },
       async find<M>(args: FindFileArgs) {
-        return internalFileService.find(args) as Promise<File<M>>;
+        return internalFileService.findFilesJSON(args) as Promise<Array<FileJSON<M>>>;
       },
       async list<M>(args: ListFilesArgs) {
         return internalFileService.list(args) as Promise<Array<File<M>>>;

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -205,11 +205,11 @@ export class InternalFileService {
       }
     };
 
-    addFilters('FileKind', kind);
     addFilters('name', name);
-    addFilters('Extension', extension);
-    addFilters('mime_type', mimeType);
+    addFilters('FileKind', kind);
     addFilters('Status', status);
+    addFilters('mime_type', mimeType);
+    addFilters('extension', extension);
 
     Object.entries(meta ? getFlattenedObject(meta) : {}).forEach(([fieldName, value]) => {
       addFilters(`Meta.${fieldName}`, Array.isArray(value) ? value : [value]);

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -26,7 +26,7 @@ import {
   FileKind,
   FileJSON,
 } from '../../common';
-import { File } from '../file';
+import { File, toJSON } from '../file';
 import { FileKindsRegistry } from '../file_kinds_registry';
 import { FileNotFoundError } from './errors';
 
@@ -232,9 +232,6 @@ export class InternalFileService {
       page,
       perPage,
     });
-    return result.saved_objects.map((so) => ({
-      id: so.id,
-      ...so.attributes,
-    }));
+    return result.saved_objects.map((so) => toJSON(so.id, so.attributes));
   }
 }

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -224,6 +224,7 @@ export class InternalFileService {
                 {
                   term: { [`${this.savedObjectType}.attributes.status`]: 'READY' },
                 },
+                ...filter,
               ],
             },
           })

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -113,7 +113,7 @@ describe('FileService', () => {
 
   it('retrieves a file', async () => {
     const { id } = await createDisposableFile({ fileKind, name: 'test' });
-    const myFile = await fileService.find({ id, fileKind });
+    const myFile = await fileService.getById({ id, fileKind });
     expect(myFile?.id).toMatch(id);
   });
 
@@ -152,7 +152,7 @@ describe('FileService', () => {
     expect(updatedFile1.alt).toBe(updatableFields.alt);
 
     // Fetch the file anew to be doubly sure
-    const updatedFile2 = await fileService.find<CustomMeta>({ fileKind, id: file.id });
+    const updatedFile2 = await fileService.getById<CustomMeta>({ fileKind, id: file.id });
     expect(updatedFile2.meta).toEqual(expect.objectContaining(updatableFields.meta));
     // Below also tests that our meta type is work as expected by using `some` field.
     expect(updatedFile2.meta?.some).toBe(updatableFields.meta.some);

--- a/x-pack/plugins/files/server/routes/README.md
+++ b/x-pack/plugins/files/server/routes/README.md
@@ -1,0 +1,16 @@
+# Routes patterns
+
+Inside each handler file you should export:
+
+* `method` that specifies the HTTP API method
+* `handler` that specifies the handler function
+* Any body, parameter or query schema definition for the route
+
+In this way, the concerns of a specific endpoint or well encapsulated in a single
+file and they can be assembled into a route later: this works really well for the
+`<fileKind>` routes (see below) and we don't need to strictly follow this registration
+pattern for other routes.
+
+Routes under `<BASEPATH>/<fileKind>` are registered dynamically because we want
+to consumers of files to specify a route-level configuration to explicitly allow
+certain types of API actions against files.

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -17,7 +17,7 @@ export const bodySchema = schema.object({
   name: commonSchemas.fileName,
   alt: commonSchemas.fileAlt,
   meta: commonSchemas.fileMeta,
-  mime: schema.maybe(schema.string()),
+  mimeType: schema.maybe(schema.string()),
 });
 
 type Body = Ensure<CreateFileKindHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
@@ -31,9 +31,11 @@ export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
 ) => {
   const { fileService } = await files;
   const {
-    body: { name, alt, meta, mime },
+    body: { name, alt, meta, mimeType },
   } = req;
-  const file = await fileService.asCurrentUser().create({ fileKind, name, alt, meta, mime });
+  const file = await fileService
+    .asCurrentUser()
+    .create({ fileKind, name, alt, meta, mime: mimeType });
   const body: Response = {
     file: file.toJSON(),
   };

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import { Ensure } from '@kbn/utility-types';
-import type { CreateHttpEndpoint } from '../../../common/api_routes';
+import type { CreateFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import * as commonSchemas from './common_schemas';
 
@@ -20,9 +20,9 @@ export const bodySchema = schema.object({
   mime: schema.maybe(schema.string()),
 });
 
-type Body = Ensure<CreateHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
+type Body = Ensure<CreateFileKindHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
 
-type Response = CreateHttpEndpoint['output'];
+type Response = CreateFileKindHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
   { fileKind, files },

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { DeleteHttpEndpoint } from '../../../common/api_routes';
+import type { DeleteFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 import { getById } from './helpers';
@@ -18,9 +18,9 @@ export const paramsSchema = schema.object({
   id: schema.string(),
 });
 
-type Params = Ensure<DeleteHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<DeleteFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-type Response = DeleteHttpEndpoint['output'];
+type Response = DeleteFileKindHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const {

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -10,7 +10,7 @@ import { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 
 import type { File } from '../../../common';
-import type { DownloadHttpEndpoint } from '../../../common/api_routes';
+import type { DownloadFileKindHttpEndpoint } from '../../../common/api_routes';
 
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
@@ -22,7 +22,7 @@ export const paramsSchema = schema.object({
   fileName: schema.maybe(schema.string()),
 });
 
-type Params = Ensure<DownloadHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<DownloadFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 type Response = Readable;
 

--- a/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
@@ -7,18 +7,18 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { GetByIdHttpEndpoint } from '../../../common/api_routes';
+import type { GetByIdFileKindHttpEndpoint } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
-type Response = GetByIdHttpEndpoint['output'];
+type Response = GetByIdFileKindHttpEndpoint['output'];
 
 export const method = 'get' as const;
 
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
-type Params = Ensure<GetByIdHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<GetByIdFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
 export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;

--- a/x-pack/plugins/files/server/routes/file_kind/helpers.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/helpers.ts
@@ -23,7 +23,7 @@ export async function getById(
 ): Promise<ResultOrHttpError> {
   let result: undefined | File;
   try {
-    result = await fileService.find({ id, fileKind });
+    result = await fileService.getById({ id, fileKind });
   } catch (e) {
     let error: undefined | IKibanaResponse;
     if (e instanceof errors.FileNotFoundError) {

--- a/x-pack/plugins/files/server/routes/file_kind/index.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/index.ts
@@ -48,7 +48,7 @@ export function registerFileKindRoutes(router: FilesRouter) {
             body: {
               output: 'stream',
               parse: false,
-              accepts: 'application/octet-stream',
+              accepts: fileKind.allowedMimeTypes ?? 'application/octet-stream',
             },
           },
         },

--- a/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
@@ -17,7 +17,7 @@ describe('File kind HTTP API', () => {
 
   beforeAll(async () => {
     testHarness = await setupIntegrationEnvironment();
-    ({ createFile, root, request } = testHarness);
+    ({ createFile, root, request, fileKind } = testHarness);
   });
 
   afterAll(async () => {

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -7,7 +7,7 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import type { FileJSON } from '../../../common';
-import type { ListHttpEndpoint } from '../../../common/api_routes';
+import type { ListFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
 export const method = 'get' as const;
@@ -17,9 +17,9 @@ export const querySchema = schema.object({
   perPage: schema.maybe(schema.number({ defaultValue: 100 })),
 });
 
-type Query = Ensure<ListHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+type Query = Ensure<ListFileKindHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
 
-type Response = ListHttpEndpoint['output'];
+type Response = ListFileKindHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<unknown, Query> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -7,7 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { UpdateHttpEndpoint } from '../../../common/api_routes';
+import type { UpdateFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import { getById } from './helpers';
 
@@ -21,15 +21,15 @@ export const bodySchema = schema.object({
   meta: schema.maybe(commonSchemas.fileMeta),
 });
 
-type Body = Ensure<UpdateHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
+type Body = Ensure<UpdateFileKindHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
 
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
 
-type Params = Ensure<UpdateHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<UpdateFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-type Response = UpdateHttpEndpoint['output'];
+type Response = UpdateFileKindHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -8,7 +8,7 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
-import type { UploadHttpEndpoint } from '../../../common/api_routes';
+import type { UploadFileKindHttpEndpoint } from '../../../common/api_routes';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
@@ -20,9 +20,9 @@ type Body = TypeOf<typeof bodySchema>;
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
-type Params = Ensure<UploadHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+type Params = Ensure<UploadFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
 
-type Response = UploadHttpEndpoint['output'];
+type Response = UploadFileKindHttpEndpoint['output'];
 
 export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   { files, fileKind },

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema, TypeOf } from '@kbn/config-schema';
+import { Ensure } from '@kbn/utility-types';
+
+import type { FindFilesHttpEndpoint } from '../../common/api_routes';
+import type { FilesRequestHandler } from './types';
+
+export const method = 'post' as const;
+
+const stringOrArrayOfStrings = schema.oneOf([schema.string(), schema.arrayOf(schema.string())]);
+
+const paramsSchema = schema.object({
+  kind: schema.maybe(stringOrArrayOfStrings),
+  name: schema.maybe(stringOrArrayOfStrings),
+  meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+  mimeType: schema.maybe(stringOrArrayOfStrings),
+  extension: schema.maybe(stringOrArrayOfStrings),
+});
+
+const querySchema = schema.object({
+  page: schema.maybe(schema.number()),
+  perPage: schema.maybe(schema.number({ defaultValue: 100 })),
+});
+
+type Body = Ensure<FindFilesHttpEndpoint['inputs']['body'], TypeOf<typeof paramsSchema>>;
+
+type Query = Ensure<FindFilesHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+
+type Response = FindFilesHttpEndpoint['output'];
+
+export const handler: FilesRequestHandler<unknown, Query, Body> = async ({ files }, req, res) => {
+  const { fileService } = await files;
+  const { body: reqBody, query } = req;
+  const body: Response = {
+    files: await fileService.asCurrentUser().find({
+      ...reqBody,
+      ...query,
+    }),
+  };
+  return res.ok({
+    body,
+  });
+};

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -17,9 +17,9 @@ const stringOrArrayOfStrings = schema.oneOf([schema.string(), schema.arrayOf(sch
 const paramsSchema = schema.object({
   kind: schema.maybe(stringOrArrayOfStrings),
   name: schema.maybe(stringOrArrayOfStrings),
-  meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   mimeType: schema.maybe(stringOrArrayOfStrings),
   extension: schema.maybe(stringOrArrayOfStrings),
+  meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 
 const querySchema = schema.object({

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -21,9 +21,9 @@ const nameStringOrArrayOfNameStrings = schema.oneOf([string256, schema.arrayOf(s
 
 const bodySchema = schema.object({
   kind: schema.maybe(stringOrArrayOfStrings),
-  name: schema.maybe(nameStringOrArrayOfNameStrings),
-  mimeType: schema.maybe(stringOrArrayOfStrings),
   status: schema.maybe(stringOrArrayOfStrings),
+  mimeType: schema.maybe(stringOrArrayOfStrings),
+  name: schema.maybe(nameStringOrArrayOfNameStrings),
   meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 
@@ -52,10 +52,10 @@ const handler: FilesRequestHandler<unknown, Query, Body> = async ({ files }, req
   const body: Response = {
     files: await fileService.asCurrentUser().find({
       kind: kind && toArray(kind),
-      extension: extension && toArray(extension),
-      mimeType: mimeType && toArray(mimeType),
       name: name && toArray(name),
       status: status && toArray(status),
+      mimeType: mimeType && toArray(mimeType),
+      extension: extension && toArray(extension),
       meta,
       ...query,
     }),

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -13,14 +13,17 @@ import type { FilesRequestHandler } from './types';
 
 export const method = 'post' as const;
 
-const stringOrArrayOfStrings = schema.oneOf([schema.string(), schema.arrayOf(schema.string())]);
+const string64 = schema.string({ maxLength: 64 });
+const string256 = schema.string({ maxLength: 256 });
+
+const stringOrArrayOfStrings = schema.oneOf([string64, schema.arrayOf(string64)]);
+const nameStringOrArrayOfNameStrings = schema.oneOf([string256, schema.arrayOf(string256)]);
 
 const bodySchema = schema.object({
   kind: schema.maybe(stringOrArrayOfStrings),
-  name: schema.maybe(stringOrArrayOfStrings),
+  name: schema.maybe(nameStringOrArrayOfNameStrings),
   mimeType: schema.maybe(stringOrArrayOfStrings),
   status: schema.maybe(stringOrArrayOfStrings),
-  kuery: schema.maybe(stringOrArrayOfStrings),
   meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 

--- a/x-pack/plugins/files/server/routes/index.ts
+++ b/x-pack/plugins/files/server/routes/index.ts
@@ -7,7 +7,10 @@
 
 import { FilesRouter } from './types';
 import { registerFileKindRoutes } from './file_kind';
+import * as find from './find';
 
 export function registerRoutes(router: FilesRouter) {
   registerFileKindRoutes(router);
+
+  find.register(router);
 }

--- a/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
+++ b/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
@@ -5,4 +5,118 @@
  * 2.0.
  */
 
-describe('File HTTP API', () => {});
+import type { CreateFileKindHttpEndpoint } from '../../../common/api_routes';
+import { setupIntegrationEnvironment, TestEnvironmentUtils } from '../tests';
+
+describe('File HTTP API', () => {
+  let testHarness: TestEnvironmentUtils;
+  let root: TestEnvironmentUtils['root'];
+  let request: TestEnvironmentUtils['request'];
+  let createFile: TestEnvironmentUtils['createFile'];
+
+  beforeAll(async () => {
+    testHarness = await setupIntegrationEnvironment();
+    ({ request, createFile, root } = testHarness);
+  });
+
+  afterAll(async () => {
+    testHarness.cleanupAfterAll();
+  });
+
+  describe('find', () => {
+    beforeEach(async () => {
+      const args: Array<CreateFileKindHttpEndpoint['inputs']['body']> = [
+        {
+          name: 'firstFile',
+          alt: 'my first alt',
+          meta: {
+            cool: 'beans',
+          },
+          mimeType: 'image/png',
+        },
+        {
+          name: 'secondFile',
+          alt: 'my second alt',
+          meta: {
+            other: 'beans',
+          },
+          mimeType: 'application/pdf',
+        },
+        {
+          name: 'thirdFile',
+          alt: 'my first alt',
+          meta: {
+            cool: 'bones',
+          },
+          mimeType: 'image/png',
+        },
+      ];
+
+      const files = await Promise.all(args.map((arg) => createFile(arg)));
+
+      for (const file of files.slice(0, 2)) {
+        await request
+          .put(root, `/api/files/files/${testHarness.fileKind}/${file.id}/blob`)
+          .set('Content-Type', 'application/octet-stream')
+          .send('hello world')
+          .expect(200);
+      }
+    });
+    afterEach(async () => {
+      await testHarness.cleanupAfterEach();
+    });
+
+    test('without filters', async () => {
+      const result = await request.post(root, '/api/files/files/find').send({}).expect(200);
+      expect(result.body.files).toHaveLength(3);
+    });
+
+    test('names', async () => {
+      const result = await request
+        .post(root, '/api/files/files/find')
+        .send({ name: ['firstFile', 'secondFile'] })
+        .expect(200);
+      expect(result.body.files).toHaveLength(2);
+    });
+
+    test('file kind', async () => {
+      {
+        const result = await request
+          .post(root, `/api/files/files/find`)
+          .send({ kind: 'non-existent' })
+          .expect(200);
+        expect(result.body.files).toHaveLength(0);
+      }
+
+      {
+        const result = await request
+          .post(root, '/api/files/files/find')
+          .send({ kind: testHarness.fileKind })
+          .expect(200);
+        expect(result.body.files).toHaveLength(3);
+      }
+    });
+
+    test('status', async () => {
+      const result = await request
+        .post(root, '/api/files/files/find')
+        .send({
+          status: 'READY',
+        })
+        .expect(200);
+      expect(result.body.files).toHaveLength(2);
+    });
+
+    test('combination', async () => {
+      const result = await request
+        .post(root, '/api/files/files/find')
+        .send({
+          kind: testHarness.fileKind,
+          name: ['firstFile', 'secondFile'],
+          meta: { cool: 'beans' },
+        })
+        .expect(200);
+      expect(result.body.files).toHaveLength(1);
+    });
+  });
+});

--- a/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
+++ b/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+describe('File HTTP API', () => {});

--- a/x-pack/plugins/files/server/routes/tests/index.ts
+++ b/x-pack/plugins/files/server/routes/tests/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { setupIntegrationEnvironment } from './setup_integration_environment';
+export type { TestEnvironmentUtils } from './setup_integration_environment';

--- a/x-pack/plugins/files/server/routes/tests/index.ts
+++ b/x-pack/plugins/files/server/routes/tests/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { setupIntegrationEnvironment } from './setup_integration_environment';

--- a/x-pack/plugins/files/server/routes/tests/setup_integration_environment.ts
+++ b/x-pack/plugins/files/server/routes/tests/setup_integration_environment.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  createRootWithCorePlugins,
+  createTestServers,
+  request,
+} from '@kbn/core/test_helpers/kbn_server';
+import pRetry from 'p-retry';
+import { fileKindsRegistry } from '../../file_kinds_registry';
+
+export async function setupIntegrationEnvironment() {
+  const fileKind: string = 'test-file-kind';
+  const testIndex = '.kibana-test-files';
+  const testConfig = {
+    xpack: {
+      reporting: { enabled: false },
+    },
+  };
+
+  fileKindsRegistry.register({
+    id: fileKind,
+    blobStoreSettings: {
+      esFixedSizeIndex: { index: testIndex },
+    },
+    http: {
+      create: { tags: ['access:myapp'] },
+      delete: { tags: ['access:myapp'] },
+      update: { tags: ['access:myapp'] },
+      download: { tags: ['access:myapp'] },
+      getById: { tags: ['access:myapp'] },
+      list: { tags: ['access:myapp'] },
+    },
+  });
+
+  const { startES } = createTestServers({
+    adjustTimeout: jest.setTimeout,
+    settings: {
+      es: {
+        license: 'basic',
+      },
+    },
+  });
+  const manageES = await startES();
+  const root = createRootWithCorePlugins(testConfig, { oss: false });
+  const coreStart = await root.start();
+  const esClient = coreStart.elasticsearch.client.asInternalUser;
+  await root.preboot();
+  await root.setup();
+
+  await pRetry(() => request.get(root, '/api/licensing/info').expect(200), { retries: 5 });
+
+  return {
+    manageES,
+    esClient,
+    root,
+    coreStart,
+    fileKind,
+    testIndex,
+  };
+}

--- a/x-pack/plugins/files/server/saved_objects/file.ts
+++ b/x-pack/plugins/files/server/saved_objects/file.ts
@@ -37,7 +37,7 @@ const properties: Properties = {
     type: 'long',
   },
   Meta: {
-    type: 'object',
+    type: 'flattened',
   },
   FileKind: {
     type: 'keyword',
@@ -49,7 +49,7 @@ const properties: Properties = {
     type: 'keyword',
   },
   hash: {
-    type: 'object',
+    type: 'flattened',
   },
 };
 

--- a/x-pack/plugins/files/server/saved_objects/file.ts
+++ b/x-pack/plugins/files/server/saved_objects/file.ts
@@ -30,7 +30,7 @@ const properties: Properties = {
   mime_type: {
     type: 'keyword',
   },
-  Extension: {
+  extension: {
     type: 'keyword',
   },
   size: {

--- a/x-pack/plugins/files/server/types.ts
+++ b/x-pack/plugins/files/server/types.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import type { SecurityPluginSetup } from '@kbn/security-plugin/server';
 import { FileKind } from '../common';
 import { FileServiceFactory } from './file_service';
 


### PR DESCRIPTION
## Summary

Adds a new "find" endpoint that can be used to search files based on many different attributes. This provides a read-only view of the current files objects.

Supports the following style of queries (written as kuery):

```
(name: A OR name: B) AND (FileKind: C)
```

This enables asking for sets of mutual (OR) attribute values while excluding (AND) files that don't have those attributes.