### PR TITLE
[Security Solution][Endpoint][Response Actions] Hide console done button

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/components/console_page_overlay.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/components/console_page_overlay.tsx
@@ -26,10 +26,11 @@ export interface ConsolePageOverlayProps {
   pageTitle?: ReactNode;
   body?: ReactNode;
   actions?: ReactNode[];
+  showCloseButton?: boolean;
 }
 
 export const ConsolePageOverlay = memo<ConsolePageOverlayProps>(
-  ({ console, onHide, isHidden, body, actions, pageTitle = '' }) => {
+  ({ console, onHide, isHidden, body, actions, pageTitle = '', showCloseButton }) => {
     const getTestId = useTestIdGenerator('consolePageOverlay');
     const handleCloseOverlayOnClick: MouseEventHandler = useCallback(
       (ev) => {
@@ -55,27 +56,31 @@ export const ConsolePageOverlay = memo<ConsolePageOverlayProps>(
             size="xs"
             iconType="arrowLeft"
             onClick={handleCloseOverlayOnClick}
+            data-test-subj={getTestId('header-back-link')}
           >
             {BACK_LABEL}
           </EuiButtonEmpty>
         ),
-        actions: [
-          <EuiButton
-            fill
-            onClick={handleCloseOverlayOnClick}
-            minWidth="auto"
-            data-test-subj={getTestId('doneButton')}
-          >
-            <FormattedMessage
-              id="xpack.securitySolution.consolePageOverlay.doneButtonLabel"
-              defaultMessage="Done"
-            />
-          </EuiButton>,
+        // hide the close button for now
+        actions: showCloseButton
+          ? [
+              <EuiButton
+                fill
+                onClick={handleCloseOverlayOnClick}
+                minWidth="auto"
+                data-test-subj={getTestId('doneButton')}
+              >
+                <FormattedMessage
+                  id="xpack.securitySolution.consolePageOverlay.doneButtonLabel"
+                  defaultMessage="Done"
+                />
+              </EuiButton>,
 
-          ...(actions ?? []),
-        ],
+              ...(actions ?? []),
+            ]
+          : [...(actions ?? [])],
       };
-    }, [actions, getTestId, handleCloseOverlayOnClick, isHidden, pageTitle, body]);
+    }, [actions, body, getTestId, handleCloseOverlayOnClick, isHidden, pageTitle, showCloseButton]);
 
     return (
       <PageOverlay

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/components/console_page_overlay.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/components/console_page_overlay.tsx
@@ -30,7 +30,7 @@ export interface ConsolePageOverlayProps {
 }
 
 export const ConsolePageOverlay = memo<ConsolePageOverlayProps>(
-  ({ console, onHide, isHidden, body, actions, pageTitle = '', showCloseButton }) => {
+  ({ console, onHide, isHidden, body, actions, pageTitle = '', showCloseButton = false }) => {
     const getTestId = useTestIdGenerator('consolePageOverlay');
     const handleCloseOverlayOnClick: MouseEventHandler = useCallback(
       (ev) => {

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.test.tsx
@@ -249,15 +249,21 @@ describe('When using ConsoleManager', () => {
       expect(renderResult.getByTestId('testRunningConsole')).toBeTruthy();
     });
 
-    it('should show `Done` button', async () => {
+    it('should not show `Done` button', async () => {
       await render();
 
-      expect(renderResult.getByTestId('consolePageOverlay-doneButton')).toBeTruthy();
+      expect(renderResult.queryByTestId('consolePageOverlay-doneButton')).toBeFalsy();
+    });
+
+    it('should show `Back` link', async () => {
+      await render();
+
+      expect(renderResult.getByTestId('consolePageOverlay-header-back-link')).toBeTruthy();
     });
 
     it('should hide the console page overlay', async () => {
       await render();
-      userEvent.click(renderResult.getByTestId('consolePageOverlay-doneButton'));
+      userEvent.click(renderResult.getByTestId('consolePageOverlay-header-back-link'));
 
       expect(renderResult.queryByTestId('consolePageOverlay')).toBeNull();
     });

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/console_manager.tsx
@@ -19,7 +19,11 @@ import { Console } from '../../console';
 interface ManagedConsole
   extends Pick<
     ConsoleRegistrationInterface,
-    'consoleProps' | 'PageTitleComponent' | 'PageBodyComponent' | 'ActionComponents'
+    | 'consoleProps'
+    | 'PageTitleComponent'
+    | 'PageBodyComponent'
+    | 'ActionComponents'
+    | 'showCloseButton'
   > {
   client: RegisteredConsoleClient;
   console: JSX.Element; // actual console component
@@ -291,6 +295,7 @@ export const ConsoleManager = memo<ConsoleManagerProps>(({ storage = {}, childre
               return <ActionComponent meta={visibleConsoleMeta} />;
             })
           }
+          showCloseButton={visibleConsole.showCloseButton}
         />
       )}
     </ConsoleManagerContext.Provider>

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/mocks.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/mocks.tsx
@@ -74,7 +74,7 @@ export const getConsoleManagerMockRenderResultQueriesAndActions = (
     },
 
     hideOpenedConsole: async () => {
-      userEvent.click(renderResult.getByTestId('consolePageOverlay-doneButton'));
+      userEvent.click(renderResult.getByTestId('consolePageOverlay-header-back-link'));
 
       await waitFor(() => {
         expect(renderResult.queryByTestId('consolePageOverlay')).toBeNull();

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/types.ts
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_manager/types.ts
@@ -35,6 +35,9 @@ export interface ConsoleRegistrationInterface<TMeta extends object = any> {
    * the Responder page overlay is shown.
    */
   ActionComponents?: Array<ComponentType<ManagedConsoleExtensionComponentProps<TMeta>>>;
+
+  /** controls the visibility of the console close button */
+  showCloseButton?: boolean;
 }
 
 /**

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
@@ -55,6 +55,8 @@ export const useWithShowEndpointResponder = (): ShowEndpointResponseActionsConso
             PageTitleComponent: () => <>{RESPONDER_PAGE_TITLE}</>,
             PageBodyComponent: () => <OfflineCallout endpointId={endpointAgentId} />,
             ActionComponents: [ActionLogButton],
+            // hide the console Done/close button
+            showCloseButton: false,
           })
           .show();
       }

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
@@ -55,8 +55,6 @@ export const useWithShowEndpointResponder = (): ShowEndpointResponseActionsConso
             PageTitleComponent: () => <>{RESPONDER_PAGE_TITLE}</>,
             PageBodyComponent: () => <OfflineCallout endpointId={endpointAgentId} />,
             ActionComponents: [ActionLogButton],
-            // hide the console Done/close button
-            showCloseButton: false,
           })
           .show();
       }

--- a/x-pack/test/security_solution_endpoint/page_objects/endpoint_responder.ts
+++ b/x-pack/test/security_solution_endpoint/page_objects/endpoint_responder.ts
@@ -21,7 +21,7 @@ export function EndpointResponderPageObjects({ getService }: FtrProviderContext)
 
   const closeResponder = async () => {
     await ensureOnResponder();
-    (await testSubjects.find('consolePageOverlay-doneButton')).click();
+    (await testSubjects.find('consolePageOverlay-header-back-link')).click();
     await testSubjects.missingOrFail(TEST_SUBJ.responderPage);
   };
 


### PR DESCRIPTION
## Summary

Removes the close/Done button on the console.
![Screenshot 2022-07-22 at 09 34 32](https://user-images.githubusercontent.com/1849116/180388134-adc52ef0-41ce-48d2-a6e1-1f4bd0c0f004.png)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

