### PR TITLE
Properly sort the results returned by the user profiles bulk get API.

### DIFF
--- a/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
@@ -348,20 +348,9 @@ describe('UserProfileService', () => {
   });
 
   describe('#bulkGet', () => {
-    it('properly parses returned profiles', async () => {
+    it('properly parses and sorts returned profiles', async () => {
       mockStartParams.clusterClient.asInternalUser.transport.request.mockResolvedValue({
         profiles: [
-          userProfileMock.createWithSecurity({
-            uid: 'UID-1',
-            user: {
-              username: 'user-1',
-              display_name: 'display-name-1',
-              full_name: 'full-name-1',
-              realm_name: 'some-realm',
-              realm_domain: 'some-domain',
-              roles: ['role-1'],
-            },
-          }),
           userProfileMock.createWithSecurity({
             uid: 'UID-2',
             user: {
@@ -371,6 +360,17 @@ describe('UserProfileService', () => {
               realm_name: 'some-realm',
               realm_domain: 'some-domain',
               roles: ['role-2'],
+            },
+          }),
+          userProfileMock.createWithSecurity({
+            uid: 'UID-1',
+            user: {
+              username: 'user-1',
+              display_name: 'display-name-1',
+              full_name: 'full-name-1',
+              realm_name: 'some-realm',
+              realm_domain: 'some-domain',
+              roles: ['role-1'],
             },
           }),
         ],
@@ -417,9 +417,9 @@ describe('UserProfileService', () => {
     it('filters out not requested profiles', async () => {
       mockStartParams.clusterClient.asInternalUser.transport.request.mockResolvedValue({
         profiles: [
-          userProfileMock.createWithSecurity({ uid: 'UID-1' }),
           userProfileMock.createWithSecurity({ uid: 'UID-2' }),
           userProfileMock.createWithSecurity({ uid: 'UID-NOT-REQUESTED' }),
+          userProfileMock.createWithSecurity({ uid: 'UID-1' }),
         ],
       });
 

--- a/x-pack/test/security_api_integration/tests/user_profiles/bulk_get.ts
+++ b/x-pack/test/security_api_integration/tests/user_profiles/bulk_get.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
 
-  // Failing: See https://github.com/elastic/kibana/issues/136827
-  describe.skip('Getting user profiles in bulk', () => {
+  describe('Getting user profiles in bulk', () => {
     const usersSessions = new Map<string, { cookie: Cookie; uid: string }>();
     before(async () => {
       // 1. Create test users
@@ -30,7 +29,9 @@ export default function ({ getService }: FtrProviderContext) {
         )
       );
 
-      // 2. Activate user profiles
+      // 2. Activate user profiles (activation time affects the order in which Elasticsearch returns results, but the
+      // `bulk_get` operation should always manually sort the results before returning them to the consumers, and the
+      // activation order should not matter for these tests).
       await Promise.all(
         ['one', 'two', 'three'].map(async (userPrefix) => {
           const response = await supertestWithoutAuth
@@ -75,17 +76,17 @@ export default function ({ getService }: FtrProviderContext) {
           Object {
             "data": Object {},
             "user": Object {
-              "email": "two@elastic.co",
-              "full_name": "TWO",
-              "username": "user_two",
+              "email": "one@elastic.co",
+              "full_name": "ONE",
+              "username": "user_one",
             },
           },
           Object {
             "data": Object {},
             "user": Object {
-              "email": "one@elastic.co",
-              "full_name": "ONE",
-              "username": "user_one",
+              "email": "two@elastic.co",
+              "full_name": "TWO",
+              "username": "user_two",
             },
           },
         ]
@@ -119,17 +120,17 @@ export default function ({ getService }: FtrProviderContext) {
           Object {
             "data": Object {},
             "user": Object {
-              "email": "two@elastic.co",
-              "full_name": "TWO",
-              "username": "user_two",
+              "email": "one@elastic.co",
+              "full_name": "ONE",
+              "username": "user_one",
             },
           },
           Object {
             "data": Object {},
             "user": Object {
-              "email": "one@elastic.co",
-              "full_name": "ONE",
-              "username": "user_one",
+              "email": "two@elastic.co",
+              "full_name": "TWO",
+              "username": "user_two",
             },
           },
         ]
@@ -151,22 +152,22 @@ export default function ({ getService }: FtrProviderContext) {
         Array [
           Object {
             "data": Object {
-              "some": "data-two",
-            },
-            "user": Object {
-              "email": "two@elastic.co",
-              "full_name": "TWO",
-              "username": "user_two",
-            },
-          },
-          Object {
-            "data": Object {
               "some": "data-one",
             },
             "user": Object {
               "email": "one@elastic.co",
               "full_name": "ONE",
               "username": "user_one",
+            },
+          },
+          Object {
+            "data": Object {
+              "some": "data-two",
+            },
+            "user": Object {
+              "email": "two@elastic.co",
+              "full_name": "TWO",
+              "username": "user_two",
             },
           },
         ]


### PR DESCRIPTION
## Summary

Since we use Elasticsearch's `Suggest User Profiles` API to simulate `User Profiles Bulk Get` API (that isn't provided by Elasticsearch _yet_), we have to explicitly handle the following issue in Kibana: the `Suggest User Profiles` API is supposed to sort results by relevance i.e. first by the search score (if `name` parameter is specified which isn't the case here) and then by the activation time. The `User Profiles Bulk Get` API, on the contrary, should always return results in the order the consumer specified UIDs in (in our case, the insertion order for the `Set` we use as the UIDs parameter). 

This is what is implemented in this PR + re-enabling bulk get test disabled in https://github.com/elastic/kibana/issues/136827.

__Note:__ Once Elasticsearch provides `User Profiles Bulk Get` API, we can revert this change.

__Flaky Test Runner:__ :heavy_check_mark: [#914](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/914) (x50 runs)

__Fixes: https://github.com/elastic/kibana/issues/136827__