### PR TITLE
[8.4] [Enterprise Search] Do not include precision_enabled in requests for precision tuning (#137220)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -549,6 +549,8 @@ describe('RelevanceTuningLogic', () => {
               },
             ],
           },
+          precision: 5,
+          precision_enabled: true,
         };
 
         const searchSettingsWithoutNewBoostProp = {
@@ -561,6 +563,7 @@ describe('RelevanceTuningLogic', () => {
               },
             ],
           },
+          precision: 5,
         };
         mount({
           searchSettings: searchSettingsWithNewBoostProp,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
@@ -65,10 +65,13 @@ export interface SearchField {
   weight: number;
 }
 
-export interface SearchSettings {
+export interface SearchSettingsRequest {
   boosts: Record<string, Boost[]>;
   search_fields: Record<string, SearchField>;
   result_fields?: object;
   precision: number;
+}
+
+export interface SearchSettings extends SearchSettingsRequest {
   precision_enabled: boolean;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
@@ -58,8 +58,10 @@ describe('removeBoostStateProps', () => {
       precision: 10,
       precision_enabled: true,
     };
+    const { precision_enabled: precisionEnabled, ...searchSettingsWithoutPrecisionEnabled } =
+      searchSettings;
     expect(removeBoostStateProps(searchSettings)).toEqual({
-      ...searchSettings,
+      ...searchSettingsWithoutPrecisionEnabled,
       boosts: {
         foo: [
           {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
@@ -9,15 +9,22 @@ import { cloneDeep, omit } from 'lodash';
 
 import { SchemaType } from '../../../shared/schema/types';
 
-import { RawBoost, Boost, SearchSettings, BoostType, ValueBoost } from './types';
+import {
+  RawBoost,
+  Boost,
+  SearchSettingsRequest,
+  SearchSettings,
+  BoostType,
+  ValueBoost,
+} from './types';
 
 // If the user hasn't entered a filter, then we can skip filtering the array entirely
 export const filterIfTerm = (array: string[], filterTerm: string): string[] => {
   return filterTerm === '' ? array : array.filter((item) => item.includes(filterTerm));
 };
 
-export const removeBoostStateProps = (searchSettings: SearchSettings): SearchSettings => {
-  const updatedSettings = cloneDeep(searchSettings);
+export const removeBoostStateProps = (searchSettings: SearchSettings): SearchSettingsRequest => {
+  const { precision_enabled: precisionEnabled, ...updatedSettings } = cloneDeep(searchSettings);
   const { boosts } = updatedSettings;
   const keys = Object.keys(boosts);
   keys.forEach((key) => boosts[key].forEach((boost) => delete boost.newBoost));


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [Enterprise Search] Do not include precision_enabled in requests for precision tuning (#137220)

{defaultPrDescription}

<!--BACKPORT {commits} BACKPORT-->