### PR TITLE
Switch to the new `Get User Profile` API request and response signatures.

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -249,6 +249,7 @@ enabled:
   - x-pack/test/security_functional/oidc.config.ts
   - x-pack/test/security_functional/saml.config.ts
   - x-pack/test/security_functional/insecure_cluster_warning.config.ts
+  - x-pack/test/security_functional/user_profiles.config.ts
   - x-pack/test/security_solution_endpoint_api_int/config.ts
   - x-pack/test/security_solution_endpoint/config.ts
   - x-pack/test/session_view/basic/config.ts

--- a/x-pack/plugins/cases/public/containers/user_profiles/api.mock.ts
+++ b/x-pack/plugins/cases/public/containers/user_profiles/api.mock.ts
@@ -10,6 +10,7 @@ import { UserProfile } from '@kbn/security-plugin/common';
 export const userProfiles: UserProfile[] = [
   {
     uid: 'u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0',
+    enabled: true,
     data: {},
     user: {
       username: 'damaged_raccoon',
@@ -19,6 +20,7 @@ export const userProfiles: UserProfile[] = [
   },
   {
     uid: 'u_A_tM4n0wPkdiQ9smmd8o0Hr_h61XQfu8aRPh9GMoRoc_0',
+    enabled: true,
     data: {},
     user: {
       username: 'physical_dinosaur',
@@ -28,6 +30,7 @@ export const userProfiles: UserProfile[] = [
   },
   {
     uid: 'u_9xDEQqUqoYCnFnPPLq5mIRHKL8gBTo_NiKgOnd5gGk0_0',
+    enabled: true,
     data: {},
     user: {
       username: 'wet_dingo',

--- a/x-pack/plugins/security/common/model/user_profile.ts
+++ b/x-pack/plugins/security/common/model/user_profile.ts
@@ -29,6 +29,11 @@ export interface UserProfile<D extends UserProfileData = UserProfileData> {
   uid: string;
 
   /**
+   * Indicates whether user profile is enabled or not.
+   */
+  enabled: boolean;
+
+  /**
    * Information about the user that owns profile.
    */
   user: UserProfileUserInfo;

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile_api_client.test.ts
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile_api_client.test.ts
@@ -39,4 +39,11 @@ describe('UserProfileAPIClient', () => {
       body: '{"avatar":{"imageUrl":"avatar.png"}}',
     });
   });
+
+  it('should get user profiles in bulk', async () => {
+    await apiClient.bulkGet({ uids: new Set(['UID-1', 'UID-2']), dataPath: '*' });
+    expect(coreStart.http.post).toHaveBeenCalledWith('/internal/security/user_profile/_bulk_get', {
+      body: '{"uids":["UID-1","UID-2"],"dataPath":"*"}',
+    });
+  });
 });

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile_api_client.ts
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile_api_client.ts
@@ -94,7 +94,8 @@ export class UserProfileAPIClient {
    */
   public bulkGet<D extends UserProfileData>(params: UserProfileBulkGetParams) {
     return this.http.post<Array<UserProfile<D>>>('/internal/security/user_profile/_bulk_get', {
-      body: JSON.stringify(params),
+      // Convert `Set` with UIDs to an array to make it serializable.
+      body: JSON.stringify({ ...params, uids: [...params.uids] }),
     });
   }
 

--- a/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
@@ -81,7 +81,7 @@ describe('UserProfileService', () => {
       });
 
       mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockResolvedValue({
-        [mockUserProfile.uid]: mockUserProfile,
+        profiles: [mockUserProfile],
       } as unknown as SecurityGetUserProfileResponse);
     });
 
@@ -160,6 +160,33 @@ describe('UserProfileService', () => {
       });
     });
 
+    it('fails if cannot find user profile', async () => {
+      mockStartParams.session.get.mockResolvedValue(
+        sessionMock.createValue({ userProfileId: mockUserProfile.uid })
+      );
+
+      mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockResolvedValue({
+        profiles: [],
+      } as unknown as SecurityGetUserProfileResponse);
+
+      const startContract = userProfileService.start(mockStartParams);
+      await expect(
+        startContract.getCurrent({ request: mockRequest })
+      ).rejects.toMatchInlineSnapshot(`[Error: User profile is not found.]`);
+
+      expect(mockStartParams.session.get).toHaveBeenCalledTimes(1);
+      expect(mockStartParams.session.get).toHaveBeenCalledWith(mockRequest);
+
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledWith({
+        uid: 'UID',
+      });
+    });
+
     it('properly parses returned profile', async () => {
       mockStartParams.session.get.mockResolvedValue(
         sessionMock.createValue({ userProfileId: mockUserProfile.uid })
@@ -206,10 +233,12 @@ describe('UserProfileService', () => {
       );
 
       mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockResolvedValue({
-        [mockUserProfile.uid]: userProfileMock.createWithSecurity({
-          ...mockUserProfile,
-          data: { kibana: { avatar: 'fun.gif' }, other_app: { secret: 'data' } },
-        }),
+        profiles: [
+          userProfileMock.createWithSecurity({
+            ...mockUserProfile,
+            data: { kibana: { avatar: 'fun.gif' }, other_app: { secret: 'data' } },
+          }),
+        ],
       } as unknown as SecurityGetUserProfileResponse);
 
       const startContract = userProfileService.start(mockStartParams);
@@ -460,19 +489,8 @@ describe('UserProfileService', () => {
 
   describe('#bulkGet', () => {
     it('properly parses and sorts returned profiles', async () => {
-      mockStartParams.clusterClient.asInternalUser.transport.request.mockResolvedValue({
+      mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockResolvedValue({
         profiles: [
-          userProfileMock.createWithSecurity({
-            uid: 'UID-2',
-            user: {
-              username: 'user-2',
-              display_name: 'display-name-2',
-              full_name: 'full-name-2',
-              realm_name: 'some-realm',
-              realm_domain: 'some-domain',
-              roles: ['role-2'],
-            },
-          }),
           userProfileMock.createWithSecurity({
             uid: 'UID-1',
             user: {
@@ -484,8 +502,19 @@ describe('UserProfileService', () => {
               roles: ['role-1'],
             },
           }),
+          userProfileMock.createWithSecurity({
+            uid: 'UID-2',
+            user: {
+              username: 'user-2',
+              display_name: 'display-name-2',
+              full_name: 'full-name-2',
+              realm_name: 'some-realm',
+              realm_domain: 'some-domain',
+              roles: ['role-2'],
+            },
+          }),
         ],
-      });
+      } as unknown as SecurityGetUserProfileResponse);
 
       const startContract = userProfileService.start(mockStartParams);
       await expect(startContract.bulkGet({ uids: new Set(['UID-1', 'UID-2']) })).resolves
@@ -515,72 +544,25 @@ describe('UserProfileService', () => {
                           },
                         ]
                     `);
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledTimes(
-        1
-      );
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledWith({
-        method: 'POST',
-        path: '_security/profile/_suggest',
-        body: { hint: { uids: ['UID-1', 'UID-2'] }, size: 2 },
-      });
-    });
-
-    it('filters out not requested profiles', async () => {
-      mockStartParams.clusterClient.asInternalUser.transport.request.mockResolvedValue({
-        profiles: [
-          userProfileMock.createWithSecurity({ uid: 'UID-2' }),
-          userProfileMock.createWithSecurity({ uid: 'UID-NOT-REQUESTED' }),
-          userProfileMock.createWithSecurity({ uid: 'UID-1' }),
-        ],
-      });
-
-      const startContract = userProfileService.start(mockStartParams);
-      await expect(startContract.bulkGet({ uids: new Set(['UID-1', 'UID-2', 'UID-3']) })).resolves
-        .toMatchInlineSnapshot(`
-                        Array [
-                          Object {
-                            "data": Object {},
-                            "enabled": true,
-                            "uid": "UID-1",
-                            "user": Object {
-                              "display_name": undefined,
-                              "email": "some@email",
-                              "full_name": undefined,
-                              "username": "some-username",
-                            },
-                          },
-                          Object {
-                            "data": Object {},
-                            "enabled": true,
-                            "uid": "UID-2",
-                            "user": Object {
-                              "display_name": undefined,
-                              "email": "some@email",
-                              "full_name": undefined,
-                              "username": "some-username",
-                            },
-                          },
-                        ]
-                    `);
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledTimes(
-        1
-      );
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledWith({
-        method: 'POST',
-        path: '_security/profile/_suggest',
-        body: { hint: { uids: ['UID-1', 'UID-2', 'UID-3'] }, size: 3 },
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledWith({
+        uid: 'UID-1,UID-2',
       });
     });
 
     it('should request data if data path is specified', async () => {
-      mockStartParams.clusterClient.asInternalUser.transport.request.mockResolvedValue({
+      mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockResolvedValue({
         profiles: [
           userProfileMock.createWithSecurity({
             uid: 'UID-1',
             data: { some: 'data', kibana: { some: 'kibana-data' } },
           }),
         ],
-      });
+      } as unknown as SecurityGetUserProfileResponse);
 
       const startContract = userProfileService.start(mockStartParams);
       await expect(startContract.bulkGet({ uids: new Set(['UID-1']), dataPath: '*' })).resolves
@@ -601,17 +583,14 @@ describe('UserProfileService', () => {
                 },
               ]
             `);
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledTimes(
-        1
-      );
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledWith({
-        method: 'POST',
-        path: '_security/profile/_suggest',
-        body: {
-          hint: { uids: ['UID-1'] },
-          data: 'kibana.*',
-          size: 1,
-        },
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledWith({
+        uid: 'UID-1',
+        data: 'kibana.*',
       });
     });
 
@@ -619,7 +598,7 @@ describe('UserProfileService', () => {
       const failureReason = new errors.ResponseError(
         securityMock.createApiResponse({ statusCode: 500, body: 'some message' })
       );
-      mockStartParams.clusterClient.asInternalUser.transport.request.mockRejectedValue(
+      mockStartParams.clusterClient.asInternalUser.security.getUserProfile.mockRejectedValue(
         failureReason
       );
 
@@ -627,13 +606,13 @@ describe('UserProfileService', () => {
       await expect(startContract.bulkGet({ uids: new Set(['UID-1', 'UID-2']) })).rejects.toBe(
         failureReason
       );
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledTimes(
-        1
-      );
-      expect(mockStartParams.clusterClient.asInternalUser.transport.request).toHaveBeenCalledWith({
-        method: 'POST',
-        path: '_security/profile/_suggest',
-        body: { hint: { uids: ['UID-1', 'UID-2'] }, size: 2 },
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockStartParams.clusterClient.asInternalUser.security.getUserProfile
+      ).toHaveBeenCalledWith({
+        uid: 'UID-1,UID-2',
       });
     });
   });

--- a/x-pack/test/functional/apps/security/user_email.ts
+++ b/x-pack/test/functional/apps/security/user_email.ts
@@ -13,14 +13,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['security', 'settings', 'common', 'accountSetting']);
   const log = getService('log');
   const security = getService('security');
-  const kibanaServer = getService('kibanaServer');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/138528
-  describe.skip('useremail', function () {
+  describe('useremail', function () {
     before(async () => {
-      await kibanaServer.importExport.load(
-        'x-pack/test/functional/fixtures/kbn_archiver/security/discover'
-      );
       await security.testUser.setRoles(['cluster_security_manager']);
       await PageObjects.settings.navigateTo();
       await PageObjects.security.clickElasticsearchUsers();
@@ -63,9 +58,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async function () {
       // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
-      await kibanaServer.importExport.unload(
-        'x-pack/test/functional/fixtures/kbn_archiver/security/discover'
-      );
       await security.testUser.restoreDefaults();
     });
   });

--- a/x-pack/test/security_api_integration/tests/user_profiles/bulk_get.ts
+++ b/x-pack/test/security_api_integration/tests/user_profiles/bulk_get.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/138528
-  describe.skip('Getting user profiles in bulk', () => {
+  describe('Getting user profiles in bulk', () => {
     const usersSessions = new Map<string, { cookie: Cookie; uid: string }>();
     before(async () => {
       // 1. Create test users

--- a/x-pack/test/security_api_integration/tests/user_profiles/get_current.ts
+++ b/x-pack/test/security_api_integration/tests/user_profiles/get_current.ts
@@ -12,8 +12,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/138528
-  describe.skip('Getting user profile for the current user', () => {
+  describe('Getting user profile for the current user', () => {
     const testUserName = 'user_with_profile';
 
     async function login() {

--- a/x-pack/test/security_functional/fixtures/common/test_endpoints/kibana.json
+++ b/x-pack/test/security_functional/fixtures/common/test_endpoints/kibana.json
@@ -3,6 +3,7 @@
   "owner": { "name": "Platform Security", "githubTeam": "kibana-security" },
   "version": "8.0.0",
   "kibanaVersion": "kibana",
+  "requiredPlugins":["security"],
   "server": true,
   "ui": true
 }

--- a/x-pack/test/security_functional/tests/user_profiles/client_side_apis.ts
+++ b/x-pack/test/security_functional/tests/user_profiles/client_side_apis.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { parse as parseCookie } from 'tough-cookie';
+import { adminTestUser } from '@kbn/test';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['security', 'common']);
+  const testSubjects = getService('testSubjects');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const security = getService('security');
+  const retry = getService('retry');
+
+  describe('User Profiles client side APIs', function () {
+    const userProfileUids: string[] = [];
+    before(async () => {
+      // 1. Create test users
+      await Promise.all(
+        ['one', 'two', 'three'].map((userPrefix) =>
+          security.user.create(`user_${userPrefix}`, {
+            password: 'changeme',
+            roles: [`role_${userPrefix}`],
+          })
+        )
+      );
+
+      // 2. Activate user profiles and update data.
+      for (const userPrefix of ['one', 'two', 'three']) {
+        const response = await supertestWithoutAuth
+          .post('/internal/security/login')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            providerType: 'basic',
+            providerName: 'basic',
+            currentURL: '/',
+            params: { username: `user_${userPrefix}`, password: 'changeme' },
+          })
+          .expect(200);
+
+        const cookie = parseCookie(response.headers['set-cookie'][0])!.cookieString();
+        await supertestWithoutAuth
+          .post('/internal/security/user_profile/_data')
+          .set('kbn-xsrf', 'xxx')
+          .set('Cookie', cookie)
+          .send({ some: `data-${userPrefix}` })
+          .expect(200);
+
+        const { body: profile } = await supertestWithoutAuth
+          .get('/internal/security/user_profile')
+          .set('Cookie', cookie)
+          .expect(200);
+
+        userProfileUids.push(profile.uid);
+      }
+    });
+
+    after(async () => {
+      await Promise.all(
+        ['one', 'two', 'three'].map((userPrefix) => security.user.delete(`user_${userPrefix}`))
+      );
+    });
+
+    beforeEach(async () => {
+      await PageObjects.security.loginPage.login(undefined, undefined, { expectSuccess: true });
+    });
+
+    afterEach(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+    });
+
+    it('can retrieve own user profile and user profiles for other users', async () => {
+      await PageObjects.common.navigateToUrlWithBrowserHistory(
+        'user_profiles_app',
+        '',
+        `?${userProfileUids.map((uid) => `uid=${uid}`).join('&')}`,
+        { ensureCurrentUrl: true, shouldLoginIfPrompted: false }
+      );
+
+      await retry.try(async () => {
+        const currentUserProfileText = await testSubjects.getVisibleText(
+          'testEndpointsUserProfilesAppCurrentUserProfile'
+        );
+        expect(currentUserProfileText).to.equal(`${adminTestUser.username}:{}`);
+
+        for (const userPrefix of ['one', 'two', 'three']) {
+          const userProfileText = await testSubjects.getVisibleText(
+            `testEndpointsUserProfilesAppUserProfile_user_${userPrefix}`
+          );
+          expect(userProfileText).to.equal(`user_${userPrefix}:{"some":"data-${userPrefix}"}`);
+        }
+      });
+    });
+  });
+}

--- a/x-pack/test/security_functional/tests/user_profiles/index.ts
+++ b/x-pack/test/security_functional/tests/user_profiles/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('security app - user profiles', function () {
+    loadTestFile(require.resolve('./client_side_apis'));
+  });
+}

--- a/x-pack/test/security_functional/user_profiles.config.ts
+++ b/x-pack/test/security_functional/user_profiles.config.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { resolve } from 'path';
+import { FtrConfigProviderContext } from '@kbn/test';
+import { services } from '../functional/services';
+import { pageObjects } from '../functional/page_objects';
+
+// the default export of config files must be a config provider
+// that returns an object with the projects config values
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const xPackKibanaFunctionalConfig = await readConfigFile(
+    require.resolve('../functional/config.base.js')
+  );
+
+  const testEndpointsPlugin = resolve(__dirname, './fixtures/common/test_endpoints');
+
+  return {
+    testFiles: [resolve(__dirname, './tests/user_profiles')],
+
+    services,
+    pageObjects,
+
+    servers: xPackKibanaFunctionalConfig.get('servers'),
+    esTestCluster: xPackKibanaFunctionalConfig.get('esTestCluster'),
+
+    kbnTestServer: {
+      ...xPackKibanaFunctionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...xPackKibanaFunctionalConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${testEndpointsPlugin}`,
+      ],
+    },
+    apps: {
+      ...xPackKibanaFunctionalConfig.get('apps'),
+      user_profiles_app: { pathname: '/app/user_profiles_app' },
+    },
+
+    junit: {
+      reportName: 'Chrome X-Pack Security Functional Tests (User Profiles)',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

In this PR we're switching to the new `Get User Profile` API request and response signatures. The API now supports requesting multiple profiles (aka Bulk Get API).

The PR also fixes client-side serializing logic for the `Set` with UIDs and adds a functional test to make sure we'd don't break this in the future.

__Flaky Test Runner: (:heavy_check_mark: [x50 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1022))__

__Fixes: https://github.com/elastic/kibana/issues/138528__

__Related: https://github.com/elastic/elasticsearch/pull/89023__