### PR TITLE
[Fleet] Fix error pop up on kibana update

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -157,8 +157,8 @@ export async function ensurePreconfiguredPackagesAndPolicies(
           policy
         );
 
-        const newFields = {
-          defaultDownloadSourceId: defaultDownloadSource.id,
+        const newFields: Partial<AgentPolicy> = {
+          download_source_id: defaultDownloadSource.id,
           ...fields,
         };
         if (hasChanged) {


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/137938

Fix wrong parameter in passed to `agentPolicy` in `ensurePreconfiguredPackagesAndPolicies`. It was causing a bug when  updating from 7.15.0 to 8.4.0 on cloud.

![Screenshot 2022-08-04 at 12 08 51](https://user-images.githubusercontent.com/16084106/182833184-b17b334e-6b1f-4345-a4ee-5f921ca0c193.png)


I'm not sure how to test this locally, as it's a specific combination that's triggering it.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->