### PR TITLE
[CI] Parallelize eslint to speed it up

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -79,9 +79,9 @@ steps:
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      queue: n2-2-spot
+      queue: n2-8-spot
     key: linting
-    timeout_in_minutes: 90
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,25 +7,43 @@ steps:
 
   - wait
 
-  - command: PARALLEL_LINT=8 .buildkite/scripts/steps/lint.sh
+  - command: PARALLEL_LINT=2 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
+    agents:
+      queue: n2-2-spot
+    timeout_in_minutes: 90
+
+  - command: PARALLEL_LINT=2 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
+    agents:
+      queue: n2-4-spot
+    timeout_in_minutes: 90
+
+  - command: PARALLEL_LINT=4 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
+    agents:
+      queue: n2-4-spot
+    timeout_in_minutes: 90
+
+  - command: PARALLEL_LINT=4 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-8-spot
     timeout_in_minutes: 90
 
-  - command: PARALLEL_LINT=10 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-8-spot
-    timeout_in_minutes: 90
-
-  - command: PARALLEL_LINT=12 .buildkite/scripts/steps/lint.sh
+  - command: PARALLEL_LINT=5 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-8-spot
     timeout_in_minutes: 90
 
   - command: PARALLEL_LINT=6 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
+    agents:
+      queue: n2-8-spot
+    timeout_in_minutes: 90
+
+  - command: PARALLEL_LINT=7 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-8-spot

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -10,7 +10,7 @@ steps:
   - command: PARALLEL_LINT=3 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      queue: n2-2-spot
+      queue: n2-4-spot
     timeout_in_minutes: 90
 
   - command: PARALLEL_LINT=6 .buildkite/scripts/steps/lint.sh

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,43 +7,13 @@ steps:
 
   - wait
 
-  - command: PARALLEL_LINT=2 .buildkite/scripts/steps/lint.sh
+  - command: PARALLEL_LINT=3 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-2-spot
     timeout_in_minutes: 90
 
-  - command: PARALLEL_LINT=2 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-4-spot
-    timeout_in_minutes: 90
-
-  - command: PARALLEL_LINT=4 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-4-spot
-    timeout_in_minutes: 90
-
-  - command: PARALLEL_LINT=4 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-8-spot
-    timeout_in_minutes: 90
-
-  - command: PARALLEL_LINT=5 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-8-spot
-    timeout_in_minutes: 90
-
   - command: PARALLEL_LINT=6 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
-    agents:
-      queue: n2-8-spot
-    timeout_in_minutes: 90
-
-  - command: PARALLEL_LINT=7 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-8-spot

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,71 +7,26 @@ steps:
 
   - wait
 
-  - command: .buildkite/scripts/steps/build_kibana.sh
-    label: Build Kibana Distribution and Plugins
-    agents:
-      queue: c2-16
-    key: build
-    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
-    timeout_in_minutes: 60
-
-  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-    label: 'Pick Test Group Run Order'
-    agents:
-      queue: kibana-default
-    env:
-      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/lint.sh
+  - command: PARALLEL_LINT=8 .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      queue: n2-2
-    key: linting
+      queue: n2-8-spot
     timeout_in_minutes: 90
 
-  - command: .buildkite/scripts/steps/lint_with_types.sh
-    label: 'Linting (with types)'
+  - command: PARALLEL_LINT=10 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
     agents:
-      queue: c2-16
-    key: linting_with_types
+      queue: n2-8-spot
     timeout_in_minutes: 90
 
-  - command: .buildkite/scripts/steps/checks.sh
-    label: 'Checks'
+  - command: PARALLEL_LINT=12 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
     agents:
-      queue: n2-2-spot
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
+      queue: n2-8-spot
+    timeout_in_minutes: 90
 
-  - command: .buildkite/scripts/steps/check_types.sh
-    label: 'Check Types'
+  - command: PARALLEL_LINT=6 .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
     agents:
-      queue: c2-8
-    timeout_in_minutes: 60
-
-  - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
-    label: 'Build Storybooks'
-    agents:
-      queue: c2-4
-    key: storybooks
-    timeout_in_minutes: 60
-
-  - command: .buildkite/scripts/steps/build_api_docs.sh
-    label: 'Build API Docs'
-    agents:
-      queue: n2-4-spot
-    key: build_api_docs
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
+      queue: n2-8-spot
+    timeout_in_minutes: 90

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -32,7 +32,12 @@ steps:
     label: 'Linting'
     agents:
       queue: n2-8-spot
