### PR TITLE
[Fleet] Removed successful message from toast when upgrading agents

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -169,23 +169,14 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
         }
       );
       setIsSubmitting(false);
-      const successMessage = isSingleAgent
-        ? i18n.translate('xpack.fleet.upgradeAgents.successSingleNotificationTitle', {
+
+      if (isSingleAgent && counts.success === counts.total) {
+        notifications.toasts.addSuccess(
+          i18n.translate('xpack.fleet.upgradeAgents.successSingleNotificationTitle', {
             defaultMessage: 'Upgrading {count} agent',
             values: { count: 1 },
           })
-        : i18n.translate('xpack.fleet.upgradeAgents.successMultiNotificationTitle', {
-            defaultMessage:
-              'Upgrading {isMixed, select, true {{success} of {total}} other {{isAllAgents, select, true {all selected} other {{success}} }}} agents',
-            values: {
-              isMixed: counts.success !== counts.total,
-              success: counts.success,
-              total: counts.total,
-              isAllAgents,
-            },
-          });
-      if (counts.success === counts.total) {
-        notifications.toasts.addSuccess(successMessage);
+        );
       } else if (counts.error === counts.total) {
         notifications.toasts.addDanger(
           i18n.translate('xpack.fleet.upgradeAgents.bulkResultAllErrorsNotificationTitle', {
@@ -196,7 +187,6 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
         );
       } else {
         notifications.toasts.addWarning({
-          title: successMessage,
           text: i18n.translate('xpack.fleet.upgradeAgents.bulkResultErrorResultsSummary', {
             defaultMessage:
               '{count} {count, plural, one {agent was} other {agents were}} not successful',

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -13683,7 +13683,6 @@
     "xpack.fleet.upgradeAgents.hourLabel": "{option} {count, plural, one {heure} other {heures}}",
     "xpack.fleet.upgradeAgents.scheduleUpgradeMultipleTitle": "Planifier la mise à niveau pour {count, plural, one {l'agent} other {{count} agents} =true {tous les agents sélectionnés}}",
     "xpack.fleet.upgradeAgents.startTimeLabel": "Date et heure sélectionnées",
-    "xpack.fleet.upgradeAgents.successMultiNotificationTitle": "{isMixed, select, true {{success} agents sur {total}} other {{isAllAgents, select, true {Tous les agents sélectionnés} other {{success}} }}} mis à niveau",
     "xpack.fleet.upgradeAgents.successSingleNotificationTitle": "{count} agent mis à niveau",
     "xpack.fleet.upgradeAgents.upgradeMultipleDescription": "Cette action met à niveau plusieurs agents vers la version {version}. Impossible d'annuler cette action. Voulez-vous vraiment continuer ?",
     "xpack.fleet.upgradeAgents.upgradeMultipleTitle": "Mettre à niveau {count, plural, one {l'agent} other {{count} agents} =true {tous les agents sélectionnés}}",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -13673,7 +13673,6 @@
     "xpack.fleet.upgradeAgents.hourLabel": "{option} {count, plural, other {時間}}",
     "xpack.fleet.upgradeAgents.scheduleUpgradeMultipleTitle": "{count, plural, other {{count}個のエージェント} =true {すべての選択されたエージェント}}のアップグレードをスケジュール",
     "xpack.fleet.upgradeAgents.startTimeLabel": "スケジュールされた日時",
-    "xpack.fleet.upgradeAgents.successMultiNotificationTitle": "{isMixed, select, true {{success}/{total}個の} other {{isAllAgents, select, true {すべての選択された} other {{success}} }}}エージェントをアップグレードしました",
     "xpack.fleet.upgradeAgents.successSingleNotificationTitle": "{count}個のエージェントをアップグレードしました",
     "xpack.fleet.upgradeAgents.upgradeMultipleDescription": "このアクションにより、複数のエージェントがバージョン{version}にアップグレードされます。このアクションは元に戻せません。続行していいですか？",
     "xpack.fleet.upgradeAgents.upgradeMultipleTitle": "{count, plural, other  {{count}個のエージェント} =true {すべての選択されたエージェント}}をアップグレード",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13690,7 +13690,6 @@
     "xpack.fleet.upgradeAgents.hourLabel": "{option} {count, plural, other {小时}}",
     "xpack.fleet.upgradeAgents.scheduleUpgradeMultipleTitle": "计划升级{count, plural, one {代理} other {{count} 个代理} =true {所有选定代理}}",
     "xpack.fleet.upgradeAgents.startTimeLabel": "计划日期和时间",
-    "xpack.fleet.upgradeAgents.successMultiNotificationTitle": "已升级{isMixed, select, true { {success} 个（共 {total} 个）} other {{isAllAgents, select, true {所有选定} other { {success} 个} }}}代理",
     "xpack.fleet.upgradeAgents.successSingleNotificationTitle": "已升级 {count} 个代理",
     "xpack.fleet.upgradeAgents.upgradeMultipleDescription": "此操作会将多个代理升级到版本 {version}。此操作无法撤消。是否确定要继续？",
     "xpack.fleet.upgradeAgents.upgradeMultipleTitle": "升级{count, plural, one {代理} other { {count} 个代理} =true {所有选定代理}}",


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135701#event-7056995309

Explanation of the issue on [this comment](https://github.com/elastic/kibana/issues/135701#issuecomment-1177838367). 

- Remove the `Upgrading n of tot agents` from the toast notification when the upgrading agents as it's often conflicting with the callout on top.
- Keep the warning notifications the upgrades failed for one or more agents.

#### Testing
- Try to upgrade multiple agents
  - The toast notification should only appear when some or all agents were not successful
- Try to upgrade one agent
  - The toast notification should be visible also when it was successful




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->