### PR TITLE
[Stack integration] Workaround for dataview name conflict on creation with CCS 

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
+++ b/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
@@ -130,7 +130,8 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('create index pattern for data from both clusters', async () => {
-      await PageObjects.settings.createIndexPattern('*:makelogs工程-*', '@timestamp', true, false);
+      await PageObjects.settings.createIndexPattern('*:makelogs工程-*', '@timestamp', true, false, "*:makelogs工程-*");
+      // line about is workaround for https://github.com/elastic/kibana/issues/136757  
       const patternName = await PageObjects.settings.getIndexPageHeading();
       expect(patternName).to.be('*:makelogs工程-*');
     });


### PR DESCRIPTION
## Summary
This PR sets a default name for the data view, working around issue: https://github.com/elastic/kibana/issues/136757



