### PR TITLE
[8.4] Update dependency @elastic/charts to v47.1.1 (#137762)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "47.0.0",
+    "@elastic/charts": "47.1.1",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.3.0-canary.1",
     "@elastic/ems-client": "8.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,10 +1443,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@47.0.0":
-  version "47.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-47.0.0.tgz#031dcb82b6cc787df211356b81acf32f260b5cce"
-  integrity sha512-wyxO/GsnIGHX42PaZ3Xl2Wpo83eVhX3ZL0GSa7C8qiPt3HIJVviOcXR/6dC8ylP0XNjXa4NwVnhQZCn/+z7FOg==
+"@elastic/charts@47.1.1":
+  version "47.1.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-47.1.1.tgz#0ee237c616323112887a7bf7529601dc6f1d65eb"
+  integrity sha512-kPIPUtUcO3wCkp4TkgiFXqfT9jmrJtdhAnmKGOzgDH4Ku5j8mJ2caimdYZhEIGNW1tSqmbjjSYlGH0N+iG6CLw==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"
@@ -1465,7 +1465,7 @@
     redux "^4.0.4"
     reselect "^4.0.0"
     resize-observer-polyfill "^1.5.1"
-    ts-debounce "^3.0.0"
+    ts-debounce "^4.0.0"
     utility-types "^3.10.0"
     uuid "^3.3.2"
 
@@ -27741,10 +27741,10 @@ trough@^1.0.0:
   dependencies:
     glob "^6.0.4"
 
-ts-debounce@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-3.0.0.tgz#9beedf59c04de3b5bef8ff28bd6885624df357be"
-  integrity sha512-7jiRWgN4/8IdvCxbIwnwg2W0bbYFBH6BxFqBjMKk442t7+liF2Z1H6AUCcl8e/pD93GjPru+axeiJwFmRww1WQ==
+ts-debounce@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-4.0.0.tgz#33440ef64fab53793c3d546a8ca6ae539ec15841"
+  integrity sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==
 
 ts-dedent@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Update dependency @elastic/charts to v47.1.1 (#137762)](https://github.com/elastic/kibana/pull/137762)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"renovate[bot]","email":"29139614+renovate[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-08-03T20:29:42Z","message":"Update dependency @elastic/charts to v47.1.1 (#137762)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\r\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"aea860375113478db637ac5f0fe382b72d7d6e0f","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:DataVis","auto-backport"],"number":137762,"url":"https://github.com/elastic/kibana/pull/137762","mergeCommit":{"message":"Update dependency @elastic/charts to v47.1.1 (#137762)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\r\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"aea860375113478db637ac5f0fe382b72d7d6e0f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->