### PR TITLE
TopNFunctions: Handle events without stacktrace

### DIFF
--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -59,7 +59,9 @@ export function createTopNFunctions(
 
     totalCount += count;
 
-    const frames = metadata.get(traceHash)!;
+    // It is possible that we do not have a stacktrace for an event,
+    // e.g. when stopping the host agent or on network errors.
+    const frames = metadata.get(traceHash) ?? [];
     for (let i = 0; i < frames.length; i++) {
       const frameGroup = defaultGroupBy(frames[i]);
       const frameGroupID = hashFrameGroup(frameGroup);


### PR DESCRIPTION
This handles the case where a stacktrace event ends up without a matching document in the ES index `profiling-stacktraces`.

Fixes https://github.com/elastic/prodfiler/issues/2446