### PR TITLE
[Cloud Posture] Cloud Posture page titles beta tags

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
@@ -19,9 +19,16 @@ export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta
     {isBeta && (
       <EuiFlexItem grow={false}>
         <EuiBetaBadge
-          label={i18n.translate('xpack.csp.common.cloudPosturePageTitle.BetaTagLabel', {
+          label={i18n.translate('xpack.csp.common.cloudPosturePageTitle.BetaBadgeLabel', {
             defaultMessage: 'Beta',
           })}
+          tooltipContent={i18n.translate(
+            'xpack.csp.common.cloudPosturePageTitle.BetaBadgeTooltip',
+            {
+              defaultMessage:
+                'This functionality is in beta and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in beta are not subject to the support SLA of official GA features.',
+            }
+          )}
         />
       </EuiFlexItem>
     )}

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+
+export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta: boolean }) => (
+  <EuiFlexGroup alignItems="center" gutterSize="s">
+    <EuiFlexItem grow={false}>
+      <EuiTitle>
+        <h1>{title}</h1>
+      </EuiTitle>
+    </EuiFlexItem>
+    {isBeta && (
+      <EuiFlexItem grow={false}>
+        <EuiBetaBadge label={'Beta'} />
+      </EuiFlexItem>
+    )}
+  </EuiFlexGroup>
+);

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 
 export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta: boolean }) => (
@@ -17,7 +18,11 @@ export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta
     </EuiFlexItem>
     {isBeta && (
       <EuiFlexItem grow={false}>
-        <EuiBetaBadge label={'Beta'} />
+        <EuiBetaBadge
+          label={i18n.translate('xpack.csp.common.cloudPosturePageTitle.BetaTagLabel', {
+            defaultMessage: 'Beta',
+          })}
+        />
       </EuiFlexItem>
     )}
   </EuiFlexGroup>

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -20,6 +20,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import useDebounce from 'react-use/lib/useDebounce';
 import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../components/cloud_posture_page_title';
 import { CloudPosturePage } from '../../components/cloud_posture_page';
 import { useCISIntegrationLink } from '../../common/navigation/use_navigate_to_cis_integration';
 import { BenchmarksTable } from './benchmarks_table';
@@ -140,10 +141,15 @@ export const Benchmarks = () => {
     <CloudPosturePage>
       <EuiPageHeader
         data-test-subj={TEST_SUBJ.BENCHMARKS_PAGE_HEADER}
-        pageTitle={i18n.translate(
-          'xpack.csp.benchmarks.benchmarksPageHeader.benchmarkIntegrationsTitle',
-          { defaultMessage: 'Benchmark Integrations' }
-        )}
+        pageTitle={
+          <CloudPosturePageTitle
+            isBeta
+            title={i18n.translate(
+              'xpack.csp.benchmarks.benchmarksPageHeader.benchmarkIntegrationsTitle',
+              { defaultMessage: 'Benchmark Integrations' }
+            )}
+          />
+        }
         rightSideItems={[<AddCisIntegrationButton />]}
         bottomBorder
       />

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 import { EuiSpacer, EuiPageHeader } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../components/cloud_posture_page_title';
 import { CloudPosturePage } from '../../components/cloud_posture_page';
 import { DASHBOARD_CONTAINER } from './test_subjects';
 import { SummarySection } from './dashboard_sections/summary_section';
@@ -30,9 +31,14 @@ export const ComplianceDashboard = () => {
     <CloudPosturePage query={getDashboardData}>
       <EuiPageHeader
         bottomBorder
-        pageTitle={i18n.translate('xpack.csp.dashboard.cspPageTemplate.pageTitle', {
-          defaultMessage: 'Cloud Posture',
-        })}
+        pageTitle={
+          <CloudPosturePageTitle
+            isBeta
+            title={i18n.translate('xpack.csp.dashboard.cspPageTemplate.pageTitle', {
+              defaultMessage: 'Cloud Posture',
+            })}
+          />
+        }
       />
       <EuiSpacer />
       <div

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiBottomBar, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../../components/cloud_posture_page_title';
 import type { FindingsBaseProps } from '../types';
 import { FindingsTable } from './latest_findings_table';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
@@ -168,9 +169,11 @@ const LatestFindingsPageTitle = () => (
   <PageTitle>
     <PageTitleText
       title={
-        <FormattedMessage
-          id="xpack.csp.findings.latestFindings.latestFindingsPageTitle"
-          defaultMessage="Findings"
+        <CloudPosturePageTitle
+          isBeta
+          title={i18n.translate('xpack.csp.findings.latestFindings.latestFindingsPageTitle', {
+            defaultMessage: 'Findings',
+          })}
         />
       }
     />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -6,9 +6,9 @@
  */
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../../components/cloud_posture_page_title';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
 import { useUrlQuery } from '../../../common/hooks/use_url_query';
@@ -92,9 +92,12 @@ const LatestFindingsByResource = ({ dataView }: FindingsBaseProps) => {
       <PageTitle>
         <PageTitleText
           title={
-            <FormattedMessage
-              id="xpack.csp.findings.findingsByResource.findingsByResourcePageTitle"
-              defaultMessage="Findings"
+            <CloudPosturePageTitle
+              isBeta
+              title={i18n.translate(
+                'xpack.csp.findings.findingsByResource.findingsByResourcePageTitle',
+                { defaultMessage: 'Findings' }
+              )}
             />
           }
         />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import { EuiSpacer, EuiButtonEmpty } from '@elastic/eui';
 import { Link, useParams } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useEuiTheme } from '@elastic/eui';
 import { generatePath } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { CloudPosturePageTitle } from '../../../../components/cloud_posture_page_title';
@@ -54,9 +53,7 @@ const BackToResourcesButton = () => (
 );
 
 export const ResourceFindings = ({ dataView }: FindingsBaseProps) => {
-  const { euiTheme } = useEuiTheme();
   const params = useParams<{ resourceId: string }>();
-
   const getPersistedDefaultQuery = usePersistedQuery(getDefaultQuery);
   const { urlQuery, setUrlQuery } = useUrlQuery(getPersistedDefaultQuery);
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -98,18 +98,16 @@ export const ResourceFindings = ({ dataView }: FindingsBaseProps) => {
         <BackToResourcesButton />
         <PageTitleText
           title={
-            <div style={{ padding: euiTheme.size.s }}>
-              <CloudPosturePageTitle
-                isBeta
-                title={i18n.translate(
-                  'xpack.csp.findings.resourceFindings.resourceFindingsPageTitle',
-                  {
-                    defaultMessage: '{resourceId} - Findings',
-                    values: { resourceId: params.resourceId },
-                  }
-                )}
-              />
-            </div>
+            <CloudPosturePageTitle
+              isBeta
+              title={i18n.translate(
+                'xpack.csp.findings.resourceFindings.resourceFindingsPageTitle',
+                {
+                  defaultMessage: '{resourceId} - Findings',
+                  values: { resourceId: params.resourceId },
+                }
+              )}
+            />
           }
         />
       </PageTitle>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_container.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useEuiTheme } from '@elastic/eui';
 import { generatePath } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../../../components/cloud_posture_page_title';
 import * as TEST_SUBJECTS from '../../test_subjects';
 import { PageTitle, PageTitleText } from '../../layout/findings_layout';
 import { findingsNavigation } from '../../../../common/navigation/constants';
@@ -98,10 +99,15 @@ export const ResourceFindings = ({ dataView }: FindingsBaseProps) => {
         <PageTitleText
           title={
             <div style={{ padding: euiTheme.size.s }}>
-              <FormattedMessage
-                id="xpack.csp.findings.resourceFindings.resourceFindingsPageTitle"
-                defaultMessage="{resourceId} - Findings"
-                values={{ resourceId: params.resourceId }}
+              <CloudPosturePageTitle
+                isBeta
+                title={i18n.translate(
+                  'xpack.csp.findings.resourceFindings.resourceFindingsPageTitle',
+                  {
+                    defaultMessage: '{resourceId} - Findings',
+                    values: { resourceId: params.resourceId },
+                  }
+                )}
               />
             </div>
           }

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -10,6 +10,8 @@ import { generatePath, Link, type RouteComponentProps } from 'react-router-dom';
 import { EuiTextColor, EuiButtonEmpty, EuiFlexGroup, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { CloudPosturePageTitle } from '../../components/cloud_posture_page_title';
 import type { BreadcrumbEntry } from '../../common/navigation/types';
 import { RulesContainer, type PageUrlParams } from './rules_container';
 import { cloudPosturePages } from '../../common/navigation/constants';
@@ -80,12 +82,14 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
                 />
               </EuiButtonEmpty>
             </Link>
-            <FormattedMessage
-              id="xpack.csp.rules.rulePageHeader.pageHeaderTitle"
-              defaultMessage="Rules - {integrationName}"
-              values={{
-                integrationName: packageInfo?.name,
-              }}
+            <CloudPosturePageTitle
+              isBeta
+              title={i18n.translate('xpack.csp.rules.rulePageHeader.pageHeaderTitle', {
+                defaultMessage: 'Rules - {integrationName}',
+                values: {
+                  integrationName: packageInfo?.name,
+                },
+              })}
             />
           </EuiFlexGroup>
         }


### PR DESCRIPTION
## Summary

All Cloud Posture page titles are now displaying a beta tag

https://user-images.githubusercontent.com/51442161/183288672-510f2630-0081-4b4f-a1ef-c3c3e2f471f1.mov
 
<img width="338" alt="image" src="https://user-images.githubusercontent.com/51442161/183289461-6225a4a6-dccb-436c-b3df-9068d571dbf7.png">
