### PR TITLE
[ML] Explain log rate spikes: adds table sorting

### DIFF
--- a/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
+++ b/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
@@ -57,7 +57,10 @@ export function ProgressControls({
       <EuiFlexItem grow={false}>
         {!isRunning && (
           <EuiButton size="s" onClick={onRefresh}>
-            <FormattedMessage id="xpack.aiops.rerunAnalysisButtonTitle" defaultMessage="Rerun analysis" />
+            <FormattedMessage
+              id="xpack.aiops.rerunAnalysisButtonTitle"
+              defaultMessage="Rerun analysis"
+            />
           </EuiButton>
         )}
         {isRunning && (

--- a/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
+++ b/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
@@ -57,7 +57,7 @@ export function ProgressControls({
       <EuiFlexItem grow={false}>
         {!isRunning && (
           <EuiButton size="s" onClick={onRefresh}>
-            <FormattedMessage id="xpack.aiops.refreshButtonTitle" defaultMessage="Refresh" />
+            <FormattedMessage id="xpack.aiops.rerunAnalysisButtonTitle" defaultMessage="Rerun analysis" />
           </EuiButton>
         )}
         {isRunning && (

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -10,6 +10,7 @@ import {
   EuiBadge,
   EuiBasicTable,
   EuiBasicTableColumn,
+  EuiIcon,
   EuiTableSortingType,
   EuiToolTip,
 } from '@elastic/eui';
@@ -49,8 +50,8 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
 }) => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
-  const [sortField, setSortField] = useState(DEFAULT_SORT_FIELD);
-  const [sortDirection, setSortDirection] = useState(DEFAULT_SORT_DIRECTION);
+  const [sortField, setSortField] = useState<keyof ChangePoint>(DEFAULT_SORT_FIELD);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(DEFAULT_SORT_DIRECTION);
 
   const columns: Array<EuiBasicTableColumn<ChangePoint>> = [
     {
@@ -79,14 +80,17 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
             'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateColumnTooltip',
             {
               defaultMessage:
-                'A visual representation of the amount of impact the given field name and value have on the message rate difference.',
+                'A visual representation of the impact of the field on the message rate difference',
             }
           )}
         >
-          <FormattedMessage
-            id="xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel"
-            defaultMessage="Log rate"
-          />
+          <>
+            <FormattedMessage
+              id="xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel"
+              defaultMessage="Log rate"
+            />
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </>
         </EuiToolTip>
       ),
       render: (_, { histogram, fieldName, fieldValue }) => {
@@ -105,14 +109,17 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
             'xpack.aiops.correlations.failedTransactions.correlationsTable.pValueColumnTooltip',
             {
               defaultMessage:
-                'For statistically significant changes in the frequency of values, indicates how extreme the change is; lower values indicate greater change.',
+                'The significance of changes in the frequency of values; lower values indicate greater change',
             }
           )}
         >
-          <FormattedMessage
-            id="xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel"
-            defaultMessage="p-value"
-          />
+          <>
+            <FormattedMessage
+              id="xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel"
+              defaultMessage="p-value"
+            />
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </>
         </EuiToolTip>
       ),
       render: (pValue: number) => pValue.toPrecision(3),
@@ -126,22 +133,24 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
           content={i18n.translate(
             'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabelColumnTooltip',
             {
-              defaultMessage:
-                'Indicates the level of impact of the given field name and value on the message rate difference.',
+              defaultMessage: 'The level of impact of the field on the message rate difference',
             }
           )}
         >
-          <FormattedMessage
-            id="xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel"
-            defaultMessage="Impact"
-          />
+          <>
+            <FormattedMessage
+              id="xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel"
+              defaultMessage="Impact"
+            />
+            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+          </>
         </EuiToolTip>
       ),
       render: (_, { pValue }) => {
         const label = getFailedTransactionsCorrelationImpactLabel(pValue);
         return label ? <EuiBadge color={label.color}>{label.impact}</EuiBadge> : null;
       },
-      sortable: false,
+      sortable: true,
     },
   ];
 
