### PR TITLE
Check Apm Label for 'false' string

### DIFF
--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -209,6 +209,9 @@ export class ApmConfiguration {
       return {};
     }
 
+    const isPr =
+      !!process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false';
+
     return {
       globalLabels: {
         branch: process.env.GIT_BRANCH || '',
@@ -216,8 +219,8 @@ export class ApmConfiguration {
         ciBuildNumber: process.env.BUILDKITE_BUILD_NUMBER || '',
         ciBuildId: process.env.BUILDKITE_BUILD_ID || '',
         ciBuildJobId: process.env.BUILDKITE_JOB_ID || '',
-        isPr: process.env.BUILDKITE_PULL_REQUEST ? true : false,
-        prId: process.env.BUILDKITE_PULL_REQUEST || '',
+        isPr,
+        prId: isPr ? process.env.BUILDKITE_PULL_REQUEST : '',
       },
     };
   }


### PR DESCRIPTION
We have seen some labels that are inconsistent with each other. For example there are documents [labels.isPr: true and labels.prId: false](https://kibana-ops-e2e-perf.kb.us-central1.gcp.cloud.es.io:9243/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(),filters:!(),index:apm_static_index_pattern_id,interval:auto,query:(language:kuery,query:'labels.isPr:%20true%20and%20labels.prId:%20false'),sort:!(!('@timestamp',desc)))) which doesn't make much sense. This PR aims to resolve these issues.