### PR TITLE
[Fleet] updated openapi spec for bulk actions

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1273,6 +1273,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/bulk_upgrade_agents"
+              },
+              "example": {
+                "version": "8.4.0",
+                "source_uri": "https://artifacts.elastic.co/downloads/beats/elastic-agent",
+                "rollout_duration_seconds": 3600,
+                "agents": [
+                  "agent1",
+                  "agent2"
+                ],
+                "start_time": "2022-08-03T14:00:00.000Z"
               }
             }
           }
@@ -1768,6 +1778,10 @@
                   "policy_id",
                   "agents"
                 ]
+              },
+              "example": {
+                "policy_id": "policy_id",
+                "agents": "fleet-agents.policy_id : (\"policy1\" or \"policy2\")"
               }
             }
           }
@@ -1842,6 +1856,14 @@
                 },
                 "required": [
                   "agents"
+                ]
+              },
+              "example": {
+                "revoke": true,
+                "force": false,
+                "agents": [
+                  "agent1",
+                  "agent2"
                 ]
               }
             }
@@ -1924,6 +1946,18 @@
                 },
                 "required": [
                   "agents"
+                ]
+              },
+              "example": {
+                "agents": [
+                  "agent1",
+                  "agent2"
+                ],
+                "tagsToAdd": [
+                  "newTag"
+                ],
+                "tagsToRemove": [
+                  "existingTag"
                 ]
               }
             }
@@ -4247,13 +4281,16 @@
             "description": "version to upgrade to"
           },
           "source_uri": {
-            "type": "string"
+            "type": "string",
+            "description": "alternative upgrade binary download url"
           },
           "rollout_duration_seconds": {
-            "type": "number"
+            "type": "number",
+            "description": "rolling upgrade window duration in seconds"
           },
           "start_time": {
-            "type": "string"
+            "type": "string",
+            "description": "start time of upgrade in ISO 8601 format"
           },
           "agents": {
             "oneOf": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1745,18 +1745,21 @@
                 "type": "object",
                 "properties": {
                   "policy_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "new agent policy id"
                   },
                   "agents": {
                     "oneOf": [
                       {
-                        "type": "string"
+                        "type": "string",
+                        "description": "KQL query string, leave empty to action all agents"
                       },
                       {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "description": "list of agent IDs"
                       }
                     ]
                   }
@@ -1814,21 +1817,25 @@
                 "type": "object",
                 "properties": {
                   "revoke": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Revokes API keys of agents"
                   },
                   "force": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Unenroll hosted agents too"
                   },
                   "agents": {
                     "oneOf": [
                       {
-                        "type": "string"
+                        "type": "string",
+                        "description": "KQL query string, leave empty to action all agents"
                       },
                       {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "description": "list of agent IDs"
                       }
                     ]
                   }
