### PR TITLE
[Fleet] Add force to upgrade openAPI

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/bulk_upgrade_agents.yaml
@@ -21,6 +21,9 @@ properties:
         items:
           type: string
         description: list of agent IDs
+  force:
+    type: boolean
+    description: Force upgrade, skipping validation (should be used with caution)
 required:
   - agents
   - version

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_agent.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_agent.yaml
@@ -1,16 +1,12 @@
 title: Upgrade agent
-oneOf:
-  - type: object
-    properties:
-      version:
-        type: string
-    required:
-      - version
-  - type: object
-    properties:
-      version:
-        type: string
-      source_uri:
-        type: string
-    required:
-      - version
+type: object
+  properties:
+    version:
+      type: string
+    source_uri:
+      type: string
+    force:
+      type: boolean
+      description: Force upgrade, skipping validation
+  required:
+    - version

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_agent.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_agent.yaml
@@ -1,12 +1,12 @@
 title: Upgrade agent
 type: object
-  properties:
-    version:
-      type: string
-    source_uri:
-      type: string
-    force:
-      type: boolean
-      description: Force upgrade, skipping validation
-  required:
-    - version
+properties:
+  version:
+    type: string
+  source_uri:
+    type: string
+  force:
+    type: boolean
+    description: Force upgrade, skipping validation (should be used with caution)
+required:
+  - version


### PR DESCRIPTION
## Summary

The upgrade APIs (single agent and bulk upgrade) support a `force` parameter that was not documented.

The `force` parameter allow to skip validation.

That PR fix that and document that parameter.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->