### PR TITLE
[Security Solution][Timeline][Fix] - Use dynamic language for search bar

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/timelines/search_or_filter.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timelines/search_or_filter.cy.ts
@@ -16,7 +16,11 @@ import { cleanKibana } from '../../tasks/common';
 
 import { login, visit, visitWithoutDateRange } from '../../tasks/login';
 import { openTimelineUsingToggle } from '../../tasks/security_main';
-import { executeTimelineKQL } from '../../tasks/timeline';
+import {
+  changeTimelineQueryLanguage,
+  executeTimelineKQL,
+  executeTimelineSearch,
+} from '../../tasks/timeline';
 import { waitForTimelinesPanelToBeLoaded } from '../../tasks/timelines';
 
 import { HOSTS_URL, TIMELINES_URL } from '../../urls/navigation';
@@ -35,6 +39,15 @@ describe('Timeline search and filters', () => {
       const hostExistsQuery = 'host.name: *';
       openTimelineUsingToggle();
       executeTimelineKQL(hostExistsQuery);
+
+      cy.get(SERVER_SIDE_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
+    });
+
+    it('executes a Lucene query', () => {
+      const messageProcessQuery = 'message:Process\\ zsh*';
+      openTimelineUsingToggle();
+      changeTimelineQueryLanguage('lucene');
+      executeTimelineSearch(messageProcessQuery);
 
       cy.get(SERVER_SIDE_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
     });

--- a/x-pack/plugins/security_solution/cypress/screens/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/timeline.ts
@@ -215,6 +215,16 @@ export const TIMELINE_KQLMODE_SEARCH = '[data-test-subj="kqlModePopoverSearch"]'
 
 export const TIMELINE_KQLMODE_FILTER = '[data-test-subj="kqlModePopoverFilter"]';
 
+export const QUERYBAR_MENU_POPOVER = '[data-test-subj="queryBarMenuPopover"]';
+
+export const TIMELINE_SHOWQUERYBARMENU_BUTTON = `${TIMELINE_FLYOUT} [data-test-subj="showQueryBarMenu"]`;
+
+export const TIMELINE_SWITCHQUERYLANGUAGE_BUTTON = '[data-test-subj="switchQueryLanguageButton"]';
+
+export const TIMELINE_LUCENELANGUAGE_BUTTON = '[data-test-subj="luceneLanguageMenuItem"]';
+
+export const TIMELINE_KQLLANGUAGE_BUTTON = '[data-test-subj="kqlLanguageMenuItem"]';
+
 export const TIMELINE_TITLE = '[data-test-subj="timeline-title"]';
 
 export const TIMELINE_TITLE_INPUT = '[data-test-subj="save-timeline-title"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -74,6 +74,11 @@ import {
   EMPTY_DROPPABLE_DATA_PROVIDER_GROUP,
   GET_TIMELINE_GRID_CELL,
   HOVER_ACTIONS,
+  TIMELINE_SWITCHQUERYLANGUAGE_BUTTON,
+  TIMELINE_SHOWQUERYBARMENU_BUTTON,
+  TIMELINE_LUCENELANGUAGE_BUTTON,
+  TIMELINE_KQLLANGUAGE_BUTTON,
+  TIMELINE_QUERY,
 } from '../screens/timeline';
 import { REFRESH_BUTTON, TIMELINE } from '../screens/timelines';
 import { drag, drop } from './common';
@@ -168,6 +173,16 @@ export const addFilter = (filter: TimelineFilter): Cypress.Chainable<JQuery<HTML
     cy.get(TIMELINE_FILTER_VALUE).type(`${filter.value}{enter}`);
   }
   return cy.get(SAVE_FILTER_BTN).click();
+};
+
+export const changeTimelineQueryLanguage = (language: 'kuery' | 'lucene') => {
+  cy.get(TIMELINE_SHOWQUERYBARMENU_BUTTON).click();
+  cy.get(TIMELINE_SWITCHQUERYLANGUAGE_BUTTON).click();
+  if (language === 'lucene') {
+    cy.get(TIMELINE_LUCENELANGUAGE_BUTTON).click();
+  } else {
+    cy.get(TIMELINE_KQLLANGUAGE_BUTTON).click();
+  }
 };
 
 export const addDataProvider = (filter: TimelineFilter): Cypress.Chainable<JQuery<HTMLElement>> => {
@@ -278,6 +293,10 @@ export const createNewTimelineTemplate = () => {
 
 export const executeTimelineKQL = (query: string) => {
   cy.get(`${SEARCH_OR_FILTER_CONTAINER} textarea`).type(`${query} {enter}`);
+};
+
+export const executeTimelineSearch = (query: string) => {
+  cy.get(TIMELINE_QUERY).type(`${query} {enter}`, { force: true });
 };
 
 export const expandFirstTimelineEventDetails = () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/__snapshots__/index.test.tsx.snap
@@ -305,6 +305,7 @@ In other use cases the message field can be used to concatenate different values
   }
   kqlMode="search"
   kqlQueryExpression=" "
+  kqlQueryLanguage="kuery"
   onEventClosed={[MockFunction]}
   renderCellValue={[Function]}
   rowRenderers={

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.test.tsx
@@ -137,6 +137,7 @@ describe('Timeline', () => {
       itemsPerPageOptions: [5, 10, 20],
       kqlMode: 'search' as QueryTabContentComponentProps['kqlMode'],
       kqlQueryExpression: ' ',
+      kqlQueryLanguage: 'kuery',
       onEventClosed: jest.fn(),
       renderCellValue: DefaultCellRenderer,
       rowRenderers: defaultRowRenderers,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -179,6 +179,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   itemsPerPageOptions,
   kqlMode,
   kqlQueryExpression,
+  kqlQueryLanguage,
   onEventClosed,
   renderCellValue,
   rowRenderers,
@@ -223,8 +224,8 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     query: string;
     language: KueryFilterQueryKind;
   } = useMemo(
-    () => ({ query: kqlQueryExpression.trim(), language: 'kuery' }),
-    [kqlQueryExpression]
+    () => ({ query: kqlQueryExpression.trim(), language: kqlQueryLanguage }),
+    [kqlQueryExpression, kqlQueryLanguage]
   );
 
   const combinedQueries = combineQueries({
@@ -493,6 +494,11 @@ const makeMapStateToProps = () => {
         ? ' '
         : kqlQueryTimeline?.expression ?? '';
 
+    const kqlQueryLanguage =
+      isEmpty(dataProviders) && timelineType === 'template'
+        ? 'kuery'
+        : kqlQueryTimeline?.kind ?? 'kuery';
+
     return {
       activeTab,
       columns,
@@ -506,6 +512,7 @@ const makeMapStateToProps = () => {
       itemsPerPageOptions,
       kqlMode,
       kqlQueryExpression,
+      kqlQueryLanguage,
       showCallOutUnauthorizedMsg: getShowCallOutUnauthorizedMsg(state),
       show,
       showExpandedDetails:

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/epic_local_storage.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/epic_local_storage.test.tsx
@@ -78,6 +78,7 @@ describe('epicLocalStorage', () => {
       itemsPerPageOptions: [5, 10, 20],
       kqlMode: 'search' as QueryTabContentComponentProps['kqlMode'],
       kqlQueryExpression: '',
+      kqlQueryLanguage: 'kuery',
       onEventClosed: jest.fn(),
       renderCellValue: DefaultCellRenderer,
       rowRenderers: defaultRowRenderers,


### PR DESCRIPTION
## Summary

Addresses #137357

This PR replaces the hardcoded `kuery` value with the selected query type in the kql search bar to allow users to run lucene queries in the timeline
