### PR TITLE
[cli-dev-mode/base-path-proxy] switch to integration tests

### DIFF
--- a/packages/kbn-cli-dev-mode/jest.integration.config.js
+++ b/packages/kbn-cli-dev-mode/jest.integration.config.js
@@ -7,7 +7,7 @@
  */
 
 module.exports = {
-  preset: '@kbn/test/jest_node',
+  preset: '@kbn/test/jest_integration_node',
   rootDir: '../..',
   roots: ['<rootDir>/packages/kbn-cli-dev-mode'],
 };

--- a/packages/kbn-cli-dev-mode/src/integration_tests/base_path_proxy_server.test.ts
+++ b/packages/kbn-cli-dev-mode/src/integration_tests/base_path_proxy_server.test.ts
@@ -18,9 +18,9 @@ import {
 } from '@kbn/server-http-tools';
 import { ByteSizeValue } from '@kbn/config-schema';
 
-import { BasePathProxyServer, BasePathProxyServerOptions } from './base_path_proxy_server';
-import { DevConfig } from './config/dev_config';
-import { TestLog } from './log';
+import { BasePathProxyServer, BasePathProxyServerOptions } from '../base_path_proxy_server';
+import { DevConfig } from '../config/dev_config';
+import { TestLog } from '../log';
 
 describe('BasePathProxyServer', () => {
   let server: Server;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/99583

We sometimes see failures in the `BasePathProxy` tests, which start a whole server instance on a pre-defined port in "unit" tests. These seem pretty clearly to be integration tests so I suspect that moving them will reduce the amount of times they fail.