### PR TITLE
[Fleet] Allow to create sub tag in bulk edit tag

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
 
 import { useUpdateTags } from '../hooks';
 
@@ -38,15 +39,17 @@ describe('TagsAddRemove', () => {
 
   const renderComponent = (agentId?: string, agents?: string | string[]) => {
     return render(
-      <TagsAddRemove
-        agentId={agentId}
-        agents={agents}
-        allTags={allTags}
-        selectedTags={selectedTags}
-        button={button}
-        onTagsUpdated={onTagsUpdated}
-        onClosePopover={onClosePopover}
-      />
+      <I18nProvider>
+        <TagsAddRemove
+          agentId={agentId}
+          agents={agents}
+          allTags={allTags}
+          selectedTags={selectedTags}
+          button={button}
+          onTagsUpdated={onTagsUpdated}
+          onClosePopover={onClosePopover}
+        />
+      </I18nProvider>
     );
   };
 
@@ -83,6 +86,25 @@ describe('TagsAddRemove', () => {
       expect.anything(),
       undefined,
       undefined
+    );
+  });
+
+  it('should show add new tag when not exactly found in search and allow to add the tag', () => {
+    const result = renderComponent('agent1');
+    const searchInput = result.getByRole('combobox');
+
+    fireEvent.input(searchInput, {
+      target: { value: 'tag' },
+    });
+
+    fireEvent.click(result.getByTestId('createTagBtn'));
+
+    expect(mockUpdateTags).toHaveBeenCalledWith(
+      'agent1',
+      ['tag1', 'tag'],
+      expect.anything(),
+      'Tag created',
+      'Tag creation failed'
     );
   });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, useCallback, useEffect, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState, useMemo } from 'react';
 import { difference } from 'lodash';
 import styled from 'styled-components';
 import type { EuiSelectableOption } from '@elastic/eui';
@@ -79,6 +79,11 @@ export const TagsAddRemove: React.FC<Props> = ({
     setLabels(labelsFromTags(allTags));
   }, [allTags, labelsFromTags]);
 
+  const isExactMatch = useMemo(
+    () => labels.some((label) => label.label === searchValue),
+    [labels, searchValue]
+  );
+
   const updateTags = async (
     tagsToAdd: string[],
     tagsToRemove: string[],
@@ -135,6 +140,43 @@ export const TagsAddRemove: React.FC<Props> = ({
     );
   };
 
+  const createTagButton = (
+    <EuiButtonEmpty
+      color="text"
+      data-test-subj="createTagBtn"
+      onClick={() => {
+        if (!searchValue) {
+          return;
+        }
+        updateTags(
+          [searchValue],
+          [],
+          i18n.translate('xpack.fleet.createAgentTags.successNotificationTitle', {
+            defaultMessage: 'Tag created',
+          }),
+          i18n.translate('xpack.fleet.createAgentTags.errorNotificationTitle', {
+            defaultMessage: 'Tag creation failed',
+          })
+        );
+      }}
+    >
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="plus" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <FormattedMessage
+            id="xpack.fleet.tagsAddRemove.createText"
+            defaultMessage='Create a new tag "{name}"'
+            values={{
+              name: searchValue,
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiButtonEmpty>
+  );
+
   return (
     <>
       <EuiWrappingPopover
@@ -162,41 +204,6 @@ export const TagsAddRemove: React.FC<Props> = ({
           }}
           options={labels}
           renderOption={renderOption}
-          noMatchesMessage={
-            <EuiButtonEmpty
-              color="text"
-              onClick={() => {
-                if (!searchValue) {
-                  return;
-                }
-                updateTags(
-                  [searchValue],
-                  [],
-                  i18n.translate('xpack.fleet.createAgentTags.successNotificationTitle', {
-                    defaultMessage: 'Tag created',
-                  }),
-                  i18n.translate('xpack.fleet.createAgentTags.errorNotificationTitle', {
-                    defaultMessage: 'Tag creation failed',
-                  })
-                );
-              }}
-            >
-              <EuiFlexGroup alignItems="center" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <EuiIcon type="plus" />
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <FormattedMessage
-                    id="xpack.fleet.tagsAddRemove.createText"
-                    defaultMessage='Create a new tag "{name}"'
-                    values={{
-                      name: searchValue,
-                    }}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiButtonEmpty>
-          }
         >
           {(list, search) => (
             <Fragment>
@@ -205,6 +212,7 @@ export const TagsAddRemove: React.FC<Props> = ({
             </Fragment>
           )}
         </EuiSelectable>
+        {!isExactMatch && labels.length && searchValue !== '' ? createTagButton : null}
       </EuiWrappingPopover>
     </>
   );


### PR DESCRIPTION
## Summary

Resolve #136192

Allow to create sub tag in the assing/remove tag popover (for example create the "test" tag if a "test1" tag exist)


## UI Changes

<img width="631" alt="Screen Shot 2022-08-08 at 2 22 44 PM" src="https://user-images.githubusercontent.com/1336873/183487560-dcee104a-a092-43b4-bb9b-ed366e7c4698.png">
<img width="622" alt="Screen Shot 2022-08-08 at 2 22 34 PM" src="https://user-images.githubusercontent.com/1336873/183487569-f2399f05-7766-442b-ad36-694630269982.png">
<img width="622" alt="Screen Shot 2022-08-08 at 2 22 29 PM" src="https://user-images.githubusercontent.com/1336873/183487570-df6259b2-30cd-40c4-9651-4b3b069a6515.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->