### PR TITLE
[Security Solution] Client side check for safe number in PID and correct usage message

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/endpoint_response_actions_console_commands.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/endpoint_response_actions_console_commands.ts
@@ -29,7 +29,7 @@ const pidValidator = (argData: ParsedArgData): true | string => {
   const emptyResult = emptyArgumentValidator(argData);
   if (emptyResult !== true) {
     return emptyResult;
-  } else if (Number.isInteger(Number(argData)) && Number(argData) > 0) {
+  } else if (Number.isSafeInteger(Number(argData)) && Number(argData) > 0) {
     return true;
   } else {
     return i18n.translate('xpack.securitySolution.endpointConsoleCommands.invalidPidMessage', {
@@ -97,7 +97,7 @@ export const getEndpointResponseActionsConsoleCommands = (
       meta: {
         endpointId: endpointAgentId,
       },
-      exampleUsage: 'release --comment "isolate this host"',
+      exampleUsage: 'release --comment "release this host"',
       exampleInstruction: ENTER_OR_ADD_COMMENT_ARG_INSTRUCTION,
       args: {
         comment: {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/kill_process_action.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/kill_process_action.test.tsx
@@ -138,6 +138,15 @@ describe('When using the kill-process action from response actions console', () 
     );
   });
 
+  it('should check the pid is a safe number', async () => {
+    await render();
+    enterConsoleCommand(renderResult, 'kill-process --pid 123123123123123123123');
+
+    expect(renderResult.getByTestId('test-badArgument-message').textContent).toEqual(
+      'Invalid argument value: --pid. Argument must be a positive number representing the PID of a process'
+    );
+  });
+
   it('should check the entityId has a given value', async () => {
     await render();
     enterConsoleCommand(renderResult, 'kill-process --entityId');


### PR DESCRIPTION
## Summary

This PR addresses two small bugs in the response console for `8.4`

Bug tickets:
https://github.com/elastic/kibana/issues/137250
https://github.com/elastic/kibana/issues/136944

Our API checked for safe numbers when validating PID arguments, but there wasn't a proper client side check.  This adds that.

![image](https://user-images.githubusercontent.com/56395104/182152001-a5238900-aa4e-45c0-8d8a-2d449687af87.png)

We also correct the usage text for the `release` command.

![image](https://user-images.githubusercontent.com/56395104/182152064-42316b1a-ae76-42bf-8f89-f29eb7c9f9f4.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