@@ -1888,7 +1895,7 @@
                     "oneOf": [
                       {
                         "type": "string",
-                        "description": "KQL query string, can be empty"
+                        "description": "KQL query string, leave empty to action all agents"
                       },
                       {
                         "type": "array",
@@ -4236,7 +4243,8 @@
         "type": "object",
         "properties": {
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "version to upgrade to"
           },
           "source_uri": {
             "type": "string"
@@ -4250,13 +4258,15 @@
           "agents": {
             "oneOf": [
               {
+                "type": "string",
+                "description": "KQL query string, leave empty to action all agents"
+              },
+              {
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
-              },
-              {
-                "type": "string"
+                },
+                "description": "list of agent IDs"
               }
             ]
           }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1072,12 +1072,15 @@ paths:
               properties:
                 policy_id:
                   type: string
+                  description: new agent policy id
                 agents:
                   oneOf:
                     - type: string
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
+                      description: list of agent IDs
               required:
                 - policy_id
                 - agents
@@ -1112,14 +1115,18 @@ paths:
               properties:
                 revoke:
                   type: boolean
+                  description: Revokes API keys of agents
                 force:
                   type: boolean
+                  description: Unenroll hosted agents too
                 agents:
                   oneOf:
                     - type: string
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
+                      description: list of agent IDs
               required:
                 - agents
   /agents/bulk_update_agent_tags:
@@ -1154,7 +1161,7 @@ paths:
                 agents:
                   oneOf:
                     - type: string
-                      description: KQL query string, can be empty
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
@@ -2666,6 +2673,7 @@ components:
       properties:
         version:
           type: string
+          description: version to upgrade to
         source_uri:
           type: string
         rollout_duration_seconds:
@@ -2674,10 +2682,12 @@ components:
           type: string
         agents:
           oneOf:
+            - type: string
+              description: KQL query string, leave empty to action all agents
             - type: array
               items:
                 type: string
-            - type: string
+              description: list of agent IDs
       required:
         - agents
         - version

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -782,6 +782,14 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bulk_upgrade_agents'
+            example:
+              version: 8.4.0
+              source_uri: https://artifacts.elastic.co/downloads/beats/elastic-agent
+              rollout_duration_seconds: 3600
+              agents:
+                - agent1
+                - agent2
+              start_time: '2022-08-03T14:00:00.000Z'
   /agents/current_upgrades:
     get:
       summary: Agents - Current Bulk Upgrades
@@ -1084,6 +1092,9 @@ paths:
               required:
                 - policy_id
                 - agents
+            example:
+              policy_id: policy_id
+              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
   /agents/bulk_unenroll:
     post:
       summary: Agents - Bulk unenroll
@@ -1129,6 +1140,12 @@ paths:
                       description: list of agent IDs
               required:
                 - agents
+            example:
+              revoke: true
+              force: false
+              agents:
+                - agent1
+                - agent2
   /agents/bulk_update_agent_tags:
     post:
       summary: Agents - Bulk update tags
@@ -1178,6 +1195,14 @@ paths:
                   type: number
               required:
                 - agents
+            example:
+              agents:
+                - agent1
+                - agent2
+              tagsToAdd:
+                - newTag
+              tagsToRemove:
+                - existingTag
   /agents/tags:
     get:
       summary: Agent Tags - List
@@ -2676,10 +2701,13 @@ components:
           description: version to upgrade to
         source_uri:
           type: string
+          description: alternative upgrade binary download url
         rollout_duration_seconds:
           type: number
+          description: rolling upgrade window duration in seconds
         start_time:
           type: string
+          description: start time of upgrade in ISO 8601 format
         agents:
           oneOf:
             - type: string

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   version:
     type: string
+    description: version to upgrade to
   source_uri:
     type: string
   rollout_duration_seconds:
@@ -11,10 +12,12 @@ properties:
     type: string
   agents:
     oneOf:
+      - type: string
+        description: KQL query string, leave empty to action all agents
       - type: array
         items:
           type: string
-      - type: string
+        description: list of agent IDs
 required:
   - agents
   - version

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
@@ -6,10 +6,13 @@ properties:
     description: version to upgrade to
   source_uri:
     type: string
+    description: alternative upgrade binary download url
   rollout_duration_seconds:
     type: number
+    description: rolling upgrade window duration in seconds
   start_time:
     type: string
+    description: start time of upgrade in ISO 8601 format
   agents:
     oneOf:
       - type: string

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
@@ -28,12 +28,15 @@ post:
           properties:
             policy_id:
               type: string
+              description: new agent policy id
             agents:
               oneOf:
                 - type: string
+                  description: KQL query string, leave empty to action all agents
                 - type: array
                   items:
                     type: string
+                  description: list of agent IDs
           required:
             - policy_id
             - agents

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
@@ -40,3 +40,6 @@ post:
           required:
             - policy_id
             - agents
+        example:
+          policy_id: policy_id
+          agents: "fleet-agents.policy_id : (\"policy1\" or \"policy2\")"

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
@@ -42,3 +42,7 @@ post:
                   description: list of agent IDs
           required:
             - agents
+        example:
+          revoke: true
+          force: false
+          agents: [agent1, agent2]

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
@@ -28,13 +28,17 @@ post:
           properties:
             revoke:
               type: boolean
+              description: Revokes API keys of agents
             force:
               type: boolean
+              description: Unenroll hosted agents too
             agents:
               oneOf:
                 - type: string
+                  description: KQL query string, leave empty to action all agents
                 - type: array
                   items:
                     type: string
+                  description: list of agent IDs
           required:
             - agents

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
@@ -46,3 +46,7 @@ post:
               type: number    
           required:
             - agents
+        example:
+          agents: [agent1, agent2]
+          tagsToAdd: [newTag]
+          tagsToRemove: [existingTag]    

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
@@ -29,7 +29,7 @@ post:
             agents:
               oneOf:
                 - type: string
-                  description: KQL query string, can be empty
+                  description: KQL query string, leave empty to action all agents
                 - type: array
                   items:
                     type: string

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_upgrade.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_upgrade.yaml
@@ -32,3 +32,9 @@ post:
       application/json:
         schema:
           $ref: ../components/schemas/bulk_upgrade_agents.yaml
+        example:
+          version: 8.4.0
+          source_uri: https://artifacts.elastic.co/downloads/beats/elastic-agent
+          rollout_duration_seconds: 3600
+          agents: [agent1, agent2]
+          start_time: 2022-08-03T14:00:00.000Z


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/135519

Updated openapi spec to add description for `agents` and other properties of bulk action requests.

See preview here: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/99282d5e0b5b78895f6aee613c4f0974c93e40c7/x-pack/plugins/fleet/common/openapi/bundled.json#/default/bulk-upgrade-agents

EDIT: added example values in latest update:
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/dcff6663269443105c65cae842884bcc629151fd/x-pack/plugins/fleet/common/openapi/bundled.json#/default/bulk-upgrade-agents

<img width="622" alt="image" src="https://user-images.githubusercontent.com/90178898/182404379-990bd9cc-966c-4d37-9c68-9c55152407d5.png">


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->