### PR TITLE
[Fleet] Fix flaky package install version integration test

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/upgrade_package_install_version.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/upgrade_package_install_version.test.ts
@@ -39,6 +39,8 @@ const fakeRequest = {
   },
 } as unknown as KibanaRequest;
 
+const PACKAGES = ['fleet_server', 'system', 'nginx', 'apache'];
+
 describe('Uprade package install version', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let kbnServer: kbnTestServer.TestKibanaUtils;
@@ -145,8 +147,7 @@ describe('Uprade package install version', () => {
     await stopServers();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/137934
-  describe.skip('with package installed with a previous format install version', () => {
+  describe('with package installed with a previous format install version', () => {
     let soClient: SavedObjectsClientContract;
 
     const OUTDATED_PACKAGES = ['nginx', 'apache'];
@@ -184,6 +185,10 @@ describe('Uprade package install version', () => {
 
       res.saved_objects.forEach((so) => {
         expect(so.attributes.install_format_schema_version).toBe(FLEET_INSTALL_FORMAT_VERSION);
+        if (!PACKAGES.includes(so.attributes.name)) {
+          return;
+        }
+
         if (!OUTDATED_PACKAGES.includes(so.attributes.name)) {
           expect(new Date(so.updated_at as string).getTime()).toBeLessThan(now);
         } else {


### PR DESCRIPTION
## Summary

Resolve #137934

This integration test was failing as the synthetics package is automatically installed by synthetics (maybe we should provide a better way to install package automatically, or plugin should only install package on user action).

That PR remove that flakyness by explicitly specify which packages are used in this test.


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->