### PR TITLE
[fleet] Do not create agent policy twice when there is a verification error

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -228,7 +228,13 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   );
 
   const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
-
+  const updateSelectedPolicyTab = useCallback(
+    (selectedTab) => {
+      setSelectedPolicyTab(selectedTab);
+      setPolicyValidation(selectedTab, newAgentPolicy);
+    },
+    [setSelectedPolicyTab, newAgentPolicy]
+  );
   // Update package policy validation
   const updatePackagePolicyValidation = useCallback(
     (newPackagePolicy?: NewPackagePolicy) => {
@@ -451,7 +457,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         validation={validation}
         packageInfo={packageInfo}
         setHasAgentPolicyError={setHasAgentPolicyError}
-        updateSelectedTab={setSelectedPolicyTab}
+        updateSelectedTab={updateSelectedPolicyTab}
         selectedAgentPolicyId={queryParamsPolicyId}
       />
     ),
@@ -463,7 +469,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       updateNewAgentPolicy,
       validation,
       withSysMonitoring,
-      setSelectedPolicyTab,
+      updateSelectedPolicyTab,
       queryParamsPolicyId,
     ]
   );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -96,7 +96,6 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   } = useConfig();
   const { params } = useRouteMatch<AddToPolicyParams>();
   const [agentPolicy, setAgentPolicy] = useState<AgentPolicy | undefined>();
-
   const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>({
     name: 'Agent policy 1',
     description: '',
@@ -228,14 +227,6 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     [setNewAgentPolicy, newAgentPolicy, selectedPolicyTab]
   );
 
-  const updateSelectedPolicy = useCallback(
-    (policy) => {
-      setSelectedPolicyTab(policy);
-      setPolicyValidation(policy, newAgentPolicy);
-    },
-    [setSelectedPolicyTab, newAgentPolicy]
-  );
-
   const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
 
   // Update package policy validation
@@ -313,32 +304,31 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     [agentCount]
   );
 
