### PR TITLE
[APM] Adding tech preview on Alert Tab feature

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -332,14 +332,14 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
         query,
       }),
       label: (
-        <EuiFlexGroup direction="row" gutterSize="xs">
-          <EuiFlexItem>
-            <TechnicalPreviewBadge icon="beaker" />
-          </EuiFlexItem>
+        <EuiFlexGroup gutterSize="xs">
           <EuiFlexItem>
             {i18n.translate('xpack.apm.home.alertsTabLabel', {
               defaultMessage: 'Alerts',
             })}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <TechnicalPreviewBadge icon="beaker" />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -36,6 +36,7 @@ import { ServiceIcons } from '../../../shared/service_icons';
 import { ApmMainTemplate } from '../apm_main_template';
 import { AnalyzeDataButton } from './analyze_data_button';
 import { getAlertingCapabilities } from '../../../alerting/get_alerting_capabilities';
+import { TechnicalPreviewBadge } from '../../../shared/technical_preview_badge';
 
 type Tab = NonNullable<EuiPageHeaderProps['tabs']>[0] & {
   key:
@@ -330,9 +331,18 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
         path: { serviceName },
         query,
       }),
-      label: i18n.translate('xpack.apm.home.alertsTabLabel', {
-        defaultMessage: 'Alerts',
-      }),
+      label: (
+        <EuiFlexGroup direction="row" gutterSize="xs">
+          <EuiFlexItem>
+            <TechnicalPreviewBadge icon="beaker" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {i18n.translate('xpack.apm.home.alertsTabLabel', {
+              defaultMessage: 'Alerts',
+            })}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
       hidden: !(isAlertingAvailable && canReadAlerts),
     },
   ];


### PR DESCRIPTION

<img width="1527" alt="Screenshot 2022-07-19 at 14 34 08" src="https://user-images.githubusercontent.com/3369346/179751238-14892c00-d95c-4704-86bd-33ceabb5f892.png">
<img width="1527" alt="Screenshot 2022-07-19 at 14 33 57" src="https://user-images.githubusercontent.com/3369346/179751256-35347f5b-d617-4a28-a550-6be9ffdbbca0.png">

Follows the same design as span links tech preview - https://github.com/elastic/kibana/pull/132280 