### PR TITLE
[7.17][ML] Fix anomaly detection module manifest queries to ignore frozen and cold data tiers

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json
@@ -12,7 +12,8 @@
         { "exists": { "field": "source.address" } },
         { "exists": { "field": "url.original" } },
         { "exists": { "field": "http.response.status_code" } }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_jsbase/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_jsbase/manifest.json
@@ -7,7 +7,8 @@
   "defaultIndexPattern": "apm-*",
   "query": {
     "bool": {
-      "filter": [{ "term": { "agent.name": "js-base" } }]
+      "filter": [{ "term": { "agent.name": "js-base" } }],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_nodejs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_nodejs/manifest.json
@@ -6,7 +6,10 @@
   "logoFile": "logo.json",
   "defaultIndexPattern": "apm-*",
   "query": {
-    "bool": { "filter": [{ "term": { "agent.name": "nodejs" } }] }
+    "bool": {
+      "filter": [{ "term": { "agent.name": "nodejs" } }],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+    }
   },
   "jobs": [
     {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_transaction/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_transaction/manifest.json
@@ -10,7 +10,8 @@
       "filter": [
         { "term": { "processor.event": "transaction" } },
         { "exists": { "field": "transaction.duration" } }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_docker_ecs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_docker_ecs/manifest.json
@@ -13,7 +13,8 @@
       ],
       "must": {
         "exists": { "field": "auditd.data.syscall" }
-      }
+      },
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json
@@ -13,9 +13,10 @@
       "must": {
         "exists": { "field": "auditd.data.syscall" }
       },
-      "must_not": {
-        "exists": { "field": "container.runtime" }
-      }
+      "must_not": [
+        { "exists": { "field": "container.runtime" } },
+        { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+      ]
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/manifest.json
@@ -14,7 +14,8 @@
             "system.filesystem"
           ]
         }
-      }
+      },
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/manifest.json
@@ -12,7 +12,8 @@
         { "exists": { "field": "source.address" } },
         { "exists": { "field": "url.original" } },
         { "exists": { "field": "http.response.status_code" } }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/manifest.json
@@ -13,7 +13,8 @@
             "event.category": "authentication"
           }
         }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json
@@ -40,7 +40,8 @@
             }
           }
         }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json
@@ -13,7 +13,8 @@
             "event.category": "network"
           }
         }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json
@@ -30,7 +30,8 @@
             ]
           }
         }
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json
@@ -9,7 +9,8 @@
     "bool": {
       "filter": [
         {"term": {"agent.type": "auditbeat"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json
@@ -10,7 +10,8 @@
       "filter": [
         {"term": {"event.category": "authentication"}},
         {"term": {"agent.type": "auditbeat"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_cloudtrail/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_cloudtrail/manifest.json
@@ -9,7 +9,8 @@
     "bool": {
       "filter": [
         {"term": {"event.dataset": "aws.cloudtrail"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_packetbeat/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_packetbeat/manifest.json
@@ -9,7 +9,8 @@
     "bool": {
       "filter": [
         {"term": {"agent.type": "packetbeat"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json
@@ -9,7 +9,8 @@
     "bool": {
       "filter": [
         {"term": {"agent.type": "winlogbeat"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json
@@ -10,7 +10,8 @@
       "filter": [
         {"term": {"agent.type": "winlogbeat"}},
         {"term": {"event.category": "authentication"}}
-      ]
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/manifest.json
@@ -7,7 +7,8 @@
   "defaultIndexPattern": "heartbeat-*",
   "query": {
     "bool": {
-      "filter": [{ "term": { "agent.type": "heartbeat" } }]
+      "filter": [{ "term": { "agent.type": "heartbeat" } }],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
     }
   },
   "jobs": [


### PR DESCRIPTION
## Summary

Backports #119635 to 7.17.

The queries defined in the `manifest.json` files of anomaly detection modules are run to determine if the module is match for data in the selected index. These queries run over the full time range of the index so can potentially take a long time to return, particularly if searching over documents which are not in the hot or warm data tiers. This PR adds an extra condition to the manifest queries to ignore data from the `cold` and `frozen` tiers.

```
"must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
```

Note this will help users who created their indices in the later 7.x releases where the `_tier` field existed (queryable `_tier` metadata field was added in 7.13).  It won't help users who created their indices in the early 7.x releases, but it won't hurt them either.

Note for reviewers - this extra condition was added to all modules except for:
- Logs UI modules -manifest contains no query as the jobs cannot be created from the ML data recognizer job wizard
- Metrics UI modules -manifest contains no query as the jobs cannot be created from the ML data recognizer job wizard
- Sample data modules - run against the small Kibana sample data indices and so should not be in the cold / frozen tier