### PR TITLE
[Lens] Metric fix sticky default color

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/metric/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/dimension_editor.tsx
@@ -291,6 +291,7 @@ function PrimaryMetricEditor(props: Props) {
                   };
             setState({
               ...state,
+              color: undefined,
               ...params,
             });
           }}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/138241

By removing the static color from the state when the user is switching to dynamic coloring.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->