### PR TITLE
[Security Solution] Pull source data index from kibana.alert.rule.indices

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.tsx
@@ -36,6 +36,7 @@ import {
   ALERT_RULE_TIMELINE_ID,
   ALERT_THRESHOLD_RESULT,
   ALERT_NEW_TERMS,
+  ALERT_RULE_INDICES,
 } from '../../../../common/field_maps/field_names';
 import type { TimelineResult } from '../../../../common/types/timeline';
 import { TimelineId, TimelineStatus, TimelineType } from '../../../../common/types/timeline';
@@ -439,7 +440,7 @@ const createThresholdTimeline = async (
     });
     const language = params.language ?? alertDoc.signal?.rule?.language ?? 'kuery';
     const query = params.query ?? alertDoc.signal?.rule?.query ?? '';
-    const indexNames = params.index ?? alertDoc.signal?.rule?.index ?? [];
+    const indexNames = getField(alertDoc, ALERT_RULE_INDICES) ?? alertDoc.signal?.rule?.index ?? [];
 
     const { thresholdFrom, thresholdTo, dataProviders } = getThresholdAggregationData(alertDoc);
     const exceptions = await getExceptions(ecsData);
@@ -588,7 +589,7 @@ const createNewTermsTimeline = async (
     });
     const language = params.language ?? alertDoc.signal?.rule?.language ?? 'kuery';
     const query = params.query ?? alertDoc.signal?.rule?.query ?? '';
-    const indexNames = params.index ?? alertDoc.signal?.rule?.index ?? [];
+    const indexNames = getField(alertDoc, ALERT_RULE_INDICES) ?? alertDoc.signal?.rule?.index ?? [];
 
     const { from, to, dataProviders } = getNewTermsData(alertDoc);
     const exceptions = await getExceptions(ecsData);


### PR DESCRIPTION
## Summary

Alerts generated from rules that use data views instead of index patterns don't populate `kibana.alert.rule.parameters.index`, instead they populate a data view ID that is used to fetch index patterns at runtime. All rules that use either index patterns or data views populate the alert field `kibana.alert.rule.indices` with the actual index patterns that were queried by the rule, regardless of whether they came from raw index patterns or a data view on the rule.

This PR updates the timeline action to use `kibana.alert.rule.indices` so that alerts from both data view and index pattern rules can be sent to timeline correctly.
