### PR TITLE
Ad-hoc dataviews

### DIFF
--- a/src/plugins/data/common/query/filters/persistable_state.test.ts
+++ b/src/plugins/data/common/query/filters/persistable_state.test.ts
@@ -26,7 +26,7 @@ describe('filter manager persistable state tests', () => {
       const updatedFilters = inject(filters, [
         { type: DATA_VIEW_SAVED_OBJECT_TYPE, name: 'test123', id: '123' },
       ]);
-      expect(updatedFilters[0]).toHaveProperty('meta.index', undefined);
+      expect(updatedFilters[0]).toHaveProperty('meta.index', 'test');
     });
   });
 

--- a/src/plugins/data/common/query/filters/persistable_state.ts
+++ b/src/plugins/data/common/query/filters/persistable_state.ts
@@ -46,7 +46,8 @@ export const inject = (filters: Filter[], references: SavedObjectReference[]) =>
       ...filter,
       meta: {
         ...filter.meta,
-        index: reference && reference.id,
+        // if no reference has been found, keep the current "index" property (used for adhoc data views)
+        index: reference ? reference.id : filter.meta.index,
       },
     };
   });

--- a/src/plugins/data/common/query/persistable_state.test.ts
+++ b/src/plugins/data/common/query/persistable_state.test.ts
@@ -41,7 +41,7 @@ describe('query service persistable state tests', () => {
       const updatedQueryState = inject(queryState, [
         { type: DATA_VIEW_SAVED_OBJECT_TYPE, name: 'test123', id: '123' },
       ]);
-      expect(updatedQueryState.filters[0]).toHaveProperty('meta.index', undefined);
+      expect(updatedQueryState.filters[0]).toHaveProperty('meta.index', 'test');
     });
   });
 

--- a/src/plugins/discover/public/application/main/components/layout/types.ts
+++ b/src/plugins/discover/public/application/main/components/layout/types.ts
@@ -21,7 +21,7 @@ export interface DiscoverLayoutProps {
   dataViewList: Array<SavedObject<DataViewAttributes>>;
   inspectorAdapters: { requests: RequestAdapter };
   navigateTo: (url: string) => void;
-  onChangeDataView: (id: string) => void;
+  onChangeDataView: (id: string | DataView) => void;
   onUpdateQuery: (
     payload: { dateRange: TimeRange; query?: Query | AggregateQuery },
     isUpdate?: boolean

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -250,6 +250,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
               onSave: async (dataView) => {
                 onDataViewCreated(dataView);
               },
+              allowAdHocDataView: true,
             });
             if (setDataViewEditorRef) {
               setDataViewEditorRef(ref);

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import type { Query, TimeRange, AggregateQuery } from '@kbn/es-query';
-import { DataViewType } from '@kbn/data-views-plugin/public';
+import { DataViewType, type DataView } from '@kbn/data-views-plugin/public';
 import type { DataViewPickerProps } from '@kbn/unified-search-plugin/public';
 import { ENABLE_SQL } from '../../../../../common';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
@@ -31,7 +31,7 @@ export type DiscoverTopNavProps = Pick<
   ) => void;
   stateContainer: GetStateReturn;
   resetSavedSearch: () => void;
-  onChangeDataView: (dataView: string) => void;
+  onChangeDataView: (dataView: string | DataView) => void;
   isPlainRecord: boolean;
   textBasedLanguageModeErrors?: Error;
   onFieldEdited: () => void;
