### PR TITLE
[maps] Automatically display the maps legend

### DIFF
--- a/x-pack/plugins/maps/public/actions/layer_actions.ts
+++ b/x-pack/plugins/maps/public/actions/layer_actions.ts
@@ -24,7 +24,7 @@ import {
 } from '../selectors/map_selectors';
 import { FLYOUT_STATE } from '../reducers/ui';
 import { cancelRequest, getInspectorAdapters } from '../reducers/non_serializable_instances';
-import { hideTOCDetails, setDrawMode, updateFlyout } from './ui_actions';
+import { hideTOCDetails, setDrawMode, showTOCDetails, updateFlyout } from './ui_actions';
 import {
   ADD_LAYER,
   ADD_WAITING_FOR_MAP_READY_LAYER,
@@ -74,7 +74,6 @@ import { notifyLicensedFeatureUsage } from '../licensed_features';
 import { IESAggField } from '../classes/fields/agg';
 import { IField } from '../classes/fields/field';
 import type { IESSource } from '../classes/sources/es_source';
-import { showTOCDetails } from './ui_actions';
 import { getDrawMode, getOpenTOCDetails } from '../selectors/ui_selectors';
 
 export function trackCurrentLayerState(layerId: string) {

--- a/x-pack/plugins/maps/public/actions/layer_actions.ts
+++ b/x-pack/plugins/maps/public/actions/layer_actions.ts
@@ -24,7 +24,7 @@ import {
 } from '../selectors/map_selectors';
 import { FLYOUT_STATE } from '../reducers/ui';
 import { cancelRequest, getInspectorAdapters } from '../reducers/non_serializable_instances';
-import { setDrawMode, updateFlyout } from './ui_actions';
+import { hideTOCDetails, setDrawMode, updateFlyout } from './ui_actions';
 import {
   ADD_LAYER,
   ADD_WAITING_FOR_MAP_READY_LAYER,
@@ -75,7 +75,7 @@ import { IESAggField } from '../classes/fields/agg';
 import { IField } from '../classes/fields/field';
 import type { IESSource } from '../classes/sources/es_source';
 import { showTOCDetails } from './ui_actions';
-import { getDrawMode } from '../selectors/ui_selectors';
+import { getDrawMode, getOpenTOCDetails } from '../selectors/ui_selectors';
 
 export function trackCurrentLayerState(layerId: string) {
   return {
@@ -618,6 +618,10 @@ function removeLayerFromLayerList(layerId: string) {
     const editState = getEditState(getState());
     if (layerId === editState?.layerId) {
       dispatch(setDrawMode(DRAW_MODE.NONE));
+    }
+    const openTOCDetails = getOpenTOCDetails(getState());
+    if (openTOCDetails.includes(layerId)) {
+      dispatch(hideTOCDetails(layerId));
     }
   };
 }

--- a/x-pack/plugins/maps/public/actions/ui_actions.ts
+++ b/x-pack/plugins/maps/public/actions/ui_actions.ts
@@ -8,7 +8,7 @@
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { MapStoreState } from '../reducers/store';
-import { getFlyoutDisplay } from '../selectors/ui_selectors';
+import { getFlyoutDisplay, getOpenTOCDetails } from '../selectors/ui_selectors';
 import { FLYOUT_STATE } from '../reducers/ui';
 import { setQuery, trackMapSettings } from './map_actions';
 import { setSelectedLayer } from './layer_actions';
@@ -82,9 +82,20 @@ export function setOpenTOCDetails(layerIds?: string[]) {
 }
 
 export function showTOCDetails(layerId: string) {
-  return {
-    type: SHOW_TOC_DETAILS,
-    layerId,
+  return (
+    dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
+    getState: () => MapStoreState
+  ) => {
+    const openTOCDetails = getOpenTOCDetails(getState());
+    if (openTOCDetails.includes(layerId)) {
+      // details already open, nothing to do
+      return;
+    }
+
+    dispatch({
+      type: SHOW_TOC_DETAILS,
+      layerId,
+    });
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/136626

automatically expanded legend when user adds any "by value" field in a layer. This is the case when:

Users add a document/top hits/tracks/point-to-point/EMS boundaries layer and edit the layer styles: Fill color, Border color, Label color, Label border, Label size, Symbol size
Users add a cluster layer: clusters are automatically coloured "by value"
Users add a cloropeth layer: regions are automatically coloured "by value"
Users add a heatmap layer

<img width="500" alt="Screen Shot 2022-07-21 at 1 03 19 PM" src="https://user-images.githubusercontent.com/373691/180296366-f24a862a-5a51-4925-acba-dc3b42c14945.png">
