### PR TITLE
[ResponseOps] [Actionable Observability] [BUG] - Fix responsivity Alert Summary chart in the Rule details page

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_summary/rule_alerts_summary.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_summary/rule_alerts_summary.tsx
@@ -5,38 +5,29 @@
  * 2.0.
  */
 
-import { BarSeries, Chart, ScaleType, Settings, PartialTheme, TooltipType } from '@elastic/charts';
+import { BarSeries, Chart, ScaleType, Settings, TooltipType } from '@elastic/charts';
 import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
   EuiLoadingSpinner,
   EuiPanel,
+  EuiSpacer,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useEffect, useMemo, useState } from 'react';
+import {
+  EUI_CHARTS_THEME_LIGHT,
+  EUI_SPARKLINE_THEME_PARTIAL,
+} from '@elastic/eui/dist/eui_charts_theme';
 import { useLoadRuleAlertsAggs } from '../../../../hooks/use_load_rule_alerts_aggregations';
 import { useLoadRuleTypes } from '../../../../hooks/use_load_rule_types';
 import { formatChartAlertData, getColorSeries } from '.';
 import { RuleAlertsSummaryProps } from '.';
 
-const theme: PartialTheme = {
-  chartMargins: {
-    bottom: 0,
-    left: 0,
-    top: 20,
-    right: 0,
-  },
-  chartPaddings: {
-    bottom: 0,
-    left: 0,
-    top: 0,
-    right: 0,
-  },
-};
 const Y_ACCESSORS = ['y'];
 const X_ACCESSORS = ['x'];
 const G_ACCESSORS = ['g'];
@@ -142,8 +133,12 @@ export const RuleAlertsSummary = ({ rule, filteredRuleTypes }: RuleAlertsSummary
           </EuiTitle>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <Chart size={['100%', '35%']}>
-        <Settings tooltip={TooltipType.None} theme={theme} />
+      <EuiSpacer size="m" />
+      <Chart size={{ height: 50 }}>
+        <Settings
+          tooltip={TooltipType.None}
+          theme={[EUI_SPARKLINE_THEME_PARTIAL, EUI_CHARTS_THEME_LIGHT.theme]}
+        />
         <BarSeries
           id="bars"
           xScaleType={ScaleType.Time}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_summary/rule_alerts_summary.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/alert_summary/rule_alerts_summary.tsx
@@ -20,9 +20,11 @@ import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  EUI_CHARTS_THEME_DARK,
   EUI_CHARTS_THEME_LIGHT,
   EUI_SPARKLINE_THEME_PARTIAL,
 } from '@elastic/eui/dist/eui_charts_theme';
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { useLoadRuleAlertsAggs } from '../../../../hooks/use_load_rule_alerts_aggregations';
 import { useLoadRuleTypes } from '../../../../hooks/use_load_rule_types';
 import { formatChartAlertData, getColorSeries } from '.';
@@ -34,6 +36,14 @@ const G_ACCESSORS = ['g'];
 
 export const RuleAlertsSummary = ({ rule, filteredRuleTypes }: RuleAlertsSummaryProps) => {
   const [features, setFeatures] = useState<string>('');
+  const isDarkMode = useUiSetting<boolean>('theme:darkMode');
+  const theme = useMemo(
+    () => [
+      EUI_SPARKLINE_THEME_PARTIAL,
+      isDarkMode ? EUI_CHARTS_THEME_DARK.theme : EUI_CHARTS_THEME_LIGHT.theme,
+    ],
+    [isDarkMode]
+  );
   const { ruleTypes } = useLoadRuleTypes({
     filteredRuleTypes,
   });
@@ -135,10 +145,7 @@ export const RuleAlertsSummary = ({ rule, filteredRuleTypes }: RuleAlertsSummary
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <Chart size={{ height: 50 }}>
-        <Settings
-          tooltip={TooltipType.None}
-          theme={[EUI_SPARKLINE_THEME_PARTIAL, EUI_CHARTS_THEME_LIGHT.theme]}
-        />
+        <Settings tooltip={TooltipType.None} theme={theme} />
         <BarSeries
           id="bars"
           xScaleType={ScaleType.Time}


### PR DESCRIPTION
## Summary

it fixes #137173 

### Before
![image](https://user-images.githubusercontent.com/6838659/181000420-9d5e3854-d969-4782-a4c4-477a8356bda9.png)

### After
https://user-images.githubusercontent.com/6838659/181000489-c8885dc7-a067-45f9-8538-94493fadb721.mov

