### PR TITLE
[Files] Add coverage for audit logging

### DIFF
--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -16,6 +16,15 @@ import type {
   FindFileArgs,
 } from './internal_file_service';
 
+export type {
+  CreateFileArgs,
+  UpdateFileArgs,
+  DeleteFileArgs,
+  GetByIdArgs,
+  ListFilesArgs,
+  FindFileArgs,
+};
+
 /**
  * Public file service interface.
  */

--- a/x-pack/plugins/files/server/file_service/index.ts
+++ b/x-pack/plugins/files/server/file_service/index.ts
@@ -6,5 +6,13 @@
  */
 
 export { FileServiceFactory } from './file_service_factory';
-export type { FileServiceStart } from './file_service';
+export type {
+  FileServiceStart,
+  CreateFileArgs,
+  DeleteFileArgs,
+  FindFileArgs,
+  GetByIdArgs,
+  ListFilesArgs,
+  UpdateFileArgs,
+} from './file_service';
 export * as errors from './errors';

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -11,15 +11,15 @@ import {
   createRootWithCorePlugins,
   TestElasticsearchUtils,
 } from '@kbn/core/test_helpers/kbn_server';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import type { AuditLogger } from '@kbn/security-plugin/server';
 import { Readable } from 'stream';
 
 import type { FileStatus, File } from '../../common';
 
 import { fileKindsRegistry } from '../file_kinds_registry';
 import { BlobStorageService } from '../blob_storage_service';
-import { FileServiceFactory } from '../file_service';
-import { FileServiceStart } from '../file_service/file_service';
-import { CreateFileArgs } from '../file_service/internal_file_service';
+import { FileServiceStart, CreateFileArgs, FileServiceFactory } from '../file_service';
 
 describe('FileService', () => {
   const fileKind: string = 'test';
@@ -35,6 +35,8 @@ describe('FileService', () => {
   let coreSetup: Awaited<ReturnType<typeof kbnRoot.setup>>;
   let coreStart: CoreStart;
   let fileServiceFactory: FileServiceFactory;
+  let security: ReturnType<typeof securityMock.createSetup>;
+  let auditLogger: AuditLogger;
 
   beforeAll(async () => {
     const { startES } = createTestServers({ adjustTimeout: jest.setTimeout });
@@ -67,11 +69,15 @@ describe('FileService', () => {
   });
 
   beforeEach(() => {
+    security = securityMock.createSetup();
+    auditLogger = { enabled: true, log: jest.fn() };
+    (security.audit.asScoped as jest.Mock).mockReturnValue(auditLogger);
+    security.audit.withoutRequest = auditLogger;
     blobStorageService = new BlobStorageService(esClient, kbnRoot.logger.get('test-blob-service'));
     fileServiceFactory = new FileServiceFactory(
       coreStart.savedObjects,
       blobStorageService,
-      undefined, // skip security for these tests
+      security,
       fileKindsRegistry,
       kbnRoot.logger.get('test-file-service')
     );
@@ -96,6 +102,15 @@ describe('FileService', () => {
     expect(file.name).toEqual('test');
     expect(file.fileKind).toEqual(fileKind);
     expect(file.status).toBe('AWAITING_UPLOAD' as FileStatus);
+    expect(auditLogger.log).toHaveBeenCalledTimes(1);
+    expect(auditLogger.log).toHaveBeenCalledWith({
+      error: undefined,
+      event: {
+        action: 'create',
+        outcome: 'success',
+      },
+      message: expect.stringContaining('Created file "test"'),
+    });
   });
 
   it('uploads file content', async () => {
@@ -195,6 +210,23 @@ describe('FileService', () => {
           fileId: file.id,
         })
       );
+      expect(auditLogger.log).toHaveBeenCalledTimes(2);
+      expect(auditLogger.log).toHaveBeenNthCalledWith(1, {
+        error: undefined,
+        event: {
+          action: 'create',
+          outcome: 'success',
+        },
+        message: expect.stringContaining('Created file "test"'),
+      });
+      expect(auditLogger.log).toHaveBeenNthCalledWith(2, {
+        error: undefined,
+        event: {
+          action: 'create',
+          outcome: 'success',
+        },
+        message: expect.stringContaining('Shared file "test"'),
+      });
     });
 
     it('retrieves a a file share object', async () => {
@@ -276,6 +308,31 @@ describe('FileService', () => {
       expect(await file.listShares()).toHaveLength(1);
       await file.unshare({ shareId: id });
       expect(await file.listShares()).toEqual([]);
+      expect(auditLogger.log).toHaveBeenCalledTimes(3);
+      expect(auditLogger.log).toHaveBeenNthCalledWith(1, {
+        error: undefined,
+        event: {
+          action: 'create',
+          outcome: 'success',
+        },
+        message: expect.stringContaining('Created file "myfile"'),
+      });
+      expect(auditLogger.log).toHaveBeenNthCalledWith(2, {
+        error: undefined,
+        event: {
+          action: 'create',
+          outcome: 'success',
+        },
+        message: expect.stringContaining('Shared file "myfile"'),
+      });
+      expect(auditLogger.log).toHaveBeenNthCalledWith(3, {
+        error: undefined,
+        event: {
+          action: 'delete',
+          outcome: 'success',
+        },
+        message: expect.stringContaining('Removed share for "myfile"'),
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Simple update to the file service integration tests to also assert the expected audit log calls have been made.