### PR TITLE
[IDM] Assign author: Kibana Core to packages owned by core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -296,7 +296,7 @@
 /packages/kbn-config/ @elastic/kibana-core
 /packages/kbn-logging/ @elastic/kibana-core
 /packages/kbn-logging-mocks/ @elastic/kibana-core
-/packages/kbn-http-tools/ @elastic/kibana-core
+/packages/kbn-server-http-tools/ @elastic/kibana-core
 /packages/kbn-es-errors/ @elastic/kibana-core
 /src/plugins/saved_objects_management/ @elastic/kibana-core
 /src/plugins/advanced_settings/ @elastic/kibana-core

--- a/packages/analytics/client/package.json
+++ b/packages/analytics/client/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/analytics/shippers/elastic_v3/browser/package.json
+++ b/packages/analytics/shippers/elastic_v3/browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/analytics/shippers/elastic_v3/common/package.json
+++ b/packages/analytics/shippers/elastic_v3/common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/analytics/shippers/elastic_v3/server/package.json
+++ b/packages/analytics/shippers/elastic_v3/server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/analytics/shippers/fullstory/package.json
+++ b/packages/analytics/shippers/fullstory/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-browser-internal/package.json
+++ b/packages/core/analytics/core-analytics-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-browser-mocks/package.json
+++ b/packages/core/analytics/core-analytics-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-browser/package.json
+++ b/packages/core/analytics/core-analytics-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-server-internal/package.json
+++ b/packages/core/analytics/core-analytics-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-server-mocks/package.json
+++ b/packages/core/analytics/core-analytics-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/analytics/core-analytics-server/package.json
+++ b/packages/core/analytics/core-analytics-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-browser-internal/package.json
+++ b/packages/core/base/core-base-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-browser-mocks/package.json
+++ b/packages/core/base/core-base-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-common-internal/package.json
+++ b/packages/core/base/core-base-common-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-common/package.json
+++ b/packages/core/base/core-base-common/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-server-internal/package.json
+++ b/packages/core/base/core-base-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/base/core-base-server-mocks/package.json
+++ b/packages/core/base/core-base-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/capabilities/core-capabilities-common/package.json
+++ b/packages/core/capabilities/core-capabilities-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/capabilities/core-capabilities-server-internal/package.json
+++ b/packages/core/capabilities/core-capabilities-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/capabilities/core-capabilities-server-mocks/package.json
+++ b/packages/core/capabilities/core-capabilities-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/capabilities/core-capabilities-server/package.json
+++ b/packages/core/capabilities/core-capabilities-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/config/core-config-server-internal/package.json
+++ b/packages/core/config/core-config-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/deprecations/core-deprecations-browser-internal/package.json
+++ b/packages/core/deprecations/core-deprecations-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/deprecations/core-deprecations-browser-mocks/package.json
+++ b/packages/core/deprecations/core-deprecations-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/deprecations/core-deprecations-browser/package.json
+++ b/packages/core/deprecations/core-deprecations-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/deprecations/core-deprecations-common/package.json
+++ b/packages/core/deprecations/core-deprecations-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-browser-internal/package.json
+++ b/packages/core/doc-links/core-doc-links-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-browser-mocks/package.json
+++ b/packages/core/doc-links/core-doc-links-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-browser/package.json
+++ b/packages/core/doc-links/core-doc-links-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-server-internal/package.json
+++ b/packages/core/doc-links/core-doc-links-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-server-mocks/package.json
+++ b/packages/core/doc-links/core-doc-links-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/doc-links/core-doc-links-server/package.json
+++ b/packages/core/doc-links/core-doc-links-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/package.json
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-mocks/package.json
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/package.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/elasticsearch/core-elasticsearch-server-mocks/package.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/elasticsearch/core-elasticsearch-server/package.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/environment/core-environment-server-internal/package.json
+++ b/packages/core/environment/core-environment-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/environment/core-environment-server-mocks/package.json
+++ b/packages/core/environment/core-environment-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-browser-internal/package.json
+++ b/packages/core/execution-context/core-execution-context-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-browser-mocks/package.json
+++ b/packages/core/execution-context/core-execution-context-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-browser/package.json
+++ b/packages/core/execution-context/core-execution-context-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-common/package.json
+++ b/packages/core/execution-context/core-execution-context-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-server-internal/package.json
+++ b/packages/core/execution-context/core-execution-context-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-server-mocks/package.json
+++ b/packages/core/execution-context/core-execution-context-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/execution-context/core-execution-context-server/package.json
+++ b/packages/core/execution-context/core-execution-context-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/fatal-errors/core-fatal-errors-browser-internal/package.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/fatal-errors/core-fatal-errors-browser-mocks/package.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/fatal-errors/core-fatal-errors-browser/package.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-browser-internal/package.json
+++ b/packages/core/http/core-http-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-browser-mocks/package.json
+++ b/packages/core/http/core-http-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-browser/package.json
+++ b/packages/core/http/core-http-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-common/package.json
+++ b/packages/core/http/core-http-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-context-server-internal/package.json
+++ b/packages/core/http/core-http-context-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-context-server-mocks/package.json
+++ b/packages/core/http/core-http-context-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-router-server-internal/package.json
+++ b/packages/core/http/core-http-router-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-router-server-mocks/package.json
+++ b/packages/core/http/core-http-router-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-server-internal/package.json
+++ b/packages/core/http/core-http-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-server-mocks/package.json
+++ b/packages/core/http/core-http-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/http/core-http-server/package.json
+++ b/packages/core/http/core-http-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/i18n/core-i18n-browser-internal/package.json
+++ b/packages/core/i18n/core-i18n-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/i18n/core-i18n-browser-mocks/package.json
+++ b/packages/core/i18n/core-i18n-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/i18n/core-i18n-browser/package.json
+++ b/packages/core/i18n/core-i18n-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/injected-metadata/core-injected-metadata-browser-internal/package.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/injected-metadata/core-injected-metadata-browser-mocks/package.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/injected-metadata/core-injected-metadata-browser/package.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/injected-metadata/core-injected-metadata-common-internal/package.json
+++ b/packages/core/injected-metadata/core-injected-metadata-common-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/integrations/core-integrations-browser-internal/package.json
+++ b/packages/core/integrations/core-integrations-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/integrations/core-integrations-browser-mocks/package.json
+++ b/packages/core/integrations/core-integrations-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/logging/core-logging-server-internal/package.json
+++ b/packages/core/logging/core-logging-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/logging/core-logging-server-mocks/package.json
+++ b/packages/core/logging/core-logging-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/logging/core-logging-server/package.json
+++ b/packages/core/logging/core-logging-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/metrics/core-metrics-collectors-server-internal/package.json
+++ b/packages/core/metrics/core-metrics-collectors-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/metrics/core-metrics-collectors-server-mocks/package.json
+++ b/packages/core/metrics/core-metrics-collectors-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/metrics/core-metrics-server-internal/package.json
+++ b/packages/core/metrics/core-metrics-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/metrics/core-metrics-server-mocks/package.json
+++ b/packages/core/metrics/core-metrics-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/metrics/core-metrics-server/package.json
+++ b/packages/core/metrics/core-metrics-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/mount-utils/core-mount-utils-browser-internal/package.json
+++ b/packages/core/mount-utils/core-mount-utils-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/mount-utils/core-mount-utils-browser/package.json
+++ b/packages/core/mount-utils/core-mount-utils-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/node/core-node-server-internal/package.json
+++ b/packages/core/node/core-node-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/node/core-node-server-mocks/package.json
+++ b/packages/core/node/core-node-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/node/core-node-server/package.json
+++ b/packages/core/node/core-node-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/notifications/core-notifications-browser-internal/package.json
+++ b/packages/core/notifications/core-notifications-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/notifications/core-notifications-browser-mocks/package.json
+++ b/packages/core/notifications/core-notifications-browser-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/notifications/core-notifications-browser/package.json
+++ b/packages/core/notifications/core-notifications-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/overlays/core-overlays-browser-internal/package.json
+++ b/packages/core/overlays/core-overlays-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/overlays/core-overlays-browser-mocks/package.json
+++ b/packages/core/overlays/core-overlays-browser-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/overlays/core-overlays-browser/package.json
+++ b/packages/core/overlays/core-overlays-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/preboot/core-preboot-server-internal/package.json
+++ b/packages/core/preboot/core-preboot-server-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/preboot/core-preboot-server-mocks/package.json
+++ b/packages/core/preboot/core-preboot-server-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/preboot/core-preboot-server/package.json
+++ b/packages/core/preboot/core-preboot-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/saved-objects/core-saved-objects-api-browser/package.json
+++ b/packages/core/saved-objects/core-saved-objects-api-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/saved-objects/core-saved-objects-api-server/package.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/saved-objects/core-saved-objects-common/package.json
+++ b/packages/core/saved-objects/core-saved-objects-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/saved-objects/core-saved-objects-server/package.json
+++ b/packages/core/saved-objects/core-saved-objects-server/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/test-helpers/core-test-helpers-http-setup-browser/package.json
+++ b/packages/core/test-helpers/core-test-helpers-http-setup-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/theme/core-theme-browser-internal/package.json
+++ b/packages/core/theme/core-theme-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/theme/core-theme-browser-mocks/package.json
+++ b/packages/core/theme/core-theme-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/theme/core-theme-browser/package.json
+++ b/packages/core/theme/core-theme-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/ui-settings/core-ui-settings-browser-internal/package.json
+++ b/packages/core/ui-settings/core-ui-settings-browser-internal/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/ui-settings/core-ui-settings-browser-mocks/package.json
+++ b/packages/core/ui-settings/core-ui-settings-browser-mocks/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/ui-settings/core-ui-settings-browser/package.json
+++ b/packages/core/ui-settings/core-ui-settings-browser/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/core/ui-settings/core-ui-settings-common/package.json
+++ b/packages/core/ui-settings/core-ui-settings-common/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "./target_node/index.js",
   "browser": "./target_web/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/kbn-analytics/package.json
