### PR TITLE
[Fleet] Skip agent.spec flaky test

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -14,7 +14,9 @@ const createAgentDocs = (kibanaVersion: string) => [
 ];
 
 let docs: any[] = [];
-describe('View agents', () => {
+// Skipping this spec as it is flaky
+// TODO: create fleet server, fix version of agent to upgrade to an allowed version (>= fleet server's, < kibana)
+describe.skip('View agents', () => {
   before(() => {
     cy.task('deleteDocsByQuery', {
       index: '.fleet-agents',

--- a/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/agent.spec.ts
@@ -14,8 +14,8 @@ const createAgentDocs = (kibanaVersion: string) => [
 ];
 
 let docs: any[] = [];
-// Skipping this spec as it is flaky
 // TODO: create fleet server, fix version of agent to upgrade to an allowed version (>= fleet server's, < kibana)
+// https://github.com/elastic/kibana/issues/138121
 describe.skip('View agents', () => {
   before(() => {
     cy.task('deleteDocsByQuery', {


### PR DESCRIPTION
## Summary

Skip the `agent.spec` cypress test as it became flaky, until the whole test gets refactored. 
I'll open a ticket to fix it and re-enable it.

Backporting to 8.4.0 because it's failing in some PRs that need to be backported as well.




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->