### PR TITLE
[Discover] Disable dangerouslySetInnerHTML rendering

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
+++ b/src/plugins/discover/public/components/discover_grid/get_render_cell_value.tsx
@@ -113,10 +113,9 @@ export const getRenderCellValueFn =
           {pairs.map(([key, value]) => (
             <Fragment key={key}>
               <EuiDescriptionListTitle>{key}</EuiDescriptionListTitle>
-              <EuiDescriptionListDescription
-                className="dscDiscoverGrid__descriptionListDescription"
-                dangerouslySetInnerHTML={{ __html: value }}
-              />
+              <EuiDescriptionListDescription className="dscDiscoverGrid__descriptionListDescription">
+                {value}
+              </EuiDescriptionListDescription>
             </Fragment>
           ))}
         </EuiDescriptionList>
@@ -124,14 +123,9 @@ export const getRenderCellValueFn =
     }
 
     return (
-      <span
-        className={CELL_CLASS}
-        // formatFieldValue guarantees sanitized values
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{
-          __html: formatFieldValue(row.flattened[columnId], row.raw, fieldFormats, dataView, field),
-        }}
-      />
+      <span className={CELL_CLASS}>
+        {formatFieldValue(row.flattened[columnId], row.raw, fieldFormats, dataView, field)}
+      </span>
     );
   };
 
@@ -208,20 +202,9 @@ function renderPopoverContent({
   return (
     <EuiFlexGroup gutterSize="none" direction="row" responsive={false}>
       <EuiFlexItem>
-        <span
-          className="dscDiscoverGrid__cellPopoverValue eui-textBreakWord"
-          // formatFieldValue guarantees sanitized values
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: formatFieldValue(
-              row.flattened[columnId],
-              row.raw,
-              fieldFormats,
-              dataView,
-              field
-            ),
-          }}
-        />
+        <span className="dscDiscoverGrid__cellPopoverValue eui-textBreakWord">
+          {formatFieldValue(row.flattened[columnId], row.raw, fieldFormats, dataView, field)}
+        </span>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>{closeButton}</EuiFlexItem>
     </EuiFlexGroup>

--- a/src/plugins/discover/public/components/doc_table/utils/row_formatter.tsx
+++ b/src/plugins/discover/public/components/doc_table/utils/row_formatter.tsx
@@ -26,11 +26,8 @@ const TemplateComponent = ({ defPairs }: Props) => {
             {pair[0]}
             {!!pair[1] && ':'}
           </dt>
-          <dd
-            className="rowFormatter__value"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: pair[1] }}
-          />{' '}
+          <dd className="rowFormatter__value" />
+          {pair[1]}
         </Fragment>
       ))}
     </dl>

--- a/src/plugins/discover/public/services/doc_views/components/doc_viewer_table/table_cell_value.tsx
+++ b/src/plugins/discover/public/services/doc_views/components/doc_viewer_table/table_cell_value.tsx
@@ -125,13 +125,9 @@ export const TableFieldValue = ({
           )}
         </EuiFlexGroup>
       )}
-      <div
-        className={valueClassName}
-        data-test-subj={`tableDocViewRow-${field}-value`}
-        // Value returned from formatFieldValue is always sanitized
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: formattedValue }}
-      />
+      <div className={valueClassName} data-test-subj={`tableDocViewRow-${field}-value`}>
+        {formattedValue}
+      </div>
     </Fragment>
   );
 };


### PR DESCRIPTION
## Summary

Experimental PR to disable the rendering of  values with `dangerouslySetInnerHTML` in Discover.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
