### PR TITLE
[7.17] [ResponseOps][Actions] Should trim values before validation in UI and API (#136840)

### DIFF
--- a/x-pack/plugins/actions/server/lib/index.ts
+++ b/x-pack/plugins/actions/server/lib/index.ts
@@ -28,3 +28,4 @@ export {
   asHttpRequestExecutionSource,
   isHttpRequestExecutionSource,
 } from './action_execution_source';
+export { validateEmptyStrings } from './validate_empty_strings';

--- a/x-pack/plugins/actions/server/lib/validate_empty_strings.test.ts
+++ b/x-pack/plugins/actions/server/lib/validate_empty_strings.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateEmptyStrings } from './validate_empty_strings';
+
+describe('validateEmptyStrings', () => {
+  const action = {
+    name: 'my name',
+    actionTypeId: 'my-action-type',
+    config: {
+      param1: ' ',
+    },
+    secrets: {
+      param1: [' ', 'param1'],
+    },
+  };
+
+  it('should not throw an error if the trimmed string is not empty', () => {
+    expect(() => validateEmptyStrings(action.name)).not.toThrow();
+  });
+
+  it('should throw an error if the trimmed strings in an array are empty', () => {
+    expect(() => validateEmptyStrings(action.secrets)).toThrowErrorMatchingInlineSnapshot(
+      `"value '' is not valid"`
+    );
+  });
+
+  it('should throw an error if the trimmed strings in an object are empty', () => {
+    expect(() => validateEmptyStrings(action)).toThrowErrorMatchingInlineSnapshot(
+      `"value '' is not valid"`
+    );
+  });
+});

--- a/x-pack/plugins/actions/server/lib/validate_empty_strings.ts
+++ b/x-pack/plugins/actions/server/lib/validate_empty_strings.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isObject, keys, get, isString } from 'lodash';
+
+export function validateEmptyStrings(value: unknown) {
+  if (isString(value)) {
+    if (value.trim() === '') {
+      throw new Error(`value '' is not valid`);
+    }
+  } else if (Array.isArray(value)) {
+    value.forEach((item) => {
+      validateEmptyStrings(item);
+    });
+  } else if (isObject(value)) {
+    keys(value).forEach((key) => {
+      validateEmptyStrings(get(value, key));
+    });
+  }
+}

--- a/x-pack/plugins/actions/server/routes/create.test.ts
+++ b/x-pack/plugins/actions/server/routes/create.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createActionRoute } from './create';
+import { createActionRoute, bodySchema } from './create';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../lib/license_state.mock';
 import { mockHandlerArguments } from './legacy/_mock_handler_arguments';
@@ -158,5 +158,17 @@ describe('createActionRoute', () => {
     );
 
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
+  });
+
+  test('validates body to prevent empty strings', async () => {
+    const body = {
+      name: 'My name',
+      connector_type_id: 'abc',
+      config: { foo: ' ' },
+      secrets: {},
+    };
+    expect(() => bodySchema.validate(body)).toThrowErrorMatchingInlineSnapshot(
+      `"[config.foo]: value '' is not valid"`
+    );
   });
 });

--- a/x-pack/plugins/actions/server/routes/create.ts
+++ b/x-pack/plugins/actions/server/routes/create.ts
@@ -8,16 +8,20 @@
 import { schema } from '@kbn/config-schema';
 import { IRouter } from 'kibana/server';
 import { ActionResult, ActionsRequestHandlerContext } from '../types';
-import { ILicenseState } from '../lib';
+import { ILicenseState, validateEmptyStrings } from '../lib';
 import { BASE_ACTION_API_PATH, RewriteRequestCase, RewriteResponseCase } from '../../common';
 import { verifyAccessAndContext } from './verify_access_and_context';
 import { CreateOptions } from '../actions_client';
 
 export const bodySchema = schema.object({
-  name: schema.string(),
-  connector_type_id: schema.string(),
-  config: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
-  secrets: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
+  name: schema.string({ validate: validateEmptyStrings }),
+  connector_type_id: schema.string({ validate: validateEmptyStrings }),
+  config: schema.recordOf(schema.string(), schema.any({ validate: validateEmptyStrings }), {
+    defaultValue: {},
+  }),
+  secrets: schema.recordOf(schema.string(), schema.any({ validate: validateEmptyStrings }), {
+    defaultValue: {},
+  }),
 });
 
 const rewriteBodyReq: RewriteRequestCase<CreateOptions['action']> = ({

--- a/x-pack/plugins/actions/server/routes/update.test.ts
+++ b/x-pack/plugins/actions/server/routes/update.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { updateActionRoute } from './update';
+import { bodySchema, updateActionRoute } from './update';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../lib/license_state.mock';
 import { mockHandlerArguments } from './legacy/_mock_handler_arguments';
@@ -169,5 +169,16 @@ describe('updateActionRoute', () => {
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
 
     expect(verifyAccessAndContext).toHaveBeenCalledWith(licenseState, expect.any(Function));
+  });
+
+  test('validates body to prevent empty strings', async () => {
+    const body = {
+      name: ' ',
+      config: { foo: true },
+      secrets: { key: 'i8oh34yf9783y39' },
+    };
+    expect(() => bodySchema.validate(body)).toThrowErrorMatchingInlineSnapshot(
+      `"[name]: value '' is not valid"`
+    );
   });
 });

