### PR TITLE
[Fleet] fix for tags auto scroll

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -139,6 +139,8 @@ export const TagsAddRemove: React.FC<Props> = ({
         anchorPosition="leftUp"
       >
         <EuiSelectable
+          // workaround for auto-scroll to first element after clearing search
+          onFocus={() => {}}
           aria-label={i18n.translate('xpack.fleet.tagsAddRemove.selectableTagsLabel', {
             defaultMessage: 'Add / remove tags',
           })}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136371

Added fix for auto scroll happening after search field is cleared in tags selectable list.

To verify:
- Enroll agent in Fleet
- Click on action `Add / remove tags`
- Create multiple tags so that the scrollbar becomes visible
- Create a new tag/search for a tag name to see results highlighted
- Clear search field, scroll down to bottom
- verify that scroll position stays in place, does not jump to the top like before.


https://user-images.githubusercontent.com/90178898/180011841-d0845bd9-04f8-4107-9698-03bbe0df3228.mov