@@ -125,9 +125,10 @@ export const DiscoverTopNav = ({
             closeDataViewEditor.current = dataViewEditor.openEditor({
               onSave: async (dataViewToSave) => {
                 if (dataViewToSave.id) {
-                  onChangeDataView(dataViewToSave.id);
+                  onChangeDataView(dataViewToSave);
                 }
               },
+              allowAdHocDataView: true,
             });
           }
         : undefined,

--- a/src/plugins/discover/public/application/main/discover_main_route.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.tsx
@@ -13,6 +13,7 @@ import {
   DataViewAttributes,
   DataViewSavedObjectConflictError,
 } from '@kbn/data-views-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import { redirectWhenMissing } from '@kbn/kibana-utils-plugin/public';
 import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import {
@@ -111,69 +112,73 @@ export function DiscoverMainRoute(props: Props) {
     [config, data.dataViews, history, isDev, toastNotifications]
   );
 
-  const loadSavedSearch = useCallback(async () => {
-    try {
-      const currentSavedSearch = await getSavedSearch(id, {
-        search: services.data.search,
-        savedObjectsClient: core.savedObjects.client,
-        spaces: services.spaces,
-      });
+  const loadSavedSearch = useCallback(
+    async (dataview?: DataView) => {
+      try {
+        const currentSavedSearch = await getSavedSearch(id, {
+          search: services.data.search,
+          savedObjectsClient: core.savedObjects.client,
+          spaces: services.spaces,
+        });
 
-      const currentDataView = await loadDefaultOrCurrentDataView(currentSavedSearch.searchSource);
+        const currentDataView =
+          dataview ?? (await loadDefaultOrCurrentDataView(currentSavedSearch.searchSource));
 
-      if (!currentDataView) {
-        return;
-      }
+        if (!currentDataView) {
+          return;
+        }
 
-      if (!currentSavedSearch.searchSource.getField('index')) {
-        currentSavedSearch.searchSource.setField('index', currentDataView);
-      }
+        if (!currentSavedSearch.searchSource.getField('index')) {
+          currentSavedSearch.searchSource.setField('index', currentDataView);
+        }
 
-      setSavedSearch(currentSavedSearch);
+        setSavedSearch(currentSavedSearch);
 
-      if (currentSavedSearch.id) {
-        chrome.recentlyAccessed.add(
-          getSavedSearchFullPathUrl(currentSavedSearch.id),
-          currentSavedSearch.title ?? '',
-          currentSavedSearch.id
-        );
-      }
-    } catch (e) {
-      if (e instanceof DataViewSavedObjectConflictError) {
-        setError(e);
-      } else {
-        redirectWhenMissing({
-          history,
-          navigateToApp: core.application.navigateToApp,
-          basePath,
-          mapping: {
-            search: '/',
-            'index-pattern': {
-              app: 'management',
-              path: `kibana/objects/savedSearches/${id}`,
+        if (currentSavedSearch.id) {
+          chrome.recentlyAccessed.add(
+            getSavedSearchFullPathUrl(currentSavedSearch.id),
+            currentSavedSearch.title ?? '',
+            currentSavedSearch.id
+          );
+        }
+      } catch (e) {
+        if (e instanceof DataViewSavedObjectConflictError) {
+          setError(e);
+        } else {
+          redirectWhenMissing({
+            history,
+            navigateToApp: core.application.navigateToApp,
+            basePath,
+            mapping: {
+              search: '/',
+              'index-pattern': {
+                app: 'management',
+                path: `kibana/objects/savedSearches/${id}`,
+              },
             },
-          },
-          toastNotifications,
-          onBeforeRedirect() {
-            getUrlTracker().setTrackedUrl('/');
-          },
-          theme: core.theme,
-        })(e);
+            toastNotifications,
+            onBeforeRedirect() {
+              getUrlTracker().setTrackedUrl('/');
+            },
+            theme: core.theme,
+          })(e);
+        }
       }
-    }
-  }, [
-    id,
-    services.data.search,
-    services.spaces,
-    core.savedObjects.client,
-    core.application.navigateToApp,
-    core.theme,
-    loadDefaultOrCurrentDataView,
-    chrome.recentlyAccessed,
-    history,
-    basePath,
-    toastNotifications,
-  ]);
+    },
+    [
+      id,
+      services.data.search,
+      services.spaces,
+      core.savedObjects.client,
+      core.application.navigateToApp,
+      core.theme,
+      loadDefaultOrCurrentDataView,
+      chrome.recentlyAccessed,
+      history,
+      basePath,
+      toastNotifications,
+    ]
+  );
 
   const onDataViewCreated = useCallback(
     async (nextDataView: unknown) => {

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -35,13 +35,17 @@ import {
   SearchSessionInfoProvider,
   syncQueryStateWithUrl,
 } from '@kbn/data-plugin/public';
-import { DataView } from '@kbn/data-views-plugin/public';
+import { DataView, DataViewSpec } from '@kbn/data-views-plugin/public';
 import { DiscoverGridSettings } from '../../../components/discover_grid/types';
 import { SavedSearch } from '../../../services/saved_searches';
 import { handleSourceColumnState } from '../../../utils/state_helpers';
 import { DISCOVER_APP_LOCATOR, DiscoverAppLocatorParams } from '../../../locator';
 import { VIEW_MODE } from '../../../components/view_mode_toggle';
 import { cleanupUrlState } from '../utils/cleanup_url_state';
+
+function isDataViewSpec(dataView: string | DataViewSpec | undefined): dataView is DataViewSpec {
+  return Boolean(dataView) && typeof dataView !== 'string';
+}
 
 export interface AppState {
   /**
@@ -63,7 +67,7 @@ export interface AppState {
   /**
    * id of the used data view
    */
-  index?: string;
+  index?: string | DataViewSpec;
   /**
    * Used interval of the histogram
    */
@@ -290,7 +294,10 @@ export function getState({
       filterManager: FilterManager,
       data: DataPublicPluginStart
     ) => {
-      if (appStateContainer.getState().index !== dataView.id) {
+      const dataViewId = !isDataViewSpec(appStateContainer.getState().index)
+        ? appStateContainer.getState().index
+        : '';
+      if (dataViewId && dataViewId !== dataView.id) {
         // used data view is different than the given by url/state which is invalid
         setState(appStateContainerModified, { index: dataView.id });
       }

--- a/src/plugins/discover/public/application/main/utils/get_switch_data_view_app_state.test.ts
+++ b/src/plugins/discover/public/application/main/utils/get_switch_data_view_app_state.test.ts
@@ -32,6 +32,7 @@ const getDataView = (id: string, timeFieldName: string, fields: string[]) => {
           .find((field) => field.name === name);
       },
     },
+    isPersisted: () => true,
   } as DataView;
 };
 

--- a/src/plugins/discover/public/application/main/utils/get_switch_data_view_app_state.ts
+++ b/src/plugins/discover/public/application/main/utils/get_switch_data_view_app_state.ts
@@ -57,7 +57,7 @@ export function getDataViewAppState(
   }
 
   return {
-    index: nextDataView.id,
+    index: nextDataView.isPersisted() ? nextDataView.id : nextDataView.toSpec(),
     columns,
     sort: nextSort,
   };

--- a/src/plugins/discover/public/locator.ts
+++ b/src/plugins/discover/public/locator.ts
@@ -8,6 +8,7 @@
 
 import type { SerializableRecord } from '@kbn/utility-types';
 import type { Filter, TimeRange, Query, AggregateQuery } from '@kbn/es-query';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { GlobalQueryStateFromUrl, RefreshInterval } from '@kbn/data-plugin/public';
 import type { LocatorDefinition, LocatorPublic } from '@kbn/share-plugin/public';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
@@ -24,7 +25,7 @@ export interface DiscoverAppLocatorParams extends SerializableRecord {
   /**
    * Optionally set index pattern / data view ID.
    */
-  indexPatternId?: string;
+  indexPatternId?: string | DataViewSpec;
 
   /**
    * Optionally set the time range in the time picker.
@@ -118,7 +119,7 @@ export class DiscoverAppLocatorDefinition implements LocatorDefinition<DiscoverA
     const appState: {
       query?: Query | AggregateQuery;
       filters?: Filter[];
-      index?: string;
+      index?: string | DataViewSpec;
       columns?: string[];
       interval?: string;
       sort?: string[][];


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
