### PR TITLE
[VisEditors] Replace deprecated `data.fieldFormats` -> `fieldFormats`

### DIFF
--- a/src/plugins/vis_types/table/kibana.json
+++ b/src/plugins/vis_types/table/kibana.json
@@ -9,6 +9,7 @@
     "fieldFormats"
   ],
   "requiredBundles": [
+    "data",
     "kibanaUtils",
     "kibanaReact",
     "share",

--- a/src/plugins/vis_types/table/kibana.json
+++ b/src/plugins/vis_types/table/kibana.json
@@ -6,7 +6,7 @@
   "requiredPlugins": [
     "expressions",
     "visualizations",
-    "data"
+    "fieldFormats"
   ],
   "requiredBundles": [
     "kibanaUtils",

--- a/src/plugins/vis_types/table/public/plugin.ts
+++ b/src/plugins/vis_types/table/public/plugin.ts
@@ -6,12 +6,15 @@
  * Side Public License, v 1.
  */
 
-import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
-import { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
-import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
-import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import type { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
+import type { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
+import type {
+  UsageCollectionSetup,
+  UsageCollectionStart,
+} from '@kbn/usage-collection-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { setFormatService } from './services';
 import { registerTableVis } from './register_vis';
 
@@ -24,7 +27,7 @@ export interface TablePluginSetupDependencies {
 
 /** @internal */
 export interface TablePluginStartDependencies {
-  data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   usageCollection?: UsageCollectionStart;
 }
 
@@ -36,7 +39,7 @@ export class TableVisPlugin
     registerTableVis(core, deps);
   }
 
-  public start(core: CoreStart, { data }: TablePluginStartDependencies) {
-    setFormatService(data.fieldFormats);
+  public start(core: CoreStart, { fieldFormats }: TablePluginStartDependencies) {
+    setFormatService(fieldFormats);
   }
 }

--- a/src/plugins/vis_types/table/public/services.ts
+++ b/src/plugins/vis_types/table/public/services.ts
@@ -7,11 +7,11 @@
  */
 
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 
 export const [getFormatService, setFormatService] =
-  createGetterSetter<DataPublicPluginStart['fieldFormats']>('table data.fieldFormats');
+  createGetterSetter<FieldFormatsStart>('FieldFormats');
 
 export const [getUsageCollectionStart, setUsageCollectionStart] =
   createGetterSetter<UsageCollectionStart>('UsageCollection', false);

--- a/src/plugins/vis_types/timeseries/kibana.json
+++ b/src/plugins/vis_types/timeseries/kibana.json
@@ -4,7 +4,7 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews"],
+  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews", "fieldFormats"],
   "optionalPlugins": ["home"],
   "requiredBundles": ["unifiedSearch", "kibanaUtils", "kibanaReact", "fieldFormats"],
   "owner": {

--- a/src/plugins/vis_types/timeseries/public/plugin.ts
+++ b/src/plugins/vis_types/timeseries/public/plugin.ts
@@ -6,13 +6,15 @@
  * Side Public License, v 1.
  */
 
-import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
-import { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
-import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
-import { ChartsPluginStart } from '@kbn/charts-plugin/public';
-import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import type { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
+import type { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+
 import { EditorController, TSVB_EDITOR_NAME } from './application/editor_controller';
 
 import { createMetricsFn } from './metrics_fn';
@@ -38,6 +40,7 @@ export interface MetricsPluginSetupDependencies {
 /** @internal */
 export interface MetricsPluginStartDependencies {
   data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   dataViews: DataViewsPublicPluginStart;
   charts: ChartsPluginStart;
   usageCollection?: UsageCollectionStart;
@@ -66,11 +69,11 @@ export class MetricsPlugin implements Plugin<void, void> {
 
   public start(
     core: CoreStart,
-    { data, charts, dataViews, usageCollection }: MetricsPluginStartDependencies
+    { data, charts, dataViews, usageCollection, fieldFormats }: MetricsPluginStartDependencies
   ) {
     setCharts(charts);
     setI18n(core.i18n);
-    setFieldFormats(data.fieldFormats);
+    setFieldFormats(fieldFormats);
     setDataStart(data);
     setDataViewsStart(dataViews);
     setCoreStart(core);

--- a/src/plugins/vis_types/timeseries/public/services.ts
+++ b/src/plugins/vis_types/timeseries/public/services.ts
@@ -8,6 +8,7 @@
 
 import type { I18nStart, IUiSettingsClient, CoreStart } from '@kbn/core/public';
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
@@ -16,7 +17,7 @@ import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
 
 export const [getFieldFormats, setFieldFormats] =
-  createGetterSetter<DataPublicPluginStart['fieldFormats']>('FieldFormats');
+  createGetterSetter<FieldFormatsStart>('FieldFormats');
 
 export const [getCoreStart, setCoreStart] = createGetterSetter<CoreStart>('CoreStart');
 

--- a/src/plugins/vis_types/timeseries/server/plugin.ts
+++ b/src/plugins/vis_types/timeseries/server/plugin.ts
@@ -21,6 +21,7 @@ import { map } from 'rxjs/operators';
 import { HomeServerPluginSetup } from '@kbn/home-plugin/server';
 import { PluginStart } from '@kbn/data-plugin/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/server';
 import type { PluginStart as DataViewsPublicPluginStart } from '@kbn/data-views-plugin/server';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 import { VisTypeTimeseriesConfig } from './config';
@@ -50,6 +51,7 @@ interface VisTypeTimeseriesPluginSetupDependencies {
 
 interface VisTypeTimeseriesPluginStartDependencies {
   data: PluginStart;
+  fieldFormats: FieldFormatsStart;
   dataViews: DataViewsPublicPluginStart;
 }
 
@@ -112,9 +114,9 @@ export class VisTypeTimeseriesPlugin implements Plugin<VisTypeTimeseriesSetup> {
         );
       },
       getFieldFormatsService: async (uiSettings) => {
-        const [, { data }] = await core.getStartServices();
+        const [, { fieldFormats }] = await core.getStartServices();
 
-        return data.fieldFormats.fieldFormatServiceFactory(uiSettings);
+        return fieldFormats.fieldFormatServiceFactory(uiSettings);
       },
     };
 

--- a/src/plugins/vis_types/vislib/kibana.json
+++ b/src/plugins/vis_types/vislib/kibana.json
@@ -3,9 +3,9 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["charts", "data", "expressions", "visualizations"],
+  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "fieldFormats"],
   "optionalPlugins": ["usageCollection"],
-  "requiredBundles": ["kibanaUtils", "visTypeXy", "visTypePie", "visTypeHeatmap", "visTypeGauge", "fieldFormats", "kibanaReact"],
+  "requiredBundles": ["kibanaUtils", "visTypeXy", "visTypePie", "visTypeHeatmap", "visTypeGauge", "kibanaReact"],
   "owner": {
     "name": "Vis Editors",
     "githubTeam": "kibana-vis-editors"

--- a/src/plugins/vis_types/vislib/public/plugin.ts
+++ b/src/plugins/vis_types/vislib/public/plugin.ts
@@ -6,16 +6,17 @@
  * Side Public License, v 1.
  */
 
-import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
+import type { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
+import type { ChartsPluginSetup } from '@kbn/charts-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
-import { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
-import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
-import { ChartsPluginSetup } from '@kbn/charts-plugin/public';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { LEGACY_PIE_CHARTS_LIBRARY } from '@kbn/vis-type-pie-plugin/common';
 import { LEGACY_HEATMAP_CHARTS_LIBRARY } from '@kbn/vis-type-heatmap-plugin/common';
 import { LEGACY_GAUGE_CHARTS_LIBRARY } from '@kbn/vis-type-gauge-plugin/common';
-import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import { setUsageCollectionStart } from './services';
 import { heatmapVisTypeDefinition } from './heatmap';
 
@@ -37,6 +38,7 @@ export interface VisTypeVislibPluginSetupDependencies {
 /** @internal */
 export interface VisTypeVislibPluginStartDependencies {
   data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   usageCollection?: UsageCollectionStart;
 }
 
@@ -76,8 +78,11 @@ export class VisTypeVislibPlugin
     }
   }
 
-  public start(core: CoreStart, { data, usageCollection }: VisTypeVislibPluginStartDependencies) {
-    setFormatService(data.fieldFormats);
+  public start(
+    core: CoreStart,
+    { data, usageCollection, fieldFormats }: VisTypeVislibPluginStartDependencies
+  ) {
+    setFormatService(fieldFormats);
     setDataActions(data.actions);
     setTheme(core.theme);
     if (usageCollection) {

--- a/src/plugins/vis_types/vislib/public/services.ts
+++ b/src/plugins/vis_types/vislib/public/services.ts
@@ -9,14 +9,14 @@
 import { ThemeServiceStart } from '@kbn/core/public';
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 export const [getDataActions, setDataActions] =
   createGetterSetter<DataPublicPluginStart['actions']>('vislib data.actions');
 
-export const [getFormatService, setFormatService] = createGetterSetter<
-  DataPublicPluginStart['fieldFormats']
->('vislib data.fieldFormats');
+export const [getFormatService, setFormatService] =
+  createGetterSetter<FieldFormatsStart>('FieldFormats');
 
 export const [getTheme, setTheme] = createGetterSetter<ThemeServiceStart>('vislib theme service');
 

--- a/src/plugins/vis_types/xy/kibana.json
+++ b/src/plugins/vis_types/xy/kibana.json
@@ -3,7 +3,7 @@
   "version": "kibana",
   "ui": true,
   "server": true,
-  "requiredPlugins": ["charts", "data", "expressions", "visualizations"],
+  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "fieldFormats"],
   "requiredBundles": ["kibanaUtils", "visDefaultEditor", "kibanaReact"],
   "optionalPlugins": ["usageCollection"],
   "extraPublicDirs": ["common/index"],

--- a/src/plugins/vis_types/xy/public/plugin.ts
+++ b/src/plugins/vis_types/xy/public/plugin.ts
@@ -6,12 +6,16 @@
  * Side Public License, v 1.
  */
 
-import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
-import { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
-import { VisualizationsSetup, VisualizationsStart } from '@kbn/visualizations-plugin/public';
-import { ChartsPluginSetup, ChartsPluginStart } from '@kbn/charts-plugin/public';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import type { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
+import type { VisualizationsSetup, VisualizationsStart } from '@kbn/visualizations-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { ChartsPluginSetup, ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type {
+  UsageCollectionSetup,
+  UsageCollectionStart,
+} from '@kbn/usage-collection-plugin/public';
 import { createStartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import {
   setDataActions,
@@ -46,6 +50,7 @@ export interface VisTypeXyPluginStartDependencies {
   expressions: ReturnType<ExpressionsPublicPlugin['start']>;
   visualizations: VisualizationsStart;
   data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   charts: ChartsPluginStart;
   usageCollection?: UsageCollectionStart;
 }
@@ -93,8 +98,8 @@ export class VisTypeXyPlugin
     return {};
   }
 
-  public start(core: CoreStart, { data, charts }: VisTypeXyPluginStartDependencies) {
-    setFormatService(data.fieldFormats);
+  public start(core: CoreStart, { data, charts, fieldFormats }: VisTypeXyPluginStartDependencies) {
+    setFormatService(fieldFormats);
     setDataActions(data.actions);
     setDocLinks(core.docLinks);
     setActiveCursor(charts.activeCursor);

--- a/src/plugins/vis_types/xy/public/services.ts
+++ b/src/plugins/vis_types/xy/public/services.ts
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { CoreSetup, DocLinksStart } from '@kbn/core/public';
+import type { CoreSetup, DocLinksStart } from '@kbn/core/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ChartsPluginSetup, ChartsPluginStart } from '@kbn/charts-plugin/public';
+
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { ChartsPluginSetup, ChartsPluginStart } from '@kbn/charts-plugin/public';
 
 export const [getUISettings, setUISettings] =
   createGetterSetter<CoreSetup['uiSettings']>('xy core.uiSettings');
@@ -18,7 +20,7 @@ export const [getDataActions, setDataActions] =
   createGetterSetter<DataPublicPluginStart['actions']>('xy data.actions');
 
 export const [getFormatService, setFormatService] =
-  createGetterSetter<DataPublicPluginStart['fieldFormats']>('xy data.fieldFormats');
+  createGetterSetter<FieldFormatsStart>('xy fieldFormats');
 
 export const [getThemeService, setThemeService] =
   createGetterSetter<ChartsPluginSetup['theme']>('xy charts.theme');

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -100,6 +100,7 @@ export function DimensionEditor(props: DimensionEditorProps) {
   } = props;
   const services = {
     data: props.data,
+    fieldFormats: props.fieldFormats,
     uiSettings: props.uiSettings,
     savedObjectsClient: props.savedObjectsClient,
     http: props.http,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -19,6 +19,7 @@ import {
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import {
   IndexPatternDimensionEditorComponent,
   IndexPatternDimensionEditorProps,
@@ -216,6 +217,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
       uiSettings: {} as IUiSettingsClient,
       savedObjectsClient: {} as SavedObjectsClientContract,
       http: {} as HttpSetup,
+      fieldFormats: fieldFormatsServiceMock.createStartContract(),
       unifiedSearch: unifiedSearchPluginMock.createStartContract(),
       dataViews: dataViewPluginMocks.createStartContract(),
       data: {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.tsx
@@ -10,6 +10,7 @@ import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/c
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { DatasourceDimensionTriggerProps, DatasourceDimensionEditorProps } from '../../types';
 import { GenericIndexPatternColumn } from '../indexpattern';
@@ -33,6 +34,7 @@ export type IndexPatternDimensionEditorProps =
     layerId: string;
     http: HttpSetup;
     data: DataPublicPluginStart;
+    fieldFormats: FieldFormatsStart;
     unifiedSearch: UnifiedSearchPublicPluginStart;
     dataViews: DataViewsPublicPluginStart;
     uniqueLabel: string;

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/reference_editor.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/reference_editor.test.tsx
@@ -12,6 +12,7 @@ import { EuiComboBox } from '@elastic/eui';
 import { mountWithIntl as mount } from '@kbn/test-jest-helpers';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import type { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -72,6 +73,7 @@ describe('reference editor', () => {
       savedObjectsClient: {} as SavedObjectsClientContract,
       http: {} as HttpSetup,
       data: {} as DataPublicPluginStart,
+      fieldFormats: fieldFormatsServiceMock.createStartContract(),
       unifiedSearch: {} as UnifiedSearchPublicPluginStart,
       dataViews: dataViewPluginMocks.createStartContract(),
       dimensionGroups: [],

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/reference_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/reference_editor.tsx
@@ -12,6 +12,7 @@ import { EuiFormRowProps, EuiSpacer, EuiComboBox, EuiComboBoxOptionOption } from
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DateRange } from '../../../common';
@@ -105,6 +106,7 @@ export interface ReferenceEditorProps {
   savedObjectsClient: SavedObjectsClientContract;
   http: HttpSetup;
   data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   dataViews: DataViewsPublicPluginStart;
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -378,6 +378,7 @@ export function getIndexPatternDatasource({
               <IndexPatternDimensionEditor
                 uiSettings={uiSettings}
                 storage={storage}
+                fieldFormats={fieldFormats}
                 savedObjectsClient={core.savedObjects.client}
                 http={core.http}
                 data={data}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
@@ -11,6 +11,7 @@ import { dateHistogramOperation } from '.';
 import { mount, shallow } from 'enzyme';
 import { EuiSwitch } from '@elastic/eui';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import type { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
@@ -98,6 +99,7 @@ const defaultOptions = {
     toDate: 'now',
   },
   data: dataStart,
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchStart,
   dataViews: dataViewsStart,
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filters.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filters.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import type { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
@@ -27,6 +28,7 @@ const defaultProps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
   data: dataPluginMock.createStartContract(),
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
@@ -11,13 +11,14 @@ import {
   HttpSetup,
   CoreStart,
 } from '@kbn/core/public';
-import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
-import {
+import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import type {
   ExpressionAstExpressionBuilder,
   ExpressionAstFunction,
 } from '@kbn/expressions-plugin/public';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { termsOperation } from './terms';
 import { filtersOperation } from './filters';
@@ -190,6 +191,7 @@ export interface ParamEditorProps<
   http: HttpSetup;
   dateRange: DateRange;
   data: DataPublicPluginStart;
+  fieldFormats: FieldFormatsStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   dataViews: DataViewsPublicPluginStart;
   activeData?: IndexPatternDimensionEditorProps['activeData'];

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/last_value.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/last_value.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { EuiComboBox, EuiFormRow } from '@elastic/eui';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
@@ -27,6 +28,7 @@ const defaultProps = {
   uiSettings: uiSettingsMock,
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   data: dataPluginMock.createStartContract(),

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.test.tsx
@@ -11,6 +11,7 @@ import { EuiRange } from '@elastic/eui';
 import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import { EuiFormRow } from '@elastic/eui';
 import { shallow, mount } from 'enzyme';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
@@ -44,6 +45,7 @@ const defaultProps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
   data: dataPluginMock.createStartContract(),
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile_ranks.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile_ranks.test.tsx
@@ -11,6 +11,7 @@ import { EuiFieldNumber } from '@elastic/eui';
 import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import { EuiFormRow } from '@elastic/eui';
 import { shallow, mount } from 'enzyme';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
@@ -38,6 +39,7 @@ const defaultProps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
   data: dataPluginMock.createStartContract(),
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
@@ -13,6 +13,7 @@ import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/c
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import type { IndexPatternLayer, IndexPattern } from '../../../types';
 import { rangeOperation } from '..';
@@ -54,6 +55,7 @@ jest.mock('lodash', () => {
 
 const dataPluginMockValue = dataPluginMock.createStartContract();
 const unifiedSearchPluginMockValue = unifiedSearchPluginMock.createStartContract();
+const fieldFormatsPluginMockValue = fieldFormatsServiceMock.createStartContract();
 const dataViewsPluginMockValue = dataViewPluginMocks.createStartContract();
 // need to overwrite the formatter field first
 dataPluginMockValue.fieldFormats.deserialize = jest.fn().mockImplementation(({ id, params }) => {
@@ -96,6 +98,7 @@ const defaultOptions = {
     toDate: 'now',
   },
   data: dataPluginMockValue,
+  fieldFormats: fieldFormatsPluginMockValue,
   unifiedSearch: unifiedSearchPluginMockValue,
   dataViews: dataViewsPluginMockValue,
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.tsx
@@ -183,7 +183,7 @@ export const rangeOperation: OperationDefinition<RangeIndexPatternColumn, 'field
     paramEditorUpdater,
     indexPattern,
     uiSettings,
-    data,
+    fieldFormats,
   }) => {
     const currentField = indexPattern.getFieldByName(currentColumn.sourceField);
     const numberFormat = currentColumn.params.format;
@@ -192,7 +192,7 @@ export const rangeOperation: OperationDefinition<RangeIndexPatternColumn, 'field
       supportedFormats[numberFormat.id] &&
       supportedFormats[numberFormat.id].decimalsToPattern(numberFormat.params?.decimals || 0);
 
-    const rangeFormatter = data.fieldFormats.deserialize({
+    const rangeFormatter = fieldFormats.deserialize({
       ...(currentColumn.params.parentFormat || { id: 'range' }),
       params: {
         ...currentColumn.params.parentFormat?.params,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/static_value.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/static_value.test.tsx
@@ -11,6 +11,7 @@ import { EuiFieldNumber } from '@elastic/eui';
 import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from '@kbn/core/public';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { shallow, mount } from 'enzyme';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
@@ -37,6 +38,7 @@ const defaultProps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
   data: dataPluginMock.createStartContract(),
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   http: {} as HttpSetup,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -15,6 +15,7 @@ import type {
   HttpSetup,
   CoreStart,
 } from '@kbn/core/public';
+import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
@@ -68,6 +69,7 @@ const defaultProps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   dateRange: { fromDate: 'now-1d', toDate: 'now' },
   data: dataPluginMock.createStartContract(),
+  fieldFormats: fieldFormatsServiceMock.createStartContract(),
   unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   dataViews: dataViewPluginMocks.createStartContract(),
   http: {} as HttpSetup,


### PR DESCRIPTION
Part of #137735

## Summary

Replace deprecated `data.fieldFormats` -> `fieldFormats`