### PR TITLE
[Fleet] Fix agent reassign bulk selection and package icon alignment

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_reassign_policy_modal/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiConfirmModal,
@@ -44,13 +44,24 @@ export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
     perPage: SO_SEARCH_LIMIT,
   });
 
-  const agentPolicies = agentPoliciesRequest.data
-    ? agentPoliciesRequest.data.items.filter((policy) => policy && !policy.is_managed)
-    : [];
+  const agentPolicies = useMemo(
+    () =>
+      agentPoliciesRequest.data
+        ? agentPoliciesRequest.data.items.filter((policy) => policy && !policy.is_managed)
+        : [],
+    [agentPoliciesRequest.data]
+  );
 
   const [selectedAgentPolicyId, setSelectedAgentPolicyId] = useState<string | undefined>(
-    isSingleAgent ? (agents[0] as Agent).policy_id : agentPolicies[0]?.id ?? undefined
+    isSingleAgent ? (agents[0] as Agent).policy_id : undefined
   );
+
+  // Select the first policy if not policy is selected
+  useEffect(() => {
+    if (!selectedAgentPolicyId && agentPolicies.length) {
+      setSelectedAgentPolicyId(agentPolicies[0]?.id);
+    }
+  }, [selectedAgentPolicyId, agentPolicies]);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   async function onSubmit() {
@@ -146,8 +157,13 @@ export const AgentReassignAgentPolicyModal: React.FunctionComponent<Props> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="l" />
-
-      {selectedAgentPolicyId && <AgentPolicyPackageBadges agentPolicyId={selectedAgentPolicyId} />}
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          {selectedAgentPolicyId && (
+            <AgentPolicyPackageBadges agentPolicyId={selectedAgentPolicyId} />
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiConfirmModal>
   );
 };

--- a/x-pack/plugins/fleet/public/components/agent_policy_package_badge.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_policy_package_badge.tsx
@@ -33,13 +33,6 @@ export const AgentPolicyPackageBadge: React.FunctionComponent<Props> = ({
             packageName={pkgName}
             version={pkgVersion || ''}
             tryApi={pkgVersion !== undefined}
-            style={
-              // when a custom SVG is used the logo is rendered with <img class="euiIcon euiIcon--small">
-              // this collides with some EuiText (+img) CSS from the EuiIcon component
-              // which  makes the button large, wide, and poorly layed out
-              // override those styles until the bug is fixed or we find a better approach
-              { margin: 'unset', width: '16px' }
-            }
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>{pkgTitle}</EuiFlexItem>

--- a/x-pack/plugins/fleet/public/components/package_icon.tsx
+++ b/x-pack/plugins/fleet/public/components/package_icon.tsx
@@ -6,18 +6,28 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import type { EuiIconProps } from '@elastic/eui';
 import { EuiIcon } from '@elastic/eui';
 
 import type { UsePackageIconType } from '../hooks';
 import { usePackageIconType } from '../hooks';
 
+// when a custom SVG is used the logo is rendered with <img class="euiIcon euiIcon--small">
+// this collides with some EuiText (+img) CSS from the EuiIcon component
+// which  makes the button large, wide, and poorly layed out
+// override those styles until the bug is fixed or we find a better approach
+const Icon = styled(EuiIcon)`
+  width: '16px';
+  margin: unset !important;
+`;
+
 export const PackageIcon: React.FunctionComponent<
   UsePackageIconType & Omit<EuiIconProps, 'type'>
 > = ({ packageName, integrationName, version, icons, tryApi, ...euiIconProps }) => {
   const iconType = usePackageIconType({ packageName, integrationName, version, icons, tryApi });
   // @ts-expect-error loading="lazy" is not supported by EuiIcon
-  return <EuiIcon size="s" type={iconType} {...euiIconProps} loading="lazy" />;
+  return <Icon size="s" type={iconType} {...euiIconProps} loading="lazy" />;
 };
 
 export const CardIcon: React.FunctionComponent<UsePackageIconType & Omit<EuiIconProps, 'type'>> = (


### PR DESCRIPTION
## Summary

Resolve #136373 #135637

Fix two bug in the modal that allow to reasign an agent to another policy:
* When performing a bulk upgrade the policy was not selected until the user change it, we now select the first one by default
* The package icon where not aligned this fix it 

#### UI Changes


### Before

<img width="499" alt="Screen Shot 2022-07-29 at 9 27 07 AM" src="https://user-images.githubusercontent.com/1336873/181770355-27b31202-89fc-4dc4-8d35-3394352382f4.png">


### After

<img width="686" alt="Screen Shot 2022-07-29 at 9 26 48 AM" src="https://user-images.githubusercontent.com/1336873/181770360-2b02bea7-acd5-4039-afee-a804c7abda98.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->