### PR TITLE
[Profiling] Differential views comparison UI

### DIFF
--- a/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { PrimaryProfilingSearchBar } from './profiling_app_page_template/primary_profiling_search_bar';
+import { ProfilingSearchBar } from './profiling_app_page_template/profiling_search_bar';
+import { useAnyOfProfilingParams } from '../hooks/use_profiling_params';
+import { useProfilingRouter } from '../hooks/use_profiling_router';
+import { useProfilingRoutePath } from '../hooks/use_profiling_route_path';
+
+export function PrimaryAndComparisonSearchBar() {
+  const {
+    path,
+    query,
+    query: { comparisonKuery, comparisonRangeFrom, comparisonRangeTo },
+  } = useAnyOfProfilingParams('/flamegraphs/differential', '/functions/differential');
+
+  const profilingRouter = useProfilingRouter();
+  const routePath = useProfilingRoutePath() as
+    | '/flamegraphs/differential'
+    | '/functions/differential';
+
+  return (
+    <EuiFlexGroup direction="row" gutterSize="xs">
+      <EuiFlexItem>
+        <PrimaryProfilingSearchBar showSubmitButton={false} />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <ProfilingSearchBar
+          kuery={comparisonKuery}
+          rangeFrom={comparisonRangeFrom}
+          rangeTo={comparisonRangeTo}
+          onQuerySubmit={(next) => {
+            profilingRouter.push(routePath, {
+              path,
+              query: {
+                ...query,
+                comparisonKuery: String(next.query?.query || ''),
+                comparisonRangeFrom: next.dateRange.from,
+                comparisonRangeTo: next.dateRange.to,
+              },
+            });
+          }}
+          onRefresh={(nextDateRange) => {
+            profilingRouter.push(routePath, {
+              path,
+              query: {
+                ...query,
+                comparisonRangeFrom: nextDateRange.dateRange.from,
+                comparisonRangeTo: nextDateRange.dateRange.to,
+              },
+            });
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
@@ -27,7 +27,7 @@ export function PrimaryAndComparisonSearchBar() {
   return (
     <EuiFlexGroup direction="row" gutterSize="xs">
       <EuiFlexItem>
-        <PrimaryProfilingSearchBar showSubmitButton={false} />
+        <PrimaryProfilingSearchBar />
       </EuiFlexItem>
       <EuiFlexItem>
         <ProfilingSearchBar

--- a/x-pack/plugins/profiling/public/components/profiling_app_page_template/index.tsx
+++ b/x-pack/plugins/profiling/public/components/profiling_app_page_template/index.tsx
@@ -7,70 +7,31 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiPageHeaderContentProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { SearchBar } from '@kbn/unified-search-plugin/public';
-import { compact } from 'lodash';
-import React, { useEffect, useState } from 'react';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { INDEX_EVENTS } from '../../../common';
-import { useProfilingParams } from '../../hooks/use_profiling_params';
-import { useProfilingRouter } from '../../hooks/use_profiling_router';
-import { useProfilingRoutePath } from '../../hooks/use_profiling_route_path';
 import { useProfilingDependencies } from '../contexts/profiling_dependencies/use_profiling_dependencies';
+import { PrimaryProfilingSearchBar } from './primary_profiling_search_bar';
 
 export function ProfilingAppPageTemplate({
   children,
   tabs,
+  hideSearchBar = false,
 }: {
   children: React.ReactElement;
   tabs: EuiPageHeaderContentProps['tabs'];
+  hideSearchBar?: boolean;
 }) {
   const {
-    path,
-    query,
-    query: { rangeFrom, rangeTo, kuery },
-  } = useProfilingParams('/*');
-
-  const {
-    start: { observability, data, dataViews },
+    start: { observability },
   } = useProfilingDependencies();
 
   const { PageTemplate: ObservabilityPageTemplate } = observability.navigation;
 
-  const profilingRouter = useProfilingRouter();
-  const routePath = useProfilingRoutePath();
-
-  const [dataView, setDataView] = useState<DataView>();
-
   const history = useHistory();
-
-  useEffect(() => {
-    // set time if both to and from are given in the url
-    if (rangeFrom && rangeTo) {
-      data.query.timefilter.timefilter.setTime({
-        from: rangeFrom,
-        to: rangeTo,
-      });
-      return;
-    }
-  }, [rangeFrom, rangeTo, data]);
-
-  useEffect(() => {
-    dataViews
-      .create({
-        title: INDEX_EVENTS,
-      })
-      .then((nextDataView) => setDataView(nextDataView));
-  }, [dataViews]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [history.location.pathname]);
-
-  const searchBarQuery: Required<React.ComponentProps<typeof SearchBar>>['query'] = {
-    language: 'kuery',
-    query: kuery,
-  };
 
   return (
     <ObservabilityPageTemplate
@@ -86,40 +47,11 @@ export function ProfilingAppPageTemplate({
       }}
     >
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <SearchBar
-            onQuerySubmit={(next) => {
-              profilingRouter.push(routePath, {
-                path,
-                query: {
-                  ...query,
-                  kuery: next.query?.query || '',
-                  rangeFrom: next.dateRange.from,
-                  rangeTo: next.dateRange.to,
-                },
-              });
-            }}
-            showQueryBar
-            showQueryInput
-            showDatePicker
-            showFilterBar={false}
-            showSaveQuery={false}
-            query={searchBarQuery}
-            dateRangeFrom={rangeFrom}
-            dateRangeTo={rangeTo}
-            indexPatterns={compact([dataView])}
-            onRefresh={(nextDateRange) => {
-              profilingRouter.push(routePath, {
-                path,
-                query: {
-                  ...query,
-                  rangeFrom: nextDateRange.dateRange.from,
-                  rangeTo: nextDateRange.dateRange.to,
-                },
-              });
-            }}
-          />
-        </EuiFlexItem>
+        {!hideSearchBar && (
+          <EuiFlexItem>
+            <PrimaryProfilingSearchBar />
+          </EuiFlexItem>
+        )}
         <EuiFlexItem>{children}</EuiFlexItem>
       </EuiFlexGroup>
     </ObservabilityPageTemplate>

--- a/x-pack/plugins/profiling/public/components/profiling_app_page_template/primary_profiling_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/profiling_app_page_template/primary_profiling_search_bar.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import { useProfilingParams } from '../../hooks/use_profiling_params';
+import { useProfilingRouter } from '../../hooks/use_profiling_router';
+import { useProfilingRoutePath } from '../../hooks/use_profiling_route_path';
+import { useProfilingDependencies } from '../contexts/profiling_dependencies/use_profiling_dependencies';
+import { ProfilingSearchBar } from './profiling_search_bar';
+
+export function PrimaryProfilingSearchBar({ showSubmitButton }: { showSubmitButton?: boolean }) {
+  const {
+    start: { data },
+  } = useProfilingDependencies();
+
+  const profilingRouter = useProfilingRouter();
+  const routePath = useProfilingRoutePath();
+
+  const {
+    path,
+    query,
+    query: { rangeFrom, rangeTo, kuery },
+  } = useProfilingParams('/*');
+
+  useEffect(() => {
+    // set time if both to and from are given in the url
+    if (rangeFrom && rangeTo) {
+      data.query.timefilter.timefilter.setTime({
+        from: rangeFrom,
+        to: rangeTo,
+      });
+      return;
+    }
+  }, [rangeFrom, rangeTo, data]);
+
+  return (
+    <ProfilingSearchBar
+      kuery={kuery}
+      rangeFrom={rangeFrom}
+      rangeTo={rangeTo}
+      onQuerySubmit={(next) => {
+        profilingRouter.push(routePath, {
+          path,
+          query: {
+            ...query,
+            kuery: String(next.query?.query || ''),
+            rangeFrom: next.dateRange.from,
+            rangeTo: next.dateRange.to,
+          },
+        });
+      }}
+      onRefresh={(nextDateRange) => {
+        profilingRouter.push(routePath, {
+          path,
+          query: {
+            ...query,
+            rangeFrom: nextDateRange.dateRange.from,
+            rangeTo: nextDateRange.dateRange.to,
+          },
+        });
+      }}
+      showSubmitButton={showSubmitButton}
+    />
+  );
+}

--- a/x-pack/plugins/profiling/public/components/profiling_app_page_template/profiling_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/profiling_app_page_template/profiling_search_bar.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useState } from 'react';
+import { SearchBar } from '@kbn/unified-search-plugin/public';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { compact } from 'lodash';
+import { Query, TimeRange } from '@kbn/es-query';
+import { useProfilingDependencies } from '../contexts/profiling_dependencies/use_profiling_dependencies';
+import { INDEX_EVENTS } from '../../../common';
+
+export function ProfilingSearchBar({
+  kuery,
+  rangeFrom,
+  rangeTo,
+  onQuerySubmit,
+  onRefresh,
+  showSubmitButton = true,
+}: {
+  kuery: string;
+  rangeFrom: string;
+  rangeTo: string;
+  onQuerySubmit: (
+    payload: {
+      dateRange: TimeRange;
+      query?: Query;
+    },
+    isUpdate?: boolean
+  ) => void;
+  onRefresh: Required<React.ComponentProps<typeof SearchBar>>['onRefresh'];
+  showSubmitButton?: boolean;
+}) {
+  const {
+    start: { dataViews },
+  } = useProfilingDependencies();
+
+  const [dataView, setDataView] = useState<DataView>();
+
+  useEffect(() => {
+    dataViews
+      .create({
+        title: INDEX_EVENTS,
+      })
+      .then((nextDataView) => setDataView(nextDataView));
+  }, [dataViews]);
+
+  const searchBarQuery: Required<React.ComponentProps<typeof SearchBar>>['query'] = {
+    language: 'kuery',
+    query: kuery,
+  };
+
+  return (
+    <SearchBar<Query>
+      onQuerySubmit={onQuerySubmit}
+      showQueryBar
+      showQueryInput
+      showDatePicker
+      showFilterBar={false}
+      showSaveQuery={false}
+      showSubmitButton={showSubmitButton}
+      query={searchBarQuery}
+      dateRangeFrom={rangeFrom}
+      dateRangeTo={rangeTo}
+      indexPatterns={compact([dataView])}
+      onRefresh={onRefresh}
+    />
+  );
+}

--- a/x-pack/plugins/profiling/public/hooks/use_profiling_params.ts
+++ b/x-pack/plugins/profiling/public/hooks/use_profiling_params.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { PathsOf, TypeOf, useParams } from '@kbn/typed-react-router-config';
+import { ValuesType } from 'utility-types';
 import { ProfilingRoutes } from '../routing';
 
 export function useProfilingParams<T extends PathsOf<ProfilingRoutes>>(
@@ -12,4 +13,10 @@ export function useProfilingParams<T extends PathsOf<ProfilingRoutes>>(
   ...args: any[]
 ): TypeOf<ProfilingRoutes, T> {
   return useParams(path, ...args) as TypeOf<ProfilingRoutes, T>;
+}
+
+export function useAnyOfProfilingParams<TPaths extends Array<PathsOf<ProfilingRoutes>>>(
+  ...paths: TPaths
+): TypeOf<ProfilingRoutes, ValuesType<TPaths>> {
+  return useParams(...paths)! as TypeOf<ProfilingRoutes, ValuesType<TPaths>>;
 }

--- a/x-pack/plugins/profiling/public/routing/index.tsx
+++ b/x-pack/plugins/profiling/public/routing/index.tsx
@@ -98,6 +98,13 @@ const routes = {
                     <Outlet />
                   </RouteBreadcrumb>
                 ),
+                params: t.type({
+                  query: t.type({
+                    comparisonRangeFrom: t.string,
+                    comparisonRangeTo: t.string,
+                    comparisonKuery: t.string,
+                  }),
+                }),
               },
             },
           },
@@ -138,6 +145,13 @@ const routes = {
                     <Outlet />
                   </RouteBreadcrumb>
                 ),
+                params: t.type({
+                  query: t.type({
+                    comparisonRangeFrom: t.string,
+                    comparisonRangeTo: t.string,
+                    comparisonKuery: t.string,
+                  }),
+                }),
               },
             },
           },


### PR DESCRIPTION
Adds a comparison search bar (filter bar + date picker) for the differential views in the Flamegraph and Functions views. Nothing more, so people can work on the implementation of the actual chart/table separately.

<img width="1916" alt="CleanShot 2022-08-01 at 14 03 32@2x" src="https://user-images.githubusercontent.com/352732/182143756-6a34c4bf-85a8-4117-9b22-568091673e71.png">
