### PR TITLE
[Fleet] Use autosubmit for agent logs query bar

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
@@ -52,6 +52,7 @@ export const LogQueryBar: React.FunctionComponent<{
   return (
     <QueryStringInput
       iconType="search"
+      autoSubmit={true}
       disableLanguageSwitcher={true}
       indexPatterns={
         indexPatternFields


### PR DESCRIPTION
## Summary

Resolve #136920

Use auto submit for agent logs query bar, this allow to automatically submit the query (refresh the data and sync the state in the URL) when the user:
* clear the search bar 
* select a suggestion in the search bar

Before the user has to type `enter` in the search bar to trigger the search.

