### PR TITLE
Creates simple saved object mock

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/src/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/src/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { savedObjectsServiceMock } from './saved_objects_service.mock';
+export { simpleSavedObjectMock } from './simple_saved_object.mock';

--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
@@ -6,36 +6,15 @@
  * Side Public License, v 1.
  */
 
-// import type { MockedKeys } from '@kbn/utility-types-jest';
-import type {
-  SavedObjectsClientContract,
-  SimpleSavedObject,
-} from '@kbn/core-saved-objects-api-browser';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-browser';
 import { SimpleSavedObjectImpl } from '@kbn/core-saved-objects-browser-internal';
-
-// const simpleSavedObjectInstanceMock: MockedKeys<SimpleSavedObject> = {
-//   attributes: {},
-//   id: '',
-//   type: '',
-//   migrationVersion: {},
-//   coreMigrationVersion: '',
-//   error: undefined,
-//   references: [],
-//   updatedAt: '',
-//   namespaces: undefined,
-//   get: jest.fn().mockReturnThis(),
-//   set: jest.fn().mockReturnThis(),
-//   has: jest.fn().mockReturnValue(true),
-//   save: jest.fn().mockResolvedValue({}),
-//   delete: jest.fn().mockResolvedValue({}),
-// };
+import type { SavedObject } from '@kbn/core-saved-objects-common';
 
 const createSimpleSavedObjectMock = (
   client: SavedObjectsClientContract,
-  savedObject: SimpleSavedObject
+  savedObject: SavedObject<unknown>
 ) => new SimpleSavedObjectImpl(client, savedObject);
 
 export const simpleSavedObjectMock = {
   create: createSimpleSavedObjectMock,
-  // createBlank: jest.fn().mockReturnValue(simpleSavedObjectInstanceMock),
 };

--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// import type { MockedKeys } from '@kbn/utility-types-jest';
+import type {
+  SavedObjectsClientContract,
+  SimpleSavedObject,
+} from '@kbn/core-saved-objects-api-browser';
+import { SimpleSavedObjectImpl } from '@kbn/core-saved-objects-browser-internal';
+
+// const simpleSavedObjectInstanceMock: MockedKeys<SimpleSavedObject> = {
+//   attributes: {},
+//   id: '',
+//   type: '',
+//   migrationVersion: {},
+//   coreMigrationVersion: '',
+//   error: undefined,
+//   references: [],
+//   updatedAt: '',
+//   namespaces: undefined,
+//   get: jest.fn().mockReturnThis(),
+//   set: jest.fn().mockReturnThis(),
+//   has: jest.fn().mockReturnValue(true),
+//   save: jest.fn().mockResolvedValue({}),
+//   delete: jest.fn().mockResolvedValue({}),
+// };
+
+const createSimpleSavedObjectMock = (
+  client: SavedObjectsClientContract,
+  savedObject: SimpleSavedObject
+) => new SimpleSavedObjectImpl(client, savedObject);
+
+export const simpleSavedObjectMock = {
+  create: createSimpleSavedObjectMock,
+  // createBlank: jest.fn().mockReturnValue(simpleSavedObjectInstanceMock),
+};

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -128,8 +128,6 @@ export type {
   NavigateToAppOptions,
   NavigateToUrlOptions,
 } from './application';
