### PR TITLE
[scalability testing] get ES queries for each single user performance journey

### DIFF
--- a/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+++ b/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
@@ -13,7 +13,7 @@ GCS_BUCKET="gs://kibana-performance/scalability-tests"
 .buildkite/scripts/bootstrap.sh
 
 echo "--- Extract APM metrics"
-scalabilityJourneys=("login" "promotion_tracking_dashboard")
+journeys=("login" "ecommerce_dashboard" "flight_dashboard" "web_logs_dashboard" "promotion_tracking_dashboard" "many_fields_discover")
 
 for i in "${scalabilityJourneys[@]}"; do
     JOURNEY_NAME="${i}"

--- a/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+++ b/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
@@ -13,7 +13,7 @@ GCS_BUCKET="gs://kibana-performance/scalability-tests"
 .buildkite/scripts/bootstrap.sh
 
 echo "--- Extract APM metrics"
-journeys=("login" "ecommerce_dashboard" "flight_dashboard" "web_logs_dashboard" "promotion_tracking_dashboard" "many_fields_discover")
+scalabilityJourneys=("login" "ecommerce_dashboard" "flight_dashboard" "web_logs_dashboard" "promotion_tracking_dashboard" "many_fields_discover")
 
 for i in "${scalabilityJourneys[@]}"; do
     JOURNEY_NAME="${i}"

