### PR TITLE
Remove outdated `removeBy` from `fetch` in `SearchSource`

### DIFF
--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -380,7 +380,6 @@ export class SearchSource {
   /**
    * Fetch this source and reject the returned Promise on error
    * @deprecated Use the `fetch$` method instead
-   * @removeBy 8.1
    */
   fetch(options: ISearchOptions = {}) {
     return lastValueFrom(this.fetch$(options)).then((r) => {


### PR DESCRIPTION
## Summary

`8.1` is in the past and this is still used by multiple teams.
I think we can keep this without `removeBy` for now, as I think there is no practical reason to expedite the removal, and we can just leave this deprecated.



