### PR TITLE
Navigate to `home` app's FTR helper should handle the Welcome screen

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -265,6 +265,20 @@ export class CommonPageObject extends FtrService {
           await this.testSubjects.find('kibanaChrome');
         }
 
+        // If navigating to the `home` app, and we want to skip the Welcome page, but the chrome is still hidden,
+        // set the relevant localStorage key to skip the Welcome page and throw an error to try to navigate again.
+        if (
+          appName === 'home' &&
+          currentUrl.includes('app/home') &&
+          disableWelcomePrompt &&
+          (await this.isChromeHidden())
+        ) {
+          await this.browser.setLocalStorageItem('home:welcome:show', 'false');
+          const msg = `Failed to skip the Welcome page when navigating the app ${appName}`;
+          this.log.debug(msg);
+          throw new Error(msg);
+        }
+
         currentUrl = (await this.browser.getCurrentUrl()).replace(/\/\/\w+:\w+@/, '//');
 
         const navSuccessful = currentUrl

--- a/test/functional/page_objects/newsfeed_page.ts
+++ b/test/functional/page_objects/newsfeed_page.ts
@@ -17,7 +17,7 @@ export class NewsfeedPageObject extends FtrService {
   private readonly common = this.ctx.getPageObject('common');
 
   async resetPage() {
-    await this.common.navigateToUrl('home', '', { useActualUrl: true });
+    await this.common.navigateToApp('home', { disableWelcomePrompt: true });
   }
 
   async closeNewsfeedPanel() {


### PR DESCRIPTION
## Summary

Resolves #135251.

Flaky test runner (x100): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/905

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
