### PR TITLE
[TIP] Prevent IndicatorsTable flash

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
@@ -11,7 +11,10 @@ import { TestProvidersComponent } from '../../common/mocks/test_providers';
 import { IndicatorsPage } from './indicators_page';
 import { useIndicators } from './hooks/use_indicators';
 import { useIndicatorsTotalCount } from './hooks/use_indicators_total_count';
-import { TABLE_TEST_ID as INDICATORS_TABLE_TEST_ID } from './components/indicators_table/indicators_table';
+import {
+  TABLE_TEST_ID as INDICATORS_TABLE_TEST_ID,
+  TABLE_TEST_ID,
+} from './components/indicators_table/indicators_table';
 import { EMPTY_PROMPT_TEST_ID } from '../../components/empty_page';
 import { useIntegrationsPageLink } from '../../hooks/use_integrations_page_link';
 import { useTIDocumentationLink } from '../../hooks/use_documentation_link';
@@ -50,43 +53,77 @@ describe('<IndicatorsPage />', () => {
     });
   });
 
-  it('should render empty page when no indicators are found', async () => {
-    (
-      useIndicatorsTotalCount as jest.MockedFunction<typeof useIndicatorsTotalCount>
-    ).mockReturnValue({
-      count: 0,
-      isLoading: false,
+  describe('checking if the page should be visible (based on indicator count)', () => {
+    describe('when indicator count is being loaded', () => {
+      it('should render nothing at all', () => {
+        (
+          useIndicatorsTotalCount as jest.MockedFunction<typeof useIndicatorsTotalCount>
+        ).mockReturnValue({
+          count: 0,
+          isLoading: true,
+        });
+        (
+          useIntegrationsPageLink as jest.MockedFunction<typeof useIntegrationsPageLink>
+        ).mockReturnValue('');
+        (
+          useTIDocumentationLink as jest.MockedFunction<typeof useTIDocumentationLink>
+        ).mockReturnValue('');
+
+        const { queryByTestId } = render(
+          <TestProvidersComponent>
+            <IndicatorsPage />
+          </TestProvidersComponent>
+        );
+
+        expect(queryByTestId(EMPTY_PROMPT_TEST_ID)).not.toBeInTheDocument();
+        expect(queryByTestId(TABLE_TEST_ID)).not.toBeInTheDocument();
+      });
     });
-    (
-      useIntegrationsPageLink as jest.MockedFunction<typeof useIntegrationsPageLink>
-    ).mockReturnValue('');
-    (useTIDocumentationLink as jest.MockedFunction<typeof useTIDocumentationLink>).mockReturnValue(
-      ''
-    );
 
-    const { queryByTestId } = render(
-      <TestProvidersComponent>
-        <IndicatorsPage />
-      </TestProvidersComponent>
-    );
+    describe('when indicator count is loaded and there are no indicators', () => {
+      it('should render empty page when no indicators are found', async () => {
+        (
+          useIndicatorsTotalCount as jest.MockedFunction<typeof useIndicatorsTotalCount>
+        ).mockReturnValue({
+          count: 0,
+          isLoading: false,
+        });
+        (
+          useIntegrationsPageLink as jest.MockedFunction<typeof useIntegrationsPageLink>
+        ).mockReturnValue('');
+        (
+          useTIDocumentationLink as jest.MockedFunction<typeof useTIDocumentationLink>
+        ).mockReturnValue('');
 
-    expect(queryByTestId(EMPTY_PROMPT_TEST_ID)).toBeInTheDocument();
+        const { queryByTestId } = render(
+          <TestProvidersComponent>
+            <IndicatorsPage />
+          </TestProvidersComponent>
+        );
+
+        expect(queryByTestId(TABLE_TEST_ID)).not.toBeInTheDocument();
+        expect(queryByTestId(EMPTY_PROMPT_TEST_ID)).toBeInTheDocument();
+      });
+    });
   });
 
-  it('should render indicators table when count is being loaded', async () => {
-    (
-      useIndicatorsTotalCount as jest.MockedFunction<typeof useIndicatorsTotalCount>
-    ).mockReturnValue({
-      count: 0,
-      isLoading: true,
+  describe('when loading is done and we have some indicators', () => {
+    it('should render indicators table', async () => {
+      (
+        useIndicatorsTotalCount as jest.MockedFunction<typeof useIndicatorsTotalCount>
+      ).mockReturnValue({
+        count: 7,
+        isLoading: false,
+      });
+
+      const { queryByTestId } = render(
+        <TestProvidersComponent>
+          <IndicatorsPage />
+        </TestProvidersComponent>
+      );
+
+      expect(queryByTestId(INDICATORS_TABLE_TEST_ID)).toBeInTheDocument();
+      expect(queryByTestId(EMPTY_PROMPT_TEST_ID)).not.toBeInTheDocument();
     });
-
-    const { queryByTestId } = render(
-      <TestProvidersComponent>
-        <IndicatorsPage />
-      </TestProvidersComponent>
-    );
-
-    expect(queryByTestId(INDICATORS_TABLE_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
@@ -18,7 +18,6 @@ import QueryBar from './components/query_bar';
 export const IndicatorsPage: VFC = () => {
   const { count: indicatorsTotalCount, isLoading: isIndicatorsTotalCountLoading } =
     useIndicatorsTotalCount();
-  const showEmptyPage = !isIndicatorsTotalCountLoading && indicatorsTotalCount === 0;
 
   const {
     timeRange,
@@ -37,6 +36,15 @@ export const IndicatorsPage: VFC = () => {
     filterQuery,
     timeRange,
   });
+
+  // This prevents indicators table flash when total count is loading.
+  // TODO: Improve this with custom loader component. It would require changes to security solutions' template wrapper - to allow
+  // 'template' overrides.
+  if (isIndicatorsTotalCountLoading) {
+    return null;
+  }
+
+  const showEmptyPage = indicatorsTotalCount === 0;
 
   return showEmptyPage ? (
     <EmptyPage />


### PR DESCRIPTION
## Summary

This fixes visible glitch when ThreatIntelligence plugin is initialized.

Before - you can see the table flash for a sec before we see the landing page message about integrations etc.


[screen-capture (1).webm](https://user-images.githubusercontent.com/11671118/182362775-cbec35e0-37c3-4c79-a0b0-704bfd3278b0.webm)

After:

[screen-capture (2).webm](https://user-images.githubusercontent.com/11671118/182363015-b4b8dbd2-e419-4b08-911e-9132a510eb81.webm)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->