### PR TITLE
Allow to configure `roundUp` in `date` helper of url drilldown

### DIFF
--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -46,7 +46,8 @@ a|Format dates. Supports relative dates expressions (for example,  "now-15d"). R
 Example:
 
 `{{date event.from “YYYY MM DD”}}` +
-`{{date “now-15”}}`
+`{{date “now-15d”}}` + 
+`{{date “now/d” roundUp=true}}`
 
 |formatNumber
 a|Format numbers. Numbers can be formatted to look like currency, percentages, times or numbers with decimal places, thousands, and abbreviations.

--- a/src/plugins/ui_actions_enhanced/public/drilldowns/url_drilldown/handlebars.ts
+++ b/src/plugins/ui_actions_enhanced/public/drilldowns/url_drilldown/handlebars.ts
@@ -49,12 +49,13 @@ handlebars.registerHelper(
 
 handlebars.registerHelper('date', (...args) => {
   const values = args.slice(0, -1) as [string | Date, string | undefined];
+  const { hash } = args.slice(-1)[0] as Handlebars.HelperOptions;
   // eslint-disable-next-line prefer-const
   let [date, format] = values;
   if (typeof date === 'undefined') throw new Error(`[date]: unknown variable`);
   let momentDate: Moment | undefined;
   if (typeof date === 'string') {
-    momentDate = dateMath.parse(date);
+    momentDate = dateMath.parse(date, { roundUp: hash.roundUp === true });
     if (!momentDate || !momentDate.isValid()) {
       const ts = Number(date);
       if (!Number.isNaN(ts)) {

--- a/src/plugins/ui_actions_enhanced/public/drilldowns/url_drilldown/url_template.test.ts
+++ b/src/plugins/ui_actions_enhanced/public/drilldowns/url_drilldown/url_template.test.ts
@@ -108,6 +108,13 @@ describe('date helper', () => {
     );
   });
 
+  test('can configure roundUp for dateMath', async () => {
+    const url = 'https://elastic.co/from={{date from}}&to={{date to roundUp=true}}';
+    expect(await compile(url, { from: 'now/d', to: 'now/d' })).toMatchInlineSnapshot(
+      `"https://elastic.co/from=2020-08-18T00:00:00.000Z&to=2020-08-18T23:59:59.999Z"`
+    );
+  });
+
   test('can use format', async () => {
     const url = 'https://elastic.co/{{date time "dddd, MMMM Do YYYY, h:mm:ss a"}}';
     expect(await compile(url, { time: 'now' })).toMatchInlineSnapshot(


### PR DESCRIPTION
## Summary

Close https://github.com/elastic/kibana/issues/137883

When Kibana's time range is configured with relative range, e.g.: `today`, `this week` , `last 15 days` we allow to use `date` helper in URL drilldown to convert the relative date to an absolute one. 
The problem is that this helper didn't have an option to round up relative date to an upper bound of the range making it impossible to create a proper template with `from=` `to=` values.  

For example it wasn't possible to properly configure template like this when relative dates are used in Kibana's time range: `start_date={{date context.panel.timeRange.from "YYYY-MM-DDTHH:mm:ssZ"}}&end_date={{date context.panel.timeRange.to "YYYY-MM-DDTHH:mm:ssZ"}}`

Now it is possible with a new `roundUp=true` option: 

`start_date={{date context.panel.timeRange.from "YYYY-MM-DDTHH:mm:ssZ"}}&end_date={{date context.panel.timeRange.to "YYYY-MM-DDTHH:mm:ssZ" roundUp=true}}`


### Release Notes

Url drilldown's `date` helper now allows rounding up relative dates 