### PR TITLE
[Discover] Disable refresh interval for data views without time fields and rollups

### DIFF
--- a/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
@@ -33,6 +33,7 @@ import { FetchStatus } from '../../types';
 import { getSwitchIndexPatternAppState } from '../utils/get_switch_index_pattern_app_state';
 import { SortPairArr } from '../../../components/doc_table/utils/get_sort';
 import { DataTableRecord } from '../../../types';
+import { DataViewType } from '@kbn/data-views-plugin/public';
 
 const MAX_NUM_OF_COLUMNS = 50;
 
@@ -252,10 +253,18 @@ export function useDiscoverState({
   }, [state.query, prevQuery]);
 
   useEffect(() => {
-    if (indexPattern) {
+    const fetchDataView = async () => {
+      if (!indexPattern.isTimeBased() || indexPattern.type === DataViewType.ROLLUP) {
+        await stateContainer.pauseAutoRefreshInterval();
+      }
+
       refetch$.next(undefined);
+    };
+
+    if (indexPattern) {
+      fetchDataView();
     }
-  }, [initialFetchStatus, refetch$, indexPattern, savedSearch.id]);
+  }, [initialFetchStatus, refetch$, indexPattern, savedSearch.id, stateContainer]);
 
   const getResultColumns = useCallback(() => {
     if (documentState.result?.length && documentState.fetchStatus === FetchStatus.COMPLETE) {

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -26,6 +26,8 @@ const uiSettingsMock = {
 } as IUiSettingsClient;
 
 describe('Test discover state', () => {
+  let stopSync = () => {};
+
   beforeEach(async () => {
     history = createBrowserHistory();
     history.push('/');
@@ -35,10 +37,11 @@ describe('Test discover state', () => {
       uiSettings: uiSettingsMock,
     });
     await state.replaceUrlAppState({});
-    await state.startSync();
+    stopSync = state.startSync();
   });
   afterEach(() => {
-    state.stopSync();
+    stopSync();
+    stopSync = () => {};
   });
   test('setting app state and syncing to URL', async () => {
     state.setAppState({ index: 'modified' });
@@ -89,7 +92,7 @@ describe('Test discover initial state sort handling', () => {
       uiSettings: uiSettingsMock,
     });
     await state.replaceUrlAppState({});
-    await state.startSync();
+    const stopSync = state.startSync();
     expect(state.appStateContainer.getState().sort).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -98,6 +101,7 @@ describe('Test discover initial state sort handling', () => {
         ],
       ]
     `);
+    stopSync();
   });
   test('Empty sort in URL should allow fallback state defaults', async () => {
     history = createBrowserHistory();
@@ -109,7 +113,7 @@ describe('Test discover initial state sort handling', () => {
       uiSettings: uiSettingsMock,
     });
     await state.replaceUrlAppState({});
-    await state.startSync();
+    const stopSync = state.startSync();
     expect(state.appStateContainer.getState().sort).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -118,6 +122,7 @@ describe('Test discover initial state sort handling', () => {
         ],
       ]
     `);
+    stopSync();
   });
 });
 

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -80,6 +80,13 @@ describe('Test discover state', () => {
     state.setAppState({ index: 'second' });
     expect(state.getPreviousAppState()).toEqual(stateA);
   });
+
+  test('pauseAutoRefreshInterval sets refreshInterval.pause to true', async () => {
+    history.push('/#?_g=(refreshInterval:(pause:!f,value:5000))');
+    expect(getCurrentUrl()).toBe('/#?_g=(refreshInterval:(pause:!f,value:5000))');
+    await state.pauseAutoRefreshInterval();
+    expect(getCurrentUrl()).toBe('/#?_g=(refreshInterval:(pause:!t,value:5000))');
+  });
 });
 describe('Test discover initial state sort handling', () => {
   test('Non-empty sort in URL should not fallback to state defaults', async () => {

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -150,7 +150,7 @@ export interface GetStateReturn {
     data: DataPublicPluginStart
   ) => () => void;
   /**
-   * Start sync between state and URL
+   * Start sync between state and URL -- only used for testing
    */
   startSync: () => () => void;
   /**
@@ -232,6 +232,12 @@ export function getState({
     },
   };
 
+  // Calling syncState from within initializeAndSync causes state syncing issues.
+  // syncState takes a snapshot of the initial state when it's called to compare
+  // against before syncing state updates. When syncState is called from outside
+  // of initializeAndSync, the snapshot doesn't get reset when the data view is
+  // changed. Then when the user presses the back button, the new state appears
+  // to be the same as the initial state, so syncState ignores the update.
   const syncAppState = () =>
     syncState({
       storageKey: APP_STATE_URL_KEY,

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -152,11 +152,7 @@ export interface GetStateReturn {
   /**
    * Start sync between state and URL
    */
-  startSync: () => void;
-  /**
-   * Stop sync between state and URL
-   */
-  stopSync: () => void;
+  startSync: () => () => void;
   /**
    * Set app state to with a partial new app state
    */
@@ -259,19 +255,13 @@ export function getState({
     }
   };
 
-  let testStop = () => {};
-
   return {
     kbnUrlStateStorage: stateStorage,
     appStateContainer: appStateContainerModified,
     startSync: () => {
       const { start, stop } = syncAppState();
-      testStop = stop;
       start();
-    },
-    stopSync: () => {
-      testStop();
-      testStop = () => {};
+      return stop;
     },
     setAppState: (newPartial: AppState) => setState(appStateContainerModified, newPartial),
     replaceUrlAppState,

--- a/test/functional/apps/discover/_indexpattern_without_timefield.ts
+++ b/test/functional/apps/discover/_indexpattern_without_timefield.ts
@@ -103,5 +103,16 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         async () => !(await PageObjects.timePicker.timePickerExists())
       );
     });
+
+    it('should disable the auto refresh interval when switching to a data view without a time field', async () => {
+      const autoRefreshInterval = 5;
+      await PageObjects.discover.selectIndexPattern('with-timefield');
+      await PageObjects.timePicker.startAutoRefresh(autoRefreshInterval);
+      let url = await browser.getCurrentUrl();
+      expect(url).to.contain(`refreshInterval:(pause:!f,value:${autoRefreshInterval * 1000})`);
+      await PageObjects.discover.selectIndexPattern('without-timefield');
+      url = await browser.getCurrentUrl();
+      expect(url).to.contain(`refreshInterval:(pause:!t,value:${autoRefreshInterval * 1000})`);
+    });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where the auto refresh interval continues to run after switching to a data view without time fields even though the date picker is hidden. This means there is no way to disable the refresh interval except by switching back to a data view with a time field. Now the refresh interval will automatically be paused when the date picker is hidden.

![auto-refresh](https://user-images.githubusercontent.com/25592674/181107076-1f2ddcbe-6fb7-41e3-92f8-9529a3bc1e67.gif)

There is also a fix for an issue that was affecting the interval refresh where pressing the back button would update the URL and global state, but the app state and the data view wouldn't update:

![data-view-not-updating](https://user-images.githubusercontent.com/25592674/181151467-5ba2b750-b66f-43a3-b371-0dd1d5dc4eea.gif)

Fixes #102132.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->