### PR TITLE
[Enterprise Search] Add Crawler docLinks to Content app

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -116,6 +116,9 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     enterpriseSearch: {
       bulkApi: `${ELASTICSEARCH_DOCS}docs-bulk.html`,
       configuration: `${ENTERPRISE_SEARCH_DOCS}configuration.html`,
+      crawlerGettingStarted: `${ENTERPRISE_SEARCH_DOCS}crawler-getting-started.html`,
+      crawlerManaging: `${ENTERPRISE_SEARCH_DOCS}crawler-managing.html`,
+      crawlerOverview: `${ENTERPRISE_SEARCH_DOCS}crawler.html`,
       languageAnalyzers: `${ELASTICSEARCH_DOCS}analysis-lang-analyzer.html`,
       licenseManagement: `${ENTERPRISE_SEARCH_DOCS}license-management.html`,
       mailService: `${ENTERPRISE_SEARCH_DOCS}mailer-configuration.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -103,6 +103,9 @@ export interface DocLinks {
   readonly enterpriseSearch: {
     readonly bulkApi: string;
     readonly configuration: string;
+    readonly crawlerGettingStarted: string;
+    readonly crawlerManaging: string;
+    readonly crawlerOverview: string;
     readonly languageAnalyzers: string;
     readonly licenseManagement: string;
     readonly mailService: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawl_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawl_rules_table.tsx
@@ -23,6 +23,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../shared/doc_links';
 import { clearFlashMessages, flashSuccessToast } from '../../../shared/flash_messages';
 import { GenericEndpointInlineEditableTable } from '../../../shared/tables/generic_endpoint_inline_editable_table';
 
@@ -101,7 +102,7 @@ const DEFAULT_DESCRIPTION = (
       defaultMessage="Create a crawl rule to include or exclude pages whose URL matches the rule. Rules run in sequential order, and each URL is evaluated according to the first match. {link}"
       values={{
         link: (
-          <EuiLink href={'' /* TODO GET DOC LINK */} target="_blank" external>
+          <EuiLink href={docLinks.crawlerManaging} target="_blank" external>
             {i18n.translate('xpack.enterpriseSearch.crawler.crawlRulesTable.descriptionLinkText', {
               defaultMessage: 'Learn more about crawl rules',
             })}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/deduplication_panel/deduplication_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/deduplication_panel/deduplication_panel.tsx
@@ -29,6 +29,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { DataPanel } from '../../../../shared/data_panel/data_panel';
+import { docLinks } from '../../../../shared/doc_links';
 import { CrawlerDomainDetailLogic } from '../crawler_domain_detail_logic';
 
 import { getCheckedOptionLabels, getSelectableOptions } from './utils';
@@ -84,7 +85,7 @@ export const DeduplicationPanel: React.FC = () => {
           documents on this domain. {documentationLink}."
           values={{
             documentationLink: (
-              <EuiLink href={'' /* TODO add docs url */} target="_blank" external>
+              <EuiLink href={docLinks.crawlerManaging} target="_blank" external>
                 {i18n.translate(
                   'xpack.enterpriseSearch.crawler.deduplicationPanel.learnMoreMessage',
                   {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/entry_points_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/entry_points_table.tsx
@@ -14,6 +14,7 @@ import { EuiFieldText, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eu
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../shared/doc_links';
 import { GenericEndpointInlineEditableTable } from '../../../shared/tables/generic_endpoint_inline_editable_table';
 
 import { InlineEditableTableColumn } from '../../../shared/tables/inline_editable_table/types';
@@ -75,7 +76,7 @@ export const EntryPointsTable: React.FC<EntryPointsTableProps> = ({ domain, inde
             defaultMessage:
               'Include the most important URLs for your website here. Entry point URLs will be the first pages to be indexed and processed for links to other pages.',
           })}{' '}
-          <EuiLink href={'' /* TODO get docs url */} target="_blank" external>
+          <EuiLink href={docLinks.crawlerManaging} target="_blank" external>
             {i18n.translate('xpack.enterpriseSearch.crawler.entryPointsTable.learnMoreLinkText', {
               defaultMessage: 'Learn more about entry points.',
             })}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-/**
- * TODO:
- * - Need to add documentation URLs (search for `#`s)
- * - Port over Connector views from App Search to the panel below.
- */
-
 import React from 'react';
 
 import { useActions, useValues } from 'kea';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
@@ -5,20 +5,16 @@
  * 2.0.
  */
 
-/**
- * TODO:
- * - Need to add documentation URLs (search for `#`s)
- * - Port over existing Crawler view from App Search to the panel below.
- */
-
 import React from 'react';
 
 import { useValues, useActions } from 'kea';
 
 import { EuiSteps, EuiText } from '@elastic/eui';
+
 import { i18n } from '@kbn/i18n';
 
 import { Status } from '../../../../../../common/types/api';
+import { docLinks } from '../../../../shared/doc_links';
 import { CreateCrawlerIndexApiLogic } from '../../../api/crawler/create_crawler_index_api_logic';
 import { NewSearchIndexTemplate } from '../new_search_index_template';
 
@@ -41,6 +37,7 @@ export const MethodCrawler: React.FC = () => {
       type="crawler"
       onSubmit={(indexName, language) => makeRequest({ indexName, language })}
       buttonLoading={status === Status.LOADING}
+      docsUrl={docLinks.crawlerOverview}
     >
       <EuiSteps
         steps={[

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -5,13 +5,6 @@
  * 2.0.
  */
 
-/**
- * TODO:
- * - Need to add logic to take a query param to select the correct method when applicable.
- *   This is needed for the use case where a user clicks on an integration method from the
- *   Kibana intgegrations page
- */
-
 import React, { useState } from 'react';
 
 import { useLocation } from 'react-router-dom';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-/**
- * TODO:
- * - Need to add documentation URLs (search for `#`s)
- * - Bind create index button
- */
-
 import React, { ChangeEvent } from 'react';
 
 import { useValues, useActions } from 'kea';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../../../../shared/constants';
 import { DataPanel } from '../../../../../shared/data_panel/data_panel';
 
+import { docLinks } from '../../../../../shared/doc_links/doc_links';
 import { CrawlUnits } from '../../../../api/crawler/types';
 
 import { AutomaticCrawlSchedulerLogic } from './automatic_crawl_scheduler_logic';
@@ -71,7 +72,7 @@ export const AutomaticCrawlScheduler: React.FC = () => {
             defaultMessage="Setup automated crawling. {readMoreMessage}."
             values={{
               readMoreMessage: (
-                <EuiLink href={'' /* TODO Add docs url */} target="_blank">
+                <EuiLink href={docLinks.crawlerManaging} target="_blank" external>
                   {i18n.translate(
                     'xpack.enterpriseSearch.crawler.automaticCrawlSchedule.readMoreLink',
                     {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_nav.tsx
@@ -70,7 +70,6 @@ export const useSearchIndicesNav = () => {
       }),
       'data-test-subj': 'IndexIndexMappingsLink',
     },
-    // TODO Conditionally display links for connector/crawler
   ];
 
   return navItems;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -54,6 +54,9 @@ class DocLinks {
   public clientsRubyOverview: string;
   public clientsRustOverview: string;
   public cloudIndexManagement: string;
+  public crawlerGettingStarted: string;
+  public crawlerManaging: string;
+  public crawlerOverview: string;
   public elasticsearchCreateIndex: string;
   public elasticsearchGettingStarted: string;
   public elasticsearchMapping: string;
@@ -147,6 +150,9 @@ class DocLinks {
     this.clientsRubyOverview = '';
     this.clientsRustOverview = '';
     this.cloudIndexManagement = '';
+    this.crawlerGettingStarted = '';
+    this.crawlerManaging = '';
+    this.crawlerOverview = '';
     this.elasticsearchCreateIndex = '';
     this.elasticsearchGettingStarted = '';
     this.elasticsearchMapping = '';
@@ -242,6 +248,9 @@ class DocLinks {
     this.clientsRubyOverview = docLinks.links.clients.rubyOverview;
     this.clientsRustOverview = docLinks.links.clients.rustOverview;
     this.cloudIndexManagement = docLinks.links.cloud.indexManagement;
+    this.crawlerGettingStarted = docLinks.links.enterpriseSearch.crawlerGettingStarted;
+    this.crawlerManaging = docLinks.links.enterpriseSearch.crawlerManaging;
+    this.crawlerOverview = docLinks.links.enterpriseSearch.crawlerOverview;
     this.elasticsearchCreateIndex = docLinks.links.elasticsearch.createIndex;
     this.elasticsearchGettingStarted = docLinks.links.elasticsearch.gettingStarted;
     this.elasticsearchMapping = docLinks.links.elasticsearch.mapping;


### PR DESCRIPTION
## Summary

These were picked in collaboration with @leemthompo 


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->