+++ b/packages/kbn-analytics/package.json
@@ -5,6 +5,6 @@
   "description": "Kibana Analytics tool",
   "main": "target_node/index.js",
   "browser": "target_web/index.js",
-  "author": "Ahmad Bamieh <ahmadbamieh@gmail.com>",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/kbn-config-mocks/package.json
+++ b/packages/kbn-config-mocks/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/kbn-config-schema/package.json
+++ b/packages/kbn-config-schema/package.json
@@ -3,5 +3,6 @@
   "main": "./target_node/index.js",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
+  "author": "Kibana Core",
   "private": true
 }

--- a/packages/kbn-config/package.json
+++ b/packages/kbn-config/package.json
@@ -2,6 +2,7 @@
   "name": "@kbn/config",
   "main": "./target_node/index.js",
   "version": "1.0.0",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true
 }

--- a/packages/kbn-docs-utils/src/api_docs/README.md
+++ b/packages/kbn-docs-utils/src/api_docs/README.md
@@ -3,7 +3,7 @@
 [RFC](https://github.com/elastic/kibana/blob/main/legacy_rfcs/text/0014_api_documentation.md))
 
 This is an experimental api documentation system that is managed by the Kibana Tech Leads until
-we determine the value of such a system and what kind of maintenance burder it will incur.
+we determine the value of such a system and what kind of maintenance burden it will incur.
 
 To generate the docs run 
 

--- a/packages/kbn-es-errors/package.json
+++ b/packages/kbn-es-errors/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "main": "./target_node/index.js",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }

