### PR TITLE
[Enterprise Search] Remove last updated stat card from Index Detail: Overview in Content app

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
@@ -54,7 +54,7 @@ export const GenerateApiKeyPanel: React.FC = () => {
       )}
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiPanel>
+          <EuiPanel hasBorder>
             <EuiFlexGroup direction="column">
               <EuiFlexItem>
                 <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -51,9 +51,15 @@ export const SearchIndexOverview: React.FC = () => {
           }
         />
       )}
-      {isApi && <GenerateApiKeyPanel />}
+      {isApi && (
+        <>
+          <EuiSpacer />
+          <GenerateApiKeyPanel />
+        </>
+      )}
       {isCrawler && (
         <>
+          <EuiSpacer />
           <CrawlRequestsPanel />
           <CrawlDetailsFlyout />
         </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/total_stats.tsx
@@ -13,8 +13,6 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiStat, EuiStatProps } from '@ela
 
 import { i18n } from '@kbn/i18n';
 
-import { CustomFormattedTimestamp } from '../../../shared/custom_formatted_timestamp/custom_formatted_timestamp';
-
 import { OverviewLogic } from './overview.logic';
 
 interface TotalStatsProps {
@@ -26,9 +24,6 @@ interface TotalStatsProps {
 export const TotalStats: React.FC<TotalStatsProps> = ({ ingestionType, additionalItems = [] }) => {
   const { indexData, isSuccess } = useValues(OverviewLogic);
   const documentCount = indexData?.total.docs.count ?? 0;
-  const lastUpdated = (
-    <CustomFormattedTimestamp timestamp={Date.now() - 1000 * 60 * 12 /* TODO: Implement this */} />
-  );
   const isLoading = !isSuccess;
   const stats: EuiStatProps[] = [
     {
@@ -50,16 +45,6 @@ export const TotalStats: React.FC<TotalStatsProps> = ({ ingestionType, additiona
       ),
       isLoading,
       title: documentCount,
-    },
-    {
-      description: i18n.translate(
-        'xpack.enterpriseSearch.content.searchIndex.totalStats.lastUpdatedCardLabel',
-        {
-          defaultMessage: 'Last updated',
-        }
-      ),
-      isLoading,
-      title: lastUpdated,
     },
     ...additionalItems,
   ];


### PR DESCRIPTION
## Summary

According to latest design direction

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/2479295/179815346-bda9291e-8d78-465f-bf86-92a51b0ea26e.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/2479295/179814755-9d0a3249-b307-4206-bb19-9e5021eef93f.png">


### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

