### PR TITLE
Removes design team as code owner on all SCSS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -607,7 +607,6 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 /x-pack/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
 
 # Design (at the bottom for specificity of SASS files)
-**/*.scss  @elastic/kibana-design
 #CC# /packages/kbn-ui-framework/ @elastic/kibana-design
 
 # Observability design


### PR DESCRIPTION
I want to open this up to a discussion about if we can remove this broad ownership. Requiring a review from the design team for any SCSS file that is touched has the appearance of only delaying the PR cycle.

Does @elastic/kibana-design feel this is still beneficial to prevent issues?