### PR TITLE
[APM] Errors: Update the theme for the error occurrence histogram

### DIFF
--- a/x-pack/plugins/apm/public/components/app/error_group_details/distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/distribution/index.tsx
@@ -15,12 +15,16 @@ import {
   Settings,
 } from '@elastic/charts';
 import { EuiTitle } from '@elastic/eui';
+import {
+  EUI_CHARTS_THEME_DARK,
+  EUI_CHARTS_THEME_LIGHT,
+} from '@elastic/eui/dist/eui_charts_theme';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { usePreviousPeriodLabel } from '../../../../hooks/use_previous_period_text';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
+import { usePreviousPeriodLabel } from '../../../../hooks/use_previous_period_text';
 import { useTheme } from '../../../../hooks/use_theme';
 import { APIReturnType } from '../../../../services/rest/create_call_apm_api';
 import { ChartContainer } from '../../../shared/charts/chart_container';
@@ -89,6 +93,11 @@ export function ErrorDistribution({ distribution, title, fetchStatus }: Props) {
             showLegend
             showLegendExtra
             legendPosition={Position.Bottom}
+            theme={
+              theme.darkMode
+                ? EUI_CHARTS_THEME_DARK.theme
+                : EUI_CHARTS_THEME_LIGHT.theme
+            }
           />
           <Axis
             id="x-axis"


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/87449

<img width="1181" alt="Screen Shot 2022-07-27 at 1 38 51 PM" src="https://user-images.githubusercontent.com/55978943/181313653-3b7d4cc1-6b16-42a3-b361-60ac0c1d7506.png">
<img width="1065" alt="Screen Shot 2022-07-27 at 1 39 39 PM" src="https://user-images.githubusercontent.com/55978943/181313656-8203e12d-f12f-4598-89fa-84c0cf06227a.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->