### PR TITLE
[Enterprise Search] Add link for connector documentation on create index

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
@@ -119,6 +119,7 @@ export const MethodConnector: React.FC = () => {
 
   return (
     <NewSearchIndexTemplate
+      docsUrl="https://github.com/elastic/connectors-ruby/blob/main/README.md"
       error={errorToMessage(error)}
       title={i18n.translate('xpack.enterpriseSearch.content.newIndex.steps.buildConnector.title', {
         defaultMessage: 'Build a connector',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -38,6 +38,7 @@ import { LanguageForOptimization } from './types';
 
 export interface Props {
   buttonLoading?: boolean;
+  docsUrl?: string;
   error?: string | React.ReactNode;
   onNameChange?(name: string): void;
   onSubmit(name: string, language: LanguageForOptimization): void;
@@ -47,6 +48,7 @@ export interface Props {
 
 export const NewSearchIndexTemplate: React.FC<Props> = ({
   children,
+  docsUrl,
   error,
   title,
   onNameChange,
@@ -208,16 +210,18 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
               )}
             </EuiButton>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiLink target="_blank" href="#">
-              {i18n.translate(
-                'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.viewDocumentation.linkText',
-                {
-                  defaultMessage: 'View the documentation',
-                }
-              )}
-            </EuiLink>
-          </EuiFlexItem>
+          {!!docsUrl && (
+            <EuiFlexItem grow={false}>
+              <EuiLink target="_blank" href={docsUrl}>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.viewDocumentation.linkText',
+                  {
+                    defaultMessage: 'View the documentation',
+                  }
+                )}
+              </EuiLink>
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </EuiForm>
       <EuiHorizontalRule />


### PR DESCRIPTION
This adds the correct link on the create index page for the connector to view documentation.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->