### PR TITLE
[Fleet] Generate dynamic template mappings for field with wildcard in name

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/fields/field.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.test.ts
@@ -624,4 +624,50 @@ describe('processFields', () => {
     ];
     expect(processFields(fields)).toEqual(fieldsExpected);
   });
+
+  test('handle wildcard field', () => {
+    const wildcardFields = [
+      {
+        name: 'a.*.b',
+        type: 'keyword',
+      },
+      {
+        name: 'a.b.*',
+        type: 'scaled_float',
+      },
+    ];
+
+    expect(processFields(wildcardFields)).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "a",
+          "type": "group",
+          "fields": [
+            {
+              "name": "*",
+              "type": "group",
+              "fields": [
+                {
+                  "name": "b",
+                  "type": "object",
+                  "object_type": "keyword"
+                }
+              ]
+            },
+            {
+              "name": "b",
+              "type": "group",
+              "fields": [
+                {
+                  "name": "*",
+                  "type": "object",
+                  "object_type": "scaled_float"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    `);
+  });
 });

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -249,7 +249,9 @@ export const getField = (fields: Fields, pathNames: string[]): Field | undefined
 export function processFieldsWithWildcard(fields: Fields): Fields {
   const newFields: Fields = [];
   for (const field of fields) {
-    if (field.name.includes('*') && (field.type !== 'object' || !field.object_type)) {
+    const hasWildcard = field.name.includes('*');
+    const hasNotObjectType = !field.object_type;
+    if (hasWildcard && hasNotObjectType) {
       newFields.push({ ...field, type: 'object', object_type: field.type });
     } else {
       newFields.push({ ...field });

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -246,8 +246,21 @@ export const getField = (fields: Fields, pathNames: string[]): Field | undefined
   return undefined;
 };
 
+export function processFieldsWithWildcard(fields: Fields): Fields {
+  const newFields: Fields = [];
+  for (const field of fields) {
+    if (field.name.includes('*') && (field.type !== 'object' || !field.object_type)) {
+      newFields.push({ ...field, type: 'object', object_type: field.type });
+    } else {
+      newFields.push({ ...field });
+    }
+  }
+  return newFields;
+}
+
 export function processFields(fields: Fields): Fields {
-  const expandedFields = expandFields(fields);
+  const processedFields = processFieldsWithWildcard(fields);
+  const expandedFields = expandFields(processedFields);
   const dedupedFields = dedupFields(expandedFields);
   return validateFields(dedupedFields, dedupedFields);
 }

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -250,8 +250,8 @@ export function processFieldsWithWildcard(fields: Fields): Fields {
   const newFields: Fields = [];
   for (const field of fields) {
     const hasWildcard = field.name.includes('*');
-    const hasNotObjectType = !field.object_type;
-    if (hasWildcard && hasNotObjectType) {
+    const hasObjectType = field.object_type;
+    if (hasWildcard && !hasObjectType) {
       newFields.push({ ...field, type: 'object', object_type: field.type });
     } else {
       newFields.push({ ...field });


### PR DESCRIPTION
## Description

Resolve #129344

Fleet create datastream mappings based on fields yaml provided by the integration, it was decided that the fields that contains a `*` in the name should be installed as dynamic template and not property mappings that PR change that.

If a field name contains a `*` the field will be transformed to be of type `object` with `${object_type:field.type}`, for example the followed field will be transformed like this 
```yaml
- name: test.*.toto
  type: scaled_float
  description: test

# will become
- name: test.*.toto
  type: object
  object_type: scaled_float
  description: test

```

And with the work introduced in https://github.com/elastic/kibana/pull/137772 this will result in dynamic_templates in the final mappings.

@jsoriano Does it make sense to you?

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->