### PR TITLE
Fix bug in which Console was attempting to detach the suggestions completer even when it wasn't rendered

### DIFF
--- a/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
@@ -229,7 +229,10 @@ export class LegacyCoreEditor implements CoreEditor {
   }
 
   detachCompleter() {
-    return (this.editor as unknown as { completer: { detach(): void } }).completer.detach();
+    // In some situations we need to detach the autocomplete suggestions element manually,
+    // such as when navigating away from Console when the suggestions list is open.
+    const completer = (this.editor as unknown as { completer: { detach(): void } }).completer;
+    return completer?.detach();
   }
 
   private forceRetokenize() {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/137991

In 8.4 via https://github.com/elastic/kibana/pull/136268 we introduced a bugfix for navigating away from Console while the autocompletion suggestions list was open. The fix manually removes the list, but doesn't check whether the list is open before attempting to do so, resulting in the reported error. This PR handles that case.

To test, navigate to Console. Open the browser console. Navigate to Search Profiler. Observe no error in the browser console.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->