### PR TITLE
[SecuritySolution] Add `rule.name` to global highlighted fields

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
@@ -653,6 +653,12 @@ export const generateAlertDetailsDataMock = () => [
     values: ['dummy.exe'],
     originalValue: ['dummy.exe'],
   },
+  {
+    category: 'rule',
+    field: 'rule.name',
+    values: ['Test Rule Name'],
+    originalValue: ['Test Rule Name'],
+  },
 ];
 
 export const mockAlertDetailsData = generateAlertDetailsDataMock();

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -74,7 +74,7 @@ describe('AlertSummaryView', () => {
         </TestProviders>
       );
 
-      ['host.name', 'user.name', i18n.RULE_TYPE, 'query'].forEach((fieldId) => {
+      ['host.name', 'user.name', i18n.RULE_TYPE, 'query', 'rule.name'].forEach((fieldId) => {
         expect(getByText(fieldId));
       });
     });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -38,6 +38,7 @@ const alwaysDisplayedFields: EventSummaryField[] = [
   { id: 'host.name' },
   { id: 'agent.id', overrideField: AGENT_STATUS_FIELD_NAME, label: i18n.AGENT_STATUS },
   { id: 'user.name' },
+  { id: 'rule.name' },
   { id: ALERT_RULE_TYPE, label: i18n.RULE_TYPE },
 ];
 


### PR DESCRIPTION
This enables quick checks of malware signatures for the new vulnerable driver protection we're shipping in 8.4

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios