### PR TITLE
[Security Solution][Admin][Responder] Unit tests to check if responder option is disabled when endpoint capabilities are insufficient

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -73,4 +73,13 @@ export const failedFleetActionErrorCode = '424';
 
 export const ENDPOINT_DEFAULT_PAGE = 0;
 export const ENDPOINT_DEFAULT_PAGE_SIZE = 10;
-export const RESPONDER_CAPABILITIES = ['kill_process', 'suspend_process', 'running_processes'];
+
+/**
+ * The list of capabilities, reported by the endpoint in the metadata document, that are
+ * needed in order for the Responder UI to be accessible
+ */
+export const RESPONDER_CAPABILITIES = [
+  'kill_process',
+  'suspend_process',
+  'running_processes',
+] as const;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { useWithShowEndpointResponder } from '../../../../hooks';
@@ -28,12 +27,6 @@ import { UPGRADE_ENDPOINT_FOR_RESPONDER } from '../../../../../common/translatio
 interface Options {
   isEndpointList: boolean;
 }
-
-const launchResponderMenuText = i18n.translate('xpack.securitySolution.endpoint.actions.console', {
-  defaultMessage: 'Launch responder',
-});
-
-// const launchResponderMenuText = <FormattedMessage id="xpack.securitySolution.endpoint.actions.console" defaultMessage="Launch responder" />
 
 /**
  * Returns a list (array) of actions for an individual endpoint

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -7,7 +7,9 @@
 
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
+import { EuiToolTip } from '@elastic/eui';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { useWithShowEndpointResponder } from '../../../../hooks';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
@@ -29,6 +31,13 @@ interface Options {
 }
 
 const responderCapabilitiesList = ['kill_process', 'suspend_process', 'running_processes'];
+
+const launchResponderMenuText = i18n.translate('xpack.securitySolution.endpoint.actions.console', {
+  defaultMessage: 'Launch responder',
+});
+
+// const launchResponderMenuText = <FormattedMessage id="xpack.securitySolution.endpoint.actions.console" defaultMessage="Launch responder" />
+
 /**
  * Returns a list (array) of actions for an individual endpoint
  * @param endpointMetadata
@@ -126,9 +135,7 @@ export const useEndpointActionItems = (
 
       return [
         ...isolationActions,
-        ...(isResponseActionsConsoleEnabled &&
-        canAccessResponseConsole &&
-        isResponderCapabilitiesEnabled
+        ...(isResponseActionsConsoleEnabled && canAccessResponseConsole
           ? [
               {
                 'data-test-subj': 'console',
@@ -139,11 +146,20 @@ export const useEndpointActionItems = (
                   ev.preventDefault();
                   showEndpointResponseActionsConsole(endpointMetadata);
                 },
-                children: (
-                  <FormattedMessage
-                    id="xpack.securitySolution.endpoint.actions.console"
-                    defaultMessage="Launch responder"
-                  />
+                children: isResponderCapabilitiesEnabled ? (
+                  launchResponderMenuText
+                ) : (
+                  <EuiToolTip
+                    content={i18n.translate(
+                      'xpack.securitySolution.endpoint.actions.disabledResponder.tooltip',
+                      {
+                        defaultMessage:
+                          'The current version of the Agent does not support this feature. Upgrade your Agent through Fleet to use this feature and new response actions such as killing and suspending processes.',
+                      }
+                    )}
+                  >
+                    <p>{launchResponderMenuText}</p>
+                  </EuiToolTip>
                 ),
                 toolTipContent: !isResponderCapabilitiesEnabled
                   ? UPGRADE_ENDPOINT_FOR_RESPONDER

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -28,6 +28,7 @@ interface Options {
   isEndpointList: boolean;
 }
 
+const responderCapabilitiesList = ['kill_process', 'suspend_process', 'running_processes'];
 /**
  * Returns a list (array) of actions for an individual endpoint
  * @param endpointMetadata
@@ -49,6 +50,9 @@ export const useEndpointActionItems = (
 
   return useMemo<ContextMenuItemNavByRouterProps[]>(() => {
     if (endpointMetadata) {
+      const isResponderCapabilitiesEnabled = responderCapabilitiesList.every((capability) =>
+        endpointMetadata.Endpoint.capabilities?.includes(capability)
+      );
       const isIsolated = isEndpointHostIsolated(endpointMetadata);
       const endpointId = endpointMetadata.agent.id;
       const endpointPolicyId = endpointMetadata.Endpoint.policy.applied.id;
@@ -122,7 +126,9 @@ export const useEndpointActionItems = (
 
       return [
         ...isolationActions,
-        ...(isResponseActionsConsoleEnabled && canAccessResponseConsole
+        ...(isResponseActionsConsoleEnabled &&
+        canAccessResponseConsole &&
+        isResponderCapabilitiesEnabled
           ? [
               {
                 'data-test-subj': 'console',

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -9,7 +9,6 @@ import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
-import { EuiToolTip } from '@elastic/eui';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { useWithShowEndpointResponder } from '../../../../hooks';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
@@ -29,8 +28,6 @@ import { UPGRADE_ENDPOINT_FOR_RESPONDER } from '../../../../../common/translatio
 interface Options {
   isEndpointList: boolean;
 }
-
-const responderCapabilitiesList = ['kill_process', 'suspend_process', 'running_processes'];
 
 const launchResponderMenuText = i18n.translate('xpack.securitySolution.endpoint.actions.console', {
   defaultMessage: 'Launch responder',
@@ -59,9 +56,6 @@ export const useEndpointActionItems = (
 
   return useMemo<ContextMenuItemNavByRouterProps[]>(() => {
     if (endpointMetadata) {
-      const isResponderCapabilitiesEnabled = responderCapabilitiesList.every((capability) =>
-        endpointMetadata.Endpoint.capabilities?.includes(capability)
-      );
       const isIsolated = isEndpointHostIsolated(endpointMetadata);
       const endpointId = endpointMetadata.agent.id;
       const endpointPolicyId = endpointMetadata.Endpoint.policy.applied.id;
@@ -146,20 +140,11 @@ export const useEndpointActionItems = (
                   ev.preventDefault();
                   showEndpointResponseActionsConsole(endpointMetadata);
                 },
-                children: isResponderCapabilitiesEnabled ? (
-                  launchResponderMenuText
-                ) : (
-                  <EuiToolTip
-                    content={i18n.translate(
-                      'xpack.securitySolution.endpoint.actions.disabledResponder.tooltip',
-                      {
-                        defaultMessage:
-                          'The current version of the Agent does not support this feature. Upgrade your Agent through Fleet to use this feature and new response actions such as killing and suspending processes.',
-                      }
-                    )}
-                  >
-                    <p>{launchResponderMenuText}</p>
-                  </EuiToolTip>
+                children: (
+                  <FormattedMessage
+                    id="xpack.securitySolution.endpoint.actions.console"
+                    defaultMessage="Launch responder"
+                  />
                 ),
                 toolTipContent: !isResponderCapabilitiesEnabled
                   ? UPGRADE_ENDPOINT_FOR_RESPONDER

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -50,7 +50,11 @@ import {
   HOST_METADATA_LIST_ROUTE,
   metadataTransformPrefix,
   METADATA_UNITED_TRANSFORM,
+  RESPONDER_CAPABILITIES,
 } from '../../../../../common/endpoint/constants';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { initialUserPrivilegesState as mockInitialUserPrivilegesState } from '../../../../common/components/user_privileges/user_privileges_context';
+import { getUserPrivilegesMockDefaultValue } from '../../../../common/components/user_privileges/__mocks__';
 
 // not sure why this can't be imported from '../../../../common/mock/formatted_relative';
 // but sure enough it needs to be inline in this one file
@@ -63,6 +67,7 @@ jest.mock('@kbn/i18n-react', () => {
     FormattedRelative,
   };
 });
+jest.mock('../../../../common/components/user_privileges');
 jest.mock('../../../../common/components/link_to');
 jest.mock('../../../services/policies/ingest', () => {
   const originalModule = jest.requireActual('../../../services/policies/ingest');
@@ -998,37 +1003,66 @@ describe('when on the endpoint list page', () => {
 
   describe('when the more actions column is opened', () => {
     const generator = new EndpointDocGenerator('seed');
-    let hostInfo: HostInfo;
+    let hostInfo: HostInfo[];
     let agentId: string;
     let agentPolicyId: string;
     let renderResult: ReturnType<AppContextTestRender['render']>;
 
+    // 2nd endpoint only has isolation capabilities
     const mockEndpointListApi = () => {
-      const { data: hosts } = mockEndpointResultList();
-      hostInfo = {
-        host_status: hosts[0].host_status,
-        metadata: {
-          ...hosts[0].metadata,
-          Endpoint: {
-            ...hosts[0].metadata.Endpoint,
-            state: {
-              ...hosts[0].metadata.Endpoint.state,
-              isolation: false,
+      const { data: hosts } = mockEndpointResultList({ total: 2 });
+      hostInfo = [
+        {
+          host_status: hosts[0].host_status,
+          metadata: {
+            ...hosts[0].metadata,
+            Endpoint: {
+              ...hosts[0].metadata.Endpoint,
+              capabilities: RESPONDER_CAPABILITIES,
+              state: {
+                ...hosts[0].metadata.Endpoint.state,
+                isolation: false,
+              },
             },
-          },
-          host: {
-            ...hosts[0].metadata.host,
-            os: {
-              ...hosts[0].metadata.host.os,
-              name: 'Windows',
+            host: {
+              ...hosts[0].metadata.host,
+              os: {
+                ...hosts[0].metadata.host.os,
+                name: 'Windows',
+              },
             },
-          },
-          agent: {
-            ...hosts[0].metadata.agent,
-            version: '7.14.0',
+            agent: {
+              ...hosts[0].metadata.agent,
+              version: '7.14.0',
+            },
           },
         },
-      };
+        {
+          host_status: hosts[1].host_status,
+          metadata: {
+            ...hosts[1].metadata,
+            Endpoint: {
+              ...hosts[1].metadata.Endpoint,
+              capabilities: ['isolation'],
+              state: {
+                ...hosts[1].metadata.Endpoint.state,
+                isolation: false,
+              },
+            },
+            host: {
+              ...hosts[1].metadata.host,
+              os: {
+                ...hosts[1].metadata.host.os,
+                name: 'Windows',
+              },
+            },
+            agent: {
+              ...hosts[1].metadata.agent,
+              version: '8.4.0',
+            },
+          },
+        },
+      ];
 
       const packagePolicy = docGenerator.generatePolicyPackagePolicy();
       packagePolicy.id = hosts[0].metadata.Endpoint.policy.applied.id;
@@ -1037,7 +1071,7 @@ describe('when on the endpoint list page', () => {
       agentId = hosts[0].metadata.elastic.agent.id;
 
       setEndpointListApiMockImplementation(coreStart.http, {
-        endpointsResults: [hostInfo],
+        endpointsResults: hostInfo,
         endpointPackagePolicies: [packagePolicy],
         agentPolicy,
       });
@@ -1045,6 +1079,10 @@ describe('when on the endpoint list page', () => {
 
     beforeEach(async () => {
       mockEndpointListApi();
+      (useUserPrivileges as jest.Mock).mockReturnValue({
+        ...mockInitialUserPrivilegesState(),
+        endpointPrivileges: { canAccessResponseConsole: true },
+      });
 
       reactTestingLibrary.act(() => {
         history.push(`${MANAGEMENT_PATH}/endpoints`);
@@ -1054,7 +1092,9 @@ describe('when on the endpoint list page', () => {
       await middlewareSpy.waitForAction('serverReturnedEndpointList');
       await middlewareSpy.waitForAction('serverReturnedEndpointAgentPolicies');
 
-      const endpointActionsButton = await renderResult.findByTestId('endpointTableRowActions');
+      const endpointActionsButton = (
+        await renderResult.findAllByTestId('endpointTableRowActions')
+      )[0];
 
       reactTestingLibrary.act(() => {
         reactTestingLibrary.fireEvent.click(endpointActionsButton);
@@ -1063,6 +1103,25 @@ describe('when on the endpoint list page', () => {
 
     afterEach(() => {
       jest.clearAllMocks();
+      (useUserPrivileges as jest.Mock).mockReturnValue(getUserPrivilegesMockDefaultValue());
+    });
+
+    it('shows the Responder option when all 3 processes capabilities are present in the endpoint', async () => {
+      const responderButton = await renderResult.findByTestId('console');
+      expect(responderButton).not.toHaveAttribute('disabled');
+    });
+
+    it('disables the Responder option and shows a tooltip when no processes capabilities are present in the endpoint', async () => {
+      const firstActionButton = (await renderResult.findAllByTestId('endpointTableRowActions'))[0];
+      const secondActionButton = (await renderResult.findAllByTestId('endpointTableRowActions'))[1];
+
+      reactTestingLibrary.act(() => {
+        // close any open action menus
+        reactTestingLibrary.fireEvent.click(firstActionButton);
+        reactTestingLibrary.fireEvent.click(secondActionButton);
+      });
+      const responderButton = await renderResult.findByTestId('console');
+      expect(responderButton).toHaveAttribute('disabled');
     });
 
     it('navigates to the Actions log flyout', async () => {
@@ -1073,7 +1132,7 @@ describe('when on the endpoint list page', () => {
           name: 'endpointActivityLog',
           page_index: '0',
           page_size: '10',
-          selected_endpoint: hostInfo.metadata.agent.id,
+          selected_endpoint: hostInfo[0].metadata.agent.id,
         })}`
       );
     });
@@ -1085,7 +1144,7 @@ describe('when on the endpoint list page', () => {
           name: 'endpointIsolate',
           page_index: '0',
           page_size: '10',
-          selected_endpoint: hostInfo.metadata.agent.id,
+          selected_endpoint: hostInfo[0].metadata.agent.id,
         })}`
       );
     });
@@ -1093,7 +1152,7 @@ describe('when on the endpoint list page', () => {
     it('navigates to the Security Solution Host Details page', async () => {
       const hostLink = await renderResult.findByTestId('hostLink');
       expect(hostLink.getAttribute('href')).toEqual(
-        `${APP_PATH}/hosts/${hostInfo.metadata.host.hostname}`
+        `${APP_PATH}/hosts/${hostInfo[0].metadata.host.hostname}`
       );
     });
     it('navigates to the Ingest Agent Policy page', async () => {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -1018,7 +1018,7 @@ describe('when on the endpoint list page', () => {
             ...hosts[0].metadata,
             Endpoint: {
               ...hosts[0].metadata.Endpoint,
-              capabilities: RESPONDER_CAPABILITIES,
+              capabilities: [...RESPONDER_CAPABILITIES],
               state: {
                 ...hosts[0].metadata.Endpoint.state,
                 isolation: false,
@@ -1081,7 +1081,10 @@ describe('when on the endpoint list page', () => {
       mockEndpointListApi();
       (useUserPrivileges as jest.Mock).mockReturnValue({
         ...mockInitialUserPrivilegesState(),
-        endpointPrivileges: { canAccessResponseConsole: true },
+        endpointPrivileges: {
+          ...mockInitialUserPrivilegesState().endpointPrivileges,
+          canAccessResponseConsole: true,
+        },
       });
 
       reactTestingLibrary.act(() => {
@@ -1117,8 +1120,8 @@ describe('when on the endpoint list page', () => {
 
       reactTestingLibrary.act(() => {
         // close any open action menus
-        reactTestingLibrary.fireEvent.click(firstActionButton);
-        reactTestingLibrary.fireEvent.click(secondActionButton);
+        userEvent.click(firstActionButton);
+        userEvent.click(secondActionButton);
       });
       const responderButton = await renderResult.findByTestId('console');
       expect(responderButton).toHaveAttribute('disabled');

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
@@ -34,7 +34,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     await pageObjects.responder.closeResponder();
   };
 
-  describe('Response Actions Responder', function () {
+  describe.skip('Response Actions Responder', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     before(async () => {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
@@ -34,7 +34,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     await pageObjects.responder.closeResponder();
   };
 
-  describe.skip('Response Actions Responder', function () {
+  describe('Response Actions Responder', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     before(async () => {


### PR DESCRIPTION
## Summary
- [x] Adds unit tests to check if responder option is disabled when `kill_process`, `suspend_process` and `running_processes` are not present in the endpoints capabilities
- [x] Adds doc comments to the endpoint capabilities list