### PR TITLE
[Security Solution] [Analyzer] Fix typo in events of type analyzer query

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/data_access_layer/factory.ts
+++ b/x-pack/plugins/security_solution/public/resolver/data_access_layer/factory.ts
@@ -93,7 +93,7 @@ export function dataAccessLayerFactory(
         return context.services.http.post('/api/endpoint/resolver/events', {
           query: commonFields.query,
           body: JSON.stringify({
-            ...commonFields,
+            ...commonFields.body,
             entityType: 'alerts',
             eventID: entityID,
           }),
@@ -102,7 +102,7 @@ export function dataAccessLayerFactory(
         return context.services.http.post('/api/endpoint/resolver/events', {
           query: commonFields.query,
           body: JSON.stringify({
-            ...commonFields,
+            ...commonFields.body,
             filter: JSON.stringify({
               bool: {
                 filter: [


### PR DESCRIPTION
## Summary

Fixes a typo in the events of type query for analyzer, introduced in a commit addressing pr feedback https://github.com/elastic/kibana/pull/135340/commits/52acdbcecfc38bf824625b95ffb7fc1b4904227d

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/56408403/180889752-5e38d58a-1cc1-477b-b015-157c53b47b5b.png">

