### PR TITLE
[Maps] Cancel button when editing by value from dashboard

### DIFF
--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -332,6 +332,14 @@ export class SavedMap {
     return this._originatingApp ? this.getAppNameFromId(this._originatingApp) : undefined;
   }
 
+  public hasOriginatingApp(): boolean {
+    return !!this._originatingApp;
+  }
+
+  public getOriginatingPath(): string | undefined {
+    return this._originatingPath;
+  }
+
   public getAppNameFromId = (appId: string): string | undefined => {
     return this._getStateTransfer().getAppNameFromId(appId);
   };
@@ -341,7 +349,7 @@ export class SavedMap {
   }
 
   public hasSaveAndReturnConfig() {
-    const hasOriginatingApp = !!this._originatingApp;
+    const hasOriginatingApp = this.hasOriginatingApp();
     const isNewMap = !this.getSavedObjectId();
     return getIsAllowByValueEmbeddables() ? hasOriginatingApp : !isNewMap && hasOriginatingApp;
   }

--- a/x-pack/plugins/maps/public/routes/map_page/top_nav_config.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/top_nav_config.tsx
@@ -19,6 +19,7 @@ import {
   withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import {
+  getNavigateToApp,
   getMapsCapabilities,
   getIsAllowByValueEmbeddables,
   getInspector,
@@ -95,6 +96,23 @@ export function getTopNavConfig({
       },
     }
   );
+
+  if (savedMap.hasOriginatingApp()) {
+    topNavConfigs.push({
+      label: i18n.translate('xpack.maps.topNav.cancel', {
+        defaultMessage: 'Cancel',
+      }),
+      run: () => {
+        getNavigateToApp()(savedMap.getOriginatingApp()!, {
+          path: savedMap.getOriginatingPath(),
+        });
+      },
+      testId: 'mapsCancelButton',
+      description: i18n.translate('xpack.maps.topNav.cancelButtonAriaLabel', {
+        defaultMessage: 'Return to the last app without saving changes',
+      }),
+    });
+  }
 
   if (getMapsCapabilities().save) {
     const hasSaveAndReturnConfig = savedMap.hasSaveAndReturnConfig();
@@ -197,7 +215,7 @@ export function getTopNavConfig({
 
         let saveModal;
 
-        if (savedMap.getOriginatingApp() || !getIsAllowByValueEmbeddables()) {
+        if (savedMap.hasOriginatingApp() || !getIsAllowByValueEmbeddables()) {
           saveModal = (
             <SavedObjectSaveModalOrigin
               {...saveModalProps}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/126306

Adds "Cancel" button when editing by-value map.

<img width="600" alt="Screen Shot 2022-08-02 at 9 55 59 AM" src="https://user-images.githubusercontent.com/373691/182418873-7e0739c1-58ed-4e19-a034-2e27643a63bd.png">

To test.
* Install sample data set.
* Create dashboard
* Click "Map icon" to create a by-value map
* Notice "Cancel" button, Clicking button should return you to empty dashboard without map
* Click "Map icon" to create a by-value map
* Add layer to map and click "Save and return"
* In Dashboard, click "Edit map"
* Add new layer in map
* Click "Cancel". You should return to dashboard with no changes to your map panel
