### PR TITLE
[Fleet] minor agent binary host flyout fixes

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
@@ -54,13 +54,13 @@ export const EditDownloadSourceFlyout: React.FunctionComponent<EditDownloadSourc
             {!downloadSource ? (
               <FormattedMessage
                 id="xpack.fleet.settings.editDownloadSourcesFlyout.createTitle"
-                defaultMessage="Add new agent binary download host"
+                defaultMessage="Add new agent binary source"
                 data-test-subj="editDownloadSourcesFlyout.add.title"
               />
             ) : (
               <FormattedMessage
                 id="xpack.fleet.settings.editDownloadSourcesFlyout.editTitle"
-                defaultMessage="Edit agent binary download host"
+                defaultMessage="Edit agent binary source"
                 data-test-subj="editDownloadSourcesFlyout.edit.title"
               />
             )}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
@@ -116,6 +116,7 @@ export const EditDownloadSourceFlyout: React.FunctionComponent<EditDownloadSourc
                 defaultMessage="Host"
               />
             }
+            {...inputs.hostInput.formRowProps}
           >
             <EuiFieldText
               data-test-subj="editDownloadSourcesFlyout.hostInput"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/index.tsx
@@ -54,13 +54,13 @@ export const EditDownloadSourceFlyout: React.FunctionComponent<EditDownloadSourc
             {!downloadSource ? (
               <FormattedMessage
                 id="xpack.fleet.settings.editDownloadSourcesFlyout.createTitle"
-                defaultMessage="Add new agent download binary host"
+                defaultMessage="Add new agent binary download host"
                 data-test-subj="editDownloadSourcesFlyout.add.title"
               />
             ) : (
               <FormattedMessage
                 id="xpack.fleet.settings.editDownloadSourcesFlyout.editTitle"
-                defaultMessage="Edit agent download binary host"
+                defaultMessage="Edit agent binary download host"
                 data-test-subj="editDownloadSourcesFlyout.edit.title"
               />
             )}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
@@ -58,8 +58,8 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
       setIsloading(true);
 
       const data: PostDownloadSourceRequest['body'] = {
-        name: nameInput.value,
-        host: hostInput.value,
+        name: nameInput.value.trim(),
+        host: hostInput.value.trim(),
         is_default: defaultDownloadSourceInput.value,
       };
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
@@ -123,7 +123,7 @@ function validateName(value: string) {
 
 export function validateHost(value: string) {
   try {
-    if (!value || value === '') {
+    if (!value) {
       return [
         i18n.translate('xpack.fleet.settings.dowloadSourceFlyoutForm.HostIsRequiredErrorMessage', {
           defaultMessage: 'Host is required',


### PR DESCRIPTION
## Summary

Closes #138008

1. Make title test more ocnsistent with other terminology
2. Display errors with ost input
3. Host inoput title now goes red when there is an error
4. Trim values before sending them to the server (previously URLs with a space infront would pass client validation but fail server validation)
<img width="1499" alt="Screenshot 2022-08-08 at 20 07 10" src="https://user-images.githubusercontent.com/3315046/183495362-a7c769e2-fd31-4119-ad78-2fec95f3d1f3.png">


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->