### PR TITLE
[ML] Lock the delete annotation button on click   

### DIFF
--- a/x-pack/plugins/ml/public/application/components/annotations/annotation_flyout/index.tsx
+++ b/x-pack/plugins/ml/public/application/components/annotations/annotation_flyout/index.tsx
@@ -78,6 +78,8 @@ interface State {
 }
 
 export class AnnotationFlyoutUI extends Component<CommonProps & Props> {
+  private deletionInProgress = false;
+
   public state: State = {
     isDeleteModalVisible: false,
     applyAnnotationToSeries: true,
@@ -121,12 +123,16 @@ export class AnnotationFlyoutUI extends Component<CommonProps & Props> {
   };
 
   public deleteHandler = async () => {
+    if (this.deletionInProgress) return;
+
     const { annotationState } = this.state;
     const toastNotifications = getToastNotifications();
 
     if (annotationState === null || annotationState._id === undefined) {
       return;
     }
+
+    this.deletionInProgress = true;
 
     try {
       await ml.annotations.deleteAnnotation(annotationState._id);
@@ -153,6 +159,8 @@ export class AnnotationFlyoutUI extends Component<CommonProps & Props> {
     }
 
     this.closeDeleteModal();
+
+    this.deletionInProgress = false;
 
     const { annotationUpdatesService } = this.props;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/134361 

Prevents calling the delete annotation endpoint multiple times on several consecutive button clicks.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->