### PR TITLE
[Files] File errors

### DIFF
--- a/x-pack/plugins/files/server/file/errors.ts
+++ b/x-pack/plugins/files/server/file/errors.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+
+class FileError extends Error {
+  constructor(message?: string) {
+    super(message);
+    Error.captureStackTrace(this);
+  }
+}
+
+export class ContentAlreadyUploadedError extends FileError {}
+export class NoDownloadAvailableError extends FileError {}
+export class UploadInProgressError extends FileError {}
+export class AlreadyDeletedError extends FileError {}

--- a/x-pack/plugins/files/server/file/index.ts
+++ b/x-pack/plugins/files/server/file/index.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import * as fileErrors from './errors';
+
 export { File } from './file';
-
 export { toJSON } from './to_json';
-
 export { createDefaultFileAttributes, fileAttributesReducer } from './file_attributes_reducer';
 export type { Action } from './file_attributes_reducer';
+export { fileErrors };

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -8,6 +8,7 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import type { DeleteFileKindHttpEndpoint } from '../../../common/api_routes';
+import { fileErrors } from '../../file';
 import type { FileKindsRequestHandler } from './types';
 
 import { getById } from './helpers';
@@ -32,6 +33,12 @@ export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind
   try {
     await file.delete();
   } catch (e) {
+    if (
+      e instanceof fileErrors.AlreadyDeletedError ||
+      e instanceof fileErrors.UploadInProgressError
+    ) {
+      return res.badRequest({ body: e.message });
+    }
     return res.customError({
       statusCode: 500,
       body: {

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -6,7 +6,6 @@
  */
 import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
-import type { FileJSON } from '../../../common';
 import type { ListFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 
@@ -30,21 +29,9 @@ export const handler: FileKindsRequestHandler<unknown, Query> = async (
     query: { page, perPage },
   } = req;
   const { fileService } = await files;
-  let results: FileJSON[] = [];
-  try {
-    const response = await fileService.asCurrentUser().list({ fileKind, page, perPage });
-    results = response.map((result) => result.toJSON());
-  } catch (e) {
-    return res.customError({
-      statusCode: 500,
-      body: {
-        message:
-          'Something went wrong while update file attributes. Check server logs for more details.',
-      },
-    });
-  }
+  const response = await fileService.asCurrentUser().list({ fileKind, page, perPage });
   const body: Response = {
-    files: results,
+    files: response.map((result) => result.toJSON()),
   };
   return res.ok({ body });
 };

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -9,6 +9,7 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import type { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 import type { UploadFileKindHttpEndpoint } from '../../../common/api_routes';
+import { fileErrors } from '../../file';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
@@ -39,8 +40,11 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   try {
     await file.uploadContent(stream as Readable);
   } catch (e) {
-    if (e?.message.startsWith('Already uploaded file')) {
-      return res.badRequest({ body: 'File content already uploaded' });
+    if (
+      e instanceof fileErrors.ContentAlreadyUploadedError ||
+      e instanceof fileErrors.UploadInProgressError
+    ) {
+      return res.badRequest({ body: e });
     }
     throw e;
   }


### PR DESCRIPTION
## Summary

Added several file errors that can be thrown by the `File` class.

```ts
export class ContentAlreadyUploadedError extends FileError {}
export class NoDownloadAvailableError extends FileError {}
export class UploadInProgressError extends FileError {}
export class AlreadyDeletedError extends FileError {}
```

These are used to map to appropriate RESTful HTTP responses for the resource.