### PR TITLE
load shakespeare data only once instead of twice

### DIFF
--- a/test/functional/apps/getting_started/_shakespeare.ts
+++ b/test/functional/apps/getting_started/_shakespeare.ts
@@ -14,7 +14,6 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
   const retry = getService('retry');
   const security = getService('security');
   const browser = getService('browser');
@@ -47,9 +46,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await security.testUser.setRoles(['kibana_admin', 'test_shakespeare_reader']);
       await kibanaServer.savedObjects.cleanStandardList();
       log.debug('Load shakespeare data');
-      await esArchiver.loadIfNeeded(
-        'test/functional/fixtures/es_archiver/getting_started/shakespeare'
-      );
 
       if (!isNewChartsLibraryEnabled) {
         await kibanaServer.uiSettings.update({
@@ -61,7 +57,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await security.testUser.restoreDefaults();
-      await esArchiver.unload('test/functional/fixtures/es_archiver/getting_started/shakespeare');
       kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.uiSettings.replace({});
     });

--- a/test/functional/apps/getting_started/index.ts
+++ b/test/functional/apps/getting_started/index.ts
@@ -11,10 +11,18 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const browser = getService('browser');
   const kibanaServer = getService('kibanaServer');
+  const esArchiver = getService('esArchiver');
 
   describe('Getting Started ', function () {
     before(async function () {
       await browser.setWindowSize(1200, 800);
+      await esArchiver.loadIfNeeded(
+        'test/functional/fixtures/es_archiver/getting_started/shakespeare'
+      );
+    });
+
+    after(async function () {
+      await esArchiver.unload('test/functional/fixtures/es_archiver/getting_started/shakespeare');
     });
 
     // TODO: Remove when vislib is removed


### PR DESCRIPTION
## Summary

While working on another issue I realized that this group of tests loads and unloads a rather large set of data twice when it doesn't need to.  I moved the load and unload from the test into the index file before/after.

From my local run you can see that the load takes almost 1 minute;
```
[10:29:12.040204000] │ info [test/functional/fixtures/es_archiver/getting_started/shakespeare] Created index "shakespeare"
[10:29:12.046982000] │ debg [test/functional/fixtures/es_archiver/getting_started/shakespeare] "shakespeare" settings {"index":{"number_of_replicas":"1","number_of_shards":"5"}}
[10:29:18.137860000] │ info progress: 12601
[10:29:28.137379000] │ info progress: 35100
[10:29:38.137666000] │ info progress: 59101
[10:29:48.137599000] │ info progress: 83701
[10:29:58.137999000] │ info progress: 108300
[10:29:59.388061000] │ info [test/functional/fixtures/es_archiver/getting_started/shakespeare] Indexed 111396 docs into "shakespeare"
```
