### PR TITLE
[Enterprise Search] Fix API Ingest Example

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/constants.ts
@@ -26,40 +26,20 @@ export const NEW_INDEX_TEMPLATE_TYPES: { [key: string]: string } = {
   }),
 };
 
-export const DOCUMENTS_API_JSON_EXAMPLE = [
-  {
-    index: {
-      id: 'park_rocky-mountain',
-      title: 'Rocky Mountain',
-      description:
-        'Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra. Wildlife including mule deer, bighorn sheep, black bears, and cougars inhabit its igneous mountains and glacial valleys. Longs Peak, a classic Colorado fourteener, and the scenic Bear Lake are popular destinations, as well as the historic Trail Ridge Road, which reaches an elevation of more than 12,000 feet (3,700 m).',
-      nps_link: 'https://www.nps.gov/romo/index.htm',
-      states: ['Colorado'],
-      visitors: 4517585,
-      world_heritage_site: false,
-      location: '40.4,-105.58',
-      acres: 265795.2,
-      square_km: 1075.6,
-      date_established: '1915-01-26T06:00:00Z',
-    },
-  },
-  {
-    index: {
-      id: 'park_saguaro',
-      title: 'Saguaro',
-      description:
-        'Split into the separate Rincon Mountain and Tucson Mountain districts, this park is evidence that the dry Sonoran Desert is still home to a great variety of life spanning six biotic communities. Beyond the namesake giant saguaro cacti, there are barrel cacti, chollas, and prickly pears, as well as lesser long-nosed bats, spotted owls, and javelinas.',
-      nps_link: 'https://www.nps.gov/sagu/index.htm',
-      states: ['Arizona'],
-      visitors: 820426,
-      world_heritage_site: false,
-      location: '32.25,-110.5',
-      acres: 91715.72,
-      square_km: 371.2,
-      date_established: '1994-10-14T05:00:00Z',
-    },
-  },
-];
+export const DOCUMENTS_API_JSON_EXAMPLE = {
+  id: 'park_rocky-mountain',
+  title: 'Rocky Mountain',
+  description:
+    'Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra. Wildlife including mule deer, bighorn sheep, black bears, and cougars inhabit its igneous mountains and glacial valleys. Longs Peak, a classic Colorado fourteener, and the scenic Bear Lake are popular destinations, as well as the historic Trail Ridge Road, which reaches an elevation of more than 12,000 feet (3,700 m).',
+  nps_link: 'https://www.nps.gov/romo/index.htm',
+  states: ['Colorado'],
+  visitors: 4517585,
+  world_heritage_site: false,
+  location: '40.4,-105.58',
+  acres: 265795.2,
+  square_km: 1075.6,
+  date_established: '1915-01-26T06:00:00Z',
+};
 
 export const UNIVERSAL_LANGUAGE_VALUE = '';
 


### PR DESCRIPTION
## Summary

The API Example we were showing on the API Ingest overview page had a body reminiscent of the bulk API. Changed to a body the [Index API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html) would expect.

closes https://github.com/elastic/enterprise-search-team/issues/2355