### PR TITLE
Remove base64 fileid padding

### DIFF
--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -154,13 +154,7 @@ export function decodeStackTrace(input: EncodedStackTrace): StackTrace {
     } else {
       const buf = Buffer.from(fileIDChunk, 'base64url');
 
-      // We have to manually append '==' since we use the FileID string for
-      // comparing / looking up the FileID strings in the ES indices, which have
-      // the '==' appended.
-      //
-      // We may want to remove '==' in the future to reduce the uncompressed
-      // storage size by 10%.
-      fileIDs[j] = buf.toString('base64url', 0, 16) + '==';
+      fileIDs[j] = buf.toString('base64url', 0, 16);
       fileIDChunkToFileIDCache.set(fileIDChunk, fileIDs[j]);
     }
   }


### PR DESCRIPTION
This removes the padding from the values of the FileID cache in `decodeStackTrace()`.
This is not changing functionality, but is in line with the latest collector/backend changes.

Related to https://github.com/elastic/prodfiler/issues/2454