### PR TITLE
[Security Solution][Endpoint] Fix input area showing error state when invalid input is replaced with a valid command using the Help panel

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_input/hooks/use_input_hints.ts
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_input/hooks/use_input_hints.ts
@@ -82,6 +82,8 @@ export const useInputHints = () => {
           type: 'updateFooterContent',
           payload: { value: hint },
         });
+
+        dispatch({ type: 'setInputState', payload: { value: undefined } });
       } else {
         dispatch({
           type: 'updateFooterContent',


### PR DESCRIPTION
## Summary

- Fixes the input area so that if an invalid typed command is replaced with a valid entry via the Help panel `+` icon, the error state is reset.

Addresses #137252 

![olm-137252-fix-input-area-error-state](https://user-images.githubusercontent.com/56442535/181282299-25b12104-bc02-4a87-86ec-071bbe63aec3.gif)





<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->