### PR TITLE
[Security Solution][Cypress] Add navigation test coverage

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
@@ -19,6 +19,14 @@ import {
   EXCEPTIONS,
   USERS,
   DETECTION_RESPONSE,
+  DASHBOARDS,
+  CSP_DASHBOARD,
+  KUBERNETES,
+  THREAT_INTELLIGENCE,
+  BLOCKLIST,
+  CSP_BENCHMARKS,
+  CSP_FINDINGS,
+  POLICIES,
 } from '../../screens/security_header';
 
 import { login, visit } from '../../tasks/login';
@@ -42,6 +50,13 @@ import {
   DETECTION_RESPONSE_URL,
   EXPLORE_URL,
   MANAGE_URL,
+  CSP_DASHBOARD_URL,
+  KUBERNETES_URL,
+  THREAT_INTELLIGENCE_URL,
+  BLOCKLIST_URL,
+  CSP_BENCHMARKS_URL,
+  CSP_FINDINGS_URL,
+  POLICIES_URL,
 } from '../../urls/navigation';
 import {
   openKibanaNavigation,
@@ -54,6 +69,7 @@ import {
   MANAGE_PAGE,
   DASHBOARDS_PAGE,
   TIMELINES_PAGE,
+  FINDINGS_PAGE,
 } from '../../screens/kibana_navigation';
 
 before(() => {
@@ -63,6 +79,11 @@ before(() => {
 describe('top-level navigation common to all pages in the Security app', () => {
   before(() => {
     visit(TIMELINES_URL);
+  });
+
+  it('navigates to the Dashboards page', () => {
+    navigateFromHeaderTo(DASHBOARDS);
+    cy.url().should('include', DASHBOARDS_URL);
   });
 
   it('navigates to the Overview page', () => {
@@ -75,9 +96,29 @@ describe('top-level navigation common to all pages in the Security app', () => {
     cy.url().should('include', DETECTION_RESPONSE_URL);
   });
 
+  it('navigates to the Kubernetes page', () => {
+    navigateFromHeaderTo(KUBERNETES);
+    cy.url().should('include', KUBERNETES_URL);
+  });
+
+  it('navigates to the CSP dashboard page', () => {
+    navigateFromHeaderTo(CSP_DASHBOARD);
+    cy.url().should('include', CSP_DASHBOARD_URL);
+  });
+
   it('navigates to the Alerts page', () => {
     navigateFromHeaderTo(ALERTS);
     cy.url().should('include', ALERTS_URL);
+  });
+
+  it('navigates to the Findings page', () => {
+    navigateFromHeaderTo(CSP_FINDINGS);
+    cy.url().should('include', CSP_FINDINGS_URL);
+  });
+
+  it('navigates to the Timelines page', () => {
+    navigateFromHeaderTo(TIMELINES);
+    cy.url().should('include', TIMELINES_URL);
   });
 
   it('navigates to the Hosts page', () => {
@@ -95,6 +136,11 @@ describe('top-level navigation common to all pages in the Security app', () => {
     cy.url().should('include', USERS_URL);
   });
 
+  it('navigates to the Threat Intelligence page', () => {
+    navigateFromHeaderTo(THREAT_INTELLIGENCE);
+    cy.url().should('include', THREAT_INTELLIGENCE_URL);
+  });
+
   it('navigates to the Rules page', () => {
     navigateFromHeaderTo(RULES);
     cy.url().should('include', DETECTIONS_RULE_MANAGEMENT_URL);
@@ -103,11 +149,6 @@ describe('top-level navigation common to all pages in the Security app', () => {
   it('navigates to the Exceptions page', () => {
     navigateFromHeaderTo(EXCEPTIONS);
     cy.url().should('include', EXCEPTIONS_URL);
-  });
-
-  it('navigates to the Timelines page', () => {
-    navigateFromHeaderTo(TIMELINES);
-    cy.url().should('include', TIMELINES_URL);
   });
 
   it('navigates to the Cases page', () => {
@@ -119,6 +160,10 @@ describe('top-level navigation common to all pages in the Security app', () => {
     navigateFromHeaderTo(ENDPOINTS);
     cy.url().should('include', ENDPOINTS_URL);
   });
+  it('navigates to the Policies page', () => {
+    navigateFromHeaderTo(POLICIES);
+    cy.url().should('include', POLICIES_URL);
+  });
   it('navigates to the Trusted Apps page', () => {
     navigateFromHeaderTo(TRUSTED_APPS);
     cy.url().should('include', TRUSTED_APPS_URL);
@@ -126,6 +171,14 @@ describe('top-level navigation common to all pages in the Security app', () => {
   it('navigates to the Event Filters page', () => {
     navigateFromHeaderTo(EVENT_FILTERS);
     cy.url().should('include', EVENT_FILTERS_URL);
+  });
+  it('navigates to the Blocklist page', () => {
+    navigateFromHeaderTo(BLOCKLIST);
+    cy.url().should('include', BLOCKLIST_URL);
+  });
+  it('navigates to the CSP Benchmarks page', () => {
+    navigateFromHeaderTo(CSP_BENCHMARKS);
+    cy.url().should('include', CSP_BENCHMARKS_URL);
   });
 });
 
@@ -144,6 +197,11 @@ describe('Kibana navigation to all pages in the Security app ', () => {
   it('navigates to the Alerts page', () => {
     navigateFromKibanaCollapsibleTo(ALERTS_PAGE);
     cy.url().should('include', ALERTS_URL);
+  });
+
+  it('navigates to the Findings page', () => {
+    navigateFromKibanaCollapsibleTo(FINDINGS_PAGE);
+    cy.url().should('include', CSP_FINDINGS_URL);
   });
 
   it('navigates to the Timelines page', () => {

--- a/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
@@ -27,6 +27,8 @@ import {
   CSP_BENCHMARKS,
   CSP_FINDINGS,
   POLICIES,
+  EXPLORE,
+  MANAGE,
 } from '../../screens/security_header';
 
 import { login, visit } from '../../tasks/login';
@@ -81,7 +83,7 @@ describe('top-level navigation common to all pages in the Security app', () => {
     visit(TIMELINES_URL);
   });
 
-  it('navigates to the Dashboards page', () => {
+  it('navigates to the Dashboards landing page', () => {
     navigateFromHeaderTo(DASHBOARDS);
     cy.url().should('include', DASHBOARDS_URL);
   });
@@ -121,6 +123,11 @@ describe('top-level navigation common to all pages in the Security app', () => {
     cy.url().should('include', TIMELINES_URL);
   });
 
+  it('navigates to the Explore landing page', () => {
+    navigateFromHeaderTo(EXPLORE);
+    cy.url().should('include', EXPLORE_URL);
+  });
+
   it('navigates to the Hosts page', () => {
     navigateFromHeaderTo(HOSTS);
     cy.url().should('include', HOSTS_URL);
@@ -154,6 +161,11 @@ describe('top-level navigation common to all pages in the Security app', () => {
   it('navigates to the Cases page', () => {
     navigateFromHeaderTo(CASES);
     cy.url().should('include', CASES_URL);
+  });
+
+  it('navigates to the Manage landing page', () => {
+    navigateFromHeaderTo(MANAGE);
+    cy.url().should('include', MANAGE_URL);
   });
 
   it('navigates to the Endpoints page', () => {

--- a/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
@@ -11,6 +11,9 @@ export const DASHBOARDS_PAGE =
 export const ALERTS_PAGE =
   '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Alerts"]';
 
+export const FINDINGS_PAGE =
+  '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Findings"]';
+
 export const TIMELINES_PAGE =
   '[data-test-subj="collapsibleNavGroup-securitySolution"] [title="Timelines"]';
 

--- a/x-pack/plugins/security_solution/cypress/screens/security_header.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/security_header.ts
@@ -10,6 +10,8 @@ export const DASHBOARDS = '[data-test-subj="groupedNavItemLink-dashboards"]';
 
 export const ALERTS = '[data-test-subj="groupedNavItemLink-alerts"]';
 
+export const CSP_FINDINGS = '[data-test-subj="groupedNavItemLink-cloud_security_posture-findings"]';
+
 export const CASES = '[data-test-subj="groupedNavItemLink-cases"]';
 
 export const TIMELINES = '[data-test-subj="groupedNavItemLink-timelines"]';
@@ -23,17 +25,31 @@ export const OVERVIEW = '[data-test-subj="groupedNavPanelLink-overview"]';
 
 export const DETECTION_RESPONSE = '[data-test-subj="groupedNavPanelLink-detection_response"]';
 
+export const KUBERNETES = '[data-test-subj="groupedNavPanelLink-kubernetes"]';
+
+export const CSP_DASHBOARD =
+  '[data-test-subj="groupedNavPanelLink-cloud_security_posture-dashboard"]';
+
 export const HOSTS = '[data-test-subj="groupedNavPanelLink-hosts"]';
 
 export const ENDPOINTS = '[data-test-subj="groupedNavPanelLink-endpoints"]';
+
+export const POLICIES = '[data-test-subj="groupedNavPanelLink-policy"]';
 
 export const TRUSTED_APPS = '[data-test-subj="groupedNavPanelLink-trusted_apps"]';
 
 export const EVENT_FILTERS = '[data-test-subj="groupedNavPanelLink-event_filters"]';
 
+export const BLOCKLIST = '[data-test-subj="groupedNavPanelLink-blocklist"]';
+
+export const CSP_BENCHMARKS =
+  '[data-test-subj="groupedNavPanelLink-cloud_security_posture-benchmarks"]';
+
 export const NETWORK = '[data-test-subj="groupedNavPanelLink-network"]';
 
 export const USERS = '[data-test-subj="groupedNavPanelLink-users"]';
+
+export const THREAT_INTELLIGENCE = '[data-test-subj="groupedNavPanelLink-threat-intelligence"]';
 
 export const RULES = '[data-test-subj="groupedNavPanelLink-rules"]';
 
@@ -53,13 +69,16 @@ export const openNavigationPanelFor = (page: string) => {
   let panel;
   switch (page) {
     case OVERVIEW:
-    case DETECTION_RESPONSE: {
+    case DETECTION_RESPONSE:
+    case KUBERNETES:
+    case CSP_DASHBOARD: {
       panel = DASHBOARDS;
       break;
     }
     case HOSTS:
     case NETWORK:
-    case USERS: {
+    case USERS:
+    case THREAT_INTELLIGENCE: {
       panel = EXPLORE;
       break;
     }
@@ -67,7 +86,10 @@ export const openNavigationPanelFor = (page: string) => {
     case TRUSTED_APPS:
     case EVENT_FILTERS:
     case RULES:
-    case EXCEPTIONS: {
+    case POLICIES:
+    case EXCEPTIONS:
+    case BLOCKLIST:
+    case CSP_BENCHMARKS: {
       panel = MANAGE;
       break;
     }

--- a/x-pack/plugins/security_solution/cypress/urls/navigation.ts
+++ b/x-pack/plugins/security_solution/cypress/urls/navigation.ts
@@ -5,33 +5,39 @@
  * 2.0.
  */
 
+export const KIBANA_HOME = '/app/home#/';
+export const KIBANA_SAVED_OBJECTS = '/app/management/kibana/objects';
+
 export const ALERTS_URL = 'app/security/alerts';
-export const DETECTIONS_RULE_MANAGEMENT_URL = 'app/security/rules';
-export const ruleDetailsUrl = (ruleId: string) => `app/security/rules/id/${ruleId}`;
-export const detectionsRuleDetailsUrl = (ruleId: string) =>
-  `app/security/detections/rules/id/${ruleId}`;
-
-export const ruleEditUrl = (ruleId: string) => `${ruleDetailsUrl(ruleId)}/edit`;
-export const detectionRuleEditUrl = (ruleId: string) => `${detectionsRuleDetailsUrl(ruleId)}/edit`;
-
+export const ENDPOINTS_URL = '/app/security/administration/endpoints';
+export const POLICIES_URL = '/app/security/administration/policy';
+export const USERS_URL = '/app/security/users/allUsers';
+export const DETECTIONS_RESPONSE_URL = '/app/security/detection_response';
+export const TRUSTED_APPS_URL = '/app/security/administration/trusted_apps';
+export const EVENT_FILTERS_URL = '/app/security/administration/event_filters';
+export const BLOCKLIST_URL = '/app/security/administration/blocklist';
+export const CSP_BENCHMARKS_URL = '/app/security/cloud_security_posture/benchmarks';
+export const NETWORK_URL = '/app/security/network';
+export const OVERVIEW_URL = '/app/security/overview';
+export const DASHBOARDS_URL = '/app/security/dashboards';
+export const DETECTION_RESPONSE_URL = '/app/security/detection_response';
+export const KUBERNETES_URL = '/app/security/kubernetes';
+export const CSP_DASHBOARD_URL = '/app/security/cloud_security_posture/dashboard';
+export const THREAT_INTELLIGENCE_URL = '/app/security/threat_intelligence';
+export const EXPLORE_URL = '/app/security/explore';
+export const MANAGE_URL = '/app/security/manage';
+export const RULE_CREATION = 'app/security/rules/create';
+export const TIMELINES_URL = '/app/security/timelines';
+export const TIMELINE_TEMPLATES_URL = '/app/security/timelines/template';
 export const CASES_URL = '/app/security/cases';
+export const EXCEPTIONS_URL = 'app/security/exceptions';
+export const HOSTS_URL = '/app/security/hosts/allHosts';
+export const CSP_FINDINGS_URL = 'app/security/cloud_security_posture/findings';
+export const DETECTIONS_RULE_MANAGEMENT_URL = 'app/security/rules';
 export const DETECTIONS = '/app/siem#/detections';
 export const SECURITY_DETECTIONS_URL = '/app/security/detections';
 export const SECURITY_DETECTIONS_RULES_URL = '/app/security/detections/rules';
 export const SECURITY_DETECTIONS_RULES_CREATION_URL = '/app/security/detections/rules/create';
-
-export const EXCEPTIONS_URL = 'app/security/exceptions';
-
-export const HOSTS_URL = '/app/security/hosts/allHosts';
-
-export const hostDetailsUrl = (hostName: string) =>
-  `/app/security/hosts/${hostName}/authentications`;
-
-export const USERS_URL = '/app/security/users/allUsers';
-
-export const DETECTIONS_RESPONSE_URL = '/app/security/detection_response';
-
-export const userDetailsUrl = (userName: string) => `/app/security/users/${userName}/allUsers`;
 
 export const HOSTS_PAGE_TAB_URLS = {
   allHosts: '/app/security/hosts/allHosts',
@@ -39,23 +45,21 @@ export const HOSTS_PAGE_TAB_URLS = {
   events: '/app/security/hosts/events',
   uncommonProcesses: '/app/security/hosts/uncommonProcesses',
 };
-export const KIBANA_HOME = '/app/home#/';
-export const KIBANA_SAVED_OBJECTS = '/app/management/kibana/objects';
-export const ENDPOINTS_URL = '/app/security/administration/endpoints';
-export const TRUSTED_APPS_URL = '/app/security/administration/trusted_apps';
-export const EVENT_FILTERS_URL = '/app/security/administration/event_filters';
-export const NETWORK_URL = '/app/security/network';
-export const OVERVIEW_URL = '/app/security/overview';
-export const DASHBOARDS_URL = '/app/security/dashboards';
-export const DETECTION_RESPONSE_URL = '/app/security/detection_response';
-export const EXPLORE_URL = '/app/security/explore';
-export const MANAGE_URL = '/app/security/manage';
-export const RULE_CREATION = 'app/security/rules/create';
-export const TIMELINES_URL = '/app/security/timelines';
-export const TIMELINE_TEMPLATES_URL = '/app/security/timelines/template';
 export const LOGOUT_URL = '/logout';
 
 export const DISCOVER_WITH_FILTER_URL =
   "/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now%2Fd,to:now%2Fd))&_a=(columns:!(),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:security-solution-default,key:host.name,negate:!f,params:(query:test-host),type:phrase),query:(match_phrase:(host.name:test-host)))),index:security-solution-default,interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))";
 export const DISCOVER_WITH_PINNED_FILTER_URL =
   "/app/discover#/?_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:security-solution-default,key:host.name,negate:!f,params:(query:test-host),type:phrase),query:(match_phrase:(host.name:test-host)))),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(),filters:!(),index:security-solution-default,interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))";
+
+export const ruleDetailsUrl = (ruleId: string) => `app/security/rules/id/${ruleId}`;
+export const detectionsRuleDetailsUrl = (ruleId: string) =>
+  `app/security/detections/rules/id/${ruleId}`;
+
+export const ruleEditUrl = (ruleId: string) => `${ruleDetailsUrl(ruleId)}/edit`;
+export const detectionRuleEditUrl = (ruleId: string) => `${detectionsRuleDetailsUrl(ruleId)}/edit`;
+
+export const hostDetailsUrl = (hostName: string) =>
+  `/app/security/hosts/${hostName}/authentications`;
+
+export const userDetailsUrl = (userName: string) => `/app/security/users/${userName}/allUsers`;


### PR DESCRIPTION
Added test coverage for all new Security Solution link navigation, from the new side nav and the global collapsible nav.
New links tested:

- Dashboard Landing
- Explore Landing
- Manage Landing
- CSP Dashboard
- CSP Findings
- CSP Benchmarks
- Threat Intelligence
- Kubernetes Dashboard

Added also added missing test for links that already existed:
- Blocklist
- Policies

