### PR TITLE
[Fleet] Bump version of bundled elastic_agent package

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -19,7 +19,7 @@
   },
   {
     "name": "elastic_agent",
-    "version": "1.3.3"
+    "version": "1.3.4"
   },
   {
     "name": "endpoint",


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/issues/138257

Bumps the bundled version of `elastic_agent` to the latest available version `1.3.4` in preparation for the 8.4.0 release.

