### PR TITLE
[DOCS] Adds openAPI spec for get alerts endpoint

### DIFF
--- a/docs/api/cases/cases-api-get-alerts.asciidoc
+++ b/docs/api/cases/cases-api-get-alerts.asciidoc
@@ -38,11 +38,11 @@ default space is used.
 
 === {api-examples-title}
 
-Return all alerts attached to case `293f1bc0-74f6-11ea-b83a-553aecdb28b6`:
+Return all alerts attached to case `a8b26350-0c55-11ed-918a-2d2edf3e58bc`:
 
 [source,sh]
 --------------------------------------------------
-GET api/cases/293f1bc0-74f6-11ea-b83a-553aecdb28b6/alerts
+GET api/cases/a8b26350-0c55-11ed-918a-2d2edf3e58bc/alerts
 --------------------------------------------------
 // KIBANA
 
@@ -52,9 +52,9 @@ The API returns a JSON array listing the alerts. For example:
 --------------------------------------------------
 [
    {
-      "id": "09f0c261e39e36351d75995b78bb83673774d1bc2cca9df2d15f0e5c0a99a540",
-      "index": ".internal.alerts-security.alerts-default-000001",
-      "attached_at": "2022-04-13T21:35:24.602Z"
+      "id": "f6a7d0c3-d52d-432c-b2e6-447cd7fce04d",
+      "index": ".alerts-observability.logs.alerts-default",
+      "attached_at": "2022-07-25T20:09:40.963Z"
    }
 ]
 --------------------------------------------------

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -2857,6 +2857,53 @@
         }
       ]
     },
