### PR TITLE
Reduce zIndex value of troubesome container

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/styles.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/styles.tsx
@@ -470,7 +470,7 @@ export const FullWidthFlexGroup = styled(EuiFlexGroup)<{ $visible?: boolean }>`
 export const UpdatedFlexGroup = styled(EuiFlexGroup)<{ $view?: ViewSelection }>`
   ${({ $view, theme }) => ($view === 'gridView' ? `margin-right: ${theme.eui.euiSizeXL};` : '')}
   position: absolute;
-  z-index: ${({ theme }) => theme.eui.euiZLevel1};
+  z-index: ${({ theme }) => theme.eui.euiZLevel1 - 3};
   right: 0px;
 `;
 


### PR DESCRIPTION
## Summary
closes: https://github.com/elastic/kibana/issues/137182

Update the zIndex of the `UpdatedFlexGroup` to be lower than the `StyledStickyWrapper` so that it appears UNDER the header search bar

|Before |After  
--- | --- 
|<img width="332" alt="image" src="https://user-images.githubusercontent.com/28942857/182884383-c61c6fb0-fe83-4b3e-a702-4f9fb71b5d8b.png">|<img width="351" alt="image" src="https://user-images.githubusercontent.com/28942857/182883326-508cdf61-df76-4968-8444-040a70cce5d7.png">



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->