### PR TITLE
[ML] Explain log rate spikes: Fix check for time field based data view.

### DIFF
--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_app_state.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_app_state.tsx
@@ -5,15 +5,18 @@
  * 2.0.
  */
 
-import React, { FC, useCallback, useEffect } from 'react';
-import { Filter, Query } from '@kbn/es-query';
-import { i18n } from '@kbn/i18n';
+import React, { FC, useCallback } from 'react';
 import { parse, stringify } from 'query-string';
 import { isEqual } from 'lodash';
 import { encode } from 'rison-node';
 import { useHistory, useLocation } from 'react-router-dom';
-import { SavedSearch } from '@kbn/discover-plugin/public';
 
+import { EuiCallOut } from '@elastic/eui';
+
+import type { Filter, Query } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+
+import type { SavedSearch } from '@kbn/discover-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 
 import {
@@ -21,7 +24,6 @@ import {
   SearchQueryLanguage,
   SavedSearchSavedObject,
 } from '../../application/utils/search_utils';
-import { useAiOpsKibana } from '../../kibana_context';
 import {
   Accessor,
   Dictionary,
@@ -68,29 +70,8 @@ export const ExplainLogRateSpikesAppState: FC<ExplainLogRateSpikesAppStateProps>
   dataView,
   savedSearch,
 }) => {
-  const { services } = useAiOpsKibana();
-  const { notifications } = services;
-  const { toasts } = notifications;
-
   const history = useHistory();
   const { search: urlSearchString } = useLocation();
-
-  useEffect(() => {
-    if (!dataView.isTimeBased()) {
-      toasts.addWarning({
-        title: i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationTitle', {
-          defaultMessage: 'The data view {dataViewTitle} is not based on a time series',
-          values: { dataViewTitle: dataView.title },
-        }),
-        text: i18n.translate(
-          'xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationDescription',
-          {
-            defaultMessage: 'Log rate spike analysis only runs over time-based indices',
-          }
-        ),
-      });
-    }
-  }, [dataView, toasts]);
 
   const setUrlState: SetUrlState = useCallback(
     (
@@ -155,6 +136,25 @@ export const ExplainLogRateSpikesAppState: FC<ExplainLogRateSpikesAppStateProps>
   );
 
   if (!dataView) return null;
+
+  if (!dataView.isTimeBased()) {
+    return (
+      <EuiCallOut
+        title={i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationTitle', {
+          defaultMessage: 'The data view "{dataViewTitle}" is not based on a time series.',
+          values: { dataViewTitle: dataView.getName() },
+        })}
+        color="danger"
+        iconType="alert"
+      >
+        <p>
+          {i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationDescription', {
+            defaultMessage: 'Log rate spike analysis only runs over time-based indices.',
+          })}
+        </p>
+      </EuiCallOut>
+    );
+  }
 
   return (
     <UrlStateContextProvider value={{ searchString: urlSearchString, setUrlState }}>

--- a/x-pack/plugins/ml/public/application/aiops/explain_log_rate_spikes.tsx
+++ b/x-pack/plugins/ml/public/application/aiops/explain_log_rate_spikes.tsx
@@ -43,9 +43,7 @@ export const ExplainLogRateSpikesPage: FC = () => {
           </EuiFlexItem>
         </EuiFlexGroup>
       </MlPageHeader>
-      {dataView.timeFieldName && (
-        <ExplainLogRateSpikes dataView={dataView} savedSearch={savedSearch} />
-      )}
+      {dataView && <ExplainLogRateSpikes dataView={dataView} savedSearch={savedSearch} />}
       <HelpMenu docLink={docLinks.links.ml.guide} />
     </>
   );


### PR DESCRIPTION
## Summary

Part of #136265.

Fixes the check to allow only data views with time fields for the Explain Log Rate Spikes UI. Previously the check was done on an outer component and didn't reach the component that would display an error message, the user ended up with an empty page. Instead of a non-working UI and an error message in a toast, this now hides the entire UI and just displays an error callout component. As a follow-up, we could investigate if the page the user comes from to select data views could be filtered by the ones which have time fields only. 

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/230104/182238400-42c0d676-739e-448c-a4f8-2339da567ddf.png">

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->