### PR TITLE
[APM] Fix custom link filter select value

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/settings/custom_links.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/settings/custom_links.spec.ts
@@ -34,4 +34,17 @@ describe('Custom links', () => {
     cy.get('[data-test-subj="editCustomLink"]').click();
     cy.contains('Delete').click();
   });
+
+  it('clears filter values when field is selected', () => {
+    cy.visit(basePath);
+    cy.contains('Create custom link').click();
+    cy.get('[data-test-subj="filter-0"]').select('service.name');
+    cy.get(
+      '[data-test-subj="service.name.value"] [data-test-subj="comboBoxSearchInput"]'
+    ).type('foo');
+    cy.get('[data-test-subj="filter-0"]').select('service.environment');
+    cy.get(
+      '[data-test-subj="service.environment.value"] [data-test-subj="comboBoxInput"]'
+    ).should('not.contain', 'foo');
+  });
 });

--- a/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
@@ -108,6 +108,7 @@ export function FiltersSection({
                   }
                 )}
                 onChange={(e) =>
+                  // set value to empty string to reset value when new field is selected
                   onChangeFilter(e.target.value as FilterKey, '', idx)
                 }
                 isInvalid={

--- a/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
@@ -108,7 +108,7 @@ export function FiltersSection({
                   }
                 )}
                 onChange={(e) =>
-                  onChangeFilter(e.target.value as FilterKey, value, idx)
+                  onChangeFilter(e.target.value as FilterKey, '', idx)
                 }
                 isInvalid={
                   !isEmpty(value) &&
@@ -118,6 +118,7 @@ export function FiltersSection({
             </EuiFlexItem>
             <EuiFlexItem>
               <SuggestionsSelect
+                key={key}
                 dataTestSubj={`${key}.value`}
                 fieldName={key}
                 placeholder={i18n.translate(


### PR DESCRIPTION
Closes #126066.

Fixes bug where the custom links flyout was retaining filter values after a new field was selected. This was done by setting the value to `''` when a selected, and also providing the rendered `SuggestionSelect` element with a unique key which ensures state input state does not linger.