### PR TITLE
[Profiling] Simplify stackframe metadata

### DIFF
--- a/x-pack/plugins/profiling/common/callercallee.test.ts
+++ b/x-pack/plugins/profiling/common/callercallee.test.ts
@@ -24,7 +24,6 @@ describe('Caller-callee operations', () => {
       SourceID: 'd670b496cafcaea431a23710fb5e4f58',
       SourceLine: 30,
       ExeFileName: 'libc-2.26.so',
-      Index: 1,
     });
     const parent = createCallerCalleeIntermediateNode(parentFrame, 10);
 
@@ -36,7 +35,6 @@ describe('Caller-callee operations', () => {
       SourceID: 'f0a7901dcefed6cc8992a324b9df733c',
       SourceLine: 150,
       ExeFileName: 'auditd',
-      Index: 0,
     });
     const child = createCallerCalleeIntermediateNode(childFrame, 10);
 

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -161,7 +161,7 @@ export function groupStackFrameMetadataByStackTrace(
       const executable = executables.get(trace.FileID[i])!;
 
       const metadata = createStackFrameMetadata({
-        FileID: Buffer.from(trace.FileID[i], 'base64url').toString('hex'),
+        FileID: trace.FileID[i],
         FrameType: trace.Type[i],
         AddressOrLine: frame.LineNumber,
         FunctionName: frame.FunctionName,

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -93,8 +93,6 @@ export interface StackFrameMetadata {
   SourcePackageURL: string;
   // unused atm due to lack of symbolization metadata
   SourceType: number;
-
-  Index: number;
 }
 
 export function createStackFrameMetadata(
@@ -117,7 +115,6 @@ export function createStackFrameMetadata(
   metadata.SourcePackageHash = options.SourcePackageHash ?? '';
   metadata.SourcePackageURL = options.SourcePackageURL ?? '';
   metadata.SourceType = options.SourceType ?? 0;
-  metadata.Index = options.Index ?? 0;
 
   return metadata;
 }
@@ -174,7 +171,6 @@ export function groupStackFrameMetadataByStackTrace(
         FunctionOffset: frame.FunctionOffset,
         SourceLine: frame.LineNumber,
         ExeFileName: executable.FileName,
-        Index: i,
       });
 
       frameMetadata.push(metadata);

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -64,8 +64,6 @@ export interface StackFrameMetadata {
   FileID: FileID;
   // StackTrace.Type
   FrameType: FrameType;
-  // stringified FrameType -- FrameType.String()
-  FrameTypeString: string;
 
   // StackFrame.LineNumber?
   AddressOrLine: number;
@@ -102,7 +100,6 @@ export function createStackFrameMetadata(
 
   metadata.FileID = options.FileID ?? '';
   metadata.FrameType = options.FrameType ?? 0;
-  metadata.FrameTypeString = options.FrameTypeString ?? '';
   metadata.AddressOrLine = options.AddressOrLine ?? 0;
   metadata.FunctionName = options.FunctionName ?? '';
   metadata.FunctionOffset = options.FunctionOffset ?? 0;


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2479

This PR uses a few micro-optimizations to reduce the response size and time for the flamegraph, TopN functions, and traces APIs.

The `StackFrameMetadata` interface is used in the Kibana server to organize the relevant data for each respective API. Also, the interface is part of the response for the TopN function and traces response payload. By removing two unused fields and skipping the deserialization of the file ID, we are able to make modest improvements to the response size and time.

After the updates:
* the traces API has a 15% smaller compressed response size and a 10% smaller response time
* the TopN functions API has a 7% smaller compressed response size and a 10% smaller response time
* the flamegraph API has no change to the response size and a 5% smaller response time

It should be noted that:
* these are local measurements with a 7-day time range
* the flamegraph API does not use `StackTraceMetadata` in the response payload so no change in the size is expected
* `FileID` is not visible in the UI at this time so the deserialization step is not needed

