### PR TITLE
[Fleet] Fix logstash output preconfiguration and fleet server instructions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/install_fleet_server.tsx
@@ -62,16 +62,18 @@ const InstallFleetServerStepContent: React.FunctionComponent<{
   const kibanaVersion = useKibanaVersion();
   const { output } = useDefaultOutput();
 
+  const commandOutput = output?.type === 'elasticsearch' ? output : undefined;
+
   const installCommands = (['linux', 'mac', 'windows', 'deb', 'rpm'] as PLATFORM_TYPE[]).reduce(
     (acc, platform) => {
       acc[platform] = getInstallCommandForPlatform(
         platform,
-        output?.hosts?.[0] ?? '',
+        commandOutput?.hosts?.[0] ?? '<ELASTICSEARCH_HOST>',
         serviceToken ?? '',
         fleetServerPolicyId,
         fleetServerHost,
         deploymentMode === 'production',
-        output?.ca_trusted_fingerprint,
+        commandOutput?.ca_trusted_fingerprint,
         kibanaVersion
       );
 

--- a/x-pack/plugins/fleet/server/services/preconfiguration/outputs.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/outputs.test.ts
@@ -112,6 +112,26 @@ describe('output preconfiguration', () => {
     expect(spyAgentPolicyServicBumpAllAgentPoliciesForOutput).not.toBeCalled();
   });
 
+  it('should create preconfigured logstash output that does not exists', async () => {
+    const soClient = savedObjectsClientMock.create();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    await createOrUpdatePreconfiguredOutputs(soClient, esClient, [
+      {
+        id: 'non-existing-output-1',
+        name: 'Output 1',
+        type: 'logstash',
+        is_default: false,
+        is_default_monitoring: false,
+        hosts: ['test.fr'],
+        ssl: { certificate: 'test', key: 'test' },
+      },
+    ]);
+
+    expect(mockedOutputService.create).toBeCalled();
+    expect(mockedOutputService.update).not.toBeCalled();
+    expect(spyAgentPolicyServicBumpAllAgentPoliciesForOutput).not.toBeCalled();
+  });
+
   it('should set default hosts if hosts is not set output that does not exists', async () => {
     const soClient = savedObjectsClientMock.create();
     const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;

--- a/x-pack/plugins/fleet/server/services/preconfiguration/outputs.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/outputs.test.ts
@@ -112,7 +112,7 @@ describe('output preconfiguration', () => {
     expect(spyAgentPolicyServicBumpAllAgentPoliciesForOutput).not.toBeCalled();
   });
 
-  it('should create preconfigured logstash output that does not exists', async () => {
+  it('should create preconfigured logstash output that does not exist', async () => {
     const soClient = savedObjectsClientMock.create();
     const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
     await createOrUpdatePreconfiguredOutputs(soClient, esClient, [

--- a/x-pack/plugins/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/outputs.ts
@@ -159,8 +159,12 @@ function isPreconfiguredOutputDifferentFromCurrent(
     existingOutput.type !== preconfiguredOutput.type ||
     (preconfiguredOutput.hosts &&
       !isEqual(
-        existingOutput.hosts?.map(normalizeHostsForAgents),
-        preconfiguredOutput.hosts.map(normalizeHostsForAgents)
+        existingOutput?.type === 'elasticsearch'
+          ? existingOutput.hosts?.map(normalizeHostsForAgents)
+          : existingOutput.hosts,
+        preconfiguredOutput.type === 'elasticsearch'
+          ? preconfiguredOutput.hosts.map(normalizeHostsForAgents)
+          : preconfiguredOutput.hosts
       )) ||
     (preconfiguredOutput.ssl && !isEqual(preconfiguredOutput.ssl, existingOutput.ssl)) ||
     existingOutput.ca_sha256 !== preconfiguredOutput.ca_sha256 ||


### PR DESCRIPTION
## Description 

Resolve #137304

When setting logstash as the default output the fleet server instructions where not correct as we were showing the logstash url in the `--fleet-server-es` flag, that PR fix that.

While testing I created a preconfigured output and found a bug (the output was not created) there so that PR fix that too.

<img width="1257" alt="Screen Shot 2022-07-28 at 10 47 13 AM" src="https://user-images.githubusercontent.com/1336873/181570714-2c357e07-49fe-4aab-8ba4-166c4964cbb4.png">


## How to test

add this to your kibana yml config and when you setup Fleet Server host you should not see the logstash host in `--fleet-server-es`

```
xpack.fleet.outputs:
  - name: test123
    id: test123
    is_default: true
    hosts: ['test.fr']
    type: 'logstash'
```


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->