### PR TITLE
[Actions] Fix bug on case connector schema

### DIFF
--- a/x-pack/plugins/actions/server/sub_action_framework/case.test.ts
+++ b/x-pack/plugins/actions/server/sub_action_framework/case.test.ts
@@ -13,7 +13,7 @@ import { TestCaseConnector } from './mocks';
 import { ActionsConfigurationUtilities } from '../actions_config';
 
 describe('CaseConnector', () => {
-  const pushToServiceParams = { externalId: null, comments: [] };
+  const pushToServiceParams = { incident: { externalId: null }, comments: [] };
   let logger: MockedLogger;
   let services: ReturnType<typeof actionsMock.createServices>;
   let mockedActionsConfig: jest.Mocked<ActionsConfigurationUtilities>;
@@ -57,11 +57,11 @@ describe('CaseConnector', () => {
       const subAction = subActions.get('pushToService');
       expect(
         subAction?.schema?.validate({
-          externalId: 'test',
+          incident: { externalId: 'test' },
           comments: [{ comment: 'comment', commentId: 'comment-id' }],
         })
       ).toEqual({
-        externalId: 'test',
+        incident: { externalId: 'test' },
         comments: [{ comment: 'comment', commentId: 'comment-id' }],
       });
     });
@@ -69,7 +69,7 @@ describe('CaseConnector', () => {
     it('should accept null for externalId', async () => {
       const subActions = service.getSubActions();
       const subAction = subActions.get('pushToService');
-      expect(subAction?.schema?.validate({ externalId: null, comments: [] }));
+      expect(subAction?.schema?.validate({ incident: { externalId: null }, comments: [] }));
     });
 
     it.each([[undefined], [1], [false], [{ test: 'hello' }], [['test']], [{ test: 'hello' }]])(
@@ -84,7 +84,7 @@ describe('CaseConnector', () => {
     it('should accept null for comments', async () => {
       const subActions = service.getSubActions();
       const subAction = subActions.get('pushToService');
-      expect(subAction?.schema?.validate({ externalId: 'test', comments: null }));
+      expect(subAction?.schema?.validate({ incident: { externalId: 'test' }, comments: null }));
     });
 
     it.each([
@@ -98,30 +98,35 @@ describe('CaseConnector', () => {
     ])('should throw if comments %p', async (comments) => {
       const subActions = service.getSubActions();
       const subAction = subActions.get('pushToService');
-      expect(() => subAction?.schema?.validate({ externalId: 'test', comments }));
+      expect(() => subAction?.schema?.validate({ incident: { externalId: 'test' }, comments }));
     });
 
     it('should allow any field in the params', async () => {
       const subActions = service.getSubActions();
       const subAction = subActions.get('pushToService');
+
       expect(
         subAction?.schema?.validate({
-          externalId: 'test',
+          incident: {
+            externalId: 'test',
+            foo: 'foo',
+            bar: 1,
+            baz: [{ test: 'hello' }, 1, 'test', false],
+            isValid: false,
+            val: null,
+          },
           comments: [{ comment: 'comment', commentId: 'comment-id' }],
+        })
+      ).toEqual({
+        incident: {
+          externalId: 'test',
           foo: 'foo',
           bar: 1,
           baz: [{ test: 'hello' }, 1, 'test', false],
           isValid: false,
           val: null,
-        })
-      ).toEqual({
-        externalId: 'test',
+        },
         comments: [{ comment: 'comment', commentId: 'comment-id' }],
-        foo: 'foo',
-        bar: 1,
-        baz: [{ test: 'hello' }, 1, 'test', false],
-        isValid: false,
-        val: null,
       });
     });
   });
@@ -138,7 +143,11 @@ describe('CaseConnector', () => {
     });
 
     it('should update an incident if externalId is not null', async () => {
-      const res = await service.pushToService({ ...pushToServiceParams, externalId: 'test-id' });
+      const res = await service.pushToService({
+        ...pushToServiceParams,
+        incident: { externalId: 'test-id' },
+      });
+
       expect(res).toEqual({
         id: 'update-incident',
         title: 'Test incident',

--- a/x-pack/plugins/actions/server/sub_action_framework/case.ts
+++ b/x-pack/plugins/actions/server/sub_action_framework/case.ts
@@ -44,20 +44,20 @@ export abstract class CaseConnector<Config, Secrets>
     this.registerSubAction({
       name: 'pushToService',
       method: 'pushToService',
-      schema: schema.object(
-        {
-          externalId: schema.nullable(schema.string()),
-          comments: schema.nullable(
-            schema.arrayOf(
-              schema.object({
-                comment: schema.string(),
-                commentId: schema.string(),
-              })
-            )
-          ),
-        },
-        { unknowns: 'allow' }
-      ),
+      schema: schema.object({
+        incident: schema.object(
+          { externalId: schema.nullable(schema.string()) },
+          { unknowns: 'allow' }
+        ),
+        comments: schema.nullable(
+          schema.arrayOf(
+            schema.object({
+              comment: schema.string(),
+              commentId: schema.string(),
+            })
+          )
+        ),
+      }),
     });
   }
 
@@ -82,7 +82,8 @@ export abstract class CaseConnector<Config, Secrets>
   public abstract getIncident({ id }: { id: string }): Promise<ExternalServiceIncidentResponse>;
 
   public async pushToService(params: PushToServiceParams) {
-    const { externalId, comments, ...rest } = params;
+    const { incident, comments } = params;
+    const { externalId, ...rest } = incident;
 
     let res: PushToServiceResponse;
 

--- a/x-pack/plugins/actions/server/sub_action_framework/types.ts
+++ b/x-pack/plugins/actions/server/sub_action_framework/types.ts
@@ -61,9 +61,11 @@ export interface SubAction {
 }
 
 export interface PushToServiceParams {
-  externalId: string | null;
+  incident: {
+    externalId: string | null;
+    [x: string]: unknown;
+  };
   comments: Array<{ commentId: string; comment: string }>;
-  [x: string]: unknown;
 }
 
 export interface ExternalServiceIncidentResponse {


### PR DESCRIPTION
## Summary

All current incident management connectors use the following schema for the `subActionParmas`:

```
{
  incident: { externalIncidentId: string | null } & T
  comments?: Array<{ comment: string; commentId: string }>
}
```

This PR fixes a bug in the schema of the case connector in the sub-action framework. It converts the schema to align with the current schema used by cases and all current incident management connectors. The schema change does not need any migration because no one uses the framework at the moment.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
