### PR TITLE
[Files] Added metrics endpoint and functionality

### DIFF
--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -7,7 +7,7 @@
 
 import * as qs from 'query-string';
 import { PLUGIN_ID } from './constants';
-import { FileJSON } from './types';
+import type { FileJSON, FilesMetrics } from './types';
 
 const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
@@ -40,6 +40,7 @@ export const FILE_KIND_API_ROUTES_CLIENT = {
 
 export const FILES_API_ROUTES = {
   find: `${FILES_API_BASE_PATH}/find`,
+  metrics: `${FILES_API_BASE_PATH}/metrics`,
 };
 
 export interface HttpApiInterfaceEntryDefinition<
@@ -153,4 +154,11 @@ export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<
     status?: string[];
   },
   { files: FileJSON[] }
+>;
+
+export type FilesMetricsHttpEndpoint = HttpApiInterfaceEntryDefinition<
+  unknown,
+  unknown,
+  unknown,
+  FilesMetrics
 >;

--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -16,5 +16,5 @@ export type {
   FileKind,
   BlobStorageSettings,
   FileJSON,
-  FilesDiagnostics,
+  FilesMetrics,
 } from './types';

--- a/x-pack/plugins/files/common/index.ts
+++ b/x-pack/plugins/files/common/index.ts
@@ -16,4 +16,5 @@ export type {
   FileKind,
   BlobStorageSettings,
   FileJSON,
+  FilesDiagnostics,
 } from './types';

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -241,7 +241,7 @@ export interface FileKind {
   };
 }
 
