### PR TITLE
[Enterprise Search] Remove duplicate messages after domain is deleted from crawler index

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail_logic.ts
@@ -7,13 +7,11 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import { HttpError, Status } from '../../../../../common/types/api';
 
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 
-import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_messages';
+import { flashAPIErrors } from '../../../shared/flash_messages';
 
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
@@ -125,16 +123,8 @@ export const CrawlerDomainDetailLogic = kea<
         });
       }
     },
-    deleteApiSuccess: ({ domain }) => {
+    deleteApiSuccess: () => {
       const { indexName } = IndexNameLogic.values;
-      flashSuccessToast(
-        i18n.translate('xpack.enterpriseSearch.crawler.action.deleteDomain.successMessage', {
-          defaultMessage: "Domain '{domainUrl}' was deleted",
-          values: {
-            domainUrl: domain?.url,
-          },
-        })
-      );
       KibanaLogic.values.navigateToUrl(
         generateEncodedPath(SEARCH_INDEX_TAB_PATH, {
           indexName,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
@@ -13,18 +13,15 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import { Meta } from '../../../../../../../common/types';
 import { HttpError, Status } from '../../../../../../../common/types/api';
 import { DEFAULT_META } from '../../../../../shared/constants';
-import { flashAPIErrors, flashSuccessToast } from '../../../../../shared/flash_messages';
+import { flashAPIErrors } from '../../../../../shared/flash_messages';
 import { updateMetaPageIndex } from '../../../../../shared/table_pagination';
 import { DeleteCrawlerDomainApiLogic } from '../../../../api/crawler/delete_crawler_domain_api_logic';
 import { GetCrawlerDomainsApiLogic } from '../../../../api/crawler/get_crawler_domains_api_logic';
 import { CrawlerDomain, CrawlerDomainsWithMeta } from '../../../../api/crawler/types';
 import { IndexNameLogic } from '../../index_name_logic';
-import { CrawlerLogic } from '../crawler_logic';
 
 interface DomainManagementValues {
   deleteStatus: Status;
@@ -74,17 +71,8 @@ export const DomainManagementLogic = kea<
     deleteApiError: (error) => {
       flashAPIErrors(error);
     },
-    deleteApiSuccess: ({ domain }) => {
+    deleteApiSuccess: () => {
       actions.getDomains(values.meta);
-      flashSuccessToast(
-        i18n.translate('xpack.enterpriseSearch.crawler.domainsTable.action.delete.successMessage', {
-          defaultMessage: "Successfully deleted domain '{domainUrl}'",
-          values: {
-            domainUrl: domain.url,
-          },
-        })
-      );
-      CrawlerLogic.actions.fetchCrawlerData();
     },
     deleteDomain: ({ domain }) => {
       const { indexName } = IndexNameLogic.values;

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -11602,7 +11602,6 @@
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.stepsTitle": "Créer de belles expériences de recherche avec Enterprise Search",
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.tableTitle": "Rechercher dans les index",
     "xpack.enterpriseSearch.crawler.action.deleteDomain.confirmationPopupMessage": "Voulez-vous vraiment supprimer le domaine \"{domainUrl}\" et tous ses paramètres ?",
-    "xpack.enterpriseSearch.crawler.action.deleteDomain.successMessage": "Le domaine \"{domainUrl}\" a été supprimé",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.openButtonLabel": "Ajouter un domaine",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.title": "Ajouter un nouveau domaine",
     "xpack.enterpriseSearch.crawler.addDomainForm.contentVerificationLabel": "Vérification de contenu",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -11591,7 +11591,6 @@
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.stepsTitle": "エンタープライズ サーチで構築する優れた検索エクスペリエンス",
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.tableTitle": "インデックスの検索",
     "xpack.enterpriseSearch.crawler.action.deleteDomain.confirmationPopupMessage": "ドメイン\"{domainUrl}\"とすべての設定を削除しますか？",
-    "xpack.enterpriseSearch.crawler.action.deleteDomain.successMessage": "ドメイン'{domainUrl}'が削除されました",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.openButtonLabel": "ドメインを追加",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.title": "新しいドメインを追加",
     "xpack.enterpriseSearch.crawler.addDomainForm.contentVerificationLabel": "コンテンツ検証",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11606,7 +11606,6 @@
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.stepsTitle": "通过 Enterprise Search 构建出色的搜索体验",
     "xpack.enterpriseSearch.content.searchIndices.searchIndices.tableTitle": "搜索索引",
     "xpack.enterpriseSearch.crawler.action.deleteDomain.confirmationPopupMessage": "确定要移除域“{domainUrl}”和其所有设置？",
-    "xpack.enterpriseSearch.crawler.action.deleteDomain.successMessage": "域“{domainUrl}”已删除",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.openButtonLabel": "添加域",
     "xpack.enterpriseSearch.crawler.addDomainFlyout.title": "添加新域",
     "xpack.enterpriseSearch.crawler.addDomainForm.contentVerificationLabel": "内容验证",


### PR DESCRIPTION
## Summary

In some cases we were displaying up to three of these.  Now only using one, controlled by the modal which actually makes the delete call in the first place.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->