### PR TITLE
[DOCS] Update link to common cluster issues page

### DIFF
--- a/docs/setup/upgrade/resolving-migration-failures.asciidoc
+++ b/docs/setup/upgrade/resolving-migration-failures.asciidoc
@@ -177,7 +177,7 @@ If the cluster exceeded the low watermark for disk usage, the output should cont
 --------------------------------------------
 "The node is above the low watermark cluster setting [cluster.routing.allocation.disk.watermark.low=85%], using more disk space than the maximum allowed [85.0%], actual free: [11.692661332965082%]"
 --------------------------------------------
-Refer to the {es} guide for how to {ref}/fix-common-cluster-issues.html[fix common cluster issues].
+Refer to the {es} guide for how to {ref}/disk-usage-exceeded.html[fix common cluster issues].
 
 If routing allocation is the issue, the `_cluster/allocation/explain` API will return an entry similar to this:
 


### PR DESCRIPTION
Following up on https://github.com/elastic/kibana/pull/136378, this PR updates a link to point to the new disk usage exceeded page in the Elasticsearch docs.