### PR TITLE
[Fleet] Enable package signature verification feature

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -13,7 +13,7 @@ export type ExperimentalFeatures = typeof allowedExperimentalValues;
  */
 export const allowedExperimentalValues = Object.freeze({
   createPackagePolicyMultiPageLayout: true,
-  packageVerification: false,
+  packageVerification: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -528,6 +528,12 @@ const expectAssetsInstalled = ({
     // during a reinstall the items can change
     const sortedRes = {
       ...res.attributes,
+      // verification_key_id can be null or undefined for install or reinstall cases,
+      // kbn/expect only does strict equality so undefined is normalised to null
+      verification_key_id:
+        res.attributes.verification_key_id === undefined
+          ? null
+          : res.attributes.verification_key_id,
       installed_kibana: sortBy(res.attributes.installed_kibana, (o: AssetReference) => o.type),
       installed_es: sortBy(res.attributes.installed_es, (o: AssetReference) => o.type),
       package_assets: sortBy(res.attributes.package_assets, (o: AssetReference) => o.type),
@@ -768,6 +774,7 @@ const expectAssetsInstalled = ({
       install_source: 'registry',
       install_format_schema_version: FLEET_INSTALL_FORMAT_VERSION,
       verification_status: 'unknown',
+      verification_key_id: null,
     });
   });
 };

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -514,6 +514,7 @@ export default function (providerContext: FtrProviderContext) {
         install_source: 'registry',
         install_format_schema_version: FLEET_INSTALL_FORMAT_VERSION,
         verification_status: 'unknown',
+        verification_key_id: null,
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes #133822 
Enable the package signature verification feature by default.

Package signature verification allows users to better trust the contents of packages. When package registry v2 is launched all packages will be accompanied by a .sig file generated by elastic. Enabling the feature flag means that all packages with a signature available will have the package zip checked against this signature.

If a package fails verification then the user will be alerted in the UI.

If a package does not have a signature, the package will be marked as having an "unknown" verification status, which currently does not show in the UI. This prevents already installed packages from showing as unverified.
