### PR TITLE
[Stack Monitoring] Document multi-node ES setup from source

### DIFF
--- a/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md
+++ b/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md
@@ -425,8 +425,8 @@ filebeat.modules:
     server:
       enabled: true
       var.paths:
-        - ../../elasticsearch/build/distribution/local/elasticsearch-8.1.0-SNAPSHOT/logs/*.log
-        - ../../elasticsearch/build/distribution/local/elasticsearch-8.1.0-SNAPSHOT/logs/*_server.json
+        - ../../elasticsearch/build/distribution/local/elasticsearch-*-SNAPSHOT/logs/*.log
+        - ../../elasticsearch/build/distribution/local/elasticsearch-*-SNAPSHOT/logs/*_server.json
 
 output.elasticsearch:
   hosts: [ "http://localhost:9200" ]

--- a/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md
+++ b/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md
@@ -40,7 +40,7 @@ For multi-cluster tests its best to create a package first:
 Then move into the distro path:
 
 ```shell
-cd build/distribution/local/*
+cd "$(ls -1dt build/distribution/local/elasticsearch-* | head -n1)"
 ```
 
 Then start the server (for example with internal collection enabled):


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/137547

Adds a monitoring dev doc section covering ES multi-node configuration.

This includes a couple other small tweaks, namely:
- A safer `cd (localDistro)`
- A broader filebeat config
- Moving the "secondary" to port 9210 + 9310 to avoid port conflict with the multi-node config

cc @miltonhultgren who might have comflicting changes from our session yesterday.

## Testing

Read through the docs and follow the steps. Let me know if anything doesn't work out.

If you start kibana & metricbeat as well you should end up with a screen like this showing 3 nodes for main & secondary.

![Screen Shot 2022-07-29 at 10 26 21](https://user-images.githubusercontent.com/690/181668401-4a9c5432-36bb-4ee3-8ab0-920da8d8bb80.png)



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->