### PR TITLE
[Security Solution][Endpoint] Rename Responder `cls` command to `clear`

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
@@ -219,7 +219,7 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
   const getFilteredCommands = useCallback(
     (commandsByGroup): CommandDefinition[] =>
       commandsByGroup.filter(
-        (current: CommandDefinition) => current.name !== 'help' && current.name !== 'cls'
+        (current: CommandDefinition) => current.name !== 'help' && current.name !== 'clear'
       ),
     []
   );

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
@@ -48,14 +48,14 @@ describe('When a Console command is entered by the user', () => {
     });
   });
 
-  it('should clear the command output history when `cls` is entered', async () => {
+  it('should clear the command output history when `clear` is entered', async () => {
     render();
     enterCommand('help');
     enterCommand('help');
 
     expect(renderResult.getByTestId('test-historyOutput').childElementCount).toBe(2);
 
-    enterCommand('cls');
+    enterCommand('clear');
 
     expect(renderResult.getByTestId('test-historyOutput').childElementCount).toBe(0);
   });

--- a/x-pack/plugins/security_solution/public/management/components/console/service/builtin_commands.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/service/builtin_commands.tsx
@@ -45,7 +45,7 @@ export const getBuiltinCommands = (): CommandDefinition[] => {
       helpCommandPosition: 1,
     },
     {
-      name: 'cls',
+      name: 'clear',
       about: i18n.translate('xpack.securitySolution.console.builtInCommands.clearAbout', {
         defaultMessage: 'Clear console screen',
       }),


### PR DESCRIPTION
## Summary

- Renames the clear command to `clear` (from `cls`)

![olm-rename-cls-command-to-clear](https://user-images.githubusercontent.com/56442535/180891848-3c6ac2f7-b508-4aa4-8a3d-81fb3ad19c85.gif)
