### PR TITLE
[Index Management] Fix edit component template without fleet datastream

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/steps/step_review.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/steps/step_review.tsx
@@ -69,7 +69,7 @@ export const StepReview: React.FunctionComponent<Props> = React.memo(
     } = serializedComponentTemplate;
 
     const isFleetDatastreamsVisible =
-      dataStreams?.length && componentTemplate._meta?.managed_by === MANAGED_BY_FLEET;
+      Boolean(dataStreams?.length) && componentTemplate._meta?.managed_by === MANAGED_BY_FLEET;
 
     const SummaryTab = () => (
       <div data-test-subj="summaryTab">
@@ -125,7 +125,7 @@ export const StepReview: React.FunctionComponent<Props> = React.memo(
               </EuiDescriptionListDescription>
             </EuiDescriptionList>
           </EuiFlexItem>
-          {isFleetDatastreamsVisible && (
+          {isFleetDatastreamsVisible && dataStreams && (
             <EuiFlexItem>
               {/* Datastream mappings */}
               <FormattedMessage


### PR DESCRIPTION
## Summary

Fix a bug introduced in https://github.com/elastic/kibana/pull/135845  where we show a 0 in the middle of the UI if there is no Fleet datastream 

#### Before

<img width="1233" alt="Screen Shot 2022-07-19 at 4 58 50 PM" src="https://user-images.githubusercontent.com/1336873/179847750-a5c47d63-23bb-42a1-8aca-b50b6899d54f.png">

#### After

<img width="1228" alt="Screen Shot 2022-07-19 at 4 59 52 PM" src="https://user-images.githubusercontent.com/1336873/179847748-2b02a803-640d-4372-8227-053a2ea87614.png">