-    timeout_in_minutes: 90
+    key: linting
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
 
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -7,14 +7,70 @@ steps:
 
   - wait
 
-  - command: PARALLEL_LINT=3 .buildkite/scripts/steps/lint.sh
-    label: 'Linting'
+  - command: .buildkite/scripts/steps/build_kibana.sh
+    label: Build Kibana Distribution and Plugins
     agents:
-      queue: n2-4-spot
-    timeout_in_minutes: 90
+      queue: c2-16
+    key: build
+    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+    timeout_in_minutes: 60
 
-  - command: PARALLEL_LINT=6 .buildkite/scripts/steps/lint.sh
+  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
+    label: 'Pick Test Group Run Order'
+    agents:
+      queue: kibana-default
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
       queue: n2-8-spot
     timeout_in_minutes: 90
+
+  - command: .buildkite/scripts/steps/lint_with_types.sh
+    label: 'Linting (with types)'
+    agents:
+      queue: c2-16
+    key: linting_with_types
+    timeout_in_minutes: 90
+
+  - command: .buildkite/scripts/steps/checks.sh
+    label: 'Checks'
+    agents:
+      queue: n2-2-spot
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
+  - command: .buildkite/scripts/steps/check_types.sh
+    label: 'Check Types'
+    agents:
+      queue: c2-8
+    timeout_in_minutes: 60
+
+  - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
+    label: 'Build Storybooks'
+    agents:
+      queue: c2-4
+    key: storybooks
+    timeout_in_minutes: 60
+
+  - command: .buildkite/scripts/steps/build_api_docs.sh
+    label: 'Build API Docs'
+    agents:
+      queue: n2-4-spot
+    key: build_api_docs
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -15,11 +15,10 @@ echo '--- Lint: eslint'
 # disable "Exit immediately" mode so that we can run eslint, capture it's exit code, and respond appropriately
 # after possibly commiting fixed files to the repo
 set +e;
-PARALLEL_LINT=${PARALLEL_LINT:-4}
 if is_pr && ! is_auto_commit_disabled; then
-  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P "$PARALLEL_LINT" node scripts/eslint --no-cache --fix
+  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache --fix
 else
-  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P "$PARALLEL_LINT" node scripts/eslint --no-cache
+  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache
 fi
 
 eslint_exit=$?

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -16,9 +16,9 @@ echo '--- Lint: eslint'
 # after possibly commiting fixed files to the repo
 set +e;
 if is_pr && ! is_auto_commit_disabled; then
-  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache --fix
+  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache --fix
 else
-  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache
+  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache
 fi
 
 eslint_exit=$?

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -15,7 +15,7 @@ echo '--- Lint: eslint'
 # disable "Exit immediately" mode so that we can run eslint, capture it's exit code, and respond appropriately
 # after possibly commiting fixed files to the repo
 set +e;
-PARALLEL_LINT=$(PARALLEL_LINT:-4)
+PARALLEL_LINT=${PARALLEL_LINT:-4}
 if is_pr && ! is_auto_commit_disabled; then
   git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P "$PARALLEL_LINT" node scripts/eslint --no-cache --fix
 else

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -15,10 +15,11 @@ echo '--- Lint: eslint'
 # disable "Exit immediately" mode so that we can run eslint, capture it's exit code, and respond appropriately
 # after possibly commiting fixed files to the repo
 set +e;
+PARALLEL_LINT=$(PARALLEL_LINT:-4)
 if is_pr && ! is_auto_commit_disabled; then
-  node scripts/eslint --no-cache --fix
+  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P "$PARALLEL_LINT" node scripts/eslint --no-cache --fix
 else
-  node scripts/eslint --no-cache
+  git ls-files | grep -E '\.(js|ts|tsx)$' | xargs -n 250 -P "$PARALLEL_LINT" node scripts/eslint --no-cache
 fi
 
 eslint_exit=$?


### PR DESCRIPTION
Brings eslint down from 50+ minutes to 23min, and brings the (albeit small) cost down by 50-60%.

- Use n2-8-spot instances. These run the workspace in memory, and are actually cheaper than n2-2 instances.
- Run 6 eslint processes in parallel

I did various tests here with different CPU/parallel numbers: https://buildkite.com/elastic/kibana-pull-request/builds/59963

<!--ONMERGE {"backportTargets":["8.3"]} ONMERGE-->