### PR TITLE
[Maps] fix Tool tip with large field list exceeds browser screen and cannot be accessed or dismissed

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/feature_properties.test.tsx.snap
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/feature_properties.test.tsx.snap
@@ -1,44 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FeatureProperties should render 1`] = `
-<table
-  className="eui-yScrollWithShadows mapFeatureTooltip_table"
+<div
+  className="mapFeatureTooltip_tableWrapper"
 >
-  <tbody>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop1"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+  <table
+    className="eui-yScrollWithShadows mapFeatureTooltip_table"
+  >
+    <tbody>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop1"
       >
-        prop1
-      </td>
-      <td
-        className="eui-textBreakWord"
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        >
+          prop1
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar1
+        </td>
+        <td />
+      </tr>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop2"
       >
-        foobar1
-      </td>
-      <td />
-    </tr>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop2"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
-      >
-        prop2
-      </td>
-      <td
-        className="eui-textBreakWord"
-      >
-        foobar2
-      </td>
-      <td />
-    </tr>
-  </tbody>
-</table>
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        >
+          prop2
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar2
+        </td>
+        <td />
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;
 
 exports[`FeatureProperties should show error message if unable to load tooltip content 1`] = `
@@ -55,81 +59,28 @@ exports[`FeatureProperties should show error message if unable to load tooltip c
 `;
 
 exports[`FeatureProperties should show filter button for filterable properties 1`] = `
-<table
-  className="eui-yScrollWithShadows mapFeatureTooltip_table"
+<div
+  className="mapFeatureTooltip_tableWrapper"
 >
-  <tbody>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop1"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+  <table
+    className="eui-yScrollWithShadows mapFeatureTooltip_table"
+  >
+    <tbody>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop1"
       >
-        prop1
-      </td>
-      <td
-        className="eui-textBreakWord"
-      >
-        foobar1
-      </td>
-      <td>
-        <EuiButtonEmpty
-          aria-label="Filter on property"
-          data-test-subj="mapTooltipCreateFilterButton"
-          onClick={[Function]}
-          size="xs"
-          title="Filter on property"
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
         >
-          <EuiIcon
-            type="filter"
-          />
-        </EuiButtonEmpty>
-      </td>
-    </tr>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop2"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
-      >
-        prop2
-      </td>
-      <td
-        className="eui-textBreakWord"
-      >
-        foobar2
-      </td>
-      <td />
-    </tr>
-  </tbody>
-</table>
-`;
-
-exports[`FeatureProperties should show view actions button when there are available actions 1`] = `
-<table
-  className="eui-yScrollWithShadows mapFeatureTooltip_table"
->
-  <tbody>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop1"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
-      >
-        prop1
-      </td>
-      <td
-        className="eui-textBreakWord"
-      >
-        foobar1
-      </td>
-      <td
-        className="mapFeatureTooltip_actionsRow"
-      >
-        <span>
+          prop1
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar1
+        </td>
+        <td>
           <EuiButtonEmpty
             aria-label="Filter on property"
             data-test-subj="mapTooltipCreateFilterButton"
@@ -141,36 +92,97 @@ exports[`FeatureProperties should show view actions button when there are availa
               type="filter"
             />
           </EuiButtonEmpty>
-          <EuiButtonEmpty
-            aria-label="View filter actions"
-            data-test-subj="mapTooltipMoreActionsButton"
-            onClick={[Function]}
-            size="xs"
-            title="View filter actions"
-          >
-            <EuiIcon
-              type="arrowRight"
-            />
-          </EuiButtonEmpty>
-        </span>
-      </td>
-    </tr>
-    <tr
-      className="mapFeatureTooltip_row"
-      key="prop2"
-    >
-      <td
-        className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        </td>
+      </tr>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop2"
       >
-        prop2
-      </td>
-      <td
-        className="eui-textBreakWord"
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        >
+          prop2
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar2
+        </td>
+        <td />
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`FeatureProperties should show view actions button when there are available actions 1`] = `
+<div
+  className="mapFeatureTooltip_tableWrapper"
+>
+  <table
+    className="eui-yScrollWithShadows mapFeatureTooltip_table"
+  >
+    <tbody>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop1"
       >
-        foobar2
-      </td>
-      <td />
-    </tr>
-  </tbody>
-</table>
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        >
+          prop1
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar1
+        </td>
+        <td
+          className="mapFeatureTooltip_actionsRow"
+        >
+          <span>
+            <EuiButtonEmpty
+              aria-label="Filter on property"
+              data-test-subj="mapTooltipCreateFilterButton"
+              onClick={[Function]}
+              size="xs"
+              title="Filter on property"
+            >
+              <EuiIcon
+                type="filter"
+              />
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              aria-label="View filter actions"
+              data-test-subj="mapTooltipMoreActionsButton"
+              onClick={[Function]}
+              size="xs"
+              title="View filter actions"
+            >
+              <EuiIcon
+                type="arrowRight"
+              />
+            </EuiButtonEmpty>
+          </span>
+        </td>
+      </tr>
+      <tr
+        className="mapFeatureTooltip_row"
+        key="prop2"
+      >
+        <td
+          className="eui-textBreakWord mapFeatureTooltip__propertyLabel"
+        >
+          prop2
+        </td>
+        <td
+          className="eui-textBreakWord"
+        >
+          foobar2
+        </td>
+        <td />
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/_index.scss
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/_index.scss
@@ -1,10 +1,14 @@
 .mapFeatureTooltip_table {
   width: 100%;
-  max-height: calc(49vh - #{$euiSizeXL * 2});
 
   td {
     padding: $euiSizeXS;
   }
+}
+
+.mapFeatureTooltip_tableWrapper {
+  overflow: auto;
+  max-height: calc(49vh - 64px);
 }
 
 .mapFeatureTooltip_row {

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/_index.scss
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/_index.scss
@@ -24,6 +24,7 @@
 }
 
 .mapFeatureTooltip__propertyLabel {
+  min-width: $euiSizeXL * 2.5;
   max-width: $euiSizeXL * 4;
   font-weight: $euiFontWeightSemiBold;
 }

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
@@ -336,9 +336,11 @@ export class FeatureProperties extends Component<Props, State> {
     });
 
     return (
-      <table className="eui-yScrollWithShadows mapFeatureTooltip_table" ref={this._tableRef}>
-        <tbody>{rows}</tbody>
-      </table>
+      <div className="mapFeatureTooltip_tableWrapper">
+        <table className="eui-yScrollWithShadows mapFeatureTooltip_table" ref={this._tableRef}>
+          <tbody>{rows}</tbody>
+        </table>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/136428

<img width="400" alt="Screen Shot 2022-08-03 at 3 04 35 PM" src="https://user-images.githubusercontent.com/373691/182711573-a90220bf-451c-4466-ab13-4df9378d0af7.png">

To test
* Download world countries geojson from https://vector.maps.elastic.co/files/world_countries_v7.geo.json?elastic_tile_service_tos=agree&my_app_name=ems-landing-page&my_app_version=8.3.0&license=643c1faf-80fc-4ab0-9323-4d9bd11f4bbc
* Create new map
* Click "Add layer"
* Select "Upload file" and upload world countries geojson. Add layer to map.
* Add "geometry" to Tooltip fields.
* Mouse over country with complex geometry and verify tooltip does not overflow screen height.