### PR TITLE
[Enterprise Search] Add missing pagination to documents

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -96,3 +96,5 @@ export const ENTERPRISE_SEARCH_AUDIT_LOGS_SOURCE_ID = 'ent-search-audit-logs';
 export const APP_SEARCH_URL = '/app/enterprise_search/app_search';
 export const ENTERPRISE_SEARCH_ELASTICSEARCH_URL = '/app/enterprise_search/elasticsearch';
 export const WORKPLACE_SEARCH_URL = '/app/enterprise_search/workplace_search';
+
+export const ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT = 25;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_logic.ts
@@ -13,18 +13,20 @@ import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
 import { HttpLogic } from '../../../shared/http';
 
 export const searchDocuments = async ({
+  docsPerPage,
   indexName,
-  meta,
+  pagination,
   query: q,
 }: {
+  docsPerPage?: number;
   indexName: string;
-  meta: Meta;
+  pagination: { pageIndex: number; pageSize: number; totalItemCount: number };
   query: string;
 }) => {
   const route = `/internal/enterprise_search/indices/${indexName}/search/${q}`;
   const query = {
-    page: meta.page.current,
-    size: meta.page.size,
+    page: pagination.pageIndex,
+    size: docsPerPage || pagination.pageSize,
   };
 
   return await HttpLogic.values.http.get<{ meta: Meta; results: SearchResponseBody }>(route, {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_logic.ts
@@ -7,19 +7,29 @@
 
 import { SearchResponseBody } from '@elastic/elasticsearch/lib/api/types';
 
+import { Meta } from '../../../../../common/types';
+
 import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
 import { HttpLogic } from '../../../shared/http';
 
 export const searchDocuments = async ({
   indexName,
-  query,
+  meta,
+  query: q,
 }: {
   indexName: string;
+  meta: Meta;
   query: string;
 }) => {
-  const route = `/internal/enterprise_search/indices/${indexName}/search/${query}`;
+  const route = `/internal/enterprise_search/indices/${indexName}/search/${q}`;
+  const query = {
+    page: meta.page.current,
+    size: meta.page.size,
+  };
 
-  return await HttpLogic.values.http.get<SearchResponseBody>(route);
+  return await HttpLogic.values.http.get<{ meta: Meta; results: SearchResponseBody }>(route, {
+    query,
+  });
 };
 
 export const SearchDocumentsApiLogic = createApiLogic(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues, setMockActions } from '../../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiCallOut, EuiPagination } from '@elastic/eui';
+
+import { Status } from '../../../../../../../common/types/api';
+
+import { Result } from '../../../../../shared/result/result';
+
+import { INDEX_DOCUMENTS_META_DEFAULT } from '../../documents_logic';
+
+import { DocumentList } from './document_list';
+
+const mockActions = {};
+
+export const DEFAULT_VALUES = {
+  data: undefined,
+  indexName: 'indexName',
+  isLoading: true,
+  mappingData: undefined,
+  mappingStatus: 0,
+  meta: INDEX_DOCUMENTS_META_DEFAULT,
+  query: '',
+  results: [],
+  status: Status.IDLE,
+};
+
+const mockValues = { ...DEFAULT_VALUES };
+
+describe('DocumentList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues(mockValues);
+    setMockActions(mockActions);
+  });
+  it('renders empty', () => {
+    const wrapper = shallow(<DocumentList />);
+    expect(wrapper.find(Result)).toHaveLength(0);
+    expect(wrapper.find(EuiPagination)).toHaveLength(2);
+  });
+
+  it('renders documents when results when there is data and mappings', () => {
+    setMockValues({
+      ...mockValues,
+      results: [
+        {
+          _id: 'M9ntXoIBTq5dF-1Xnc8A',
+          _index: 'kibana_sample_data_flights',
+          _score: 1,
+          _source: {
+            AvgTicketPrice: 268.24159591388866,
+          },
+        },
+        {
+          _id: 'NNntXoIBTq5dF-1Xnc8A',
+          _index: 'kibana_sample_data_flights',
+          _score: 1,
+          _source: {
+            AvgTicketPrice: 68.91388866,
+          },
+        },
+      ],
+      simplifiedMapping: {
+        AvgTicketPrice: {
+          type: 'float',
+        },
+      },
+    });
+
+    const wrapper = shallow(<DocumentList />);
+    expect(wrapper.find(Result)).toHaveLength(2);
+  });
+
+  it('renders callout when total results are 10.000', () => {
+    setMockValues({
+      ...mockValues,
+      meta: {
+        page: {
+          ...INDEX_DOCUMENTS_META_DEFAULT.page,
+          total_results: 10000,
+        },
+      },
+    });
+    const wrapper = shallow(<DocumentList />);
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 
-import { useActions } from 'kea';
+import { useActions, useValues } from 'kea';
 
 import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 
@@ -19,7 +19,9 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPagination,
+  EuiProgress,
   EuiPopover,
+  EuiText,
   EuiSpacer,
 } from '@elastic/eui';
 
@@ -38,7 +40,8 @@ interface DocumentListProps {
 }
 
 export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, meta }) => {
-  const { onPaginate } = useActions(DocumentsLogic);
+  const { isLoading } = useValues(DocumentsLogic);
+  const { onPaginate, setDocsPerPage } = useActions(DocumentsLogic);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const resultToField = (result: SearchHit) => {
     if (mappings && result._source && !Array.isArray(result._source)) {
@@ -66,7 +69,10 @@ export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, m
     >
       {i18n.translate(
         'xpack.enterpriseSearch.content.searchIndex.documents.documentList.pagination.itemsPerPage',
-        { defaultMessage: 'Documents per page: {docPerPage}', values: { docPerPage: '50' } }
+        {
+          defaultMessage: 'Documents per page: {docPerPage}',
+          values: { docPerPage: meta.page.size },
+        }
       )}
     </EuiButtonEmpty>
   );
@@ -77,34 +83,43 @@ export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, m
 
   const docsPerPageOptions = [
     <EuiContextMenuItem
-      key="20 rows"
-      icon={getIconType(20)}
-      onClick={() => setIsPopoverOpen(false)}
+      key="10 rows"
+      icon={getIconType(10)}
+      onClick={() => {
+        setIsPopoverOpen(false);
+        setDocsPerPage(10);
+      }}
     >
       {i18n.translate(
         'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
-        { defaultMessage: '{docCount} documents', values: { docCount: 20 } }
+        { defaultMessage: '{docCount} documents', values: { docCount: 10 } }
       )}
     </EuiContextMenuItem>,
 
     <EuiContextMenuItem
+      key="25 rows"
+      icon={getIconType(25)}
+      onClick={() => {
+        setIsPopoverOpen(false);
+        setDocsPerPage(25);
+      }}
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
+        { defaultMessage: '{docCount} documents', values: { docCount: 25 } }
+      )}
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
       key="50 rows"
       icon={getIconType(50)}
-      onClick={() => setIsPopoverOpen(false)}
+      onClick={() => {
+        setIsPopoverOpen(false);
+        setDocsPerPage(50);
+      }}
     >
       {i18n.translate(
         'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
         { defaultMessage: '{docCount} documents', values: { docCount: 50 } }
-      )}
-    </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      key="100 rows"
-      icon={getIconType(100)}
-      onClick={() => setIsPopoverOpen(false)}
-    >
-      {i18n.translate(
-        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
-        { defaultMessage: '{docCount} documents', values: { docCount: 100 } }
       )}
     </EuiContextMenuItem>,
   ];
@@ -120,6 +135,15 @@ export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, m
         activePage={meta.page.current}
         onPageClick={onPaginate}
       />
+      <EuiSpacer size="m" />
+      <EuiText size="xs">
+        <p>
+          Showing <strong>{results.length}</strong> of <strong>{meta.page.total_results}</strong>.
+          Search results maxed at 10.000 documents.
+        </p>
+      </EuiText>
+      {isLoading && <EuiProgress size="xs" color="primary" />}
+      <EuiSpacer size="m" />
       {results.map((result) => {
         return (
           <>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import { useActions } from 'kea';
+
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+
+import {
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPagination,
+  EuiPopover,
+  EuiSpacer,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { Meta } from '../../../../../../../common/types';
+import { Result } from '../../../../../shared/result/result';
+import { DocumentsLogic } from '../../documents_logic';
+
+import type { DocumentsLogicValues } from '../../documents_logic';
+
+interface DocumentListProps {
+  mappings: DocumentsLogicValues['simplifiedMapping'];
+  meta: Meta;
+  results: DocumentsLogicValues['results'];
+}
+
+export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, meta }) => {
+  const { onPaginate } = useActions(DocumentsLogic);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const resultToField = (result: SearchHit) => {
+    if (mappings && result._source && !Array.isArray(result._source)) {
+      if (typeof result._source === 'object') {
+        return Object.entries(result._source).map(([key, value]) => {
+          return {
+            fieldName: key,
+            fieldType: mappings[key]?.type ?? 'object',
+            fieldValue: JSON.stringify(value, null, 2),
+          };
+        });
+      }
+    }
+    return [];
+  };
+
+  const docsPerPageButton = (
+    <EuiButtonEmpty
+      size="s"
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={() => {
+        setIsPopoverOpen(true);
+      }}
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.pagination.itemsPerPage',
+        { defaultMessage: 'Documents per page: {docPerPage}', values: { docPerPage: '50' } }
+      )}
+    </EuiButtonEmpty>
+  );
+
+  const getIconType = (size: number) => {
+    return size === meta.page.size ? 'check' : 'empty';
+  };
+
+  const docsPerPageOptions = [
+    <EuiContextMenuItem
+      key="20 rows"
+      icon={getIconType(20)}
+      onClick={() => setIsPopoverOpen(false)}
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
+        { defaultMessage: '{docCount} documents', values: { docCount: 20 } }
+      )}
+    </EuiContextMenuItem>,
+
+    <EuiContextMenuItem
+      key="50 rows"
+      icon={getIconType(50)}
+      onClick={() => setIsPopoverOpen(false)}
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
+        { defaultMessage: '{docCount} documents', values: { docCount: 50 } }
+      )}
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="100 rows"
+      icon={getIconType(100)}
+      onClick={() => setIsPopoverOpen(false)}
+    >
+      {i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationOptions.option',
+        { defaultMessage: '{docCount} documents', values: { docCount: 100 } }
+      )}
+    </EuiContextMenuItem>,
+  ];
+
+  return (
+    <>
+      <EuiPagination
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationAriaLabel',
+          { defaultMessage: 'Pagination for document list' }
+        )}
+        pageCount={meta.page.total_pages}
+        activePage={meta.page.current}
+        onPageClick={onPaginate}
+      />
+      {results.map((result) => {
+        return (
+          <>
+            <Result
+              fields={resultToField(result)}
+              metaData={{
+                id: result._id,
+              }}
+            />
+            <EuiSpacer size="s" />
+          </>
+        );
+      })}
+
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiPagination
+            aria-label={i18n.translate(
+              'xpack.enterpriseSearch.content.searchIndex.documents.documentList.paginationAriaLabel',
+              { defaultMessage: 'Pagination for document list' }
+            )}
+            pageCount={meta.page.total_pages}
+            activePage={meta.page.current}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            button={docsPerPageButton}
+            isOpen={isPopoverOpen}
+            closePopover={() => {
+              setIsPopoverOpen(false);
+            }}
+            panelPaddingSize="none"
+            anchorPosition="downLeft"
+          >
+            <EuiContextMenuPanel size="s" items={docsPerPageOptions} />
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer />
+      {meta.page.total_results === 10000 && (
+        <EuiCallOut size="s" title="Results are limited to 10.000 documents" iconType="search">
+          <p>
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.searchIndex.documents.documentList.resultLimit',
+              {
+                defaultMessage:
+                  'Only the first 10,000 results are available for paging. Please use the search bar to filter down your results.',
+              }
+            )}
+          </p>
+        </EuiCallOut>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -27,20 +27,11 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { Meta } from '../../../../../../../common/types';
 import { Result } from '../../../../../shared/result/result';
 import { DocumentsLogic } from '../../documents_logic';
 
