### PR TITLE
[kbn/pm] remove extra trailing chars

### DIFF
--- a/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -25,16 +25,16 @@ export const command = {
     changes build artifacts will be downloaded from the remote cache.
   `,
   flagsHelp: `
-    --force-install      Use this flag to force bootstrap to install yarn dependencies. By default the',
-                          command will attempt to only run yarn installs when necessary, but if you manually',
-                          delete the node modules directory or have an issue in your node_modules directory',
-                          you might need to force the install manually.',
-    --offline            Run the installation process without consulting online resources. This is useful and',
-                          sometimes necessary for using bootstrap on an airplane for instance. The local caches',
-                          will be used exclusively, including a yarn-registry local mirror which is created and',
-                          maintained by successful online bootstrap executions.',
-    --no-validate        By default bootstrap validates the yarn.lock file to check for a handfull of',
-                          conditions. If you run into issues with this process locally you can disable it by',
+    --force-install      Use this flag to force bootstrap to install yarn dependencies. By default the
+                          command will attempt to only run yarn installs when necessary, but if you manually
+                          delete the node modules directory or have an issue in your node_modules directory
+                          you might need to force the install manually.
+    --offline            Run the installation process without consulting online resources. This is useful and
+                          sometimes necessary for using bootstrap on an airplane for instance. The local caches
+                          will be used exclusively, including a yarn-registry local mirror which is created and
+                          maintained by successful online bootstrap executions.
+    --no-validate        By default bootstrap validates the yarn.lock file to check for a handfull of
+                          conditions. If you run into issues with this process locally you can disable it by
                           passing this flag.
     --no-vscode          By default bootstrap updates the .vscode directory to include commonly useful vscode
                           settings for local development. Disable this process either pass this flag or set

--- a/kbn_pm/src/commands/watch_command.mjs
+++ b/kbn_pm/src/commands/watch_command.mjs
@@ -13,10 +13,10 @@ export const command = {
   name: 'watch',
   description: 'Runs a build in the Bazel built packages and keeps watching them for changes',
   flagsHelp: `
-    --offline            Run the installation process without consulting online resources. This is useful and',
-                          sometimes necessary for using bootstrap on an airplane for instance. The local caches',
-                          will be used exclusively, including a yarn-registry local mirror which is created and',
-                          maintained by successful online bootstrap executions.',
+    --offline            Run the installation process without consulting online resources. This is useful and
+                          sometimes necessary for using bootstrap on an airplane for instance. The local caches
+                          will be used exclusively, including a yarn-registry local mirror which is created and
+                          maintained by successful online bootstrap executions.
   `,
   reportTimings: {
     group: 'scripts/kbn watch',

--- a/kbn_pm/src/lib/help.mjs
+++ b/kbn_pm/src/lib/help.mjs
@@ -44,13 +44,11 @@ export async function getHelp(cmdName = undefined) {
     return ['', ...cmdLines(0, cmd)].join('\n');
   }
 
-  const lines = [
+  return [
     'Usage:',
     '  yarn kbn <command> [...flags]',
     '',
     'Commands:',
     ...COMMANDS.map((cmd) => cmdLines(2, cmd)).flat(),
-  ];
-
-  return lines.join('\n');
+  ].join('\n');
 }


### PR DESCRIPTION
At some point the kbn/pm help text was an array of strings, and some of the characters were left around from that time. This PR removes those characters.