### PR TITLE
[Lens] Fixes bug with multi percentiles and terms breakdown

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.test.ts
@@ -15,9 +15,11 @@ import {
   getDisallowedTermsMessage,
   getMultiTermsScriptedFieldErrorMessage,
   isSortableByColumn,
+  computeOrderForMultiplePercentiles,
 } from './helpers';
 import { ReferenceBasedIndexPatternColumn } from '../column_types';
 import type { PercentileRanksIndexPatternColumn } from '../percentile_ranks';
+import type { PercentileIndexPatternColumn } from '../percentile';
 import { MULTI_KEY_VISUAL_SEPARATOR } from './constants';
 
 const indexPattern = createMockedIndexPattern();
@@ -378,6 +380,101 @@ describe('getDisallowedTermsMessage()', () => {
         },
       })
     );
+  });
+});
+
+describe('computeOrderForMultiplePercentiles()', () => {
+  it('should return null for no percentile orderColumn', () => {
+    expect(
+      computeOrderForMultiplePercentiles(
+        {
+          label: 'Percentile rank (1024.5) of bytes',
+          dataType: 'number',
+          operationType: 'percentile_rank',
+          sourceField: 'bytes',
+          isBucketed: false,
+          scale: 'ratio',
+          params: { value: 1024.5 },
+        } as PercentileRanksIndexPatternColumn,
+        getLayer(getStringBasedOperationColumn(), [
+          {
+            label: 'Percentile rank (1024.5) of bytes',
+            dataType: 'number',
+            operationType: 'percentile_rank',
+            sourceField: 'bytes',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { value: 1024.5 },
+          } as PercentileRanksIndexPatternColumn,
+        ]),
+        ['col1', 'col2']
+      )
+    ).toBeNull();
+  });
+
+  it('should return null for single percentile', () => {
+    expect(
+      computeOrderForMultiplePercentiles(
+        {
+          label: 'Percentile 95 of bytes',
+          dataType: 'number',
+          operationType: 'percentile',
+          sourceField: 'bytes',
+          isBucketed: false,
+          scale: 'ratio',
+          params: { percentile: 95 },
+        } as PercentileIndexPatternColumn,
+        getLayer(getStringBasedOperationColumn(), [
+          {
+            label: 'Percentile 95 of bytes',
+            dataType: 'number',
+            operationType: 'percentile',
+            sourceField: 'bytes',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { percentile: 95 },
+          } as PercentileIndexPatternColumn,
+        ]),
+        ['col1', 'col2']
+      )
+    ).toBeNull();
+  });
+
+  it('should return correct orderBy for multiple percentile', () => {
+    expect(
+      computeOrderForMultiplePercentiles(
+        {
+          label: 'Percentile 95 of bytes',
+          dataType: 'number',
+          operationType: 'percentile',
+          sourceField: 'bytes',
+          isBucketed: false,
+          scale: 'ratio',
+          params: { percentile: 95 },
+        } as PercentileIndexPatternColumn,
+        getLayer(getStringBasedOperationColumn(), [
+          {
+            label: 'Percentile 95 of bytes',
+            dataType: 'number',
+            operationType: 'percentile',
+            sourceField: 'bytes',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { percentile: 95 },
+          } as PercentileIndexPatternColumn,
+          {
+            label: 'Percentile 65 of bytes',
+            dataType: 'number',
+            operationType: 'percentile',
+            sourceField: 'bytes',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { percentile: 65 },
+          } as PercentileIndexPatternColumn,
+        ]),
+        ['col1', 'col2', 'col3']
+      )
+    ).toBe('1.95');
   });
 });
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.test.ts
@@ -440,7 +440,7 @@ describe('computeOrderForMultiplePercentiles()', () => {
     ).toBeNull();
   });
 
