### PR TITLE
[8.4] [Synthetics UI] Fix effect dependency issue for monitor enable/disable feature (#137901)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.test.tsx
@@ -52,6 +52,7 @@ describe('<MonitorAsyncError />', () => {
       error: null,
       loading: true,
       loaded: false,
+      monitorUpsertStatuses: {},
       data: {
         absoluteTotal: 6,
         perPage: 5,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_enabled.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_enabled.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiSwitch, EuiSwitchEvent, EuiLoadingSpinner } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FETCH_STATUS } from '@kbn/observability-plugin/public';
 import { useCanEditSynthetics } from '../../../../../../hooks/use_capabilities';
 import { ConfigKey, EncryptedSyntheticsMonitor } from '../../../../../../../common/runtime_types';
@@ -23,15 +23,19 @@ interface Props {
 export const MonitorEnabled = ({ id, monitor, reloadPage, initialLoading }: Props) => {
   const isDisabled = !useCanEditSynthetics();
 
-  const { isEnabled, setIsEnabled, status } = useMonitorEnableHandler({
+  const monitorName = monitor[ConfigKey.NAME];
+  const statusLabels = useMemo(() => {
+    return {
+      failureLabel: labels.getMonitorEnabledUpdateFailureMessage(monitorName),
+      enabledSuccessLabel: labels.getMonitorEnabledSuccessLabel(monitorName),
+      disabledSuccessLabel: labels.getMonitorDisabledSuccessLabel(monitorName),
+    };
+  }, [monitorName]);
+
+  const { isEnabled, updateMonitorEnabledState, status } = useMonitorEnableHandler({
     id,
-    monitor,
     reloadPage,
-    labels: {
-      failureLabel: labels.getMonitorEnabledUpdateFailureMessage(monitor[ConfigKey.NAME]),
-      enabledSuccessLabel: labels.getMonitorEnabledSuccessLabel(monitor[ConfigKey.NAME]),
-      disabledSuccessLabel: labels.getMonitorDisabledSuccessLabel(monitor[ConfigKey.NAME]),
-    },
+    labels: statusLabels,
   });
 
   const enabled = isEnabled ?? monitor[ConfigKey.ENABLED];
@@ -39,7 +43,7 @@ export const MonitorEnabled = ({ id, monitor, reloadPage, initialLoading }: Prop
 
   const handleEnabledChange = (event: EuiSwitchEvent) => {
     const checked = event.target.checked;
-    setIsEnabled(checked);
+    updateMonitorEnabledState(monitor, checked);
   };
 
   return (

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_enable_handler.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_enable_handler.tsx
@@ -6,10 +6,15 @@
  */
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { FETCH_STATUS, useFetcher } from '@kbn/observability-plugin/public';
-import React, { useEffect, useState } from 'react';
+import { FETCH_STATUS } from '@kbn/observability-plugin/public';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { ConfigKey, EncryptedSyntheticsMonitor } from '../components/monitors_page/overview/types';
-import { fetchUpsertMonitor } from '../state';
+import {
+  clearMonitorUpsertStatus,
+  fetchUpsertMonitorAction,
+  selectMonitorUpsertStatuses,
+} from '../state';
 
 export interface EnableStateMonitorLabels {
   failureLabel: string;
@@ -19,41 +24,63 @@ export interface EnableStateMonitorLabels {
 
 export function useMonitorEnableHandler({
   id,
-  monitor,
   reloadPage,
   labels,
 }: {
   id: string;
-  monitor: EncryptedSyntheticsMonitor;
   reloadPage: () => void;
   labels?: EnableStateMonitorLabels;
 }) {
+  const dispatch = useDispatch();
+  const upsertStatuses = useSelector(selectMonitorUpsertStatuses);
+  const status = upsertStatuses[id]?.status;
+  const savedObjEnabledState = upsertStatuses[id]?.enabled;
   const [isEnabled, setIsEnabled] = useState<boolean | null>(null);
-  const { status } = useFetcher(() => {
-    if (isEnabled !== null) {
-      return fetchUpsertMonitor({ id, monitor: { ...monitor, [ConfigKey.ENABLED]: isEnabled } });
-    }
-  }, [isEnabled]);
+  const updateMonitorEnabledState = useCallback(
+    (monitor: EncryptedSyntheticsMonitor, enabled: boolean) => {
+      dispatch(
+        fetchUpsertMonitorAction({
+          id,
+          monitor: { ...monitor, [ConfigKey.ENABLED]: enabled },
+        })
+      );
+    },
+    [dispatch, id]
+  );
+
   const { notifications } = useKibana();
+
   useEffect(() => {
-    if (status === FETCH_STATUS.FAILURE && labels) {
+    if (status === FETCH_STATUS.SUCCESS && labels) {
+      notifications.toasts.success({
+        title: (
+          <p data-test-subj="uptimeMonitorEnabledUpdateSuccess">
+            {savedObjEnabledState ? labels.enabledSuccessLabel : labels.disabledSuccessLabel}
+          </p>
+        ),
+        toastLifeTimeMs: 3000,
+      });
+      setIsEnabled(!!savedObjEnabledState);
+      dispatch(clearMonitorUpsertStatus(id));
+      reloadPage();
+    } else if (status === FETCH_STATUS.FAILURE && labels) {
       notifications.toasts.danger({
         title: <p data-test-subj="uptimeMonitorEnabledUpdateFailure">{labels.failureLabel}</p>,
         toastLifeTimeMs: 3000,
       });
       setIsEnabled(null);
-    } else if (status === FETCH_STATUS.SUCCESS && labels) {
-      notifications.toasts.success({
-        title: (
-          <p data-test-subj="uptimeMonitorEnabledUpdateSuccess">
-            {isEnabled ? labels.enabledSuccessLabel : labels.disabledSuccessLabel}
-          </p>
-        ),
-        toastLifeTimeMs: 3000,
-      });
-      reloadPage();
+      dispatch(clearMonitorUpsertStatus(id));
     }
-  }, [status, labels]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    status,
+    labels,
+    notifications.toasts,
+    isEnabled,
+    dispatch,
+    id,
+    reloadPage,
+    savedObjEnabledState,
+  ]);
 
-  return { isEnabled, setIsEnabled, status };
+  return { isEnabled, setIsEnabled, updateMonitorEnabledState, status };
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/actions.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { MonitorManagementListResult } from '../../../../../common/runtime_types';
+import { IHttpFetchError } from '@kbn/core-http-browser';
+import { createAction } from '@reduxjs/toolkit';
+import {
+  EncryptedSyntheticsMonitor,
+  MonitorManagementListResult,
+} from '../../../../../common/runtime_types';
 import { createAsyncAction } from '../utils/actions';
 
 import { MonitorListPageState } from './models';
@@ -14,3 +19,17 @@ export const fetchMonitorListAction = createAsyncAction<
   MonitorListPageState,
   MonitorManagementListResult
 >('fetchMonitorListAction');
+
+export interface UpsertMonitorRequest {
+  id: string;
+  monitor: EncryptedSyntheticsMonitor;
+}
+export const fetchUpsertMonitorAction = createAction<UpsertMonitorRequest>('fetchUpsertMonitor');
+export const fetchUpsertSuccessAction = createAction<{
+  id: string;
+  attributes: { enabled: boolean };
+}>('fetchUpsertMonitorSuccess');
+export const fetchUpsertFailureAction = createAction<{ id: string; error: IHttpFetchError }>(
+  'fetchUpsertMonitorFailure'
+);
+export const clearMonitorUpsertStatus = createAction<string>('clearMonitorUpsertStatus');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/effects.ts
@@ -5,10 +5,18 @@
  * 2.0.
  */
 
-import { takeLeading } from 'redux-saga/effects';
+import { IHttpFetchError } from '@kbn/core-http-browser';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { call, put, takeLeading } from 'redux-saga/effects';
 import { fetchEffectFactory } from '../utils/fetch_effect';
-import { fetchMonitorListAction } from './actions';
-import { fetchMonitorManagementList } from './api';
+import {
+  fetchMonitorListAction,
+  fetchUpsertFailureAction,
+  fetchUpsertMonitorAction,
+  fetchUpsertSuccessAction,
+  UpsertMonitorRequest,
+} from './actions';
+import { fetchMonitorManagementList, fetchUpsertMonitor } from './api';
 
 export function* fetchMonitorListEffect() {
   yield takeLeading(
@@ -18,5 +26,23 @@ export function* fetchMonitorListEffect() {
       fetchMonitorListAction.success,
       fetchMonitorListAction.fail
     )
+  );
+}
+
+export function* upsertMonitorEffect() {
+  yield takeLeading(
+    fetchUpsertMonitorAction,
+    function* (action: PayloadAction<UpsertMonitorRequest>): Generator {
+      try {
+        const response = yield call(fetchUpsertMonitor, action.payload);
+        yield put(
+          fetchUpsertSuccessAction(response as { id: string; attributes: { enabled: boolean } })
+        );
+      } catch (error) {
+        yield put(
+          fetchUpsertFailureAction({ id: action.payload.id, error: error as IHttpFetchError })
+        );
+      }
+    }
   );
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/index.ts
@@ -6,16 +6,24 @@
  */
 
 import { createReducer } from '@reduxjs/toolkit';
+import { FETCH_STATUS } from '@kbn/observability-plugin/public';
 
 import { ConfigKey, MonitorManagementListResult } from '../../../../../common/runtime_types';
 
 import { IHttpSerializedFetchError, serializeHttpFetchError } from '../utils/http_error';
 
 import { MonitorListPageState } from './models';
-import { fetchMonitorListAction } from './actions';
+import {
+  clearMonitorUpsertStatus,
+  fetchMonitorListAction,
+  fetchUpsertFailureAction,
+  fetchUpsertMonitorAction,
+  fetchUpsertSuccessAction,
+} from './actions';
 
 export interface MonitorListState {
   data: MonitorManagementListResult;
+  monitorUpsertStatuses: Record<string, { status: FETCH_STATUS; enabled?: boolean }>;
   pageState: MonitorListPageState;
   loading: boolean;
   loaded: boolean;
@@ -24,6 +32,7 @@ export interface MonitorListState {
 
 const initialState: MonitorListState = {
   data: { page: 1, perPage: 10, total: null, monitors: [], syncErrors: [], absoluteTotal: 0 },
+  monitorUpsertStatuses: {},
   pageState: {
     pageIndex: 0,
     pageSize: 10,
@@ -50,6 +59,25 @@ export const monitorListReducer = createReducer(initialState, (builder) => {
     .addCase(fetchMonitorListAction.fail, (state, action) => {
       state.loading = false;
       state.error = serializeHttpFetchError(action.payload);
+    })
+    .addCase(fetchUpsertMonitorAction, (state, action) => {
+      state.monitorUpsertStatuses[action.payload.id] = {
+        status: FETCH_STATUS.LOADING,
+      };
+    })
+    .addCase(fetchUpsertSuccessAction, (state, action) => {
+      state.monitorUpsertStatuses[action.payload.id] = {
+        status: FETCH_STATUS.SUCCESS,
+        enabled: action.payload.attributes.enabled,
+      };
+    })
+    .addCase(fetchUpsertFailureAction, (state, action) => {
+      state.monitorUpsertStatuses[action.payload.id] = { status: FETCH_STATUS.FAILURE };
+    })
+    .addCase(clearMonitorUpsertStatus, (state, action) => {
+      if (state.monitorUpsertStatuses[action.payload]) {
+        delete state.monitorUpsertStatuses[action.payload];
+      }
     });
 });
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/selectors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/selectors.ts
@@ -20,3 +20,5 @@ export const selectEncryptedSyntheticsSavedMonitors = createSelector(
       updated_at: monitor.updated_at,
     })) as EncryptedSyntheticsSavedMonitor[]
 );
+export const selectMonitorUpsertStatuses = (state: SyntheticsAppState) =>
+  state.monitorList.monitorUpsertStatuses;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
@@ -9,7 +9,7 @@ import { all, fork } from 'redux-saga/effects';
 import { fetchMonitorStatusEffect, fetchSyntheticsMonitorEffect } from './monitor_summary';
 import { fetchIndexStatusEffect } from './index_status';
 import { fetchSyntheticsEnablementEffect } from './synthetics_enablement';
-import { fetchMonitorListEffect } from './monitor_list';
+import { fetchMonitorListEffect, upsertMonitorEffect } from './monitor_list';
 import { fetchMonitorOverviewEffect } from './overview';
 import { fetchServiceLocationsEffect } from './service_locations';
 
@@ -17,6 +17,7 @@ export const rootEffect = function* root(): Generator {
   yield all([
     fork(fetchIndexStatusEffect),
     fork(fetchSyntheticsEnablementEffect),
+    fork(upsertMonitorEffect),
     fork(fetchServiceLocationsEffect),
     fork(fetchMonitorListEffect),
     fork(fetchMonitorStatusEffect),

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/syncthetics_store.mock.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/syncthetics_store.mock.ts
@@ -66,6 +66,7 @@ export const mockState: SyntheticsAppState = {
       sortOrder: 'asc',
       sortField: `${ConfigKey.NAME}.keyword`,
     },
+    monitorUpsertStatuses: {},
     data: {
       total: 0,
       monitors: [],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[Synthetics UI] Fix effect dependency issue for monitor enable/disable feature (#137901)](https://github.com/elastic/kibana/pull/137901)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2022-08-02T20:35:59Z","message":"[Synthetics UI] Fix effect dependency issue for monitor enable/disable feature (#137901)\n\n* Migrate synthetics monitor status enabled state update from `useEffect` to dedicated Redux state/saga solution.\r\n\r\n* Fix types.","sha":"2316dc654365206eeeafbd07a0c539f6a5775cc8","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:uptime","release_note:skip","v8.4.0","v8.5.0"],"number":137901,"url":"https://github.com/elastic/kibana/pull/137901","mergeCommit":{"message":"[Synthetics UI] Fix effect dependency issue for monitor enable/disable feature (#137901)\n\n* Migrate synthetics monitor status enabled state update from `useEffect` to dedicated Redux state/saga solution.\r\n\r\n* Fix types.","sha":"2316dc654365206eeeafbd07a0c539f6a5775cc8"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/137901","number":137901,"mergeCommit":{"message":"[Synthetics UI] Fix effect dependency issue for monitor enable/disable feature (#137901)\n\n* Migrate synthetics monitor status enabled state update from `useEffect` to dedicated Redux state/saga solution.\r\n\r\n* Fix types.","sha":"2316dc654365206eeeafbd07a0c539f6a5775cc8"}}]}] BACKPORT-->