### PR TITLE
[Fleet] Add cypress test for add agent flyout

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -5,63 +5,7 @@
  * 2.0.
  */
 
-// 8.1.0 is not significant its just a version < current version
-const createAgentDoc = (
-  id: string,
-  policy: string,
-  status = 'online',
-  version: string = '8.1.0'
-) => ({
-  access_api_key_id: 'abcdefghijklmn',
-  action_seq_no: [-1],
-  active: true,
-  agent: {
-    id,
-    version,
-  },
-  enrolled_at: '2022-03-07T14:02:00Z',
-  local_metadata: {
-    elastic: {
-      agent: {
-        'build.original': version,
-        id,
-        log_level: 'info',
-        snapshot: true,
-        upgradeable: true,
-        version,
-      },
-    },
-    host: {
-      architecture: 'x86_64',
-      hostname: id,
-      id: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
-      ip: ['127.0.0.1/8'],
-      mac: ['ab:cd:12:34:56:78'],
-      name: id,
-    },
-    os: {
-      family: 'darwin',
-      full: 'Mac OS X(10.16)',
-      kernel: '21.3.0',
-      name: 'Mac OS X',
-      platform: 'darwin',
-      version: '10.16',
-    },
-  },
-  policy_id: policy,
-  type: 'PERMANENT',
-  default_api_key: 'abcdefg',
-  default_api_key_id: 'abcd',
-  policy_output_permissions_hash: 'somehash',
-  updated_at: '2022-03-07T16:35:03Z',
-  last_checkin_status: status,
-  last_checkin: new Date(),
-  policy_revision_idx: 1,
-  policy_coordinator_idx: 1,
-  policy_revision: 1,
-  status,
-  packages: [],
-});
+import { createAgentDoc } from '../tasks/agents';
 
 const createAgentDocs = (kibanaVersion: string) => [
   createAgentDoc('agent-1', 'policy-1'), // this agent will have upgrade available

--- a/x-pack/plugins/fleet/cypress/integration/fleet_agent_flyout.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/fleet_agent_flyout.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ADD_AGENT_BUTTON, ADD_AGENT_FLYOUT } from '../screens/fleet';
+import { cleanupAgentPolicies } from '../tasks/cleanup';
+import { createAgentDoc } from '../tasks/agents';
+import { setFleetServerHost } from '../tasks/fleet';
+import { FLEET, navigateTo } from '../tasks/navigation';
+
+const FLEET_SERVER_POLICY_ID = 'fleet-server-policy';
+
+function cleanUp() {
+  cy.task('deleteDocsByQuery', {
+    index: '.fleet-agents',
+    query: { match_all: {} },
+    ignoreUnavailable: true,
+  });
+  cy.task('deleteDocsByQuery', {
+    index: '.fleet-servers',
+    query: { match_all: {} },
+    ignoreUnavailable: true,
+  });
+  cleanupAgentPolicies();
+}
+let kibanaVersion: string;
+describe('Fleet add agent flyout', () => {
+  describe('Create policies', () => {
+    beforeEach(() => {
+      cleanUp();
+      let policyId: string;
+      // Create a Fleet server policy
+      cy.request({
+        method: 'POST',
+        url: '/api/fleet/agent_policies',
+        headers: { 'kbn-xsrf': 'xx' },
+        body: {
+          id: FLEET_SERVER_POLICY_ID,
+          name: 'Fleet Server policy',
+          namespace: 'default',
+          has_fleet_server: true,
+        },
+      }).then((response: any) => {
+        // setup Fleet server
+        policyId = response.body.item.id;
+      });
+
+      cy.getKibanaVersion().then((version) => {
+        kibanaVersion = version;
+      });
+
+      cy.wrap(null).then(() => {
+        cy.task('insertDocs', {
+          index: '.fleet-agents',
+          docs: [createAgentDoc('agent1', policyId, 'online', kibanaVersion)],
+        });
+        cy.task('insertDocs', {
+          index: '.fleet-servers',
+          docs: [
+            {
+              '@timestamp': new Date().toISOString(),
+            },
+          ],
+        });
+        setFleetServerHost();
+      });
+    });
+
+    afterEach(() => {
+      cleanUp();
+    });
+
+    it('works in managed mode without agent policy created', () => {
+      const AGENT_ID = 'agent' + Date.now();
+      navigateTo(FLEET);
+
+      cy.getBySel(ADD_AGENT_BUTTON).click();
+      cy.intercept('POST', '/api/fleet/agent_policies?sys_monitoring=true').as('createAgentPolicy');
+
+      cy.getBySel('createPolicyBtn').click();
+
+      let agentPolicyId: string;
+      const startTime = Date.now();
+      cy.wait('@createAgentPolicy', { timeout: 180000 }).then((xhr: any) => {
+        cy.log('Create agent policy took: ' + (Date.now() - startTime) / 1000 + ' s');
+        agentPolicyId = xhr.response.body.item.id;
+      });
+      // verify create button changed to dropdown
+      cy.getBySel('agentPolicyDropdown');
+
+      cy.wrap(null).then(() => {
+        cy.task('insertDoc', {
+          index: '.fleet-agents',
+          id: AGENT_ID,
+          doc: createAgentDoc(AGENT_ID, agentPolicyId!, 'online', kibanaVersion),
+        });
+      });
+
+      cy.getBySel(ADD_AGENT_FLYOUT.CONFIRM_AGENT_ENROLLMENT_BUTTON);
+
+      cy.wrap(null).then(() => {
+        cy.task('insertDoc', {
+          index: 'logs-cypress-test',
+          id: 'test-' + Date.now(),
+          doc: {
+            '@timestamp': new Date().toISOString(),
+            'agent.id': AGENT_ID,
+            message: 'Test log 1',
+          },
+        });
+      });
+
+      cy.getBySel(ADD_AGENT_FLYOUT.INCOMING_DATA_CONFIRMED_CALL_OUT);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/cypress/integration/fleet_agent_flyout.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/fleet_agent_flyout.spec.ts
@@ -28,7 +28,7 @@ function cleanUp() {
 }
 let kibanaVersion: string;
 describe('Fleet add agent flyout', () => {
-  describe('Create policies', () => {
+  describe('With a Fleet Server already setup', () => {
     beforeEach(() => {
       cleanUp();
       let policyId: string;

--- a/x-pack/plugins/fleet/cypress/plugins/index.ts
+++ b/x-pack/plugins/fleet/cypress/plugins/index.ts
@@ -12,10 +12,13 @@ const plugin: Cypress.PluginConfig = (on, config) => {
     esUrl: config.env.ELASTICSEARCH_URL,
   });
   on('task', {
+    async insertDoc({ index, doc, id }: { index: string; doc: any; id: string }) {
+      return client.create({ id, document: doc, index, refresh: 'wait_for' });
+    },
     async insertDocs({ index, docs }: { index: string; docs: any[] }) {
       const operations = docs.flatMap((doc) => [{ index: { _index: index } }, doc]);
 
-      return client.bulk({ operations });
+      return client.bulk({ operations, refresh: 'wait_for' });
     },
     async deleteDocsByQuery({
       index,
@@ -26,7 +29,12 @@ const plugin: Cypress.PluginConfig = (on, config) => {
       query: any;
       ignoreUnavailable?: boolean;
     }) {
-      return client.deleteByQuery({ index, query, ignore_unavailable: ignoreUnavailable });
+      return client.deleteByQuery({
+        index,
+        query,
+        ignore_unavailable: ignoreUnavailable,
+        refresh: true,
+      });
     },
   });
 };

--- a/x-pack/plugins/fleet/cypress/screens/fleet.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet.ts
@@ -23,3 +23,8 @@ export const FLEET_SERVER_MISSING_PRIVILEGES_TITLE = 'fleetServerMissingPrivileg
 export const AGENT_POLICY_SAVE_INTEGRATION = 'saveIntegration';
 export const PACKAGE_POLICY_TABLE_LINK = 'PackagePoliciesTableLink';
 export const ADD_PACKAGE_POLICY_BTN = 'addPackagePolicyButton';
+
+export const ADD_AGENT_FLYOUT = {
+  CONFIRM_AGENT_ENROLLMENT_BUTTON: 'ConfirmAgentEnrollmentButton',
+  INCOMING_DATA_CONFIRMED_CALL_OUT: 'IncomingDataConfirmedCallOut',
+};

--- a/x-pack/plugins/fleet/cypress/tasks/agents.ts
+++ b/x-pack/plugins/fleet/cypress/tasks/agents.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const createAgentDoc = (
+  id: string,
+  policy: string,
+  status = 'online',
+  version: string = '8.1.0'
+) => ({
+  access_api_key_id: 'abcdefghijklmn',
+  action_seq_no: [-1],
+  active: true,
+  agent: {
+    id,
+    version,
+  },
+  enrolled_at: new Date().toISOString(),
+  local_metadata: {
+    elastic: {
+      agent: {
+        'build.original': version,
+        id,
+        log_level: 'info',
+        snapshot: true,
+        upgradeable: true,
+        version,
+      },
+    },
+    host: {
+      architecture: 'x86_64',
+      hostname: id,
+      id: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      ip: ['127.0.0.1/8'],
+      mac: ['ab:cd:12:34:56:78'],
+      name: id,
+    },
+    os: {
+      family: 'darwin',
+      full: 'Mac OS X(10.16)',
+      kernel: '21.3.0',
+      name: 'Mac OS X',
+      platform: 'darwin',
+      version: '10.16',
+    },
+  },
+  policy_id: policy,
+  type: 'PERMANENT',
+  default_api_key: 'abcdefg',
+  default_api_key_id: 'abcd',
+  policy_output_permissions_hash: 'somehash',
+  updated_at: '2022-03-07T16:35:03Z',
+  last_checkin_status: status,
+  last_checkin: new Date().toISOString(),
+  policy_revision_idx: 1,
+  policy_coordinator_idx: 1,
+  policy_revision: 1,
+  status,
+  packages: [],
+});

--- a/x-pack/plugins/fleet/cypress/tasks/fleet.ts
+++ b/x-pack/plugins/fleet/cypress/tasks/fleet.ts
@@ -56,3 +56,14 @@ export function verifyAgentPackage() {
   cy.visit('/app/integrations/installed');
   cy.getBySel('integration-card:epr:elastic_agent');
 }
+
+export function setFleetServerHost(host = 'https://fleetserver:8220') {
+  cy.request({
+    method: 'PUT',
+    url: '/api/fleet/settings',
+    headers: { 'kbn-xsrf': 'xx' },
+    body: {
+      fleet_server_hosts: [host],
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Add a basic cypress test to redesigned agent Flyout (with confirmed agents and confirmed data)

That test use the real API and only test the green path.

<img width="1266" alt="Screen Shot 2022-07-18 at 3 17 02 PM" src="https://user-images.githubusercontent.com/1336873/179599937-acb25132-421e-45d7-bcb9-593b2a68b151.png">
