### PR TITLE
[Enterprise Search] Add polling for index data to Search Index view in Content app

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -143,7 +143,7 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
     fetchIndexTimeoutId: [
       null,
       {
-        clearFetchIndexTimeoutId: () => null,
+        clearFetchIndexTimeout: () => null,
         setFetchIndexTimeoutId: (_, { timeoutId }) => timeoutId,
       },
     ],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.logic.ts
@@ -38,10 +38,10 @@ interface OverviewLogicValues {
   data: typeof FetchIndexApiLogic.values.data;
   indexData: typeof FetchIndexApiLogic.values.data;
   isClientsPopoverOpen: boolean;
+  isError: boolean;
   isGenerateModalOpen: boolean;
   isLoading: boolean;
   isManageKeysPopoverOpen: boolean;
-  isSuccess: boolean;
   status: typeof FetchIndexApiLogic.values.status;
 }
 
@@ -107,6 +107,6 @@ export const OverviewLogic = kea<MakeLogicType<OverviewLogicValues, OverviewLogi
       (status, data) =>
         status === Status.IDLE || (typeof data === 'undefined' && status === Status.LOADING),
     ],
-    isSuccess: [() => [selectors.status], (status) => status === Status.SUCCESS],
+    isError: [() => [selectors.status], (status) => status === Status.ERROR],
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.logic.ts
@@ -102,7 +102,11 @@ export const OverviewLogic = kea<MakeLogicType<OverviewLogicValues, OverviewLogi
         apiKeyStatus === Status.SUCCESS ? apiKeyData.apiKey.api_key : '',
     ],
     indexData: [() => [selectors.data], (data) => data],
-    isLoading: [() => [selectors.status], (status) => status === Status.LOADING],
+    isLoading: [
+      () => [selectors.status, selectors.data],
+      (status, data) =>
+        status === Status.IDLE || (typeof data === 'undefined' && status === Status.LOADING),
+    ],
     isSuccess: [() => [selectors.status], (status) => status === Status.SUCCESS],
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -36,6 +36,7 @@ import { SearchIndexDomainManagement } from './crawler/domain_management/domain_
 import { SearchIndexDocuments } from './documents';
 import { SearchIndexIndexMappings } from './index_mappings';
 import { IndexNameLogic } from './index_name_logic';
+import { IndexViewLogic } from './index_view_logic';
 import { SearchIndexOverview } from './overview';
 
 export enum SearchIndexTabId {
@@ -51,8 +52,8 @@ export enum SearchIndexTabId {
 }
 
 export const SearchIndex: React.FC = () => {
-  const { makeRequest, apiReset } = useActions(FetchIndexApiLogic);
   const { data: indexData, status: indexApiStatus } = useValues(FetchIndexApiLogic);
+  const { startFetchIndexPoll, stopFetchIndexPoll } = useActions(IndexViewLogic);
   const { isCalloutVisible } = useValues(IndexCreatedCalloutLogic);
   const { tabId = SearchIndexTabId.OVERVIEW } = useParams<{
     tabId?: string;
@@ -61,8 +62,8 @@ export const SearchIndex: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
 
   useEffect(() => {
-    makeRequest({ indexName });
-    return apiReset;
+    startFetchIndexPoll();
+    return stopFetchIndexPoll;
   }, [indexName]);
 
   const ALL_INDICES_TABS: EuiTabbedContentTab[] = [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -147,7 +147,10 @@ export const SearchIndex: React.FC = () => {
     <EnterpriseSearchContentPageTemplate
       pageChrome={[...baseBreadcrumbs, indexName]}
       pageViewTelemetry={tabId}
-      isLoading={indexApiStatus === Status.LOADING || indexApiStatus === Status.IDLE}
+      isLoading={
+        indexApiStatus === Status.IDLE ||
+        (typeof indexData === 'undefined' && indexApiStatus === Status.LOADING)
+      }
       pageHeader={{
         pageTitle: indexName,
         rightSideItems: getHeaderActions(indexData),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/total_stats.tsx
@@ -22,9 +22,10 @@ interface TotalStatsProps {
 }
 
 export const TotalStats: React.FC<TotalStatsProps> = ({ ingestionType, additionalItems = [] }) => {
-  const { indexData, isSuccess } = useValues(OverviewLogic);
+  const { indexData, isError, isLoading } = useValues(OverviewLogic);
   const documentCount = indexData?.total.docs.count ?? 0;
-  const isLoading = !isSuccess;
+  const hideStats = isLoading || isError;
+
   const stats: EuiStatProps[] = [
     {
       description: i18n.translate(
@@ -33,7 +34,7 @@ export const TotalStats: React.FC<TotalStatsProps> = ({ ingestionType, additiona
           defaultMessage: 'Ingestion type',
         }
       ),
-      isLoading,
+      isLoading: hideStats,
       title: ingestionType,
     },
     {
@@ -43,7 +44,7 @@ export const TotalStats: React.FC<TotalStatsProps> = ({ ingestionType, additiona
           defaultMessage: 'Document count',
         }
       ),
-      isLoading,
+      isLoading: hideStats,
       title: documentCount,
     },
     ...additionalItems,


### PR DESCRIPTION
## Summary

Adds a poll for index data, usually 5 seconds but on error it waits 30 seconds before the next attempt.  

TODO: tests

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios