### PR TITLE
[APM] When comparison feature is disabled, we still see the shaded area

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -113,8 +113,6 @@ function SparkPlotItem({
     width: compact ? unit * 4 : unit * 5,
   };
 
-  const Sparkline = hasComparisonSeries ? LineSeries : AreaSeries;
-
   if (isLoading) {
     return (
       <div
@@ -138,7 +136,7 @@ function SparkPlotItem({
           showLegend={false}
           tooltip="none"
         />
-        <Sparkline
+        <LineSeries
           id="Sparkline"
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/134825

<img width="1130" alt="Screen Shot 2022-07-26 at 2 27 19 PM" src="https://user-images.githubusercontent.com/55978943/181084420-93d7cb1d-096f-43d6-a134-5a9dbeda960f.png">
<img width="1156" alt="Screen Shot 2022-07-26 at 2 27 27 PM" src="https://user-images.githubusercontent.com/55978943/181084423-ea028bba-26ee-4d23-b2f7-0ad28a9a3c6b.png">
