### PR TITLE
[Fleet] Added new API to query all tags with terms aggregation

### DIFF
--- a/x-pack/plugins/fleet/common/constants/routes.ts
+++ b/x-pack/plugins/fleet/common/constants/routes.ts
@@ -123,6 +123,7 @@ export const AGENT_API_ROUTES = {
   UPGRADE_PATTERN: `${API_ROOT}/agents/{agentId}/upgrade`,
   BULK_UPGRADE_PATTERN: `${API_ROOT}/agents/bulk_upgrade`,
   CURRENT_UPGRADES_PATTERN: `${API_ROOT}/agents/current_upgrades`,
+  LIST_TAGS_PATTERN: `${API_ROOT}/agents/tags`,
 };
 
 export const ENROLLMENT_API_KEY_ROUTES = {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1924,6 +1924,25 @@
         }
       }
     },
+    "/agents/tags": {
+      "get": {
+        "summary": "Agent Tags - List",
+        "description": "List all agent tags",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_agent_tags_response"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-agent-tags"
+      }
+    },
     "/agent_policies": {
       "get": {
         "summary": "Agent policies - List",
@@ -4322,6 +4341,18 @@
           }
         ]
       },
+      "get_agent_tags_response": {
+        "title": "Get Agent Tags response",
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "new_agent_policy": {
         "title": "New agent policy",
         "type": "object",
@@ -4942,7 +4973,6 @@
           }
         },
         "required": [
-          "id",
           "is_default",
           "name",
           "host"

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1171,6 +1171,18 @@ paths:
                   type: number
               required:
                 - agents
+  /agents/tags:
+    get:
+      summary: Agent Tags - List
+      description: List all agent tags
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/get_agent_tags_response'
+      operationId: get-agent-tags
   /agent_policies:
     get:
       summary: Agent policies - List
@@ -2714,6 +2726,14 @@ components:
                     - info
                     - warning
                     - error
+    get_agent_tags_response:
+      title: Get Agent Tags response
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: string
     new_agent_policy:
       title: New agent policy
       type: object
@@ -3122,7 +3142,6 @@ components:
         host:
           type: string
       required:
-        - id
         - is_default
         - name
         - host

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/get_agent_tags_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/get_agent_tags_response.yaml
@@ -1,0 +1,7 @@
+title: Get Agent Tags response
+type: object
+properties:
+  items:
+    type: array
+    items:
+      type: string

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -73,6 +73,8 @@ paths:
     $ref: 'paths/agents@bulk_unenroll.yaml'
   '/agents/bulk_update_agent_tags':
     $ref: 'paths/agents@bulk_update_tags.yaml'
+  /agents/tags:
+    $ref: paths/agent_tags.yaml
   #  Agent policies endpoints
   /agent_policies:
     $ref: paths/agent_policies.yaml

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_tags.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_tags.yaml
@@ -1,0 +1,11 @@
+get:
+  summary: Agent Tags - List
+  description: List all agent tags
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/get_agent_tags_response.yaml
+  operationId: get-agent-tags

--- a/x-pack/plugins/fleet/common/services/routes.ts
+++ b/x-pack/plugins/fleet/common/services/routes.ts
@@ -198,6 +198,7 @@ export const agentRouteService = {
   getIncomingDataPath: () => AGENT_API_ROUTES.DATA_PATTERN,
   getCreateActionPath: (agentId: string) =>
     AGENT_API_ROUTES.ACTIONS_PATTERN.replace('{agentId}', agentId),
+  getListTagsPath: () => AGENT_API_ROUTES.LIST_TAGS_PATTERN,
 };
 
 export const outputRoutesService = {

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -24,6 +24,10 @@ export interface GetAgentsResponse extends ListResult<Agent> {
   list?: Agent[];
 }
 
+export interface GetAgentTagsResponse {
+  items: string[];
+}
+
 export interface GetOneAgentRequest {
   params: {
     agentId: string;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -148,7 +148,7 @@ export const TagsAddRemove: React.FC<Props> = ({
           searchProps={{
             'data-test-subj': 'addRemoveTags',
             placeholder: i18n.translate('xpack.fleet.tagsAddRemove.findOrCreatePlaceholder', {
-              defaultMessage: 'Find or create label...',
+              defaultMessage: 'Find or create tag...',
             }),
             onChange: (value: string) => {
               setSearchValue(sanitizeTag(value));

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
@@ -32,6 +32,7 @@ jest.mock('../../../hooks', () => ({
   },
   useFleetStatus: jest.fn().mockReturnValue({}),
   sendGetAgentStatus: jest.fn(),
+  sendGetAgentTags: jest.fn().mockReturnValue({ data: { items: ['tag1', 'tag2'] } }),
   useAuthz: jest.fn().mockReturnValue({ fleet: { all: true } }),
   useStartServices: jest.fn().mockReturnValue({
     notifications: {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -32,6 +32,7 @@ import {
   useKibanaVersion,
   useStartServices,
   useFlyoutContext,
+  sendGetAgentTags,
 } from '../../../hooks';
 import { AgentEnrollmentFlyout, AgentPolicySummaryLine } from '../../../components';
 import { AgentStatusKueryHelper, isAgentUpgradeable } from '../../../services';
@@ -236,7 +237,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         isLoadingVar.current = true;
         try {
           setIsLoading(true);
-          const [agentsRequest, agentsStatusRequest] = await Promise.all([
+          const [agentsResponse, agentsStatusResponse, agentTagsResponse] = await Promise.all([
             sendGetAgents({
               page: pagination.currentPage,
               perPage: pagination.pageSize,
@@ -249,36 +250,41 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             sendGetAgentStatus({
               kuery: kuery && kuery !== '' ? kuery : undefined,
             }),
+            sendGetAgentTags(),
           ]);
           isLoadingVar.current = false;
           // Return if a newer request has been triggered
           if (currentRequestRef.current !== currentRequest) {
             return;
           }
-          if (agentsRequest.error) {
-            throw agentsRequest.error;
+          if (agentsResponse.error) {
+            throw agentsResponse.error;
           }
-          if (!agentsRequest.data) {
+          if (!agentsResponse.data) {
             throw new Error('Invalid GET /agents response');
           }
-          if (agentsStatusRequest.error) {
-            throw agentsStatusRequest.error;
+          if (agentsStatusResponse.error) {
+            throw agentsStatusResponse.error;
           }
-          if (!agentsStatusRequest.data) {
-            throw new Error('Invalid GET /agents-status response');
+          if (!agentsStatusResponse.data) {
+            throw new Error('Invalid GET /agents_status response');
+          }
+          if (agentTagsResponse.error) {
+            throw agentsStatusResponse.error;
+          }
+          if (!agentTagsResponse.data) {
+            throw new Error('Invalid GET /agent/tags response');
           }
 
           setAgentsStatus({
-            healthy: agentsStatusRequest.data.results.online,
-            unhealthy: agentsStatusRequest.data.results.error,
-            offline: agentsStatusRequest.data.results.offline,
-            updating: agentsStatusRequest.data.results.updating,
-            inactive: agentsRequest.data.totalInactive,
+            healthy: agentsStatusResponse.data.results.online,
+            unhealthy: agentsStatusResponse.data.results.error,
+            offline: agentsStatusResponse.data.results.offline,
+            updating: agentsStatusResponse.data.results.updating,
+            inactive: agentsResponse.data.totalInactive,
           });
 
-          const newAllTags = Array.from(
-            new Set(agentsRequest.data.items.flatMap((agent) => agent.tags ?? []))
-          );
+          const newAllTags = agentTagsResponse.data.items;
 
           // We only want to update the list of available tags if
           // - We haven't set any tags yet
@@ -288,9 +294,9 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             setAllTags(newAllTags);
           }
 
-          setAgents(agentsRequest.data.items);
-          setTotalAgents(agentsRequest.data.total);
-          setTotalInactiveAgents(agentsRequest.data.totalInactive);
+          setAgents(agentsResponse.data.items);
+          setTotalAgents(agentsResponse.data.total);
+          setTotalInactiveAgents(agentsResponse.data.totalInactive);
         } catch (error) {
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentList.errorFetchingDataTitle', {

--- a/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/agents.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { PostBulkUpdateAgentTagsRequest, UpdateAgentRequest } from '../../../common';
+import type {
+  GetAgentTagsResponse,
+  PostBulkUpdateAgentTagsRequest,
+  UpdateAgentRequest,
+} from '../../../common';
 
 import { agentRouteService } from '../../services';
 
@@ -90,6 +94,13 @@ export function sendGetAgentStatus(
     path: agentRouteService.getStatusPath(),
     query,
     ...options,
+  });
+}
+
+export function sendGetAgentTags() {
+  return sendRequest<GetAgentTagsResponse>({
+    method: 'get',
+    path: agentRouteService.getListTagsPath(),
   });
 }
 

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -16,6 +16,7 @@ import type {
   PutAgentReassignResponse,
   PostBulkAgentReassignResponse,
   PostBulkUpdateAgentTagsResponse,
+  GetAgentTagsResponse,
 } from '../../../common/types';
 import type {
   GetAgentsRequestSchema,
@@ -180,6 +181,26 @@ export const getAgentsHandler: RequestHandler<
       totalInactive,
       page,
       perPage,
+    };
+    return response.ok({ body });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
+  }
+};
+
+export const getAgentTagsHandler: RequestHandler<undefined, undefined, undefined> = async (
+  context,
+  request,
+  response
+) => {
+  const coreContext = await context.core;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+  try {
+    const tags = await AgentService.getAgentTags(esClient);
+
+    const body: GetAgentTagsResponse = {
+      items: tags,
     };
     return response.ok({ body });
   } catch (error) {

--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -30,6 +30,7 @@ import { PostBulkUpdateAgentTagsRequestSchema } from '../../types/rest_spec/agen
 
 import {
   getAgentsHandler,
+  getAgentTagsHandler,
   getAgentHandler,
   updateAgentHandler,
   deleteAgentHandler,
@@ -105,6 +106,17 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       },
     },
     getAgentsHandler
+  );
+  // List Agent Tags
+  router.get(
+    {
+      path: AGENT_API_ROUTES.LIST_TAGS_PATTERN,
+      validate: {},
+      fleetAuthz: {
+        fleet: { all: true },
+      },
+    },
+    getAgentTagsHandler
   );
 
   // Agent actions

--- a/x-pack/plugins/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.test.ts
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { errors } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
 
 import type { Agent } from '../../types';
 
-import { errorsToResults, getAgentsByKuery, processAgentsInBatches } from './crud';
+import { errorsToResults, getAgentsByKuery, getAgentTags, processAgentsInBatches } from './crud';
 
 jest.mock('../../../common', () => ({
   ...jest.requireActual('../../../common'),
@@ -40,6 +40,41 @@ describe('Agents CRUD test', () => {
       },
     };
   }
+
+  describe('getAgentTags', () => {
+    it('should return tags from aggs', async () => {
+      searchMock.mockResolvedValueOnce({
+        aggregations: {
+          tags: { buckets: [{ key: 'tag1' }, { key: 'tag2' }] },
+        },
+      });
+
+      const result = await getAgentTags(esClientMock);
+
+      expect(result).toEqual(['tag1', 'tag2']);
+    });
+
+    it('should return empty list if no agent tags', async () => {
+      searchMock.mockResolvedValueOnce({
+        aggregations: {
+          tags: {},
+        },
+      });
+
+      const result = await getAgentTags(esClientMock);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty list if no agent index', async () => {
+      searchMock.mockRejectedValueOnce(new errors.ResponseError({ statusCode: 404 } as any));
+
+      const result = await getAgentTags(esClientMock);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getAgentsByKuery', () => {
     it('should return upgradeable on first page', async () => {
       searchMock

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -121,7 +121,7 @@ export async function getAgentTags(esClient: ElasticsearchClient): Promise<strin
       size: 0,
       aggs: {
         tags: {
-          terms: { field: 'tags' },
+          terms: { field: 'tags', size: SO_SEARCH_LIMIT },
         },
       },
     });

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -114,6 +114,27 @@ export async function closePointInTime(esClient: ElasticsearchClient, pitId: str
   }
 }
 
+export async function getAgentTags(esClient: ElasticsearchClient): Promise<string[]> {
+  try {
+    const result = await esClient.search<{}, { tags: { buckets: Array<{ key: string }> } }>({
+      index: AGENTS_INDEX,
+      size: 0,
+      aggs: {
+        tags: {
+          terms: { field: 'tags' },
+        },
+      },
+    });
+    const buckets = result.aggregations?.tags.buckets;
+    return buckets?.map((bucket) => bucket.key) ?? [];
+  } catch (err) {
+    if (isESClientError(err) && err.meta.statusCode === 404) {
+      return [];
+    }
+    throw err;
+  }
+}
+
 export async function getAgentsByKuery(
   esClient: ElasticsearchClient,
   options: ListWithKuery & {

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -101,5 +101,10 @@ export default function ({ getService }: FtrProviderContext) {
         'agent3',
       ]);
     });
+
+    it('should return tags of all agents', async () => {
+      const { body: apiResponse } = await supertest.get('/api/fleet/agents/tags').expect(200);
+      expect(apiResponse.items).to.eql(['existingTag', 'tag1']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135888

Added new API to query all tags with terms aggregation

To verify:
- enroll at least 21 agents
- add a new tag on an agent on the second page in agent list view
- go back to first page, verify that the Tags filter shows the tag from second page too


https://user-images.githubusercontent.com/90178898/180207421-50b60aa2-5739-45d1-9781-49f204b2effd.mov



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
