### PR TITLE
[Security Solution] Add logic to generate usages for simple commands without parameters

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_usage.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_usage.tsx
@@ -45,7 +45,7 @@ export const CommandInputUsage = memo<Pick<CommandUsageProps, 'commandDef'>>(({ 
                 })}
               </ConsoleCodeBlock>
             ),
-            description: usageHelp,
+            description: usageHelp && usageHelp.length > 0 ? usageHelp : commandDef.name,
           },
         ]}
         descriptionProps={additionalProps}


### PR DESCRIPTION
## Summary

Update the way the Usage field is generated so that it is not blank for simple commands with no parameters.

Addresses:
https://github.com/elastic/kibana/issues/137426
https://github.com/elastic/kibana/issues/137427
https://github.com/elastic/kibana/issues/137425

Usage is now not blank:

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/56395104/183426456-85c9c344-dc38-4e54-a825-9a628dbab00b.png">

More complex commands still display correctly:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/183426537-3baec047-3aab-4ca5-a8d7-7324d5e30508.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
