### PR TITLE
[Synthetics UI] Update copy for test now functionality on private locations

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/columns/test_now_col.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/columns/test_now_col.tsx
@@ -82,7 +82,8 @@ export const TEST_NOW_AVAILABLE_LABEL = i18n.translate(
 export const PRIVATE_AVAILABLE_LABEL = i18n.translate(
   'xpack.synthetics.monitorList.testNow.available.private',
   {
-    defaultMessage: 'For now, Test now is disabled for private locations monitors.',
+    defaultMessage:
+      'Test now is currently not available for monitors running on Private Locations.',
   }
 );
 

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/columns/test_now_col.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/monitor_list/columns/test_now_col.tsx
@@ -82,8 +82,7 @@ export const TEST_NOW_AVAILABLE_LABEL = i18n.translate(
 export const PRIVATE_AVAILABLE_LABEL = i18n.translate(
   'xpack.synthetics.monitorList.testNow.available.private',
   {
-    defaultMessage:
-      'Test now is currently not available for monitors running on Private Locations.',
+    defaultMessage: `You can't currently test monitors running on private locations on demand.`,
   }
 );
 


### PR DESCRIPTION
## Summary

Resolves #137898.

Modifies the copy displayed on a tooltip in the application.


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->