### PR TITLE
[Cloud Posture] Timestamps cells with human readable tooltips

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/constants.ts
@@ -10,3 +10,4 @@ import { euiPaletteForStatus } from '@elastic/eui';
 const [success, warning, danger] = euiPaletteForStatus(3);
 
 export const statusColors = { success, warning, danger };
+export const CSP_MOMENT_FORMAT = 'MMMM D, YYYY @ HH:mm:ss.SSS';

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_timestamp_table_cell.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_timestamp_table_cell.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import moment, { type MomentInput } from 'moment';
+import { EuiToolTip } from '@elastic/eui';
+
+export const CspTimestampTableCell = ({ timestamp }: { timestamp: MomentInput }) => (
+  <EuiToolTip position="top" content={moment(timestamp).format('MMMM D, YYYY @ HH:mm:ss.SSS')}>
+    <span>{moment(timestamp).fromNow()}</span>
+  </EuiToolTip>
+);

--- a/x-pack/plugins/cloud_security_posture/public/components/timestamp_table_cell.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/timestamp_table_cell.tsx
@@ -8,9 +8,10 @@
 import React from 'react';
 import moment, { type MomentInput } from 'moment';
 import { EuiToolTip } from '@elastic/eui';
+import { CSP_MOMENT_FORMAT } from '../common/constants';
 
