### PR TITLE
[Unified search] Allows rendering the datepicker without the refresh button

### DIFF
--- a/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
+++ b/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
@@ -430,6 +430,15 @@ storiesOf('SearchBar', module)
       showSubmitButton: false,
     } as SearchBarProps)
   )
+  .add('show only datepicker without submit', () =>
+    wrapSearchBarInContext({
+      showDatePicker: true,
+      showFilterBar: false,
+      showAutoRefreshOnly: false,
+      showQueryInput: false,
+      showSubmitButton: false,
+    } as SearchBarProps)
+  )
   .add('with filter bar on but pinning option is hidden from menus', () =>
     wrapSearchBarInContext({
       showDatePicker: false,

--- a/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
+++ b/src/plugins/unified_search/public/__stories__/search_bar.stories.tsx
@@ -439,6 +439,15 @@ storiesOf('SearchBar', module)
       showSubmitButton: false,
     } as SearchBarProps)
   )
+  .add('show only query bar and timepicker without submit', () =>
+    wrapSearchBarInContext({
+      showDatePicker: true,
+      showFilterBar: false,
+      showAutoRefreshOnly: false,
+      showQueryInput: true,
+      showSubmitButton: false,
+    } as SearchBarProps)
+  )
   .add('with filter bar on but pinning option is hidden from menus', () =>
     wrapSearchBarInContext({
       showDatePicker: false,

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -113,6 +113,7 @@ function wrapQueryBarTopRowInContext(testProps: any) {
 describe('QueryBarTopRowTopRow', () => {
   const QUERY_INPUT_SELECTOR = 'QueryStringInputUI';
   const TIMEPICKER_SELECTOR = 'Memo(EuiSuperDatePicker)';
+  const REFRESH_BUTTON_SELECTOR = 'EuiSuperUpdateButton';
   const TIMEPICKER_DURATION = '[data-shared-timefilter-duration]';
 
   beforeEach(() => {
@@ -192,6 +193,23 @@ describe('QueryBarTopRowTopRow', () => {
     );
 
     expect(component.find(QUERY_INPUT_SELECTOR).length).toBe(0);
+    expect(component.find(TIMEPICKER_SELECTOR).length).toBe(1);
+  });
+
+  it('Should render timepicker without the submit button if showSubmitButton is false', () => {
+    const component = mount(
+      wrapQueryBarTopRowInContext({
+        isDirty: false,
+        screenTitle: 'Another Screen',
+        showDatePicker: true,
+        showSubmitButton: false,
+        dateRangeFrom: 'now-7d',
+        dateRangeTo: 'now',
+        timeHistory: mockTimeHistory,
+      })
+    );
+
+    expect(component.find(REFRESH_BUTTON_SELECTOR).length).toBe(0);
     expect(component.find(TIMEPICKER_SELECTOR).length).toBe(1);
   });
 

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -375,6 +375,9 @@ export const QueryBarTopRow = React.memo(
     }
 
     function renderUpdateButton() {
+      if (!shouldRenderUpdatebutton() && !shouldRenderDatePicker()) {
+        return null;
+      }
       const buttonLabelUpdate = i18n.translate('unifiedSearch.queryBarTopRow.submitButton.update', {
         defaultMessage: 'Needs updating',
       });
@@ -416,6 +419,11 @@ export const QueryBarTopRow = React.memo(
           />
         </EuiFlexItem>
       );
+
+      // allows to render the button without the datepicker
+      if (!shouldRenderDatePicker() && shouldRenderUpdatebutton()) {
+        return button;
+      }
 
       return (
         <EuiFlexItem grow={false}>

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -375,10 +375,6 @@ export const QueryBarTopRow = React.memo(
     }
 
     function renderUpdateButton() {
-      if (!shouldRenderUpdatebutton()) {
-        return null;
-      }
-
       const buttonLabelUpdate = i18n.translate('unifiedSearch.queryBarTopRow.submitButton.update', {
         defaultMessage: 'Needs updating',
       });
@@ -421,16 +417,12 @@ export const QueryBarTopRow = React.memo(
         </EuiFlexItem>
       );
 
-      if (!shouldRenderDatePicker()) {
-        return button;
-      }
-
       return (
         <EuiFlexItem grow={false}>
           <NoDataPopover storage={storage} showNoDataPopover={props.indicateNoData}>
             <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              {renderDatePicker()}
-              {button}
+              {shouldRenderDatePicker() ? renderDatePicker() : null}
+              {shouldRenderUpdatebutton() ? button : null}
             </EuiFlexGroup>
           </NoDataPopover>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/137812

The refresh button was coupled with the datepicker. It was required to show the refresh button if you wanted to have a datepicker. This PR decouples them. Now a user can have something like:

```
wrapSearchBarInContext({
      showDatePicker: true,
      showFilterBar: false,
      showAutoRefreshOnly: false,
      showQueryInput: false,
      showSubmitButton: false,
    } as SearchBarProps)
```
which translates to: I want to have the datepicker without the refresh button.

<img width="1562" alt="image" src="https://user-images.githubusercontent.com/17003240/182567906-96cc8636-1a9e-4208-8553-f5082b6c6cc2.png">

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios