### PR TITLE
[ML] Use data view name in anomaly detection job wizards

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
@@ -51,6 +51,7 @@ export class JobCreator {
   protected _indexPattern: DataView;
   protected _savedSearch: SavedSearchSavedObject | null;
   protected _indexPatternTitle: IndexPatternTitle = '';
+  protected _indexPatternDisplayName: string = '';
   protected _job_config: Job;
   protected _calendars: Calendar[];
   protected _datafeed_config: Datafeed;
@@ -79,7 +80,11 @@ export class JobCreator {
   constructor(indexPattern: DataView, savedSearch: SavedSearchSavedObject | null, query: object) {
     this._indexPattern = indexPattern;
     this._savedSearch = savedSearch;
-    this._indexPatternTitle = indexPattern.title;
+
+    const title = this._indexPattern.title;
+    const name = this._indexPattern.getName();
+    this._indexPatternDisplayName = name === title ? name : `${name} (${title})`;
+    this._indexPatternTitle = title;
 
     this._job_config = createEmptyJob();
     this._calendars = [];
@@ -102,6 +107,10 @@ export class JobCreator {
 
   public get indexPatternTitle(): string {
     return this._indexPatternTitle;
+  }
+
+  public get indexPatternDisplayName(): string {
+    return this._indexPatternDisplayName;
   }
 
   protected _addDetector(detector: Detector, agg: Aggregation, field: Field) {

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/job_type/page.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/job_type/page.tsx
@@ -72,7 +72,7 @@ export const Page: FC = () => {
       })
     : i18n.translate('xpack.ml.newJob.wizard.jobType.dataViewPageTitleLabel', {
         defaultMessage: 'data view {dataViewName}',
-        values: { dataViewName: currentDataView.title },
+        values: { dataViewName: currentDataView.getName() },
       });
 
   const recognizerResults = {

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/new_job/page.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/new_job/page.tsx
@@ -216,7 +216,7 @@ export const Page: FC<PageProps> = ({ existingJobsAndGroups, jobType }) => {
             <FormattedMessage
               id="xpack.ml.newJob.page.createJob.dataViewName"
               defaultMessage="Using data view {dataViewName}"
-              values={{ dataViewName: jobCreator.indexPatternTitle }}
+              values={{ dataViewName: jobCreator.indexPatternDisplayName }}
             />
           </EuiPageContentHeaderSection>
         </EuiPageContentHeader>

--- a/x-pack/plugins/ml/public/application/jobs/new_job/recognize/page.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/recognize/page.tsx
@@ -101,7 +101,7 @@ export const Page: FC<PageProps> = ({ moduleId, existingGroupIds }) => {
         })
       : i18n.translate('xpack.ml.newJob.recognize.dataViewPageTitle', {
           defaultMessage: 'data view {dataViewName}',
-          values: { dataViewName: dataView.title },
+          values: { dataViewName: dataView.getName() },
         });
   const displayQueryWarning = savedSearch !== null;
   const tempQuery = savedSearch === null ? undefined : combinedQuery;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/138175

Job type selection page now uses the data view verbose name in the title:

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/22172091/183416609-db4ea07a-78c6-4163-af49-02c9fd896393.png">


Job wizards show the verbose name, and the pattern (if the verbose name has been used)
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/22172091/183416691-aa1aa94e-9e09-4905-b04f-02aa3468d7e3.png">


Recognizer page shows the verbose name:
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/22172091/183417311-9ee14c06-5b5a-46ba-82ba-64a6be428544.png">




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->