-  const createAgentPolicy = useCallback(
-    async ({ force }: { force?: boolean } = {}): Promise<string | undefined> => {
-      let policyId;
-      setFormState('LOADING');
-      // do not create agent policy with system integration if package policy already is for system package
-      const packagePolicyIsSystem = packagePolicy?.package?.name === FLEET_SYSTEM_PACKAGE;
-      const resp = await sendCreateAgentPolicy(newAgentPolicy, {
-        withSysMonitoring: withSysMonitoring && !packagePolicyIsSystem,
-      });
-      if (resp.error) {
-        setFormState('VALID');
-        throw resp.error;
-      }
-      if (resp.data) {
-        policyId = resp.data.item.id;
-        setAgentPolicy(resp.data.item);
-        setSelectedPolicyTab(SelectedPolicyTab.EXISTING);
-        updatePackagePolicy({ policy_id: policyId });
-      }
-      return policyId;
-    },
-    [newAgentPolicy, updatePackagePolicy, withSysMonitoring, packagePolicy]
-  );
+  const createAgentPolicy = useCallback(async (): Promise<AgentPolicy | undefined> => {
+    let createdAgentPolicy;
+    setFormState('LOADING');
+    // do not create agent policy with system integration if package policy already is for system package
+    const packagePolicyIsSystem = packagePolicy?.package?.name === FLEET_SYSTEM_PACKAGE;
+    const resp = await sendCreateAgentPolicy(newAgentPolicy, {
+      withSysMonitoring: withSysMonitoring && !packagePolicyIsSystem,
+    });
+    if (resp.error) {
+      setFormState('VALID');
+      throw resp.error;
+    }
+    if (resp.data) {
+      createdAgentPolicy = resp.data.item;
+      setAgentPolicy(createdAgentPolicy);
+      updatePackagePolicy({ policy_id: createdAgentPolicy.id });
+    }
+    return createdAgentPolicy;
+  }, [packagePolicy?.package?.name, newAgentPolicy, withSysMonitoring, updatePackagePolicy]);
 
   const onSubmit = useCallback(
-    async ({ force }: { force?: boolean } = {}) => {
+    async ({
+      force,
+      overrideCreatedAgentPolicy,
+    }: { overrideCreatedAgentPolicy?: AgentPolicy; force?: boolean } = {}) => {
       if (formState === 'VALID' && hasErrors) {
         setFormState('INVALID');
         return;
@@ -347,10 +337,10 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         setFormState('CONFIRM');
         return;
       }
-      let policyId;
-      if (selectedPolicyTab === SelectedPolicyTab.NEW) {
+      let createdPolicy = overrideCreatedAgentPolicy;
+      if (selectedPolicyTab === SelectedPolicyTab.NEW && !overrideCreatedAgentPolicy) {
         try {
-          policyId = await createAgentPolicy({ force });
+          createdPolicy = await createAgentPolicy();
         } catch (e) {
           notifications.toasts.addError(e, {
             title: i18n.translate('xpack.fleet.createAgentPolicy.errorNotificationTitle', {
@@ -365,7 +355,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       // passing pkgPolicy with policy_id here as setPackagePolicy doesn't propagate immediately
       const { error, data } = await savePackagePolicy({
         ...packagePolicy,
-        policy_id: policyId ?? packagePolicy.policy_id,
+        policy_id: createdPolicy?.id ?? packagePolicy.policy_id,
         force,
       });
       if (!error) {
@@ -397,12 +387,12 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         });
       } else {
         if (isVerificationError(error)) {
+          setFormState('VALID'); // don't show the add agent modal
           const forceInstall = await confirmForceInstall(packagePolicy.package!);
 
           if (forceInstall) {
-            onSubmit({ force: true });
-          } else {
-            setFormState('VALID');
+            // skip creating the agent policy because it will have already been successfully created
+            onSubmit({ overrideCreatedAgentPolicy: createdPolicy, force: true });
           }
           return;
         }
@@ -461,7 +451,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         validation={validation}
         packageInfo={packageInfo}
         setHasAgentPolicyError={setHasAgentPolicyError}
-        updateSelectedTab={updateSelectedPolicy}
+        updateSelectedTab={setSelectedPolicyTab}
         selectedAgentPolicyId={queryParamsPolicyId}
       />
     ),
@@ -473,7 +463,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       updateNewAgentPolicy,
       validation,
       withSysMonitoring,
-      updateSelectedPolicy,
+      setSelectedPolicyTab,
       queryParamsPolicyId,
     ]
   );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -96,6 +96,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   } = useConfig();
   const { params } = useRouteMatch<AddToPolicyParams>();
   const [agentPolicy, setAgentPolicy] = useState<AgentPolicy | undefined>();
+
   const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>({
     name: 'Agent policy 1',
     description: '',
@@ -227,7 +228,6 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     [setNewAgentPolicy, newAgentPolicy, selectedPolicyTab]
   );
 
-  const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
   const updateSelectedPolicyTab = useCallback(
     (selectedTab) => {
       setSelectedPolicyTab(selectedTab);
@@ -235,6 +235,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     },
     [setSelectedPolicyTab, newAgentPolicy]
   );
+
+  const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
   // Update package policy validation
   const updatePackagePolicyValidation = useCallback(
     (newPackagePolicy?: NewPackagePolicy) => {


### PR DESCRIPTION
## Summary

Solves a reasonably niche bug but made me notice some flaws in the package policy page logic. The root issue is that when a package fails verification, we only find out after creating the agent policy, but we weren't recording the fact that we had created the new policy and then attempting to create it again.

but what bug is actually being solved? 😅 ...

The niche bug that revealed this is that if you elected to create a new agent policy, then there was a verification error, then you changed your mind and wanted to assign to an existing agent policy, we still tried to create a new agent policy.

We were setting the selected agent policy tab from the package policy page but this doesn't actually change the selected tab, only which tab we think is selected, meaning this state could get "out of sync"



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->