### PR TITLE
[7.17] Skip ESTF failures (#136912)

### DIFF
--- a/x-pack/test/api_integration/apis/monitoring/apm/instance_mb.js
+++ b/x-pack/test/api_integration/apis/monitoring/apm/instance_mb.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('instance detail mb', () => {
+  describe('instance detail mb', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup services present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     const archive = 'x-pack/test/functional/es_archives/monitoring/apm_mb';
     const timeRange = {
       min: '2018-08-31T12:59:49.104Z',

--- a/x-pack/test/api_integration/apis/monitoring/apm/instances_mb.js
+++ b/x-pack/test/api_integration/apis/monitoring/apm/instances_mb.js
@@ -11,7 +11,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('list mb', () => {
+  describe('list mb', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup services present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     const archive = 'x-pack/test/functional/es_archives/monitoring/apm_mb';
     const timeRange = {
       min: '2018-08-31T12:59:49.104Z',

--- a/x-pack/test/api_integration/apis/monitoring/cluster/list.js
+++ b/x-pack/test/api_integration/apis/monitoring/cluster/list.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('list', () => {
+  describe('list', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup services present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     describe('with trial license clusters', () => {
       const archive = 'x-pack/test/functional/es_archives/monitoring/multicluster';
       const timeRange = {

--- a/x-pack/test/api_integration/apis/monitoring/cluster/list_mb.js
+++ b/x-pack/test/api_integration/apis/monitoring/cluster/list_mb.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('list mb', () => {
+  describe('list mb', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup services present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     describe('with trial license clusters', () => {
       const archive = 'x-pack/test/functional/es_archives/monitoring/multicluster_mb';
       const timeRange = {

--- a/x-pack/test/api_integration/apis/monitoring/standalone_cluster/cluster.js
+++ b/x-pack/test/api_integration/apis/monitoring/standalone_cluster/cluster.js
@@ -12,7 +12,10 @@ export default function ({ getService }) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('cluster', () => {
+  describe('cluster', function () {
+    // Archive contains non-cgroup data which collides with the in-cgroup services present by default on cloud deployments
+    this.tags(['skipCloud']);
+
     const archive = 'x-pack/test/functional/es_archives/monitoring/standalone_cluster';
     const timeRange = {
       min: '2019-02-04T16:52:11.741Z',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Skip ESTF failures (#136912)](https://github.com/elastic/kibana/pull/136912)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mat Schaffer","email":"mat@elastic.co"},"sourceCommit":{"committedDate":"2022-07-22T16:59:44Z","message":"Skip ESTF failures (#136912)\n\n* Skip ESTF failures\r\n\r\n* Right, can't tag stabby lambdas","sha":"63c7beeb31a8caae9f3b9efce6ca8624f806734f","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Infra Monitoring UI","release_note:skip","v8.4.0","backport:all-open","v8.3.3"],"number":136912,"url":"https://github.com/elastic/kibana/pull/136912","mergeCommit":{"message":"Skip ESTF failures (#136912)\n\n* Skip ESTF failures\r\n\r\n* Right, can't tag stabby lambdas","sha":"63c7beeb31a8caae9f3b9efce6ca8624f806734f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/136912","number":136912,"mergeCommit":{"message":"Skip ESTF failures (#136912)\n\n* Skip ESTF failures\r\n\r\n* Right, can't tag stabby lambdas","sha":"63c7beeb31a8caae9f3b9efce6ca8624f806734f"}},{"branch":"8.3","label":"v8.3.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/136978","number":136978,"state":"MERGED","mergeCommit":{"sha":"51ff3b899efe8d7e6604d549237d501d749811ae","message":"Skip ESTF failures (#136912) (#136978)\n\n* Skip ESTF failures\n\n* Right, can't tag stabby lambdas\n\n(cherry picked from commit 63c7beeb31a8caae9f3b9efce6ca8624f806734f)\n\nCo-authored-by: Mat Schaffer <mat@elastic.co>"}}]}] BACKPORT-->