### PR TITLE
[Telemetry] Validate ES and SO clients status before fetching telemetry

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -79,6 +79,12 @@ export class FetcherTask {
     if (this.isSending) {
       return;
     }
+
+    // Skip this run if Kibana is not in a healthy state to fetch telemetry.
+    if (!(await this.telemetryCollectionManager?.shouldGetTelemetry())) {
+      return;
+    }
+
     let telemetryConfig: TelemetryConfig | undefined;
 
     try {

--- a/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.ts
@@ -73,6 +73,15 @@ export function registerTelemetryOptInStatsRoutes(
         const newOptInStatus = req.body.enabled;
         const unencrypted = req.body.unencrypted;
 
+        if (!(await telemetryCollectionManager.shouldGetTelemetry())) {
+          // We probably won't reach here because there is a license check in the auth phase of the HTTP requests.
+          // But let's keep it here should that changes at any point.
+          return res.customError({
+            statusCode: 503,
+            body: `Can't fetch telemetry at the moment because some services are down. Check the /status page for more details.`,
+          });
+        }
+
         const statsGetterConfig: StatsGetterConfig = {
           unencrypted,
         };

--- a/src/plugins/telemetry/server/routes/telemetry_usage_stats.test.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_usage_stats.test.ts
@@ -38,6 +38,7 @@ describe('registerTelemetryUsageStatsRoutes', () => {
   const mockCoreSetup = coreMock.createSetup();
   const mockStats = [{ clusterUuid: 'text', stats: 'enc_str' }];
   telemetryCollectionManager.getStats.mockResolvedValue(mockStats);
+  telemetryCollectionManager.shouldGetTelemetry.mockResolvedValue(true);
   const getSecurity = jest.fn();
 
   let mockRouter: IRouter;
@@ -117,6 +118,21 @@ describe('registerTelemetryUsageStatsRoutes', () => {
         unencrypted: true,
       });
       expect(mockResponse.forbidden).toBeCalled();
+    });
+
+    it('returns 503 when Kibana is not healthy enough to generate the Telemetry report', async () => {
+      telemetryCollectionManager.shouldGetTelemetry.mockResolvedValueOnce(false);
+
+      registerTelemetryUsageStatsRoutes(mockRouter, telemetryCollectionManager, true, () => void 0);
+      const { mockResponse } = await runRequest(mockRouter, {
+        refreshCache: false,
+        unencrypted: true,
+      });
+      expect(mockResponse.customError).toBeCalledTimes(1);
+      expect(mockResponse.customError).toBeCalledWith({
+        statusCode: 503,
+        body: `Can't fetch telemetry at the moment because some services are down. Check the /status page for more details.`,
+      });
     });
 
     it('returns 200 when the user has enough permissions to request unencrypted telemetry', async () => {

--- a/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
@@ -35,6 +35,15 @@ export function registerTelemetryUsageStatsRoutes(
     async (context, req, res) => {
       const { unencrypted, refreshCache } = req.body;
 
+      if (!(await telemetryCollectionManager.shouldGetTelemetry())) {
+        // We probably won't reach here because there is a license check in the auth phase of the HTTP requests.
+        // But let's keep it here should that changes at any point.
+        return res.customError({
+          statusCode: 503,
+          body: `Can't fetch telemetry at the moment because some services are down. Check the /status page for more details.`,
+        });
+      }
+
       const security = getSecurity();
       if (security && unencrypted) {
         // Normally we would use `options: { tags: ['access:decryptedTelemetry'] }` in the route definition to check authorization for an

--- a/src/plugins/telemetry_collection_manager/server/mocks.ts
+++ b/src/plugins/telemetry_collection_manager/server/mocks.ts
@@ -24,6 +24,7 @@ function createSetupContract(): Setup {
     getStats: jest.fn(),
     getOptInStats: jest.fn(),
     setCollectionStrategy: jest.fn(),
+    shouldGetTelemetry: jest.fn(),
   };
 
   return setupContract;
@@ -33,6 +34,7 @@ function createStartContract(): Start {
   const startContract: Start = {
     getOptInStats: jest.fn(),
     getStats: jest.fn(),
+    shouldGetTelemetry: jest.fn(),
   };
 
   return startContract;

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -10,17 +10,35 @@ import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@k
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { TelemetryCollectionManagerPlugin } from './plugin';
 
-export interface TelemetryCollectionManagerPluginSetup {
+/**
+ * Public contract coming from the setup method.
+ */
+export interface TelemetryCollectionManagerPluginSetup
+  extends TelemetryCollectionManagerPluginStart {
   setCollectionStrategy: <T extends BasicStatsPayload>(
     collectionConfig: CollectionStrategyConfig<T>
   ) => void;
-  getOptInStats: TelemetryCollectionManagerPlugin['getOptInStats'];
-  getStats: TelemetryCollectionManagerPlugin['getStats'];
 }
 
+/**
+ * Public contract coming from the start method.
+ */
 export interface TelemetryCollectionManagerPluginStart {
+  /**
+   * Fetches the minimum piece of data to report when Opting IN or OUT.
+   */
   getOptInStats: TelemetryCollectionManagerPlugin['getOptInStats'];
+  /**
+   * Fetches the Snapshot telemetry report.
+   */
   getStats: TelemetryCollectionManagerPlugin['getStats'];
+  /**
+   * Is it OK to fetch telemetry?
+   *
+   * It should be called before calling `getStats` or `getOptInStats` to validate that Kibana is in a healthy state
+   * to attempt to fetch the Telemetry report.
+   */
+  shouldGetTelemetry: () => Promise<boolean>;
 }
 
 export interface TelemetryOptInStats {


### PR DESCRIPTION
## Summary

Fetching the Snapshot telemetry report can be very noisy in the logs if ES or the SO services are done. With so many collectors relying on those clients, they suddenly log many connection errors.

This PR checks the status of those services before generating the Snapshot Telemetry report.

Resolves #97788
Resolves #89588

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| If a cluster is in a faulty state, becoming not available due to ES connection issues, we may never report any telemetry about that deployment. | Low | High | The snapshot data will likely be incomplete anyways. And we still have some EBT reporting the status changes. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
