### PR TITLE
[Files] Do not index `bid`

### DIFF
--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -37,7 +37,7 @@ export const mappings: MappingTypeMapping = {
   dynamic: false,
   properties: {
     data: { type: 'binary' }, // Binary fields are automatically marked as not searchable by ES
-    bid: { type: 'keyword', index: true },
+    bid: { type: 'keyword', index: false },
     last: { type: 'boolean', index: false },
   } as Record<keyof FileChunkDocument, MappingProperty>, // Ensure that our ES types and TS types stay somewhat in sync
 } as const;


### PR DESCRIPTION
## Summary

We do not need to index the `keyword` type field `bid` because we can perform queries against non-indexed (doc only) fields: https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html#doc-value-only-fields

This could save a lot of space while preserving the current functionality and implementation.