### PR TITLE
[Security Solution][Endpoint][Response Actions] Truncate long hostnames in the middle

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/console_exit_modal_info.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/console_exit_modal_info.tsx
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiText } from '@elastic/eui';
+import { EuiText, EuiToolTip } from '@elastic/eui';
 
 import { CONSOLE_EXIT_MODAL_INFO } from '../console/components/console_manager/translations';
 
@@ -16,12 +16,18 @@ const actionLogLink = i18n.translate('xpack.securitySolution.consolePageOverlay.
   defaultMessage: 'Action log',
 });
 
+const getTruncateHostName = (name: string): string => {
+  if (name.length <= 12) {
+    return name;
+  }
+  const split = [name.slice(0, 8), name.slice(-4)];
+  return split.join('..');
+};
+
 export const HostNameText = ({ hostName }: { hostName: string }) => (
-  <EuiText size="s" style={{ maxWidth: 100, display: 'inline-flex' }}>
-    <span className="eui-textTruncate">
-      <strong>{hostName}</strong>
-    </span>
-  </EuiText>
+  <EuiToolTip content={hostName}>
+    <strong>{getTruncateHostName(hostName)}</strong>
+  </EuiToolTip>
 );
 
 export const ConsoleExitModalInfo = memo(({ hostName }: { hostName: string }) => {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/console_exit_modal_info.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/console_exit_modal_info.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiText, EuiToolTip } from '@elastic/eui';
 
@@ -16,19 +16,21 @@ const actionLogLink = i18n.translate('xpack.securitySolution.consolePageOverlay.
   defaultMessage: 'Action log',
 });
 
-const getTruncateHostName = (name: string): string => {
-  if (name.length <= 12) {
-    return name;
-  }
-  const split = [name.slice(0, 8), name.slice(-4)];
-  return split.join('..');
-};
+export const HostNameText = ({ hostName }: { hostName: string }) => {
+  const truncatedHostName = useMemo(() => {
+    if (hostName.length <= 12) {
+      return hostName;
+    }
+    const split = [hostName.slice(0, 8), hostName.slice(-4)];
+    return split.join('..');
+  }, [hostName]);
 
-export const HostNameText = ({ hostName }: { hostName: string }) => (
-  <EuiToolTip content={hostName}>
-    <strong>{getTruncateHostName(hostName)}</strong>
-  </EuiToolTip>
-);
+  return (
+    <EuiToolTip content={hostName}>
+      <strong>{truncatedHostName}</strong>
+    </EuiToolTip>
+  );
+};
 
 export const ConsoleExitModalInfo = memo(({ hostName }: { hostName: string }) => {
   return (


### PR DESCRIPTION
## Summary

Truncates long hostnames in the middle

![Screenshot 2022-07-19 at 10 24 05](https://user-images.githubusercontent.com/1849116/179704167-f5ad8afb-7e3c-4599-905e-5a2d2c9f2583.png)

**Tooltips on hostname**
![Screenshot 2022-07-19 at 13 10 06](https://user-images.githubusercontent.com/1849116/179737100-ff34cbc8-3b57-4b54-ae44-159b9a22d2a4.png)
![Screenshot 2022-07-19 at 13 10 13](https://user-images.githubusercontent.com/1849116/179737108-b9d54ffc-585f-4b84-98d0-d58c36dad091.png)



