### PR TITLE
[eslint/module_migration] add exact option

### DIFF
--- a/packages/kbn-eslint-plugin-eslint/rules/module_migration.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/module_migration.js
@@ -12,7 +12,8 @@ const KIBANA_ROOT = findKibanaRoot();
 
 function checkModuleNameNode(context, mappings, node, desc = 'Imported') {
   const mapping = mappings.find(
-    (mapping) => mapping.from === node.value || node.value.startsWith(`${mapping.from}/`)
+    (mapping) =>
+      mapping.from === node.value || (!mapping.exact && node.value.startsWith(`${mapping.from}/`))
   );
 
   if (!mapping) {
@@ -84,6 +85,10 @@ module.exports = {
             },
             exclude: {
               type: 'array',
+            },
+            exact: {
+              type: 'boolean',
+              default: false,
             },
           },
           anyOf: [

--- a/packages/kbn-eslint-plugin-eslint/rules/module_migration.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/module_migration.test.js
@@ -37,6 +37,21 @@ ruleTester.run('@kbn/eslint/module-migration', rule, {
         ],
       ],
     },
+
+    {
+      code: dedent`
+        import "foo/bar"
+      `,
+      options: [
+        [
+          {
+            from: 'foo',
+            to: 'bar',
+            exact: true,
+          },
+        ],
+      ],
+    },
   ],
 
   invalid: [
@@ -146,6 +161,32 @@ ruleTester.run('@kbn/eslint/module-migration', rule, {
       ],
       output: dedent`
         import '../../common/foo'
+      `,
+    },
+
+    {
+      code: dedent`
+        import 'foo'
+        import 'foo/bar'
+      `,
+      options: [
+        [
+          {
+            from: 'foo',
+            to: 'bar',
+            exact: true,
+          },
+        ],
+      ],
+      errors: [
+        {
+          line: 1,
+          message: 'Imported module "foo" should be "bar"',
+        },
+      ],
+      output: dedent`
+        import 'bar'
+        import 'foo/bar'
       `,
     },
   ],


### PR DESCRIPTION
Adds an `exact` option to the module migration rule so that we can match exact imports rather than just prefixes.

<!--ONMERGE {"backportTargets":["7.17","8.3"]} ONMERGE-->