### PR TITLE
[Fleet] wrapping long tags on agent details page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.tsx
@@ -8,8 +8,15 @@
 import { EuiToolTip } from '@elastic/eui';
 import { take } from 'lodash';
 import React from 'react';
+import styled from 'styled-components';
 
 import { truncateTag, MAX_TAG_DISPLAY_LENGTH } from '../utils';
+
+const Wrapped = styled.div`
+  .wrappedText {
+    white-space: pre-wrap;
+  }
+`;
 
 interface Props {
   tags: string[];
@@ -22,13 +29,16 @@ export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
   return (
     <>
       {tags.length > MAX_TAGS_TO_DISPLAY ? (
-        <>
-          <EuiToolTip content={<span data-test-subj="agentTagsTooltip">{tags.join(', ')}</span>}>
+        <Wrapped>
+          <EuiToolTip
+            anchorClassName={'wrappedText'}
+            content={<span data-test-subj="agentTagsTooltip">{tags.join(', ')}</span>}
+          >
             <span data-test-subj="agentTags">
               {take(tags, 3).map(truncateTag).join(', ')} + {tags.length - MAX_TAGS_TO_DISPLAY} more
             </span>
           </EuiToolTip>
-        </>
+        </Wrapped>
       ) : (
         <span data-test-subj="agentTags">
           {tags.map((tag, index) => (


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/136366

Added wrap around tags on agent details page.

<img width="767" alt="image" src="https://user-images.githubusercontent.com/90178898/179791395-bc37150c-b0f4-434c-a5e5-e431b5b15b8c.png">