-  it('should return correct orderBy for multiple percentile', () => {
+  it('should return correct orderBy for multiple percentile on the same field', () => {
     expect(
       computeOrderForMultiplePercentiles(
         {
@@ -475,6 +475,43 @@ describe('computeOrderForMultiplePercentiles()', () => {
         ['col1', 'col2', 'col3']
       )
     ).toBe('1.95');
+  });
+
+  it('should return null for multiple percentile on different field', () => {
+    expect(
+      computeOrderForMultiplePercentiles(
+        {
+          label: 'Percentile 95 of bytes',
+          dataType: 'number',
+          operationType: 'percentile',
+          sourceField: 'bytes',
+          isBucketed: false,
+          scale: 'ratio',
+          params: { percentile: 95 },
+        } as PercentileIndexPatternColumn,
+        getLayer(getStringBasedOperationColumn(), [
+          {
+            label: 'Percentile 95 of bytes',
+            dataType: 'number',
+            operationType: 'percentile',
+            sourceField: 'bytes',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { percentile: 95 },
+          } as PercentileIndexPatternColumn,
+          {
+            label: 'Percentile 65 of geo',
+            dataType: 'number',
+            operationType: 'percentile',
+            sourceField: 'geo',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { percentile: 65 },
+          } as PercentileIndexPatternColumn,
+        ]),
+        ['col1', 'col2', 'col3']
+      )
+    ).toBeNull();
   });
 });
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.ts
@@ -20,6 +20,7 @@ import type { FiltersIndexPatternColumn } from '..';
 import type { TermsIndexPatternColumn } from './types';
 import { LastValueIndexPatternColumn } from '../last_value';
 import type { PercentileRanksIndexPatternColumn } from '../percentile_ranks';
+import type { PercentileIndexPatternColumn } from '../percentile';
 
 import type { IndexPatternLayer, IndexPattern, IndexPatternField } from '../../../types';
 import { MULTI_KEY_VISUAL_SEPARATOR, supportedTypes } from './constants';
@@ -222,6 +223,27 @@ export function isPercentileRankSortable(column: GenericIndexPatternColumn) {
     (column.operationType === 'percentile_rank' &&
       Number.isInteger((column as PercentileRanksIndexPatternColumn).params.value))
   );
+}
+
+export function computeOrderForMultiplePercentiles(
+  column: GenericIndexPatternColumn,
+  layer: IndexPatternLayer,
+  orderedColumnIds: string[]
+) {
+  // compute the percentiles orderBy correctly for multiple percentiles
+  if (column.operationType === 'percentile') {
+    const percentileColumns = [];
+    for (const [key, value] of Object.entries(layer.columns)) {
+      if (value.operationType === 'percentile') {
+        percentileColumns.push(key);
+      }
+    }
+    if (percentileColumns.length > 1) {
+      const parentColumn = String(orderedColumnIds.indexOf(percentileColumns[0]));
+      return `${parentColumn}.${(column as PercentileIndexPatternColumn).params?.percentile}`;
+    }
+  }
+  return null;
 }
 
 export function isSortableByColumn(layer: IndexPatternLayer, columnId: string) {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/helpers.ts
@@ -234,7 +234,11 @@ export function computeOrderForMultiplePercentiles(
   if (column.operationType === 'percentile') {
     const percentileColumns = [];
     for (const [key, value] of Object.entries(layer.columns)) {
-      if (value.operationType === 'percentile') {
+      if (
+        value.operationType === 'percentile' &&
+        (value as PercentileIndexPatternColumn).sourceField ===
+          (column as PercentileIndexPatternColumn).sourceField
+      ) {
         percentileColumns.push(key);
       }
     }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -49,6 +49,7 @@ import {
   getFieldsByValidationState,
   isSortableByColumn,
   isPercentileRankSortable,
+  computeOrderForMultiplePercentiles,
 } from './helpers';
 import {
   DEFAULT_MAX_DOC_COUNT,
@@ -262,6 +263,14 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
       if (!isPercentileRankSortable(orderColumn)) {
         orderBy = '_key';
       }
+
+      const orderByMultiplePercentiles = computeOrderForMultiplePercentiles(
+        orderColumn,
+        layer,
+        orderedColumnIds
+      );
+
+      orderBy = orderByMultiplePercentiles ?? orderBy;
     }
 
     // To get more accurate results, we set shard_size to a minimum of 1000

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -336,6 +336,49 @@ describe('terms', () => {
       );
     });
 
+    it('should reflect correct orderBy for multiple percentiles', () => {
+      const newLayer = {
+        ...layer,
+        columns: {
+          ...layer.columns,
+          col2: {
+            ...layer.columns.col2,
+            operationType: 'percentile',
+            params: {
+              percentile: 95,
+            },
+          },
+          col3: {
+            ...layer.columns.col2,
+            operationType: 'percentile',
+            params: {
+              percentile: 65,
+            },
+          },
+        },
+      };
+      const termsColumn = layer.columns.col1 as TermsIndexPatternColumn;
+      const esAggsFn = termsOperation.toEsAggsFn(
+        {
+          ...termsColumn,
+          params: { ...termsColumn.params, orderBy: { type: 'column', columnId: 'col3' } },
+        },
+        'col1',
+        {} as IndexPattern,
+        newLayer,
+        uiSettingsMock,
+        ['col1', 'col2', 'col3']
+      );
+      expect(esAggsFn).toEqual(
+        expect.objectContaining({
+          function: 'aggTerms',
+          arguments: expect.objectContaining({
+            orderBy: ['1.65'],
+          }),
+        })
+      );
+    });
+
     it('should not enable missing bucket if other bucket is not set', () => {
       const termsColumn = layer.columns.col1 as TermsIndexPatternColumn;
       const esAggsFn = termsOperation.toEsAggsFn(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/138084

Fixes the unreleased bug with multiple percentiles and terms aggregation. The chart was broken when the user created a chart with multiple percentiles and top values ordered by one of the percentiles metrics.

![lens1](https://user-images.githubusercontent.com/17003240/182841406-74c700a4-35fb-4671-9eba-dd44f4f327b7.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->