### PR TITLE
[Dashboard] Deprecate Allow By Value Embeddables Setting

### DIFF
--- a/src/plugins/dashboard/server/index.ts
+++ b/src/plugins/dashboard/server/index.ts
@@ -15,6 +15,9 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     allowByValueEmbeddables: true,
   },
   schema: configSchema,
+  deprecations: ({ deprecate }) => {
+    return [deprecate('allowByValueEmbeddables', '8.6.0', { level: 'warning' })];
+  },
 };
 
 //  This exports static code and TypeScript types,


### PR DESCRIPTION
## Summary

The Allow By Value Embeddables setting was added as part of the Time to Visualize project. It was turned [on by default](https://github.com/elastic/kibana/pull/88390) in 7.12. This setting has been unused since, and is adding additional complexity to the [dashboard code](https://github.com/elastic/kibana/issues/137197).

This PR doesn't delete the setting, but it does mark it as deprecated in the hopes that we can then check its usage by counting up occurrences in the telemetry under the key `stack_stats.kibana.plugins.core.config.deprecatedKeys.unset`

@TinaHeiligers 