### PR TITLE
fix(NA): buildkite es_snapshot build job after es default branch rename to main

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -14,10 +14,6 @@ mkdir -p "$destination"
 mkdir -p elasticsearch && cd elasticsearch
 
 export ELASTICSEARCH_BRANCH="${ELASTICSEARCH_BRANCH:-$BUILDKITE_BRANCH}"
-# Until ES renames their master branch to main...
-if [[ "$ELASTICSEARCH_BRANCH" == "main" ]]; then
-  export ELASTICSEARCH_BRANCH="master"
-fi
 
 if [[ ! -d .git ]]; then
   git init


### PR DESCRIPTION
This PR fixes our BK job after the ES branch rename to main by getting rid off the conditional in the config file.