### PR TITLE
[Fleet] [7.17] Backport optional validation results changes from #125068

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_panel.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_panel.tsx
@@ -83,7 +83,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
     );
 
     // Errors state
-    const errorCount = countValidationErrors(inputValidationResults);
+    const errorCount = inputValidationResults ? countValidationErrors(inputValidationResults) : 0;
     const hasErrors = forceShowErrors && errorCount;
 
     const hasInputStreams = useMemo(
@@ -193,7 +193,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
               packageInputVars={packageInput.vars}
               packagePolicyInput={packagePolicyInput}
               updatePackagePolicyInput={updatePackagePolicyInput}
-              inputVarsValidationResults={{ vars: inputValidationResults.vars }}
+              inputVarsValidationResults={{ vars: inputValidationResults?.vars }}
               forceShowErrors={forceShowErrors}
             />
             {hasInputStreams ? <ShortenedHorizontalRule margin="m" /> : <EuiSpacer size="l" />}
@@ -238,7 +238,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                     updatePackagePolicyInput(updatedInput);
                   }}
                   inputStreamValidationResults={
-                    inputValidationResults.streams![packagePolicyInputStream!.data_stream!.dataset]
+                    inputValidationResults?.streams![packagePolicyInputStream!.data_stream!.dataset]
                   }
                   forceShowErrors={forceShowErrors}
                 />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_stream.tsx
@@ -70,9 +70,9 @@ export const PackagePolicyInputStreamConfig: React.FunctionComponent<{
     const advancedVarsWithErrorsCount: number = useMemo(
       () =>
         advancedVars.filter(
-          ({ name: varName }) => inputStreamValidationResults.vars?.[varName]?.length
+          ({ name: varName }) => inputStreamValidationResults?.vars?.[varName]?.length
         ).length,
-      [advancedVars, inputStreamValidationResults.vars]
+      [advancedVars, inputStreamValidationResults?.vars]
     );
 
     return (
@@ -128,7 +128,7 @@ export const PackagePolicyInputStreamConfig: React.FunctionComponent<{
                         },
                       });
                     }}
-                    errors={inputStreamValidationResults.vars![varName]}
+                    errors={inputStreamValidationResults?.vars![varName]}
                     forceShowErrors={forceShowErrors}
                   />
                 </EuiFlexItem>
@@ -185,7 +185,7 @@ export const PackagePolicyInputStreamConfig: React.FunctionComponent<{
                                 },
                               });
                             }}
-                            errors={inputStreamValidationResults.vars![varName]}
+                            errors={inputStreamValidationResults?.vars![varName]}
                             forceShowErrors={forceShowErrors}
                           />
                         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Some changes from https://github.com/elastic/kibana/pull/125068 weren't included in the 7.17 [backport](https://github.com/elastic/kibana/pull/126125) (likely due to conflicts), so this PR adds in those optional chaining changes based on cases where a package adds new policy templates between versions. 

@andrewkroh Once this lands in 7.17, this should unblock https://github.com/elastic/integrations/pull/2806

## Screenshot

Demonstrating we can now successfully render the upgrade UI for CrowdStrike v1.4.0 -> 1.5.0

![image](https://user-images.githubusercontent.com/6766512/181046099-0abce20b-3e25-4142-a2e2-536f740dcd33.png)

## Testing instructions

1. Check out https://github.com/elastic/integrations/pull/2806 in your local `integrations` repo
2. In `integrations`, `cd packages/crowdstrike && elastic-package build`
3. From your local `package-registry` repo, copy the built 1.5.0 crowdstrike package, e.g. `cp -r ../integrations/build/packages/log/1.0.1 ./build/package-storage/packages/log/1.0.1`
4. Ensure your package registry's `config.yml` file includes `- ./build/package-storage/packages` under the `package_paths` key
5. Run the package registry, e.g. `go run .`
6. Set `xpack.fleet.registryUrl: http://localhost:8080` in your `config/kibana.dev.yml` file
7. Start Kibana
8. Observe the 1.5.0 version of CrowdStrike is available in the integrations UI
9. Create a CrowdStrike integration policy under a prior version like 1.4.0
10. Install Crowdstrike 1.5.0
11. Upgrade your outdated CrowdStrike 1.4.0 policy
12. Note the conflicts on the required queue URL variable, and that the upgrade UI renders as expected

There's probably an easier way to test this using `elastic package stack up` but I haven't played around much with that tool yet. Feel free to comment if you use a different way to grab this development package and test the changes locally!