### PR TITLE
[ML] Limit threads per allocation to 8 in the UI control 

### DIFF
--- a/x-pack/plugins/ml/public/application/trained_models/models_management/start_deployment_setup.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/start_deployment_setup.tsx
@@ -46,7 +46,7 @@ export interface ThreadingParams {
   threadsPerAllocations: number;
 }
 
-const THREADS_MAX_EXPONENT = 6;
+const THREADS_MAX_EXPONENT = 4;
 
 /**
  * Form for setting threading params.


### PR DESCRIPTION
## Summary

Removes the 16 and 32 options for threads per allocation in the start model deployment modal (introduced in https://github.com/elastic/kibana/pull/135134). 

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/5236598/180770626-8ba3e3c3-4a13-487d-9617-0786afec566e.png">



