### PR TITLE
Fix check privileges tests

### DIFF
--- a/x-pack/plugins/security/server/authorization/check_privileges.test.ts
+++ b/x-pack/plugins/security/server/authorization/check_privileges.test.ts
@@ -1401,13 +1401,19 @@ describe('#checkPrivilegesWithRequest.atSpaces', () => {
                 [mockActions.login]: true,
                 [mockActions.version]: true,
                 [`saved_object:${savedObjectTypes[0]}/get`]: false,
+                [`saved_object:${savedObjectTypes[1]}/get`]: true,
+              },
+              'space:space_2': {
+                [mockActions.login]: true,
+                [mockActions.version]: true,
+                [`saved_object:${savedObjectTypes[0]}/get`]: false,
               },
             },
           },
         },
       });
       expect(result).toMatchInlineSnapshot(
-        `[Error: Invalid response received from Elasticsearch has_privilege endpoint. Error: [application.kibana-our_application]: Payload did not match expected resources]`
+        `[Error: Invalid response received from Elasticsearch has_privilege endpoint. Error: [application.kibana-our_application]: Payload did not match expected actions]`
       );
     });
 
@@ -1423,6 +1429,10 @@ describe('#checkPrivilegesWithRequest.atSpaces', () => {
               'space:space_1': {
                 [mockActions.login]: true,
                 [mockActions.version]: true,
+              },
+              'space:space_2': {
+                [mockActions.login]: true,
+                [mockActions.version]: true,
                 [`saved_object:${savedObjectTypes[0]}/get`]: false,
               },
             },
@@ -1430,7 +1440,7 @@ describe('#checkPrivilegesWithRequest.atSpaces', () => {
         },
       });
       expect(result).toMatchInlineSnapshot(
-        `[Error: Invalid response received from Elasticsearch has_privilege endpoint. Error: [application.kibana-our_application]: Payload did not match expected resources]`
+        `[Error: Invalid response received from Elasticsearch has_privilege endpoint. Error: [application.kibana-our_application]: Payload did not match expected actions]`
       );
     });
 

--- a/x-pack/plugins/security/server/authorization/check_privileges.test.ts
+++ b/x-pack/plugins/security/server/authorization/check_privileges.test.ts
@@ -1401,13 +1401,6 @@ describe('#checkPrivilegesWithRequest.atSpaces', () => {
                 [mockActions.login]: true,
                 [mockActions.version]: true,
                 [`saved_object:${savedObjectTypes[0]}/get`]: false,
-                [`saved_object:${savedObjectTypes[1]}/get`]: true,
-              },
-              // @ts-expect-error this is wrong on purpose
-              'space:space_1': {
-                [mockActions.login]: true,
-                [mockActions.version]: true,
-                [`saved_object:${savedObjectTypes[0]}/get`]: false,
               },
             },
           },
@@ -1427,11 +1420,6 @@ describe('#checkPrivilegesWithRequest.atSpaces', () => {
           username: 'foo-username',
           application: {
             [application]: {
-              'space:space_1': {
-                [mockActions.login]: true,
-                [mockActions.version]: true,
-              },
-              // @ts-expect-error this is wrong on purpose
               'space:space_1': {
                 [mockActions.login]: true,
                 [mockActions.version]: true,


### PR DESCRIPTION
If I understand the purpose of the two updated tests correctly, they were actually checking the wrong thing before and accidently succeeding. I've updated them now so they test what I think they should test.

Before this change the two tests just failed on `['space:space_1', 'space:space_2'] != ['space:space_1']`. With this new change, they actually look at the allowed actions and realise that they either have an extra unexpected action, or is missing an action. And then get the expected failure because of that.

<!--ONMERGE {"backportTargets":["7.17","8.3","8.4"]} ONMERGE-->