### PR TITLE
[Fleet] simplified logic of showing tags, always displaying tooltip

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.test.tsx
@@ -38,5 +38,21 @@ describe('Tags', () => {
         'tag1, tag2, tag3, tag4, tag5'
       );
     });
+
+    it('renders a list of tags with tooltip on hover', async () => {
+      const tags = ['tag1', 'tag2', 'tag3'];
+      render(<Tags tags={tags} />);
+
+      const tagsNode = screen.getByTestId('agentTags');
+
+      expect(tagsNode).toHaveTextContent('tag1, tag2, tag3');
+
+      fireEvent.mouseEnter(tagsNode);
+      await waitFor(() => {
+        screen.getByTestId('agentTagsTooltip');
+      });
+
+      expect(screen.getByTestId('agentTagsTooltip')).toHaveTextContent('tag1, tag2, tag3');
+    });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags.tsx
@@ -10,7 +10,7 @@ import { take } from 'lodash';
 import React from 'react';
 import styled from 'styled-components';
 
-import { truncateTag, MAX_TAG_DISPLAY_LENGTH } from '../utils';
+import { truncateTag } from '../utils';
 
 const Wrapped = styled.div`
   .wrappedText {
@@ -28,33 +28,19 @@ const MAX_TAGS_TO_DISPLAY = 3;
 export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
   return (
     <>
-      {tags.length > MAX_TAGS_TO_DISPLAY ? (
-        <Wrapped>
-          <EuiToolTip
-            anchorClassName={'wrappedText'}
-            content={<span data-test-subj="agentTagsTooltip">{tags.join(', ')}</span>}
-          >
-            <span data-test-subj="agentTags">
-              {take(tags, 3).map(truncateTag).join(', ')} + {tags.length - MAX_TAGS_TO_DISPLAY} more
-            </span>
-          </EuiToolTip>
-        </Wrapped>
-      ) : (
-        <span data-test-subj="agentTags">
-          {tags.map((tag, index) => (
-            <>
-              {index > 0 && ', '}
-              {tag.length > MAX_TAG_DISPLAY_LENGTH ? (
-                <EuiToolTip content={<span>{tag}</span>} key={tag}>
-                  <span>{truncateTag(tag)}</span>
-                </EuiToolTip>
-              ) : (
-                <span key={tag}>{tag}</span>
-              )}
-            </>
-          ))}
-        </span>
-      )}
+      <Wrapped>
+        <EuiToolTip
+          anchorClassName={'wrappedText'}
+          content={<span data-test-subj="agentTagsTooltip">{tags.join(', ')}</span>}
+        >
+          <span data-test-subj="agentTags">
+            {take(tags, 3).map(truncateTag).join(', ')}
+            {tags.length > MAX_TAGS_TO_DISPLAY
+              ? ` + ${tags.length - MAX_TAGS_TO_DISPLAY} more`
+              : ''}
+          </span>
+        </EuiToolTip>
+      </Wrapped>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/136368

Simplified logic so that tags are displayed in multiple lines, and tooltip is always visible. 

To verify:
- add agent with 3 tags of 20 length
- verify that tags are visible in multiple lines on agent details page, and tooltip is visible too

<img width="634" alt="image" src="https://user-images.githubusercontent.com/90178898/180808042-a27a4b6c-68b9-427b-9e38-73872d2a2315.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
