### PR TITLE
[8.3] [Discover] Fix visibility of saved search grids when one of them is in fullscreen mode (#136198)

### DIFF
--- a/src/plugins/discover/public/embeddable/saved_search_grid.scss
+++ b/src/plugins/discover/public/embeddable/saved_search_grid.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * 1. Fixes fullscreen mode for saved searches on Dashboard. Otherwise, sibling grids can obscure the grid in fullscreen mode.
+ * "euiDataGrid__restrictBody" is set to body element when a grid is in fullscreen
+ * https://github.com/elastic/kibana/issues/134032
+ */
+.euiDataGrid__restrictBody .embPanel .embPanel__content {
+  z-index: unset !important; /* 1 */
+}

--- a/src/plugins/discover/public/embeddable/saved_search_grid.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_grid.tsx
@@ -10,6 +10,7 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { DiscoverGrid, DiscoverGridProps } from '../components/discover_grid/discover_grid';
 import { TotalDocuments } from '../application/main/components/total_documents/total_documents';
 import { ElasticSearchHit } from '../types';
+import './saved_search_grid.scss';
 
 export interface DiscoverGridEmbeddableProps extends DiscoverGridProps {
   totalHitCount: number;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[Discover] Fix visibility of saved search grids when one of them is in fullscreen mode (#136198)](https://github.com/elastic/kibana/pull/136198)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2022-07-20T07:27:22Z","message":"[Discover] Fix visibility of saved search grids when one of them is in fullscreen mode (#136198)","sha":"42f2bc28c7c14d71203f0ea5ddc7bbf00d385759","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","release_note:fix","Team:Presentation","loe:hours","impact:high","backport missing","Team:DataDiscovery","v8.4.0","backport:prev-minor"],"number":136198,"url":"https://github.com/elastic/kibana/pull/136198","mergeCommit":{"message":"[Discover] Fix visibility of saved search grids when one of them is in fullscreen mode (#136198)","sha":"42f2bc28c7c14d71203f0ea5ddc7bbf00d385759"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/136198","number":136198,"mergeCommit":{"message":"[Discover] Fix visibility of saved search grids when one of them is in fullscreen mode (#136198)","sha":"42f2bc28c7c14d71203f0ea5ddc7bbf00d385759"}}]}] BACKPORT-->