### PR TITLE
[Lens] The area chart doesn't show the lines

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/__snapshots__/to_expression.test.ts.snap
+++ b/x-pack/plugins/lens/public/visualizations/xy/__snapshots__/to_expression.test.ts.snap
@@ -64,6 +64,9 @@ Object {
                   "seriesType": Array [
                     "area",
                   ],
+                  "showLines": Array [
+                    true,
+                  ],
                   "simpleView": Array [
                     false,
                   ],

--- a/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
@@ -469,6 +469,7 @@ const dataLayerToExpression = (
               )
             : [],
           seriesType: [seriesType],
+          showLines: seriesType === 'line' || seriesType === 'area' ? [true] : [false],
           accessors: layer.accessors,
           columnToLabel: [JSON.stringify(columnToLabel)],
           ...(datasourceExpression


### PR DESCRIPTION
Fixed: #138110

## Summary

Add "showLines" arg in expression
