### PR TITLE
[Enterprise Search] Add a11y test for Content and Elasticsearch apps

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
@@ -62,7 +62,7 @@ export const ElasticsearchGuide: React.FC = () => {
   return (
     <EnterpriseSearchElasticsearchPageTemplate>
       <SetPageChrome />
-      <EuiFlexGroup alignItems="flexStart">
+      <EuiFlexGroup alignItems="flexStart" data-test-subj="elasticsearchGuide">
         {/* maxWidth is needed to prevent code blocks with long unbreakable strings (Kibana PR Cloud ID) from stretching the column */}
         <EuiFlexItem grow={3} style={{ maxWidth: 800 }}>
           <EuiText>

--- a/x-pack/test/accessibility/apps/enterprise_search.ts
+++ b/x-pack/test/accessibility/apps/enterprise_search.ts
@@ -53,6 +53,34 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    describe('Content', () => {
+      before(async () => {
+        await common.navigateToApp('enterprise_search/content');
+      });
+
+      it('loads a setup guide', async function () {
+        await retry.waitFor(
+          'setup guide visible',
+          async () => await testSubjects.exists('setupGuide')
+        );
+        await a11y.testAppSnapshot();
+      });
+    });
+
+    describe('Elasticsearch', () => {
+      before(async () => {
+        await common.navigateToApp('enterprise_search/elasticsearch');
+      });
+
+      it('loads a setup guide', async function () {
+        await retry.waitFor(
+          'setup guide visible',
+          async () => await testSubjects.exists('elasticsearchGuide')
+        );
+        await a11y.testAppSnapshot();
+      });
+    });
+
     describe('App Search', () => {
       before(async () => {
         await common.navigateToApp('enterprise_search/app_search');


### PR DESCRIPTION
## Summary

We need to expand these at a later point, but I wanted to stub out the two apps we've added to the Enterprise Search plugin recently.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
