### PR TITLE
[Cloud Posture] Rules table bottom bar hiding pagination elements

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -226,7 +226,16 @@ export const RulesContainer = () => {
         />
       </EuiPanel>
       {hasChanges && (
-        <RulesBottomBar onSave={bulkUpdateRules} onCancel={discardChanges} isLoading={isUpdating} />
+        <>
+          {/* spacers to lift the table enough so the bar won't hide the pagination */}
+          <EuiSpacer size="xxl" />
+          <EuiSpacer size="xxl" />
+          <RulesBottomBar
+            onSave={bulkUpdateRules}
+            onCancel={discardChanges}
+            isLoading={isUpdating}
+          />
+        </>
       )}
       {selectedRuleId && (
         <RuleFlyout


### PR DESCRIPTION
## Summary

Rules changes bottom bar was hiding the pagination elements, added spacing.

### Before
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/51442161/183414545-3397133b-20aa-41b4-ae9c-b3b415542730.png">


### After
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/51442161/183414459-377e0d20-7b40-47bd-8c19-4048b0e8422f.png">
