### PR TITLE
[User Experience App] Fix kibana context usage

### DIFF
--- a/x-pack/plugins/observability/public/components/app/section/ux/index.tsx
+++ b/x-pack/plugins/observability/public/components/app/section/ux/index.tsx
@@ -8,6 +8,8 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { CoreStart } from '@kbn/core/public';
+import { ObservabilityPublicPluginsStart } from '../../../..';
 import type { AppDataType } from '../../../shared/exploratory_view/types';
 import { SectionContainer } from '..';
 import { getDataHandler } from '../../../../data_handler';
@@ -22,7 +24,6 @@ import {
   SERVICE_NAME,
   TRANSACTION_DURATION,
 } from '../../../shared/exploratory_view/configurations/constants/elasticsearch_fieldnames';
-import { ObservabilityAppServices } from '../../../../application/types';
 
 interface Props {
   bucketSize: BucketSize;
@@ -30,16 +31,14 @@ interface Props {
 
 export function UXSection({ bucketSize }: Props) {
   const { forceUpdate, hasDataMap } = useHasData();
-  const { services } = useKibana<ObservabilityAppServices>();
+  const { services } = useKibana<ObservabilityPublicPluginsStart>();
   const { relativeStart, relativeEnd, absoluteStart, absoluteEnd, lastUpdated } =
     useDatePickerContext();
   const uxHasDataResponse = hasDataMap.ux;
   const serviceName = uxHasDataResponse?.serviceName as string;
 
   const ExploratoryViewEmbeddable = getExploratoryViewEmbeddable(
-    services.uiSettings,
-    services.dataViews,
-    services.lens
+    services as ObservabilityPublicPluginsStart & CoreStart
   );
 
   const seriesList: AllSeries = [

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -8,10 +8,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
-import type { IUiSettingsClient } from '@kbn/core/public';
-import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
-import { LensPublicStart } from '@kbn/lens-plugin/public';
-import { useFetcher } from '../../../..';
+import type { CoreStart } from '@kbn/core/public';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { ObservabilityPublicPluginsStart, useFetcher } from '../../../..';
 import type { ExploratoryEmbeddableProps, ExploratoryEmbeddableComponentProps } from './embeddable';
 import { ObservabilityDataViews } from '../../../../utils/observability_data_views';
 import type { DataViewState } from '../hooks/use_app_data_view';
@@ -28,10 +27,12 @@ function ExploratoryViewEmbeddable(props: ExploratoryEmbeddableComponentProps) {
 }
 
 export function getExploratoryViewEmbeddable(
-  uiSettings?: IUiSettingsClient,
-  dataViews?: DataViewsPublicPluginStart,
-  lens?: LensPublicStart
+  coreStart: CoreStart,
+  pluginsStart: ObservabilityPublicPluginsStart
 ) {
+  const { lens, dataViews } = pluginsStart;
+  const { uiSettings } = coreStart;
+
   return (props: ExploratoryEmbeddableProps) => {
     if (!dataViews || !lens) {
       return null;
@@ -81,12 +82,14 @@ export function getExploratoryViewEmbeddable(
 
     return (
       <EuiThemeProvider darkMode={isDarkMode}>
-        <ExploratoryViewEmbeddable
-          {...props}
-          indexPatterns={indexPatterns}
-          lens={lens}
-          lensFormulaHelper={lensHelper.formula}
-        />
+        <KibanaContextProvider services={{ ...coreStart, ...pluginsStart }}>
+          <ExploratoryViewEmbeddable
+            {...props}
+            indexPatterns={indexPatterns}
+            lens={lens}
+            lensFormulaHelper={lensHelper.formula}
+          />
+        </KibanaContextProvider>
       </EuiThemeProvider>
     );
   };

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -28,11 +28,9 @@ function ExploratoryViewEmbeddable(props: ExploratoryEmbeddableComponentProps) {
 }
 
 export function getExploratoryViewEmbeddable(
-  coreStart: CoreStart,
-  pluginsStart: ObservabilityPublicPluginsStart
+  services: CoreStart & ObservabilityPublicPluginsStart
 ) {
-  const { lens, dataViews } = pluginsStart;
-  const { uiSettings } = coreStart;
+  const { lens, dataViews, uiSettings } = services;
 
   return (props: ExploratoryEmbeddableProps) => {
     if (!dataViews || !lens) {
@@ -84,7 +82,7 @@ export function getExploratoryViewEmbeddable(
     return (
       <EuiErrorBoundary>
         <EuiThemeProvider darkMode={isDarkMode}>
-          <KibanaContextProvider services={{ ...coreStart, ...pluginsStart }}>
+          <KibanaContextProvider services={services}>
             <ExploratoryViewEmbeddable
               {...props}
               indexPatterns={indexPatterns}

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/index.tsx
@@ -10,6 +10,7 @@ import { EuiLoadingSpinner } from '@elastic/eui';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import type { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { ObservabilityPublicPluginsStart, useFetcher } from '../../../..';
 import type { ExploratoryEmbeddableProps, ExploratoryEmbeddableComponentProps } from './embeddable';
 import { ObservabilityDataViews } from '../../../../utils/observability_data_views';
@@ -81,16 +82,18 @@ export function getExploratoryViewEmbeddable(
     }
 
     return (
-      <EuiThemeProvider darkMode={isDarkMode}>
-        <KibanaContextProvider services={{ ...coreStart, ...pluginsStart }}>
-          <ExploratoryViewEmbeddable
-            {...props}
-            indexPatterns={indexPatterns}
-            lens={lens}
-            lensFormulaHelper={lensHelper.formula}
-          />
-        </KibanaContextProvider>
-      </EuiThemeProvider>
+      <EuiErrorBoundary>
+        <EuiThemeProvider darkMode={isDarkMode}>
+          <KibanaContextProvider services={{ ...coreStart, ...pluginsStart }}>
+            <ExploratoryViewEmbeddable
+              {...props}
+              indexPatterns={indexPatterns}
+              lens={lens}
+              lensFormulaHelper={lensHelper.formula}
+            />
+          </KibanaContextProvider>
+        </EuiThemeProvider>
+      </EuiErrorBoundary>
     );
   };
 }

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -300,7 +300,7 @@ export class Plugin
       },
       createExploratoryViewUrl,
       getAppDataView: getAppDataView(pluginsStart.dataViews),
-      ExploratoryViewEmbeddable: getExploratoryViewEmbeddable(coreStart, pluginsStart),
+      ExploratoryViewEmbeddable: getExploratoryViewEmbeddable({ ...coreStart, ...pluginsStart }),
       useRulesLink: createUseRulesLink(),
     };
   }

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -300,11 +300,7 @@ export class Plugin
       },
       createExploratoryViewUrl,
       getAppDataView: getAppDataView(pluginsStart.dataViews),
-      ExploratoryViewEmbeddable: getExploratoryViewEmbeddable(
-        coreStart.uiSettings,
-        pluginsStart.dataViews,
-        pluginsStart.lens
-      ),
+      ExploratoryViewEmbeddable: getExploratoryViewEmbeddable(coreStart, pluginsStart),
       useRulesLink: createUseRulesLink(),
     };
   }


### PR DESCRIPTION
## Summary

Fixes an issue with context usage, instead of using plugin context in case of ExploratoryView being embedded, it generates context with observability plugin, to make sure this kind of problem doesn't happen.

Also added error boundary around embeddable.

Before:
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/3505601/179724325-e8f405d5-44ed-4953-9a00-16fd6a18b95f.png">


After:
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/3505601/179723867-4c5febba-5965-47c5-8e71-879c036eef2a.png">
