### PR TITLE
[Fleet] Get package info endpoint- don't go to package archive when no pkgVersion supplied

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -372,6 +372,32 @@ describe('When using EPM `get` services', () => {
 
         expect(MockRegistry.getRegistryPackage).not.toHaveBeenCalled();
       });
+
+      // when calling the get package endpoint without a package version we
+      // were previously incorrectly getting the info from archive
+      it('avoids loading archive when skipArchive = true and no version supplied', async () => {
+        const soClient = savedObjectsClientMock.create();
+        soClient.get.mockRejectedValue(SavedObjectsErrorHelpers.createGenericNotFoundError());
+        MockRegistry.fetchInfo.mockResolvedValue({
+          name: 'my-package',
+          version: '1.0.0',
+          assets: [],
+        } as unknown as RegistryPackage);
+
+        await expect(
+          getPackageInfo({
+            savedObjectsClient: soClient,
+            pkgName: 'my-package',
+            pkgVersion: '',
+            skipArchive: true,
+          })
+        ).resolves.toMatchObject({
+          latestVersion: '1.0.0',
+          status: 'not_installed',
+        });
+
+        expect(MockRegistry.getRegistryPackage).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -155,7 +155,7 @@ export async function getPackageInfo({
   // otherwise build it from the archive
   let paths: string[];
   let packageInfo: RegistryPackage | ArchivePackage | undefined = skipArchive
-    ? await Registry.fetchInfo(pkgName, pkgVersion).catch(() => undefined)
+    ? await Registry.fetchInfo(pkgName, resolvedPkgVersion).catch(() => undefined)
     : undefined;
 
   if (packageInfo) {


### PR DESCRIPTION
When getting latest package info e.g `GET /api/fleet/epm/packages/elastic_agent`, we were downloading the package archive because we were not supplying a package version to `Registry.fetchInfo` which was silently erroring.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->