@@ -159,8 +168,8 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     const pageStart = pageIndex * pageSize;
     const itemCount = changePoints?.length ?? 0;
 
-    let items = changePoints ?? [];
-    items = sortBy(changePoints, (item: ChangePoint) => item[sortField as keyof ChangePoint]);
+    let items: ChangePoint[] = changePoints ?? [];
+    items = sortBy(changePoints, (item) => item[sortField]);
     items = sortDirection === 'asc' ? items : items.reverse();
 
     return {

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -69,7 +69,7 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       name: (
         <EuiToolTip position="top" content={i18n.translate(
           'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateColumnTooltip',
-          { defaultMessage: 'Visual representation of amount of impact given field name and value have on metric change point.' }
+          { defaultMessage: 'A visual representation of the amount of impact the given field name and value have on the message rate difference.' }
         )}>
           <FormattedMessage
             id='xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel'
@@ -89,7 +89,7 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       name: (
         <EuiToolTip position="top" content={i18n.translate(
           'xpack.aiops.correlations.failedTransactions.correlationsTable.pValueColumnTooltip',
-          { defaultMessage: 'For statistically significant changes in the distribution of values, indicates how extreme the change is; lower values indicate greater change.' }
+          { defaultMessage: 'For statistically significant changes in the frequency of values, indicates how extreme the change is; lower values indicate greater change.' }
         )}>
           <FormattedMessage
             id='xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel'
@@ -105,7 +105,7 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       name: (
         <EuiToolTip position="top" content={i18n.translate(
           'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabelColumnTooltip',
-          { defaultMessage: 'Indicates level of impact of given field name and value on metric change point.' }
+          { defaultMessage: 'Indicates the level of impact of the given field name and value on the message rate difference.' }
         )}>
           <FormattedMessage
             id='xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel'

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { EuiBadge, EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiBadge, EuiBasicTable, EuiBasicTableColumn, EuiTableSortingType } from '@elastic/eui';
+import { sortBy } from 'lodash';
+
 import { i18n } from '@kbn/i18n';
 import type { ChangePoint } from '@kbn/ml-agg-utils';
 
@@ -18,6 +20,8 @@ const PAGINATION_SIZE_OPTIONS = [5, 10, 20, 50];
 const noDataText = i18n.translate('xpack.aiops.correlations.correlationsTable.noDataText', {
   defaultMessage: 'No data',
 });
+const DEFAULT_SORT_FIELD = 'pValue';
+const DEFAULT_SORT_DIRECTION = 'asc';
 
 interface SpikeAnalysisTableProps {
   changePoints: ChangePoint[];
@@ -38,6 +42,8 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
 }) => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
+  const [sortField, setSortField] = useState(DEFAULT_SORT_FIELD);
+  const [sortDirection, setSortDirection] = useState(DEFAULT_SORT_DIRECTION);
 
   const columns: Array<EuiBasicTableColumn<ChangePoint>> = [
     {
@@ -98,36 +104,44 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
         const label = getFailedTransactionsCorrelationImpactLabel(pValue);
         return label ? <EuiBadge color={label.color}>{label.impact}</EuiBadge> : null;
       },
-      sortable: true,
+      sortable: false,
     },
   ];
 
   const onChange = useCallback((tableSettings) => {
     const { index, size } = tableSettings.page;
+    const { field, direction } = tableSettings.sort;
 
     setPageIndex(index);
     setPageSize(size);
+    setSortField(field);
+    setSortDirection(direction);
   }, []);
 
-  const { pagination, pageOfItems } = useMemo(() => {
+  const { pagination, pageOfItems, sorting } = useMemo(() => {
     const pageStart = pageIndex * pageSize;
-
     const itemCount = changePoints?.length ?? 0;
+
+    let items = changePoints ?? [];
+    items = sortBy(changePoints, (item: ChangePoint) => item[sortField as keyof ChangePoint]);
+    items = sortDirection === 'asc' ? items : items.reverse();
+
     return {
-      pageOfItems: changePoints
-        // Temporary default sorting by ascending pValue until we add native table sorting
-        ?.sort((a, b) => {
-          return (a?.pValue ?? 1) - (b?.pValue ?? 0);
-        })
-        .slice(pageStart, pageStart + pageSize),
+      pageOfItems: items.slice(pageStart, pageStart + pageSize),
       pagination: {
         pageIndex,
         pageSize,
         totalItemCount: itemCount,
         pageSizeOptions: PAGINATION_SIZE_OPTIONS,
       },
+      sorting: {
+        sort: {
+          field: sortField,
+          direction: sortDirection,
+        },
+      },
     };
-  }, [pageIndex, pageSize, changePoints]);
+  }, [pageIndex, pageSize, sortField, sortDirection, changePoints]);
 
   return (
     <EuiBasicTable
@@ -139,7 +153,7 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       pagination={pagination}
       loading={loading}
       error={error}
-      // sorting={sorting}
+      sorting={sorting as EuiTableSortingType<ChangePoint>}
       rowProps={(changePoint) => {
         return {
           onClick: () => {

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -6,7 +6,13 @@
  */
 
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { EuiBadge, EuiBasicTable, EuiBasicTableColumn, EuiTableSortingType, EuiToolTip } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiTableSortingType,
+  EuiToolTip,
+} from '@elastic/eui';
 import { sortBy } from 'lodash';
 
 import { i18n } from '@kbn/i18n';
@@ -67,13 +73,19 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     {
       field: 'pValue',
       name: (
-        <EuiToolTip position="top" content={i18n.translate(
-          'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateColumnTooltip',
-          { defaultMessage: 'A visual representation of the amount of impact the given field name and value have on the message rate difference.' }
-        )}>
+        <EuiToolTip
+          position="top"
+          content={i18n.translate(
+            'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateColumnTooltip',
+            {
+              defaultMessage:
+                'A visual representation of the amount of impact the given field name and value have on the message rate difference.',
+            }
+          )}
+        >
           <FormattedMessage
-            id='xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel'
-            defaultMessage='Log rate'
+            id="xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel"
+            defaultMessage="Log rate"
           />
         </EuiToolTip>
       ),
@@ -87,13 +99,19 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     {
       field: 'pValue',
       name: (
-        <EuiToolTip position="top" content={i18n.translate(
-          'xpack.aiops.correlations.failedTransactions.correlationsTable.pValueColumnTooltip',
-          { defaultMessage: 'For statistically significant changes in the frequency of values, indicates how extreme the change is; lower values indicate greater change.' }
-        )}>
+        <EuiToolTip
+          position="top"
+          content={i18n.translate(
+            'xpack.aiops.correlations.failedTransactions.correlationsTable.pValueColumnTooltip',
+            {
+              defaultMessage:
+                'For statistically significant changes in the frequency of values, indicates how extreme the change is; lower values indicate greater change.',
+            }
+          )}
+        >
           <FormattedMessage
-            id='xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel'
-            defaultMessage='p-value'
+            id="xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel"
+            defaultMessage="p-value"
           />
         </EuiToolTip>
       ),
@@ -103,13 +121,19 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     {
       field: 'pValue',
       name: (
-        <EuiToolTip position="top" content={i18n.translate(
-          'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabelColumnTooltip',
-          { defaultMessage: 'Indicates the level of impact of the given field name and value on the message rate difference.' }
-        )}>
+        <EuiToolTip
+          position="top"
+          content={i18n.translate(
+            'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabelColumnTooltip',
+            {
+              defaultMessage:
+                'Indicates the level of impact of the given field name and value on the message rate difference.',
+            }
+          )}
+        >
           <FormattedMessage
-            id='xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel'
-            defaultMessage='Impact'
+            id="xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel"
+            defaultMessage="Impact"
           />
         </EuiToolTip>
       ),

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { EuiBadge, EuiBasicTable, EuiBasicTableColumn, EuiTableSortingType } from '@elastic/eui';
+import { EuiBadge, EuiBasicTable, EuiBasicTableColumn, EuiTableSortingType, EuiToolTip } from '@elastic/eui';
 import { sortBy } from 'lodash';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { ChangePoint } from '@kbn/ml-agg-utils';
 
 import { MiniHistogram } from '../mini_histogram';
@@ -66,14 +67,15 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     {
       field: 'pValue',
       name: (
-        <>
-          {i18n.translate(
-            'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel',
-            {
-              defaultMessage: 'Log rate',
-            }
-          )}
-        </>
+        <EuiToolTip position="top" content={i18n.translate(
+          'xpack.aiops.correlations.failedTransactions.correlationsTable.logRateColumnTooltip',
+          { defaultMessage: 'Visual representation of amount of impact given field name and value have on metric change point.' }
+        )}>
+          <FormattedMessage
+            id='xpack.aiops.correlations.failedTransactions.correlationsTable.logRateLabel'
+            defaultMessage='Log rate'
+          />
+        </EuiToolTip>
       ),
       render: (_, { histogram, fieldName, fieldValue }) => {
         return histogram ? (
@@ -84,21 +86,32 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     },
     {
       field: 'pValue',
-      name: 'p-value',
+      name: (
+        <EuiToolTip position="top" content={i18n.translate(
+          'xpack.aiops.correlations.failedTransactions.correlationsTable.pValueColumnTooltip',
+          { defaultMessage: 'For statistically significant changes in the distribution of values, indicates how extreme the change is; lower values indicate greater change.' }
+        )}>
+          <FormattedMessage
+            id='xpack.aiops.correlations.failedTransactions.correlationsTable.pValueLabel'
+            defaultMessage='p-value'
+          />
+        </EuiToolTip>
+      ),
       render: (pValue: number) => pValue.toPrecision(3),
       sortable: true,
     },
     {
       field: 'pValue',
       name: (
-        <>
-          {i18n.translate(
-            'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel',
-            {
-              defaultMessage: 'Impact',
-            }
-          )}
-        </>
+        <EuiToolTip position="top" content={i18n.translate(
+          'xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabelColumnTooltip',
+          { defaultMessage: 'Indicates level of impact of given field name and value on metric change point.' }
+        )}>
+          <FormattedMessage
+            id='xpack.aiops.correlations.failedTransactions.correlationsTable.impactLabel'
+            defaultMessage='Impact'
+          />
+        </EuiToolTip>
       ),
       render: (_, { pValue }) => {
         const label = getFailedTransactionsCorrelationImpactLabel(pValue);

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -169,7 +169,13 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
     const itemCount = changePoints?.length ?? 0;
 
     let items: ChangePoint[] = changePoints ?? [];
-    items = sortBy(changePoints, (item) => item[sortField]);
+    items = sortBy(changePoints, (item) => {
+      if (item && typeof item[sortField] === 'string') {
+        // @ts-ignore Object is possibly null or undefined
+        return item[sortField].toLowerCase();
+      }
+      return item[sortField];
+    });
     items = sortDirection === 'asc' ? items : items.reverse();
 
     return {


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/136265

This PR
- Adds full sorting functionality to spike analysis table
- updates 'Refresh' button copy to 'Rerun analysis' for spike analysis table
- adds info tooltips for p-value, log rate, and impact columns

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/6446462/180858900-dcc4d12a-f4c8-418b-b5fc-24f5604938d9.png">

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/6446462/180858945-ef10fea9-c96b-4caa-af9a-4a5285e2d851.png">

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/6446462/180858974-3dbac1d7-88b8-4f52-aa4b-06542ef06d85.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))



