### PR TITLE
[Discover] Remove field stats available fields

### DIFF
--- a/src/plugins/discover/public/application/main/components/field_stats_table/field_stats_table.tsx
+++ b/src/plugins/discover/public/application/main/components/field_stats_table/field_stats_table.tsx
@@ -145,7 +145,7 @@ export const FieldStatisticsTable = (props: FieldStatisticsTableProps) => {
         visibleFieldNames: columns,
         onAddFilter,
         sessionId: searchSessionId,
-        fieldsToFetch: columns,
+        fieldsToFetch: columns.length > 0 ? columns : undefined,
       });
       embeddable.reload();
     }

--- a/src/plugins/discover/public/application/main/components/field_stats_table/field_stats_table.tsx
+++ b/src/plugins/discover/public/application/main/components/field_stats_table/field_stats_table.tsx
@@ -21,7 +21,7 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { FIELD_STATISTICS_LOADED } from './constants';
 import type { SavedSearch } from '../../../../services/saved_searches';
 import type { GetStateReturn } from '../../services/discover_state';
-import { AvailableFields$, DataRefetch$ } from '../../hooks/use_saved_search';
+import { DataRefetch$ } from '../../hooks/use_saved_search';
 
 export interface DataVisualizerGridEmbeddableInput extends EmbeddableInput {
   dataView: DataView;
@@ -85,13 +85,11 @@ export interface FieldStatisticsTableProps {
    */
   trackUiMetric?: (metricType: UiCounterMetricType, eventName: string | string[]) => void;
   savedSearchRefetch$?: DataRefetch$;
-  availableFields$?: AvailableFields$;
   searchSessionId?: string;
 }
 
 export const FieldStatisticsTable = (props: FieldStatisticsTableProps) => {
   const {
-    availableFields$,
     dataView,
     savedSearch,
     query,
@@ -130,18 +128,11 @@ export const FieldStatisticsTable = (props: FieldStatisticsTableProps) => {
       }
     });
 
-    const fields = availableFields$?.subscribe(() => {
-      if (embeddable && !isErrorEmbeddable(embeddable) && !availableFields$?.getValue().error) {
-        embeddable.updateInput({ fieldsToFetch: availableFields$?.getValue().fields });
-      }
-    });
-
     return () => {
       sub?.unsubscribe();
       refetch?.unsubscribe();
-      fields?.unsubscribe();
     };
-  }, [embeddable, stateContainer, savedSearchRefetch$, availableFields$]);
+  }, [embeddable, stateContainer, savedSearchRefetch$]);
 
   useEffect(() => {
     if (embeddable && !isErrorEmbeddable(embeddable)) {
@@ -154,21 +145,11 @@ export const FieldStatisticsTable = (props: FieldStatisticsTableProps) => {
         visibleFieldNames: columns,
         onAddFilter,
         sessionId: searchSessionId,
-        fieldsToFetch: availableFields$?.getValue().fields,
+        fieldsToFetch: columns,
       });
       embeddable.reload();
     }
-  }, [
-    embeddable,
-    dataView,
-    savedSearch,
-    query,
-    columns,
-    filters,
-    onAddFilter,
-    searchSessionId,
-    availableFields$,
-  ]);
+  }, [embeddable, dataView, savedSearch, query, columns, filters, onAddFilter, searchSessionId]);
 
   useEffect(() => {
     if (showPreviewByDefault && embeddable && !isErrorEmbeddable(embeddable)) {

--- a/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
+++ b/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
@@ -13,7 +13,6 @@ import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import { action } from '@storybook/addon-actions';
 import { FetchStatus } from '../../../../types';
 import {
-  AvailableFields$,
   DataCharts$,
   DataDocuments$,
   DataMain$,
@@ -77,11 +76,6 @@ const documentObservables = {
     result: buildDataTableRecordList(esHits),
   }) as DataDocuments$,
 
-  availableFields$: new BehaviorSubject({
-    fetchStatus: FetchStatus.COMPLETE,
-    fields: [] as string[],
-  }) as AvailableFields$,
-
   totalHits$: new BehaviorSubject({
     fetchStatus: FetchStatus.COMPLETE,
     result: Number(esHits.length),
@@ -110,12 +104,6 @@ const plainRecordObservables = {
     result: buildDataTableRecordList(esHits),
     recordRawType: RecordRawType.PLAIN,
   }) as DataDocuments$,
-
-  availableFields$: new BehaviorSubject({
-    fetchStatus: FetchStatus.COMPLETE,
-    fields: [] as string[],
-    recordRawType: RecordRawType.PLAIN,
-  }) as AvailableFields$,
 
   totalHits$: new BehaviorSubject({
     fetchStatus: FetchStatus.COMPLETE,

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
@@ -22,7 +22,6 @@ import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_
 import { GetStateReturn } from '../../services/discover_state';
 import { DiscoverLayoutProps } from './types';
 import {
-  AvailableFields$,
   DataCharts$,
   DataDocuments$,
   DataMain$,
@@ -73,11 +72,6 @@ function mountComponent(
     fetchStatus: FetchStatus.COMPLETE,
     result: esHits.map((esHit) => buildDataTableRecord(esHit, dataView)),
   }) as DataDocuments$;
-
-  const availableFields$ = new BehaviorSubject({
-    fetchStatus: FetchStatus.COMPLETE,
-    fields: [] as string[],
-  }) as AvailableFields$;
 
   const totalHits$ = new BehaviorSubject({
     fetchStatus: FetchStatus.COMPLETE,
@@ -138,7 +132,6 @@ function mountComponent(
     documents$,
     totalHits$,
     charts$,
-    availableFields$,
   };
 
   const props = {

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -279,7 +279,6 @@ export function DiscoverLayout({
               onFieldEdited={onFieldEdited}
               viewMode={viewMode}
               onDataViewCreated={onDataViewCreated}
-              availableFields$={savedSearchData$.availableFields$}
             />
           </EuiFlexItem>
           <EuiHideFor sizes={['xs', 's']}>
@@ -369,7 +368,6 @@ export function DiscoverLayout({
                     />
                   ) : (
                     <FieldStatisticsTableMemoized
-                      availableFields$={savedSearchData$.availableFields$}
                       savedSearch={savedSearch}
                       dataView={dataView}
                       query={state.query}

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
@@ -20,8 +20,6 @@ import { discoverServiceMock as mockDiscoverServices } from '../../../../__mocks
 import { stubLogstashDataView } from '@kbn/data-plugin/common/stubs';
 import { VIEW_MODE } from '../../../../components/view_mode_toggle';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { BehaviorSubject } from 'rxjs';
-import { FetchStatus } from '../../../types';
 
 const mockGetActions = jest.fn<Promise<Array<Action<object>>>, [string, { fieldName: string }]>(
   () => Promise.resolve([])

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
@@ -22,7 +22,6 @@ import { VIEW_MODE } from '../../../../components/view_mode_toggle';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { BehaviorSubject } from 'rxjs';
 import { FetchStatus } from '../../../types';
-import { AvailableFields$ } from '../../hooks/use_saved_search';
 
 const mockGetActions = jest.fn<Promise<Array<Action<object>>>, [string, { fieldName: string }]>(
   () => Promise.resolve([])
@@ -51,10 +50,6 @@ function getCompProps(): DiscoverSidebarProps {
       fieldCounts[key] = (fieldCounts[key] || 0) + 1;
     }
   }
-  const availableFields$ = new BehaviorSubject({
-    fetchStatus: FetchStatus.COMPLETE,
-    fields: [] as string[],
-  }) as AvailableFields$;
 
   return {
     columns: ['extension'],
@@ -75,7 +70,6 @@ function getCompProps(): DiscoverSidebarProps {
     viewMode: VIEW_MODE.DOCUMENT_LEVEL,
     createNewDataView: jest.fn(),
     onDataViewCreated: jest.fn(),
-    availableFields$,
     useNewFieldsApi: true,
   };
 }

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -21,7 +21,7 @@ import {
 } from './discover_sidebar_responsive';
 import { DiscoverServices } from '../../../../build_services';
 import { FetchStatus } from '../../../types';
-import { AvailableFields$, DataDocuments$, RecordRawType } from '../../hooks/use_saved_search';
+import { DataDocuments$, RecordRawType } from '../../hooks/use_saved_search';
 import { stubLogstashDataView } from '@kbn/data-plugin/common/stubs';
 import { VIEW_MODE } from '../../../../components/view_mode_toggle';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -95,10 +95,6 @@ function getCompProps(): DiscoverSidebarResponsiveProps {
       fetchStatus: FetchStatus.COMPLETE,
       result: hits,
     }) as DataDocuments$,
-    availableFields$: new BehaviorSubject({
-      fetchStatus: FetchStatus.COMPLETE,
-      fields: [] as string[],
-    }) as AvailableFields$,
     dataViewList,
     onChangeDataView: jest.fn(),
     onAddFilter: jest.fn(),

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -28,10 +28,9 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { getDefaultFieldFilter } from './lib/field_filter';
 import { DiscoverSidebar } from './discover_sidebar';
 import { AppState } from '../../services/discover_state';
-import { AvailableFields$, DataDocuments$, RecordRawType } from '../../hooks/use_saved_search';
+import { DataDocuments$, RecordRawType } from '../../hooks/use_saved_search';
 import { calcFieldCounts } from '../../utils/calc_field_counts';
 import { VIEW_MODE } from '../../../../components/view_mode_toggle';
-import { FetchStatus } from '../../../types';
 import { DISCOVER_TOUR_STEP_ANCHOR_IDS } from '../../../../components/discover_tour';
 import { getRawRecordType } from '../../utils/get_raw_record_type';
 
@@ -103,10 +102,6 @@ export interface DiscoverSidebarResponsiveProps {
    * Discover view mode
    */
   viewMode: VIEW_MODE;
-  /**
-   * list of available fields fetched from ES
-   */
-  availableFields$: AvailableFields$;
 }
 
 /**
@@ -181,34 +176,8 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
   }, []);
 
   const { dataViewFieldEditor, dataViewEditor } = services;
-  const { availableFields$ } = props;
 
   const canEditDataView = Boolean(dataViewEditor?.userPermissions.editDataView());
-
-  useEffect(
-    () => {
-      // For an external embeddable like the Field stats
-      // it is useful to know what fields are populated in the docs fetched
-      // or what fields are selected by the user
-
-      const fieldCnts = fieldCounts.current ?? {};
-
-      const availableFields = props.columns.length > 0 ? props.columns : Object.keys(fieldCnts);
-      availableFields$.next({
-        fetchStatus: FetchStatus.COMPLETE,
-        fields: availableFields,
-      });
-    },
-    // Using columns.length here instead of columns to avoid array reference changing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      selectedDataView,
-      availableFields$,
-      fieldCounts.current,
-      documentState.result,
-      props.columns.length,
-    ]
-  );
 
   const editField = useMemo(
     () =>

--- a/src/plugins/discover/public/application/main/hooks/use_saved_search.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_saved_search.ts
@@ -30,7 +30,6 @@ export interface SavedSearchData {
   documents$: DataDocuments$;
   totalHits$: DataTotalHits$;
   charts$: DataCharts$;
-  availableFields$: AvailableFields$;
 }
 
 export interface TimechartBucketInterval {
@@ -43,7 +42,6 @@ export type DataMain$ = BehaviorSubject<DataMainMsg>;
 export type DataDocuments$ = BehaviorSubject<DataDocumentsMsg>;
 export type DataTotalHits$ = BehaviorSubject<DataTotalHitsMsg>;
 export type DataCharts$ = BehaviorSubject<DataChartsMessage>;
-export type AvailableFields$ = BehaviorSubject<DataAvailableFieldsMsg>;
 
 export type DataRefetch$ = Subject<DataRefetchMsg>;
 
@@ -134,7 +132,6 @@ export const useSavedSearch = ({
   const documents$: DataDocuments$ = useBehaviorSubject(initialState) as DataDocuments$;
   const totalHits$: DataTotalHits$ = useBehaviorSubject(initialState) as DataTotalHits$;
   const charts$: DataCharts$ = useBehaviorSubject(initialState) as DataCharts$;
-  const availableFields$: AvailableFields$ = useBehaviorSubject(initialState) as AvailableFields$;
 
   const dataSubjects = useMemo(() => {
     return {
@@ -142,9 +139,8 @@ export const useSavedSearch = ({
       documents$,
       totalHits$,
       charts$,
-      availableFields$,
     };
-  }, [main$, charts$, documents$, totalHits$, availableFields$]);
+  }, [main$, charts$, documents$, totalHits$]);
 
   /**
    * The observable to trigger data fetching in UI

--- a/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
@@ -16,7 +16,6 @@ import { AppState } from '../services/discover_state';
 import { discoverServiceMock } from '../../../__mocks__/services';
 import { fetchAll } from './fetch_all';
 import {
-  DataAvailableFieldsMsg,
   DataChartsMessage,
   DataDocumentsMsg,
   DataMainMsg,

--- a/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
@@ -73,9 +73,6 @@ describe('test fetchAll', () => {
       documents$: new BehaviorSubject<DataDocumentsMsg>({ fetchStatus: FetchStatus.UNINITIALIZED }),
       totalHits$: new BehaviorSubject<DataTotalHitsMsg>({ fetchStatus: FetchStatus.UNINITIALIZED }),
       charts$: new BehaviorSubject<DataChartsMessage>({ fetchStatus: FetchStatus.UNINITIALIZED }),
-      availableFields$: new BehaviorSubject<DataAvailableFieldsMsg>({
-        fetchStatus: FetchStatus.UNINITIALIZED,
-      }),
     };
     deps = {
       appStateContainer: {


### PR DESCRIPTION
## Summary

This PR removes `AvailableFields$` which is used to forward the results of the calculations which fields are available to Discover's field statistics. The reason for this change is that the available fields are calculated based on the max of 500 documents sample retrieved by the previous search of Discover, and therefore can be inaccurate. Field statistics should have statistics for all fields available unless there are selected fields which would filter down the result to those fields. I think the reason to limit the displayed fields to available fields, was not to fetch all fields for performance reason. However with pagination of the fetching of the results, there has already been a better solution implemented.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios