### PR TITLE
[Files] Generate download headers utility tests

### DIFF
--- a/x-pack/plugins/files/server/routes/common.test.ts
+++ b/x-pack/plugins/files/server/routes/common.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { File } from '../file';
+import { getDownloadHeadersForFile } from './common';
+
+describe('getDownloadHeadersForFile', () => {
+  function t({ cd, ct }: { cd: string; ct: string }) {
+    return {
+      'content-type': ct,
+      'content-disposition': `attachment; filename="${cd}"`,
+    };
+  }
+
+  const file = { name: 'test', mimeType: undefined } as unknown as File;
+  test('no mime type and name from file object', () => {
+    expect(getDownloadHeadersForFile(file, undefined)).toEqual(
+      t({ ct: 'application/octet-stream', cd: 'test' })
+    );
+  });
+
+  test('no mime type and name (without ext)', () => {
+    expect(getDownloadHeadersForFile(file, 'myfile')).toEqual(
+      t({ ct: 'application/octet-stream', cd: 'myfile' })
+    );
+  });
+  test('no mime type and name (with ext)', () => {
+    expect(getDownloadHeadersForFile(file, 'myfile.png')).toEqual(
+      t({ ct: 'image/png', cd: 'myfile.png' })
+    );
+  });
+  test('mime type and no name', () => {
+    const fileWithMime = { ...file, mimeType: 'application/pdf' } as File;
+    expect(getDownloadHeadersForFile(fileWithMime, undefined)).toEqual(
+      t({ ct: 'application/pdf', cd: 'test' })
+    );
+  });
+  test('mime type and name', () => {
+    const fileWithMime = { ...file, mimeType: 'application/pdf' } as File;
+    expect(getDownloadHeadersForFile(fileWithMime, 'a cool file.pdf')).toEqual(
+      t({ ct: 'application/pdf', cd: 'a cool file.pdf' })
+    );
+  });
+});

--- a/x-pack/plugins/files/server/routes/common.ts
+++ b/x-pack/plugins/files/server/routes/common.ts
@@ -4,13 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import mime from 'mime';
 import type { ResponseHeaders } from '@kbn/core/server';
 import type { File } from '../../common/types';
 
 export function getDownloadHeadersForFile(file: File, fileName?: string): ResponseHeaders {
   return {
-    'content-type': file.mimeType ?? 'application/octet-stream',
-    // note, this name can be overridden by the client if set via a "download" attribute on the HTML tag.
+    'content-type':
+      (fileName && mime.getType(fileName)) ?? file.mimeType ?? 'application/octet-stream',
+    // Note, this name can be overridden by the client if set via a "download" attribute on the HTML tag.
     'content-disposition': `attachment; filename="${fileName || getDownloadedFileName(file)}"`,
   };
 }

--- a/x-pack/plugins/files/server/routes/common.ts
+++ b/x-pack/plugins/files/server/routes/common.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema } from '@kbn/config-schema';
 import type { ResponseHeaders } from '@kbn/core/server';
 import type { File } from '../../common/types';
 
@@ -24,11 +23,3 @@ export function getDownloadedFileName(file: File): string {
   }
   return file.name;
 }