--- a/x-pack/plugins/actions/server/routes/update.ts
+++ b/x-pack/plugins/actions/server/routes/update.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { IRouter } from 'kibana/server';
-import { ILicenseState } from '../lib';
+import { ILicenseState, validateEmptyStrings } from '../lib';
 import { BASE_ACTION_API_PATH, RewriteResponseCase } from '../../common';
 import { ActionResult, ActionsRequestHandlerContext } from '../types';
 import { verifyAccessAndContext } from './verify_access_and_context';
@@ -16,10 +16,14 @@ const paramSchema = schema.object({
   id: schema.string(),
 });
 
-const bodySchema = schema.object({
-  name: schema.string(),
-  config: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
-  secrets: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
+export const bodySchema = schema.object({
+  name: schema.string({ validate: validateEmptyStrings }),
+  config: schema.recordOf(schema.string(), schema.any({ validate: validateEmptyStrings }), {
+    defaultValue: {},
+  }),
+  secrets: schema.recordOf(schema.string(), schema.any({ validate: validateEmptyStrings }), {
+    defaultValue: {},
+  }),
 });
 
 const rewriteBodyRes: RewriteResponseCase<ActionResult> = ({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/create.ts
@@ -57,6 +57,27 @@ export default function createActionTests({ getService }: FtrProviderContext) {
       });
     });
 
+    it('should handle create action request appropriately when empty strings are submitted', async () => {
+      await supertest
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/actions/connector`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          name: 'My action',
+          connector_type_id: 'test.index-record',
+          config: {
+            unencrypted: ' ',
+          },
+          secrets: {
+            encrypted: 'This value should be encrypted',
+          },
+        })
+        .expect(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: `[request body.config.unencrypted]: value '' is not valid`,
+        });
+    });
+
     describe('legacy', () => {
       it('should handle create action request appropriately', async () => {
         const response = await supertest

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/update.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/update.ts
@@ -160,6 +160,26 @@ export default function updateActionTests({ getService }: FtrProviderContext) {
       expect(new Date(noopFeature.last_used).getTime()).to.be.greaterThan(updateStart.getTime());
     });
 
+    it('should handle update action request appropriately when empty strings are submitted', async () => {
+      await supertest
+        .put(`${getUrlPrefix(Spaces.space1.id)}/api/actions/connector/custom-system-abc-connector`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          name: ' ',
+          config: {
+            unencrypted: `This value shouldn't get encrypted`,
+          },
+          secrets: {
+            encrypted: 'This value should be encrypted',
+          },
+        })
+        .expect(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: `[request body.name]: value '' is not valid`,
+        });
+    });
+
     describe('legacy', () => {
       it('should handle update action request appropriately', async () => {
         const { body: createdAction } = await supertest


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ResponseOps][Actions] Should trim values before validation in UI and API (#136840)](https://github.com/elastic/kibana/pull/136840)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"doakalexi","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-07-26T16:02:47Z","message":"[ResponseOps][Actions] Should trim values before validation in UI and API (#136840)\n\n* Updating action create function to trim values before validation\r\n\r\n* Adding tests\r\n\r\n* Removes trimming and adds validation to the api layer\r\n\r\n* Adding lint changes\r\n\r\n* Updating functional tests\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e3eaf4615ab394afb2e46e1bd68e19b205bc24ae","branchLabelMapping":{"^v8.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","v8.4.0","backport:prev-major","v8.3.3"],"number":136840,"url":"https://github.com/elastic/kibana/pull/136840","mergeCommit":{"message":"[ResponseOps][Actions] Should trim values before validation in UI and API (#136840)\n\n* Updating action create function to trim values before validation\r\n\r\n* Adding tests\r\n\r\n* Removes trimming and adds validation to the api layer\r\n\r\n* Adding lint changes\r\n\r\n* Updating functional tests\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e3eaf4615ab394afb2e46e1bd68e19b205bc24ae"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.4.0","labelRegex":"^v8.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/136840","number":136840,"mergeCommit":{"message":"[ResponseOps][Actions] Should trim values before validation in UI and API (#136840)\n\n* Updating action create function to trim values before validation\r\n\r\n* Adding tests\r\n\r\n* Removes trimming and adds validation to the api layer\r\n\r\n* Adding lint changes\r\n\r\n* Updating functional tests\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e3eaf4615ab394afb2e46e1bd68e19b205bc24ae"}},{"branch":"8.3","label":"v8.3.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/137212","number":137212,"state":"MERGED","mergeCommit":{"sha":"2f2842307309d5ec3c747bf2f85a22d9a3f613c0","message":"[ResponseOps][Actions] Should trim values before validation in UI and API (#136840) (#137212)\n\n* Updating action create function to trim values before validation\n\n* Adding tests\n\n* Removes trimming and adds validation to the api layer\n\n* Adding lint changes\n\n* Updating functional tests\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\n(cherry picked from commit e3eaf4615ab394afb2e46e1bd68e19b205bc24ae)\n\nCo-authored-by: doakalexi <109488926+doakalexi@users.noreply.github.com>"}}]}] BACKPORT-->