### PR TITLE
[Enterprise Search] Fix link for configure button on Index Detail Scheduling tab

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -94,7 +94,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
           <EuiSpacer size="s" />
           <EuiButtonTo
             to={generatePath(SEARCH_INDEX_TAB_PATH, {
-              indexName: index.connector.name,
+              indexName: index.name,
               tabId: SearchIndexTabId.CONFIGURATION,
             })}
             fill


### PR DESCRIPTION
## Summary

We were using connector name instead of index name


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->