### PR TITLE
[SecuritySolution] fix add field popover visibility issue

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/__tests__/add_data_provider_popover.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/__tests__/add_data_provider_popover.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { AddDataProviderPopover } from '../add_data_provider_popover';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestProvidersComponent } from '../../../../../common/mock/test_providers';
+import { mockBrowserFields } from '../../../../../common/containers/source/mock';
+
+const TEST_ID = {
+  ADD_FIELD: 'addField',
+};
+
+const clickOnAddField = () => {
+  const addFieldButton = screen.getByTestId(TEST_ID.ADD_FIELD);
+  fireEvent.click(addFieldButton);
+};
+
+describe('Testing AddDataProviderPopover', () => {
+  it('Test Popover is visible', async () => {
+    render(
+      <TestProvidersComponent>
+        <AddDataProviderPopover browserFields={mockBrowserFields} timelineId="some_ID" />
+      </TestProvidersComponent>
+    );
+
+    clickOnAddField();
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible();
+    });
+  });
+
+  it('Test Popover goes away after clicking again on add field', async () => {
+    render(
+      <TestProvidersComponent>
+        <AddDataProviderPopover browserFields={mockBrowserFields} timelineId="some_ID" />
+      </TestProvidersComponent>
+    );
+
+    clickOnAddField();
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible();
+    });
+
+    clickOnAddField();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/add_data_provider_popover.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/add_data_provider_popover.tsx
@@ -44,9 +44,9 @@ const AddDataProviderPopoverComponent: React.FC<AddDataProviderPopoverProps> = (
     pick(['dataProviders', 'timelineType'], getTimeline(state, timelineId))
   );
 
-  const handleOpenPopover = useCallback(
-    () => setIsAddFilterPopoverOpen(true),
-    [setIsAddFilterPopoverOpen]
+  const togglePopoverState = useCallback(
+    () => setIsAddFilterPopoverOpen(!isAddFilterPopoverOpen),
+    [setIsAddFilterPopoverOpen, isAddFilterPopoverOpen]
   );
 
   const handleClosePopover = useCallback(
@@ -152,7 +152,7 @@ const AddDataProviderPopoverComponent: React.FC<AddDataProviderPopoverProps> = (
       return (
         <EuiButton
           size="s"
-          onClick={handleOpenPopover}
+          onClick={togglePopoverState}
           data-test-subj="addField"
           iconType="arrowDown"
           fill
@@ -166,14 +166,14 @@ const AddDataProviderPopoverComponent: React.FC<AddDataProviderPopoverProps> = (
     return (
       <EuiButtonEmpty
         size="s"
-        onClick={handleOpenPopover}
+        onClick={togglePopoverState}
         data-test-subj="addField"
         iconSide="right"
       >
         <EuiText size="s">{`+ ${ADD_FIELD_LABEL}`}</EuiText>
       </EuiButtonEmpty>
     );
-  }, [handleOpenPopover, timelineType]);
+  }, [togglePopoverState, timelineType]);
 
   const content = useMemo(() => {
     if (timelineType === TimelineType.template) {


### PR DESCRIPTION
## Summary

This PR resolves : #137064

### Current Scenario
onClick handler of `Add Field` was just opening the popover and not closing it. Popover was also not getting closed when clicking on anywhere else on the screen.

### After This change
onClick handler of `Add Field` is now a toggle function for opening and closing the Popover. Now popover is also closing when clicking anywhere else on the screen.


https://user-images.githubusercontent.com/7485038/181777910-0400edaa-5c65-4309-b239-77f7794e9704.mov




### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
