### PR TITLE
[ci] Use more optimizer threads

### DIFF
--- a/.buildkite/scripts/build_kibana_plugins.sh
+++ b/.buildkite/scripts/build_kibana_plugins.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 echo "--- Build Platform Plugins"
-node scripts/build_kibana_platform_plugins --examples --test-plugins
+node scripts/build_kibana_platform_plugins --examples --test-plugins --workers 16 --no-inspect-workers --no-progress

--- a/.buildkite/scripts/build_kibana_plugins.sh
+++ b/.buildkite/scripts/build_kibana_plugins.sh
@@ -3,4 +3,5 @@
 set -euo pipefail
 
 echo "--- Build Platform Plugins"
-node scripts/build_kibana_platform_plugins --examples --test-plugins --workers 16 --no-inspect-workers --no-progress
+THREADS=$(grep -c ^processor /proc/cpuinfo)
+node scripts/build_kibana_platform_plugins --examples --test-plugins --workers "$THREADS" --no-inspect-workers --no-progress

--- a/src/dev/build/tasks/build_kibana_platform_plugins.ts
+++ b/src/dev/build/tasks/build_kibana_platform_plugins.ts
@@ -31,6 +31,7 @@ export const BuildKibanaPlatformPlugins: Task = {
       watch: false,
       dist: true,
       includeCoreBundle: true,
+      inspectWorkers: false,
       limitsPath: Path.resolve(REPO_ROOT, 'packages/kbn-optimizer/limits.yml'),
     });
 


### PR DESCRIPTION
Saves 45 seconds on building platform plugins.

https://buildkite.com/elastic/kibana-pull-request/builds/63737#01827eef-0194-4b6a-b67c-44bcbdc7bfe0/1581