+    "/api/cases/{caseId}/alerts": {
+      "get": {
+        "summary": "Gets all alerts attached to a case in the default space.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
+        "operationId": "getCaseAlertsDefaultSpace",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "x-technical-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/alert_response_properties"
+                  }
+                },
+                "examples": {
+                  "createCaseCommentResponse": {
+                    "$ref": "#/components/examples/get_case_alerts_response"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
     "/api/cases/{caseId}/comments": {
       "post": {
         "summary": "Adds a comment or alert to a case in the default space.",
@@ -6511,6 +6558,56 @@
         }
       ]
     },
+    "/s/{spaceId}/api/cases/{caseId}/alerts": {
+      "get": {
+        "summary": "Gets all alerts attached to a case.",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
+        "x-technical-preview": true,
+        "operationId": "getCaseAlerts",
+        "tags": [
+          "cases",
+          "kibana"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/space_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/alert_response_properties"
+                  }
+                },
+                "examples": {
+                  "createCaseCommentResponse": {
+                    "$ref": "#/components/examples/get_case_alerts_response"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
     "/s/{spaceId}/api/cases/{caseId}/comments": {
       "post": {
         "summary": "Adds a comment or alert to a case.",
@@ -7738,6 +7835,23 @@
         ],
         "example": "close-by-user"
       },
+      "alert_response_properties": {
+        "type": "object",
+        "properties": {
+          "attached_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The alert identifier.",
+            "type": "string"
+          },
+          "index": {
+            "description": "The alert index.",
+            "type": "string"
+          }
+        }
+      },
       "add_alert_comment_request_properties": {
         "type": "object",
         "properties": {
@@ -8758,6 +8872,16 @@
           },
           "external_service": null
         }
+      },
+      "get_case_alerts_response": {
+        "summary": "Retrieves all alerts attached to a case",
+        "value": [
+          {
+            "id": "f6a7d0c3-d52d-432c-b2e6-447cd7fce04d",
+            "index": ".alerts-observability.logs.alerts-default",
+            "attached_at": "2022-07-25T20:09:40.963Z"
+          }
+        ]
       },
       "add_comment_request": {
         "summary": "Adds a comment to a case.",

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -2418,6 +2418,36 @@ paths:
         - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
+  /api/cases/{caseId}/alerts:
+    get:
+      summary: Gets all alerts attached to a case in the default space.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're seeking.
+      operationId: getCaseAlertsDefaultSpace
+      tags:
+        - cases
+        - kibana
+      x-technical-preview: true
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/alert_response_properties'
+              examples:
+                createCaseCommentResponse:
+                  $ref: '#/components/examples/get_case_alerts_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
   /api/cases/{caseId}/comments:
     post:
       summary: Adds a comment or alert to a case in the default space.
@@ -5441,6 +5471,37 @@ paths:
         - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
+  /s/{spaceId}/api/cases/{caseId}/alerts:
+    get:
+      summary: Gets all alerts attached to a case.
+      description: >
+        You must have `read` privileges for the **Cases** feature in the
+        **Management**, **Observability**, or **Security** section of the Kibana
+        feature privileges, depending on the owner of the cases you're seeking.
+      x-technical-preview: true
+      operationId: getCaseAlerts
+      tags:
+        - cases
+        - kibana
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/space_id'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/alert_response_properties'
+              examples:
+                createCaseCommentResponse:
+                  $ref: '#/components/examples/get_case_alerts_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
   /s/{spaceId}/api/cases/{caseId}/comments:
     post:
       summary: Adds a comment or alert to a case.
@@ -6376,6 +6437,18 @@ components:
         - close-by-pushing
         - close-by-user
       example: close-by-user
+    alert_response_properties:
+      type: object
+      properties:
+        attached_at:
+          type: string
+          format: date-time
+        id:
+          description: The alert identifier.
+          type: string
+        index:
+          description: The alert index.
+          type: string
     add_alert_comment_request_properties:
       type: object
       properties:
@@ -7207,6 +7280,12 @@ components:
           type: .none
           fields: null
         external_service: null
+    get_case_alerts_response:
+      summary: Retrieves all alerts attached to a case
+      value:
+        - id: f6a7d0c3-d52d-432c-b2e6-447cd7fce04d
+          index: .alerts-observability.logs.alerts-default
+          attached_at: '2022-07-25T20:09:40.963Z'
     add_comment_request:
       summary: Adds a comment to a case.
       value:

--- a/x-pack/plugins/cases/docs/openapi/components/examples/get_case_alerts_response.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/examples/get_case_alerts_response.yaml
@@ -1,0 +1,10 @@
+summary: Retrieves all alerts attached to a case
+value: 
+  [
+    {
+      "id": "f6a7d0c3-d52d-432c-b2e6-447cd7fce04d",
+      "index": ".alerts-observability.logs.alerts-default",
+      "attached_at": "2022-07-25T20:09:40.963Z"
+    }
+  ]
+  

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_response_properties.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_response_properties.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  attached_at:
+    type: string
+    format: date-time
+  id: 
+    description: The alert identifier.
+    type: string
+  index:
+    description: The alert index.
+    type: string

--- a/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
@@ -37,8 +37,8 @@ paths:
     $ref: 'paths/api@cases@tags.yaml'
   '/api/cases/{caseId}':
     $ref: 'paths/api@cases@{caseid}.yaml'
-#  '/api/cases/{caseId}/alerts':
-#    $ref: 'paths/api@cases@{caseid}@alerts.yaml'
+  '/api/cases/{caseId}/alerts':
+    $ref: 'paths/api@cases@{caseid}@alerts.yaml'
   '/api/cases/{caseId}/comments':
     $ref: 'paths/api@cases@{caseid}@comments.yaml'
   '/api/cases/{caseId}/comments/{commentId}':
@@ -68,8 +68,8 @@ paths:
     $ref: 'paths/s@{spaceid}@api@cases@tags.yaml'
   '/s/{spaceId}/api/cases/{caseId}':
     $ref: 'paths/s@{spaceid}@api@cases@{caseid}.yaml'
- # '/s/{spaceId}/api/cases/{caseId}/alerts':
- #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml'
+  '/s/{spaceId}/api/cases/{caseId}/alerts':
+    $ref: 'paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml'
   '/s/{spaceId}/api/cases/{caseId}/comments':
     $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments.yaml'
   '/s/{spaceId}/api/cases/{caseId}/comments/{commentId}':

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
@@ -1,0 +1,29 @@
+get:
+  summary: Gets all alerts attached to a case in the default space.
+  description: >
+    You must have `read` privileges for the **Cases** feature in the
+    **Management**, **Observability**, or **Security** section of the Kibana
+    feature privileges, depending on the owner of the cases you're seeking.
+  operationId: getCaseAlertsDefaultSpace
+  tags:
+    - cases
+    - kibana
+  x-technical-preview: true
+  parameters:
+    - $ref: ../components/parameters/case_id.yaml
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/alert_response_properties.yaml'
+          examples:
+            createCaseCommentResponse:
+              $ref: '../components/examples/get_case_alerts_response.yaml'
+  servers:
+    - url: https://localhost:5601
+servers:
+  - url: https://localhost:5601

--- a/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml
@@ -1,0 +1,30 @@
+get:
+  summary: Gets all alerts attached to a case.
+  description: >
+    You must have `read` privileges for the **Cases** feature in the
+    **Management**, **Observability**, or **Security** section of the Kibana
+    feature privileges, depending on the owner of the cases you're seeking.
+  x-technical-preview: true
+  operationId: getCaseAlerts
+  tags:
+    - cases
+    - kibana
+  parameters:
+    - $ref: ../components/parameters/case_id.yaml
+    - $ref: '../components/parameters/space_id.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/alert_response_properties.yaml'
+          examples:
+            createCaseCommentResponse:
+              $ref: '../components/examples/get_case_alerts_response.yaml'
+  servers:
+    - url: https://localhost:5601
+servers:
+  - url: https://localhost:5601


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/133345

This PR copies the layout used in https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/common/openapi to model the following API: https://www.elastic.co/guide/en/kibana/master/cases-api-get-alerts.html

It also fixes the documentation example to use a different alert index.