### PR TITLE
Fix cloud.indexManagement in doc link service

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -54,7 +54,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       guide: `${KIBANA_DOCS}canvas.html`,
     },
     cloud: {
-      indexManagement: `${ELASTIC_WEBSITE_URL}/guide/en/cloud/current/ec-configure-index-management.html`,
+      indexManagement: `${ELASTIC_WEBSITE_URL}guide/en/cloud/current/ec-configure-index-management.html`,
     },
     console: {
       guide: `${KIBANA_DOCS}console-kibana.html`,


### PR DESCRIPTION
## Summary

There is an extra `/` in the doc link service for the cloud.indexManagement keyword. Though it still works, it loses some of the header as a result.

