### PR TITLE
[kbn-performance-testing-dataset-extractor] update json structure, filter out static resources on ci

### DIFF
--- a/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+++ b/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
@@ -24,7 +24,8 @@ for i in "${scalabilityJourneys[@]}"; do
         --buildId "${BUILD_ID}" \
         --es-url "${ES_SERVER_URL}" \
         --es-username "${USER_FROM_VAULT}" \
-        --es-password "${PASS_FROM_VAULT}"
+        --es-password "${PASS_FROM_VAULT}" \
+        --without-static-resources
 done
 
 echo "--- Upload Kibana build, plugins and scalability traces to the public bucket"

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
@@ -22,9 +22,13 @@ interface Labels {
   maxUsersCount: string;
 }
 
+export interface Headers {
+  readonly [key: string]: string[];
+}
+
 interface Request {
   method: string;
-  headers: string;
+  headers: Headers;
   body?: { original: string };
 }
 

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
@@ -48,6 +48,7 @@ export interface Document {
   character: string;
   quote: string;
   service: { version: string };
+  parent?: { id: string };
   processor: string;
   trace: { id: string };
   '@timestamp': string;

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -55,10 +55,10 @@ const parsePayload = (payload: string, traceId: string, log: ToolingLog): string
   return body;
 };
 
-const parseHeaders = (headers: Headers) => {
+const combineHeaderFieldValues = (headers: Headers) => {
   return Object.assign(
     {},
-    ...Object.keys(headers).map((key) => ({ [key]: headers[key].join('') }))
+    ...Object.keys(headers).map((key) => ({ [key]: headers[key].join(', ') }))
   );
 };
 
@@ -86,7 +86,7 @@ const getTraceItems = (
         environment: hit.environment,
         request: {
           path: hit.url.path,
-          headers: parseHeaders(hit.http.request.headers),
+          headers: combineHeaderFieldValues(hit.http.request.headers),
           method: hit.http.request.method,
           body: payload ? JSON.stringify(parsePayload(payload, hit.trace.id, log)) : undefined,
           statusCode: hit.http.response.status_code,

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -12,7 +12,7 @@ import { existsSync } from 'fs';
 import path from 'path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
-import { initClient, Document } from './es_client';
+import { initClient, Document, Headers } from './es_client';
 
 const DATE_FORMAT = `YYYY-MM-DD'T'HH:mm:ss.SSS'Z'`;
 const STATIC_RESOURCES_PATTERN = /\.(css|ico|js|json|jpeg|jpg|gif|png|otf|ttf|woff|woff2)$/;
@@ -55,6 +55,13 @@ const parsePayload = (payload: string, traceId: string, log: ToolingLog): string
   return body;
 };
 
+const parseHeaders = (headers: Headers) => {
+  return Object.assign(
+    {},
+    ...Object.keys(headers).map((key) => ({ [key]: headers[key].join('') }))
+  );
+};
+
 const calculateTransactionTimeRage = (hit: SearchHit<Document>) => {
   const trSource = hit._source as Document;
   const startTime = trSource['@timestamp'];
@@ -75,15 +82,16 @@ const getTraceItems = (
       return {
         processor: hit.processor,
         traceId: hit.trace.id,
-        timestamp: hit['@timestamp'],
+        date: hit['@timestamp'],
         environment: hit.environment,
         request: {
-          url: { path: hit.url.path },
-          headers: hit.http.request.headers,
+          path: hit.url.path,
+          headers: parseHeaders(hit.http.request.headers),
           method: hit.http.request.method,
           body: payload ? parsePayload(payload, hit.trace.id, log) : undefined,
+          statusCode: hit.http.response.status_code,
+          timestamp: new Date(hit['@timestamp']).getTime(),
         },
-        response: { statusCode: hit.http.response.status_code },
         transaction: {
           id: hit.transaction.id,
           name: hit.transaction.name,
@@ -93,7 +101,7 @@ const getTraceItems = (
     });
 
   return withoutStaticResources
-    ? data.filter((item) => !STATIC_RESOURCES_PATTERN.test(item.request.url.path))
+    ? data.filter((item) => !STATIC_RESOURCES_PATTERN.test(item.request.path))
     : data;
 };
 
@@ -137,14 +145,14 @@ export const extractor = async ({ param, client, log }: CLIParams) => {
     journeyName,
     kibanaVersion,
     scalabilitySetup,
-    traceItems: getTraceItems(hits, withoutStaticResources, log),
+    requests: getTraceItems(hits, withoutStaticResources, log),
   };
 
   const outputDir = path.resolve('target/scalability_traces');
   const fileName = `${output.journeyName.replace(/ /g, '')}-${buildId}.json`;
   const filePath = path.resolve(outputDir, fileName);
 
-  log.info(`Found ${output.traceItems.length} transactions, output file: ${filePath}`);
+  log.info(`Found ${output.requests.length} transactions, output file: ${filePath}`);
   if (!existsSync(outputDir)) {
     await fs.mkdir(outputDir, { recursive: true });
   }

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -32,7 +32,7 @@ interface CLIParams {
   log: ToolingLog;
 }
 
-interface Stage {
+interface InjectionStep {
   action: string;
   minUsersCount?: number;
   maxUsersCount: number;
@@ -40,8 +40,8 @@ interface Stage {
 }
 
 export interface ScalabilitySetup {
-  warmup: { stages: Stage[] };
-  test: { stages: Stage[] };
+  warmup: InjectionStep[];
+  test: InjectionStep[];
   maxDuration: string;
 }
 

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -88,7 +88,7 @@ const getTraceItems = (
           path: hit.url.path,
           headers: parseHeaders(hit.http.request.headers),
           method: hit.http.request.method,
-          body: payload ? parsePayload(payload, hit.trace.id, log) : undefined,
+          body: payload ? JSON.stringify(parsePayload(payload, hit.trace.id, log)) : undefined,
           statusCode: hit.http.response.status_code,
           timestamp: new Date(hit['@timestamp']).getTime(),
         },

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -81,8 +81,8 @@ const getTraceItems = (
       const payload = hit.http.request?.body?.original;
       return {
         processor: hit.processor,
+        parentId: hit?.parent?.id,
         traceId: hit.trace.id,
-        date: hit['@timestamp'],
         environment: hit.environment,
         request: {
           path: hit.url.path,
@@ -90,7 +90,7 @@ const getTraceItems = (
           method: hit.http.request.method,
           body: payload ? JSON.stringify(parsePayload(payload, hit.trace.id, log)) : undefined,
           statusCode: hit.http.response.status_code,
-          timestamp: new Date(hit['@timestamp']).getTime(),
+          timestamp: hit['@timestamp'],
         },
         transaction: {
           id: hit.transaction.id,

--- a/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/extractor.ts
@@ -80,17 +80,17 @@ const getTraceItems = (
     .map((hit) => {
       const payload = hit.http.request?.body?.original;
       return {
-        processor: hit.processor,
-        parentId: hit?.parent?.id,
         traceId: hit.trace.id,
+        parentId: hit?.parent?.id,
+        processor: hit.processor,
         environment: hit.environment,
         request: {
+          timestamp: hit['@timestamp'],
+          method: hit.http.request.method,
           path: hit.url.path,
           headers: combineHeaderFieldValues(hit.http.request.headers),
-          method: hit.http.request.method,
           body: payload ? JSON.stringify(parsePayload(payload, hit.trace.id, log)) : undefined,
           statusCode: hit.http.response.status_code,
-          timestamp: hit['@timestamp'],
         },
         transaction: {
           id: hit.transaction.id,

--- a/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -279,7 +279,7 @@ export const schema = Joi.object()
 
     /**
      * Optional settings to enable scalability testing for single user performance journey.
-     * If defined, 'scalabilitySetup' must include 'warmup' and 'test' stages,
+     * If defined, 'scalabilitySetup' must include 'warmup' and 'test' stage array,
      * 'maxDuration', e.g. '10m' to limit execution time to 10 minutes.
      * Each stage must include 'action', 'duration' and 'maxUsersCount'.
      * In addition, 'rampConcurrentUsers' requires 'minUsersCount' to ramp users from
@@ -287,41 +287,37 @@ export const schema = Joi.object()
      */
     scalabilitySetup: Joi.object()
       .keys({
-        warmup: Joi.object()
-          .keys({
-            stages: Joi.array().items(
-              Joi.object().keys({
-                action: Joi.string()
-                  .valid('constantConcurrentUsers', 'rampConcurrentUsers')
-                  .required(),
-                duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
-                minUsersCount: Joi.number().when('action', {
-                  is: 'rampConcurrentUsers',
-                  then: Joi.number().required().less(Joi.ref('maxUsersCount')),
-                  otherwise: Joi.forbidden(),
-                }),
-                maxUsersCount: Joi.number().required().greater(0),
-              })
-            ),
-          })
+        warmup: Joi.array()
+          .items(
+            Joi.object().keys({
+              action: Joi.string()
+                .valid('constantConcurrentUsers', 'rampConcurrentUsers')
+                .required(),
+              duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
+              minUsersCount: Joi.number().when('action', {
+                is: 'rampConcurrentUsers',
+                then: Joi.number().required().less(Joi.ref('maxUsersCount')),
+                otherwise: Joi.forbidden(),
+              }),
+              maxUsersCount: Joi.number().required().greater(0),
+            })
+          )
           .required(),
-        test: Joi.object()
-          .keys({
-            stages: Joi.array().items(
-              Joi.object().keys({
-                action: Joi.string()
-                  .valid('constantConcurrentUsers', 'rampConcurrentUsers')
-                  .required(),
-                duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
-                minUsersCount: Joi.number().when('action', {
-                  is: 'rampConcurrentUsers',
-                  then: Joi.number().required().less(Joi.ref('maxUsersCount')),
-                  otherwise: Joi.forbidden(),
-                }),
-                maxUsersCount: Joi.number().required().greater(0),
-              })
-            ),
-          })
+        test: Joi.array()
+          .items(
+            Joi.object().keys({
+              action: Joi.string()
+                .valid('constantConcurrentUsers', 'rampConcurrentUsers')
+                .required(),
+              duration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
+              minUsersCount: Joi.number().when('action', {
+                is: 'rampConcurrentUsers',
+                then: Joi.number().required().less(Joi.ref('maxUsersCount')),
+                otherwise: Joi.forbidden(),
+              }),
+              maxUsersCount: Joi.number().required().greater(0),
+            })
+          )
           .required(),
         maxDuration: Joi.string().pattern(SCALABILITY_DURATION_PATTERN).required(),
       })

--- a/x-pack/test/performance/journeys/login/config.ts
+++ b/x-pack/test/performance/journeys/login/config.ts
@@ -15,30 +15,26 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const config = {
     testFiles,
     scalabilitySetup: {
-      warmup: {
-        stages: [
-          {
-            action: 'constantConcurrentUsers',
-            maxUsersCount: 10,
-            duration: '30s',
-          },
-          {
-            action: 'rampConcurrentUsers',
-            minUsersCount: 10,
-            maxUsersCount: 50,
-            duration: '2m',
-          },
-        ],
-      },
-      test: {
-        stages: [
-          {
-            action: 'constantConcurrentUsers',
-            maxUsersCount: 50,
-            duration: '5m',
-          },
-        ],
-      },
+      warmup: [
+        {
+          action: 'constantConcurrentUsers',
+          maxUsersCount: 10,
+          duration: '30s',
+        },
+        {
+          action: 'rampConcurrentUsers',
+          minUsersCount: 10,
+          maxUsersCount: 50,
+          duration: '2m',
+        },
+      ],
+      test: [
+        {
+          action: 'constantConcurrentUsers',
+          maxUsersCount: 50,
+          duration: '5m',
+        },
+      ],
       maxDuration: '10m',
     },
     ...performanceConfig.getAll(),

--- a/x-pack/test/performance/journeys/promotion_tracking_dashboard/config.ts
+++ b/x-pack/test/performance/journeys/promotion_tracking_dashboard/config.ts
@@ -16,30 +16,26 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles,
     ...performanceConfig.getAll(),
     scalabilitySetup: {
-      warmup: {
-        stages: [
-          {
-            action: 'constantConcurrentUsers',
-            maxUsersCount: 10,
-            duration: '30s',
-          },
-          {
-            action: 'rampConcurrentUsers',
-            minUsersCount: 10,
-            maxUsersCount: 50,
-            duration: '2m',
-          },
-        ],
-      },
-      test: {
-        stages: [
-          {
-            action: 'constantConcurrentUsers',
-            maxUsersCount: 50,
-            duration: '5m',
-          },
-        ],
-      },
+      warmup: [
+        {
+          action: 'constantConcurrentUsers',
+          maxUsersCount: 10,
+          duration: '30s',
+        },
+        {
+          action: 'rampConcurrentUsers',
+          minUsersCount: 10,
+          maxUsersCount: 50,
+          duration: '2m',
+        },
+      ],
+      test: [
+        {
+          action: 'constantConcurrentUsers',
+          maxUsersCount: 50,
+          duration: '5m',
+        },
+      ],
       maxDuration: '10m',
     },
   };


### PR DESCRIPTION
## Summary

This PR makes few changes to simplify output json structure, as we will [read it directly](https://github.com/elastic/kibana-load-testing/pull/272) in Kibana-load-testing project. Gatling will be using data under `request` key to build API calls:

```
{
  "journeyName": "login",
  "kibanaVersion": "8.4.0-SNAPSHOT",
  "scalabilitySetup": {
    "warmup": [
      {
        "action": "constantConcurrentUsers",
        "maxUsersCount": 10,
        "duration": "30s"
      },
      {
        "action": "rampConcurrentUsers",
        "minUsersCount": 10,
        "maxUsersCount": 50,
        "duration": "2m"
      }
    ],
    "test": [
      {
        "action": "constantConcurrentUsers",
        "maxUsersCount": 50,
        "duration": "5m"
      }
    ],
    "maxDuration": "10m"
  },
  "requests": [
    {
      "processor": {
        "name": "transaction",
        "event": "transaction"
      },
      "parentId": "4d50d5bd60e099f1",
      "traceId": "d8d427414477e2a3a7375ba820034d6f",
      "request": {
        "path": "/internal/security/login",
        "headers": {
          "Origin": "http://localhost:5620",
          "Sec-Ch-Ua": "",
          "Accept": "*/*",
          "Kbn-Version": "8.4.0-SNAPSHOT",
          "Sec-Ch-Ua-Platform": "",
          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/98.0.4695.0 Safari/537.36",
          "Referer": "http://localhost:5620/login?next=%2F",
          "Connection": "keep-alive",
          "Sec-Fetch-Dest": "empty",
          "Sec-Fetch-Site": "same-origin",
          "X-Kbn-Context": "%7B%22name%22%3A%22security_login%22%2C%22url%22%3A%22%2Flogin%22%7D",
          "Host": "localhost:5620",
          "Accept-Encoding": "gzip, deflate, br",
          "Pragma": "no-cache",
          "Traceparent": "00-d8d427414477e2a3a7375ba820034d6f-4d50d5bd60e099f1-01",
          "Sec-Fetch-Mode": "cors",
          "Cache-Control": "no-cache",
          "Content-Length": "153",
          "Sec-Ch-Ua-Mobile": "?0",
          "Content-Type": "application/json"
        },
        "method": "POST",
        "body": "{\"providerType\":\"basic\",\"providerName\":\"basic\",\"currentURL\":\"http://localhost:5620/login?next=%2F\",\"params\":{\"username\":\"elastic\",\"password\":\"changeme\"}}",
        "statusCode": 200,
        "timestamp": "2022-07-12T16:34:43.886Z"
      },
      "transaction": {
        "id": "baab48da112ecd05",
        "name": "POST /internal/security/login",
        "type": "request"
      }
    }
  ]
}
```

This diff with previous output is available [here](https://www.diffchecker.com/Ryr5F4LR)