### PR TITLE
[Security Solution][Investigations] - Use index alias in place of backing index

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.test.tsx
@@ -9,7 +9,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { OpenInDevConsoleButton } from '.';
 import { TestProviders } from '../../mock';
 
-jest.mock('../../../risk_score/containers/common', () => ({
+jest.mock('../../hooks/use_space_id', () => ({
   useSpaceId: jest.fn().mockReturnValue('myspace'),
 }));
 

--- a/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/open_in_dev_console/index.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import { EuiButton, EuiFlexItem, EuiToolTip } from '@elastic/eui';
-import { useSpaceId } from '../../../risk_score/containers/common';
+import { useSpaceId } from '../../hooks/use_space_id';
 
 interface OpenInDevConsoleButtonProps {
   enableButton: boolean;

--- a/x-pack/plugins/security_solution/public/common/hooks/use_space_id.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_space_id.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { useKibana } from '../../../common/lib/kibana';
+import { useKibana } from '../lib/kibana';
 
 export const useSpaceId = () => {
   const { spaces } = useKibana().services;

--- a/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/risky_hosts_disabled_module.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_risky_host_links/risky_hosts_disabled_module.tsx
@@ -16,7 +16,7 @@ import { devToolPrebuiltContentUrl } from '../../../../common/constants';
 import { OpenInDevConsoleButton } from '../../../common/components/open_in_dev_console';
 import { useChcekSignalIndex } from '../../../detections/containers/detection_engine/alerts/use_check_signal_index';
 import type { LinkPanelListItem } from '../link_panel';
-import { useSpaceId } from '../../../risk_score/containers/common';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 export const RISKY_HOSTS_DOC_LINK =
   'https://www.github.com/elastic/detection-rules/blob/main/docs/experimental-machine-learning/host-risk-score.md';

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -34,7 +34,7 @@ import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import { isIndexNotFoundError } from '../../../common/utils/exceptions';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { inputsModel } from '../../../common/store';
-import { useSpaceId } from '../common';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 export interface RiskScoreState<RiskScoreType extends HostsRiskScore[] | UsersRiskScore[]> {
   data?: RiskScoreType;

--- a/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
@@ -30,7 +30,7 @@ import { isIndexNotFoundError } from '../../../common/utils/exceptions';
 import type { ESTermQuery } from '../../../../common/typed_json';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { SeverityCount } from '../../../common/components/severity/types';
-import { useSpaceId } from '../common';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 type GetHostsRiskScoreProps = KpiRiskScoreRequestOptions & {
   data: DataPublicPluginStart;

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/helpers.tsx
@@ -9,6 +9,7 @@ import { some } from 'lodash/fp';
 import { useMemo } from 'react';
 import type { TimelineEventsDetailsItem } from '../../../../../common/search_strategy';
 import { getFieldValue } from '../../../../detections/components/host_isolation/helpers';
+import { DEFAULT_ALERTS_INDEX, DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 
 interface GetBasicDataFromDetailsData {
   alertId: string;
@@ -50,4 +51,15 @@ export const useBasicDataFromDetailsData = (
     }),
     [alertId, hostName, isAlert, ruleName, timestamp]
   );
+};
+
+export const getAlertIndexAlias = (
+  index: string,
+  spaceId: string = 'default'
+): string | undefined => {
+  if (index.startsWith(`.internal${DEFAULT_ALERTS_INDEX}`)) {
+    return `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+  } else if (index.startsWith(`.internal${DEFAULT_PREVIEW_INDEX}`)) {
+    return `${DEFAULT_PREVIEW_INDEX}-${spaceId}`;
+  }
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/helpers.tsx
@@ -53,6 +53,12 @@ export const useBasicDataFromDetailsData = (
   );
 };
 
+/*
+The referenced alert _index in the flyout uses the `.internal.` such as 
+`.internal.alerts-security.alerts-spaceId` in the alert page flyout and
+.internal.preview.alerts-security.alerts-spaceId` in the rule creation preview flyout
+but we always want to use their respective aliase indices rather than accessing their backing .internal. indices.
+*/
 export const getAlertIndexAlias = (
   index: string,
   spaceId: string = 'default'

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
@@ -11,8 +11,6 @@ import '../../../../common/mock/match_media';
 import { TestProviders } from '../../../../common/mock';
 import { TimelineId, TimelineTabs } from '../../../../../common/types/timeline';
 import type { Ecs } from '../../../../../common/ecs';
-import { mockAlertDetailsData } from '../../../../common/components/event_details/__mocks__';
-import type { TimelineEventsDetailsItem } from '../../../../../common/search_strategy';
 import {
   KibanaServices,
   useKibana,
@@ -21,7 +19,9 @@ import {
 import { mockBrowserFields, mockRuntimeMappings } from '../../../../common/containers/source/mock';
 import { coreMock } from '@kbn/core/public/mocks';
 import { mockCasesContext } from '@kbn/cases-plugin/public/mocks/mock_cases_context';
+import { useTimelineEventsDetails } from '../../../containers/details';
 import { allCasesPermissions } from '../../../../cases_test_utils';
+import { DEFAULT_ALERTS_INDEX } from '../../../../../common/constants';
 
 const ecsData: Ecs = {
   _id: '1',
@@ -37,18 +37,15 @@ const ecsData: Ecs = {
   },
 };
 
-const mockAlertDetailsDataWithIsObject = mockAlertDetailsData.map((detail) => {
-  return {
-    ...detail,
-    isObjectArray: false,
-  };
-}) as TimelineEventsDetailsItem[];
-
 jest.mock('../../../../../common/endpoint/service/host_isolation/utils', () => {
   return {
     isIsolationSupported: jest.fn().mockReturnValue(true),
   };
 });
+
+jest.mock('../../../../common/hooks/use_space_id', () => ({
+  useSpaceId: jest.fn().mockReturnValue('testSpace'),
+}));
 
 jest.mock(
   '../../../../detections/containers/detection_engine/alerts/use_host_isolation_status',
@@ -101,17 +98,22 @@ const mockSearchStrategy = jest.fn();
 
 const defaultProps = {
   timelineId: TimelineId.test,
-  loadingEventDetails: false,
-  detailsEcsData: ecsData,
   isHostIsolationPanelOpen: false,
   handleOnEventClosed: jest.fn(),
   onAddIsolationStatusClick: jest.fn(),
   expandedEvent: { eventId: ecsData._id, indexName: '' },
-  detailsData: mockAlertDetailsDataWithIsObject,
   tabType: TimelineTabs.query,
   browserFields: mockBrowserFields,
   runtimeMappings: mockRuntimeMappings,
 };
+
+jest.mock('../../../containers/details', () => {
+  const actual = jest.requireActual('../../../containers/details');
+  return {
+    ...actual,
+    useTimelineEventsDetails: jest.fn().mockImplementation(() => []),
+  };
+});
 
 describe('event details footer component', () => {
   beforeEach(() => {
@@ -168,5 +170,29 @@ describe('event details footer component', () => {
     );
     const element = wrapper.queryByTestId('side-panel-flyout-footer');
     expect(element).toBeNull();
+  });
+
+  describe('Alerts', () => {
+    const propsWithAlertIndex = {
+      ...defaultProps,
+      expandedEvent: {
+        eventId: ecsData._id,
+        indexName: `.internal.${DEFAULT_ALERTS_INDEX}-testSpace`,
+      },
+    };
+    test('it uses the alias alerts index', () => {
+      render(
+        <TestProviders>
+          <EventDetailsPanel {...{ ...propsWithAlertIndex }} />
+        </TestProviders>
+      );
+      expect(useTimelineEventsDetails).toHaveBeenCalledWith({
+        entityType: 'events',
+        indexName: `${DEFAULT_ALERTS_INDEX}-testSpace`,
+        eventId: propsWithAlertIndex.expandedEvent.eventId ?? '',
+        runtimeMappings: mockRuntimeMappings,
+        skip: false,
+      });
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -20,9 +20,8 @@ import type { HostRisk } from '../../../../risk_score/containers';
 import { useHostRiskScore } from '../../../../risk_score/containers';
 import { useHostIsolationTools } from './use_host_isolation_tools';
 import { FlyoutBody, FlyoutHeader, FlyoutFooter } from './flyout';
-import { useBasicDataFromDetailsData } from './helpers';
+import { useBasicDataFromDetailsData, getAlertIndexAlias } from './helpers';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
-import { DEFAULT_ALERTS_INDEX } from '../../../../../common/constants';
 
 interface EventDetailsPanelProps {
   browserFields: BrowserFields;
@@ -57,10 +56,8 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
   // but we always want to use the alias .alerts-security.alerts-spaceId.
 
   const currentSpaceId = useSpaceId();
-  const eventIndex = expandedEvent.indexName.includes(DEFAULT_ALERTS_INDEX)
-    ? `${DEFAULT_ALERTS_INDEX}-${currentSpaceId}`
-    : expandedEvent.indexName;
-
+  const { indexName } = expandedEvent;
+  const eventIndex = getAlertIndexAlias(indexName, currentSpaceId) ?? indexName;
   const [loading, detailsData, rawEventData, ecsData, refetchFlyoutData] = useTimelineEventsDetails(
     {
       entityType,

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -52,9 +52,6 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
   timelineId,
   isReadOnly,
 }) => {
-  // The referenced alert _index is .internal.alerts-security.alerts-spaceId,
-  // but we always want to use the alias .alerts-security.alerts-spaceId.
-
   const currentSpaceId = useSpaceId();
   const { indexName } = expandedEvent;
   const eventIndex = getAlertIndexAlias(indexName, currentSpaceId) ?? indexName;

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -21,6 +21,8 @@ import { useHostRiskScore } from '../../../../risk_score/containers';
 import { useHostIsolationTools } from './use_host_isolation_tools';
 import { FlyoutBody, FlyoutHeader, FlyoutFooter } from './flyout';
 import { useBasicDataFromDetailsData } from './helpers';
+import { useSpaceId } from '../../../../common/hooks/use_space_id';
+import { DEFAULT_ALERTS_INDEX } from '../../../../../common/constants';
 
 interface EventDetailsPanelProps {
   browserFields: BrowserFields;
@@ -51,10 +53,18 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
   timelineId,
   isReadOnly,
 }) => {
+  // The referenced alert _index is .internal.alerts-security.alerts-spaceId,
+  // but we always want to use the alias .alerts-security.alerts-spaceId.
+
+  const currentSpaceId = useSpaceId();
+  const eventIndex = expandedEvent.indexName.includes(DEFAULT_ALERTS_INDEX)
+    ? `${DEFAULT_ALERTS_INDEX}-${currentSpaceId}`
+    : expandedEvent.indexName;
+
   const [loading, detailsData, rawEventData, ecsData, refetchFlyoutData] = useTimelineEventsDetails(
     {
       entityType,
-      indexName: expandedEvent.indexName ?? '',
+      indexName: eventIndex ?? '',
       eventId: expandedEvent.eventId ?? '',
       runtimeMappings,
       skip: !expandedEvent.eventId,


### PR DESCRIPTION
## Summary

This PR addresses the issue found here: https://github.com/elastic/kibana/issues/135427. The `_index` that is received with the alert in the alert details flyout is the backing index `.internal.alerts-security.alerts-${spaceId}` and in the rule preview details flyout it is `.internal.preview.alerts-security.alerts-${spaceId}` This PR updates the alert flyout to use their default alerts alias indices. It also moves the `useSpaceId` hook to a top level common folder to be used elsewhere in the security solution app.

To test (copied from the aforementioned issue):

1. Set up the t1_analyst role using the following script: [x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/post_detections_role.sh](https://github.com/elastic/kibana/blob/8619986923f2ee82fa7cfaff3cfbb7679ef0d76a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/post_detections_role.sh)
2. Set up the t1_analyst user using the following script: [8619986/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/post_detections_user.sh](https://github.com/elastic/kibana/blob/8619986923f2ee82fa7cfaff3cfbb7679ef0d76a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/post_detections_user.sh)
3. Make sure you have some alerts in the Kibana/ES instance
4. Sign in as that user
5. Navigate to Security > Alerts and open the flyout for one of the alerts in the table

Expected behavior: You should be able to see the alert details flyout
