### PR TITLE
[Guided onboarding] Added the team to the codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -674,6 +674,9 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 /src/plugins/home/server/*.ts @elastic/shared-ux
 /src/plugins/home/server/services/ @elastic/shared-ux
 
+# Landing page for guided onboarding in Home plugin
+/src/plugins/home/public/application/components/guided_onboarding @elastic/platform-onboarding
+
 ### Overview Plugin and Packages
 /src/plugins/kibana_overview/ @elastic/shared-ux
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,6 +154,10 @@
 /x-pack/plugins/apm/public/components/app/rum_dashboard @elastic/uptime
 /x-pack/test/apm_api_integration/tests/csm/ @elastic/uptime
 
+# Observability onboarding tour
+/x-pack/plugins/observability/public/components/shared/tour @elastic/platform-onboarding
+/x-pack/test/functional/apps/infra/tour.ts @elastic/platform-onboarding
+
 ### END Observability Plugins
 
 # Presentation
@@ -605,6 +609,10 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 # Cloud Security Posture
 /x-pack/plugins/cloud_security_posture/ @elastic/kibana-cloud-security-posture
 /x-pack/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
+
+# Security Solution onboarding tour
+/x-pack/plugins/security_solution/public/common/components/guided_onboarding @elastic/platform-onboarding
+/x-pack/plugins/security_solution/cypress/integration/guided_onboarding @elastic/platform-onboarding
 
 # Design (at the bottom for specificity of SASS files)
 **/*.scss  @elastic/kibana-design


### PR DESCRIPTION
## Summary

This PR adds the @elastic/platform-onboarding team as the codeowner for the onboarding tours in the Observability and Security solutions and also for the guided onboarding landing page in the Home plugin.




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->