### PR TITLE
[Session View][Bug Fix] Added instance.name field for Cloud details

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
@@ -228,10 +228,12 @@ describe('DetailPanelMetadataTab component', () => {
 
       // expand Cloud Accordion
       renderResult.queryByText('Cloud')?.click();
+      expect(renderResult.queryByText('instance.name')).toBeVisible();
       expect(renderResult.queryByText('provider')).toBeVisible();
       expect(renderResult.queryByText('region')).toBeVisible();
       expect(renderResult.queryByText('account.id')).toBeVisible();
       expect(renderResult.queryByText('project.id')).toBeVisible();
+      expect(renderResult.queryByText(TEST_CLOUD_INSTANCE_NAME)).toBeVisible();
       expect(renderResult.queryByText(TEST_CLOUD_PROVIDER)).toBeVisible();
       expect(renderResult.queryByText(TEST_CLOUD_REGION)).toBeVisible();
       expect(renderResult.queryByText(TEST_CLOUD_ACCOUNT_ID)).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.tsx
@@ -241,6 +241,19 @@ export const DetailPanelMetadataTab = ({
             })}
             listItems={[
               {
+                title: <DetailPanelListItem>instance.name</DetailPanelListItem>,
+                description: (
+                  <DetailPanelCopy
+                    textToCopy={`cloud.provider: "${cloudData.instance.name}"`}
+                    tooltipContent={cloudData.instance.name}
+                  >
+                    <EuiTextColor color="subdued" css={styles.descriptionSemibold}>
+                      {cloudData.instance.name}
+                    </EuiTextColor>
+                  </DetailPanelCopy>
+                ),
+              },
+              {
                 title: <DetailPanelListItem>provider</DetailPanelListItem>,
                 description: (
                   <DetailPanelCopy


### PR DESCRIPTION
## Summary
Fix for https://github.com/elastic/kibana/issues/136667
Added instance.name field for Cloud section on Details panel

<img width="1033" alt="instancename" src="https://user-images.githubusercontent.com/8703149/180095138-09e37a01-0a05-41fe-9304-69c77525d5f4.png">
