### PR TITLE
[ML] Fixes query in the Anomaly Explorer when viewing a job with no influencers

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
@@ -153,8 +153,8 @@ export const ExplorerQueryBar: FC<ExplorerQueryBarProps> = ({
 
   return (
     <EuiInputPopover
-      style={{ maxWidth: '100%' }}
-      closePopover={() => setErrorMessage(undefined)}
+      css={{ 'max-width': '100%' }}
+      closePopover={setErrorMessage.bind(null, undefined)}
       input={
         <QueryStringInput
           bubbleSubmitEvent={false}

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -599,6 +599,8 @@ export const Explorer: FC<ExplorerUIProps> = ({
       queryString={queryString}
       updateLanguage={updateLanguage}
     >
+      <EuiSpacer size={'m'} />
+
       {noInfluencersConfigured ? (
         <EuiFlexGroup gutterSize={'s'}>
           <EuiFlexItem grow={false}>
@@ -615,8 +617,6 @@ export const Explorer: FC<ExplorerUIProps> = ({
         </EuiFlexGroup>
       ) : (
         <div>
-          <EuiSpacer size={'m'} />
-
           <EuiResizableContainer
             direction={isMobile ? 'vertical' : 'horizontal'}
             onPanelWidthChange={onPanelWidthChange}

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -107,10 +107,7 @@ const ExplorerPage: FC<ExplorerPageProps> = ({
       <EuiPageHeaderSection style={{ width: '100%' }}>
         <JobSelector {...jobSelectorProps} />
 
-        {noInfluencersConfigured === false &&
-        influencers !== undefined &&
-        indexPattern &&
-        updateLanguage ? (
+        {indexPattern && updateLanguage ? (
           <>
             <ExplorerQueryBar
               filterActive={!!filterActive}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136977 

Always preserve a query bar to allow clearing a query string added for a previous job selection with configured influencers. 

<img width="1637" alt="image" src="https://user-images.githubusercontent.com/5236598/182116528-26c07f88-f87f-4271-816e-b65df14a9a9a.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->