### PR TITLE
[Enterprise Search] Check heartbeat for connector health

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.test.ts
@@ -57,7 +57,7 @@ describe('AddConnectorPackageLogic', () => {
         AddConnectorPackageApiLogic.actions.apiSuccess({ indexName: 'success' } as any);
         await nextTick();
         expect(flashSuccessToast).toHaveBeenCalledWith('Index created successfully', {
-          text: 'You can use a connector build a search experience for your new Elasticsearch index.',
+          text: 'You can use a connector to build a search experience for your new Elasticsearch index.',
         });
         jest.advanceTimersByTime(1001);
         await nextTick();

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.test.ts
@@ -56,9 +56,7 @@ describe('AddConnectorPackageLogic', () => {
         jest.useFakeTimers();
         AddConnectorPackageApiLogic.actions.apiSuccess({ indexName: 'success' } as any);
         await nextTick();
-        expect(flashSuccessToast).toHaveBeenCalledWith('Index created successfully', {
-          text: 'You can use a connector to build a search experience for your new Elasticsearch index.',
-        });
+        expect(flashSuccessToast).toHaveBeenCalled();
         jest.advanceTimersByTime(1001);
         await nextTick();
         expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/add_connector_package_logic.ts
@@ -56,7 +56,7 @@ export const AddConnectorPackageLogic = kea<MakeLogicType<AddConnectorValues, Ad
               'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.successToast.description',
               {
                 defaultMessage:
-                  'You can use a connector build a search experience for your new Elasticsearch index.',
+                  'You can use a connector to build a search experience for your new Elasticsearch index.',
               }
             ),
           }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_logic.test.ts
@@ -9,6 +9,8 @@ import { LogicMounter, mockFlashMessageHelpers } from '../../../__mocks__/kea_lo
 
 import { indices } from '../../__mocks__/search_indices.mock';
 
+import moment from 'moment';
+
 import { nextTick } from '@kbn/test-jest-helpers';
 
 import { HttpError, Status } from '../../../../../common/types/api';
@@ -286,6 +288,57 @@ describe('IndicesLogic', () => {
           },
           hasNoIndices: false,
           indices: viewSearchIndices,
+          isLoading: false,
+          meta: DEFAULT_META,
+          status: Status.SUCCESS,
+        });
+      });
+      it('updates ingestionStatus for connector to error when last_seen is more than half an hour ago', () => {
+        expect(IndicesLogic.values).toEqual(DEFAULT_VALUES);
+        const date = moment();
+        const lastSeen = date.subtract(31, 'minutes').format();
+        IndicesLogic.actions.apiSuccess({
+          indices: [
+            {
+              ...indices[1],
+              connector: {
+                ...indices[1].connector!,
+                last_seen: lastSeen,
+                status: ConnectorStatus.CONNECTED,
+              },
+            },
+          ],
+          isInitialRequest: true,
+          meta: DEFAULT_META,
+        });
+
+        expect(IndicesLogic.values).toEqual({
+          data: {
+            indices: [
+              {
+                ...indices[1],
+                connector: {
+                  ...indices[1].connector!,
+                  last_seen: lastSeen,
+                  status: ConnectorStatus.CONNECTED,
+                },
+              },
+            ],
+            isInitialRequest: true,
+            meta: DEFAULT_META,
+          },
+          hasNoIndices: false,
+          indices: [
+            {
+              ...connectorIndex,
+              connector: {
+                ...connectorIndex.connector,
+                last_seen: lastSeen,
+                status: ConnectorStatus.CONNECTED,
+              },
+              ingestionStatus: IngestionStatus.ERROR,
+            },
+          ],
           isLoading: false,
           meta: DEFAULT_META,
           status: Status.SUCCESS,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_logic.ts
@@ -6,6 +6,7 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
+import moment from 'moment';
 
 import { Meta } from '../../../../../common/types';
 import { HttpError, Status } from '../../../../../common/types/api';
@@ -53,6 +54,12 @@ function getIngestionStatus(
     return IngestionStatus.CONNECTED;
   }
   if (ingestionMethod === IngestionMethod.CONNECTOR) {
+    if (
+      index.connector?.last_seen &&
+      moment(index.connector.last_seen).isBefore(moment().subtract(30, 'minutes'))
+    ) {
+      return IngestionStatus.ERROR;
+    }
     if (index.connector?.last_sync_status === SyncStatus.ERROR) {
       return IngestionStatus.SYNC_ERROR;
     }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
@@ -159,7 +159,7 @@ const columns: Array<EuiBasicTableColumn<ViewSearchIndex>> = [
       }
       if (ingestionStatus === IngestionStatus.ERROR) {
         return getBadge(
-          'error',
+          'danger',
           i18n.translate(
             'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.connectorError.label',
             { defaultMessage: 'Connector failure' }
@@ -168,7 +168,7 @@ const columns: Array<EuiBasicTableColumn<ViewSearchIndex>> = [
       }
       if (ingestionStatus === IngestionStatus.SYNC_ERROR) {
         return getBadge(
-          'error',
+          'danger',
           i18n.translate(
             'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.syncError.label',
             { defaultMessage: 'Sync failure' }


### PR DESCRIPTION
## Summary

This adds a heartbeat check to the indices page in Enterprise Search Content.