### PR TITLE
[Enterprise Search] Conditionally include aliases when fetching indices

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.test.ts
@@ -72,7 +72,7 @@ describe('fetchIndices lib function', () => {
     mockClient.asCurrentUser.indices.stats.mockImplementation(() => regularIndexStatsResponse);
 
     await expect(
-      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false)
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false, true)
     ).resolves.toEqual([
       {
         health: 'green',
@@ -120,7 +120,7 @@ describe('fetchIndices lib function', () => {
     mockClient.asCurrentUser.indices.stats.mockImplementation(() => regularIndexStatsResponse);
 
     await expect(
-      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', true)
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', true, true)
     ).resolves.toEqual([
       {
         health: 'green',
@@ -180,7 +180,7 @@ describe('fetchIndices lib function', () => {
     mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => aliasedIndexResponse);
     mockClient.asCurrentUser.indices.stats.mockImplementationOnce(() => aliasedStatsResponse);
     await expect(
-      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false)
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false, true)
     ).resolves.toEqual([
       {
         health: 'green',
@@ -253,6 +253,70 @@ describe('fetchIndices lib function', () => {
     ]);
   });
 
+  it('should return index but not aliases when aliases excluded', async () => {
+    const aliasedIndexResponse = {
+      'index-without-prefix': {
+        ...regularIndexResponse['search-regular-index'],
+        aliases: {
+          'search-aliased': {},
+          'search-double-aliased': {},
+        },
+      },
+      'second-index': {
+        ...regularIndexResponse['search-regular-index'],
+        aliases: {
+          'search-aliased': {},
+        },
+      },
+    };
+    const aliasedStatsResponse = {
+      indices: {
+        'index-without-prefix': { ...regularIndexStatsResponse.indices['search-regular-index'] },
+        'second-index': { ...regularIndexStatsResponse.indices['search-regular-index'] },
+      },
+    };
+
+    mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => aliasedIndexResponse);
+    mockClient.asCurrentUser.indices.stats.mockImplementationOnce(() => aliasedStatsResponse);
+    await expect(
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false, false)
+    ).resolves.toEqual([
+      {
+        health: 'green',
+        name: 'index-without-prefix',
+        status: 'open',
+        alias: false,
+        privileges: { read: true, manage: true },
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: '105.47kb',
+          },
+        },
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+      },
+      {
+        health: 'green',
+        name: 'second-index',
+        status: 'open',
+        alias: false,
+        privileges: { read: true, manage: true },
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: '105.47kb',
+          },
+        },
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+      },
+    ]);
+  });
   it('should handle index missing in stats call', async () => {
     const missingStatsResponse = {
       indices: {
@@ -265,7 +329,7 @@ describe('fetchIndices lib function', () => {
     // simulates when an index has been deleted after get indices call
     // deleted index won't be present in the indices stats call response
     await expect(
-      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false)
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false, true)
     ).resolves.toEqual([
       {
         health: undefined,
@@ -290,7 +354,7 @@ describe('fetchIndices lib function', () => {
   it('should return empty array when no index found', async () => {
     mockClient.asCurrentUser.indices.get.mockImplementationOnce(() => ({}));
     await expect(
-      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false)
+      fetchIndices(mockClient as unknown as IScopedClusterClient, 'search-*', false, true)
     ).resolves.toEqual([]);
     expect(mockClient.asCurrentUser.indices.stats).not.toHaveBeenCalled();
   });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.ts
@@ -122,7 +122,7 @@ export const fetchIndices = async (
             ...indexData,
           });
         });
-      };
+      }
       return indicesAndAliases;
     })
     .filter(

--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_indices.ts
@@ -47,7 +47,8 @@ export const mapIndexStats = (
 export const fetchIndices = async (
   client: IScopedClusterClient,
   indexPattern: string,
-  returnHiddenIndices: boolean
+  returnHiddenIndices: boolean,
+  includeAliases: boolean
 ): Promise<ElasticsearchIndexWithPrivileges[]> => {
   // This call retrieves alias and settings information about indices
   const expandWildcards: ExpandWildcard[] = returnHiddenIndices ? ['hidden', 'all'] : ['open'];
@@ -63,9 +64,11 @@ export const fetchIndices = async (
 
   const indexAndAliasNames = Object.keys(totalIndices).reduce((accum, indexName) => {
     accum.push(indexName);
-    const aliases = Object.keys(totalIndices[indexName].aliases!);
 
-    aliases.forEach((alias) => accum.push(alias));
+    if (includeAliases) {
+      const aliases = Object.keys(totalIndices[indexName].aliases!);
+      aliases.forEach((alias) => accum.push(alias));
+    }
     return accum;
   }, [] as string[]);
 
@@ -110,14 +113,16 @@ export const fetchIndices = async (
         ...indexData,
       });
 
-      aliases.forEach((alias) => {
-        indicesAndAliases.push({
-          name: alias,
-          alias: true,
-          privileges: { read: false, manage: false, ...indexPrivileges[name] },
-          ...indexData,
+      if (includeAliases) {
+        aliases.forEach((alias) => {
+          indicesAndAliases.push({
+            name: alias,
+            alias: true,
+            privileges: { read: false, manage: false, ...indexPrivileges[name] },
+            ...indexData,
+          });
         });
-      });
+      };
       return indicesAndAliases;
     })
     .filter(

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -27,7 +27,7 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
     async (context, _, response) => {
       const { client } = (await context.core).elasticsearch;
       try {
-        const indices = await fetchIndices(client, '*', false);
+        const indices = await fetchIndices(client, '*', false, true);
         return response.ok({
           body: indices,
           headers: { 'content-type': 'application/json' },
@@ -62,7 +62,7 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
       const { client } = (await context.core).elasticsearch;
       try {
         const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
-        const totalIndices = await fetchIndices(client, indexPattern, !!returnHiddenIndices);
+        const totalIndices = await fetchIndices(client, indexPattern, !!returnHiddenIndices, false);
         const totalResults = totalIndices.length;
         const totalPages = Math.ceil(totalResults / size) || 1;
         const startIndex = (page - 1) * size;


### PR DESCRIPTION
## Summary

This changes the API that we use to fetch indices for the indices listing page to exclude aliases.

When we're looking for BYOEI candidates (in App Search), we want to include aliases.
When we're listing indices in Enterprise Search Content, we do not.

closes https://github.com/elastic/enterprise-search-team/issues/2356

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios