### PR TITLE
[ftr] prevent configs from using --oss flag

### DIFF
--- a/packages/kbn-test/src/functional_tests/lib/kibana_cli_args.ts
+++ b/packages/kbn-test/src/functional_tests/lib/kibana_cli_args.ts
@@ -112,6 +112,10 @@ export function parseRawFlags(rawFlags: string[]) {
     }
   }
 
+  if (cliArgs.has('oss')) {
+    throw new Error(`--oss is not a valid flag to pass in FTR config files`);
+  }
+
   return [...cliArgs.entries()]
     .sort(([a], [b]) => {
       const aDot = a.includes('.');

--- a/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_kibana_server.ts
@@ -78,9 +78,7 @@ export async function runKibanaServer({
   const kbnFlags = parseRawFlags([
     // When installDir is passed, we run from a built version of Kibana which uses different command line
     // arguments. If installDir is not passed, we run from source code.
-    ...(installDir
-      ? [...buildArgs, ...serverArgs.filter((a: string) => a !== '--oss')]
-      : [...sourceArgs, ...serverArgs]),
+    ...(installDir ? [...buildArgs, ...serverArgs] : [...sourceArgs, ...serverArgs]),
 
     // We also allow passing in extra Kibana server options, tack those on here so they always take precedence
     ...(options.extraKbnOpts ?? []),

--- a/test/new_visualize_flow/config.ts
+++ b/test/new_visualize_flow/config.ts
@@ -22,7 +22,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...commonConfig.get('kbnTestServer'),
       serverArgs: [
         ...commonConfig.get('kbnTestServer.serverArgs'),
-        '--oss',
         '--telemetry.optIn=false',
         '--dashboard.allowByValueEmbeddables=true',
       ],


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/136754

Previously, since CI runs the distributable, we would filter out the `--oss` field on CI. This lead to people including `--oss` only for local development but this lead to issues where FTR configs only work on CI because the `--oss` flag disables config from x-pack plugins which are defined in the base/common configs.

This change prevents people from defining the `--oss` flag in general as it isn't really valid for FTR testing at this point.