### PR TITLE
[TIP] change the link from Empty page to the new category

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/hooks/use_integrations_page_link.tsx
+++ b/x-pack/plugins/threat_intelligence/public/hooks/use_integrations_page_link.tsx
@@ -10,4 +10,4 @@ import { useKibana } from './use_kibana';
 const useKibanaBasePath = (): string => useKibana().services.http.basePath.get();
 
 export const useIntegrationsPageLink = () =>
-  `${useKibanaBasePath()}/app/integrations/browse?q=threat%20intelligence`;
+  `${useKibanaBasePath()}/app/integrations/browse/threat_intel`;


### PR DESCRIPTION
## Summary

Updating a link from the Empty Page to Threat Intelligence integrations with the newly created category