-export const CspTimestampTableCell = ({ timestamp }: { timestamp: MomentInput }) => (
-  <EuiToolTip position="top" content={moment(timestamp).format('MMMM D, YYYY @ HH:mm:ss.SSS')}>
+export const TimestampTableCell = ({ timestamp }: { timestamp: MomentInput }) => (
+  <EuiToolTip position="top" content={moment(timestamp).format(CSP_MOMENT_FORMAT)}>
     <span>{moment(timestamp).fromNow()}</span>
   </EuiToolTip>
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -11,14 +11,13 @@ import {
   type EuiBasicTableProps,
   type Pagination,
   type CriteriaWithPagination,
-  EuiToolTip,
 } from '@elastic/eui';
 import React from 'react';
-import moment from 'moment';
 import { Link, useHistory, generatePath } from 'react-router-dom';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { CspTimestampTableCell } from '../../components/csp_timestamp_table_cell';
 import type { Benchmark } from '../../../common/types';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { cloudPosturePages } from '../../common/navigation/constants';
@@ -136,9 +135,7 @@ const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<Benchmark>> = [
     dataType: 'date',
     truncateText: true,
     render: (timestamp: Benchmark['package_policy']['created_at']) => (
-      <EuiToolTip position="top" content={timestamp}>
-        <span>{moment(timestamp).fromNow()}</span>
-      </EuiToolTip>
+      <CspTimestampTableCell timestamp={timestamp} />
     ),
     sortable: true,
     'data-test-subj': TEST_SUBJ.BENCHMARKS_TABLE_COLUMNS.CREATED_AT,

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -11,6 +11,7 @@ import {
   type EuiBasicTableProps,
   type Pagination,
   type CriteriaWithPagination,
+  EuiToolTip,
 } from '@elastic/eui';
 import React from 'react';
 import moment from 'moment';
@@ -134,7 +135,11 @@ const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<Benchmark>> = [
     }),
     dataType: 'date',
     truncateText: true,
-    render: (date: Benchmark['package_policy']['created_at']) => moment(date).fromNow(),
+    render: (timestamp: Benchmark['package_policy']['created_at']) => (
+      <EuiToolTip position="top" content={timestamp}>
+        <span>{moment(timestamp).fromNow()}</span>
+      </EuiToolTip>
+    ),
     sortable: true,
     'data-test-subj': TEST_SUBJ.BENCHMARKS_TABLE_COLUMNS.CREATED_AT,
   },

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -17,7 +17,7 @@ import { Link, useHistory, generatePath } from 'react-router-dom';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { CspTimestampTableCell } from '../../components/csp_timestamp_table_cell';
+import { TimestampTableCell } from '../../components/timestamp_table_cell';
 import type { Benchmark } from '../../../common/types';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { cloudPosturePages } from '../../common/navigation/constants';
@@ -135,7 +135,7 @@ const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<Benchmark>> = [
     dataType: 'date',
     truncateText: true,
     render: (timestamp: Benchmark['package_policy']['created_at']) => (
-      <CspTimestampTableCell timestamp={timestamp} />
+      <TimestampTableCell timestamp={timestamp} />
     ),
     sortable: true,
     'data-test-subj': TEST_SUBJ.BENCHMARKS_TABLE_COLUMNS.CREATED_AT,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/overview_tab.tsx
@@ -17,6 +17,7 @@ import React, { useMemo } from 'react';
 import moment from 'moment';
 import type { EuiDescriptionListProps, EuiAccordionProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { CSP_MOMENT_FORMAT } from '../../../common/constants';
 import { LATEST_FINDINGS_INDEX_DEFAULT_NS } from '../../../../common/constants';
 import { useLatestFindingsDataView } from '../../../common/api/use_latest_findings_data_view';
 import { useKibana } from '../../../common/hooks/use_kibana';
@@ -37,7 +38,7 @@ const getDetailsList = (data: CspFinding, discoverIndexLink: string | undefined)
     title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.evaluatedAtTitle', {
       defaultMessage: 'Evaluated at',
     }),
-    description: moment(data['@timestamp']).format('MMMM D, YYYY @ HH:mm:ss.SSS'),
+    description: moment(data['@timestamp']).format(CSP_MOMENT_FORMAT),
   },
   {
     title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.resourceNameTitle', {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -15,10 +15,10 @@ import {
   PropsOf,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import moment from 'moment';
 import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 import type { Serializable } from '@kbn/utility-types';
+import { CspTimestampTableCell } from '../../../components/csp_timestamp_table_cell';
 import { ColumnNameWithTooltip } from '../../../components/column_name_with_tooltip';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
 import {
@@ -152,11 +152,7 @@ const baseColumns = [
     ),
     truncateText: true,
     sortable: true,
-    render: (timestamp: number) => (
-      <EuiToolTip position="top" content={timestamp}>
-        <span>{moment(timestamp).fromNow()}</span>
-      </EuiToolTip>
-    ),
+    render: (timestamp: number) => <CspTimestampTableCell timestamp={timestamp} />,
   },
 ] as const;
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -18,7 +18,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 import type { Serializable } from '@kbn/utility-types';
-import { CspTimestampTableCell } from '../../../components/csp_timestamp_table_cell';
+import { TimestampTableCell } from '../../../components/timestamp_table_cell';
 import { ColumnNameWithTooltip } from '../../../components/column_name_with_tooltip';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
 import {
@@ -152,7 +152,7 @@ const baseColumns = [
     ),
     truncateText: true,
     sortable: true,
-    render: (timestamp: number) => <CspTimestampTableCell timestamp={timestamp} />,
+    render: (timestamp: number) => <TimestampTableCell timestamp={timestamp} />,
   },
 ] as const;
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -15,7 +15,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { CspTimestampTableCell } from '../../components/csp_timestamp_table_cell';
+import { TimestampTableCell } from '../../components/timestamp_table_cell';
 import type { RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import type { RuleSavedObject } from './use_csp_rules';
@@ -144,7 +144,7 @@ const getColumns = ({
       defaultMessage: 'Last Modified',
     }),
     width: '15%',
-    render: (timestamp) => <CspTimestampTableCell timestamp={timestamp} />,
+    render: (timestamp) => <TimestampTableCell timestamp={timestamp} />,
   },
   {
     field: 'attributes.enabled',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -13,10 +13,9 @@ import {
   EuiBasicTable,
   EuiBasicTableProps,
   useEuiTheme,
-  EuiToolTip,
 } from '@elastic/eui';
-import moment from 'moment';
 import { i18n } from '@kbn/i18n';
+import { CspTimestampTableCell } from '../../components/csp_timestamp_table_cell';
 import type { RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import type { RuleSavedObject } from './use_csp_rules';
@@ -145,11 +144,7 @@ const getColumns = ({
       defaultMessage: 'Last Modified',
     }),
     width: '15%',
-    render: (timestamp) => (
-      <EuiToolTip position="top" content={timestamp}>
-        <span>{moment(timestamp).fromNow()}</span>
-      </EuiToolTip>
-    ),
+    render: (timestamp) => <CspTimestampTableCell timestamp={timestamp} />,
   },
   {
     field: 'attributes.enabled',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -13,6 +13,7 @@ import {
   EuiBasicTable,
   EuiBasicTableProps,
   useEuiTheme,
+  EuiToolTip,
 } from '@elastic/eui';
 import moment from 'moment';
 import { i18n } from '@kbn/i18n';
@@ -144,7 +145,11 @@ const getColumns = ({
       defaultMessage: 'Last Modified',
     }),
     width: '15%',
-    render: (timestamp) => moment(timestamp).fromNow(),
+    render: (timestamp) => (
+      <EuiToolTip position="top" content={timestamp}>
+        <span>{moment(timestamp).fromNow()}</span>
+      </EuiToolTip>
+    ),
   },
   {
     field: 'attributes.enabled',


### PR DESCRIPTION
## Summary

Findings, Benchmarks and Rules table now displays a human readable date upon hovering over `x time ago` columns.
Additionally, all of those columns are now using the same shared component.
@tinnytintin10 I've used the same time formatting we used for our flyouts. if you want another formatting please comment here, would be very quick change after this pr.

https://user-images.githubusercontent.com/51442161/183295952-8c63c80f-f88e-4fb4-bcb6-f5476f3c0ac4.mov



