### PR TITLE
Fix unable to open host or user detail pages when their names conflict with tabs

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/ml/ml_conditional_links.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/ml/ml_conditional_links.spec.ts
@@ -146,7 +146,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostSingleHostNullKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -154,7 +154,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostSingleHostKqlQueryVariable);
     cy.url().should(
       'include',
-      '/app/security/hosts/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -162,7 +162,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostSingleHostKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/siem-windows/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -170,7 +170,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostMultiHostNullKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -178,7 +178,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostMultiHostKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%20and%20((process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22))%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%20and%20((process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22))%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -186,7 +186,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostVariableHostNullKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -194,7 +194,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostVariableHostKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 });

--- a/x-pack/plugins/security_solution/cypress/integration/ml/ml_conditional_links.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/ml/ml_conditional_links.spec.ts
@@ -170,7 +170,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostMultiHostNullKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -178,7 +178,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostMultiHostKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%20and%20((process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22))%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(host.name:%20%22siem-windows%22%20or%20host.name:%20%22siem-suricata%22)%20and%20((process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22))%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -186,7 +186,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostVariableHostNullKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 
@@ -194,7 +194,7 @@ describe('ml conditional links', () => {
     visitWithoutDateRange(mlHostVariableHostKqlQuery);
     cy.url().should(
       'include',
-      '/app/security/hosts/name/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
+      '/app/security/hosts/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27auditbeat-*%27)))&query=(language:kuery,query:%27(process.name:%20%22conhost.exe%22%20or%20process.name:%20%22sc.exe%22)%27)&timerange=(global:(linkTo:!(timeline),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)),timeline:(linkTo:!(global),timerange:(from:%272019-06-06T06:00:00.000Z%27,kind:absolute,to:%272019-06-07T05:59:59.999Z%27)))'
     );
   });
 });

--- a/x-pack/plugins/security_solution/cypress/integration/urls/state.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/urls/state.spec.ts
@@ -255,7 +255,7 @@ describe('url state', () => {
     cy.get(ANOMALIES_TAB).should(
       'have.attr',
       'href',
-      "/app/security/hosts/siem-kibana/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!('auditbeat-*')))&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')),timeline:(linkTo:!(global),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')))&query=(language:kuery,query:'agent.type:%20%22auditbeat%22%20')"
+      "/app/security/hosts/name/siem-kibana/anomalies?sourcerer=(default:(id:security-solution-default,selectedPatterns:!('auditbeat-*')))&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')),timeline:(linkTo:!(global),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')))&query=(language:kuery,query:'agent.type:%20%22auditbeat%22%20')"
     );
 
     cy.get(BREADCRUMBS)
@@ -270,7 +270,7 @@ describe('url state', () => {
       .should(
         'have.attr',
         'href',
-        `/app/security/hosts/siem-kibana?sourcerer=(default:(id:security-solution-default,selectedPatterns:!('auditbeat-*')))&query=(language:kuery,query:'agent.type:%20%22auditbeat%22%20')&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')),timeline:(linkTo:!(global),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')))`
+        `/app/security/hosts/name/siem-kibana?sourcerer=(default:(id:security-solution-default,selectedPatterns:!('auditbeat-*')))&query=(language:kuery,query:'agent.type:%20%22auditbeat%22%20')&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')),timeline:(linkTo:!(global),timerange:(from:'2019-08-01T20:03:29.186Z',kind:absolute,to:'2023-01-01T21:33:29.186Z')))`
       );
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_hosts.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_hosts.tsx
@@ -15,10 +15,10 @@ export const getTabsOnHostsUrl = (tabName: HostsTableType, search?: string) =>
   `/${tabName}${appendSearch(search)}`;
 
 export const getHostDetailsUrl = (detailName: string, search?: string) =>
-  `name/${detailName}${appendSearch(search)}`;
+  `/name/${detailName}${appendSearch(search)}`;
 
 export const getTabsOnHostDetailsUrl = (
   detailName: string,
   tabName: HostsTableType,
   search?: string
-) => `name/${detailName}/${tabName}${appendSearch(search)}`;
+) => `/name/${detailName}/${tabName}${appendSearch(search)}`;

--- a/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_hosts.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_hosts.tsx
@@ -15,10 +15,10 @@ export const getTabsOnHostsUrl = (tabName: HostsTableType, search?: string) =>
   `/${tabName}${appendSearch(search)}`;
 
 export const getHostDetailsUrl = (detailName: string, search?: string) =>
-  `/${detailName}${appendSearch(search)}`;
+  `name/${detailName}${appendSearch(search)}`;
 
 export const getTabsOnHostDetailsUrl = (
   detailName: string,
   tabName: HostsTableType,
   search?: string
-) => `/${detailName}/${tabName}${appendSearch(search)}`;
+) => `name/${detailName}/${tabName}${appendSearch(search)}`;

--- a/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_users.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_users.tsx
@@ -9,10 +9,10 @@ import type { UsersTableType } from '../../../users/store/model';
 import { appendSearch } from './helpers';
 
 export const getUsersDetailsUrl = (detailName: string, search?: string) =>
-  `name/${detailName}${appendSearch(search)}`;
+  `/name/${detailName}${appendSearch(search)}`;
 
 export const getTabsOnUsersDetailsUrl = (
   detailName: string,
   tabName: UsersTableType,
   search?: string
-) => `name/${detailName}/${tabName}${appendSearch(search)}`;
+) => `/name/${detailName}/${tabName}${appendSearch(search)}`;

--- a/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_users.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/link_to/redirect_to_users.tsx
@@ -9,10 +9,10 @@ import type { UsersTableType } from '../../../users/store/model';
 import { appendSearch } from './helpers';
 
 export const getUsersDetailsUrl = (detailName: string, search?: string) =>
-  `/${detailName}${appendSearch(search)}`;
+  `name/${detailName}${appendSearch(search)}`;
 
 export const getTabsOnUsersDetailsUrl = (
   detailName: string,
   tabName: UsersTableType,
   search?: string
-) => `/${detailName}/${tabName}${appendSearch(search)}`;
+) => `name/${detailName}/${tabName}${appendSearch(search)}`;

--- a/x-pack/plugins/security_solution/public/common/components/links/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/links/index.test.tsx
@@ -60,13 +60,13 @@ describe('Custom Links', () => {
   describe('HostDetailsLink', () => {
     test('should render valid link to Host Details with hostName as the display text', () => {
       const wrapper = mount(<HostDetailsLink hostName={hostName} />);
-      expect(wrapper.find('EuiLink').prop('href')).toEqual(`/${encodeURIComponent(hostName)}`);
+      expect(wrapper.find('EuiLink').prop('href')).toEqual(`/name/${encodeURIComponent(hostName)}`);
       expect(wrapper.text()).toEqual(hostName);
     });
 
     test('should render valid link to Host Details with child text as the display text', () => {
       const wrapper = mount(<HostDetailsLink hostName={hostName}>{hostName}</HostDetailsLink>);
-      expect(wrapper.find('EuiLink').prop('href')).toEqual(`/${encodeURIComponent(hostName)}`);
+      expect(wrapper.find('EuiLink').prop('href')).toEqual(`/name/${encodeURIComponent(hostName)}`);
       expect(wrapper.text()).toEqual(hostName);
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/ml/conditional_links/ml_host_conditional_container.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml/conditional_links/ml_host_conditional_container.tsx
@@ -88,7 +88,9 @@ export const MlHostConditionalContainer = React.memo(() => {
             });
 
             return (
-              <Redirect to={`${HOSTS_PATH}/${hostName}/${HostsTableType.anomalies}?${reEncoded}`} />
+              <Redirect
+                to={`${HOSTS_PATH}/name/${hostName}/${HostsTableType.anomalies}?${reEncoded}`}
+              />
             );
           }
         }}

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -240,7 +240,7 @@ describe('Navigation Breadcrumbs', () => {
           hostsBreadcrumbs,
           {
             text: 'siem-kibana',
-            href: 'securitySolutionUI/hosts/siem-kibana',
+            href: 'securitySolutionUI/hosts/name/siem-kibana',
           },
           { text: 'Authentications', href: '' },
         ]);
@@ -458,7 +458,7 @@ describe('Navigation Breadcrumbs', () => {
           }),
           expect.objectContaining({
             text: 'siem-kibana',
-            href: 'securitySolutionUI/hosts/siem-kibana',
+            href: 'securitySolutionUI/hosts/name/siem-kibana',
             onClick: expect.any(Function),
           }),
           {
@@ -556,7 +556,7 @@ describe('Navigation Breadcrumbs', () => {
           hostsBreadcrumbs,
           {
             text: 'siem-kibana',
-            href: 'securitySolutionUI/hosts/siem-kibana',
+            href: 'securitySolutionUI/hosts/name/siem-kibana',
           },
           { text: 'Authentications', href: '' },
         ]);
@@ -787,7 +787,7 @@ describe('Navigation Breadcrumbs', () => {
           }),
           expect.objectContaining({
             text: 'siem-kibana',
-            href: 'securitySolutionUI/hosts/siem-kibana',
+            href: 'securitySolutionUI/hosts/name/siem-kibana',
             onClick: expect.any(Function),
           }),
           {

--- a/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/index.test.tsx
@@ -89,7 +89,7 @@ describe('Table Navigation', () => {
       `EuiTab[data-test-subj="navigation-${HostsTableType.authentications}"]`
     );
     expect(firstTab.props().href).toBe(
-      `/app/securitySolutionUI/hosts/siem-window/authentications${SEARCH_QUERY}`
+      `/app/securitySolutionUI/hosts/name/siem-window/authentications${SEARCH_QUERY}`
     );
   });
 

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.test.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.test.tsx
@@ -97,7 +97,7 @@ describe('body', () => {
     test(`it should pass expected object properties to ${componentName}`, () => {
       const wrapper = mount(
         <TestProviders>
-          <MemoryRouter initialEntries={[`/hosts/host-1/${path}`]}>
+          <MemoryRouter initialEntries={[`/hosts/name/host-1/${path}`]}>
             <HostDetailsTabs
               isInitializing={false}
               detailName={'host-1'}

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/nav_tabs.tsx
@@ -12,7 +12,7 @@ import { HostsTableType } from '../../store/model';
 import { HOSTS_PATH } from '../../../../common/constants';
 
 const getTabsOnHostDetailsUrl = (hostName: string, tabName: HostsTableType) =>
-  `${HOSTS_PATH}/${hostName}/${tabName}`;
+  `${HOSTS_PATH}/name/${hostName}/${tabName}`;
 
 export const navTabsHostDetails = ({
   hasMlUserPermissions,

--- a/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
@@ -72,16 +72,16 @@ export const HostsContainer = React.memo(() => (
       )}
     />
     <Route // Compatibility redirect for the old user detail path.
-      path={`${HOSTS_PATH}/:detailName`}
+      path={`${HOSTS_PATH}/:detailName/:tabName?`}
       render={({
         match: {
-          params: { detailName },
+          params: { detailName, tabName = HostsTableType.authentications },
         },
         location: { search = '' },
       }) => (
         <Redirect
           to={{
-            pathname: `${HOSTS_PATH}/name/${detailName}/${HostsTableType.authentications}`,
+            pathname: `${HOSTS_PATH}/name/${detailName}/${tabName}`,
             search,
           }}
         />

--- a/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
@@ -55,7 +55,7 @@ export const HostsContainer = React.memo(() => (
         />
       )}
     />
-    <Route
+    <Route // Redirect to the first tab when tabName is not present.
       path={hostDetailsPagePath}
       render={({
         match: {
@@ -65,14 +65,29 @@ export const HostsContainer = React.memo(() => (
       }) => (
         <Redirect
           to={{
-            pathname: `${HOSTS_PATH}/${detailName}/${HostsTableType.authentications}`,
+            pathname: `${HOSTS_PATH}/name/${detailName}/${HostsTableType.authentications}`,
             search,
           }}
         />
       )}
     />
-
-    <Route
+    <Route // Compatibility redirect for the old user detail path.
+      path={`${HOSTS_PATH}/:detailName`}
+      render={({
+        match: {
+          params: { detailName },
+        },
+        location: { search = '' },
+      }) => (
+        <Redirect
+          to={{
+            pathname: `${HOSTS_PATH}/name/${detailName}/${HostsTableType.authentications}`,
+            search,
+          }}
+        />
+      )}
+    />
+    <Route // Redirect to the first tab when tabName is not present.
       path={HOSTS_PATH}
       render={({ location: { search = '' } }) => (
         <Redirect to={{ pathname: `${HOSTS_PATH}/${HostsTableType.hosts}`, search }} />

--- a/x-pack/plugins/security_solution/public/hosts/pages/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/types.ts
@@ -13,7 +13,7 @@ import type { GlobalTimeArgs } from '../../common/containers/use_global_time';
 import type { InputsModelId } from '../../common/store/inputs/constants';
 import { HOSTS_PATH } from '../../../common/constants';
 
-export const hostDetailsPagePath = `${HOSTS_PATH}/:detailName`;
+export const hostDetailsPagePath = `${HOSTS_PATH}/name/:detailName`;
 
 export type HostsTabsProps = GlobalTimeArgs & {
   filterQuery: string;

--- a/x-pack/plugins/security_solution/public/timelines/components/field_renderers/__snapshots__/field_renderers.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/field_renderers/__snapshots__/field_renderers.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`Field Renderers #hostIdRenderer it renders correctly against snapshot 1
                 <a
                   class="euiLink emotion-euiLink-primary"
                   data-test-subj="host-details-button"
-                  href="securitySolutionUI/hosts/raspberrypi"
+                  href="securitySolutionUI/hosts/name/raspberrypi"
                   rel="noreferrer"
                 >
                   raspberrypi
@@ -201,7 +201,7 @@ exports[`Field Renderers #hostNameRenderer it renders correctly against snapshot
                 <a
                   class="euiLink emotion-euiLink-primary"
                   data-test-subj="host-details-button"
-                  href="securitySolutionUI/hosts/raspberrypi"
+                  href="securitySolutionUI/hosts/name/raspberrypi"
                   rel="noreferrer"
                 >
                   raspberrypi

--- a/x-pack/plugins/security_solution/public/users/pages/constants.ts
+++ b/x-pack/plugins/security_solution/public/users/pages/constants.ts
@@ -8,7 +8,7 @@
 import { USERS_PATH } from '../../../common/constants';
 import { UsersTableType } from '../store/model';
 
-export const usersDetailsPagePath = `${USERS_PATH}/:detailName`;
+export const usersDetailsPagePath = `${USERS_PATH}/name/:detailName`;
 
 export const usersTabPath = `${USERS_PATH}/:tabName(${UsersTableType.allUsers}|${UsersTableType.authentications}|${UsersTableType.anomalies}|${UsersTableType.risk}|${UsersTableType.events}|)`;
 

--- a/x-pack/plugins/security_solution/public/users/pages/details/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/details/nav_tabs.tsx
@@ -12,7 +12,7 @@ import { UsersTableType } from '../../store/model';
 import { USERS_PATH } from '../../../../common/constants';
 
 const getTabsOnUsersDetailsUrl = (userName: string, tabName: UsersTableType) =>
-  `${USERS_PATH}/${userName}/${tabName}`;
+  `${USERS_PATH}/name/${userName}/${tabName}`;
 
 export const navTabsUsersDetails = (
   userName: string,

--- a/x-pack/plugins/security_solution/public/users/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/index.tsx
@@ -34,7 +34,7 @@ export const UsersContainer = React.memo(() => {
           />
         )}
       />
-      <Route
+      <Route // Redirect to the first tab when tabName is not present.
         path={usersDetailsPagePath}
         render={({
           match: {
@@ -44,13 +44,30 @@ export const UsersContainer = React.memo(() => {
         }) => (
           <Redirect
             to={{
-              pathname: `${USERS_PATH}/${detailName}/${UsersTableType.authentications}`,
+              pathname: `${USERS_PATH}/name/${detailName}/${UsersTableType.authentications}`,
               search,
             }}
           />
         )}
       />
-      <Route
+
+      <Route // Compatibility redirect for the old user detail path.
+        path={`${USERS_PATH}/:detailName`}
+        render={({
+          match: {
+            params: { detailName },
+          },
+          location: { search = '' },
+        }) => (
+          <Redirect
+            to={{
+              pathname: `${USERS_PATH}/name/${detailName}/${UsersTableType.authentications}`,
+              search,
+            }}
+          />
+        )}
+      />
+      <Route // Redirect to the first tab when tabName is not present.
         path={USERS_PATH}
         render={({ location: { search = '' } }) => (
           <Redirect to={{ pathname: `${USERS_PATH}/${UsersTableType.allUsers}`, search }} />

--- a/x-pack/plugins/security_solution/public/users/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/index.tsx
@@ -52,16 +52,16 @@ export const UsersContainer = React.memo(() => {
       />
 
       <Route // Compatibility redirect for the old user detail path.
-        path={`${USERS_PATH}/:detailName`}
+        path={`${USERS_PATH}/:detailName/:tabName?`}
         render={({
           match: {
-            params: { detailName },
+            params: { detailName, tabName = UsersTableType.authentications },
           },
           location: { search = '' },
         }) => (
           <Redirect
             to={{
-              pathname: `${USERS_PATH}/name/${detailName}/${UsersTableType.authentications}`,
+              pathname: `${USERS_PATH}/name/${detailName}/${tabName}`,
               search,
             }}
           />


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/132040
## Summary

* Update User details URL from `/users/<username>/<tab>` to `/users/name/<username>/<tab>`
* Update Host details URL from `/hosts/<hostname>/<tab>` to `/hosts/name/<hostname>/<tab>`
* Add compatibility redirect from `/hosts/<hostname>/<tab>?` to `/hosts/name/<hostname>/<tab>`
* Add compatibility redirect from `/users/<username>/<tab>?` to `/users/name/<username>/<tab>`


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->