### PR TITLE
[Unified search] Improve the way that spaces are handled on inline mode

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.test.ts
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { parseErrors } from './helpers';
+import { parseErrors, getInlineEditorText } from './helpers';
 
 describe('helpers', function () {
   describe('parseErrors', function () {
@@ -100,6 +100,32 @@ describe('helpers', function () {
           startLineNumber: 1,
         },
       ]);
+    });
+  });
+
+  describe('getInlineEditorText', function () {
+    it('should return the entire query if it is one liner', function () {
+      const text = getInlineEditorText(
+        'SELECT field1, count(*) FROM index1 ORDER BY field1',
+        false
+      );
+      expect(text).toEqual(text);
+    });
+
+    it('should return the query on one line with extra space if is multiliner', function () {
+      const text = getInlineEditorText(
+        'SELECT field1, count(*)\nFROM index1 ORDER BY field1',
+        true
+      );
+      expect(text).toEqual('SELECT field1, count(*) FROM index1 ORDER BY field1');
+    });
+
+    it('should return the query on one line with extra spaces removed if is multiliner', function () {
+      const text = getInlineEditorText(
+        'SELECT field1, count(*)\nFROM index1 \n   ORDER BY field1',
+        true
+      );
+      expect(text).toEqual('SELECT field1, count(*) FROM index1 ORDER BY field1');
     });
   });
 });

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.ts
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.ts
@@ -134,6 +134,5 @@ export const getDocumentationSections = async (language: string) => {
 };
 
 export const getInlineEditorText = (queryString: string, isMultiLine: boolean) => {
-  const trimmedText = queryString.replace(/\r?\n|\r/g, ' ').replace(/  +/g, ' ');
-  return isMultiLine ? trimmedText : queryString;
+  return isMultiLine ? queryString.replace(/\r?\n|\r/g, ' ').replace(/  +/g, ' ') : queryString;
 };

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.ts
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/helpers.ts
@@ -132,3 +132,8 @@ export const getDocumentationSections = async (language: string) => {
     };
   }
 };
+
+export const getInlineEditorText = (queryString: string, isMultiLine: boolean) => {
+  const trimmedText = queryString.replace(/\r?\n|\r/g, ' ').replace(/  +/g, ' ');
+  return isMultiLine ? trimmedText : queryString;
+};

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
@@ -35,7 +35,12 @@ import {
   EDITOR_MIN_HEIGHT,
 } from './text_based_languages_editor.styles';
 import { MemoizedDocumentation, DocumentationSections } from './documentation';
-import { useDebounceWithOptions, parseErrors, getDocumentationSections } from './helpers';
+import {
+  useDebounceWithOptions,
+  parseErrors,
+  getInlineEditorText,
+  getDocumentationSections,
+} from './helpers';
 import { EditorFooter } from './editor_footer';
 
 import './overwrite.scss';
@@ -228,8 +233,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
         if (hasLines && !updateLinesFromModel) {
           setLines(queryString.split(/\r|\n/).length);
         }
-        const trimmedText = queryString.replace(/\r?\n|\r/g, '');
-        const text = hasLines ? trimmedText : queryString;
+        const text = getInlineEditorText(queryString, Boolean(hasLines));
         const queryLength = text.length;
         const unusedSpace =
           errors && errors.length


### PR DESCRIPTION
## Summary

Fixes the bug described here https://github.com/elastic/kibana/issues/136950#issuecomment-1199208135

When the user has an SQL query with multilines but the editor is on the inline mode we want to convert the query to oneliner but with one space between the words.

![uni1](https://user-images.githubusercontent.com/17003240/182125099-54e0e728-2db3-46c2-98c3-d0fe4bdbd13b.gif)

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios