### PR TITLE
[Fleet] Fix default source_uri host

### DIFF
--- a/x-pack/plugins/fleet/common/constants/download_source.ts
+++ b/x-pack/plugins/fleet/common/constants/download_source.ts
@@ -6,8 +6,7 @@
  */
 
 // Default source URI used to download Elastic Agent
-export const DEFAULT_DOWNLOAD_SOURCE_URI =
-  'https://artifacts.elastic.co/downloads/beats/elastic-agent';
+export const DEFAULT_DOWNLOAD_SOURCE_URI = 'https://artifacts.elastic.co/downloads/';
 
 export const DOWNLOAD_SOURCE_SAVED_OBJECT_TYPE = 'ingest-download-sources';
 

--- a/x-pack/plugins/fleet/cypress/integration/agent_binary_download_source.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent_binary_download_source.spec.ts
@@ -26,7 +26,7 @@ describe('Agent binary download source section', () => {
 
     cy.getBySel(AGENT_BINARY_SOURCES_TABLE).find('tr').should('have.length', '2');
     cy.getBySel(AGENT_BINARY_SOURCES_TABLE_ACTIONS.HOST).contains(
-      'https://artifacts.elastic.co/downloads/beats/elastic-agent'
+      'https://artifacts.elastic.co/downloads/'
     );
     cy.getBySel(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE).should('exist');
     cy.getBySel(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT).click();

--- a/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
+++ b/x-pack/plugins/fleet/server/integration_tests/__snapshots__/cloud_preconfiguration.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Fleet preconfiguration reset Preconfigured cloud policy With a full pre
 Object {
   "agent": Object {
     "download": Object {
-      "source_uri": "https://artifacts.elastic.co/downloads/beats/elastic-agent",
+      "source_uri": "https://artifacts.elastic.co/downloads/",
     },
     "monitoring": Object {
       "enabled": false,

--- a/x-pack/test/fleet_api_integration/apis/download_sources/crud.ts
+++ b/x-pack/test/fleet_api_integration/apis/download_sources/crud.ts
@@ -52,7 +52,7 @@ export default function (providerContext: FtrProviderContext) {
           id: 'fleet-default-download-source',
           name: 'Elastic Artifacts',
           is_default: true,
-          host: 'https://artifacts.elastic.co/downloads/beats/elastic-agent',
+          host: 'https://artifacts.elastic.co/downloads/',
         });
       });
     });
@@ -68,7 +68,7 @@ export default function (providerContext: FtrProviderContext) {
             id: 'fleet-default-download-source',
             name: 'Elastic Artifacts',
             is_default: true,
-            host: 'https://artifacts.elastic.co/downloads/beats/elastic-agent',
+            host: 'https://artifacts.elastic.co/downloads/',
           },
         });
       });


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/133828

Fixes default `source_uri` host as per @michalpristas [comment](https://github.com/elastic/elastic-agent/pull/686#issuecomment-1194392288):
> the preconfigured URI on kibana side is incorrect it's https://artifacts.elastic.co/downloads/elastic-agent should be https://artifacts.elastic.co/downloads/ because it's common for all artifacts. artifact name such as elastic-agent or filebeat is computed.



### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
