### PR TITLE
[Profiling] Aggregate by terms and then timestamp

### DIFF
--- a/x-pack/plugins/profiling/common/topn.ts
+++ b/x-pack/plugins/profiling/common/topn.ts
@@ -21,6 +21,10 @@ export interface TopNSamples {
   TopN: TopNSample[];
 }
 
+export interface TopNResponse extends TopNSamples {
+  TotalCount: number;
+}
+
 export interface TopNSamplesHistogramResponse {
   buckets: Array<{
     key: string | number;
@@ -76,9 +80,8 @@ export interface TopNSubchart {
   Index: number;
 }
 
-export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
+export function groupSamplesByCategory(samples: TopNSample[], totalCount: number): TopNSubchart[] {
   const seriesByCategory = new Map<string, CountPerTime[]>();
-  let total = 0;
 
   for (let i = 0; i < samples.length; i++) {
     const sample = samples[i];
@@ -88,8 +91,6 @@ export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
     }
     const series = seriesByCategory.get(sample.Category)!;
     series.push({ Timestamp: sample.Timestamp, Count: sample.Count });
-
-    total += sample.Count ?? 0;
   }
 
   const subcharts: Array<Omit<TopNSubchart, 'Color' | 'Index'>> = [];
@@ -98,7 +99,7 @@ export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
     const totalPerCategory = series.reduce((sum, { Count }) => sum + (Count ?? 0), 0);
     subcharts.push({
       Category: category,
-      Percentage: (totalPerCategory / total) * 100,
+      Percentage: (totalPerCategory / totalCount) * 100,
       Series: series,
     });
   }

--- a/x-pack/plugins/profiling/common/topn.ts
+++ b/x-pack/plugins/profiling/common/topn.ts
@@ -34,30 +34,30 @@ export interface TopNSamplesHistogramResponse {
 export function createTopNSamples(
   histogram: TopNSamplesHistogramResponse | undefined
 ): TopNSample[] {
-  const bucketsByTimestamp = new Map();
-  const uniqueCategories = new Set<string>();
+  const bucketsByCategories = new Map();
+  const uniqueTimestamps = new Set<number>();
 
-  // Convert the histogram into nested maps and record the unique categories
+  // Convert the histogram into nested maps and record the unique timestamps
   const histogramBuckets = histogram?.buckets ?? [];
   for (let i = 0; i < histogramBuckets.length; i++) {
-    const frameCountsByCategory = new Map();
+    const frameCountsByTimestamp = new Map();
     const items = histogramBuckets[i].group_by.buckets;
 
     for (let j = 0; j < items.length; j++) {
-      uniqueCategories.add(String(items[j].key));
-      frameCountsByCategory.set(items[j].key, items[j].count.value);
+      uniqueTimestamps.add(Number(items[j].key));
+      frameCountsByTimestamp.set(items[j].key, items[j].count.value);
     }
-    bucketsByTimestamp.set(histogramBuckets[i].key, frameCountsByCategory);
+    bucketsByCategories.set(histogramBuckets[i].key, frameCountsByTimestamp);
   }
 
   // Normalize samples so there are an equal number of data points per each timestamp
   const samples: TopNSample[] = [];
-  for (const timestamp of bucketsByTimestamp.keys()) {
-    for (const category of uniqueCategories.values()) {
-      const frameCountsByCategory = bucketsByTimestamp.get(timestamp);
+  for (const category of bucketsByCategories.keys()) {
+    for (const timestamp of uniqueTimestamps) {
+      const frameCountsByTimestamp = bucketsByCategories.get(category);
       const sample: TopNSample = {
         Timestamp: timestamp,
-        Count: frameCountsByCategory.get(category) ?? 0,
+        Count: frameCountsByTimestamp.get(timestamp) ?? 0,
         Category: category,
       };
       samples.push(sample);

--- a/x-pack/plugins/profiling/common/topn.ts
+++ b/x-pack/plugins/profiling/common/topn.ts
@@ -25,6 +25,7 @@ export interface TopNSamplesHistogramResponse {
   buckets: Array<{
     key: string | number;
     doc_count: number;
+    count: { value: number | null };
     group_by: {
       buckets: Array<{ doc_count: number; key: string | number; count: { value: number | null } }>;
     };

--- a/x-pack/plugins/profiling/public/components/stack_traces_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/stack_traces_view/index.tsx
@@ -8,7 +8,7 @@ import { EuiButton, EuiButtonGroup, EuiFlexGroup, EuiFlexItem, EuiPanel } from '
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
 import { StackTracesDisplayOption } from '../../../common/stack_traces';
-import { groupSamplesByCategory, TopNSamples, TopNSubchart } from '../../../common/topn';
+import { groupSamplesByCategory, TopNResponse, TopNSubchart } from '../../../common/topn';
 import { useProfilingParams } from '../../hooks/use_profiling_params';
 import { useProfilingRouter } from '../../hooks/use_profiling_router';
 import { useProfilingRoutePath } from '../../hooks/use_profiling_route_path';
@@ -64,9 +64,10 @@ export function StackTracesView() {
       timeFrom: new Date(timeRange.start).getTime() / 1000,
       timeTo: new Date(timeRange.end).getTime() / 1000,
       kuery,
-    }).then((response: TopNSamples) => {
+    }).then((response: TopNResponse) => {
+      const totalCount = response.TotalCount;
       const samples = response.TopN;
-      const charts = groupSamplesByCategory(samples);
+      const charts = groupSamplesByCategory(samples, totalCount);
       setTopN({ charts });
     });
   }, [topNType, timeRange.start, timeRange.end, fetchTopN, kuery]);

--- a/x-pack/plugins/profiling/public/services.ts
+++ b/x-pack/plugins/profiling/public/services.ts
@@ -9,7 +9,7 @@ import { CoreStart, HttpFetchQuery } from '@kbn/core/public';
 import { getRoutePaths } from '../common';
 import { ElasticFlameGraph } from '../common/flamegraph';
 import { TopNFunctions } from '../common/functions';
-import { TopNSamples } from '../common/topn';
+import { TopNResponse } from '../common/topn';
 
 export interface Services {
   fetchTopN: (params: {
@@ -17,7 +17,7 @@ export interface Services {
     timeFrom: number;
     timeTo: number;
     kuery: string;
-  }) => Promise<TopNSamples>;
+  }) => Promise<TopNResponse>;
   fetchTopNFunctions: (params: {
     timeFrom: number;
     timeTo: number;

--- a/x-pack/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/plugins/profiling/server/routes/flamechart.ts
@@ -62,8 +62,8 @@ export function registerFlameChartElasticSearchRoute({ router, logger }: RouteRe
       path: paths.FlamechartElastic,
       validate: {
         query: schema.object({
-          timeFrom: schema.string(),
-          timeTo: schema.string(),
+          timeFrom: schema.number(),
+          timeTo: schema.number(),
           kuery: schema.string(),
         }),
       },

--- a/x-pack/plugins/profiling/server/routes/functions.ts
+++ b/x-pack/plugins/profiling/server/routes/functions.ts
@@ -51,8 +51,8 @@ async function queryTopNFunctions({
 }
 
 const querySchema = schema.object({
-  timeFrom: schema.string(),
-  timeTo: schema.string(),
+  timeFrom: schema.number(),
+  timeTo: schema.number(),
   startIndex: schema.number(),
   endIndex: schema.number(),
   kuery: schema.string(),

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -18,8 +18,8 @@ export function createCommonFilter({
   timeTo,
 }: {
   kuery: string;
-  timeFrom: string;
-  timeTo: string;
+  timeFrom: number;
+  timeTo: number;
 }): ProjectTimeQuery {
   return {
     bool: {
@@ -28,8 +28,8 @@ export function createCommonFilter({
         {
           range: {
             '@timestamp': {
-              gte: timeFrom,
-              lt: timeTo,
+              gte: String(timeFrom),
+              lt: String(timeTo),
               format: 'epoch_second',
               boost: 1.0,
             },

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -54,10 +54,7 @@ export function aggregateByFieldAndTimestamp(searchField: string, interval: stri
   return {
     terms: {
       field: searchField,
-      // We remove the ordering since we will rely directly on the natural
-      // ordering of Elasticsearch: by default this will be the descending count
-      // of matched documents. This is not equal to the ordering by sum of Count field,
-      // but it's a good-enough approximation given the distribution of Count.
+      order: { count: 'desc' },
       size: 100,
       // 'execution_hint: map' skips the slow building of ordinals that we don't need.
       // Especially with high cardinality fields, this setting speeds up the aggregation.

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -42,22 +42,22 @@ export function createCommonFilter({
 
 export function autoHistogramSumCountOnGroupByField(searchField: string) {
   return {
-    auto_date_histogram: {
-      field: '@timestamp',
-      buckets: 50,
+    terms: {
+      field: searchField,
+      // We remove the ordering since we will rely directly on the natural
+      // ordering of Elasticsearch: by default this will be the descending count
+      // of matched documents. This is not equal to the ordering by sum of Count field,
+      // but it's a good-enough approximation given the distribution of Count.
+      size: 100,
+      // 'execution_hint: map' skips the slow building of ordinals that we don't need.
+      // Especially with high cardinality fields, this setting speeds up the aggregation.
+      execution_hint: 'map',
     },
     aggs: {
       group_by: {
-        terms: {
-          field: searchField,
-          // We remove the ordering since we will rely directly on the natural
-          // ordering of Elasticsearch: by default this will be the descending count
-          // of matched documents. This is not equal to the ordering by sum of Count field,
-          // but it's a good-enough approximation given the distribution of Count.
-          size: 100,
-          // 'execution_hint: map' skips the slow building of ordinals that we don't need.
-          // Especially with high cardinality fields, this setting speeds up the aggregation.
-          execution_hint: 'map',
+        auto_date_histogram: {
+          field: '@timestamp',
+          buckets: 50,
         },
         aggs: {
           count: {

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -40,7 +40,17 @@ export function createCommonFilter({
   };
 }
 
-export function autoHistogramSumCountOnGroupByField(searchField: string) {
+export function findFixedIntervalForBucketsPerTimeRange(
+  timeFrom: number,
+  timeTo: number,
+  buckets: number
+): string {
+  const range = timeTo - timeFrom;
+  const interval = Math.max(Math.floor(range / buckets), 1);
+  return `${interval}s`;
+}
+
+export function aggregateByFieldAndTimestamp(searchField: string, interval: string) {
   return {
     terms: {
       field: searchField,
@@ -55,9 +65,9 @@ export function autoHistogramSumCountOnGroupByField(searchField: string) {
     },
     aggs: {
       group_by: {
-        auto_date_histogram: {
+        date_histogram: {
           field: '@timestamp',
-          buckets: 50,
+          fixed_interval: interval,
         },
         aggs: {
           count: {

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -50,15 +50,21 @@ export function findFixedIntervalForBucketsPerTimeRange(
   return `${interval}s`;
 }
 
-export function aggregateByFieldAndTimestamp(searchField: string, interval: string) {
+export function aggregateByFieldAndTimestamp(
+  searchField: string,
+  highCardinality: boolean,
+  interval: string
+) {
+  // 'execution_hint: map' skips the slow building of ordinals that we don't need.
+  // Especially with high cardinality fields, this setting speeds up the aggregation.
+  const executionHint = highCardinality ? 'map' : 'global_ordinals';
+
   return {
     terms: {
       field: searchField,
       order: { count: 'desc' },
       size: 100,
-      // 'execution_hint: map' skips the slow building of ordinals that we don't need.
-      // Especially with high cardinality fields, this setting speeds up the aggregation.
-      execution_hint: 'map',
+      execution_hint: executionHint,
     },
     aggs: {
       group_by: {

--- a/x-pack/plugins/profiling/server/routes/query.ts
+++ b/x-pack/plugins/profiling/server/routes/query.ts
@@ -77,6 +77,11 @@ export function aggregateByFieldAndTimestamp(searchField: string, interval: stri
           },
         },
       },
+      count: {
+        sum: {
+          field: 'Count',
+        },
+      },
     },
   };
 }

--- a/x-pack/plugins/profiling/server/routes/topn.test.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.test.ts
@@ -39,7 +39,7 @@ describe('TopN data from Elasticsearch', () => {
         context.elasticsearch.client.asCurrentUser.search(request) as Promise<any>
     ),
     mget: jest.fn(
-      (ooperationName, request) =>
+      (operationName, request) =>
         context.elasticsearch.client.asCurrentUser.search(request) as Promise<any>
     ),
   };

--- a/x-pack/plugins/profiling/server/routes/topn.test.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.test.ts
@@ -57,6 +57,7 @@ describe('TopN data from Elasticsearch', () => {
         timeFrom: 456,
         timeTo: 789,
         searchField: 'StackTraceID',
+        highCardinality: false,
         kuery: '',
         response: kibanaResponseFactory,
       });

--- a/x-pack/plugins/profiling/server/routes/topn.test.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.test.ts
@@ -13,13 +13,20 @@ import { ProfilingESClient } from '../utils/create_profiling_es_client';
 import { topNElasticSearchQuery } from './topn';
 
 const anyQuery = 'any::query';
+const smallestInterval = '1s';
 const testAgg = { aggs: { test: {} } };
 
 jest.mock('./query', () => ({
   createCommonFilter: ({}: {}) => {
     return anyQuery;
   },
-  autoHistogramSumCountOnGroupByField: (searchField: string): AggregationsAggregationContainer => {
+  findFixedIntervalForBucketsPerTimeRange: (from: number, to: number, buckets: number): string => {
+    return smallestInterval;
+  },
+  aggregateByFieldAndTimestamp: (
+    searchField: string,
+    interval: string
+  ): AggregationsAggregationContainer => {
     return testAgg;
   },
 }));

--- a/x-pack/plugins/profiling/server/routes/topn.test.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.test.ts
@@ -54,8 +54,8 @@ describe('TopN data from Elasticsearch', () => {
       const response = await topNElasticSearchQuery({
         client,
         logger,
-        timeFrom: '456',
-        timeTo: '789',
+        timeFrom: 456,
+        timeTo: 789,
         searchField: 'StackTraceID',
         kuery: '',
         response: kibanaResponseFactory,

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -34,8 +34,8 @@ export async function topNElasticSearchQuery({
 }: {
   client: ProfilingESClient;
   logger: Logger;
-  timeFrom: string;
-  timeTo: string;
+  timeFrom: number;
+  timeTo: number;
   searchField: string;
   response: KibanaResponseFactory;
   kuery: string;
@@ -133,8 +133,8 @@ export function queryTopNCommon(
       path: pathName,
       validate: {
         query: schema.object({
-          timeFrom: schema.string(),
-          timeTo: schema.string(),
+          timeFrom: schema.number(),
+          timeTo: schema.number(),
           kuery: schema.string(),
         }),
       },

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -72,6 +72,7 @@ export async function topNElasticSearchQuery({
   if (!resEvents.aggregations) {
     return response.ok({
       body: {
+        TotalCount: 0,
         TopN: [],
         Metadata: {},
       },
@@ -88,7 +89,7 @@ export async function topNElasticSearchQuery({
 
   if (searchField !== 'StackTraceID') {
     return response.ok({
-      body: { TopN: topN, Metadata: {} },
+      body: { TotalCount: totalSampledStackTraces, TopN: topN, Metadata: {} },
     });
   }
 
@@ -121,6 +122,7 @@ export async function topNElasticSearchQuery({
     );
     return response.ok({
       body: {
+        TotalCount: totalSampledStackTraces,
         TopN: topN,
         Metadata: metadata,
       },

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -88,7 +88,7 @@ export async function topNElasticSearchQuery({
 
   const histogramBuckets = histogram?.buckets ?? [];
   for (let i = 0; i < histogramBuckets.length; i++) {
-    totalDocCount += histogramBuckets[i].doc_count;
+    totalDocCount += histogramBuckets[i].count.value;
     histogramBuckets[i].group_by.buckets.forEach((stackTraceItem) => {
       const count = stackTraceItem.count.value ?? 0;
       const oldCount = stackTraceEvents.get(String(stackTraceItem.key));

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -29,6 +29,7 @@ export async function topNElasticSearchQuery({
   timeFrom,
   timeTo,
   searchField,
+  highCardinality,
   response,
   kuery,
 }: {
@@ -37,6 +38,7 @@ export async function topNElasticSearchQuery({
   timeFrom: number;
   timeTo: number;
   searchField: string;
+  highCardinality: boolean;
   response: KibanaResponseFactory;
   kuery: string;
 }) {
@@ -57,7 +59,7 @@ export async function topNElasticSearchQuery({
     size: 0,
     query: filter,
     aggs: {
-      histogram: aggregateByFieldAndTimestamp(searchField, fixedInterval),
+      histogram: aggregateByFieldAndTimestamp(searchField, highCardinality, fixedInterval),
       total_count: {
         sum: {
           field: 'Count',
@@ -134,7 +136,8 @@ export function queryTopNCommon(
   router: IRouter<ProfilingRequestHandlerContext>,
   logger: Logger,
   pathName: string,
-  searchField: string
+  searchField: string,
+  highCardinality: boolean
 ) {
   router.get(
     {
@@ -158,6 +161,7 @@ export function queryTopNCommon(
           timeFrom,
           timeTo,
           searchField,
+          highCardinality,
           response,
           kuery,
         });
@@ -182,7 +186,8 @@ export function registerTraceEventsTopNContainersSearchRoute({
     router,
     logger,
     paths.TopNContainers,
-    getFieldNameForTopNType(TopNType.Containers)
+    getFieldNameForTopNType(TopNType.Containers),
+    false
   );
 }
 
@@ -195,7 +200,8 @@ export function registerTraceEventsTopNDeploymentsSearchRoute({
     router,
     logger,
     paths.TopNDeployments,
-    getFieldNameForTopNType(TopNType.Deployments)
+    getFieldNameForTopNType(TopNType.Deployments),
+    false
   );
 }
 
@@ -204,7 +210,13 @@ export function registerTraceEventsTopNHostsSearchRoute({
   logger,
 }: RouteRegisterParameters) {
   const paths = getRoutePaths();
-  return queryTopNCommon(router, logger, paths.TopNHosts, getFieldNameForTopNType(TopNType.Hosts));
+  return queryTopNCommon(
+    router,
+    logger,
+    paths.TopNHosts,
+    getFieldNameForTopNType(TopNType.Hosts),
+    false
+  );
 }
 
 export function registerTraceEventsTopNStackTracesSearchRoute({
@@ -216,7 +228,8 @@ export function registerTraceEventsTopNStackTracesSearchRoute({
     router,
     logger,
     paths.TopNTraces,
-    getFieldNameForTopNType(TopNType.Traces)
+    getFieldNameForTopNType(TopNType.Traces),
+    false
   );
 }
 
@@ -229,6 +242,7 @@ export function registerTraceEventsTopNThreadsSearchRoute({
     router,
     logger,
     paths.TopNThreads,
-    getFieldNameForTopNType(TopNType.Threads)
+    getFieldNameForTopNType(TopNType.Threads),
+    true
   );
 }


### PR DESCRIPTION
Part of [elastic/prodfiler#2451](https://github.com/elastic/prodfiler/issues/2451)

~~This PR removes `size` from the terms aggregation query. Since the default size per bucket is 10 and we were previously using 100, this gives us fewer unique categories. In addition to reducing the response size and time, we also have a faster rendering time and a less cluttered graph.~~

After considering the initial [feedback](https://github.com/elastic/kibana/pull/137139#issuecomment-1195612764) and experimenting with a few alternatives, this PR improves upon the response size and time using a new approach.

It also addresses the server error that sometimes occurs for larger time ranges, causing a graph to not render. The error results from the server hitting the `max_bucket_size` limit. For instance, the `Before` graph for the `24h` time range is the same as the `12h` time range because of this server error.

Unrelated to the original purpose of the PR, it was discovered that the category percentages were previously incorrect. This has been fixed.

**Notes**

1. Prior to this PR, samples were aggregated first by `auto_date_histogram` and then by `terms`. After trial-and-error, it was determined that a more optimal and accurate approach was aggregation by `terms` and then `date_histogram` (roughly 50% faster).
2. Aggregation by `date_histogram` was used instead of `auto_date_histogram` since the fixed bucket size used by `date_histogram` was the only way to normalize the x-axis across all subcharts when `@timestamp` was used as the secondary aggregation.
3. A side effect of aggregating by `terms` first is that `size: 100` becomes the maximum number of top N values shown in the view. We may wish to update the limit in the future, but there will be a tradeoff with the response size and time.
4. According to empirical measurements both locally and on the MVP cluster, traces appear to have a long-tail distribution. Across a given time range, there may be thousands of unique traces, but the majority of them have small counts. This means a maximum top N limit of 100 (described in the previous note) captures most of the heavier traces.
5. Percentages for each subchart were previously incorrect. The values were too high since percentages were calculated based on the total count from the sample and not the global total count in Elasticsearch for the given time range.
6. Other top N stacktrace views beside `Traces` benefit from the above improvements.

| Before | After |
|-|-|
| ![30 minutes](https://user-images.githubusercontent.com/6038/182207912-958cb9b1-566d-4f9b-9734-a683f707c342.png) | ![30 minutes](https://user-images.githubusercontent.com/6038/182208109-e90b7b47-7ea5-4b1c-9660-1810c4461ab6.png) |
| ![1 hour](https://user-images.githubusercontent.com/6038/182207963-538b280e-bc64-45d4-a838-37b862566e7d.png) | ![1 hour](https://user-images.githubusercontent.com/6038/182208137-9d74af95-35c3-48a7-99a8-acb1d23de8b6.png) |
| ![24 hours](https://user-images.githubusercontent.com/6038/182208006-ee82d51e-4190-455c-81ed-0bae4d4dbf50.png) | ![24 hours](https://user-images.githubusercontent.com/6038/182208168-fca5cb12-9994-479c-a2b7-01d855ef0c88.png) |
| ![7 days](https://user-images.githubusercontent.com/6038/182208061-32e93e1d-f293-4f69-8990-8d097a5e9967.png) | ![7 days](https://user-images.githubusercontent.com/6038/182208208-098d56d1-9295-427e-9823-634323a5bebe.png) |