-export interface FilesDiagnostics {
+export interface FilesMetrics {
   [ES_FIXED_SIZE_INDEX_BLOB_STORE]: {
     /**
      * The total size in bytes that can be used in this storage medium

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -240,3 +240,20 @@ export interface FileKind {
     };
   };
 }
+
+export interface FilesDiagnostics {
+  [ES_FIXED_SIZE_INDEX_BLOB_STORE]: {
+    /**
+     * The total size in bytes that can be used in this storage medium
+     */
+    capacity: number;
+    /**
+     * Bytes currently used
+     */
+    used: number;
+    /**
+     * Bytes currently available
+     */
+    available: number;
+  };
+}

--- a/x-pack/plugins/files/common/types.ts
+++ b/x-pack/plugins/files/common/types.ts
@@ -242,18 +242,22 @@ export interface FileKind {
 }
 
 export interface FilesMetrics {
-  [ES_FIXED_SIZE_INDEX_BLOB_STORE]: {
-    /**
-     * The total size in bytes that can be used in this storage medium
-     */
-    capacity: number;
-    /**
-     * Bytes currently used
-     */
-    used: number;
-    /**
-     * Bytes currently available
-     */
-    available: number;
+  storage: {
+    [ES_FIXED_SIZE_INDEX_BLOB_STORE]: {
+      /**
+       * The total size in bytes that can be used in this storage medium
+       */
+      capacity: number;
+      /**
+       * Bytes currently used
+       */
+      used: number;
+      /**
+       * Bytes currently available
+       */
+      available: number;
+    };
   };
+  countByStatus: Record<FileStatus, number>;
+  countByExtension: Record<string, number>;
 }

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -184,6 +184,7 @@ export class ContentStream extends Duplex {
     this.logger.debug(`Clearing existing chunks for ${bid}`);
     await this.client.deleteByQuery({
       index: this.index,
+      ignore_unavailable: true,
       query: {
         bool: {
           must: { match: { bid } },

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -38,9 +38,14 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     );
   }
 
-  // TODO: We should use a MutEx here to ensure that the initial creation request of this
-  // index only happens once. Otherwise we can hit an edge case where if two files are being
-  // uploaded in the same instant one of the requests to upload can fail.
+  /**
+   * @note
+   * There is a known issue where calling this function simultaneously can result
+   * in a race condition where one of the calls will fail because the index is already
+   * being created.
+   *
+   * This is only an issue for the very first time the index is being created.
+   */
   private async createIndexIfNotExists(): Promise<void> {
     const index = this.index;
     if (await this.esClient.indices.exists({ index })) {

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -23,6 +23,8 @@ import { mappings } from './mappings';
  */
 export const BLOB_STORAGE_SYSTEM_INDEX_NAME = '.kibana_blob_storage';
 
+export const MAX_BLOB_STORE_SIZE_BYTES = 50 * 1024 * 1024; // 50GiB
+
 export class ElasticsearchBlobStorage implements BlobStorage {
   constructor(
     private readonly esClient: ElasticsearchClient,

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -38,6 +38,9 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     );
   }
 
+  // TODO: We should use a MutEx here to ensure that the initial creation request of this
+  // index only happens once. Otherwise we can hit an edge case where if two files are being
+  // uploaded in the same instant one of the requests to upload can fail.
   private async createIndexIfNotExists(): Promise<void> {
     const index = this.index;
     if (await this.esClient.indices.exists({ index })) {
@@ -62,7 +65,6 @@ export class ElasticsearchBlobStorage implements BlobStorage {
     } catch (e) {
       if (e instanceof errors.ResponseError && e.statusCode === 400) {
         this.logger.warn('Unable to create blob storage index, it may have been created already.');
-        return;
       }
       throw e;
     }

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/index.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { ElasticsearchBlobStorage } from './es';
+export { ElasticsearchBlobStorage, MAX_BLOB_STORE_SIZE_BYTES } from './es';

--- a/x-pack/plugins/files/server/blob_storage_service/adapters/index.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { ElasticsearchBlobStorage } from './es';
+export { ElasticsearchBlobStorage, MAX_BLOB_STORE_SIZE_BYTES } from './es';

--- a/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/blob_storage_service.ts
@@ -6,9 +6,9 @@
  */
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
-import { BlobStorageSettings } from '../../common';
+import { BlobStorageSettings, ES_FIXED_SIZE_INDEX_BLOB_STORE } from '../../common';
 import { BlobStorage } from './types';
-import { ElasticsearchBlobStorage } from './adapters';
+import { ElasticsearchBlobStorage, MAX_BLOB_STORE_SIZE_BYTES } from './adapters';
 
 interface ElasticsearchBlobStorageSettings {
   index?: string;
@@ -29,5 +29,13 @@ export class BlobStorageService {
 
   public createBlobStorage(args?: BlobStorageSettings): BlobStorage {
     return this.createESBlobStorage({ ...args?.esFixedSizeIndex });
+  }
+
+  public getStaticBlobStorageSettings() {
+    return {
+      [ES_FIXED_SIZE_INDEX_BLOB_STORE]: {
+        capacity: MAX_BLOB_STORE_SIZE_BYTES,
+      },
+    };
   }
 }

--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { File, FileJSON } from '../../common';
-import { FileShareServiceStart } from '../file_share_service/types';
-import {
+import type { File, FileJSON, FilesMetrics } from '../../common';
+import type { FileShareServiceStart } from '../file_share_service/types';
+import type {
   CreateFileArgs,
   UpdateFileArgs,
   DeleteFileArgs,
@@ -61,4 +61,11 @@ export interface FileServiceStart {
    * Update an instance of a share object
    */
   updateShareObject: FileShareServiceStart['update'];
+
+  /**
+   * Get the current usage metrics for all storage media.
+   *
+   * Returns diagnostics or `undefined` if metrics could not be retrieved.
+   */
+  getUsageMetrics(): Promise<FilesMetrics>;
 }

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -80,6 +80,9 @@ export class FileServiceFactory {
       async list<M>(args: ListFilesArgs) {
         return internalFileService.list(args) as Promise<Array<File<M>>>;
       },
+      async getUsageMetrics() {
+        return internalFileService.getUsageMetrics();
+      },
       getShareObject: internalFileShareService.get.bind(internalFileShareService),
       updateShareObject: internalFileShareService.update.bind(internalFileShareService),
     };

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -28,6 +28,7 @@ import {
   FileJSON,
   FilesMetrics,
   ES_FIXED_SIZE_INDEX_BLOB_STORE,
+  FileStatus,
 } from '../../common';
 import { File, toJSON } from '../file';
 import { FileKindsRegistry } from '../file_kinds_registry';
@@ -232,12 +233,14 @@ export class InternalFileService {
     let pit: undefined | SavedObjectsOpenPointInTimeResponse;
     try {
       pit = await this.soClient.openPointInTimeForType(this.savedObjectType);
+      const deleted: FileStatus = 'DELETED';
       const { aggregations } = await this.soClient.find<
         FileSavedObjectAttributes,
         { size: AggregationsSumAggregate }
       >({
         type: this.savedObjectType,
         pit,
+        filter: `NOT ${this.savedObjectType}.attributes.Status: ${deleted}`,
         aggs: {
           size: {
             sum: {

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -36,7 +36,7 @@ export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind
       statusCode: 500,
       body: {
         message:
-          'Something went wrong while update file attributes. Check server logs for more details.',
+          'Something went wrong while deleting the file. Check server logs for more details.',
       },
     });
   }

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -11,7 +11,7 @@ import type { FilesRouter } from './types';
 import { FindFilesHttpEndpoint, FILES_API_ROUTES } from '../../common/api_routes';
 import type { FilesRequestHandler } from './types';
 
-export const method = 'post' as const;
+const method = 'post' as const;
 
 const string64 = schema.string({ maxLength: 64 });
 const string256 = schema.string({ maxLength: 256 });
@@ -71,7 +71,7 @@ const handler: FilesRequestHandler<unknown, Query, Body> = async ({ files }, req
 // Alternatively, we can remove the access controls on the "file kind" endpoints
 // or remove them entirely.
 export function register(router: FilesRouter) {
-  router.post(
+  router[method](
     {
       path: FILES_API_ROUTES.find,
       validate: {

--- a/x-pack/plugins/files/server/routes/index.ts
+++ b/x-pack/plugins/files/server/routes/index.ts
@@ -8,9 +8,11 @@
 import { FilesRouter } from './types';
 import { registerFileKindRoutes } from './file_kind';
 import * as find from './find';
+import * as metrics from './metrics';
 
 export function registerRoutes(router: FilesRouter) {
   registerFileKindRoutes(router);
 
   find.register(router);
+  metrics.register(router);
 }

--- a/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
+++ b/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
@@ -130,10 +130,14 @@ describe('File HTTP API', () => {
       {
         const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
         expect(metrics).toEqual({
-          esFixedSizeIndex: {
-            capacity: esMaxCapacity,
-            available: esMaxCapacity,
-            used: 0,
+          countByExtension: {},
+          countByStatus: {},
+          storage: {
+            esFixedSizeIndex: {
+              capacity: esMaxCapacity,
+              available: esMaxCapacity,
+              used: 0,
+            },
           },
         });
       }
@@ -143,10 +147,18 @@ describe('File HTTP API', () => {
       {
         const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
         expect(metrics).toEqual({
-          esFixedSizeIndex: {
-            capacity: esMaxCapacity,
-            available: esMaxCapacity,
-            used: 0,
+          countByExtension: {
+            png: 3,
+          },
+          countByStatus: {
+            AWAITING_UPLOAD: 3,
+          },
+          storage: {
+            esFixedSizeIndex: {
+              capacity: esMaxCapacity,
+              available: esMaxCapacity,
+              used: 0,
+            },
           },
         });
       }
@@ -165,10 +177,19 @@ describe('File HTTP API', () => {
       {
         const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
         expect(metrics).toEqual({
-          esFixedSizeIndex: {
-            capacity: esMaxCapacity,
-            available: 52428774,
-            used: 26,
+          countByExtension: {
+            png: 3,
+          },
+          countByStatus: {
+            AWAITING_UPLOAD: 1,
+            READY: 2,
+          },
+          storage: {
+            esFixedSizeIndex: {
+              capacity: esMaxCapacity,
+              available: 52428774,
+              used: 26,
+            },
           },
         });
       }

--- a/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
+++ b/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
@@ -13,14 +13,15 @@ describe('File HTTP API', () => {
   let root: TestEnvironmentUtils['root'];
   let request: TestEnvironmentUtils['request'];
   let createFile: TestEnvironmentUtils['createFile'];
+  let fileKind: string;
 
   beforeAll(async () => {
     testHarness = await setupIntegrationEnvironment();
-    ({ request, createFile, root } = testHarness);
+    ({ request, createFile, root, fileKind } = testHarness);
   });
 
   afterAll(async () => {
-    testHarness.cleanupAfterAll();
+    await testHarness.cleanupAfterAll();
   });
 
   describe('find', () => {
@@ -117,6 +118,60 @@ describe('File HTTP API', () => {
         })
         .expect(200);
       expect(result.body.files).toHaveLength(1);
+    });
+  });
+
+  describe('metrics', () => {
+    const esMaxCapacity = 50 * 1024 * 1024;
+    afterEach(async () => {
+      await testHarness.cleanupAfterEach();
+    });
+    test('returns usage metrics', async () => {
+      {
+        const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
+        expect(metrics).toEqual({
+          esFixedSizeIndex: {
+            capacity: esMaxCapacity,
+            available: esMaxCapacity,
+            used: 0,
+          },
+        });
+      }
+
+      const [file1, file2] = await Promise.all([createFile(), createFile(), createFile()]);
+
+      {
+        const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
+        expect(metrics).toEqual({
+          esFixedSizeIndex: {
+            capacity: esMaxCapacity,
+            available: esMaxCapacity,
+            used: 0,
+          },
+        });
+      }
+
+      await request
+        .put(root, `/api/files/files/${fileKind}/${file1.id}/blob`)
+        .set('Content-Type', 'application/octet-stream')
+        .send('what have you')
+        .expect(200);
+      await request
+        .put(root, `/api/files/files/${fileKind}/${file2.id}/blob`)
+        .set('Content-Type', 'application/octet-stream')
+        .send('what have you')
+        .expect(200);
+
+      {
+        const { body: metrics } = await request.get(root, '/api/files/files/metrics').expect(200);
+        expect(metrics).toEqual({
+          esFixedSizeIndex: {
+            capacity: esMaxCapacity,
+            available: 52428774,
+            used: 26,
+          },
+        });
+      }
     });
   });
 });

--- a/x-pack/plugins/files/server/routes/metrics.ts
+++ b/x-pack/plugins/files/server/routes/metrics.ts
@@ -25,7 +25,7 @@ export function register(router: FilesRouter) {
   router[method](
     {
       path: FILES_API_ROUTES.metrics,
-      validate: false,
+      validate: {},
     },
     handler
   );

--- a/x-pack/plugins/files/server/routes/metrics.ts
+++ b/x-pack/plugins/files/server/routes/metrics.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { FilesRouter } from './types';
+
+import { FilesMetricsHttpEndpoint, FILES_API_ROUTES } from '../../common/api_routes';
+import type { FilesRequestHandler } from './types';
+
+const method = 'get' as const;
+
+type Response = FilesMetricsHttpEndpoint['output'];
+
+const handler: FilesRequestHandler = async ({ files }, req, res) => {
+  const { fileService } = await files;
+  const body: Response = await fileService.asCurrentUser().getUsageMetrics();
+  return res.ok({
+    body,
+  });
+};
+
+export function register(router: FilesRouter) {
+  router[method](
+    {
+      path: FILES_API_ROUTES.metrics,
+      validate: false,
+    },
+    handler
+  );
+}

--- a/x-pack/plugins/files/server/routes/tests/setup_integration_environment.ts
+++ b/x-pack/plugins/files/server/routes/tests/setup_integration_environment.ts
@@ -26,6 +26,9 @@ export async function setupIntegrationEnvironment() {
     },
   };
 
+  /**
+   * Functionality to create files easily
+   */
   let disposables: Array<() => Promise<void>> = [];
   const createFile = async (
     fileAttrs: Partial<{
@@ -55,6 +58,9 @@ export async function setupIntegrationEnvironment() {
     return result.body.file;
   };
 
+  /**
+   * Register a test file type
+   */
   fileKindsRegistry.register({
     id: fileKind,
     blobStoreSettings: {
@@ -79,6 +85,9 @@ export async function setupIntegrationEnvironment() {
     },
   });
 
+  /**
+   * Clean up methods
+   */
   const cleanupAfterEach = async () => {
     await Promise.all(disposables.map((dispose) => dispose()));
     disposables = [];
@@ -90,6 +99,9 @@ export async function setupIntegrationEnvironment() {
     await manageES.stop();
   };
 
+  /**
+   * Start the servers and set them up
+   */
   const manageES = await startES();
 
   const root = createRootWithCorePlugins(testConfig, { oss: false });
@@ -98,6 +110,9 @@ export async function setupIntegrationEnvironment() {
   const coreStart = await root.start();
   const esClient = coreStart.elasticsearch.client.asInternalUser;
 
+  /**
+   * Wait for endpoints to be available
+   */
   await pRetry(() => request.get(root, '/api/licensing/info').expect(200), { retries: 5 });
 
   return {


### PR DESCRIPTION
## Summary

Added the "metrics" endpoint and functionality.

The intention is to use this endpoint for File Management. The primary use case is for users to get an idea of how much space they have used and how much space they have left.

The implementation use a Saved Objects aggregation to sum together the `size` values of all files saved objects. This means that for files where the size is not known, now size will be added.

One alternative, for the ES storage adapter, is that we use the [`_stats` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html) to get the full size of the index. This might be more accurate, since it is not vulnerable to missing values, but this will not work for files that are not stored in Elasticsearch.