### PR TITLE
[Security Solution][Investigations] - Make rule creation prominent on alerts page

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -44,7 +44,7 @@ import { DetectionEngineNoIndex } from './detection_engine_no_index';
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
 import { DetectionEngineUserUnauthenticated } from './detection_engine_user_unauthenticated';
 import * as i18n from './translations';
-import { LinkAnchor } from '../../../common/components/links';
+import { SecuritySolutionLinkButton } from '../../../common/components/links';
 import { useFormatUrl } from '../../../common/components/link_to';
 import { useGlobalFullScreen } from '../../../common/containers/use_full_screen';
 import { Display } from '../../../hosts/pages/display';
@@ -76,6 +76,7 @@ import {
 import { EmptyPage } from '../../../common/components/empty_page';
 import { HeaderPage } from '../../../common/components/header_page';
 import { LandingPageComponent } from '../../../common/components/landing_page';
+import { usePrePackagedRules } from '../../containers/detection_engine/rules';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -112,7 +113,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
   const query = useDeepEqualSelector(getGlobalQuerySelector);
   const filters = useDeepEqualSelector(getGlobalFiltersQuerySelector);
-
   const { to, from } = useGlobalTime();
   const { globalFullScreen } = useGlobalFullScreen();
   const [
@@ -120,6 +120,8 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
       loading: userInfoLoading,
       isAuthenticated: isUserAuthenticated,
       hasEncryptionKey,
+      canUserCRUD,
+      isSignalIndexExists,
       signalIndexName,
       hasIndexWrite = false,
       hasIndexMaintenance = false,
@@ -136,6 +138,13 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
     loading: isLoadingIndexPattern,
   } = useSourcererDataView(SourcererScopeName.detections);
 
+  const { rulesCustomInstalled, rulesNotInstalled } = usePrePackagedRules({
+    canUserCRUD,
+    hasIndexWrite,
+    isSignalIndexExists,
+    isAuthenticated: isUserAuthenticated,
+    hasEncryptionKey,
+  });
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
   const [showBuildingBlockAlerts, setShowBuildingBlockAlerts] = useState(false);
   const [showOnlyThreatIndicatorAlerts, setShowOnlyThreatIndicatorAlerts] = useState(false);
@@ -332,13 +341,14 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
           >
             <Display show={!globalFullScreen}>
               <HeaderPage title={i18n.PAGE_TITLE}>
-                <LinkAnchor
+                <SecuritySolutionLinkButton
                   onClick={goToRules}
-                  href={formatUrl(getRulesUrl())}
+                  deepLinkId={SecurityPageName.rules}
                   data-test-subj="manage-alert-detection-rules"
+                  fill
                 >
                   {i18n.BUTTON_MANAGE_RULES}
-                </LinkAnchor>
+                </SecuritySolutionLinkButton>
               </HeaderPage>
               <EuiHorizontalRule margin="m" />
               <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
@@ -375,7 +385,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
 
               <EuiSpacer size="l" />
             </Display>
-
             <AlertsTable
               timelineId={TimelineId.detectionsPage}
               loading={loading}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -76,7 +76,6 @@ import {
 import { EmptyPage } from '../../../common/components/empty_page';
 import { HeaderPage } from '../../../common/components/header_page';
 import { LandingPageComponent } from '../../../common/components/landing_page';
-import { usePrePackagedRules } from '../../containers/detection_engine/rules';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -113,6 +112,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
   const query = useDeepEqualSelector(getGlobalQuerySelector);
   const filters = useDeepEqualSelector(getGlobalFiltersQuerySelector);
+
   const { to, from } = useGlobalTime();
   const { globalFullScreen } = useGlobalFullScreen();
   const [
@@ -120,8 +120,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
       loading: userInfoLoading,
       isAuthenticated: isUserAuthenticated,
       hasEncryptionKey,
-      canUserCRUD,
-      isSignalIndexExists,
       signalIndexName,
       hasIndexWrite = false,
       hasIndexMaintenance = false,
@@ -138,13 +136,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
     loading: isLoadingIndexPattern,
   } = useSourcererDataView(SourcererScopeName.detections);
 
-  const { rulesCustomInstalled, rulesNotInstalled } = usePrePackagedRules({
-    canUserCRUD,
-    hasIndexWrite,
-    isSignalIndexExists,
-    isAuthenticated: isUserAuthenticated,
-    hasEncryptionKey,
-  });
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
   const [showBuildingBlockAlerts, setShowBuildingBlockAlerts] = useState(false);
   const [showOnlyThreatIndicatorAlerts, setShowOnlyThreatIndicatorAlerts] = useState(false);


### PR DESCRIPTION
## Summary

Currently, when users visit the alerts page for the first time, we show a message asking them to update their time range or modify their search to look for alerts, when they may not even have any rules to generate said alerts as seen in the image below. The goal of this PR is to help nudge users towards creating rules if none happen to be present.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/17211684/182671173-c4160351-b403-44a4-8f2c-7a1dd7c86957.png">

This PR just updates the manage rules to be a button on the alerts page, to be more prominent for the user since the rules link has been removed from the top level navigation in security

	
<img width="1788" alt="Screen Shot 2022-08-03 at 1 10 48 PM" src="https://user-images.githubusercontent.com/17211684/182670778-d8ed8a34-dba2-463a-968f-33a8ccbd4560.png">


**ARCHIVED:**

This PR has two commits:

- 083a1481979615a9db20254455f1ddb63167ce53 - This commit simply updates the manage rules to be a button on the alerts page, to be more prominent for the user since the rules link has been removed from the top level navigation in security
	- After this commit: 
	
<img width="1788" alt="Screen Shot 2022-08-03 at 1 10 48 PM" src="https://user-images.githubusercontent.com/17211684/182670778-d8ed8a34-dba2-463a-968f-33a8ccbd4560.png">

- dcfc947a907d7e4b8da30565228209e7b2ad947f - This commit adds some logic that checks if any prebuilt or custom rules have been installed. If none have been created or installed and the user has crud permissions, we will show a message similar to the empty cases list message prompting the user to add rules. In the event the user does not have crud permissions they will see the aforementioned alert table with the default empty message. 
	- After this commit:

https://user-images.githubusercontent.com/17211684/182670819-207469c8-bc11-46e5-bcf4-292c4039bf2e.mov

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->