-
-const fileNameRegex = /^["]+$/;
-export const fileNameSchema = schema.string({
-  maxLength: 256,
-  validate: (v) => {
-    return fileNameRegex.test(v) ? `File name must not contain any double quotes` : undefined;
-  },
-});

--- a/x-pack/plugins/files/server/routes/common_schemas.ts
+++ b/x-pack/plugins/files/server/routes/common_schemas.ts
@@ -7,7 +7,8 @@
 
 import { schema } from '@kbn/config-schema';
 
-const ALPHA_NUMERIC_WITH_SPACES_REGEX = /^[a-zA-Z0-9\s]+$/;
+const ALPHA_NUMERIC_WITH_SPACES_REGEX = /^[a-z0-9\s]+$/i;
+const ALPHA_NUMERIC_WITH_SPACES_EXT_REGEX = /^[a-z0-9\s\.]+$/i;
 
 function alphanumericValidation(v: string) {
   return ALPHA_NUMERIC_WITH_SPACES_REGEX.test(v)
@@ -15,10 +16,22 @@ function alphanumericValidation(v: string) {
     : 'Only alphanumeric characters are allowed as file names';
 }
 
+function alphanumericWithExtValidation(v: string) {
+  return ALPHA_NUMERIC_WITH_SPACES_EXT_REGEX.test(v)
+    ? undefined
+    : 'Only alphanumeric characters, spaces (" ") and dots (".") are allowed';
+}
+
 export const fileName = schema.string({
   minLength: 1,
   maxLength: 256,
   validate: alphanumericValidation,
+});
+
+export const fileNameWithExt = schema.string({
+  minLength: 1,
+  maxLength: 256,
+  validate: alphanumericWithExtValidation,
 });
 
 export const fileAlt = schema.maybe(

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -9,7 +9,7 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { Ensure } from '@kbn/utility-types';
 import type { CreateFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
-import * as commonSchemas from './common_schemas';
+import * as commonSchemas from '../common_schemas';
 
 export const method = 'post' as const;
 

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -10,8 +10,9 @@ import { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 
 import type { DownloadFileKindHttpEndpoint } from '../../../common/api_routes';
+import { fileNameWithExt } from '../common_schemas';
 import { fileErrors } from '../../file';
-import { getDownloadHeadersForFile, fileNameSchema } from '../common';
+import { getDownloadHeadersForFile } from '../common';
 import { getById } from './helpers';
 import type { FileKindsRequestHandler } from './types';
 
@@ -19,7 +20,7 @@ export const method = 'get' as const;
 
 export const paramsSchema = schema.object({
   id: schema.string(),
-  fileName: schema.maybe(fileNameSchema),
+  fileName: schema.maybe(fileNameWithExt),
 });
 
 type Params = Ensure<DownloadFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -11,7 +11,7 @@ import type { UpdateFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKindsRequestHandler } from './types';
 import { getById } from './helpers';
 
-import * as commonSchemas from './common_schemas';
+import * as commonSchemas from '../common_schemas';
 
 export const method = 'patch' as const;
 

--- a/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
+++ b/x-pack/plugins/files/server/routes/integration_tests/routes.test.ts
@@ -228,11 +228,12 @@ describe('File HTTP API', () => {
         .expect(200);
 
       const { body: buffer, header } = await request
+        // By providing a file name like "myfilename.pdf" we imply that we want a pdf
         .get(root, `/api/files/public/blob/myfilename.pdf?token=${token}`)
         .buffer()
         .expect(200);
 
-      expect(header['content-type']).toEqual('image/png');
+      expect(header['content-type']).toEqual('application/pdf');
       expect(header['content-disposition']).toEqual('attachment; filename="myfilename.pdf"');
       expect(buffer.toString('utf8')).toEqual('test');
     });

--- a/x-pack/plugins/files/server/routes/public/download.ts
+++ b/x-pack/plugins/files/server/routes/public/download.ts
@@ -15,7 +15,8 @@ import {
 } from '../../file_share_service/errors';
 import type { FilesRouter, FilesRequestHandler } from '../types';
 import { FilePublicDownloadHttpEndpoint, FILES_API_ROUTES } from '../api_routes';
-import { getDownloadHeadersForFile, fileNameSchema } from '../common';
+import { getDownloadHeadersForFile } from '../common';
+import { fileNameWithExt } from '../common_schemas';
 
 const method = 'get' as const;
 
@@ -24,7 +25,7 @@ const querySchema = schema.object({
 });
 
 export const paramsSchema = schema.object({
-  fileName: schema.maybe(fileNameSchema),
+  fileName: schema.maybe(fileNameWithExt),
 });
 
 type Query = Ensure<FilePublicDownloadHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;


### PR DESCRIPTION
## Summary

Per the title.

Also updated the behaviour to determine content type:
1. Extract content type from a provided file name
2. Extract content type from the one configured in `File` object
3. Use `application/octet-stream`

