### PR TITLE
[Fleet] truncate tag label so that action button remains visible

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -7,6 +7,7 @@
 
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { difference } from 'lodash';
+import styled from 'styled-components';
 import type { EuiSelectableOption } from '@elastic/eui';
 import {
   EuiButtonEmpty,
@@ -25,6 +26,13 @@ import { useUpdateTags } from '../hooks';
 import { sanitizeTag } from '../utils';
 
 import { TagOptions } from './tag_options';
+
+const TruncatedEuiHighlight = styled(EuiHighlight)`
+  width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 interface Props {
   agentId?: string;
@@ -95,11 +103,12 @@ export const TagsAddRemove: React.FC<Props> = ({
   const renderOption = (option: EuiSelectableOption<any>, search: string) => {
     return (
       <EuiFlexGroup
+        gutterSize={'s'}
         onMouseEnter={() => setIsTagHovered({ ...isTagHovered, [option.label]: true })}
         onMouseLeave={() => setIsTagHovered({ ...isTagHovered, [option.label]: false })}
       >
         <EuiFlexItem>
-          <EuiHighlight
+          <TruncatedEuiHighlight
             search={search}
             onClick={() => {
               const tagsToAdd = option.checked === 'on' ? [] : [option.label];
@@ -108,7 +117,7 @@ export const TagsAddRemove: React.FC<Props> = ({
             }}
           >
             {option.label}
-          </EuiHighlight>
+          </TruncatedEuiHighlight>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <TagOptions


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/136258

Added css to truncate tag name, so that the hover button remains visible for long tag names.

To test:
- enroll agent, go to agent list in Fleet, add a long tag name `ABCDEFGHIJKLMNOPQRST`
- go to Actions, `Add / remove tags`
- verify that hover button is visible to rename/delete tag

<img width="467" alt="image" src="https://user-images.githubusercontent.com/90178898/179774428-92ef5249-9369-4a11-a88b-57a76cacfcdb.png">

