### PR TITLE
[Fleet] Use checkmark icon in download sources table to indicate default entry

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_table/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_table/index.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiCheckbox } from '@elastic/eui';
+import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -75,13 +75,8 @@ export const DownloadSourceTable: React.FunctionComponent<DownloadSourceTablePro
         }),
       },
       {
-        render: (downloadSource: DownloadSource) => (
-          <EuiCheckbox
-            id={`checkbox_${downloadSource.id}`}
-            checked={downloadSource.is_default}
-            onChange={(e) => undefined}
-          />
-        ),
+        render: (downloadSource: DownloadSource) =>
+          downloadSource.is_default ? <EuiIcon type="check" /> : null,
         width: '200px',
         name: i18n.translate('xpack.fleet.settings.downloadSourcesTable.defaultColumnTitle', {
           defaultMessage: 'Default',


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136504

Replace non-clickable checkbox with checkmark icon in download source table to indicate which is default

![Screenshot 2022-07-19 at 14 20 54](https://user-images.githubusercontent.com/16084106/179797804-12167f67-7237-47a7-a46b-36d269f06ab4.png)


### Checklist

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))