--- a/packages/kbn-performance-testing-dataset-extractor/src/cli.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/cli.ts
@@ -58,8 +58,9 @@ export async function runExtractor() {
       const scalabilitySetup: ScalabilitySetup = config.get('scalabilitySetup');
 
       if (!scalabilitySetup) {
-        log.error(`'scalabilitySetup' must be defined in config file!`);
-        return;
+        log.warning(
+          `'scalabilitySetup' is not defined in config file, output file for Kibana scalability run won't be generated`
+        );
       }
 
       const env = config.get(`kbnTestServer.env`);

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
@@ -43,22 +43,34 @@ interface Transaction {
   duration: { us: number };
 }
 
-export interface Document {
-  labels: Labels;
-  character: string;
-  quote: string;
-  service: { version: string };
-  parent?: { id: string };
-  processor: string;
-  trace: { id: string };
+interface Document {
   '@timestamp': string;
-  environment: string;
+  labels?: Labels;
+  parent?: { id: string };
+  service: { name: string; environment: string };
+  trace: { id: string };
+  transaction: Transaction;
+}
+
+export interface ESQueryDocument extends Omit<Document, 'transaction'> {
+  transaction: { id: string };
+  span: {
+    id: string;
+    name: string;
+    action: string;
+    duration: { us: number };
+    db?: { statement?: string };
+  };
+}
+
+export interface TransactionDocument extends Omit<Document, 'service'> {
+  service: { name: string; environment: string; version: string };
+  processor: string;
   url: { path: string };
   http: {
     request: Request;
     response: Response;
   };
-  transaction: Transaction;
 }
 
 const addBooleanFilter = (filter: { field: string; value: string }): QueryDslQueryContainer => {
@@ -88,81 +100,92 @@ const addRangeFilter = (range: { startTime: string; endTime: string }): QueryDsl
   };
 };
 
-export function initClient(options: ClientOptions, log: ToolingLog) {
-  const client = new Client({
-    node: options.node,
-    auth: {
-      username: options.username,
-      password: options.password,
-    },
-  });
+export class ESClient {
+  client: Client;
+  log: ToolingLog;
 
-  return {
-    async getKibanaServerTransactions(
-      buildId: string,
-      journeyName: string,
-      range?: { startTime: string; endTime: string }
-    ) {
-      const filters = [
-        { field: 'transaction.type', value: 'request' },
-        { field: 'processor.event', value: 'transaction' },
-        { field: 'labels.testBuildId', value: buildId },
-        { field: 'labels.journeyName', value: journeyName },
-      ];
-      const queryFilters = filters.map((filter) => addBooleanFilter(filter));
-      if (range) {
-        queryFilters.push(addRangeFilter(range));
-      }
-      return await this.getTransactions(queryFilters);
-    },
-    async getFtrTransactions(buildId: string, journeyName: string) {
-      const filters = [
-        { field: 'service.name', value: 'functional test runner' },
-        { field: 'processor.event', value: 'transaction' },
-        { field: 'labels.testBuildId', value: buildId },
-        { field: 'labels.journeyName', value: journeyName },
-        { field: 'labels.performancePhase', value: 'TEST' },
-      ];
-      const queryFilters = filters.map((filter) => addBooleanFilter(filter));
-      return await this.getTransactions(queryFilters);
-    },
+  constructor(options: ClientOptions, log: ToolingLog) {
+    this.client = new Client({
+      node: options.node,
+      auth: {
+        username: options.username,
+        password: options.password,
+      },
+    });
+    this.log = log;
+  }
 
-    async getTransactions(queryFilters: QueryDslQueryContainer[]) {
-      const searchRequest: SearchRequest = {
-        body: {
-          track_total_hits: true,
-          sort: [
-            {
-              '@timestamp': {
-                order: 'asc',
-                unmapped_type: 'boolean',
-              },
-            },
-          ],
-          size: 10000,
-          stored_fields: ['*'],
-          _source: true,
-          query: {
-            bool: {
-              must: [],
-              filter: [
-                {
-                  bool: {
-                    filter: queryFilters,
-                  },
-                },
-              ],
-              should: [],
-              must_not: [],
+  async getTransactions<T>(queryFilters: QueryDslQueryContainer[]) {
+    const searchRequest: SearchRequest = {
+      body: {
+        track_total_hits: true,
+        sort: [
+          {
+            '@timestamp': {
+              order: 'asc',
+              unmapped_type: 'boolean',
             },
           },
+        ],
+        size: 10000,
+        stored_fields: ['*'],
+        _source: true,
+        query: {
+          bool: {
+            must: [],
+            filter: [
+              {
+                bool: {
+                  filter: queryFilters,
+                },
+              },
+            ],
+            should: [],
+            must_not: [],
+          },
         },
-      };
+      },
+    };
 
-      log.debug(`Search request: ${JSON.stringify(searchRequest)}`);
-      const result = await client.search<Document>(searchRequest);
-      log.debug(`Search result: ${JSON.stringify(result)}`);
-      return result?.hits?.hits;
-    },
-  };
+    this.log.debug(`Search request: ${JSON.stringify(searchRequest)}`);
+    const result = await this.client.search<T>(searchRequest);
+    this.log.debug(`Search result: ${JSON.stringify(result)}`);
+    return result?.hits?.hits;
+  }
+
+  async getFtrServiceTransactions(buildId: string, journeyName: string) {
+    const filters = [
+      { field: 'service.name', value: 'functional test runner' },
+      { field: 'processor.event', value: 'transaction' },
+      { field: 'labels.testBuildId', value: buildId },
+      { field: 'labels.journeyName', value: journeyName },
+      { field: 'labels.performancePhase', value: 'TEST' },
+    ];
+    const queryFilters = filters.map((filter) => addBooleanFilter(filter));
+    return await this.getTransactions<TransactionDocument>(queryFilters);
+  }
+
+  async getKibanaServerTransactions(
+    buildId: string,
+    journeyName: string,
+    range?: { startTime: string; endTime: string }
+  ) {
+    const filters = [
+      { field: 'transaction.type', value: 'request' },
+      { field: 'processor.event', value: 'transaction' },
+      { field: 'labels.testBuildId', value: buildId },
+      { field: 'labels.journeyName', value: journeyName },
+    ];
+    const queryFilters = filters.map((filter) => addBooleanFilter(filter));
+    if (range) {
+      queryFilters.push(addRangeFilter(range));
+    }
+    return await this.getTransactions<TransactionDocument>(queryFilters);
+  }
+
+  async getSpans(transactionId: string) {
+    const filters = [{ field: 'parent.id', value: transactionId }];
+    const queryFilters = filters.map((filter) => addBooleanFilter(filter));
+    return await this.getTransactions<ESQueryDocument>(queryFilters);
+  }
 }

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_query.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_query.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ESClient, ESQueryDocument } from './es_client';
+import { KibanaRequest } from './server_request';
+
+const httpMethodRegExp = /(GET|POST|DELETE|HEAD|PUT|OPTIONS)/;
+const httpPathRegExp = /(?<=GET|POST|DELETE|HEAD|PUT|OPTIONS).*/;
+
+interface ESQuery {
+  id: string;
+  transactionId: string;
+  name: string;
+  action: string;
+  request: {
+    method?: string;
+    path?: string;
+    params?: string;
+    body?: JSON;
+  };
+  date: string;
+  duration: number;
+}
+
+interface Stream {
+  startTime: number;
+  endTime: number;
+  queries: ESQuery[];
+}
+
+const strToJSON = (str: string): JSON | undefined => {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return;
+  }
+};
+
+const findFirstMatch = (regExp: RegExp, testString: string) => {
+  const found = regExp.exec(testString);
+  return found ? found[0] : undefined;
+};
+
+const parseQueryStatement = (statement: string): { params?: string; body?: JSON } => {
+  // github.com/elastic/apm-agent-nodejs/blob/5ba1b2609d18b12a64e1e559236717dd38d64a51/lib/instrumentation/elasticsearch-shared.js#L27-L29
+  // Some ES endpoints support both query params and a body, statement string might contain both of it
+  const split = statement.split('\n\n');
+  if (split.length === 2) {
+    return { params: split[0], body: strToJSON(split[1]) };
+  } else {
+    const body = strToJSON(split[0]);
+    return body ? { body } : { params: split[0] };
+  }
+};
+
+export const fetchQueries = async (esClient: ESClient, transactions: KibanaRequest[]) => {
+  const esQueries = new Array<ESQuery>();
+  for (let i = 0; i < transactions.length; i++) {
+    const transactionId = transactions[i].transaction.id;
+    const esHits = await esClient.getSpans(transactionId);
+    const spans = esHits
+      .map((hit) => hit!._source as ESQueryDocument)
+      .map((hit) => {
+        const query = hit?.span.db?.statement ? parseQueryStatement(hit?.span.db?.statement) : {};
+        return {
+          id: hit.span.id,
+          transactionId: hit.transaction.id,
+          name: hit.span.name,
+          action: hit.span?.action,
+          request: {
+            method: findFirstMatch(httpMethodRegExp, hit.span.name),
+            path: findFirstMatch(httpPathRegExp, hit.span.name.replace(/\s+/g, '')),
+            params: query?.params,
+            body: query?.body,
+          },
+          date: hit['@timestamp'],
+          duration: hit.span?.duration?.us,
+        };
+      })
+      // filter out queries without method, path and POST/PUT/DELETE without body
+      .filter(
+        (hit) =>
+          hit &&
+          hit.request?.method &&
+          hit.request?.path &&
+          (hit.request?.method === 'GET' || hit.request?.body)
+      );
+    esQueries.push(...spans);
+  }
+  return esQueries;
+};
+
+export const queriesToStreams = (esQueries: ESQuery[]) => {
+  const sorted = esQueries.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const streams = new Map<string, Stream>();
+
+  for (const query of sorted) {
+    const startTime = new Date(query.date).getTime();
+    const endTime = new Date(query.date).getTime() + query.duration / 1000;
+    // searching if query starts before any existing stream ended
+    const match = Array.from(streams.keys()).filter((key) => {
+      const streamEndTime = streams.get(key)?.endTime;
+      return streamEndTime ? startTime < streamEndTime : false;
+    });
+    const stream = streams.get(match[0]);
+    if (stream) {
+      // adding query to the existing stream
+      stream.queries.push(query);
+      // updating the stream endTime if needed
+      if (endTime > stream.endTime) {
+        stream.endTime = endTime;
+      }
+      // saving updated stream
+      streams.set(match[0], stream);
+    } else {
+      // add a new stream
+      streams.set(query.date, {
+        startTime,
+        endTime,
+        queries: [query],
+      });
+    }
+  }
+
+  const values = Array.from(streams.values());
+  return values.map((stream) => {
+    return {
+      startTime: new Date(stream.startTime).toISOString(),
+      endTime: new Date(stream.endTime).toISOString(),
+      queries: stream.queries,
+    };
+  });
+};

--- a/packages/kbn-performance-testing-dataset-extractor/src/server_request.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/server_request.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { ToolingLog } from '@kbn/tooling-log';
+import { TransactionDocument, Headers } from './es_client';
+
+const staticResourcesRegExp = /\.(css|ico|js|json|jpeg|jpg|gif|png|otf|ttf|woff|woff2)$/;
+
+export interface KibanaRequest {
+  traceId: string;
+  parentId?: string;
+  processor: string;
+  environment: string;
+  request: {
+    timestamp: string;
+    method: string;
+    path: string;
+    headers: { [key: string]: string };
+    body?: string;
+    statusCode: number;
+  };
+  transaction: {
+    id: string;
+    name: string;
+    type: string;
+  };
+}
+
+const parsePayload = (payload: string, traceId: string, log: ToolingLog): string | undefined => {
+  let body;
+  try {
+    body = JSON.parse(payload);
+  } catch (error) {
+    log.error(`Failed to parse payload - trace_id: '${traceId}'`);
+  }
+  return body;
+};
+
+const combineHeaderFieldValues = (headers: Headers): { [key: string]: string } => {
+  return Object.assign(
+    {},
+    ...Object.keys(headers).map((key) => ({ [key]: headers[key].join(', ') }))
+  );
+};
+
+export const getRequests = (
+  hits: Array<SearchHit<TransactionDocument>>,
+  withoutStaticResources: boolean,
+  log: ToolingLog
+): KibanaRequest[] => {
+  const data = hits
+    .map((hit) => hit!._source as TransactionDocument)
+    .map((hit) => {
+      const payload = hit.http.request?.body?.original;
+      return {
+        traceId: hit.trace.id,
+        parentId: hit?.parent?.id,
+        processor: hit.processor,
+        environment: hit.service.environment,
+        request: {
+          timestamp: hit['@timestamp'],
+          method: hit.http.request.method,
+          path: hit.url.path,
+          headers: combineHeaderFieldValues(hit.http.request.headers),
+          body: payload ? JSON.stringify(parsePayload(payload, hit.trace.id, log)) : undefined,
+          statusCode: hit.http.response.status_code,
+        },
+        transaction: {
+          id: hit.transaction.id,
+          name: hit.transaction.name,
+          type: hit.transaction.type,
+        },
+      };
+    });
+
+  return withoutStaticResources
+    ? data.filter((item) => !staticResourcesRegExp.test(item.request.path))
+    : data;
+};


### PR DESCRIPTION
## Summary

With this PR data extractor fetches and saves ES queries for each journey in json file:
- we will generate json output for all the executed journeys (Kibana scalability json output only when `scalabilitySetup` is defined in config file)
- ES queries are organised in streams, queries within each stream are considered concurrently executed
- for now we are filtering out non-GET queries without body

Known limitations:
- ES Rally to identify if some GET queries might also require body to be executed
- _pit / _async_search and some other requests are using unique identifiers and related values captured by APM (part of request body) won't work. We will need to find a solution, probably implement extra logic in load runner to make it properly work

**How to run:**

Still the same old command
```
node scripts/extract_performance_testing_dataset \
  --config x-pack/test/performance/journeys/login/config.ts \
  --buildId 0181f326-6565-4b69-beca-85e3f16fc213 \
  --es-url "https://kibana-ops-e2e-perf.es.us-central1.gcp.cloud.es.io:9243" \
  --es-username APM_LOGIN \
  --es-password $APM_PASSWORD \
  --without-static-resources
```

Output sample:

```
{
   "journeyName":"login",
   "kibanaVersion":"8.4.0-SNAPSHOT",
   "streams":[
      {
         "startTime":"2022-07-12T16:34:44.626Z",
         "endTime":"2022-07-12T16:34:44.628Z",
         "queries":[
            {
               "id":"6b8921d865e97785",
               "transactionId":"7180b8e4e5892480",
               "name":"Elasticsearch: POST /.kibana_8.4.0/_search",
               "action":"request",
               "request":{
                  "method":"POST",
                  "path":"/.kibana_8.4.0/_search",
                  "params":"rest_total_hits_as_int=true",
                  "body":{
                     "size":1000,
                     "seq_no_primary_term":true,
                     "from":0,
                     "query":{
                        "bool":{
                           "filter":[
                              {
                                 "bool":{
                                    "should":[
                                       {
                                          "bool":{
                                             "must":[
                                                {
                                                   "term":{
                                                      "type":"space"
                                                   }
                                                }
                                             ],
                                             "must_not":[
                                                {
                                                   "exists":{
                                                      "field":"namespace"
                                                   }
                                                },
                                                {
                                                   "exists":{
                                                      "field":"namespaces"
                                                   }
                                                }
                                             ]
                                          }
                                       }
                                    ],
                                    "minimum_should_match":1
                                 }
                              }
                           ]
                        }
                     },
                     "sort":[
                        {
                           "space.name.keyword":{
                              "unmapped_type":"keyword"
                           }
                        }
                     ]
                  }
               },
               "date":"2022-07-12T16:34:44.626Z",
               "duration":2625
            }
         ]
      },
      {
         "startTime":"2022-07-12T16:34:50.658Z",
         "endTime":"2022-07-12T16:34:50.663Z",
         "queries":[
            {
               "id":"1eaee65d8abf33b5",
               "transactionId":"93282a064bcbbaa2",
               "name":"Elasticsearch: GET /_security/_authenticate",
               "action":"request",
               "request":{
                  "method":"GET",
                  "path":"/_security/_authenticate"
               },
               "date":"2022-07-12T16:34:50.658Z",
               "duration":1961
            },
            {
               "id":"3b3088e58a89c660",
               "transactionId":"c0099f9961b4f711",
               "name":"Elasticsearch: GET /_security/_authenticate",
               "action":"request",
               "request":{
                  "method":"GET",
                  "path":"/_security/_authenticate"
               },
               "date":"2022-07-12T16:34:50.659Z",
               "duration":4777
            }
         ]
      }
   ]
}
```

CI [job](https://buildkite.com/elastic/kibana-single-user-performance/builds/2760) to verify the changes