### PR TITLE
Space aware dev tool urls

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -274,8 +274,8 @@ export const DETECTION_ENGINE_RULES_BULK_UPDATE =
 
 export const DEV_TOOL_PREBUILT_CONTENT =
   `/internal/prebuilt_content/dev_tool/{console_id}` as const;
-export const devToolPrebuiltContentUrl = (consoleId: string) =>
-  `/internal/prebuilt_content/dev_tool/${consoleId}` as const;
+export const devToolPrebuiltContentUrl = (spaceId: string, consoleId: string) =>
+  `/s/${spaceId}/internal/prebuilt_content/dev_tool/${consoleId}` as const;
 export const PREBUILT_SAVED_OBJECTS_BULK_CREATE =
   '/internal/prebuilt_content/saved_objects/_bulk_create/{template_name}';
 export const prebuiltSavedObjectsBulkCreateUrl = (templateName: string) =>

--- a/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
@@ -9,8 +9,12 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { OpenInDevConsoleButton } from '.';
 import { TestProviders } from '../../mock';
 
+jest.mock('../../../risk_score/containers/common', () => ({
+  useSpaceId: jest.fn().mockReturnValue('myspace'),
+}));
+
 describe('OpenInDevConsoleButton', () => {
-  it('renders open in dev console link', () => {
+  it('renders an open in dev console link', () => {
     render(
       <TestProviders>
         <OpenInDevConsoleButton
@@ -22,6 +26,22 @@ describe('OpenInDevConsoleButton', () => {
       </TestProviders>
     );
     expect(screen.getByTestId('open-in-console-button')).toBeInTheDocument();
+  });
+
+  it('renders a space-awared dev console link', () => {
+    render(
+      <TestProviders>
+        <OpenInDevConsoleButton
+          enableButton={true}
+          loadFromUrl="http://localhost:1234/s/myspace/test"
+          tooltipContent="popover"
+          title="open in dev console"
+        />
+      </TestProviders>
+    );
+    expect(screen.getByTestId('open-in-console-button').getAttribute('href')).toEqual(
+      '/s/myspace/app/dev_tools#/console?load_from=http://localhost:1234/test'
+    );
   });
 
   it('renders a disabled button', () => {

--- a/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
@@ -40,7 +40,7 @@ describe('OpenInDevConsoleButton', () => {
       </TestProviders>
     );
     expect(screen.getByTestId('open-in-console-button').getAttribute('href')).toEqual(
-      '/s/myspace/app/dev_tools#/console?load_from=http://localhost:1234/test'
+      '/s/myspace/app/dev_tools#/console?load_from=http://localhost:1234/s/myspace/test'
     );
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { EuiButton, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import { useSpaceId } from '../../../risk_score/containers/common';
 
 interface OpenInDevConsoleButtonProps {
   enableButton: boolean;
@@ -20,7 +21,8 @@ const OpenInDevConsoleButtonComponent: React.FC<OpenInDevConsoleButtonProps> = (
   tooltipContent,
   title,
 }) => {
-  const href = `/app/dev_tools#/console?load_from=${loadFromUrl}`;
+  const spaceId = useSpaceId() ?? 'default';
+  const href = `/s/${spaceId}/app/dev_tools#/console?load_from=${loadFromUrl}`;
 
   return (
     <EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/risky_hosts_disabled_module.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/risky_hosts_disabled_module.tsx
@@ -16,6 +16,7 @@ import { devToolPrebuiltContentUrl } from '../../../../common/constants';
 import { OpenInDevConsoleButton } from '../../../common/components/open_in_dev_console';
 import { useChcekSignalIndex } from '../../../detections/containers/detection_engine/alerts/use_check_signal_index';
 import type { LinkPanelListItem } from '../link_panel';
+import { useSpaceId } from '../../../risk_score/containers/common';
 
 export const RISKY_HOSTS_DOC_LINK =
   'https://www.github.com/elastic/detection-rules/blob/main/docs/experimental-machine-learning/host-risk-score.md';
@@ -24,12 +25,16 @@ const emptyList: LinkPanelListItem[] = [];
 
 export const RiskyHostsDisabledModuleComponent = () => {
   const hostRiskScoreConsoleId = 'enable_host_risk_score';
+  const spaceId = useSpaceId();
   const loadFromUrl = useMemo(() => {
     const protocol = window.location.protocol;
     const hostname = window.location.hostname;
     const port = window.location.port;
-    return `${protocol}//${hostname}:${port}${devToolPrebuiltContentUrl(hostRiskScoreConsoleId)}`;
-  }, []);
+    return `${protocol}//${hostname}:${port}${devToolPrebuiltContentUrl(
+      spaceId ?? 'default',
+      hostRiskScoreConsoleId
+    )}`;
+  }, [spaceId]);
   const { signalIndexExists } = useChcekSignalIndex();
   return (
     <DisabledLinkPanel

--- a/x-pack/plugins/security_solution/server/lib/prebuilt_saved_objects/mocks.ts
+++ b/x-pack/plugins/security_solution/server/lib/prebuilt_saved_objects/mocks.ts
@@ -328,7 +328,7 @@ export const expectedSavedObjectTemplate = [
                     operationType: 'last_value',
                     params: { sortField: '@timestamp' },
                     scale: 'ordinal',
-                    sourceField: 'risk',
+                    sourceField: 'risk.keyword',
                   },
                 },
                 incompleteColumns: {},

--- a/x-pack/plugins/security_solution/server/lib/prebuilt_saved_objects/saved_object/host_risk_score_dashboards.ts
+++ b/x-pack/plugins/security_solution/server/lib/prebuilt_saved_objects/saved_object/host_risk_score_dashboards.ts
@@ -330,7 +330,7 @@ export const hostRiskScoreDashboards: SavedObject[] = [
                     operationType: 'last_value',
                     params: { sortField: '@timestamp' },
                     scale: 'ordinal',
-                    sourceField: 'risk',
+                    sourceField: 'risk.keyword',
                   },
                 },
                 incompleteColumns: {},


### PR DESCRIPTION
## Summary

This pr is to fix the `Enable via Dev Tools` url and content appended to the Dev tools.
The Url generated before wasn't space aware and cause the incorrect space name being display in dev tools content.

This pr also fixes the `risk` field uses in the dashboard to be `risk.keyword` so it can be aggregated.

**Default space**
<img width="835" alt="Screenshot 2022-08-08 at 13 45 44" src="https://user-images.githubusercontent.com/6295984/183425277-1bca20c0-4a08-42ff-ba0a-53216b26c95b.png">

<img width="1678" alt="Screenshot 2022-08-08 at 13 52 08" src="https://user-images.githubusercontent.com/6295984/183425267-218da074-af3e-4679-981e-f2accfd2b291.png">

**Custom space**
<img width="1676" alt="Screenshot 2022-08-08 at 13 51 12" src="https://user-images.githubusercontent.com/6295984/183425271-411069fd-9651-4482-a15e-0d0059e1e48a.png">
<img width="1665" alt="Screenshot 2022-08-08 at 13 47 58" src="https://user-images.githubusercontent.com/6295984/183425274-fb112a15-f6c3-4108-943b-1fa05d7aa7f3.png">


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->