### PR TITLE
[Security Solution][Endpoint] Fix Responder page so that it displays correctly when opened on top of full screen content (ex. data grid)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/page/index.tsx
@@ -19,6 +19,23 @@ export const SecuritySolutionAppWrapper = styled.div`
 SecuritySolutionAppWrapper.displayName = 'SecuritySolutionAppWrapper';
 
 /**
+ * Stylesheet for Eui class overrides for components that may be displayed when content
+ * on the page has been set to display in full screen mode. It ensures that certain Eui
+ * components, that position themselves just below the kibana header, are displayed correctly
+ * when shown above content that is set to `full screen`.
+ */
+export const FULL_SCREEN_CONTENT_OVERRIDES_CSS_STYLESHEET = () => css`
+  .euiOverlayMask--belowHeader {
+    top: 0 !important;
+  }
+
+  .euiFlyout {
+    top: 0 !important;
+    height: 100% !important;
+  }
+`;
+
+/**
  * Stylesheet with Eui class overrides in order to address display issues caused when
  * the Timeline overlay is opened. These are normally adjustments to ensure that the
  * z-index of other EUI components continues to work with the z-index used by timeline

--- a/x-pack/plugins/security_solution/public/common/containers/use_full_screen/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/use_full_screen/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { SCROLLING_DISABLED_CLASS_NAME } from '../../../../common/constants';
@@ -75,4 +75,40 @@ export const useTimelineFullScreen = (): TimelineFullScreen => {
     [timelineFullScreen, setTimelineFullScreen]
   );
   return memoizedReturn;
+};
+
+/**
+ * Checks to see if there is a EUI Data Grid in full screen mode in the document tree
+ */
+export const useHasDataGridFullScreen = (): boolean => {
+  const [isDataGridFullScreen, setIsDataGridFullScreen] = useState(false);
+
+  useEffect(() => {
+    const observeTarget = document.body;
+    const docBodyObserver = new MutationObserver((changes) => {
+      for (const change of changes) {
+        if (change.attributeName === 'class') {
+          setIsDataGridFullScreen(observeTarget.classList.contains('euiDataGrid__restrictBody'));
+        }
+      }
+    });
+
+    docBodyObserver.observe(observeTarget, { attributes: true });
+
+    return () => docBodyObserver.disconnect();
+  }, []);
+
+  return isDataGridFullScreen;
+};
+
+/**
+ * Checks to see if any content (ex. timeline, global or data grid) is
+ * currently being displayed in full screen mode
+ */
+export const useHasFullScreenContent = (): boolean => {
+  const { globalFullScreen } = useGlobalFullScreen();
+  const { timelineFullScreen } = useTimelineFullScreen();
+  const dataGridFullScreen = useHasDataGridFullScreen();
+
+  return globalFullScreen || timelineFullScreen || dataGridFullScreen;
 };

--- a/x-pack/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
@@ -66,12 +66,12 @@ const OverlayRootContainer = styled.div`
     padding: ${({ theme: { eui } }) => eui.euiSizeXL};
   }
 
-  .fullHeight {
+  &.fullScreen {
+    top: 0;
     height: 100%;
   }
 
-  &.fullScreen {
-    top: 0;
+  .fullHeight {
     height: 100%;
   }
 `;

--- a/x-pack/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
@@ -13,6 +13,7 @@ import classnames from 'classnames';
 import { useLocation } from 'react-router-dom';
 import type { EuiPortalProps } from '@elastic/eui/src/components/portal/portal';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
+import { useHasFullScreenContent } from '../../../common/containers/use_full_screen';
 import { TIMELINE_OVERRIDES_CSS_STYLESHEET } from '../../../common/components/page';
 import {
   SELECTOR_TIMELINE_IS_VISIBLE_CSS_CLASS_NAME,
@@ -63,6 +64,11 @@ const OverlayRootContainer = styled.div`
   }
 
   .fullHeight {
+    height: 100%;
+  }
+
+  &.fullScreen {
+    top: 0;
     height: 100%;
   }
 `;
@@ -182,6 +188,7 @@ export const PageOverlay = memo<PageOverlayProps>(
   }) => {
     const { pathname } = useLocation();
     const isMounted = useIsMounted();
+    const showInFullScreen = useHasFullScreenContent();
     const [openedOnPathName, setOpenedOnPathName] = useState<null | string>(null);
     const portalEleRef = useRef<Node>();
 
@@ -204,6 +211,7 @@ export const PageOverlay = memo<PageOverlayProps>(
         [PAGE_OVERLAY_CSS_CLASSNAME]: true,
         scrolling: enableScrolling,
         hidden: isHidden,
+        fullScreen: showInFullScreen,
         'eui-scrollBar': enableScrolling,
         'padding-xs': paddingSize === 'xs',
         'padding-s': paddingSize === 's',
@@ -211,7 +219,7 @@ export const PageOverlay = memo<PageOverlayProps>(
         'padding-l': paddingSize === 'l',
         'padding-xl': paddingSize === 'xl',
       });
-    }, [enableScrolling, isHidden, paddingSize]);
+    }, [enableScrolling, isHidden, paddingSize, showInFullScreen]);
 
     // Capture the URL `pathname` that the overlay was opened for
     useEffect(() => {


### PR DESCRIPTION
## Summary

Add support to `<PageOverlay>` component for Full Screen mode:

- Adds 2 more hooks to the `use_full_screen` module that:
    - checks to see if Eui Data grid is being displayed in full screen mode, and
    - checks to see if any "known" content is being displayed in full screen mode (timeline, global full screen, eui data grid)
- Created new re-usable css stylesheet (using styled components) that contains overrides for when there is content in full screen mode. Used currently only with `<PageOverlay/>` component.
- Use new hook in `PageOverlay` component so that its height is adjusted when displayed over content that is being shown in full screen mode



![olm-137569-support-full-screen-mode](https://user-images.githubusercontent.com/56442535/182483268-3e2b5a85-e4a3-4a09-ba90-b24860a19511.gif)