-import type { DocumentsLogicValues } from '../../documents_logic';
-
-interface DocumentListProps {
-  mappings: DocumentsLogicValues['simplifiedMapping'];
-  meta: Meta;
-  results: DocumentsLogicValues['results'];
-}
-
-export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, meta }) => {
-  const { isLoading } = useValues(DocumentsLogic);
+export const DocumentList: React.FC = () => {
+  const { isLoading, meta, results, simplifiedMapping: mappings } = useValues(DocumentsLogic);
   const { onPaginate, setDocsPerPage } = useActions(DocumentsLogic);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const resultToField = (result: SearchHit) => {
@@ -146,7 +137,7 @@ export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, m
       <EuiSpacer size="m" />
       {results.map((result) => {
         return (
-          <>
+          <React.Fragment key={result._id}>
             <Result
               fields={resultToField(result)}
               metaData={{
@@ -154,7 +145,7 @@ export const DocumentList: React.FC<DocumentListProps> = ({ mappings, results, m
               }}
             />
             <EuiSpacer size="s" />
-          </>
+          </React.Fragment>
         );
       })}
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -171,6 +171,10 @@ export const DocumentList: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPopover
+            aria-label={i18n.translate(
+              'xpack.enterpriseSearch.content.searchIndex.documents.documentList.docsPerPage',
+              { defaultMessage: 'Document count per page dropdown' }
+            )}
             button={docsPerPageButton}
             isOpen={isPopoverOpen}
             closePopover={() => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -28,6 +28,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { Result } from '../../../../../shared/result/result';
+
 import { DocumentsLogic } from '../../documents_logic';
 
 export const DocumentList: React.FC = () => {
@@ -39,6 +40,7 @@ export const DocumentList: React.FC = () => {
     simplifiedMapping: mappings,
   } = useValues(DocumentsLogic);
   const { onPaginate, setDocsPerPage } = useActions(DocumentsLogic);
+
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const resultToField = (result: SearchHit) => {
     if (mappings && result._source && !Array.isArray(result._source)) {
@@ -68,7 +70,7 @@ export const DocumentList: React.FC = () => {
         'xpack.enterpriseSearch.content.searchIndex.documents.documentList.pagination.itemsPerPage',
         {
           defaultMessage: 'Documents per page: {docPerPage}',
-          values: { docPerPage: meta.page.size },
+          values: { docPerPage: docsPerPage },
         }
       )}
     </EuiButtonEmpty>
@@ -164,6 +166,7 @@ export const DocumentList: React.FC = () => {
             )}
             pageCount={meta.page.total_pages}
             activePage={meta.page.current}
+            onPageClick={onPaginate}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/document_list/document_list.tsx
@@ -31,7 +31,13 @@ import { Result } from '../../../../../shared/result/result';
 import { DocumentsLogic } from '../../documents_logic';
 
 export const DocumentList: React.FC = () => {
-  const { isLoading, meta, results, simplifiedMapping: mappings } = useValues(DocumentsLogic);
+  const {
+    docsPerPage,
+    isLoading,
+    meta,
+    results,
+    simplifiedMapping: mappings,
+  } = useValues(DocumentsLogic);
   const { onPaginate, setDocsPerPage } = useActions(DocumentsLogic);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const resultToField = (result: SearchHit) => {
@@ -69,7 +75,7 @@ export const DocumentList: React.FC = () => {
   );
 
   const getIconType = (size: number) => {
-    return size === meta.page.size ? 'check' : 'empty';
+    return size === docsPerPage ? 'check' : 'empty';
   };
 
   const docsPerPageOptions = [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -20,6 +20,8 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { convertMetaToPagination } from '../../../shared/table_pagination';
+
 import { DocumentList } from './components/document_list/document_list';
 import { DocumentsLogic, INDEX_DOCUMENTS_META_DEFAULT } from './documents_logic';
 import { IndexNameLogic } from './index_name_logic';
@@ -32,7 +34,11 @@ export const SearchIndexDocuments: React.FC = () => {
   const { makeRequest, makeMappingRequest, setSearchQuery } = useActions(DocumentsLogic);
 
   useEffect(() => {
-    makeRequest({ indexName, meta: INDEX_DOCUMENTS_META_DEFAULT, query: '' });
+    makeRequest({
+      indexName,
+      pagination: convertMetaToPagination(INDEX_DOCUMENTS_META_DEFAULT),
+      query: '',
+    });
     makeMappingRequest({ indexName });
   }, [indexName]);
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -21,7 +21,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { DocumentList } from './components/document_list/document_list';
-import { DocumentsLogic } from './documents_logic';
+import { DocumentsLogic, INDEX_DOCUMENTS_META_DEFAULT } from './documents_logic';
 import { IndexNameLogic } from './index_name_logic';
 
 import './documents.scss';
@@ -32,12 +32,12 @@ export const SearchIndexDocuments: React.FC = () => {
   const { makeRequest, makeMappingRequest, setSearchQuery } = useActions(DocumentsLogic);
 
   useEffect(() => {
-    makeRequest({ indexName, query: '' });
+    makeRequest({ indexName, meta: INDEX_DOCUMENTS_META_DEFAULT, query: '' });
     makeMappingRequest({ indexName });
   }, [indexName]);
 
   return (
-    <EuiPanel hasBorder={false} hasShadow={false}>
+    <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
       <EuiSpacer />
       <EuiFlexGroup direction="column">
         <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -20,10 +20,9 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { convertMetaToPagination } from '../../../shared/table_pagination';
-
 import { DocumentList } from './components/document_list/document_list';
-import { DocumentsLogic, INDEX_DOCUMENTS_META_DEFAULT } from './documents_logic';
+import { DocumentsLogic, DEFAULT_PAGINATION } from './documents_logic';
+
 import { IndexNameLogic } from './index_name_logic';
 
 import './documents.scss';
@@ -36,7 +35,7 @@ export const SearchIndexDocuments: React.FC = () => {
   useEffect(() => {
     makeRequest({
       indexName,
-      pagination: convertMetaToPagination(INDEX_DOCUMENTS_META_DEFAULT),
+      pagination: DEFAULT_PAGINATION,
       query: '',
     });
     makeMappingRequest({ indexName });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -28,7 +28,7 @@ import './documents.scss';
 
 export const SearchIndexDocuments: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
-  const { simplifiedMapping, results, meta } = useValues(DocumentsLogic);
+  const { simplifiedMapping } = useValues(DocumentsLogic);
   const { makeRequest, makeMappingRequest, setSearchQuery } = useActions(DocumentsLogic);
 
   useEffect(() => {
@@ -73,9 +73,7 @@ export const SearchIndexDocuments: React.FC = () => {
             i18n.translate('xpack.enterpriseSearch.content.searchIndex.documents.noMappings', {
               defaultMessage: 'No mappings found for index',
             })}
-          {simplifiedMapping && (
-            <DocumentList results={results} mappings={simplifiedMapping} meta={meta} />
-          )}
+          {simplifiedMapping && <DocumentList />}
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.test.ts
@@ -10,11 +10,14 @@ import { LogicMounter, mockFlashMessageHelpers } from '../../../__mocks__/kea_lo
 import { nextTick } from '@kbn/test-jest-helpers';
 
 import { HttpError, Status } from '../../../../../common/types/api';
-import { convertMetaToPagination } from '../../../shared/table_pagination';
 import { MappingsApiLogic } from '../../api/mappings/mappings_logic';
 import { SearchDocumentsApiLogic } from '../../api/search_documents/search_documents_logic';
 
-import { DocumentsLogic, INDEX_DOCUMENTS_META_DEFAULT } from './documents_logic';
+import {
+  DocumentsLogic,
+  INDEX_DOCUMENTS_META_DEFAULT,
+  convertMetaToPagination,
+} from './documents_logic';
 import { IndexNameLogic } from './index_name_logic';
 
 export const DEFAULT_VALUES = {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.test.ts
@@ -10,7 +10,7 @@ import { LogicMounter, mockFlashMessageHelpers } from '../../../__mocks__/kea_lo
 import { nextTick } from '@kbn/test-jest-helpers';
 
 import { HttpError, Status } from '../../../../../common/types/api';
-
+import { convertMetaToPagination } from '../../../shared/table_pagination';
 import { MappingsApiLogic } from '../../api/mappings/mappings_logic';
 import { SearchDocumentsApiLogic } from '../../api/search_documents/search_documents_logic';
 
@@ -19,6 +19,7 @@ import { IndexNameLogic } from './index_name_logic';
 
 export const DEFAULT_VALUES = {
   data: undefined,
+  docsPerPage: 25,
   indexName: 'indexName',
   isLoading: true,
   mappingData: undefined,
@@ -65,6 +66,7 @@ describe('DocumentsLogic', () => {
         DocumentsLogic.actions.setDocsPerPage(docsToShow);
         expect(DocumentsLogic.values).toEqual({
           ...DEFAULT_VALUES,
+          docsPerPage: docsToShow,
           meta: {
             page: {
               ...INDEX_DOCUMENTS_META_DEFAULT.page,
@@ -88,8 +90,9 @@ describe('DocumentsLogic', () => {
         jest.advanceTimersByTime(250);
         await nextTick();
         expect(DocumentsLogic.actions.makeRequest).toHaveBeenCalledWith({
+          docsPerPage: 25,
           indexName: 'indexName',
-          meta: INDEX_DOCUMENTS_META_DEFAULT,
+          pagination: convertMetaToPagination(INDEX_DOCUMENTS_META_DEFAULT),
           query: 'test',
         });
         jest.useRealTimers();
@@ -106,7 +109,7 @@ describe('DocumentsLogic', () => {
     it('clears flash messages on new makeRequest', () => {
       DocumentsLogic.actions.makeRequest({
         indexName: 'index',
-        meta: INDEX_DOCUMENTS_META_DEFAULT,
+        pagination: convertMetaToPagination(INDEX_DOCUMENTS_META_DEFAULT),
         query: '',
       });
       expect(mockFlashMessageHelpers.clearFlashMessages).toHaveBeenCalledTimes(1);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
@@ -14,9 +14,12 @@ import {
   SearchHit,
 } from '@elastic/elasticsearch/lib/api/types';
 
+import { Meta } from '../../../../../common/types';
 import { HttpError, Status } from '../../../../../common/types/api';
 
+import { DEFAULT_META } from '../../../shared/constants';
 import { flashAPIErrors, clearFlashMessages } from '../../../shared/flash_messages';
+import { updateMetaPageIndex } from '../../../shared/table_pagination';
 
 import { MappingsApiLogic } from '../../api/mappings/mappings_logic';
 import { SearchDocumentsApiLogic } from '../../api/search_documents/search_documents_logic';
@@ -29,15 +32,17 @@ interface DocumentsLogicActions {
   makeMappingRequest: typeof MappingsApiLogic.actions.makeRequest;
   makeRequest: typeof SearchDocumentsApiLogic.actions.makeRequest;
   mappingsApiError(error: HttpError): HttpError;
+  onPaginate(newPageIndex: number): { newPageIndex: number };
   setSearchQuery(query: string): { query: string };
 }
 
-interface DocumentsLogicValues {
+export interface DocumentsLogicValues {
   data: typeof SearchDocumentsApiLogic.values.data;
   indexName: typeof IndexNameLogic.values.indexName;
   isLoading: boolean;
   mappingData: IndicesGetMappingIndexMappingRecord;
   mappingStatus: Status;
+  meta: Meta;
   query: string;
   results: SearchHit[];
   simplifiedMapping: Record<string, MappingProperty> | undefined;
@@ -46,6 +51,7 @@ interface DocumentsLogicValues {
 
 export const DocumentsLogic = kea<MakeLogicType<DocumentsLogicValues, DocumentsLogicActions>>({
   actions: {
+    onPaginate: (newPageIndex) => ({ newPageIndex }),
     setSearchQuery: (query) => ({ query }),
   },
   connect: {
@@ -75,6 +81,13 @@ export const DocumentsLogic = kea<MakeLogicType<DocumentsLogicValues, DocumentsL
   }),
   path: ['enterprise_search', 'search_index', 'documents'],
   reducers: () => ({
+    meta: [
+      DEFAULT_META,
+      {
+        apiSuccess: (_, { meta }) => meta,
+        onPaginate: (state, { newPageIndex }) => updateMetaPageIndex(state, newPageIndex),
+      },
+    ],
     query: [
       '',
       {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
@@ -14,6 +14,7 @@ import {
   SearchHit,
 } from '@elastic/elasticsearch/lib/api/types';
 
+import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../../../../common/constants';
 import { Meta } from '../../../../../common/types';
 import { HttpError, Status } from '../../../../../common/types/api';
 
@@ -29,7 +30,7 @@ import { IndexNameLogic } from './index_name_logic';
 export const INDEX_DOCUMENTS_META_DEFAULT = {
   page: {
     ...DEFAULT_META.page,
-    size: 25,
+    size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
   },
 };
 
@@ -101,7 +102,7 @@ export const DocumentsLogic = kea<MakeLogicType<DocumentsLogicValues, DocumentsL
       {
         apiSuccess: (_, { meta }) => meta,
         onPaginate: (state, { newPageIndex }) => updateMetaPageIndex(state, newPageIndex),
-        setDocsPerPage: (state, { docsPerPage }) => ({
+        setDocsPerPage: (_, { docsPerPage }) => ({
           page: { ...INDEX_DOCUMENTS_META_DEFAULT.page, size: docsPerPage },
         }),
       },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
@@ -20,7 +20,7 @@ import { HttpError, Status } from '../../../../../common/types/api';
 
 import { DEFAULT_META } from '../../../shared/constants';
 import { flashAPIErrors, clearFlashMessages } from '../../../shared/flash_messages';
-import { updateMetaPageIndex } from '../../../shared/table_pagination';
+import { updateMetaPageIndex, convertMetaToPagination } from '../../../shared/table_pagination';
 
 import { MappingsApiLogic } from '../../api/mappings/mappings_logic';
 import { SearchDocumentsApiLogic } from '../../api/search_documents/search_documents_logic';
@@ -47,6 +47,7 @@ interface DocumentsLogicActions {
 
 export interface DocumentsLogicValues {
   data: typeof SearchDocumentsApiLogic.values.data;
+  docsPerPage: number;
   indexName: typeof IndexNameLogic.values.indexName;
   isLoading: boolean;
   mappingData: IndicesGetMappingIndexMappingRecord;
@@ -85,18 +86,39 @@ export const DocumentsLogic = kea<MakeLogicType<DocumentsLogicValues, DocumentsL
     makeRequest: () => clearFlashMessages(),
     mappingsApiError: (e) => flashAPIErrors(e),
     onPaginate: () => {
-      actions.makeRequest({ indexName: values.indexName, meta: values.meta, query: values.query });
+      actions.makeRequest({
+        docsPerPage: values.docsPerPage,
+        indexName: values.indexName,
+        pagination: convertMetaToPagination(values.meta),
+        query: values.query,
+      });
     },
     setDocsPerPage: () => {
-      actions.makeRequest({ indexName: values.indexName, meta: values.meta, query: values.query });
+      actions.makeRequest({
+        docsPerPage: values.docsPerPage,
+        indexName: values.indexName,
+        pagination: convertMetaToPagination(values.meta),
+        query: values.query,
+      });
     },
     setSearchQuery: async (_, breakpoint) => {
       await breakpoint(250);
-      actions.makeRequest({ indexName: values.indexName, meta: values.meta, query: values.query });
+      actions.makeRequest({
+        docsPerPage: values.docsPerPage,
+        indexName: values.indexName,
+        pagination: convertMetaToPagination(values.meta),
+        query: values.query,
+      });
     },
   }),
   path: ['enterprise_search', 'search_index', 'documents'],
   reducers: () => ({
+    docsPerPage: [
+      ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
+      {
+        setDocsPerPage: (_, { docsPerPage }) => docsPerPage,
+      },
+    ],
     meta: [
       INDEX_DOCUMENTS_META_DEFAULT,
       {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents_logic.ts
@@ -18,9 +18,8 @@ import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../../../../co
 import { Meta } from '../../../../../common/types';
 import { HttpError, Status } from '../../../../../common/types/api';
 
-import { DEFAULT_META } from '../../../shared/constants';
 import { flashAPIErrors, clearFlashMessages } from '../../../shared/flash_messages';
-import { updateMetaPageIndex, convertMetaToPagination } from '../../../shared/table_pagination';
+import { updateMetaPageIndex } from '../../../shared/table_pagination';
 
 import { MappingsApiLogic } from '../../api/mappings/mappings_logic';
 import { SearchDocumentsApiLogic } from '../../api/search_documents/search_documents_logic';
@@ -29,9 +28,17 @@ import { IndexNameLogic } from './index_name_logic';
 
 export const INDEX_DOCUMENTS_META_DEFAULT = {
   page: {
-    ...DEFAULT_META.page,
+    current: 0,
     size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
+    total_pages: 0,
+    total_results: 0,
   },
+};
+
+export const DEFAULT_PAGINATION = {
+  pageIndex: INDEX_DOCUMENTS_META_DEFAULT.page.current,
+  pageSize: INDEX_DOCUMENTS_META_DEFAULT.page.size,
+  totalItemCount: INDEX_DOCUMENTS_META_DEFAULT.page.total_results,
 };
 
 interface DocumentsLogicActions {
@@ -58,6 +65,12 @@ export interface DocumentsLogicValues {
   simplifiedMapping: Record<string, MappingProperty> | undefined;
   status: Status;
 }
+
+export const convertMetaToPagination = (meta: Meta) => ({
+  pageIndex: meta.page.current,
+  pageSize: meta.page.size,
+  totalItemCount: meta.page.total_results,
+});
 
 export const DocumentsLogic = kea<MakeLogicType<DocumentsLogicValues, DocumentsLogicActions>>({
   actions: {

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.test.ts
@@ -8,8 +8,11 @@
 import { SearchResponseBody } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core/server';
 
+import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../common/constants';
+
 import { fetchSearchResults } from './fetch_search_results';
 
+const DEFAULT_FROM_VALUE = 0;
 describe('fetchSearchResults lib function', () => {
   const mockClient = {
     asCurrentUser: {
@@ -82,8 +85,26 @@ describe('fetchSearchResults lib function', () => {
     ).resolves.toEqual(regularSearchResultsResponse);
 
     expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
+      from: DEFAULT_FROM_VALUE,
       index: indexName,
       q: query,
+      size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
+    });
+  });
+
+  it('should return search results with hits when no query is passed', async () => {
+    mockClient.asCurrentUser.search.mockImplementation(
+      () => regularSearchResultsResponse as SearchResponseBody
+    );
+
+    await expect(
+      fetchSearchResults(mockClient as unknown as IScopedClusterClient, indexName)
+    ).resolves.toEqual(regularSearchResultsResponse);
+
+    expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
+      from: DEFAULT_FROM_VALUE,
+      index: indexName,
+      size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
     });
   });
 
@@ -97,8 +118,10 @@ describe('fetchSearchResults lib function', () => {
     ).resolves.toEqual(emptySearchResultsResponse);
 
     expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
+      from: DEFAULT_FROM_VALUE,
       index: indexName,
       q: query,
+      size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
@@ -8,12 +8,14 @@
 import { SearchResponseBody } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core/server';
 
+import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../common/constants';
+
 export const fetchSearchResults = async (
   client: IScopedClusterClient,
   indexName: string,
   query?: string,
   from: number = 0,
-  size: number = 25
+  size: number = ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT
 ): Promise<SearchResponseBody> => {
   const results = await client.asCurrentUser.search({
     from,

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
@@ -11,10 +11,14 @@ import { IScopedClusterClient } from '@kbn/core/server';
 export const fetchSearchResults = async (
   client: IScopedClusterClient,
   indexName: string,
-  query?: string
+  query?: string,
+  from: number = 0,
+  size: number = 25
 ): Promise<SearchResponseBody> => {
   const results = await client.asCurrentUser.search({
+    from,
     index: indexName,
+    size,
     ...(!!query ? { q: query } : {}),
   });
   return results;

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.test.ts
@@ -16,7 +16,7 @@ import { fetchSearchResults } from '../../lib/fetch_search_results';
 
 import { registerSearchRoute } from './search';
 
-describe('Elasticsearch Index Mapping', () => {
+describe('Elasticsearch Search', () => {
   let mockRouter: MockRouter;
   const mockClient = {};
 
@@ -76,10 +76,104 @@ describe('Elasticsearch Index Mapping', () => {
         params: { index_name: 'search-index-name', query: 'banana' },
       });
 
-      expect(fetchSearchResults).toHaveBeenCalledWith(mockClient, 'search-index-name', 'banana');
+      expect(fetchSearchResults).toHaveBeenCalledWith(
+        mockClient,
+        'search-index-name',
+        'banana',
+        0,
+        25
+      );
 
       expect(mockRouter.response.ok).toHaveBeenCalledWith({
-        body: mockData,
+        body: {
+          meta: {
+            page: {
+              current: 0,
+              size: 1,
+              total_pages: 1,
+              total_results: 1,
+            },
+          },
+          results: mockData,
+        },
+
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+  });
+
+  describe('GET /internal/enterprise_search/indices/{index_name}/search', () => {
+    let mockRouterNoQuery: MockRouter;
+    beforeEach(() => {
+      const context = {
+        core: Promise.resolve({ elasticsearch: { client: mockClient } }),
+      } as jest.Mocked<RequestHandlerContext>;
+
+      mockRouterNoQuery = new MockRouter({
+        context,
+        method: 'get',
+        path: '/internal/enterprise_search/indices/{index_name}/search',
+      });
+
+      registerSearchRoute({
+        ...mockDependencies,
+        router: mockRouterNoQuery.router,
+      });
+    });
+    it('fails validation without index_name', () => {
+      const request = { params: {} };
+      mockRouterNoQuery.shouldThrow(request);
+    });
+
+    it('searches returns first 25 search results by default', async () => {
+      const mockData = {
+        _shards: { failed: 0, skipped: 0, successful: 2, total: 2 },
+        hits: {
+          hits: [
+            {
+              _id: '5a12292a0f5ae10021650d7e',
+              _index: 'search-regular-index',
+              _score: 4.437291,
+              _source: { id: '5a12292a0f5ae10021650d7e', name: 'banana' },
+            },
+          ],
+
+          max_score: null,
+          total: { relation: 'eq', value: 1 },
+        },
+        timed_out: false,
+        took: 4,
+      };
+
+      (fetchSearchResults as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve(mockData);
+      });
+
+      await mockRouterNoQuery.callRoute({
+        params: { index_name: 'search-index-name' },
+      });
+
+      expect(fetchSearchResults).toHaveBeenCalledWith(
+        mockClient,
+        'search-index-name',
+        'banana',
+        0,
+        25
+      );
+
+      expect(mockRouterNoQuery.response.ok).toHaveBeenCalledWith({
+        body: {
+          meta: {
+            page: {
+              current: 0,
+              size: 1,
+              total_pages: 1,
+              total_results: 1,
+            },
+          },
+          results: mockData,
+        },
+
         headers: { 'content-type': 'application/json' },
       });
     });

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -9,8 +9,31 @@ import { SearchResponseBody } from '@elastic/elasticsearch/lib/api/types';
 
 import { schema } from '@kbn/config-schema';
 
+import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../../common/constants';
+
 import { fetchSearchResults } from '../../lib/fetch_search_results';
 import { RouteDependencies } from '../../plugin';
+
+const calculateMeta = (searchResults: SearchResponseBody, page: number, size: number) => {
+  let totalResults = 0;
+  if (searchResults.hits.total === null || searchResults.hits.total === undefined) {
+    totalResults = 0;
+  } else if (typeof searchResults.hits.total === 'number') {
+    totalResults = searchResults.hits.total;
+  } else {
+    totalResults = searchResults.hits.total.value;
+  }
+  const totalPages = Math.ceil(totalResults / size) || 1;
+
+  return {
+    page: {
+      current: page,
+      size: searchResults.hits.hits.length,
+      total_pages: (Number.isFinite(totalPages) && totalPages) || 1,
+      total_results: totalResults,
+    },
+  };
+};
 
 export function registerSearchRoute({ router }: RouteDependencies) {
   router.get(
@@ -22,13 +45,16 @@ export function registerSearchRoute({ router }: RouteDependencies) {
         }),
         query: schema.object({
           page: schema.number({ defaultValue: 0, min: 0 }),
-          size: schema.number({ defaultValue: 25, min: 0 }),
+          size: schema.number({
+            defaultValue: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
+            min: 0,
+          }),
         }),
       },
     },
     async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
-      const { page, size } = request.query;
+      const { page = 0, size = ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } = request.query;
       const from = page * size;
       try {
         const searchResults: SearchResponseBody = await fetchSearchResults(
@@ -39,26 +65,9 @@ export function registerSearchRoute({ router }: RouteDependencies) {
           size
         );
 
-        let totalResults = 0;
-        if (searchResults.hits.total === null || searchResults.hits.total === undefined) {
-          totalResults = 0;
-        } else if (typeof searchResults.hits.total === 'number') {
-          totalResults = searchResults.hits.total;
-        } else {
-          totalResults = searchResults.hits.total.value;
-        }
-        const totalPages = Math.ceil(totalResults / size) || 1;
-
         return response.ok({
           body: {
-            meta: {
-              page: {
-                current: page,
-                size: searchResults.hits.hits.length,
-                total_pages: (Number.isFinite(totalPages) && totalPages) || 1,
-                total_results: totalResults,
-              },
-            },
+            meta: calculateMeta(searchResults, page, size),
             results: searchResults,
           },
           headers: { 'content-type': 'application/json' },
@@ -81,13 +90,16 @@ export function registerSearchRoute({ router }: RouteDependencies) {
         }),
         query: schema.object({
           page: schema.number({ defaultValue: 0, min: 0 }),
-          size: schema.number({ defaultValue: 25, min: 1 }),
+          size: schema.number({
+            defaultValue: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
+            min: 0,
+          }),
         }),
       },
     },
     async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
-      const { page, size } = request.query;
+      const { page = 0, size = ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } = request.query;
       const from = page * size;
       try {
         const searchResults = await fetchSearchResults(
@@ -98,25 +110,9 @@ export function registerSearchRoute({ router }: RouteDependencies) {
           size
         );
 
-        let totalResults = 0;
-        if (searchResults.hits.total === null || searchResults.hits.total === undefined) {
-          totalResults = 0;
-        } else if (typeof searchResults.hits.total === 'number') {
-          totalResults = searchResults.hits.total;
-        } else {
-          totalResults = searchResults.hits.total.value;
-        }
-        const totalPages = Math.ceil(totalResults / size) || 1;
         return response.ok({
           body: {
-            meta: {
-              page: {
-                current: page,
-                size: searchResults.hits.hits.length,
-                total_pages: (Number.isFinite(totalPages) && totalPages) || 1,
-                total_results: totalResults,
-              },
-            },
+            meta: calculateMeta(searchResults, page, size),
             results: searchResults,
           },
           headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
## Summary

Adds missing pagination to the document view.

![Screenshot 2022-08-03 at 16 52 29](https://user-images.githubusercontent.com/1410658/182639674-68d95f2c-dbbf-4488-a965-4b85fa914b7d.png)
![Screenshot 2022-08-03 at 16 52 44](https://user-images.githubusercontent.com/1410658/182639680-849860e8-af5c-46ad-8972-76184109214a.png)
![Screenshot 2022-08-03 at 16 53 01](https://user-images.githubusercontent.com/1410658/182639684-378f5967-5798-4760-bfcd-334f39e5aeb2.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->