### PR TITLE
[ResponseOps][Cases] Refactoring client args and authentication

### DIFF
--- a/x-pack/plugins/cases/kibana.json
+++ b/x-pack/plugins/cases/kibana.json
@@ -11,10 +11,9 @@
   "kibanaVersion":"kibana",
   "optionalPlugins":[
     "home",
-     "security",
-     "spaces",
-     "taskManager",
-     "usageCollection"
+    "security",
+    "taskManager",
+    "usageCollection"
   ],
   "owner":{
      "githubTeam":"response-ops",
@@ -30,7 +29,8 @@
      "kibanaReact",
      "kibanaUtils",
      "triggersActionsUi",
-     "management"
+     "management",
+     "spaces"
   ],
   "requiredBundles": [
     "savedObjects"

--- a/x-pack/plugins/cases/server/authorization/audit_logger.ts
+++ b/x-pack/plugins/cases/server/authorization/audit_logger.ts
@@ -31,11 +31,11 @@ export class AuthorizationAuditLogger {
    */
   private static createAuditMsg({ operation, error, entity }: CreateAuditMsgParams): AuditEvent {
     const doc =
-      entity !== undefined
+      entity?.id !== undefined
         ? `${operation.savedObjectType} [id=${entity.id}]`
         : `a ${operation.docType}`;
 
-    const ownerText = entity === undefined ? 'as any owners' : `as owner "${entity.owner}"`;
+    const ownerText = entity?.owner === undefined ? 'as any owners' : `as owner "${entity.owner}"`;
 
     let message: string;
     let outcome: EcsEventOutcome;
@@ -59,7 +59,7 @@ export class AuthorizationAuditLogger {
         type: [operation.ecsType],
         outcome,
       },
-      ...(entity !== undefined && {
+      ...(entity?.id !== undefined && {
         kibana: {
           saved_object: { type: operation.savedObjectType, id: entity.id },
         },

--- a/x-pack/plugins/cases/server/authorization/authorization.test.ts
+++ b/x-pack/plugins/cases/server/authorization/authorization.test.ts
@@ -9,13 +9,25 @@ import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
 import { Authorization, Operations } from '.';
-import { Space } from '@kbn/spaces-plugin/server';
+import { Space, SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
 import { AuthorizationAuditLogger } from './audit_logger';
 import { KibanaRequest } from '@kbn/core/server';
 import { KibanaFeature } from '@kbn/features-plugin/common';
 import { AuditLogger, SecurityPluginStart } from '@kbn/security-plugin/server';
 import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 import { PluginStartContract as FeaturesPluginStart } from '@kbn/features-plugin/server';
+
+const createSpacesDisabledFeaturesMock = (disabledFeatures: string[] = []) => {
+  const spacesStart: jest.Mocked<SpacesPluginStart> = spacesMock.createStart();
+  (spacesStart.spacesService.getActiveSpace as jest.Mock).mockImplementation(async () => {
+    return {
+      disabledFeatures: [],
+    };
+  });
+
+  return spacesStart;
+};
 
 describe('authorization', () => {
   let request: KibanaRequest;
@@ -29,9 +41,12 @@ describe('authorization', () => {
   describe('create', () => {
     let securityStart: jest.Mocked<SecurityPluginStart>;
     let featuresStart: jest.Mocked<FeaturesPluginStart>;
+    let spacesStart: jest.Mocked<SpacesPluginStart>;
 
     beforeEach(() => {
       securityStart = securityMock.createStart();
+      spacesStart = createSpacesDisabledFeaturesMock();
+
       featuresStart = featuresPluginMock.createStart();
       featuresStart.getKibanaFeatures.mockReturnValue([
         { id: '1', cases: ['a'] },
@@ -41,11 +56,10 @@ describe('authorization', () => {
     it('creates an Authorization object', async () => {
       expect.assertions(2);
 
-      const getSpace = jest.fn();
       const authPromise = Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace,
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -58,14 +72,14 @@ describe('authorization', () => {
     it('throws and error when a failure occurs', async () => {
       expect.assertions(1);
 
-      const getSpace = jest.fn(async () => {
+      (spacesStart.spacesService.getActiveSpace as jest.Mock).mockImplementation(() => {
         throw new Error('space error');
       });
 
       const authPromise = Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace,
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -80,6 +94,7 @@ describe('authorization', () => {
 
     let securityStart: ReturnType<typeof securityMock.createStart>;
     let featuresStart: jest.Mocked<FeaturesPluginStart>;
+    let spacesStart: jest.Mocked<SpacesPluginStart>;
     let auth: Authorization;
 
     beforeEach(async () => {
@@ -92,10 +107,12 @@ describe('authorization', () => {
       featuresStart = featuresPluginMock.createStart();
       featuresStart.getKibanaFeatures.mockReturnValue([feature] as unknown as KibanaFeature[]);
 
+      spacesStart = createSpacesDisabledFeaturesMock();
+
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
@@ -121,7 +138,7 @@ describe('authorization', () => {
 
       auth = await Authorization.create({
         request,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -240,10 +257,14 @@ describe('authorization', () => {
     it('throws an error when owner does not exist because it was from a disabled plugin', async () => {
       expect.assertions(1);
 
+      (spacesStart.spacesService.getActiveSpace as jest.Mock).mockImplementation(() => {
+        return { disabledFeatures: [feature.id] } as Space;
+      });
+
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(async () => ({ disabledFeatures: [feature.id] } as Space)),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -272,7 +293,7 @@ describe('authorization', () => {
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -299,7 +320,7 @@ describe('authorization', () => {
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(),
         logger: loggingSystemMock.createLogger(),
@@ -326,7 +347,7 @@ describe('authorization', () => {
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
@@ -396,6 +417,7 @@ describe('authorization', () => {
 
     let securityStart: ReturnType<typeof securityMock.createStart>;
     let featuresStart: jest.Mocked<FeaturesPluginStart>;
+    let spacesStart: jest.Mocked<SpacesPluginStart>;
     let auth: Authorization;
 
     beforeEach(async () => {
@@ -412,10 +434,12 @@ describe('authorization', () => {
       featuresStart = featuresPluginMock.createStart();
       featuresStart.getKibanaFeatures.mockReturnValue([feature] as unknown as KibanaFeature[]);
 
+      spacesStart = createSpacesDisabledFeaturesMock();
+
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
@@ -430,7 +454,7 @@ describe('authorization', () => {
       auth = await Authorization.create({
         request,
         securityAuth: securityStart.authz,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
@@ -472,7 +496,7 @@ describe('authorization', () => {
 
       auth = await Authorization.create({
         request,
-        getSpace: jest.fn(),
+        spaces: spacesStart,
         features: featuresStart,
         auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
@@ -742,7 +766,7 @@ describe('authorization', () => {
         auth = await Authorization.create({
           request,
           securityAuth: securityStart.authz,
-          getSpace: jest.fn(),
+          spaces: spacesStart,
           features: featuresStart,
           auditLogger: new AuthorizationAuditLogger(mockLogger),
           logger: loggingSystemMock.createLogger(),

--- a/x-pack/plugins/cases/server/authorization/types.ts
+++ b/x-pack/plugins/cases/server/authorization/types.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { EcsEventType, KibanaRequest } from '@kbn/core/server';
+import { EcsEventType } from '@kbn/core/server';
 import type { KueryNode } from '@kbn/es-query';
-import { Space } from '@kbn/spaces-plugin/server';
 import { CasesSupportedOperations } from '@kbn/security-plugin/server';
 
 /**
@@ -18,8 +17,6 @@ export interface Verbs {
   progressive: string;
   past: string;
 }
-
-export type GetSpaceFn = (request: KibanaRequest) => Promise<Space | undefined>;
 
 /**
  * Read operations for the cases APIs.
@@ -80,7 +77,7 @@ export interface OperationDetails {
    */
   name: CasesSupportedOperations;
   /**
-   * The ECS `event.action` field, should be in the form of <entity>_<operation> e.g comment_get, case_fined
+   * The ECS `event.action` field, should be in the form of <entity>_<operation> e.g comment_get, case_find
    */
   action: string;
   /**

--- a/x-pack/plugins/cases/server/client/alerts/get.test.ts
+++ b/x-pack/plugins/cases/server/client/alerts/get.test.ts
@@ -39,14 +39,14 @@ describe('getAlerts', () => {
   esClient.mget.mockResolvedValue({ docs });
 
   it('returns an empty array if the alert info are empty', async () => {
-    const clientArgs = { alertsService } as unknown as CasesClientArgs;
+    const clientArgs = { services: { alertsService } } as unknown as CasesClientArgs;
     const res = await getAlerts([], clientArgs);
 
     expect(res).toEqual([]);
   });
 
   it('returns the alerts correctly', async () => {
-    const clientArgs = { alertsService } as unknown as CasesClientArgs;
+    const clientArgs = { services: { alertsService } } as unknown as CasesClientArgs;
     const res = await getAlerts(
       [
         {
@@ -79,7 +79,7 @@ describe('getAlerts', () => {
         },
       ],
     });
-    const clientArgs = { alertsService } as unknown as CasesClientArgs;
+    const clientArgs = { services: { alertsService } } as unknown as CasesClientArgs;
 
     const res = await getAlerts(
       [
@@ -113,7 +113,7 @@ describe('getAlerts', () => {
         },
       ],
     });
-    const clientArgs = { alertsService } as unknown as CasesClientArgs;
+    const clientArgs = { services: { alertsService } } as unknown as CasesClientArgs;
 
     const res = await getAlerts(
       [

--- a/x-pack/plugins/cases/server/client/alerts/get.ts
+++ b/x-pack/plugins/cases/server/client/alerts/get.ts
@@ -21,7 +21,7 @@ export const getAlerts = async (
   alertsInfo: AlertInfo[],
   clientArgs: CasesClientArgs
 ): Promise<CasesClientGetAlertsResponse> => {
-  const { alertsService } = clientArgs;
+  const { alertsService } = clientArgs.services;
   if (alertsInfo.length === 0) {
     return [];
   }

--- a/x-pack/plugins/cases/server/client/attachments/delete.ts
+++ b/x-pack/plugins/cases/server/client/attachments/delete.ts
@@ -51,9 +51,7 @@ export async function deleteAll(
   const {
     user,
     unsecuredSavedObjectsClient,
-    caseService,
-    attachmentService,
-    userActionService,
+    services: { caseService, attachmentService, userActionService },
     logger,
     authorization,
   } = clientArgs;
@@ -118,8 +116,7 @@ export async function deleteComment(
   const {
     user,
     unsecuredSavedObjectsClient,
-    attachmentService,
-    userActionService,
+    services: { attachmentService, userActionService },
     logger,
     authorization,
   } = clientArgs;

--- a/x-pack/plugins/cases/server/client/attachments/get.ts
+++ b/x-pack/plugins/cases/server/client/attachments/get.ts
@@ -102,7 +102,12 @@ export const getAllAlertsAttachToCase = async (
   clientArgs: CasesClientArgs,
   casesClient: CasesClient
 ): Promise<AlertResponse> => {
-  const { unsecuredSavedObjectsClient, authorization, attachmentService, logger } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    authorization,
+    services: { attachmentService },
+    logger,
+  } = clientArgs;
 
   try {
     // This will perform an authorization check to ensure the user has access to the parent case
@@ -146,7 +151,12 @@ export async function find(
   { caseID, queryParams }: FindArgs,
   clientArgs: CasesClientArgs
 ): Promise<CommentsResponse> {
-  const { unsecuredSavedObjectsClient, caseService, logger, authorization } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const { filter: authorizationFilter, ensureSavedObjectsAreAuthorized } =
@@ -218,7 +228,12 @@ export async function get(
   { attachmentID, caseID }: GetArgs,
   clientArgs: CasesClientArgs
 ): Promise<CommentResponse> {
-  const { attachmentService, unsecuredSavedObjectsClient, logger, authorization } = clientArgs;
+  const {
+    services: { attachmentService },
+    unsecuredSavedObjectsClient,
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const comment = await attachmentService.get({
@@ -250,7 +265,11 @@ export async function getAll(
   { caseID }: GetAllArgs,
   clientArgs: CasesClientArgs
 ): Promise<AllCommentsResponse> {
-  const { caseService, logger, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const { filter, ensureSavedObjectsAreAuthorized } = await authorization.getAuthorizationFilter(

--- a/x-pack/plugins/cases/server/client/attachments/update.ts
+++ b/x-pack/plugins/cases/server/client/attachments/update.ts
@@ -39,7 +39,12 @@ export async function update(
   { caseID, updateRequest: queryParams }: UpdateArgs,
   clientArgs: CasesClientArgs
 ): Promise<CaseResponse> {
-  const { attachmentService, unsecuredSavedObjectsClient, logger, authorization } = clientArgs;
+  const {
+    services: { attachmentService },
+    unsecuredSavedObjectsClient,
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const {

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -41,8 +41,7 @@ export const create = async (
 ): Promise<CaseResponse> => {
   const {
     unsecuredSavedObjectsClient,
-    caseService,
-    userActionService,
+    services: { caseService, userActionService },
     user,
     logger,
     authorization: auth,

--- a/x-pack/plugins/cases/server/client/cases/delete.ts
+++ b/x-pack/plugins/cases/server/client/cases/delete.ts
@@ -22,10 +22,8 @@ import { Operations, OwnerEntity } from '../../authorization';
 export async function deleteCases(ids: string[], clientArgs: CasesClientArgs): Promise<void> {
   const {
     unsecuredSavedObjectsClient,
-    caseService,
-    attachmentService,
     user,
-    userActionService,
+    services: { caseService, attachmentService, userActionService },
     logger,
     authorization,
   } = clientArgs;

--- a/x-pack/plugins/cases/server/client/cases/find.ts
+++ b/x-pack/plugins/cases/server/client/cases/find.ts
@@ -36,7 +36,11 @@ export const find = async (
   params: CasesFindRequest,
   clientArgs: CasesClientArgs
 ): Promise<CasesFindResponse> => {
-  const { caseService, authorization, logger } = clientArgs;
+  const {
+    services: { caseService },
+    authorization,
+    logger,
+  } = clientArgs;
 
   try {
     const fields = asArray(params.fields);

--- a/x-pack/plugins/cases/server/client/cases/get.ts
+++ b/x-pack/plugins/cases/server/client/cases/get.ts
@@ -59,7 +59,11 @@ export const getCasesByAlertID = async (
   { alertID, options }: CasesByAlertIDParams,
   clientArgs: CasesClientArgs
 ): Promise<CasesByAlertId> => {
-  const { caseService, logger, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const queryParams = pipe(
@@ -155,7 +159,11 @@ export const get = async (
   { id, includeComments }: GetParams,
   clientArgs: CasesClientArgs
 ): Promise<CaseResponse> => {
-  const { caseService, logger, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const theCase: SavedObject<CaseAttributes> = await caseService.getCase({
@@ -205,7 +213,11 @@ export const resolve = async (
   { id, includeComments }: GetParams,
   clientArgs: CasesClientArgs
 ): Promise<CaseResolveResponse> => {
-  const { caseService, logger, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const {
@@ -264,7 +276,12 @@ export async function getTags(
   params: AllTagsFindRequest,
   clientArgs: CasesClientArgs
 ): Promise<string[]> {
-  const { unsecuredSavedObjectsClient, caseService, logger, authorization } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const queryParams = pipe(
@@ -296,7 +313,12 @@ export async function getReporters(
   params: AllReportersFindRequest,
   clientArgs: CasesClientArgs
 ): Promise<User[]> {
-  const { unsecuredSavedObjectsClient, caseService, logger, authorization } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const queryParams = pipe(

--- a/x-pack/plugins/cases/server/client/cases/push.ts
+++ b/x-pack/plugins/cases/server/client/cases/push.ts
@@ -50,8 +50,8 @@ function shouldCloseByPush(
 
 const changeAlertsStatusToClose = async (
   caseId: string,
-  caseService: CasesClientArgs['caseService'],
-  alertsService: CasesClientArgs['alertsService']
+  caseService: CasesClientArgs['services']['caseService'],
+  alertsService: CasesClientArgs['services']['alertsService']
 ) => {
   const alertAttachments = (await caseService.getAllCaseComments({
     id: [caseId],
@@ -99,11 +99,13 @@ export const push = async (
 ): Promise<CaseResponse> => {
   const {
     unsecuredSavedObjectsClient,
-    attachmentService,
-    caseService,
-    caseConfigureService,
-    userActionService,
-    alertsService,
+    services: {
+      attachmentService,
+      caseService,
+      caseConfigureService,
+      userActionService,
+      alertsService,
+    },
     actionsClient,
     user,
     logger,

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -236,12 +236,10 @@ export const update = async (
 ): Promise<CasesResponse> => {
   const {
     unsecuredSavedObjectsClient,
-    caseService,
-    userActionService,
+    services: { caseService, userActionService, alertsService },
     user,
     logger,
     authorization,
-    alertsService,
   } = clientArgs;
   const query = pipe(
     excess(CasesPatchRequestRt).decode(cases),

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -132,7 +132,12 @@ async function get(
   clientArgs: CasesClientArgs,
   casesClientInternal: CasesClientInternal
 ): Promise<CasesConfigurationsResponse> {
-  const { unsecuredSavedObjectsClient, caseConfigureService, logger, authorization } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { caseConfigureService },
+    logger,
+    authorization,
+  } = clientArgs;
   try {
     const queryParams = pipe(
       excess(GetConfigureFindRequestRt).decode(params),
@@ -234,8 +239,13 @@ async function update(
   clientArgs: CasesClientArgs,
   casesClientInternal: CasesClientInternal
 ): Promise<CasesConfigureResponse> {
-  const { caseConfigureService, logger, unsecuredSavedObjectsClient, user, authorization } =
-    clientArgs;
+  const {
+    services: { caseConfigureService },
+    logger,
+    unsecuredSavedObjectsClient,
+    user,
+    authorization,
+  } = clientArgs;
 
   try {
     const request = pipe(
@@ -343,8 +353,13 @@ async function create(
   clientArgs: CasesClientArgs,
   casesClientInternal: CasesClientInternal
 ): Promise<CasesConfigureResponse> {
-  const { unsecuredSavedObjectsClient, caseConfigureService, logger, user, authorization } =
-    clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { caseConfigureService },
+    logger,
+    user,
+    authorization,
+  } = clientArgs;
   try {
     let error = null;
 

--- a/x-pack/plugins/cases/server/client/configure/create_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/create_mappings.ts
@@ -16,7 +16,11 @@ export const createMappings = async (
   { connector, owner, refresh }: CreateMappingsArgs,
   clientArgs: CasesClientArgs
 ): Promise<ConnectorMappingsAttributes[]> => {
-  const { unsecuredSavedObjectsClient, connectorMappingsService, logger } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { connectorMappingsService },
+    logger,
+  } = clientArgs;
 
   try {
     const mappings = casesConnectors.get(connector.type)?.getMapping() ?? [];

--- a/x-pack/plugins/cases/server/client/configure/get_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/get_mappings.ts
@@ -16,7 +16,11 @@ export const getMappings = async (
   { connector }: MappingsArgs,
   clientArgs: CasesClientArgs
 ): Promise<SavedObjectsFindResponse<ConnectorMappings>['saved_objects']> => {
-  const { unsecuredSavedObjectsClient, connectorMappingsService, logger } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { connectorMappingsService },
+    logger,
+  } = clientArgs;
 
   try {
     const myConnectorMappings = await connectorMappingsService.find({

--- a/x-pack/plugins/cases/server/client/configure/update_mappings.ts
+++ b/x-pack/plugins/cases/server/client/configure/update_mappings.ts
@@ -16,7 +16,11 @@ export const updateMappings = async (
   { connector, mappingId, refresh }: UpdateMappingsArgs,
   clientArgs: CasesClientArgs
 ): Promise<ConnectorMappingsAttributes[]> => {
-  const { unsecuredSavedObjectsClient, connectorMappingsService, logger } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { connectorMappingsService },
+    logger,
+  } = clientArgs;
 
   try {
     const mappings = casesConnectors.get(connector.type)?.getMapping() ?? [];

--- a/x-pack/plugins/cases/server/client/metrics/actions/actions.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/actions/actions.test.ts
@@ -21,7 +21,7 @@ const getAuthorizationFilter = jest.fn().mockResolvedValue({});
 
 const clientArgs = {
   logger,
-  attachmentService,
+  services: { attachmentService },
   authorization: { getAuthorizationFilter },
 } as unknown as CasesClientArgs;
 

--- a/x-pack/plugins/cases/server/client/metrics/actions/actions.ts
+++ b/x-pack/plugins/cases/server/client/metrics/actions/actions.ts
@@ -24,8 +24,12 @@ export class Actions extends SingleCaseAggregationHandler {
   }
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
-    const { unsecuredSavedObjectsClient, authorization, attachmentService, logger } =
-      this.options.clientArgs;
+    const {
+      unsecuredSavedObjectsClient,
+      authorization,
+      services: { attachmentService },
+      logger,
+    } = this.options.clientArgs;
     const { casesClient } = this.options;
 
     try {

--- a/x-pack/plugins/cases/server/client/metrics/alerts/count.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/alerts/count.test.ts
@@ -21,7 +21,9 @@ const getAuthorizationFilter = jest.fn().mockResolvedValue({});
 
 const clientArgs = {
   logger,
-  attachmentService,
+  services: {
+    attachmentService,
+  },
   authorization: { getAuthorizationFilter },
 } as unknown as CasesClientArgs;
 

--- a/x-pack/plugins/cases/server/client/metrics/alerts/count.ts
+++ b/x-pack/plugins/cases/server/client/metrics/alerts/count.ts
@@ -17,8 +17,12 @@ export class AlertsCount extends SingleCaseBaseHandler {
   }
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
-    const { unsecuredSavedObjectsClient, authorization, attachmentService, logger } =
-      this.options.clientArgs;
+    const {
+      unsecuredSavedObjectsClient,
+      authorization,
+      services: { attachmentService },
+      logger,
+    } = this.options.clientArgs;
 
     const { casesClient } = this.options;
 

--- a/x-pack/plugins/cases/server/client/metrics/alerts/details.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/alerts/details.test.ts
@@ -37,7 +37,7 @@ describe('AlertDetails', () => {
     const handler = new AlertDetails({
       caseId: '',
       casesClient: client,
-      clientArgs: {} as CasesClientArgs,
+      clientArgs: { services: {} } as CasesClientArgs,
     });
     expect(await handler.compute()).toEqual({});
   });
@@ -50,7 +50,7 @@ describe('AlertDetails', () => {
     const handler = new AlertDetails({
       caseId: '',
       casesClient: client,
-      clientArgs: {} as CasesClientArgs,
+      clientArgs: { services: {} } as CasesClientArgs,
     });
     handler.setupFeature('alerts.hosts');
 
@@ -65,7 +65,7 @@ describe('AlertDetails', () => {
   });
 
   it('returns the default zero values for hosts when the count aggregation returns undefined', async () => {
-    mockServices.alertsService.executeAggregations.mockImplementation(async () => ({}));
+    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
 
     const handler = new AlertDetails(constructorOptions);
     handler.setupFeature('alerts.hosts');
@@ -81,7 +81,7 @@ describe('AlertDetails', () => {
   });
 
   it('returns the default zero values for users when the count aggregation returns undefined', async () => {
-    mockServices.alertsService.executeAggregations.mockImplementation(async () => ({}));
+    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
 
     const handler = new AlertDetails(constructorOptions);
     handler.setupFeature('alerts.users');
@@ -97,7 +97,7 @@ describe('AlertDetails', () => {
   });
 
   it('returns the default zero values for hosts when the top hits aggregation returns undefined', async () => {
-    mockServices.alertsService.executeAggregations.mockImplementation(async () => ({}));
+    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
 
     const handler = new AlertDetails(constructorOptions);
     handler.setupFeature('alerts.hosts');
@@ -113,7 +113,7 @@ describe('AlertDetails', () => {
   });
 
   it('returns the default zero values for users when the top hits aggregation returns undefined', async () => {
-    mockServices.alertsService.executeAggregations.mockImplementation(async () => ({}));
+    mockServices.services.alertsService.executeAggregations.mockImplementation(async () => ({}));
 
     const handler = new AlertDetails(constructorOptions);
     handler.setupFeature('alerts.users');
@@ -136,7 +136,7 @@ describe('AlertDetails', () => {
     const handler = new AlertDetails({
       caseId: '',
       casesClient: client,
-      clientArgs: {} as CasesClientArgs,
+      clientArgs: { services: {} } as CasesClientArgs,
     });
     expect(await handler.compute()).toEqual({});
   });
@@ -149,7 +149,7 @@ describe('AlertDetails', () => {
     const handler = new AlertDetails({
       caseId: '',
       casesClient: client,
-      clientArgs: {} as CasesClientArgs,
+      clientArgs: { services: {} } as CasesClientArgs,
     });
     expect(await handler.compute()).toEqual({});
     expect(await handler.compute()).toEqual({});
@@ -222,7 +222,9 @@ function createMockClientArgs() {
 
   const clientArgs = {
     logger,
-    alertsService,
+    services: {
+      alertsService,
+    },
   };
 
   return { mockServices: clientArgs, clientArgs: clientArgs as unknown as CasesClientArgs };

--- a/x-pack/plugins/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/plugins/cases/server/client/metrics/alerts/details.ts
@@ -24,7 +24,10 @@ export class AlertDetails extends SingleCaseAggregationHandler {
   }
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
-    const { alertsService, logger } = this.options.clientArgs;
+    const {
+      services: { alertsService },
+      logger,
+    } = this.options.clientArgs;
     const { casesClient } = this.options;
 
     try {

--- a/x-pack/plugins/cases/server/client/metrics/all_cases/mttr.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/all_cases/mttr.test.ts
@@ -21,7 +21,9 @@ const getAuthorizationFilter = jest.fn().mockResolvedValue({});
 
 const clientArgs = {
   logger,
-  caseService,
+  services: {
+    caseService,
+  },
   authorization: { getAuthorizationFilter },
 } as unknown as CasesClientArgs;
 

--- a/x-pack/plugins/cases/server/client/metrics/all_cases/mttr.ts
+++ b/x-pack/plugins/cases/server/client/metrics/all_cases/mttr.ts
@@ -22,7 +22,11 @@ export class MTTR extends AllCasesAggregationHandler {
   }
 
   public async compute(): Promise<CasesMetricsResponse> {
-    const { authorization, caseService, logger } = this.options.clientArgs;
+    const {
+      authorization,
+      services: { caseService },
+      logger,
+    } = this.options.clientArgs;
 
     try {
       const { filter: authorizationFilter } = await authorization.getAuthorizationFilter(

--- a/x-pack/plugins/cases/server/client/metrics/connectors.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/connectors.test.ts
@@ -19,7 +19,9 @@ describe('Connectors', () => {
 
   const clientArgs = {
     logger,
-    userActionService,
+    services: {
+      userActionService,
+    },
     authorization: { getAuthorizationFilter },
   } as unknown as CasesClientArgs;
 

--- a/x-pack/plugins/cases/server/client/metrics/connectors.ts
+++ b/x-pack/plugins/cases/server/client/metrics/connectors.ts
@@ -17,8 +17,12 @@ export class Connectors extends SingleCaseBaseHandler {
   }
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
-    const { unsecuredSavedObjectsClient, authorization, userActionService, logger } =
-      this.options.clientArgs;
+    const {
+      unsecuredSavedObjectsClient,
+      authorization,
+      services: { userActionService },
+      logger,
+    } = this.options.clientArgs;
 
     const { filter: authorizationFilter } = await authorization.getAuthorizationFilter(
       Operations.getUserActionMetrics

--- a/x-pack/plugins/cases/server/client/metrics/get_case_metrics.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/get_case_metrics.test.ts
@@ -151,7 +151,7 @@ describe('getCaseMetrics', () => {
       clientArgs
     );
 
-    expect(mockServices.alertsService.executeAggregations).toBeCalledTimes(1);
+    expect(mockServices.services.alertsService.executeAggregations).toBeCalledTimes(1);
   });
 });
 
@@ -209,11 +209,13 @@ function createMockClientArgs() {
   const clientArgs = {
     authorization,
     unsecuredSavedObjectsClient: soClient,
-    caseService,
     logger,
-    attachmentService,
-    alertsService,
-    userActionService,
+    services: {
+      caseService,
+      attachmentService,
+      alertsService,
+      userActionService,
+    },
   };
 
   return { mockServices: clientArgs, clientArgs: clientArgs as unknown as CasesClientArgs };

--- a/x-pack/plugins/cases/server/client/metrics/get_case_metrics.ts
+++ b/x-pack/plugins/cases/server/client/metrics/get_case_metrics.ts
@@ -52,7 +52,10 @@ const checkAuthorization = async (
   params: SingleCaseMetricsRequest,
   clientArgs: CasesClientArgs
 ) => {
-  const { caseService, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    authorization,
+  } = clientArgs;
 
   const caseInfo = await caseService.getCase({
     id: params.caseId,

--- a/x-pack/plugins/cases/server/client/metrics/get_cases_metrics.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/get_cases_metrics.test.ts
@@ -27,7 +27,9 @@ describe('getCasesMetrics', () => {
 
   describe('MTTR', () => {
     beforeEach(() => {
-      mockServices.caseService.executeAggregations.mockResolvedValue({ mttr: { value: 5 } });
+      mockServices.services.caseService.executeAggregations.mockResolvedValue({
+        mttr: { value: 5 },
+      });
     });
 
     it('returns the mttr metric', async () => {
@@ -46,7 +48,8 @@ describe('getCasesMetrics', () => {
         client,
         clientArgs
       );
-      expect(mockServices.caseService.executeAggregations.mock.calls[0][0]).toMatchInlineSnapshot(`
+      expect(mockServices.services.caseService.executeAggregations.mock.calls[0][0])
+        .toMatchInlineSnapshot(`
         Object {
           "aggregationBuilders": Array [
             AverageDuration {},

--- a/x-pack/plugins/cases/server/client/metrics/get_status_totals.test.ts
+++ b/x-pack/plugins/cases/server/client/metrics/get_status_totals.test.ts
@@ -24,7 +24,7 @@ describe('getStatusTotalsByType', () => {
 
   describe('MTTR', () => {
     beforeEach(() => {
-      mockServices.caseService.getCaseStatusStats.mockResolvedValue({
+      mockServices.services.caseService.getCaseStatusStats.mockResolvedValue({
         open: 1,
         'in-progress': 2,
         closed: 1,
@@ -50,7 +50,8 @@ describe('getStatusTotalsByType', () => {
         clientArgs
       );
 
-      expect(mockServices.caseService.getCaseStatusStats.mock.calls[0][0]).toMatchInlineSnapshot(`
+      expect(mockServices.services.caseService.getCaseStatusStats.mock.calls[0][0])
+        .toMatchInlineSnapshot(`
         Object {
           "searchOptions": Object {
             "filter": Object {

--- a/x-pack/plugins/cases/server/client/metrics/get_status_totals.ts
+++ b/x-pack/plugins/cases/server/client/metrics/get_status_totals.ts
@@ -27,7 +27,11 @@ export async function getStatusTotalsByType(
   params: CasesStatusRequest,
   clientArgs: CasesClientArgs
 ): Promise<CasesStatusResponse> {
-  const { caseService, logger, authorization } = clientArgs;
+  const {
+    services: { caseService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const queryParams = pipe(

--- a/x-pack/plugins/cases/server/client/metrics/lifespan.ts
+++ b/x-pack/plugins/cases/server/client/metrics/lifespan.ts
@@ -26,8 +26,12 @@ export class Lifespan extends SingleCaseBaseHandler {
   }
 
   public async compute(): Promise<SingleCaseMetricsResponse> {
-    const { unsecuredSavedObjectsClient, authorization, userActionService, logger } =
-      this.options.clientArgs;
+    const {
+      unsecuredSavedObjectsClient,
+      authorization,
+      services: { userActionService },
+      logger,
+    } = this.options.clientArgs;
 
     const { casesClient } = this.options;
 

--- a/x-pack/plugins/cases/server/client/metrics/test_utils/client.ts
+++ b/x-pack/plugins/cases/server/client/metrics/test_utils/client.ts
@@ -31,7 +31,9 @@ export function createMockClientArgs() {
   const clientArgs = {
     authorization,
     unsecuredSavedObjectsClient: soClient,
-    caseService,
+    services: {
+      caseService,
+    },
     logger,
   };
 

--- a/x-pack/plugins/cases/server/client/types.ts
+++ b/x-pack/plugins/cases/server/client/types.ts
@@ -23,18 +23,22 @@ import {
 import { PersistableStateAttachmentTypeRegistry } from '../attachment_framework/persistable_state_registry';
 import { ExternalReferenceAttachmentTypeRegistry } from '../attachment_framework/external_reference_registry';
 
+export interface CasesServices {
+  alertsService: AlertService;
+  caseService: CasesService;
+  caseConfigureService: CaseConfigureService;
+  connectorMappingsService: ConnectorMappingsService;
+  userActionService: CaseUserActionService;
+  attachmentService: AttachmentService;
+}
+
 /**
  * Parameters for initializing a cases client
  */
 export interface CasesClientArgs {
-  readonly caseConfigureService: CaseConfigureService;
-  readonly caseService: CasesService;
-  readonly connectorMappingsService: ConnectorMappingsService;
+  readonly services: CasesServices;
   readonly user: User;
   readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
-  readonly userActionService: CaseUserActionService;
-  readonly alertsService: AlertService;
-  readonly attachmentService: AttachmentService;
   readonly logger: Logger;
   readonly lensEmbeddableFactory: LensServerPluginSetup['lensEmbeddableFactory'];
   readonly authorization: PublicMethodsOf<Authorization>;

--- a/x-pack/plugins/cases/server/client/user_actions/get.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/get.ts
@@ -20,7 +20,12 @@ export const get = async (
   { caseId }: UserActionGet,
   clientArgs: CasesClientArgs
 ): Promise<CaseUserActionsResponse> => {
-  const { unsecuredSavedObjectsClient, userActionService, logger, authorization } = clientArgs;
+  const {
+    unsecuredSavedObjectsClient,
+    services: { userActionService },
+    logger,
+    authorization,
+  } = clientArgs;
 
   try {
     const userActions = await userActionService.getAll({

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -66,7 +66,7 @@ export interface PluginsStart {
   features: FeaturesPluginStart;
   taskManager?: TaskManagerStartContract;
   security?: SecurityPluginStart;
-  spaces?: SpacesPluginStart;
+  spaces: SpacesPluginStart;
 }
 
 export class CasePlugin {

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -166,9 +166,7 @@ export class CasePlugin {
     this.clientFactory.initialize({
       securityPluginSetup: this.securityPluginSetup,
       securityPluginStart: plugins.security,
-      getSpace: async (request: KibanaRequest) => {
-        return plugins.spaces?.spacesService.getActiveSpace(request);
-      },
+      spacesPluginStart: plugins.spaces,
       featuresPluginStart: plugins.features,
       actionsPluginStart: plugins.actions,
       /**


### PR DESCRIPTION
This PR refactors a few things:

It moves the cases services to a new nested property called `services`. This just seems a little more organized to me since we're going to be adding another `UserProfileService` in the future and the client args is getting really large.

I pass in the spaces plugin directly to the authentication class. This isn't necessary but seemed more inline with how we were passing in the other plugins.

I marked the spaces plugin as required (https://github.com/elastic/kibana/pull/115283)

This was mainly just some clean up that I found myself doing as I started the user profiles changes but figured it'd be better off reviewed in its own PR.