-// Export implementation only until we have a concrete mock for tests. See https://github.com/elastic/kibana/pull/137448 for more info
-export { SimpleSavedObjectImpl } from '@kbn/core-saved-objects-browser-internal';
 export type {
   SavedObjectsClientContract,
   SimpleSavedObject,

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -20,10 +20,7 @@ import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { deprecationsServiceMock } from '@kbn/core-deprecations-browser-mocks';
 import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
-import {
-  savedObjectsServiceMock,
-  simpleSavedObjectMock,
-} from '@kbn/core-saved-objects-browser-mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import type { PluginInitializerContext, AppMountParameters } from '.';
 // Import values from their individual modules instead.

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -20,7 +20,10 @@ import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { deprecationsServiceMock } from '@kbn/core-deprecations-browser-mocks';
 import { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
-import { savedObjectsServiceMock } from '@kbn/core-saved-objects-browser-mocks';
+import {
+  savedObjectsServiceMock,
+  simpleSavedObjectMock,
+} from '@kbn/core-saved-objects-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import type { PluginInitializerContext, AppMountParameters } from '.';
 // Import values from their individual modules instead.
@@ -39,7 +42,10 @@ export { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
 export { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 export { overlayServiceMock } from '@kbn/core-overlays-browser-mocks';
 export { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
-export { savedObjectsServiceMock } from '@kbn/core-saved-objects-browser-mocks';
+export {
+  savedObjectsServiceMock,
+  simpleSavedObjectMock,
+} from '@kbn/core-saved-objects-browser-mocks';
 export { scopedHistoryMock } from './application/scoped_history.mock';
 export { applicationServiceMock } from './application/application_service.mock';
 export { deprecationsServiceMock } from '@kbn/core-deprecations-browser-mocks';

--- a/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.test.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { findObjectByTitle } from './find_object_by_title';
-import { SimpleSavedObjectImpl, SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { simpleSavedObjectMock } from '@kbn/core/public/mocks';
 
 describe('findObjectByTitle', () => {
   const savedObjectsClient: SavedObjectsClientContract = {} as SavedObjectsClientContract;
@@ -22,7 +23,7 @@ describe('findObjectByTitle', () => {
   });
 
   it('matches any case', async () => {
-    const indexPattern = new SimpleSavedObjectImpl(savedObjectsClient, {
+    const indexPattern = simpleSavedObjectMock.create(savedObjectsClient, {
       attributes: { title: 'foo' },
     } as SavedObject);
     savedObjectsClient.find = jest.fn().mockImplementation(() =>

--- a/src/plugins/visualizations/public/utils/saved_objects_utils/find_object_by_title.test.ts
+++ b/src/plugins/visualizations/public/utils/saved_objects_utils/find_object_by_title.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { findObjectByTitle } from './find_object_by_title';
-import { SimpleSavedObjectImpl, SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { simpleSavedObjectMock } from '@kbn/core/public/mocks';
 
 describe('findObjectByTitle', () => {
   const savedObjectsClient: SavedObjectsClientContract = {} as SavedObjectsClientContract;
@@ -22,7 +23,7 @@ describe('findObjectByTitle', () => {
   });
 
   it('matches any case', async () => {
-    const indexPattern = new SimpleSavedObjectImpl(savedObjectsClient, {
+    const indexPattern = simpleSavedObjectMock.create(savedObjectsClient, {
       attributes: { title: 'foo' },
     } as SavedObject);
     savedObjectsClient.find = jest.fn().mockImplementation(() =>

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/find_object_by_title.test.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/find_object_by_title.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { findObjectByTitle } from './find_object_by_title';
-import { SimpleSavedObjectImpl, SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { simpleSavedObjectMock } from '@kbn/core/public/mocks';
 
 describe('findObjectByTitle', () => {
   const savedObjectsClient: SavedObjectsClientContract = {} as SavedObjectsClientContract;
@@ -21,7 +22,7 @@ describe('findObjectByTitle', () => {
   });
 
   it('matches any case', async () => {
-    const indexPattern = new SimpleSavedObjectImpl(savedObjectsClient, {
+    const indexPattern = simpleSavedObjectMock.create(savedObjectsClient, {
       attributes: { title: 'foo' },
     } as SavedObject);
     savedObjectsClient.find = jest.fn().mockImplementation(() =>


### PR DESCRIPTION
## Summary
Fix https://github.com/elastic/kibana/issues/137928
Three plugins were using the internal `SimpleSavedObjectImpl` for tests, which prevents core from truly keeping the implementation internal to core.

This PR creates a pseudo-mock (using the actual implementation) and updates the unit tests accordingly.
An actual mock will be created as a follow-up PR.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
