### PR TITLE
Update hostrisk mappings

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/prebuilt_dev_tool_content/console_templates/enable_host_risk_score.console
+++ b/x-pack/plugins/security_solution/server/lib/prebuilt_dev_tool_content/console_templates/enable_host_risk_score.console
@@ -83,7 +83,12 @@ PUT ml_host_risk_score_{{space_name}}
         "type": "date"
       },
       "risk": {
-        "type": "keyword"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type":  "keyword"
+          }
+        }
       },
       "risk_stats": {
         "properties": {
@@ -205,7 +210,12 @@ PUT ml_host_risk_score_latest_{{space_name}}
         "type": "date"
       },
       "risk": {
-        "type": "keyword"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type":  "keyword"
+          }
+        }
       },
       "risk_stats": {
         "properties": {

--- a/x-pack/plugins/security_solution/server/lib/prebuilt_dev_tool_content/routes/__snapshots__/read_prebuilt_dev_tool_content_route.test.ts.snap
+++ b/x-pack/plugins/security_solution/server/lib/prebuilt_dev_tool_content/routes/__snapshots__/read_prebuilt_dev_tool_content_route.test.ts.snap
@@ -86,7 +86,12 @@ PUT ml_host_risk_score_default
         \\"type\\": \\"date\\"
       },
       \\"risk\\": {
-        \\"type\\": \\"keyword\\"
+        \\"type\\": \\"text\\",
+        \\"fields\\": {
+          \\"keyword\\": {
+            \\"type\\":  \\"keyword\\"
+          }
+        }
       },
       \\"risk_stats\\": {
         \\"properties\\": {
@@ -208,7 +213,12 @@ PUT ml_host_risk_score_latest_default
         \\"type\\": \\"date\\"
       },
       \\"risk\\": {
-        \\"type\\": \\"keyword\\"
+        \\"type\\": \\"text\\",
+        \\"fields\\": {
+          \\"keyword\\": {
+            \\"type\\":  \\"keyword\\"
+          }
+        }
       },
       \\"risk_stats\\": {
         \\"properties\\": {


### PR DESCRIPTION
## Summary

The `risk` field mappings missed the text field, therefor the filter in host risk tab didn't work.


https://user-images.githubusercontent.com/6295984/182886238-8bddec20-32a4-431f-bfb9-84bb5bd73c0b.mov



### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->