--- a/packages/kbn-i18n-react/package.json
+++ b/packages/kbn-i18n-react/package.json
@@ -3,6 +3,7 @@
   "browser": "./target_web/browser.js",
   "main": "./target_node/index.js",
   "version": "1.0.0",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true
 }

--- a/packages/kbn-i18n/package.json
+++ b/packages/kbn-i18n/package.json
@@ -4,5 +4,6 @@
   "main": "./target_node/index.js",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
+  "author": "Kibana Core",
   "private": true
 }

--- a/packages/kbn-logging-mocks/package.json
+++ b/packages/kbn-logging-mocks/package.json
@@ -2,6 +2,7 @@
   "name": "@kbn/logging-mocks",
   "version": "1.0.0",
   "private": true,
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "./target_node/index.js"
 }

--- a/packages/kbn-logging/package.json
+++ b/packages/kbn-logging/package.json
@@ -2,6 +2,7 @@
   "name": "@kbn/logging",
   "version": "1.0.0",
   "private": true,
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "./target_node/index.js"
 }

--- a/packages/kbn-server-http-tools/package.json
+++ b/packages/kbn-server-http-tools/package.json
@@ -2,6 +2,7 @@
   "name": "@kbn/server-http-tools",
   "main": "./target_node/index.js",
   "version": "1.0.0",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true
 }

--- a/packages/kbn-std/package.json
+++ b/packages/kbn-std/package.json
@@ -2,6 +2,7 @@
   "name": "@kbn/std",
   "main": "./target_node/index.js",
   "version": "1.0.0",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true
 }

--- a/packages/kbn-telemetry-tools/package.json
+++ b/packages/kbn-telemetry-tools/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kbn/telemetry-tools",
   "version": "1.0.0",
+  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "./target_node/index.js",
   "private": true,


### PR DESCRIPTION
## Summary

This PR adds `"author": "Kibana Core"` to the `package.json` of the packages owned by core. It is needed by our `api_docs` utils to properly reference all the stats about any counts, uncommented APIs, etc.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
