### PR TITLE
[Lens] fixes annotations layer removal bug

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -190,17 +190,19 @@ export function LayerPanels(
             const layerDatasource = datasourceMap[datasourceId];
             const layerDatasourceState = datasourceStates?.[datasourceId]?.state;
 
-            const trigger = props.uiActions.getTrigger(UPDATE_FILTER_REFERENCES_TRIGGER);
-            const action = props.uiActions.getAction(UPDATE_FILTER_REFERENCES_ACTION);
+            if (datasourceId) {
+              const trigger = props.uiActions.getTrigger(UPDATE_FILTER_REFERENCES_TRIGGER);
+              const action = props.uiActions.getAction(UPDATE_FILTER_REFERENCES_ACTION);
 
-            action?.execute({
-              trigger,
-              fromDataView: layerDatasource.getUsedDataView(layerDatasourceState, layerId),
-              usedDataViews: layerDatasource
-                .getLayers(layerDatasourceState)
-                .map((layer) => layerDatasource.getUsedDataView(layerDatasourceState, layer)),
-              defaultDataView: layerDatasource.getCurrentIndexPatternId(layerDatasourceState),
-            } as ActionExecutionContext);
+              action?.execute({
+                trigger,
+                fromDataView: layerDatasource.getUsedDataView(layerDatasourceState, layerId),
+                usedDataViews: layerDatasource
+                  .getLayers(layerDatasourceState)
+                  .map((layer) => layerDatasource.getUsedDataView(layerDatasourceState, layer)),
+                defaultDataView: layerDatasource.getCurrentIndexPatternId(layerDatasourceState),
+              } as ActionExecutionContext);
+            }
 
             dispatchLens(
               removeOrClearLayer({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/138298

This is an unreleased bug. This PR fixes a bug that is triggered when a user is trying to remove an annotations layer.

The annotations layer is not included on the `datasourceLayers`, as a result the datasourceId is undefined. The update filter references trigger should not be triggered for the annotations layer. This PR fixes it.


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->