### PR TITLE
[Security Solution] Add "Rule Preview" title before the rule preview section

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
@@ -236,7 +236,6 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
 
   return (
     <>
-      <EuiSpacer />
       <EuiButtonGroup
         legend="Quick query or advanced query preview selector"
         data-test-subj="quickAdvancedToggleButtonGroup"
@@ -245,7 +244,7 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
         options={quickAdvancedToggleButtonOptions}
         color="primary"
       />
-      <EuiSpacer />
+      <EuiSpacer size="s" />
       {showAdvancedOptions && showInvocationCountWarning && (
         <>
           <EuiCallOut

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -830,34 +830,36 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
             }}
           />
         </Form>
-        <EuiSpacer size="s" />
-        <RulePreview
-          index={index}
-          dataViewId={formDataViewId}
-          isDisabled={getIsRulePreviewDisabled({
-            ruleType,
-            isQueryBarValid,
-            isThreatQueryBarValid,
-            index,
-            dataViewId: formDataViewId,
-            threatIndex,
-            threatMapping: formThreatMapping,
-            machineLearningJobId,
-            queryBar: formQuery ?? initialState.queryBar,
-            newTermsFields: formNewTermsFields,
-          })}
-          query={formQuery}
-          ruleType={ruleType}
-          threatIndex={threatIndex}
-          threatQuery={formThreatQuery}
-          threatMapping={formThreatMapping}
-          threshold={formThreshold}
-          machineLearningJobId={machineLearningJobId}
-          anomalyThreshold={anomalyThreshold}
-          eqlOptions={optionsSelected}
-          newTermsFields={newTermsFields}
-          historyWindowSize={historyWindowSize}
-        />
+        <EuiSpacer size="m" />
+        <RuleTypeEuiFormRow label={i18n.RULE_PREVIEW} $isVisible={true} fullWidth>
+          <RulePreview
+            index={index}
+            dataViewId={formDataViewId}
+            isDisabled={getIsRulePreviewDisabled({
+              ruleType,
+              isQueryBarValid,
+              isThreatQueryBarValid,
+              index,
+              dataViewId: formDataViewId,
+              threatIndex,
+              threatMapping: formThreatMapping,
+              machineLearningJobId,
+              queryBar: formQuery ?? initialState.queryBar,
+              newTermsFields: formNewTermsFields,
+            })}
+            query={formQuery}
+            ruleType={ruleType}
+            threatIndex={threatIndex}
+            threatQuery={formThreatQuery}
+            threatMapping={formThreatMapping}
+            threshold={formThreshold}
+            machineLearningJobId={machineLearningJobId}
+            anomalyThreshold={anomalyThreshold}
+            eqlOptions={optionsSelected}
+            newTermsFields={newTermsFields}
+            historyWindowSize={historyWindowSize}
+          />
+        </RuleTypeEuiFormRow>
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -831,7 +831,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
           />
         </Form>
         <EuiSpacer size="m" />
-        <RuleTypeEuiFormRow label={i18n.RULE_PREVIEW} $isVisible={true} fullWidth>
+        <RuleTypeEuiFormRow label={i18n.RULE_PREVIEW_TITLE} $isVisible={true} fullWidth>
           <RulePreview
             index={index}
             dataViewId={formDataViewId}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
@@ -98,3 +98,10 @@ export const SOURCE = i18n.translate(
     defaultMessage: 'Source',
   }
 );
+
+export const RULE_PREVIEW = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.rulePreview',
+  {
+    defaultMessage: 'Rule Preview',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
@@ -99,8 +99,8 @@ export const SOURCE = i18n.translate(
   }
 );
 
-export const RULE_PREVIEW = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.rulePreview',
+export const RULE_PREVIEW_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.rulePreviewTitle',
   {
     defaultMessage: 'Rule Preview',
   }


### PR DESCRIPTION
## Summary

This PR adds a title for the Rule Preview section in define rule step of the rule creation.

<img width="633" alt="Screenshot 2022-08-08 at 17 17 24" src="https://user-images.githubusercontent.com/2700761/183452584-317e41c5-c6e8-470a-b0cc-eddff612ccad.png">

Fixes #138165

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->