### PR TITLE
Apm per service telemetry

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
@@ -1078,6 +1078,102 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                         }
                       }
                     },
+                    "per_service": {
+                      "properties": {
+                        "service_id": {
+                          "type": "keyword"
+                        },
+                        "timed_out": {
+                          "type": "boolean"
+                        },
+                        "cloud": {
+                          "properties": {
+                            "availability_zones": {
+                              "type": "keyword"
+                            },
+                            "regions": {
+                              "type": "keyword"
+                            },
+                            "providers": {
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "faas": {
+                          "properties": {
+                            "trigger": {
+                              "properties": {
+                                "type": {
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "agent": {
+                          "properties": {
+                            "name": {
+                              "type": "keyword"
+                            },
+                            "version": {
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "service": {
+                          "properties": {
+                            "language": {
+                              "properties": {
+                                "name": {
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "framework": {
+                              "properties": {
+                                "name": {
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "runtime": {
+                              "properties": {
+                                "name": {
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "kubernetes": {
+                          "properties": {
+                            "pod": {
+                              "properties": {
+                                "name": {
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "container": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "tasks": {
                       "properties": {
                         "aggregated_transactions": {
@@ -1224,6 +1320,17 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                           }
                         },
                         "service_groups": {
+                          "properties": {
+                            "took": {
+                              "properties": {
+                                "ms": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "per_service": {
                           "properties": {
                             "took": {
                               "properties": {

--- a/x-pack/plugins/apm/dev_docs/telemetry.md
+++ b/x-pack/plugins/apm/dev_docs/telemetry.md
@@ -61,6 +61,9 @@ The collection tasks also use the [`APMDataTelemetry` type](../server/lib/apm_te
 
 Running `node scripts/telemetry_check --fix` from the root Kibana directory will update the schemas which should automatically notify the Infra team when a pull request is opened so they can update the mapping in the telemetry clusters.
 
+Running `node scripts/test/jest --updateSnapshot` from the `x-pack/plugins/apm` directory will update the
+mappings snapshot used in the jest tests.
+
 ## Behavioral Telemetry
 
 Behavioral telemetry is recorded with the ui_metrics and application_usage methods from the Usage Collection plugin.

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1207,6 +1207,9 @@ export const tasks: TelemetryTask[] = [
                           {
                             field: POD_NAME,
                           },
+                          {
+                            field: CONTAINER_ID,
+                          },
                         ],
                       },
                     },
@@ -1295,6 +1298,9 @@ export const tasks: TelemetryTask[] = [
               pod: {
                 name: serviceBucket.top_metrics?.top[0].metrics[POD_NAME],
               },
+            },
+            container: {
+              id: serviceBucket.top_metrics?.top[0].metrics[CONTAINER_ID],
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1278,45 +1278,50 @@ export const tasks: TelemetryTask[] = [
               },
             },
             agent: {
-              name: serviceBucket.top_metrics?.top[0].metrics[AGENT_NAME],
-              version: serviceBucket.top_metrics?.top[0].metrics[AGENT_VERSION],
+              name: serviceBucket.top_metrics?.top[0].metrics[
+                AGENT_NAME
+              ] as string,
+              version: serviceBucket.top_metrics?.top[0].metrics[
+                AGENT_VERSION
+              ] as string,
             },
             service: {
               language: {
                 name: serviceBucket.top_metrics?.top[0].metrics[
                   SERVICE_LANGUAGE_NAME
-                ],
-                version:
-                  serviceBucket.top_metrics?.top[0].metrics[
-                    SERVICE_LANGUAGE_VERSION
-                  ],
+                ] as string,
+                version: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_LANGUAGE_VERSION
+                ] as string,
               },
               framework: {
                 name: serviceBucket.top_metrics?.top[0].metrics[
                   SERVICE_FRAMEWORK_NAME
-                ],
-                version:
-                  serviceBucket.top_metrics?.top[0].metrics[
-                    SERVICE_FRAMEWORK_VERSION
-                  ],
+                ] as string,
+                version: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_FRAMEWORK_VERSION
+                ] as string,
               },
               runtime: {
                 name: serviceBucket.top_metrics?.top[0].metrics[
                   SERVICE_RUNTIME_NAME
-                ],
-                version:
-                  serviceBucket.top_metrics?.top[0].metrics[
-                    SERVICE_RUNTIME_VERSION
-                  ],
+                ] as string,
+                version: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_RUNTIME_VERSION
+                ] as string,
               },
             },
             kubernetes: {
               pod: {
-                name: serviceBucket.top_metrics?.top[0].metrics[POD_NAME],
+                name: serviceBucket.top_metrics?.top[0].metrics[
+                  POD_NAME
+                ] as string,
               },
             },
             container: {
-              id: serviceBucket.top_metrics?.top[0].metrics[CONTAINER_ID],
+              id: serviceBucket.top_metrics?.top[0].metrics[
+                CONTAINER_ID
+              ] as string,
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1176,9 +1176,17 @@ export const tasks: TelemetryTask[] = [
                     size: 1000,
                   },
                   aggs: {
-                    top_hits: {
-                      top_hits: {
-                        size: 1,
+                    top_metrics: {
+                      top_metrics: {
+                        sort: '_score',
+                        metrics: [
+                          {
+                            field: 'agent.name',
+                          },
+                          {
+                            field: 'agent.version',
+                          },
+                        ],
                       },
                     },
                     cloud_region: {
@@ -1230,8 +1238,9 @@ export const tasks: TelemetryTask[] = [
                 ) ?? [],
             },
             agent: {
-              name: serviceBucket.top_hits?.hits.hits[0].agent.name,
-              version: serviceBucket.top_hits?.hits.hits[0].agent.version,
+              name: serviceBucket.top_metrics?.top[0].metrics['agent.name'],
+              version:
+                serviceBucket.top_metrics?.top[0].metrics['agent.version'],
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -25,6 +25,7 @@ import {
   CLOUD_REGION,
   CONTAINER_ID,
   ERROR_GROUP_ID,
+  FAAS_TRIGGER_TYPE,
   HOST_NAME,
   HOST_OS_PLATFORM,
   OBSERVER_HOSTNAME,
@@ -1231,6 +1232,12 @@ export const tasks: TelemetryTask[] = [
                         size: 5,
                       },
                     },
+                    [FAAS_TRIGGER_TYPE]: {
+                      terms: {
+                        field: FAAS_TRIGGER_TYPE,
+                        size: 5,
+                      },
+                    },
                   },
                 },
               },
@@ -1260,6 +1267,14 @@ export const tasks: TelemetryTask[] = [
                 serviceBucket[CLOUD_PROVIDER]?.buckets.map(
                   (inner) => inner.key as string
                 ) ?? [],
+            },
+            faas: {
+              trigger: {
+                type:
+                  serviceBucket[FAAS_TRIGGER_TYPE]?.buckets.map(
+                    (inner) => inner.key as string
+                  ) ?? [],
+              },
             },
             agent: {
               name: serviceBucket.top_metrics?.top[0].metrics[AGENT_NAME],

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1154,7 +1154,7 @@ export const tasks: TelemetryTask[] = [
     name: 'per_service',
     executor: async ({ indices, search }) => {
       const response = await search({
-        index: [indices.transaction],
+        index: [indices.metric],
         body: {
           size: 0,
           timeout,
@@ -1181,30 +1181,30 @@ export const tasks: TelemetryTask[] = [
                         sort: '_score',
                         metrics: [
                           {
-                            field: 'agent.name',
+                            field: AGENT_NAME,
                           },
                           {
-                            field: 'agent.version',
+                            field: AGENT_VERSION,
                           },
                         ],
                       },
                     },
-                    cloud_region: {
+                    [CLOUD_REGION]: {
                       terms: {
                         field: CLOUD_REGION,
                         size: 5,
                       },
                     },
-                    cloud_provider: {
+                    [CLOUD_PROVIDER]: {
                       terms: {
                         field: CLOUD_PROVIDER,
                         size: 3,
                       },
                     },
-                    availability_zone: {
+                    [CLOUD_AVAILABILITY_ZONE]: {
                       terms: {
                         field: CLOUD_AVAILABILITY_ZONE,
-                        size: 3,
+                        size: 5,
                       },
                     },
                   },
@@ -1225,22 +1225,21 @@ export const tasks: TelemetryTask[] = [
           data[fullServiceName] = {
             cloud: {
               availability_zones:
-                serviceBucket.availability_zone?.buckets.map(
+                serviceBucket[CLOUD_AVAILABILITY_ZONE]?.buckets.map(
                   (inner) => inner.key as string
                 ) ?? [],
               regions:
-                serviceBucket.cloud_region?.buckets.map(
+                serviceBucket[CLOUD_REGION]?.buckets.map(
                   (inner) => inner.key as string
                 ) ?? [],
               providers:
-                serviceBucket.cloud_provider?.buckets.map(
+                serviceBucket[CLOUD_PROVIDER]?.buckets.map(
                   (inner) => inner.key as string
                 ) ?? [],
             },
             agent: {
-              name: serviceBucket.top_metrics?.top[0].metrics['agent.name'],
-              version:
-                serviceBucket.top_metrics?.top[0].metrics['agent.version'],
+              name: serviceBucket.top_metrics?.top[0].metrics[AGENT_NAME],
+              version: serviceBucket.top_metrics?.top[0].metrics[AGENT_VERSION],
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1186,6 +1186,27 @@ export const tasks: TelemetryTask[] = [
                           {
                             field: AGENT_VERSION,
                           },
+                          {
+                            field: SERVICE_LANGUAGE_NAME,
+                          },
+                          {
+                            field: SERVICE_LANGUAGE_VERSION,
+                          },
+                          {
+                            field: SERVICE_FRAMEWORK_NAME,
+                          },
+                          {
+                            field: SERVICE_FRAMEWORK_VERSION,
+                          },
+                          {
+                            field: SERVICE_RUNTIME_NAME,
+                          },
+                          {
+                            field: SERVICE_RUNTIME_VERSION,
+                          },
+                          {
+                            field: POD_NAME,
+                          },
                         ],
                       },
                     },
@@ -1240,6 +1261,40 @@ export const tasks: TelemetryTask[] = [
             agent: {
               name: serviceBucket.top_metrics?.top[0].metrics[AGENT_NAME],
               version: serviceBucket.top_metrics?.top[0].metrics[AGENT_VERSION],
+            },
+            service: {
+              language: {
+                name: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_LANGUAGE_NAME
+                ],
+                version:
+                  serviceBucket.top_metrics?.top[0].metrics[
+                    SERVICE_LANGUAGE_VERSION
+                  ],
+              },
+              framework: {
+                name: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_FRAMEWORK_NAME
+                ],
+                version:
+                  serviceBucket.top_metrics?.top[0].metrics[
+                    SERVICE_FRAMEWORK_VERSION
+                  ],
+              },
+              runtime: {
+                name: serviceBucket.top_metrics?.top[0].metrics[
+                  SERVICE_RUNTIME_NAME
+                ],
+                version:
+                  serviceBucket.top_metrics?.top[0].metrics[
+                    SERVICE_RUNTIME_VERSION
+                  ],
+              },
+            },
+            kubernetes: {
+              pod: {
+                name: serviceBucket.top_metrics?.top[0].metrics[POD_NAME],
+              },
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1245,7 +1245,7 @@ export const tasks: TelemetryTask[] = [
           },
         },
       });
-      const data: APMPerService = {};
+      const data: APMPerService[] = [];
       const envBuckets = response.aggregations?.environments.buckets ?? [];
       envBuckets.forEach((envBucket) => {
         const env = envBucket.key;
@@ -1253,7 +1253,8 @@ export const tasks: TelemetryTask[] = [
         serviceBuckets.forEach((serviceBucket) => {
           const name = serviceBucket.key;
           const fullServiceName = env + '~' + name;
-          data[fullServiceName] = {
+          data.push({
+            service_id: fullServiceName,
             timed_out: response.timed_out,
             cloud: {
               availability_zones:
@@ -1318,7 +1319,7 @@ export const tasks: TelemetryTask[] = [
             container: {
               id: serviceBucket.top_metrics?.top[0].metrics[CONTAINER_ID],
             },
-          };
+          });
         });
       });
       return {

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1176,6 +1176,11 @@ export const tasks: TelemetryTask[] = [
                     size: 1000,
                   },
                   aggs: {
+                    top_hits: {
+                      top_hits: {
+                        size: 1,
+                      },
+                    },
                     cloud_region: {
                       terms: {
                         field: CLOUD_REGION,
@@ -1223,6 +1228,10 @@ export const tasks: TelemetryTask[] = [
                 serviceBucket.cloud_provider?.buckets.map(
                   (inner) => inner.key as string
                 ) ?? [],
+            },
+            agent: {
+              name: serviceBucket.top_hits?.hits.hits[0].agent.name,
+              version: serviceBucket.top_hits?.hits.hits[0].agent.version,
             },
           };
         });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1254,6 +1254,7 @@ export const tasks: TelemetryTask[] = [
           const name = serviceBucket.key;
           const fullServiceName = env + '~' + name;
           data[fullServiceName] = {
+            timed_out: response.timed_out,
             cloud: {
               availability_zones:
                 serviceBucket[CLOUD_AVAILABILITY_ZONE]?.buckets.map(

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1245,15 +1245,14 @@ export const tasks: TelemetryTask[] = [
           },
         },
       });
-      const data: APMPerService[] = [];
       const envBuckets = response.aggregations?.environments.buckets ?? [];
-      envBuckets.forEach((envBucket) => {
+      const data: APMPerService[] = envBuckets.flatMap((envBucket) => {
         const env = envBucket.key;
         const serviceBuckets = envBucket.service_names?.buckets ?? [];
-        serviceBuckets.forEach((serviceBucket) => {
+        return serviceBuckets.map((serviceBucket) => {
           const name = serviceBucket.key;
-          const fullServiceName = env + '~' + name;
-          data.push({
+          const fullServiceName = `${env}~${name}`;
+          return {
             service_id: fullServiceName,
             timed_out: response.timed_out,
             cloud: {
@@ -1319,7 +1318,7 @@ export const tasks: TelemetryTask[] = [
             container: {
               id: serviceBucket.top_metrics?.top[0].metrics[CONTAINER_ID],
             },
-          });
+          };
         });
       });
       return {

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -236,7 +236,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
   service_groups: {
     kuery_fields: { type: 'array', items: { type: 'keyword' } },
   },
-  per_service: { type: 'array', items: apmPerServiceSchema },
+  per_service: { type: 'array', items: { ...apmPerServiceSchema } },
   tasks: {
     aggregated_transactions: { took: { ms: long } },
     cloud: { took: { ms: long } },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -12,10 +12,13 @@ import {
   TimeframeMap,
   TimeframeMap1d,
   TimeframeMapAll,
+  APMPerService,
 } from './types';
 import { ElasticAgentName } from '../../../typings/es_schemas/ui/fields/agent';
 
 const long: { type: 'long' } = { type: 'long' };
+
+const keyword: { type: 'keyword' } = { type: 'keyword' };
 
 const aggregatedTransactionCountSchema: MakeSchemaFrom<AggregatedTransactionsCounts> =
   {
@@ -113,6 +116,47 @@ const apmPerAgentSchema: Pick<
   },
 };
 
+export const apmPerServiceSchema: MakeSchemaFrom<APMPerService> = {
+  service_id: keyword,
+  timed_out: { type: 'boolean' },
+  cloud: {
+    availability_zones: { type: 'array', items: { type: 'keyword' } },
+    regions: { type: 'array', items: { type: 'keyword' } },
+    providers: { type: 'array', items: { type: 'keyword' } },
+  },
+  faas: {
+    trigger: {
+      type: { type: 'array', items: { type: 'keyword' } },
+    },
+  },
+  agent: {
+    name: keyword,
+    version: keyword,
+  },
+  service: {
+    language: {
+      name: keyword,
+      version: keyword,
+    },
+    framework: {
+      name: keyword,
+      version: keyword,
+    },
+    runtime: {
+      name: keyword,
+      version: keyword,
+    },
+  },
+  kubernetes: {
+    pod: {
+      name: keyword,
+    },
+  },
+  container: {
+    id: keyword,
+  },
+};
+
 export const apmSchema: MakeSchemaFrom<APMUsage> = {
   ...apmPerAgentSchema,
   has_any_services: { type: 'boolean' },
@@ -192,6 +236,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
   service_groups: {
     kuery_fields: { type: 'array', items: { type: 'keyword' } },
   },
+  per_service: { type: 'array', items: apmPerServiceSchema },
   tasks: {
     aggregated_transactions: { took: { ms: long } },
     cloud: { took: { ms: long } },
@@ -207,5 +252,6 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
     cardinality: { took: { ms: long } },
     environments: { took: { ms: long } },
     service_groups: { took: { ms: long } },
+    per_service: { took: { ms: long } },
   },
 };

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -38,30 +38,30 @@ export interface APMPerService {
     };
   };
   agent: {
-    name: string | number | null;
-    version: string | number | null;
+    name: string;
+    version: string;
   };
   service: {
     language: {
-      name: string | number | null;
-      version: string | number | null;
+      name: string;
+      version: string;
     };
     framework: {
-      name: string | number | null;
-      version: string | number | null;
+      name: string;
+      version: string;
     };
     runtime: {
-      name: string | number | null;
-      version: string | number | null;
+      name: string;
+      version: string;
     };
   };
   kubernetes: {
     pod: {
-      name: string | number | null;
+      name: string;
     };
   };
   container: {
-    id: string | number | null;
+    id: string;
   };
 }
 

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -33,8 +33,8 @@ export type APMPerService = Record<
       providers: string[];
     };
     agent: {
-      name: string | null;
-      version: string | null;
+      name: string | number | null;
+      version: string | number | null;
     };
   }
 >;

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -24,6 +24,17 @@ export interface AggregatedTransactionsCounts {
   transaction_count: number;
 }
 
+export type APMPerService = Record<
+  string,
+  {
+    cloud: {
+      availability_zones: string[];
+      regions: string[];
+      providers: string[];
+    };
+  }
+>;
+
 export interface APMUsage {
   has_any_services: boolean;
   services_per_agent: Record<AgentName, number>;
@@ -133,7 +144,7 @@ export interface APMUsage {
   service_groups: {
     kuery_fields: string[];
   };
-  per_service: Record<string, Record<string, Array<string | null>>>;
+  per_service: APMPerService;
   tasks: Record<
     | 'aggregated_transactions'
     | 'cloud'
@@ -148,7 +159,8 @@ export interface APMUsage {
     | 'indices_stats'
     | 'cardinality'
     | 'environments'
-    | 'service_groups',
+    | 'service_groups'
+    | 'per_service',
     { took: { ms: number } }
   >;
 }

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -36,6 +36,25 @@ export type APMPerService = Record<
       name: string | number | null;
       version: string | number | null;
     };
+    service: {
+      language: {
+        name: string | number | null;
+        version: string | number | null;
+      };
+      framework: {
+        name: string | number | null;
+        version: string | number | null;
+      };
+      runtime: {
+        name: string | number | null;
+        version: string | number | null;
+      };
+    };
+    kubernetes: {
+      pod: {
+        name: string | number | null;
+      };
+    };
   }
 >;
 

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -32,6 +32,11 @@ export type APMPerService = Record<
       regions: string[];
       providers: string[];
     };
+    faas: {
+      trigger: {
+        type: string[];
+      };
+    };
     agent: {
       name: string | number | null;
       version: string | number | null;

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -55,6 +55,9 @@ export type APMPerService = Record<
         name: string | number | null;
       };
     };
+    container: {
+      id: string | number | null;
+    };
   }
 >;
 

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -24,48 +24,46 @@ export interface AggregatedTransactionsCounts {
   transaction_count: number;
 }
 
-export type APMPerService = Record<
-  string,
-  {
-    timed_out: boolean;
-    cloud: {
-      availability_zones: string[];
-      regions: string[];
-      providers: string[];
+export interface APMPerService {
+  service_id: string;
+  timed_out: boolean;
+  cloud: {
+    availability_zones: string[];
+    regions: string[];
+    providers: string[];
+  };
+  faas: {
+    trigger: {
+      type: string[];
     };
-    faas: {
-      trigger: {
-        type: string[];
-      };
-    };
-    agent: {
+  };
+  agent: {
+    name: string | number | null;
+    version: string | number | null;
+  };
+  service: {
+    language: {
       name: string | number | null;
       version: string | number | null;
     };
-    service: {
-      language: {
-        name: string | number | null;
-        version: string | number | null;
-      };
-      framework: {
-        name: string | number | null;
-        version: string | number | null;
-      };
-      runtime: {
-        name: string | number | null;
-        version: string | number | null;
-      };
+    framework: {
+      name: string | number | null;
+      version: string | number | null;
     };
-    kubernetes: {
-      pod: {
-        name: string | number | null;
-      };
+    runtime: {
+      name: string | number | null;
+      version: string | number | null;
     };
-    container: {
-      id: string | number | null;
+  };
+  kubernetes: {
+    pod: {
+      name: string | number | null;
     };
-  }
->;
+  };
+  container: {
+    id: string | number | null;
+  };
+}
 
 export interface APMUsage {
   has_any_services: boolean;
@@ -176,7 +174,7 @@ export interface APMUsage {
   service_groups: {
     kuery_fields: string[];
   };
-  per_service: APMPerService;
+  per_service: APMPerService[];
   tasks: Record<
     | 'aggregated_transactions'
     | 'cloud'

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -32,6 +32,10 @@ export type APMPerService = Record<
       regions: string[];
       providers: string[];
     };
+    agent: {
+      name: string | null;
+      version: string | null;
+    };
   }
 >;
 

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -133,6 +133,7 @@ export interface APMUsage {
   service_groups: {
     kuery_fields: string[];
   };
+  per_service: Record<string, Record<string, Array<string | null>>>;
   tasks: Record<
     | 'aggregated_transactions'
     | 'cloud'

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -27,6 +27,7 @@ export interface AggregatedTransactionsCounts {
 export type APMPerService = Record<
   string,
   {
+    timed_out: boolean;
     cloud: {
       availability_zones: string[];
       regions: string[];

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -4015,6 +4015,117 @@
             }
           }
         },
+        "per_service": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "service_id": {
+                "type": "keyword"
+              },
+              "timed_out": {
+                "type": "boolean"
+              },
+              "cloud": {
+                "properties": {
+                  "availability_zones": {
+                    "type": "array",
+                    "items": {
+                      "type": "keyword"
+                    }
+                  },
+                  "regions": {
+                    "type": "array",
+                    "items": {
+                      "type": "keyword"
+                    }
+                  },
+                  "providers": {
+                    "type": "array",
+                    "items": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "faas": {
+                "properties": {
+                  "trigger": {
+                    "properties": {
+                      "type": {
+                        "type": "array",
+                        "items": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "agent": {
+                "properties": {
+                  "name": {
+                    "type": "keyword"
+                  },
+                  "version": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "service": {
+                "properties": {
+                  "language": {
+                    "properties": {
+                      "name": {
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "framework": {
+                    "properties": {
+                      "name": {
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "runtime": {
+                    "properties": {
+                      "name": {
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "kubernetes": {
+                "properties": {
+                  "pod": {
+                    "properties": {
+                      "name": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "container": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          }
+        },
         "tasks": {
           "properties": {
             "aggregated_transactions": {
@@ -4161,6 +4272,17 @@
               }
             },
             "service_groups": {
+              "properties": {
+                "took": {
+                  "properties": {
+                    "ms": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "per_service": {
               "properties": {
                 "took": {
                   "properties": {


### PR DESCRIPTION
## Summary

Adds a new job for telemetry collection which collects fields on a per-service basis. A "service" in this case is a combination of environment and service name.

### Checklist

No checklist items were applicable.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

Ref https://github.com/elastic/apm-dev/issues/708 and https://github.com/elastic/apm-dev/issues/752

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->