### PR TITLE
Get rid of `esArchiver` in the authentication related functional tests.

### DIFF
--- a/x-pack/test/security_functional/tests/login_selector/auth_provider_hint.ts
+++ b/x-pack/test/security_functional/tests/login_selector/auth_provider_hint.ts
@@ -10,7 +10,6 @@ import { parse } from 'url';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const security = getService('security');
   const deployment = getService('deployment');
@@ -31,14 +30,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         roles: ['superuser'],
         full_name: 'Guest',
       });
-
-      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       await PageObjects.security.forceLogout();
     });
 
     after(async () => {
       await security.user.delete('anonymous_user');
-      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     beforeEach(async () => {

--- a/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
+++ b/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
@@ -10,7 +10,6 @@ import { parse } from 'url';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   const security = getService('security');
@@ -32,14 +31,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         roles: ['kibana_admin'],
         full_name: 'Admin',
       });
-
-      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       await PageObjects.security.forceLogout();
     });
 
     after(async () => {
       await security.user.delete(testCredentials.username);
-      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     beforeEach(async () => {

--- a/x-pack/test/security_functional/tests/oidc/url_capture.ts
+++ b/x-pack/test/security_functional/tests/oidc/url_capture.ts
@@ -10,7 +10,6 @@ import { parse } from 'url';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const find = getService('find');
   const browser = getService('browser');
   const deployment = getService('deployment');
@@ -25,12 +24,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         .post('/_security/role_mapping/oidc1')
         .send({ roles: ['superuser'], enabled: true, rules: { field: { 'realm.name': 'oidc1' } } })
         .expect(200);
-
-      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
-    });
-
-    after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     afterEach(async () => {

--- a/x-pack/test/security_functional/tests/saml/url_capture.ts
+++ b/x-pack/test/security_functional/tests/saml/url_capture.ts
@@ -10,7 +10,6 @@ import { parse } from 'url';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const esArchiver = getService('esArchiver');
   const find = getService('find');
   const browser = getService('browser');
   const deployment = getService('deployment');
@@ -25,12 +24,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         .post('/_security/role_mapping/saml1')
         .send({ roles: ['superuser'], enabled: true, rules: { field: { 'realm.name': 'saml1' } } })
         .expect(200);
-
-      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
-    });
-
-    after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## Summary

Removing redundant `esArchiver` calls from the security authentication related functional tests.

__Fixes: https://github.com/elastic/kibana/issues/136467__ 

__Flaky Test Run__: :heavy_check_mark: [x50 SAML, x50 OIDC, x50 Login Selector](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/952)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->