### PR TITLE
Add unique environment per scenario

### DIFF
--- a/packages/elastic-apm-synthtrace/src/scenarios/aws_lambda.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/aws_lambda.ts
@@ -12,6 +12,8 @@ import { Scenario } from '../scripts/scenario';
 import { getLogger } from '../scripts/utils/get_common_services';
 import { RunOptions } from '../scripts/utils/parse_run_cli_flags';
 
+const ENVIRONMENT = __filename;
+
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);
 
@@ -20,7 +22,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
       const range = timerange(from, to);
       const timestamps = range.interval('1s').rate(3);
 
-      const instance = apm.service('lambda-python', 'production', 'python').instance('instance');
+      const instance = apm.service('lambda-python', ENVIRONMENT, 'python').instance('instance');
 
       const traceEventsSetups = [
         { functionName: 'lambda-python-1', coldStart: true },

--- a/packages/elastic-apm-synthtrace/src/scenarios/low_throughput.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/low_throughput.ts
@@ -14,6 +14,8 @@ import { Scenario } from '../scripts/scenario';
 import { getLogger } from '../scripts/utils/get_common_services';
 import { RunOptions } from '../scripts/utils/parse_run_cli_flags';
 
+const ENVIRONMENT = __filename;
+
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);
 
@@ -32,7 +34,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
         apm
           .service(
             `${services[index % services.length]}-${languages[index % languages.length]}-${index}`,
-            'production',
+            ENVIRONMENT,
             languages[index % languages.length]
           )
           .instance('instance')

--- a/packages/elastic-apm-synthtrace/src/scenarios/many_services.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/many_services.ts
@@ -14,6 +14,8 @@ import { getLogger } from '../scripts/utils/get_common_services';
 import { RunOptions } from '../scripts/utils/parse_run_cli_flags';
 import { ApmFields } from '../lib/apm/apm_fields';
 
+const ENVIRONMENT = __filename;
+
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);
 
@@ -31,7 +33,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
         apm
           .service(
             `${services[index % services.length]}-${languages[index % languages.length]}-${index}`,
-            'production',
+            ENVIRONMENT,
             languages[index % languages.length]
           )
           .instance('instance')

--- a/packages/elastic-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -13,6 +13,8 @@ import { Scenario } from '../scripts/scenario';
 import { getLogger } from '../scripts/utils/get_common_services';
 import { RunOptions } from '../scripts/utils/parse_run_cli_flags';
 
+const ENVIRONMENT = __filename;
+
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);
 
@@ -29,7 +31,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
       const failedTimestamps = range.interval('1s').rate(1);
 
       const instances = [...Array(numServices).keys()].map((index) =>
-        apm.service(`opbeans-go-${index}`, 'production', 'go').instance('instance')
+        apm.service(`opbeans-go-${index}`, ENVIRONMENT, 'go').instance('instance')
       );
       const instanceSpans = (instance: Instance) => {
         const successfulTraceEvents = successfulTimestamps.generator((timestamp) =>

--- a/packages/elastic-apm-synthtrace/src/scenarios/span_links.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/span_links.ts
@@ -11,6 +11,8 @@ import { apm, ApmFields, EntityArrayIterable, timerange } from '..';
 import { generateLongId, generateShortId } from '../lib/utils/generate_id';
 import { Scenario } from '../scripts/scenario';
 
+const ENVIRONMENT = __filename;
+
 function generateExternalSpanLinks() {
   // randomly creates external span links 0 - 10
   return Array(Math.floor(Math.random() * 11))
@@ -31,7 +33,8 @@ const scenario: Scenario<ApmFields> = async () => {
   return {
     generate: ({ from, to }) => {
       const producerInternalOnlyInstance = apm
-        .service('producer-internal-only', 'production', 'go')
+
+        .service('producer-internal-only', ENVIRONMENT, 'go')
         .instance('instance-a');
       const producerInternalOnlyEvents = timerange(
         new Date('2022-04-25T19:00:00.000Z'),
@@ -58,7 +61,7 @@ const scenario: Scenario<ApmFields> = async () => {
       const spanASpanLink = getSpanLinksFromEvents(producerInternalOnlyApmFields);
 
       const producerConsumerInstance = apm
-        .service('producer-consumer', 'production', 'java')
+        .service('producer-consumer', ENVIRONMENT, 'java')
         .instance('instance-b');
       const producerConsumerEvents = timerange(from, to)
         .interval('1m')
@@ -84,7 +87,7 @@ const scenario: Scenario<ApmFields> = async () => {
       const producerConsumerApmFields = producerConsumerEvents.toArray();
       const spanBSpanLink = getSpanLinksFromEvents(producerConsumerApmFields);
 
-      const consumerInstance = apm.service('consumer', 'production', 'ruby').instance('instance-c');
+      const consumerInstance = apm.service('consumer', ENVIRONMENT, 'ruby').instance('instance-c');
       const consumerEvents = timerange(from, to)
         .interval('1m')
         .rate(1)


### PR DESCRIPTION
This adds a unique `service.environment` (filename) to each synthtrace scenario