### PR TITLE
[Stack Monitoring] health api: account for ccs in indices regex

### DIFF
--- a/x-pack/plugins/monitoring/server/routes/api/v1/_health/monitored_clusters/build_monitored_clusters.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/_health/monitored_clusters/build_monitored_clusters.ts
@@ -45,10 +45,11 @@ export interface MonitoredClusters {
   [clusterUuid: string]: MonitoredProducts;
 }
 
-const internalMonitoringPattern = /^\.monitoring-(es|kibana|beats|logstash)-7-[0-9]{4}\..*/;
-const metricbeatMonitoring7Pattern = /^\.monitoring-(es|kibana|beats|logstash|ent-search)-7.*-mb.*/;
+const internalMonitoringPattern = /(.*:)?\.monitoring-(es|kibana|beats|logstash)-7-[0-9]{4}\..*/;
+const metricbeatMonitoring7Pattern =
+  /(.*:)?\.monitoring-(es|kibana|beats|logstash|ent-search)-7.*-mb.*/;
 const metricbeatMonitoring8Pattern =
-  /^\.ds-\.monitoring-(es|kibana|beats|logstash|ent-search)-8-mb.*/;
+  /(.*:)?\.ds-\.monitoring-(es|kibana|beats|logstash|ent-search)-8-mb.*/;
 
 const getCollectionMode = (index: string): CollectionMode => {
   if (internalMonitoringPattern.test(index)) return CollectionMode.Internal;


### PR DESCRIPTION
## Summary

The regex would not match a ccs indice like `my_remote_cluster:.ds-.monitoring-beats-8-mb-2022.07.20-000001`
