### PR TITLE
[build] Clean node_modules

### DIFF
--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -71,6 +71,12 @@ export const CleanExtraFilesFromModules: Task = {
       '**/CONTRIBUTING.md',
       '**/Contributing.md',
       '**/contributing.md',
+      '**/README.md',
+      '**/readme.md',
+      '**/README.markdown',
+      '**/readme.markdown',
+      '**/README',
+
       '**/History.md',
       '**/HISTORY.md',
       '**/history.md',
@@ -86,16 +92,27 @@ export const CleanExtraFilesFromModules: Task = {
 
       // bins
       '**/.bin',
+      '**/bin',
 
       // linters
       '**/.eslintrc',
       '**/.eslintrc.js',
       '**/.eslintrc.yml',
+      '**/.eslintrc.json',
+      '**/.eslintignore',
+      '**/.jshintignore',
       '**/.prettierrc',
+      '**/.prettierrc.js',
+      '**/.prettierrc.yaml',
+      '**/.prettierrc.yml',
       '**/.jshintrc',
       '**/.babelrc',
+      '**/.babelrc.js',
       '**/.jscs.json',
       '**/.lint',
+      '**/.jscsrc',
+      '**/.nycrc',
+      '**/.taprc',
 
       // hints
       '**/*.flow',
@@ -117,25 +134,36 @@ export const CleanExtraFilesFromModules: Task = {
       '**/*.sass',
       '**/.ts',
       '**/.tsx',
+      '**/.tsbuildinfo',
 
       // editors
       '**/.editorconfig',
       '**/.vscode',
+      '**/.idea',
 
       // git
+      '**/.git',
+      '**/.github',
       '**/.gitattributes',
       '**/.gitkeep',
       '**/.gitempty',
       '**/.gitmodules',
       '**/.keep',
       '**/.empty',
+      '**/.patch',
 
       // ci
       '**/.travis.yml',
+      '**/.gitlab-ci.yml',
+      '**/circle.yml',
       '**/.coveralls.yml',
-      '**/.instanbul.yml',
-      '**/appveyor.yml',
+      '**/.istanbul.yml',
+      '**/.appveyor.yml',
       '**/.zuul.yml',
+      '**/.codeclimate.yml',
+      '**/.codecov.yml',
+      '**/.airtap.yml',
+      '**/.gitpod.yml',
 
       // metadata
       '**/package-lock.json',
@@ -145,12 +173,32 @@ export const CleanExtraFilesFromModules: Task = {
 
       // misc
       '**/.*ignore',
+      '**/*.log',
+      '**/.nvmrc',
       '**/.DS_Store',
       '**/Dockerfile',
       '**/docker-compose.yml',
 
-      // https://github.com/elastic/kibana/issues/107617
-      '**/png-js/images/*.png',
+      '**/*.png',
+      '**/*.jpg',
+      '**/*.jpeg',
+      '**/*.gif',
+      '**/*.webp',
+
+      '**/*.zip',
+      '**/*.7z',
+      '**/*.rar',
+      '**/*.tar',
+      '**/*.tgz',
+      '**/*.gz',
+
+      '**/*.xml',
+
+      '**/@elastic/eui/es',
+      '**/@elastic/eui/test-env',
+      '**/@elastic/eui/dist',
+      '**/@elastic/eui/optimize',
+      '**/@elastic/eui/i18ntokens.json',
     ]);
 
     log.info(

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -196,7 +196,6 @@ export const CleanExtraFilesFromModules: Task = {
 
       '**/@elastic/eui/es',
       '**/@elastic/eui/test-env',
-      '**/@elastic/eui/dist',
       '**/@elastic/eui/optimize',
       '**/@elastic/eui/i18ntokens.json',
     ]);


### PR DESCRIPTION
I was fairly aggressive here, np with reverting parts of it.

EUI accounts for most of the file count changes.  The npm module includes test environment setup that we use in development, components that are imported on the server, and distribution files imported into shared dependencies.  

https://github.com/elastic/eui/issues/4769 is related, but without splitting the package up into multiple npm packages it's understandably large.

Metrics
```
/tmp/kbn-clean » time tar -xf before/kibana-8.5.0-SNAPSHOT-linux-x86_64.tar.gz -C before/                                                                                                                  jon@xps
tar -xf before/kibana-8.5.0-SNAPSHOT-linux-x86_64.tar.gz -C before/  3.90s user 1.56s system 128% cpu 4.243 total
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/tmp/kbn-clean » find before/kibana-8.5.0-SNAPSHOT -type f | wc -l                                                                                                                                         jon@xps
45252
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/tmp/kbn-clean » du -ah -d 1 before/kibana-8.5.0-SNAPSHOT | grep node_modules                                                                                                                              jon@xps
285M	before/kibana-8.5.0-SNAPSHOT/node_modules
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/tmp/kbn-clean » time tar -xf after/kibana-8.5.0-SNAPSHOT-linux-x86_64.tar.gz -C after                                                                                                                     jon@xps
tar -xf after/kibana-8.5.0-SNAPSHOT-linux-x86_64.tar.gz -C after  3.65s user 1.00s system 121% cpu 3.826 total
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/tmp/kbn-clean » find after/kibana-8.5.0-SNAPSHOT -type f | wc -l                                                                                                                                          jon@xps
38475
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/tmp/kbn-clean » du -ah -d 1 after/kibana-8.5.0-SNAPSHOT | grep node_modules                                                                                                                               jon@xps
238M	after/kibana-8.5.0-SNAPSHOT/node_modules
```