### PR TITLE
[Discover] Fix broken useDiscoverState

### DIFF
--- a/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
@@ -263,13 +263,10 @@ export function useDiscoverState({
    * non-time series data or rollups since we don't show the date picker
    */
   useEffect(() => {
-    if (
-      indexPattern &&
-      (!indexPattern.isTimeBased() || indexPattern.type === DataViewType.ROLLUP)
-    ) {
+    if (dataView && (!dataView.isTimeBased() || dataView.type === DataViewType.ROLLUP)) {
       stateContainer.pauseAutoRefreshInterval();
     }
-  }, [indexPattern, stateContainer]);
+  }, [dataView, stateContainer]);
 
   const getResultColumns = useCallback(() => {
     if (documentState.result?.length && documentState.fetchStatus === FetchStatus.COMPLETE) {


### PR DESCRIPTION
## Summary

Fix broken main caused by a #132012 Github. After the last CI run of #132012 , there was an commit depending on a variable that was renamed in #132012 ... this caused CI to fail
