### PR TITLE
[Security Solution][Detections] fixes timeline removal functional test for bulk edit

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/perform_bulk_action.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/perform_bulk_action.ts
@@ -634,8 +634,18 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('should correctly remove timeline', async () => {
+        const timelineId = 'test-id';
+        const timelineTitle = 'Test timeline template';
         const ruleId = 'ruleId';
-        await createRule(supertest, log, getSimpleRule(ruleId));
+        const createdRule = await createRule(supertest, log, {
+          ...getSimpleRule(ruleId),
+          timeline_id: 'test-id',
+          timeline_title: 'Test timeline template',
+        });
+
+        // ensure rule has been created with timeline properties
+        expect(createdRule.timeline_id).to.be(timelineId);
+        expect(createdRule.timeline_title).to.be(timelineTitle);
 
         const { body } = await postBulkAction()
           .send({


### PR DESCRIPTION
## Summary

Improves timeline removal functional test for bulk edit, by setting default timeline properties for rule, that being tested


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->