### PR TITLE
[Enterprise Search] Fix crawl flyout flickering after introduction of always-on crawler poll

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.test.ts
@@ -355,12 +355,12 @@ describe('CrawlCustomSettingsFlyoutLogic', () => {
           selectedDomainUrls: ['https://www.elastic.co', 'https://swiftype.com'],
         });
         CrawlerLogic.mount();
-        jest.spyOn(CrawlerLogic.actions, 'startCrawl');
+        jest.spyOn(CrawlCustomSettingsFlyoutLogic.actions, 'startCrawl');
 
         CrawlCustomSettingsFlyoutLogic.actions.startCustomCrawl();
         await nextTick();
 
-        expect(CrawlerLogic.actions.startCrawl).toHaveBeenCalledWith({
+        expect(CrawlCustomSettingsFlyoutLogic.actions.startCrawl).toHaveBeenCalledWith({
           domain_allowlist: ['https://www.elastic.co', 'https://swiftype.com'],
           max_crawl_depth: 5,
           sitemap_discovery_disabled: false,
@@ -382,12 +382,12 @@ describe('CrawlCustomSettingsFlyoutLogic', () => {
           ],
         });
         CrawlerLogic.mount();
-        jest.spyOn(CrawlerLogic.actions, 'startCrawl');
+        jest.spyOn(CrawlCustomSettingsFlyoutLogic.actions, 'startCrawl');
 
         CrawlCustomSettingsFlyoutLogic.actions.startCustomCrawl();
         await nextTick();
 
-        expect(CrawlerLogic.actions.startCrawl).toHaveBeenCalledWith({
+        expect(CrawlCustomSettingsFlyoutLogic.actions.startCrawl).toHaveBeenCalledWith({
           domain_allowlist: ['https://www.elastic.co', 'https://swiftype.com'],
           max_crawl_depth: 5,
           seed_urls: ['https://www.elastic.co/guide', 'https://swiftype.com/documentation'],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.ts
@@ -10,11 +10,10 @@ import { kea, MakeLogicType } from 'kea';
 import { Meta } from '../../../../../../../common/types';
 import { flashAPIErrors } from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
-import { GetCrawlerApiLogic } from '../../../../api/crawler/get_crawler_api_logic';
 import { DomainConfig, DomainConfigFromServer } from '../../../../api/crawler/types';
 import { domainConfigServerToClient } from '../../../../api/crawler/utils';
 import { IndexNameLogic } from '../../index_name_logic';
-import { CrawlerLogic, CrawlRequestOverrides } from '../crawler_logic';
+import { CrawlerActions, CrawlerLogic, CrawlRequestOverrides } from '../crawler_logic';
 import { extractDomainAndEntryPointFromUrl } from '../domain_management/add_domain/utils';
 
 export interface CrawlCustomSettingsFlyoutLogicValues {
@@ -49,6 +48,7 @@ export interface CrawlCustomSettingsFlyoutLogicActions {
   onSelectSitemapUrls(sitemapUrls: string[]): { sitemapUrls: string[] };
   showFlyout(): void;
   startCustomCrawl(): void;
+  startCrawl: CrawlerActions['startCrawl'];
   toggleIncludeSitemapsInRobotsTxt(): void;
 }
 
@@ -69,7 +69,7 @@ export const CrawlCustomSettingsFlyoutLogic = kea<
 >({
   path: ['enterprise_search', 'crawler', 'crawl_custom_settings_flyout_logic'],
   connect: {
-    actions: [GetCrawlerApiLogic, ['apiSuccess', 'apiError', 'makeRequest']],
+    actions: [CrawlerLogic, ['startCrawl']],
   },
   actions: () => ({
     fetchDomainConfigData: true,
@@ -124,9 +124,8 @@ export const CrawlCustomSettingsFlyoutLogic = kea<
     isFormSubmitting: [
       false,
       {
-        makeRequest: () => true,
-        apiSuccess: () => false,
-        apiError: () => false,
+        startCustomCrawl: () => true,
+        startCrawl: () => false,
       },
     ],
     isFlyoutVisible: [
@@ -134,8 +133,7 @@ export const CrawlCustomSettingsFlyoutLogic = kea<
       {
         showFlyout: () => true,
         hideFlyout: () => false,
-        apiSuccess: () => false,
-        apiError: () => false,
+        startCrawl: () => false,
       },
     ],
     maxCrawlDepth: [
@@ -253,7 +251,7 @@ export const CrawlCustomSettingsFlyoutLogic = kea<
         overrides.sitemap_urls = sitemapUrls;
       }
 
-      CrawlerLogic.actions.startCrawl(overrides);
+      actions.startCrawl(overrides);
     },
   }),
 });


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/137575 we introduced an always-own poll to all indices pages to check for the latest crawler status.  Previously, this flyout would trigger that poll, so we used a successful response for that poll to determine when to close the flyout.  Now that we're polling every 5 seconds for crawler status, the flyout would close unexpectedly after opening.  We remove the dependency on the get crawler API entirely. 


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->