### PR TITLE
[Global search bar] Create a loading spinner for the initial empty state

### DIFF
--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -18,6 +18,7 @@ import {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideOption,
   euiSelectableTemplateSitewideRenderOptions,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
@@ -254,7 +255,18 @@ export const SearchBar: FC<SearchBarProps> = ({
 
   const clearField = () => setSearchValue('');
 
-  const emptyMessage = <PopoverPlaceholder darkMode={darkMode} basePath={basePathUrl} />;
+  const noMatchesMessage = <PopoverPlaceholder darkMode={darkMode} basePath={basePathUrl} />;
+  const emptyMessage = (
+    <div style={{
+      minHeight: 300, // hardcoded in PopoverPlaceholder too
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center'
+    }}>
+      <EuiLoadingSpinner size='xl'></EuiLoadingSpinner>
+    </div>
+  );
+
   const placeholderText = i18n.translate('xpack.globalSearchBar.searchBar.placeholder', {
     defaultMessage: 'Find apps, content, and more. Ex: Discover',
   });
@@ -314,7 +326,7 @@ export const SearchBar: FC<SearchBarProps> = ({
         ) : undefined,
       }}
       emptyMessage={emptyMessage}
-      noMatchesMessage={emptyMessage}
+      noMatchesMessage={noMatchesMessage}
       popoverProps={{
         'data-test-subj': 'nav-search-popover',
         panelClassName: 'navSearch__panel',

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -257,13 +257,15 @@ export const SearchBar: FC<SearchBarProps> = ({
 
   const noMatchesMessage = <PopoverPlaceholder darkMode={darkMode} basePath={basePathUrl} />;
   const emptyMessage = (
-    <div style={{
-      minHeight: 300, // hardcoded in PopoverPlaceholder too
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center'
-    }}>
-      <EuiLoadingSpinner size='xl'></EuiLoadingSpinner>
+    <div
+      style={{
+        minHeight: 300, // hardcoded in PopoverPlaceholder too
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <EuiLoadingSpinner size="xl" />
     </div>
   );
 

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -19,6 +19,8 @@ import {
   EuiSelectableTemplateSitewideOption,
   euiSelectableTemplateSitewideRenderOptions,
   EuiLoadingSpinner,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
@@ -257,16 +259,11 @@ export const SearchBar: FC<SearchBarProps> = ({
 
   const noMatchesMessage = <PopoverPlaceholder darkMode={darkMode} basePath={basePathUrl} />;
   const emptyMessage = (
-    <div
-      style={{
-        minHeight: 300, // hardcoded in PopoverPlaceholder too
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-      }}
-    >
-      <EuiLoadingSpinner size="xl" />
-    </div>
+    <EuiFlexGroup direction="column" justifyContent="center" style={{ minHeight: '300px' }}>
+      <EuiFlexItem grow={false}>
+        <EuiLoadingSpinner size="xl" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 
   const placeholderText = i18n.translate('xpack.globalSearchBar.searchBar.placeholder', {


### PR DESCRIPTION
Fixes #135528

Create a loading spinner instead of incorrectly reusing the `<PopoverPlaceholder>` that is used for the "no results".

https://user-images.githubusercontent.com/25349407/181222265-5a0dd319-5a19-4eb0-80d8-4d19a977a8fe.mov




<!--ONMERGE {"backportTargets":["7.17","8.3","8.5"]} ONMERGE-->