### PR TITLE
Rename stacktraces fields FrameID->FrameIDs and Type->Types

### DIFF
--- a/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
+++ b/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
@@ -61,49 +61,49 @@ export const stackTraces = new Map([
   [
     stackTraceID.A,
     {
-      FileID: [fileID.A, fileID.B, fileID.C, fileID.D],
-      FrameID: [frameID.A, frameID.A, frameID.A, frameID.B],
-      Type: [3, 3, 3, 3],
+      FileIDs: [fileID.A, fileID.B, fileID.C, fileID.D],
+      FrameIDs: [frameID.A, frameID.A, frameID.A, frameID.B],
+      Types: [3, 3, 3, 3],
     },
   ],
   [
     stackTraceID.B,
     {
-      FileID: [fileID.E, fileID.E, fileID.E, fileID.E, fileID.E],
-      FrameID: [frameID.C, frameID.D, frameID.E, frameID.F, frameID.G],
-      Type: [3, 3, 3, 3, 3],
+      FileIDs: [fileID.E, fileID.E, fileID.E, fileID.E, fileID.E],
+      FrameIDs: [frameID.C, frameID.D, frameID.E, frameID.F, frameID.G],
+      Types: [3, 3, 3, 3, 3],
     },
   ],
   [
     stackTraceID.C,
     {
-      FileID: [fileID.F, fileID.F, fileID.F, fileID.F],
-      FrameID: [frameID.H, frameID.I, frameID.J, frameID.K],
-      Type: [3, 3, 3, 3],
+      FileIDs: [fileID.F, fileID.F, fileID.F, fileID.F],
+      FrameIDs: [frameID.H, frameID.I, frameID.J, frameID.K],
+      Types: [3, 3, 3, 3],
     },
   ],
   [
     stackTraceID.D,
     {
-      FileID: [fileID.G, fileID.H, fileID.I],
-      FrameID: [frameID.L, frameID.M, frameID.N],
-      Type: [3, 8, 8],
+      FileIDs: [fileID.G, fileID.H, fileID.I],
+      FrameIDs: [frameID.L, frameID.M, frameID.N],
+      Types: [3, 8, 8],
     },
   ],
   [
     stackTraceID.E,
     {
-      FileID: [fileID.F, fileID.F, fileID.F],
-      FrameID: [frameID.O, frameID.P, frameID.Q],
-      Type: [3, 3, 3],
+      FileIDs: [fileID.F, fileID.F, fileID.F],
+      FrameIDs: [frameID.O, frameID.P, frameID.Q],
+      Types: [3, 3, 3],
     },
   ],
   [
     stackTraceID.F,
     {
-      FileID: [fileID.E, fileID.E],
-      FrameID: [frameID.R, frameID.S],
-      Type: [3, 3],
+      FileIDs: [fileID.E, fileID.E],
+      FrameIDs: [frameID.R, frameID.S],
+      Types: [3, 3],
     },
   ],
 ]);

--- a/x-pack/plugins/profiling/common/elasticsearch.ts
+++ b/x-pack/plugins/profiling/common/elasticsearch.ts
@@ -17,9 +17,9 @@ export interface ProfilingESEvent {
 }
 
 export interface ProfilingStackTrace {
-  FrameID: string[];
+  FrameIDs: string[];
   LastSeen: number;
-  Type: number;
+  Types: number;
 }
 
 export interface ProfilingStackFrame {

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -42,9 +42,9 @@ export interface StackTraceEvent {
 }
 
 export interface StackTrace {
-  FileID: string[];
-  FrameID: string[];
-  Type: number[];
+  FileIDs: string[];
+  FrameIDs: string[];
+  Types: number[];
 }
 
 export interface StackFrame {
@@ -156,13 +156,13 @@ export function groupStackFrameMetadataByStackTrace(
   const frameMetadataForTraces = new Map<StackTraceID, StackFrameMetadata[]>();
   for (const [stackTraceID, trace] of stackTraces) {
     const frameMetadata = new Array<StackFrameMetadata>();
-    for (let i = 0; i < trace.FrameID.length; i++) {
-      const frame = stackFrames.get(trace.FrameID[i])!;
-      const executable = executables.get(trace.FileID[i])!;
+    for (let i = 0; i < trace.FrameIDs.length; i++) {
+      const frame = stackFrames.get(trace.FrameIDs[i])!;
+      const executable = executables.get(trace.FileIDs[i])!;
 
       const metadata = createStackFrameMetadata({
         FileID: trace.FileID[i],
-        FrameType: trace.Type[i],
+        FrameType: trace.Types[i],
         AddressOrLine: frame.LineNumber,
         FunctionName: frame.FunctionName,
         FunctionOffset: frame.FunctionOffset,

--- a/x-pack/plugins/profiling/server/routes/stacktrace.test.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.test.ts
@@ -43,24 +43,24 @@ describe('Stack trace operations', () => {
     }> = [
       {
         original: {
-          FrameID: frameID.A + frameID.B + frameID.C,
-          Type: runLengthEncodeReverse(frameTypeA).toString('base64url'),
+          FrameIDs: frameID.A + frameID.B + frameID.C,
+          Types: runLengthEncodeReverse(frameTypeA).toString('base64url'),
         } as EncodedStackTrace,
         expected: {
-          FileID: [fileID.C, fileID.B, fileID.A],
-          FrameID: [frameID.C, frameID.B, frameID.A],
-          Type: frameTypeA,
+          FileIDs: [fileID.C, fileID.B, fileID.A],
+          FrameIDs: [frameID.C, frameID.B, frameID.A],
+          Types: frameTypeA,
         } as StackTrace,
       },
       {
         original: {
-          FrameID: frameID.D + frameID.E + frameID.F + frameID.G,
-          Type: runLengthEncodeReverse(frameTypeB).toString('base64url'),
+          FrameIDs: frameID.D + frameID.E + frameID.F + frameID.G,
+          Types: runLengthEncodeReverse(frameTypeB).toString('base64url'),
         } as EncodedStackTrace,
         expected: {
-          FileID: [fileID.F, fileID.F, fileID.E, fileID.D],
-          FrameID: [frameID.G, frameID.F, frameID.E, frameID.D],
-          Type: frameTypeB,
+          FileIDs: [fileID.F, fileID.F, fileID.E, fileID.D],
+          FrameIDs: [frameID.G, frameID.F, frameID.E, frameID.D],
+          Types: frameTypeB,
         } as StackTrace,
       },
     ];


### PR DESCRIPTION
This matches https://github.com/elastic/prodfiler/pull/2475 where we change the names of these fields in order to better reflect their content.

The changes do not touch functionality - it's just renaming ES fields and corresponding struct member variables.