### PR TITLE
[Security Solution][Alerts] Pass timeline template columns through to threshold alert timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
@@ -18,6 +18,7 @@ import {
   mockTimelineDetails,
   mockTimelineResult,
   mockAADEcsDataWithAlert,
+  mockGetOneTimelineResult,
 } from '../../../common/mock';
 import type { CreateTimeline, UpdateTimelineLoading } from './types';
 import type { Ecs } from '../../../../common/ecs';
@@ -154,6 +155,48 @@ describe('alert actions', () => {
           uuid: ['c5ba41ab-aaf3-4f43-971b-bdf9434ce0ea'],
           timeline_id: undefined,
           timeline_title: undefined,
+        },
+        threshold_result: {
+          count: 99,
+          from: '2021-01-10T21:11:45.839Z',
+          cardinality: [
+            {
+              field: 'source.ip',
+              value: 1,
+            },
+          ],
+          terms: [
+            {
+              field: 'destination.ip',
+              value: 1,
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  const ecsDataMockWithTemplateTimeline = getThresholdDetectionAlertAADMock({
+    ...mockAADEcsDataWithAlert,
+    kibana: {
+      alert: {
+        ...mockAADEcsDataWithAlert.kibana?.alert,
+        rule: {
+          ...mockAADEcsDataWithAlert.kibana?.alert?.rule,
+          parameters: {
+            ...mockAADEcsDataWithAlert.kibana?.alert?.rule?.parameters,
+            threshold: {
+              field: ['destination.ip'],
+              value: 1,
+            },
+            filters: undefined,
+          },
+          name: ['mock threshold rule'],
+          saved_id: [],
+          type: ['threshold'],
+          uuid: ['c5ba41ab-aaf3-4f43-971b-bdf9434ce0ea'],
+          timeline_id: ['timeline-id'],
+          timeline_title: ['timeline-title'],
         },
         threshold_result: {
           count: 99,
@@ -727,6 +770,79 @@ describe('alert actions', () => {
 
         expect(createTimeline).not.toThrow();
         expect(toastMock).not.toHaveBeenCalled();
+      });
+
+      test('columns from timeline template are used', async () => {
+        fetchMock.mockResolvedValue({
+          hits: {
+            hits: [
+              {
+                _id: ecsDataMockWithTemplateTimeline[0]._id,
+                _index: 'mock',
+                _source: ecsDataMockWithTemplateTimeline[0],
+              },
+            ],
+          },
+        });
+        await sendAlertToTimelineAction({
+          createTimeline,
+          ecsData: ecsDataMockWithTemplateTimeline,
+          updateTimelineIsLoading,
+          searchStrategyClient,
+          getExceptions: mockGetExceptions,
+        });
+
+        const expectedFrom = '2021-01-10T21:11:45.839Z';
+        const expectedTo = '2021-01-10T21:12:45.839Z';
+
+        expect(updateTimelineIsLoading).toHaveBeenCalled();
+        expect(mockGetExceptions).toHaveBeenCalled();
+        expect(createTimeline).toHaveBeenCalledTimes(1);
+        expect(createTimeline).toHaveBeenCalledWith({
+          ...defaultTimelineProps,
+          timeline: {
+            ...defaultTimelineProps.timeline,
+            columns: mockGetOneTimelineResult.columns,
+            dataProviders: [],
+            dateRange: {
+              start: expectedFrom,
+              end: expectedTo,
+            },
+            description: '_id: 1',
+            filters: [
+              {
+                $state: {
+                  store: 'appState',
+                },
+                meta: {
+                  key: 'host.name',
+                  negate: false,
+                  params: {
+                    query: 'apache',
+                  },
+                  type: 'phrase',
+                },
+                query: {
+                  match_phrase: {
+                    'host.name': 'apache',
+                  },
+                },
+              },
+            ],
+            kqlQuery: {
+              filterQuery: {
+                kuery: {
+                  expression: '',
+                  kind: ['kuery'],
+                },
+                serializedQuery: '',
+              },
+            },
+            resolveTimelineConfig: undefined,
+          },
+          from: expectedFrom,
+          to: expectedTo,
+        });
       });
     });
 

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
@@ -403,7 +403,12 @@ const createThresholdTimeline = async (
   ecsData: Ecs,
   createTimeline: ({ from, timeline, to }: CreateTimelineProps) => void,
   noteContent: string,
-  templateValues: { filters?: Filter[]; query?: string; dataProviders?: DataProvider[] },
+  templateValues: {
+    filters?: Filter[];
+    query?: string;
+    dataProviders?: DataProvider[];
+    columns?: TGridModel['columns'];
+  },
   getExceptions: (ecs: Ecs) => Promise<ExceptionListItemSchema[]>
 ) => {
   try {
@@ -457,6 +462,7 @@ const createThresholdTimeline = async (
       notes: null,
       timeline: {
         ...timelineDefaults,
+        columns: templateValues.columns ?? timelineDefaults.columns,
         description: `_id: ${alertDoc._id}`,
         filters: allFilters,
         dataProviders: templateValues.dataProviders ?? dataProviders,
@@ -742,6 +748,7 @@ export const sendAlertToTimelineAction = async ({
               filters,
               query,
               dataProviders,
+              columns: timeline.columns,
             },
             getExceptions
           );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136449 by passing the `columns` from the timeline template through to the timeline action.
Also fixes https://github.com/elastic/kibana/issues/129966

Sidenote: We may want to explore a more formalized way of combining timeline templates with the pre-defined parameters that we extract from threshold alerts, like the time range and filters. Right now if the template supplies `dataProviders` they will override the default dataProviders we create from the threshold results. It would be great if we could automatically combine those in some way.

