### PR TITLE
[APM] Add `-grep-files` option to api test runner

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/cli.ts
+++ b/packages/kbn-test/src/functional_test_runner/cli.ts
@@ -140,7 +140,6 @@ export function runFtrCli() {
         string: [
           'config',
           'grep',
-          'grep-files',
           'include',
           'exclude',
           'include-tag',

--- a/packages/kbn-test/src/functional_test_runner/cli.ts
+++ b/packages/kbn-test/src/functional_test_runner/cli.ts
@@ -140,6 +140,7 @@ export function runFtrCli() {
         string: [
           'config',
           'grep',
+          'grep-files',
           'include',
           'exclude',
           'include-tag',

--- a/x-pack/plugins/apm/dev_docs/testing.md
+++ b/x-pack/plugins/apm/dev_docs/testing.md
@@ -18,16 +18,16 @@ open target/coverage/jest/index.html
 
 ## API Tests
 
-| Option    | Description                                     |
-| --------- | ----------------------------------------------- |
-| --basic   | Run tests with basic license                    |
-| --trial   | Run tests with trial license                    |
-| --server  | Only start ES and Kibana                        |
-| --runner  | Only run tests                                  |
-| --grep    | Specify the specs to run                        |
-| --files   | Specify the files to run                        |
-| --inspect | Add --inspect-brk flag to the ftr for debugging |
-| --times   | Repeat the test n number of times               |
+| Option       | Description                                     |
+| ------------ | ----------------------------------------------- |
+| --basic      | Run tests with basic license                    |
+| --trial      | Run tests with trial license                    |
+| --server     | Only start ES and Kibana                        |
+| --runner     | Only run tests                                  |
+| --grep       | Specify the specs to run                        |
+| --grep-files | Specify the files to run                        |
+| --inspect    | Add --inspect-brk flag to the ftr for debugging |
+| --times      | Repeat the test n number of times               |
 
 The API tests are located in [`x-pack/test/apm_api_integration/`](/x-pack/test/apm_api_integration/).
 
@@ -48,7 +48,7 @@ Once the tests finish, the instances will be terminated.
 node scripts/test/api --server --basic
 
 # run tests
-node scripts/test/api --runner --basic --files=error_group_list
+node scripts/test/api --runner --basic --grep-files=error_group_list
 ```
 
 ### Update snapshots (from Kibana root)

--- a/x-pack/plugins/apm/dev_docs/testing.md
+++ b/x-pack/plugins/apm/dev_docs/testing.md
@@ -24,7 +24,8 @@ open target/coverage/jest/index.html
 | --trial   | Run tests with trial license                    |
 | --server  | Only start ES and Kibana                        |
 | --runner  | Only run tests                                  |
-| --grep    | Specify the spec files to run                   |
+| --grep    | Specify the specs to run                        |
+| --files   | Specify the files to run                        |
 | --inspect | Add --inspect-brk flag to the ftr for debugging |
 | --times   | Repeat the test n number of times               |
 
@@ -47,7 +48,7 @@ Once the tests finish, the instances will be terminated.
 node scripts/test/api --server --basic
 
 # run tests
-node scripts/test/api --runner --basic
+node scripts/test/api --runner --basic --files=error_group_list
 ```
 
 ### Update snapshots (from Kibana root)

--- a/x-pack/plugins/apm/scripts/test/api.js
+++ b/x-pack/plugins/apm/scripts/test/api.js
@@ -97,7 +97,6 @@ const cmd = [
   ...(inspect ? ['--inspect-brk'] : []),
   `../../../../../scripts/${ftrScript}`,
   ...(grep ? [`--grep "${grep}"`] : []),
-  ...(grepFiles ? [`--grep-files "${grepFiles}"`] : []),
   ...(updateSnapshots ? [`--updateSnapshots`] : []),
   `--config ../../../../test/apm_api_integration/${license}/config.ts`,
 ].join(' ');
@@ -105,7 +104,11 @@ const cmd = [
 console.log(`Running: "${cmd}"`);
 
 function runTests() {
-  childProcess.execSync(cmd, { cwd: path.join(__dirname), stdio: 'inherit' });
+  childProcess.execSync(cmd, {
+    cwd: path.join(__dirname),
+    stdio: 'inherit',
+    env: { ...process.env, APM_TEST_GREP_FILES: grepFiles },
+  });
 }
 
 if (argv.times) {

--- a/x-pack/plugins/apm/scripts/test/api.js
+++ b/x-pack/plugins/apm/scripts/test/api.js
@@ -34,9 +34,13 @@ const { argv } = yargs(process.argv.slice(2))
   })
   .option('grep', {
     alias: 'spec',
-    default: false,
     type: 'string',
-    description: 'Specify the spec files to run',
+    description: 'Specify the specs to run',
+  })
+  .option('grep-files', {
+    alias: 'files',
+    type: 'string',
+    description: 'Specify the files to run',
   })
   .option('inspect', {
     default: false,
@@ -62,7 +66,16 @@ const { argv } = yargs(process.argv.slice(2))
   })
   .help();
 
-const { basic, trial, server, runner, grep, inspect, updateSnapshots } = argv;
+const {
+  basic,
+  trial,
+  server,
+  runner,
+  grep,
+  grepFiles,
+  inspect,
+  updateSnapshots,
+} = argv;
 
 if (trial === false && basic === false) {
   throw new Error('Please specify either --trial or --basic');
@@ -84,6 +97,7 @@ const cmd = [
   ...(inspect ? ['--inspect-brk'] : []),
   `../../../../../scripts/${ftrScript}`,
   ...(grep ? [`--grep "${grep}"`] : []),
+  ...(grepFiles ? [`--grep-files "${grepFiles}"`] : []),
   ...(updateSnapshots ? [`--updateSnapshots`] : []),
   `--config ../../../../test/apm_api_integration/${license}/config.ts`,
 ].join(' ');

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -6,18 +6,17 @@
  */
 import glob from 'glob';
 import path from 'path';
-import { argv } from 'yargs';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
 const cwd = path.join(__dirname);
 
-const argvGrepFiles = argv.grepFiles as string | undefined;
+const envGrepFiles = process.env.APM_TEST_GREP_FILES;
 function getGlobPattern() {
-  if (!argvGrepFiles) {
+  if (!envGrepFiles) {
     return '**/*.spec.ts';
   }
 
-  return argvGrepFiles.includes('.spec.ts') ? argvGrepFiles : `**/*${argvGrepFiles}*.spec.ts`;
+  return envGrepFiles.includes('.spec.ts') ? envGrepFiles : `**/*${envGrepFiles}*.spec.ts`;
 }
 
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {
@@ -26,10 +25,10 @@ export default function apmApiIntegrationTests({ getService, loadTestFile }: Ftr
   describe('APM API tests', function () {
     const tests = glob.sync(getGlobPattern(), { cwd });
 
-    if (argvGrepFiles) {
+    if (envGrepFiles) {
       // eslint-disable-next-line no-console
       console.log(
-        `\nCommand "--grep-files=${argvGrepFiles}" matched ${tests.length} file(s):\n${tests
+        `\nCommand "--grep-files=${envGrepFiles}" matched ${tests.length} file(s):\n${tests
           .map((name) => ` - ${name}`)
           .join('\n')}\n`
       );

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -6,15 +6,33 @@
  */
 import glob from 'glob';
 import path from 'path';
+import { argv } from 'yargs';
 import { FtrProviderContext } from '../common/ftr_provider_context';
 
 const cwd = path.join(__dirname);
+
+const argvGrepFiles = argv.grepFiles as string | undefined;
+function getGlobPattern() {
+  if (!argvGrepFiles) {
+    return '**/*.spec.ts';
+  }
+
+  return argvGrepFiles.includes('.spec.ts') ? argvGrepFiles : `**/*${argvGrepFiles}.spec.ts`;
+}
 
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {
   const registry = getService('registry');
 
   describe('APM API tests', function () {
-    const tests = glob.sync('**/*.spec.ts', { cwd });
+    const tests = glob.sync(getGlobPattern(), { cwd });
+
+    if (argvGrepFiles) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `\nCommand "--grep-files=${argvGrepFiles}" matching ${tests.length} file(s):\n - ${tests}\n`
+      );
+    }
+
     tests.forEach((test) => {
       describe(test, function () {
         loadTestFile(require.resolve(`./${test}`));

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -29,7 +29,9 @@ export default function apmApiIntegrationTests({ getService, loadTestFile }: Ftr
     if (argvGrepFiles) {
       // eslint-disable-next-line no-console
       console.log(
-        `\nCommand "--grep-files=${argvGrepFiles}" matching ${tests.length} file(s):\n - ${tests}\n`
+        `\nCommand "--grep-files=${argvGrepFiles}" matched ${tests.length} file(s):\n${tests
+          .map((name) => ` - ${name}`)
+          .join('\n')}\n`
       );
     }
 

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -17,7 +17,7 @@ function getGlobPattern() {
     return '**/*.spec.ts';
   }
 
-  return argvGrepFiles.includes('.spec.ts') ? argvGrepFiles : `**/*${argvGrepFiles}.spec.ts`;
+  return argvGrepFiles.includes('.spec.ts') ? argvGrepFiles : `**/*${argvGrepFiles}*.spec.ts`;
 }
 
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {


### PR DESCRIPTION
This PR adds the ability to match and run api tests by file name via a new `--grep-files` option. This is in addition to the existing `--grep` option which allows users to run ftr test specs by filtering on the spec name. 

How to use it:
```
node scripts/test/api --runner --basic --grep-files=<file_name>
```

Note: `grep-files` will automatically do wildcard matching so that `--grep-files=error_list` will match `primary_error_list.spec.ts` and `secondary_error_list.spec.ts`. 