### PR TITLE
[Discover] Remove document explorer header column edit data view field functionality

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -62,7 +62,7 @@ function DiscoverDocumentsComponent({
   setExpandedDoc: (doc?: DataTableRecord) => void;
   state: AppState;
   stateContainer: GetStateReturn;
-  onFieldEdited: () => void;
+  onFieldEdited?: () => void;
 }) {
   const { capabilities, indexPatterns, uiSettings } = useDiscoverServices();
   const useNewFieldsApi = useMemo(() => !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE), [uiSettings]);

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -364,7 +364,7 @@ export function DiscoverLayout({
                       setExpandedDoc={setExpandedDoc}
                       state={state}
                       stateContainer={stateContainer}
-                      onFieldEdited={onFieldEdited}
+                      onFieldEdited={isPlainRecord ? onFieldEdited : undefined}
                     />
                   ) : (
                     <FieldStatisticsTableMemoized

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -364,7 +364,7 @@ export function DiscoverLayout({
                       setExpandedDoc={setExpandedDoc}
                       state={state}
                       stateContainer={stateContainer}
-                      onFieldEdited={isPlainRecord ? onFieldEdited : undefined}
+                      onFieldEdited={!isPlainRecord ? onFieldEdited : undefined}
                     />
                   ) : (
                     <FieldStatisticsTableMemoized


### PR DESCRIPTION
## Summary

Removing field editing in the columns header when using SQL

<img width="194" alt="Bildschirmfoto 2022-07-20 um 16 43 10" src="https://user-images.githubusercontent.com/463851/180022982-0f2ef27f-aabc-4ebe-8cec-70a1a6c76df6.png">