### PR TITLE
[Security Solution] Disables reason column internal rendering for the rule preview table

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -13,6 +13,7 @@ import styled from 'styled-components';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { eventsViewerSelector } from '../../../../common/components/events_viewer/selectors';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -125,6 +126,9 @@ export const PreviewHistogram = ({
 
   const { globalFullScreen } = useGlobalFullScreen();
   const previousPreviewId = usePrevious(previewId);
+  const tGridEventRenderedViewEnabled = useIsExperimentalFeatureEnabled(
+    'tGridEventRenderedViewEnabled'
+  );
 
   useEffect(() => {
     if (previousPreviewId !== previewId && totalCount > 0) {
@@ -233,7 +237,7 @@ export const PreviewHistogram = ({
             runtimeMappings,
             setQuery: () => {},
             sort,
-            tGridEventRenderedViewEnabled: true,
+            tGridEventRenderedViewEnabled,
             type: 'embedded',
             leadingControlColumns: getPreviewTableControlColumn(1.5),
           })}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_histogram.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { eventsViewerSelector } from '../../../../common/components/events_viewer/selectors';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -126,9 +125,6 @@ export const PreviewHistogram = ({
 
   const { globalFullScreen } = useGlobalFullScreen();
   const previousPreviewId = usePrevious(previewId);
-  const tGridEventRenderedViewEnabled = useIsExperimentalFeatureEnabled(
-    'tGridEventRenderedViewEnabled'
-  );
 
   useEffect(() => {
     if (previousPreviewId !== previewId && totalCount > 0) {
@@ -237,7 +233,7 @@ export const PreviewHistogram = ({
             runtimeMappings,
             setQuery: () => {},
             sort,
-            tGridEventRenderedViewEnabled,
+            tGridEventRenderedViewEnabled: true,
             type: 'embedded',
             leadingControlColumns: getPreviewTableControlColumn(1.5),
           })}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
@@ -13,8 +13,8 @@ import { REASON_FIELD_NAME } from './constants';
 import { reasonColumnRenderer } from './reason_column_renderer';
 import { plainColumnRenderer } from './plain_column_renderer';
 
-import { ColumnHeaderOptions, RowRenderer, TimelineId } from '../../../../../../common/types';
-import { RowRendererId } from '../../../../../../common/types';
+import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
+import { RowRendererId, TimelineId } from '../../../../../../common/types';
 
 import { render } from '@testing-library/react';
 import { TestProviders } from '@kbn/timelines-plugin/public/mock';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
@@ -13,7 +13,7 @@ import { REASON_FIELD_NAME } from './constants';
 import { reasonColumnRenderer } from './reason_column_renderer';
 import { plainColumnRenderer } from './plain_column_renderer';
 
-import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
+import { ColumnHeaderOptions, RowRenderer, TimelineId } from '../../../../../../common/types';
 import { RowRendererId } from '../../../../../../common/types';
 
 import { render } from '@testing-library/react';
@@ -134,6 +134,20 @@ describe('reasonColumnRenderer', () => {
       const wrapper = render(<TestProviders>{renderedColumn}</TestProviders>);
 
       expect(wrapper.queryByTestId('reason-cell-renderer')).toBeInTheDocument();
+    });
+
+    it('doesn\'t render reason renderers when timeline id is for the rule preview page', () => {
+      const renderedColumn = reasonColumnRenderer.renderColumn({
+        ...defaultProps,
+        isDetails: true,
+        ecsData: validEcs,
+        rowRenderers,
+        timelineId: TimelineId.rulePreview,
+      });
+
+      const wrapper = render(<TestProviders>{renderedColumn}</TestProviders>);
+
+      expect(wrapper.queryByTestId('reason-cell-renderer')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
@@ -136,7 +136,7 @@ describe('reasonColumnRenderer', () => {
       expect(wrapper.queryByTestId('reason-cell-renderer')).toBeInTheDocument();
     });
 
-    it('doesn\'t render reason renderers when timeline id is for the rule preview page', () => {
+    it("doesn't render reason renderers when timeline id is for the rule preview page", () => {
       const renderedColumn = reasonColumnRenderer.renderColumn({
         ...defaultProps,
         isDetails: true,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -9,7 +9,8 @@ import { EuiSpacer, EuiPanel } from '@elastic/eui';
 import { isEqual } from 'lodash/fp';
 import React, { useMemo } from 'react';
 
-import { ColumnHeaderOptions, RowRenderer, TimelineId } from '../../../../../../common/types';
+import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
+import { TimelineId } from '../../../../../../common/types';
 import type { Ecs } from '../../../../../../common/ecs';
 import { eventRendererNames } from '../../../row_renderers_browser/catalog/constants';
 import type { ColumnRenderer } from './column_renderer';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -83,7 +83,6 @@ const ReasonCell: React.FC<{
 
   const rowRender = useMemo(() => {
     return (
-      timelineId !== TimelineId.rulePreview &&
       rowRenderer &&
       rowRenderer.renderRow({
         data: ecsData,
@@ -93,9 +92,12 @@ const ReasonCell: React.FC<{
     );
   }, [rowRenderer, ecsData, timelineId]);
 
+  // We don't currently show enriched renders for rule preview table
+  const isPlainText = useMemo(() => timelineId === TimelineId.rulePreview, [timelineId]);
+
   return (
     <>
-      {rowRenderer && rowRender ? (
+      {rowRenderer && rowRender && !isPlainText ? (
         <>
           {value}
           <h4>{i18n.REASON_RENDERER_TITLE(eventRendererNames[rowRenderer.id] ?? '')}</h4>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -9,7 +9,7 @@ import { EuiSpacer, EuiPanel } from '@elastic/eui';
 import { isEqual } from 'lodash/fp';
 import React, { useMemo } from 'react';
 
-import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
+import { ColumnHeaderOptions, RowRenderer, TimelineId } from '../../../../../../common/types';
 import type { Ecs } from '../../../../../../common/ecs';
 import { eventRendererNames } from '../../../row_renderers_browser/catalog/constants';
 import type { ColumnRenderer } from './column_renderer';
@@ -82,6 +82,7 @@ const ReasonCell: React.FC<{
 
   const rowRender = useMemo(() => {
     return (
+      timelineId === TimelineId.rulePreview &&
       rowRenderer &&
       rowRenderer.renderRow({
         data: ecsData,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -83,7 +83,7 @@ const ReasonCell: React.FC<{
 
   const rowRender = useMemo(() => {
     return (
-      timelineId === TimelineId.rulePreview &&
+      timelineId !== TimelineId.rulePreview &&
       rowRenderer &&
       rowRenderer.renderRow({
         data: ecsData,


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/131118

Disables custom rendering in the reason column popover for the rule preview table as the preview table doesn't contain data that will be persisted  

#### Screenshots

<img width="974" alt="Screen Shot 2022-08-08 at 3 10 23 PM" src="https://user-images.githubusercontent.com/56367316/183496115-bf0b16f9-e4a2-4817-91b5-43e5360ff540.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->