### PR TITLE
[APM] Improve synthtrace environment

### DIFF
--- a/packages/elastic-apm-synthtrace/src/lib/utils/get_synthtrace_environment.ts
+++ b/packages/elastic-apm-synthtrace/src/lib/utils/get_synthtrace_environment.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import path from 'path';
+
+export function getSynthtraceEnvironment(filename: string) {
+  return `Synthtrace: ${path.parse(filename).name}`;
+}

--- a/packages/elastic-apm-synthtrace/src/scenarios/aws_lambda.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/aws_lambda.ts
@@ -11,8 +11,9 @@ import { ApmFields } from '../lib/apm/apm_fields';
 import { Scenario } from '../cli/scenario';
 import { getLogger } from '../cli/utils/get_common_services';
 import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const ENVIRONMENT = __filename;
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);

--- a/packages/elastic-apm-synthtrace/src/scenarios/low_throughput.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/low_throughput.ts
@@ -13,8 +13,9 @@ import { Instance } from '../lib/apm/instance';
 import { Scenario } from '../cli/scenario';
 import { getLogger } from '../cli/utils/get_common_services';
 import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const ENVIRONMENT = __filename;
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);

--- a/packages/elastic-apm-synthtrace/src/scenarios/many_services.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/many_services.ts
@@ -7,14 +7,16 @@
  */
 
 import { random } from 'lodash';
+
 import { apm, timerange } from '..';
 import { Instance } from '../lib/apm/instance';
 import { Scenario } from '../cli/scenario';
 import { getLogger } from '../cli/utils/get_common_services';
 import { RunOptions } from '../cli/utils/parse_run_cli_flags';
 import { ApmFields } from '../lib/apm/apm_fields';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const ENVIRONMENT = __filename;
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);

--- a/packages/elastic-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -12,8 +12,9 @@ import { Instance } from '../lib/apm/instance';
 import { Scenario } from '../cli/scenario';
 import { getLogger } from '../cli/utils/get_common_services';
 import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const ENVIRONMENT = __filename;
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   const logger = getLogger(runOptions);

--- a/packages/elastic-apm-synthtrace/src/scenarios/span_links.ts
+++ b/packages/elastic-apm-synthtrace/src/scenarios/span_links.ts
@@ -10,8 +10,9 @@ import { compact, shuffle } from 'lodash';
 import { apm, ApmFields, EntityArrayIterable, timerange } from '..';
 import { generateLongId, generateShortId } from '../lib/utils/generate_id';
 import { Scenario } from '../cli/scenario';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const ENVIRONMENT = __filename;
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 function generateExternalSpanLinks() {
   // randomly creates external span links 0 - 10


### PR DESCRIPTION
Currently the full path of the scenario file is used as the environment. This creates some very long undecipherable environment names. This PR improves it by only using the (base) filename and prefixing with "synthtrace":

<img width="303" alt="image" src="https://user-images.githubusercontent.com/209966/182144756-c89d7a09-230a-49eb-a03b-4996893b9e58.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->