### PR TITLE
[CI] Enable skippable commits and skippable build step for PRs

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -17,6 +17,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],
+      "enable_skippable_commits": true,
       "skip_ci_on_only_changed": [
         "^dev_docs/",
         "^docs/",
@@ -38,8 +39,7 @@
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
       "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge"],
-      "kibana_build_reuse_regexes": ["^test/", "^x-pack/test/"],
-      "kibana_build_reuse_label": "ci:reuse-kibana-build"
+      "kibana_build_reuse_regexes": ["^test/", "^x-pack/test/"]
     }
   ]
 }


### PR DESCRIPTION
This PR enables:

- skippable commits (i.e. skip CI based on the changes in individual commits rather than the entire PR)
- skippable/reusable build steps where possible

for all PRs without any opt-in labels.