### PR TITLE
[Enterprise Search] New elasticsearchErrorHandler for server routes

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/error_codes.ts
+++ b/x-pack/plugins/enterprise_search/common/types/error_codes.ts
@@ -12,4 +12,5 @@ export enum ErrorCode {
   INDEX_NOT_FOUND = 'index_not_found',
   RESOURCE_NOT_FOUND = 'resource_not_found',
   UNAUTHORIZED = 'unauthorized',
+  UNCAUGHT_EXCEPTION = 'uncaught_exception',
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -5,9 +5,18 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 import { callEnterpriseSearchConfigAPI } from '../../lib/enterprise_search_config_api';
 import { RouteDependencies } from '../../plugin';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
+
+const errorMessage = i18n.translate(
+  'xpack.enterpriseSearch.server.routes.configData.errorMessage',
+  {
+    defaultMessage: 'Error fetching data from Enterprise Search',
+  }
+);
 
 export function registerConfigDataRoute({ router, config, log }: RouteDependencies) {
   router.get(
@@ -20,12 +29,12 @@ export function registerConfigDataRoute({ router, config, log }: RouteDependenci
 
       if ('responseStatus' in data) {
         return response.customError({
-          body: 'Error fetching data from Enterprise Search', // TODO i18n
+          body: errorMessage,
           statusCode: data.responseStatus,
         });
       } else if (!Object.keys(data).length) {
         return response.customError({
-          body: 'Error fetching data from Enterprise Search', // TODO i18n
+          body: errorMessage,
           statusCode: 502,
         });
       } else {

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -7,6 +7,7 @@
 
 import { callEnterpriseSearchConfigAPI } from '../../lib/enterprise_search_config_api';
 import { RouteDependencies } from '../../plugin';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 export function registerConfigDataRoute({ router, config, log }: RouteDependencies) {
   router.get(
@@ -14,18 +15,18 @@ export function registerConfigDataRoute({ router, config, log }: RouteDependenci
       path: '/internal/enterprise_search/config_data',
       validate: false,
     },
-    async (context, request, response) => {
-      const data = await callEnterpriseSearchConfigAPI({ request, config, log });
+    elasticsearchErrorHandler(log, async (context, request, response) => {
+      const data = await callEnterpriseSearchConfigAPI({ config, log, request });
 
       if ('responseStatus' in data) {
         return response.customError({
+          body: 'Error fetching data from Enterprise Search', // TODO i18n
           statusCode: data.responseStatus,
-          body: 'Error fetching data from Enterprise Search',
         });
       } else if (!Object.keys(data).length) {
         return response.customError({
+          body: 'Error fetching data from Enterprise Search', // TODO i18n
           statusCode: 502,
-          body: 'Error fetching data from Enterprise Search',
         });
       } else {
         return response.ok({
@@ -33,6 +34,6 @@ export function registerConfigDataRoute({ router, config, log }: RouteDependenci
           headers: { 'content-type': 'application/json' },
         });
       }
-    }
+    })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
@@ -6,7 +6,6 @@
  */
 
 import { schema } from '@kbn/config-schema';
-
 import { i18n } from '@kbn/i18n';
 
 import { ErrorCode } from '../../../../common/types/error_codes';
@@ -15,13 +14,14 @@ import { fetchCrawlerByIndexName } from '../../../lib/crawler/fetch_crawlers';
 
 import { RouteDependencies } from '../../../plugin';
 import { createError } from '../../../utils/create_error';
+import { elasticsearchErrorHandler } from '../../../utils/elasticsearch_error_handler';
 
 import { registerCrawlerCrawlRulesRoutes } from './crawler_crawl_rules';
 import { registerCrawlerEntryPointRoutes } from './crawler_entry_points';
 import { registerCrawlerSitemapRoutes } from './crawler_sitemaps';
 
 export function registerCrawlerRoutes(routeDependencies: RouteDependencies) {
-  const { router, enterpriseSearchRequestHandler } = routeDependencies;
+  const { router, enterpriseSearchRequestHandler, log } = routeDependencies;
 
   router.post(
     {
@@ -33,78 +33,60 @@ export function registerCrawlerRoutes(routeDependencies: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
 
-      try {
-        const indexExists = await client.asCurrentUser.indices.exists({
-          index: request.body.index_name,
+      const indexExists = await client.asCurrentUser.indices.exists({
+        index: request.body.index_name,
+      });
+      if (indexExists) {
+        return createError({
+          errorCode: ErrorCode.INDEX_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.addCrawler.indexExistsError',
+            {
+              defaultMessage: 'This index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
         });
-        if (indexExists) {
-          return createError({
-            errorCode: ErrorCode.INDEX_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.addCrawler.indexExistsError',
-              {
-                defaultMessage: 'This index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-        const crawler = await fetchCrawlerByIndexName(client, request.body.index_name);
-        if (crawler) {
-          return createError({
-            errorCode: ErrorCode.CRAWLER_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.addCrawler.crawlerExistsError',
-              {
-                defaultMessage: 'A crawler for this index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-
-        const connector = await fetchConnectorByIndexName(client, request.body.index_name);
-
-        if (connector) {
-          return createError({
-            errorCode: ErrorCode.CONNECTOR_DOCUMENT_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.addCrawler.connectorExistsError',
-              {
-                defaultMessage: 'A connector for this index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-
-        return enterpriseSearchRequestHandler.createRequest({
-          path: '/api/ent/v1/internal/indices',
-        })(context, request, response);
-      } catch (e) {
-        // 403 UNAUTHORIZED
-        if (e.meta.statusCode === 403) {
-          return createError({
-            errorCode: ErrorCode.UNAUTHORIZED,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.addCrawler.unauthorizedError',
-              {
-                defaultMessage: 'This account does not have permission to do this.',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-        throw e;
       }
-    }
+      const crawler = await fetchCrawlerByIndexName(client, request.body.index_name);
+      if (crawler) {
+        return createError({
+          errorCode: ErrorCode.CRAWLER_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.addCrawler.crawlerExistsError',
+            {
+              defaultMessage: 'A crawler for this index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
+        });
+      }
+
+      const connector = await fetchConnectorByIndexName(client, request.body.index_name);
+
+      if (connector) {
+        return createError({
+          errorCode: ErrorCode.CONNECTOR_DOCUMENT_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.addCrawler.connectorExistsError',
+            {
+              defaultMessage: 'A connector for this index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
+        });
+      }
+
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/api/ent/v1/internal/indices',
+      })(context, request, response);
+    })
   );
 
   router.post(

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
@@ -39,6 +39,7 @@ export function registerCrawlerRoutes(routeDependencies: RouteDependencies) {
       const indexExists = await client.asCurrentUser.indices.exists({
         index: request.body.index_name,
       });
+
       if (indexExists) {
         return createError({
           errorCode: ErrorCode.INDEX_ALREADY_EXISTS,
@@ -52,7 +53,9 @@ export function registerCrawlerRoutes(routeDependencies: RouteDependencies) {
           statusCode: 409,
         });
       }
+
       const crawler = await fetchCrawlerByIndexName(client, request.body.index_name);
+
       if (crawler) {
         return createError({
           errorCode: ErrorCode.CRAWLER_ALREADY_EXISTS,

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/create_api_key.ts
@@ -11,9 +11,10 @@ import { SecurityPluginStart } from '@kbn/security-plugin/server';
 
 import { createApiKey } from '../../lib/indices/create_api_key';
 import { RouteDependencies } from '../../plugin';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 export function registerCreateAPIKeyRoute(
-  { router }: RouteDependencies,
+  { log, router }: RouteDependencies,
   security: SecurityPluginStart
 ) {
   router.post(
@@ -28,24 +29,20 @@ export function registerCreateAPIKeyRoute(
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { indexName } = request.params;
       const { keyName } = request.body;
-      try {
-        const createResponse = await createApiKey(request, security, indexName, keyName);
-        if (!createResponse) {
-          throw new Error('Unable to create API Key');
-        }
-        return response.ok({
-          body: { apiKey: createResponse },
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error creating API Key',
-          statusCode: 502,
-        });
+
+      const createResponse = await createApiKey(request, security, indexName, keyName);
+
+      if (!createResponse) {
+        throw new Error('Unable to create API Key');
       }
-    }
+
+      return response.ok({
+        body: { apiKey: createResponse },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -19,27 +19,23 @@ import { fetchIndices } from '../../lib/indices/fetch_indices';
 import { generateApiKey } from '../../lib/indices/generate_api_key';
 import { RouteDependencies } from '../../plugin';
 import { createError } from '../../utils/create_error';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import { isIndexNotFoundException } from '../../utils/identify_exceptions';
 
-export function registerIndexRoutes({ router }: RouteDependencies) {
+export function registerIndexRoutes({ router, log }: RouteDependencies) {
   router.get(
     { path: '/internal/enterprise_search/search_indices', validate: false },
-    async (context, _, response) => {
+    elasticsearchErrorHandler(log, async (context, _, response) => {
       const { client } = (await context.core).elasticsearch;
-      try {
-        const indices = await fetchIndices(client, '*', false, true);
-        return response.ok({
-          body: indices,
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+      const indices = await fetchIndices(client, '*', false, true);
+
+      return response.ok({
+        body: indices,
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
+
   router.get(
     {
       path: '/internal/enterprise_search/indices',
@@ -52,7 +48,7 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const {
         page,
         size,
@@ -60,44 +56,40 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         search_query: searchQuery,
       } = request.query;
       const { client } = (await context.core).elasticsearch;
-      try {
-        const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
-        const totalIndices = await fetchIndices(client, indexPattern, !!returnHiddenIndices, false);
-        const totalResults = totalIndices.length;
-        const totalPages = Math.ceil(totalResults / size) || 1;
-        const startIndex = (page - 1) * size;
-        const endIndex = page * size;
-        const selectedIndices = totalIndices.slice(startIndex, endIndex);
-        const indexNames = selectedIndices.map(({ name }) => name);
-        const connectors = await fetchConnectors(client, indexNames);
-        const crawlers = await fetchCrawlers(client, indexNames);
-        const indices = selectedIndices.map((index) => ({
-          ...index,
-          connector: connectors.find((connector) => connector.index_name === index.name),
-          crawler: crawlers.find((crawler) => crawler.index_name === index.name),
-        }));
-        return response.ok({
-          body: {
-            indices,
-            meta: {
-              page: {
-                current: page,
-                size: indices.length,
-                total_pages: totalPages,
-                total_results: totalResults,
-              },
+
+      const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
+      const totalIndices = await fetchIndices(client, indexPattern, !!returnHiddenIndices, false);
+      const totalResults = totalIndices.length;
+      const totalPages = Math.ceil(totalResults / size) || 1;
+      const startIndex = (page - 1) * size;
+      const endIndex = page * size;
+      const selectedIndices = totalIndices.slice(startIndex, endIndex);
+      const indexNames = selectedIndices.map(({ name }) => name);
+      const connectors = await fetchConnectors(client, indexNames);
+      const crawlers = await fetchCrawlers(client, indexNames);
+      const indices = selectedIndices.map((index) => ({
+        ...index,
+        connector: connectors.find((connector) => connector.index_name === index.name),
+        crawler: crawlers.find((crawler) => crawler.index_name === index.name),
+      }));
+
+      return response.ok({
+        body: {
+          indices,
+          meta: {
+            page: {
+              current: page,
+              size: indices.length,
+              total_pages: totalPages,
+              total_results: totalResults,
             },
           },
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching index data from Elasticsearch',
-          statusCode: 502,
-        });
-      }
-    }
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
+
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}',
@@ -107,9 +99,10 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { indexName } = request.params;
       const { client } = (await context.core).elasticsearch;
+
       try {
         const index = await fetchIndex(client, indexName);
         return response.ok({
@@ -125,13 +118,12 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
             statusCode: 404,
           });
         }
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
+
+        throw error;
       }
-    }
+    })
   );
+
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/exists',
@@ -141,25 +133,21 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { indexName } = request.params;
       const { client } = (await context.core).elasticsearch;
-      try {
-        const indexExists = await client.asCurrentUser.indices.exists({ index: indexName });
-        return response.ok({
-          body: {
-            exists: indexExists,
-          },
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+
+      const indexExists = await client.asCurrentUser.indices.exists({ index: indexName });
+
+      return response.ok({
+        body: {
+          exists: indexExists,
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
+
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/api_key',
@@ -169,23 +157,19 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { indexName } = request.params;
       const { client } = (await context.core).elasticsearch;
-      try {
-        const apiKey = await generateApiKey(client, indexName);
-        return response.ok({
-          body: apiKey,
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+
+      const apiKey = await generateApiKey(client, indexName);
+
+      return response.ok({
+        body: apiKey,
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
+
   router.post(
     {
       path: '/internal/enterprise_search/indices',
@@ -196,67 +180,66 @@ export function registerIndexRoutes({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { ['index_name']: indexName, language } = request.body;
       const { client } = (await context.core).elasticsearch;
-      try {
-        const indexExists = await client.asCurrentUser.indices.exists({
-          index: request.body.index_name,
-        });
-        if (indexExists) {
-          return createError({
-            errorCode: ErrorCode.INDEX_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.createApiIndex.indexExistsError',
-              {
-                defaultMessage: 'This index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-        const crawler = await fetchCrawlerByIndexName(client, request.body.index_name);
-        if (crawler) {
-          return createError({
-            errorCode: ErrorCode.CRAWLER_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.createApiIndex.crawlerExistsError',
-              {
-                defaultMessage: 'A crawler for this index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
 
-        const connector = await fetchConnectorByIndexName(client, request.body.index_name);
+      const indexExists = await client.asCurrentUser.indices.exists({
+        index: request.body.index_name,
+      });
 
-        if (connector) {
-          return createError({
-            errorCode: ErrorCode.CONNECTOR_DOCUMENT_ALREADY_EXISTS,
-            message: i18n.translate(
-              'xpack.enterpriseSearch.server.routes.createApiIndex.connectorExistsError',
-              {
-                defaultMessage: 'A connector for this index already exists',
-              }
-            ),
-            response,
-            statusCode: 409,
-          });
-        }
-        const createIndexResponse = await createApiIndex(client, indexName, language);
-        return response.ok({
-          body: createIndexResponse,
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
+      if (indexExists) {
+        return createError({
+          errorCode: ErrorCode.INDEX_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.createApiIndex.indexExistsError',
+            {
+              defaultMessage: 'This index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
         });
       }
-    }
+
+      const crawler = await fetchCrawlerByIndexName(client, request.body.index_name);
+
+      if (crawler) {
+        return createError({
+          errorCode: ErrorCode.CRAWLER_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.createApiIndex.crawlerExistsError',
+            {
+              defaultMessage: 'A crawler for this index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
+        });
+      }
+
+      const connector = await fetchConnectorByIndexName(client, request.body.index_name);
+
+      if (connector) {
+        return createError({
+          errorCode: ErrorCode.CONNECTOR_DOCUMENT_ALREADY_EXISTS,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.createApiIndex.connectorExistsError',
+            {
+              defaultMessage: 'A connector for this index already exists',
+            }
+          ),
+          response,
+          statusCode: 409,
+        });
+      }
+
+      const createIndexResponse = await createApiIndex(client, indexName, language);
+
+      return response.ok({
+        body: createIndexResponse,
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
@@ -9,8 +9,9 @@ import { schema } from '@kbn/config-schema';
 
 import { fetchMapping } from '../../lib/fetch_mapping';
 import { RouteDependencies } from '../../plugin';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
-export function registerMappingRoute({ router }: RouteDependencies) {
+export function registerMappingRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/mappings/{index_name}',
@@ -20,20 +21,15 @@ export function registerMappingRoute({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
-      try {
-        const mapping = await fetchMapping(client, request.params.index_name);
-        return response.ok({
-          body: mapping,
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+
+      const mapping = await fetchMapping(client, request.params.index_name);
+
+      return response.ok({
+        body: mapping,
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -13,6 +13,7 @@ import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../../common/c
 
 import { fetchSearchResults } from '../../lib/fetch_search_results';
 import { RouteDependencies } from '../../plugin';
+import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 const calculateMeta = (searchResults: SearchResponseBody, page: number, size: number) => {
   let totalResults = 0;
@@ -35,7 +36,7 @@ const calculateMeta = (searchResults: SearchResponseBody, page: number, size: nu
   };
 };
 
-export function registerSearchRoute({ router }: RouteDependencies) {
+export function registerSearchRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{index_name}/search',
@@ -52,34 +53,29 @@ export function registerSearchRoute({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
       const { page = 0, size = ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } = request.query;
       const from = page * size;
-      try {
-        const searchResults: SearchResponseBody = await fetchSearchResults(
-          client,
-          request.params.index_name,
-          '',
-          from,
-          size
-        );
 
-        return response.ok({
-          body: {
-            meta: calculateMeta(searchResults, page, size),
-            results: searchResults,
-          },
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+      const searchResults: SearchResponseBody = await fetchSearchResults(
+        client,
+        request.params.index_name,
+        '',
+        from,
+        size
+      );
+
+      return response.ok({
+        body: {
+          meta: calculateMeta(searchResults, page, size),
+          results: searchResults,
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
+
   router.get(
     {
       path: '/internal/enterprise_search/indices/{index_name}/search/{query}',
@@ -97,32 +93,26 @@ export function registerSearchRoute({ router }: RouteDependencies) {
         }),
       },
     },
-    async (context, request, response) => {
+    elasticsearchErrorHandler(log, async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
       const { page = 0, size = ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } = request.query;
       const from = page * size;
-      try {
-        const searchResults = await fetchSearchResults(
-          client,
-          request.params.index_name,
-          request.params.query,
-          from,
-          size
-        );
 
-        return response.ok({
-          body: {
-            meta: calculateMeta(searchResults, page, size),
-            results: searchResults,
-          },
-          headers: { 'content-type': 'application/json' },
-        });
-      } catch (error) {
-        return response.customError({
-          body: 'Error fetching data from Enterprise Search',
-          statusCode: 502,
-        });
-      }
-    }
+      const searchResults = await fetchSearchResults(
+        client,
+        request.params.index_name,
+        request.params.query,
+        from,
+        size
+      );
+
+      return response.ok({
+        body: {
+          meta: calculateMeta(searchResults, page, size),
+          results: searchResults,
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/utils/create_error.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/create_error.ts
@@ -9,16 +9,19 @@ import { KibanaResponseFactory } from '@kbn/core-http-server';
 
 import { ErrorCode } from '../../common/types/error_codes';
 
+export interface EnterpriseSearchError {
+  errorCode: ErrorCode;
+  message: string;
+  statusCode: number;
+}
+
 export function createError({
   errorCode,
   message,
   response,
   statusCode,
-}: {
-  errorCode: ErrorCode;
-  message: string;
+}: EnterpriseSearchError & {
   response: KibanaResponseFactory;
-  statusCode: number;
 }) {
   return response.customError({
     body: {

--- a/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
@@ -61,7 +61,6 @@ export function elasticsearchErrorHandler<ContextType, RequestType, ResponseType
             defaultMessage: '{errorMessage} Check Kibana Server logs for details.',
             values: {
               errorMessage: enterpriseSearchError.message,
-              requestUrl: request.url.toString(),
             },
           }),
           response,

--- a/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IKibanaResponse, RequestHandler } from '@kbn/core/server';
+import { Logger } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
+
+import { ErrorCode } from '../../common/types/error_codes';
+
+import { createError } from './create_error';
+
+export function elasticsearchErrorHandler(
+  log: Logger,
+  requestHandler: RequestHandler
+): RequestHandler {
+  return async (context, request, response) => {
+    try {
+      return await requestHandler(context, request, response);
+    } catch (error) {
+      let kibanaResponse: IKibanaResponse | undefined;
+
+      if (error.meta.statusCode === 403) {
+        kibanaResponse = createError({
+          errorCode: ErrorCode.UNAUTHORIZED,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.addCrawler.unauthorizedError',
+            {
+              defaultMessage: 'This account does not have permission to do this.',
+            }
+          ),
+          response,
+          statusCode: 409,
+        });
+      }
+
+      if (typeof kibanaResponse !== 'undefined') {
+        log.error(error);
+        return kibanaResponse;
+      }
+
+      throw error;
+    }
+  };
+}

--- a/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
@@ -43,7 +43,7 @@ export function elasticsearchErrorHandler<ContextType, RequestType, ResponseType
         };
       }
 
-      if (typeof enterpriseSearchError !== 'undefined') {
+      if (enterpriseSearchError !== undefined) {
         log.error(
           i18n.translate('xpack.enterpriseSearch.server.routes.errorLogMessage', {
             defaultMessage:

--- a/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
@@ -5,20 +5,23 @@
  * 2.0.
  */
 
-interface ErrorResponse {
+interface ElasticsearchResponseError {
   meta?: {
     body?: {
       error?: {
         type: string;
       };
     };
+    statusCode?: number;
   };
   name: 'ResponseError';
-  statusCode: string;
 }
 
-export const isIndexNotFoundException = (error: ErrorResponse) =>
+export const isIndexNotFoundException = (error: ElasticsearchResponseError) =>
   error?.meta?.body?.error?.type === 'index_not_found_exception';
 
-export const isResourceAlreadyExistsException = (error: ErrorResponse) =>
+export const isResourceAlreadyExistsException = (error: ElasticsearchResponseError) =>
   error?.meta?.body?.error?.type === 'resource_already_exists_exception';
+
+export const isUnauthorizedException = (error: ElasticsearchResponseError) =>
+  error.meta?.statusCode === 403;


### PR DESCRIPTION
## Summary

This adds a new handler available to our server routes, `elasticsearchErrorHandler`, which is meant to be a place for catch-all errors the Kibana Elasticsearch client might throw.  This allows us to consitently handle errors with respect to messaging to users and logging.  

The first example we've added is a check for 403 UNAUTHORIZED errors, which are returned when the user attempting to make the client call does not have the correct permissions to do that call or access a specific resource through that call.  

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->