### PR TITLE
[Enterprise Search] Set Elastic crawler default schedule to 24 hours

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.test.ts
@@ -32,8 +32,8 @@ describe('AutomaticCrawlSchedulerLogic', () => {
 
     expect(AutomaticCrawlSchedulerLogic.values).toEqual({
       crawlAutomatically: false,
-      crawlFrequency: 7,
-      crawlUnit: CrawlUnits.days,
+      crawlFrequency: 24,
+      crawlUnit: CrawlUnits.hours,
       isSubmitting: false,
     });
   });
@@ -51,8 +51,8 @@ describe('AutomaticCrawlSchedulerLogic', () => {
 
         expect(AutomaticCrawlSchedulerLogic.values).toMatchObject({
           crawlAutomatically: false,
-          crawlFrequency: 7,
-          crawlUnit: CrawlUnits.days,
+          crawlFrequency: 24,
+          crawlUnit: CrawlUnits.hours,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.ts
@@ -22,8 +22,8 @@ export interface AutomaticCrawlSchedulerLogicValues {
 }
 
 const DEFAULT_VALUES: Pick<AutomaticCrawlSchedulerLogicValues, 'crawlFrequency' | 'crawlUnit'> = {
-  crawlFrequency: 7,
-  crawlUnit: CrawlUnits.days,
+  crawlFrequency: 24,
+  crawlUnit: CrawlUnits.hours,
 };
 
 export interface AutomaticCrawlSchedulerLogicActions {


### PR DESCRIPTION
## Summary

Requested by @serenachou 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios