### PR TITLE
[Fleet] Display loading content for advanced tab to reduce layout shift

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiSteps } from '@elastic/eui';
 import React from 'react';
+import { EuiLoadingContent, EuiSteps } from '@elastic/eui';
 
 import { useAdvancedForm } from './hooks';
 
@@ -24,6 +24,7 @@ interface AdvancedTabProps {
 
 export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({ selectedPolicyId }) => {
   const {
+    isSelectFleetServerPolicyLoading,
     eligibleFleetServerPolicies,
     refreshEligibleFleetServerPolicies,
     fleetServerPolicyId,
@@ -70,5 +71,9 @@ export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({ selecte
     getConfirmFleetServerConnectionStep({ isFleetServerReady, disabled: !Boolean(serviceToken) }),
   ];
 
-  return <EuiSteps steps={steps} className="eui-textLeft" />;
+  return isSelectFleetServerPolicyLoading ? (
+    <EuiLoadingContent />
+  ) : (
+    <EuiSteps steps={steps} className="eui-textLeft" />
+  );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_advanced_form.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_advanced_form.ts
@@ -19,6 +19,7 @@ import { useWaitForFleetServer } from './use_wait_for_fleet_server';
  */
 export const useAdvancedForm = (defaultAgentPolicyId?: string) => {
   const {
+    isSelectFleetServerPolicyLoading,
     eligibleFleetServerPolicies,
     refreshEligibleFleetServerPolicies,
     fleetServerPolicyId,
@@ -31,6 +32,7 @@ export const useAdvancedForm = (defaultAgentPolicyId?: string) => {
   const [deploymentMode, setDeploymentMode] = useState<DeploymentMode>('quickstart');
 
   return {
+    isSelectFleetServerPolicyLoading,
     eligibleFleetServerPolicies,
     refreshEligibleFleetServerPolicies,
     fleetServerPolicyId,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
@@ -16,6 +16,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   );
   const {
     isLoading,
+    isInitialRequest,
     data: agentPoliciesData,
     resendRequest,
   } = useGetAgentPolicies({
@@ -38,7 +39,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   }, [eligibleFleetServerPolicies, fleetServerPolicyId]);
 
   return {
-    isSelectFleetServerPolicyLoading: isLoading,
+    isSelectFleetServerPolicyLoading: isLoading && isInitialRequest,
     fleetServerPolicyId,
     setFleetServerPolicyId,
     eligibleFleetServerPolicies,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
@@ -14,7 +14,11 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   const [fleetServerPolicyId, setFleetServerPolicyId] = useState<string | undefined>(
     defaultAgentPolicyId
   );
-  const { data: agentPoliciesData, resendRequest } = useGetAgentPolicies({
+  const {
+    isLoading,
+    data: agentPoliciesData,
+    resendRequest,
+  } = useGetAgentPolicies({
     full: true,
   });
 
@@ -34,6 +38,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   }, [eligibleFleetServerPolicies, fleetServerPolicyId]);
 
   return {
+    isSelectFleetServerPolicyLoading: isLoading,
     fleetServerPolicyId,
     setFleetServerPolicyId,
     eligibleFleetServerPolicies,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/add_fleet_server_host.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/add_fleet_server_host.tsx
@@ -106,7 +106,6 @@ export const AddFleetServerHostStepContent = ({
       <EuiSpacer size="m" />
       <EuiFlexGroup wrap>
         <EuiFlexItem
-          grow={false}
           css={`
             max-width: 100%;
           `}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/138073

The `AdvancedTab` component requires requesting a list of agent policies to determine whether eligible Fleet Server policies exist to populate the "select policy" dropdown in the first step we display. While this request is loading, we were originally displaying the step in a state as if no eligible policies existed. This isn't accurate, and resulted in a pretty nasty bit of flickering/UI shifting while the request to determine what policies to populate in the dropdown was in progress. 

This PR adds some `<EuiLoadingContent />` in place of the `<EuiSteps />` component for the advanced tab UI while the Fleet Server policies request is loading. This reduces the layout shift because the transition between the loading content and the tab content is much less than between the two variations of the first step.

With proper caching and better network call hooks, this problem might not be very evident. Perhaps more motivation to look further into wider adoption of https://tanstack.com/query/v4 like in other plugins. 

## Screen Recording

Screen recording includes rendering the Advanced Tab UI on Slow 3G network -> Fast 3G network -> No throttling to demonstrate loading behavior in a variety of network conditions. 

https://user-images.githubusercontent.com/6766512/182884313-06666078-9097-415a-b3da-30d6596ba01e.mov

