### PR TITLE
[Lens] Make sure render is not called after destroy

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -555,10 +555,10 @@ export class Embeddable
    */
   render(domNode: HTMLElement | Element) {
     this.domNode = domNode;
-    super.render(domNode as HTMLElement);
     if (!this.savedVis || !this.isInitialized || this.isDestroyed) {
       return;
     }
+    super.render(domNode as HTMLElement);
     if (this.input.onLoad) {
       this.input.onLoad(true);
     }
@@ -874,8 +874,8 @@ export class Embeddable
   }
 
   destroy() {
-    super.destroy();
     this.isDestroyed = true;
+    super.destroy();
     if (this.inputReloadSubscriptions.length > 0) {
       this.inputReloadSubscriptions.forEach((reloadSub) => {
         reloadSub.unsubscribe();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/137958 by making sure the `isDestroyed` flag is set before anything else is happening and render isn't calling through if the embeddable is destroyed already