### PR TITLE
[Fleet] Improve tests around upgrade

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/index.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { UpgradeStatusCallout } from './upgrade';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/upgrade.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/upgrade.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiCallOut,
+  EuiLink,
+  EuiFlyout,
+  EuiCodeBlock,
+  EuiPortal,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import styled from 'styled-components';
+
+import type { UpgradePackagePolicyDryRunResponse } from '../../../../../../../common/types/rest_spec';
+
+const FlyoutBody = styled(EuiFlyoutBody)`
+  .euiFlyoutBody__overflowContent {
+    padding: 0;
+  }
+`;
+
+export const UpgradeStatusCallout: React.FunctionComponent<{
+  dryRunData: UpgradePackagePolicyDryRunResponse;
+}> = ({ dryRunData }) => {
+  const [isPreviousVersionFlyoutOpen, setIsPreviousVersionFlyoutOpen] = useState<boolean>(false);
+
+  if (!dryRunData) {
+    return null;
+  }
+
+  const isReadyForUpgrade = !dryRunData[0].hasErrors;
+
+  const [currentPackagePolicy, proposedUpgradePackagePolicy] = dryRunData[0].diff || [];
+
+  return (
+    <>
+      {isPreviousVersionFlyoutOpen && currentPackagePolicy && (
+        <EuiPortal>
+          <EuiFlyout onClose={() => setIsPreviousVersionFlyoutOpen(false)} size="l" maxWidth={640}>
+            <EuiFlyoutHeader hasBorder>
+              <EuiTitle size="m">
+                <h2 id="FleetPackagePolicyPreviousVersionFlyoutTitle">
+                  <FormattedMessage
+                    id="xpack.fleet.upgradePackagePolicy.previousVersionFlyout.title"
+                    defaultMessage="'{name}' integration policy"
+                    values={{ name: currentPackagePolicy?.name }}
+                  />
+                </h2>
+              </EuiTitle>
+            </EuiFlyoutHeader>
+            <FlyoutBody>
+              <EuiCodeBlock isCopyable fontSize="m" whiteSpace="pre">
+                {JSON.stringify(dryRunData[0].agent_diff?.[0] || [], null, 2)}
+              </EuiCodeBlock>
+            </FlyoutBody>
+          </EuiFlyout>
+        </EuiPortal>
+      )}
+
+      {isReadyForUpgrade && currentPackagePolicy ? (
+        <EuiCallOut
+          title={i18n.translate('xpack.fleet.upgradePackagePolicy.statusCallOut.successTitle', {
+            defaultMessage: 'Ready to upgrade',
+          })}
+          color="success"
+          iconType="checkInCircleFilled"
+        >
+          <FormattedMessage
+            id="xpack.fleet.upgradePackagePolicy.statusCallout.successContent"
+            defaultMessage="This integration is ready to be upgraded from version {currentVersion} to {upgradeVersion}. Review the changes below and save to upgrade."
+            values={{
+              currentVersion: currentPackagePolicy?.package?.version,
+              upgradeVersion: proposedUpgradePackagePolicy?.package?.version,
+            }}
+          />
+        </EuiCallOut>
+      ) : (
+        <EuiCallOut
+          title={i18n.translate('xpack.fleet.upgradePackagePolicy.statusCallOut.errorTitle', {
+            defaultMessage: 'Review field conflicts',
+          })}
+          color="warning"
+          iconType="alert"
+        >
+          <FormattedMessage
+            id="xpack.fleet.upgradePackagePolicy.statusCallout.errorContent"
+            defaultMessage="This integration has conflicting fields from version {currentVersion} to {upgradeVersion} Review the configuration and save to perform the upgrade. You may reference your {previousConfigurationLink} for comparison."
+            values={{
+              currentVersion: currentPackagePolicy?.package?.version,
+              upgradeVersion: proposedUpgradePackagePolicy?.package?.version,
+              previousConfigurationLink: (
+                <EuiLink onClick={() => setIsPreviousVersionFlyoutOpen(true)}>
+                  <FormattedMessage
+                    id="xpack.fleet.upgradePackagePolicy.statusCallout.previousConfigurationLink"
+                    defaultMessage="previous configuration"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </EuiCallOut>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -15,20 +15,11 @@ import deepEqual from 'fast-deep-equal';
 import {
   EuiButtonEmpty,
   EuiBottomBar,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiLink,
-  EuiFlyout,
-  EuiCodeBlock,
-  EuiPortal,
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
-  EuiTitle,
   EuiErrorBoundary,
 } from '@elastic/eui';
-import styled from 'styled-components';
 
 import type { AgentPolicy, PackageInfo, UpdatePackagePolicy, PackagePolicy } from '../../../types';
 import {
@@ -71,6 +62,7 @@ import { pkgKeyFromPackageInfo } from '../../../services';
 
 import { fixApmDurationVars, hasUpgradeAvailable } from './utils';
 import { useHistoryBlock } from './hooks';
+import { UpgradeStatusCallout } from './components';
 
 export const EditPackagePolicyPage = memo(() => {
   const {
@@ -759,95 +751,4 @@ const UpgradeBreadcrumb: React.FunctionComponent<{
 }> = ({ policyName, policyId }) => {
   useBreadcrumbs('upgrade_package_policy', { policyName, policyId });
   return null;
-};
-
-const FlyoutBody = styled(EuiFlyoutBody)`
-  .euiFlyoutBody__overflowContent {
-    padding: 0;
-  }
-`;
-
-const UpgradeStatusCallout: React.FunctionComponent<{
-  dryRunData: UpgradePackagePolicyDryRunResponse;
-}> = ({ dryRunData }) => {
-  const [isPreviousVersionFlyoutOpen, setIsPreviousVersionFlyoutOpen] = useState<boolean>(false);
-
-  if (!dryRunData) {
-    return null;
-  }
-
-  const isReadyForUpgrade = !dryRunData[0].hasErrors;
-
-  const [currentPackagePolicy, proposedUpgradePackagePolicy] = dryRunData[0].diff || [];
-
-  return (
-    <>
-      {isPreviousVersionFlyoutOpen && currentPackagePolicy && (
-        <EuiPortal>
-          <EuiFlyout onClose={() => setIsPreviousVersionFlyoutOpen(false)} size="l" maxWidth={640}>
-            <EuiFlyoutHeader hasBorder>
-              <EuiTitle size="m">
-                <h2 id="FleetPackagePolicyPreviousVersionFlyoutTitle">
-                  <FormattedMessage
-                    id="xpack.fleet.upgradePackagePolicy.previousVersionFlyout.title"
-                    defaultMessage="'{name}' integration policy"
-                    values={{ name: currentPackagePolicy?.name }}
-                  />
-                </h2>
-              </EuiTitle>
-            </EuiFlyoutHeader>
-            <FlyoutBody>
-              <EuiCodeBlock isCopyable fontSize="m" whiteSpace="pre">
-                {JSON.stringify(dryRunData[0].agent_diff?.[0] || [], null, 2)}
-              </EuiCodeBlock>
-            </FlyoutBody>
-          </EuiFlyout>
-        </EuiPortal>
-      )}
-
-      {isReadyForUpgrade && currentPackagePolicy ? (
-        <EuiCallOut
-          title={i18n.translate('xpack.fleet.upgradePackagePolicy.statusCallOut.successTitle', {
-            defaultMessage: 'Ready to upgrade',
-          })}
-          color="success"
-          iconType="checkInCircleFilled"
-        >
-          <FormattedMessage
-            id="xpack.fleet.upgradePackagePolicy.statusCallout.successContent"
-            defaultMessage="This integration is ready to be upgraded from version {currentVersion} to {upgradeVersion}. Review the changes below and save to upgrade."
-            values={{
-              currentVersion: currentPackagePolicy?.package?.version,
-              upgradeVersion: proposedUpgradePackagePolicy?.package?.version,
-            }}
-          />
-        </EuiCallOut>
-      ) : (
-        <EuiCallOut
-          title={i18n.translate('xpack.fleet.upgradePackagePolicy.statusCallOut.errorTitle', {
-            defaultMessage: 'Review field conflicts',
-          })}
-          color="warning"
-          iconType="alert"
-        >
-          <FormattedMessage
-            id="xpack.fleet.upgradePackagePolicy.statusCallout.errorContent"
-            defaultMessage="This integration has conflicting fields from version {currentVersion} to {upgradeVersion} Review the configuration and save to perform the upgrade. You may reference your {previousConfigurationLink} for comparison."
-            values={{
-              currentVersion: currentPackagePolicy?.package?.version,
-              upgradeVersion: proposedUpgradePackagePolicy?.package?.version,
-              previousConfigurationLink: (
-                <EuiLink onClick={() => setIsPreviousVersionFlyoutOpen(true)}>
-                  <FormattedMessage
-                    id="xpack.fleet.upgradePackagePolicy.statusCallout.previousConfigurationLink"
-                    defaultMessage="previous configuration"
-                  />
-                </EuiLink>
-              ),
-            }}
-          />
-        </EuiCallOut>
-      )}
-    </>
-  );
 };


### PR DESCRIPTION
## Summary

Resolve #125236 

I added some unit test on the server side code that detect conflict.

@kpollich On the client side the whole flow is already covered by a unit test here, I personally think it's enough and adding a cypress test here will be a lot of work and potentially a lot to maintain too but I am curious to have your thoughts https://github.com/nchaulet/kibana/blob/8a9976d61d618a0bfce0b93dc30d44f90864bded/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx#L376