### PR TITLE
[Security Solution Platform] Allow customizable plugin page layout #4666

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.test.tsx
@@ -167,7 +167,7 @@ describe('HomePage', () => {
   it('calls useInitializeUrlParam for appQuery, filters and savedQuery', () => {
     render(
       <TestProviders>
-        <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+        <HomePage setHeaderActionMenu={jest.fn()}>
           <span />
         </HomePage>
       </TestProviders>
@@ -193,7 +193,7 @@ describe('HomePage', () => {
 
     render(
       <TestProviders>
-        <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+        <HomePage setHeaderActionMenu={jest.fn()}>
           <span />
         </HomePage>
       </TestProviders>
@@ -234,7 +234,7 @@ describe('HomePage', () => {
 
     render(
       <TestProviders>
-        <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+        <HomePage setHeaderActionMenu={jest.fn()}>
           <span />
         </HomePage>
       </TestProviders>
@@ -266,7 +266,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -301,7 +301,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders store={mockStore}>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -318,7 +318,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -360,7 +360,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -405,7 +405,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -455,7 +455,7 @@ describe('HomePage', () => {
 
       const TestComponent = () => (
         <TestProviders store={mockStore}>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -512,7 +512,7 @@ describe('HomePage', () => {
 
       const TestComponent = () => (
         <TestProviders store={mockStore}>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -552,7 +552,7 @@ describe('HomePage', () => {
 
       render(
         <TestProviders>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -577,7 +577,7 @@ describe('HomePage', () => {
 
       const TestComponent = () => (
         <TestProviders store={store}>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>
@@ -605,7 +605,7 @@ describe('HomePage', () => {
 
       const TestComponent = () => (
         <TestProviders store={store}>
-          <HomePage onAppLeave={jest.fn()} setHeaderActionMenu={jest.fn()}>
+          <HomePage setHeaderActionMenu={jest.fn()}>
             <span />
           </HomePage>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import type { AppLeaveHandler, AppMountParameters } from '@kbn/core/public';
+import type { AppMountParameters } from '@kbn/core/public';
 import { DragDropContextWrapper } from '../../common/components/drag_and_drop/drag_drop_context_wrapper';
 import { SecuritySolutionAppWrapper } from '../../common/components/page';
 
@@ -20,7 +20,6 @@ import {
 } from '../../common/containers/sourcerer';
 import { useUpgradeSecurityPackages } from '../../common/hooks/use_upgrade_security_packages';
 import { GlobalHeader } from './global_header';
-import { SecuritySolutionTemplateWrapper } from './template_wrapper';
 import { ConsoleManager } from '../../management/components/console/components/console_manager';
 
 import { TourContextProvider } from '../../common/components/guided_onboarding';
@@ -30,15 +29,10 @@ import { useUpdateBrowserTitle } from '../../common/hooks/use_update_browser_tit
 
 interface HomePageProps {
   children: React.ReactNode;
-  onAppLeave: (handler: AppLeaveHandler) => void;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
 }
 
-const HomePageComponent: React.FC<HomePageProps> = ({
-  children,
-  onAppLeave,
-  setHeaderActionMenu,
-}) => {
+const HomePageComponent: React.FC<HomePageProps> = ({ children, setHeaderActionMenu }) => {
   const { pathname } = useLocation();
   useInitSourcerer(getScopeFromPath(pathname));
   useUrlState();
@@ -59,9 +53,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({
           <>
             <GlobalHeader setHeaderActionMenu={setHeaderActionMenu} />
             <DragDropContextWrapper browserFields={browserFields}>
-              <SecuritySolutionTemplateWrapper onAppLeave={onAppLeave}>
-                {children}
-              </SecuritySolutionTemplateWrapper>
+              {children}
             </DragDropContextWrapper>
             <HelpMenu />
           </>

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import type { KibanaPageTemplateProps } from '@kbn/shared-ux-page-kibana-template';
-import type { AppLeaveHandler } from '@kbn/core/public';
+import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { AutoSaveWarningMsg } from '../../../../timelines/components/timeline/auto_save_warning';
 import { Flyout } from '../../../../timelines/components/flyout';
@@ -17,17 +17,18 @@ import { useResolveRedirect } from '../../../../common/hooks/use_resolve_redirec
 
 export const BOTTOM_BAR_CLASSNAME = 'timeline-bottom-bar';
 
-export const SecuritySolutionBottomBar = React.memo(
-  ({ onAppLeave }: { onAppLeave: (handler: AppLeaveHandler) => void }) => {
-    useResolveRedirect();
-    return (
-      <>
-        <AutoSaveWarningMsg />
-        <Flyout timelineId={TimelineId.active} onAppLeave={onAppLeave} />
-      </>
-    );
-  }
-);
+export const SecuritySolutionBottomBar = React.memo(() => {
+  useResolveRedirect();
+
+  const { onAppLeave } = useKibana().services;
+
+  return (
+    <>
+      <AutoSaveWarningMsg />
+      <Flyout timelineId={TimelineId.active} onAppLeave={onAppLeave} />
+    </>
+  );
+});
 
 export const SecuritySolutionBottomBarProps: KibanaPageTemplateProps['bottomBarProps'] = {
   className: BOTTOM_BAR_CLASSNAME,

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.test.tsx
@@ -52,7 +52,7 @@ jest.mock('../../../common/components/navigation/use_security_solution_navigatio
 const renderComponent = () => {
   return render(
     <TestProviders>
-      <SecuritySolutionTemplateWrapper onAppLeave={() => null}>
+      <SecuritySolutionTemplateWrapper>
         <div>{'child of wrapper'}</div>
       </SecuritySolutionTemplateWrapper>
     </TestProviders>

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { EuiPanel, EuiThemeProvider, useEuiTheme } from '@elastic/eui';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
-import type { AppLeaveHandler } from '@kbn/core/public';
+import type { KibanaPageTemplateProps } from '@kbn/shared-ux-page-kibana-template';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { useSecuritySolutionNavigation } from '../../../common/components/navigation/use_security_solution_navigation';
 import { TimelineId } from '../../../../common/types/timeline';
@@ -32,10 +32,6 @@ const NO_DATA_PAGE_MAX_WIDTH = 950;
 const NO_DATA_PAGE_TEMPLATE_PROPS = {
   restrictWidth: NO_DATA_PAGE_MAX_WIDTH,
   template: 'centeredBody',
-  pageContentProps: {
-    hasShadow: false,
-    color: 'transparent',
-  },
 };
 
 /**
@@ -73,70 +69,69 @@ const StyledKibanaPageTemplate = styled(KibanaPageTemplate)<{
   `}
 `;
 
-interface SecuritySolutionPageWrapperProps {
-  onAppLeave: (handler: AppLeaveHandler) => void;
-}
+export const SecuritySolutionTemplateWrapper: React.FC<{
+  template?: KibanaPageTemplateProps['template'] | 'noData';
+}> = React.memo(({ children, template = 'default' }) => {
+  const solutionNav = useSecuritySolutionNavigation();
+  const isPolicySettingsVisible = useIsPolicySettingsBarVisible();
+  const [isTimelineBottomBarVisible] = useShowTimeline();
+  const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
+  const { show: isShowingTimelineOverlay } = useDeepEqualSelector((state) =>
+    getTimelineShowStatus(state, TimelineId.active)
+  );
+  const isGroupedNavEnabled = useIsGroupedNavigationEnabled();
+  const addBottomPadding =
+    isTimelineBottomBarVisible || isPolicySettingsVisible || isGroupedNavEnabled;
 
-export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapperProps> =
-  React.memo(({ children, onAppLeave }) => {
-    const solutionNav = useSecuritySolutionNavigation();
-    const isPolicySettingsVisible = useIsPolicySettingsBarVisible();
-    const [isTimelineBottomBarVisible] = useShowTimeline();
-    const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
-    const { show: isShowingTimelineOverlay } = useDeepEqualSelector((state) =>
-      getTimelineShowStatus(state, TimelineId.active)
-    );
-    const isGroupedNavEnabled = useIsGroupedNavigationEnabled();
-    const addBottomPadding =
-      isTimelineBottomBarVisible || isPolicySettingsVisible || isGroupedNavEnabled;
+  const showEmptyState = useShowPagesWithEmptyView();
 
-    const showEmptyState = useShowPagesWithEmptyView();
-    const emptyStateProps = showEmptyState
+  const emptyStateProps =
+    showEmptyState || template === 'noData'
       ? {
           ...NO_DATA_PAGE_TEMPLATE_PROPS,
-          template: 'centeredContent',
-          pageContentProps: { verticalPosition: 'top' },
+          template: 'centeredContent' as const,
         }
-      : {};
+      : { template };
 
-    // The bottomBar by default has a set 'dark' colorMode that doesn't match the global colorMode from the Advanced Settings
-    // To keep the mode in sync, we pass in the globalColorMode to the bottom bar here
-    const { colorMode: globalColorMode } = useEuiTheme();
-    /*
-     * StyledKibanaPageTemplate is a styled EuiPageTemplate. Security solution currently passes the header
-     * and page content as the children of StyledKibanaPageTemplate, as opposed to using the pageHeader prop,
-     * which may account for any style discrepancies, such as the bottom border not extending the full width of the page,
-     * between EuiPageTemplate and the security solution pages.
-     */
-    return (
-      <StyledKibanaPageTemplate
-        $addBottomPadding={addBottomPadding}
-        $isShowingTimelineOverlay={isShowingTimelineOverlay}
-        bottomBarProps={SecuritySolutionBottomBarProps}
-        bottomBar={
-          isTimelineBottomBarVisible && (
-            <EuiThemeProvider colorMode={globalColorMode}>
-              <SecuritySolutionBottomBar onAppLeave={onAppLeave} />
-            </EuiThemeProvider>
-          )
-        }
-        paddingSize="none"
-        solutionNav={solutionNav}
-        restrictWidth={false}
-        template="default"
-        {...emptyStateProps}
-      >
-        <>
-          <GlobalKQLHeader />
-          <EuiPanel
-            className="securityPageWrapper"
-            data-test-subj="pageContainer"
-            hasShadow={false}
-            paddingSize="l"
-          >
-            {children}
-          </EuiPanel>
-        </>
-      </StyledKibanaPageTemplate>
-    );
-  });
+  // The bottomBar by default has a set 'dark' colorMode that doesn't match the global colorMode from the Advanced Settings
+  // To keep the mode in sync, we pass in the globalColorMode to the bottom bar here
+  const { colorMode: globalColorMode } = useEuiTheme();
+  /*
+   * StyledKibanaPageTemplate is a styled EuiPageTemplate. Security solution currently passes the header
+   * and page content as the children of StyledKibanaPageTemplate, as opposed to using the pageHeader prop,
+   * which may account for any style discrepancies, such as the bottom border not extending the full width of the page,
+   * between EuiPageTemplate and the security solution pages.
+   */
+  return (
+    <StyledKibanaPageTemplate
+      $addBottomPadding={addBottomPadding}
+      $isShowingTimelineOverlay={isShowingTimelineOverlay}
+      bottomBarProps={SecuritySolutionBottomBarProps}
+      bottomBar={
+        isTimelineBottomBarVisible && (
+          <EuiThemeProvider colorMode={globalColorMode}>
+            <SecuritySolutionBottomBar />
+          </EuiThemeProvider>
+        )
+      }
+      paddingSize="none"
+      solutionNav={solutionNav}
+      restrictWidth={false}
+      {...emptyStateProps}
+    >
+      <>
+        <GlobalKQLHeader />
+        <EuiPanel
+          className="securityPageWrapper"
+          data-test-subj="pageContainer"
+          hasShadow={false}
+          paddingSize="l"
+        >
+          {children}
+        </EuiPanel>
+      </>
+    </StyledKibanaPageTemplate>
+  );
+});
+
+SecuritySolutionTemplateWrapper.displayName = 'SecuritySolutionTemplateWrapper';

--- a/x-pack/plugins/security_solution/public/app/routes.tsx
+++ b/x-pack/plugins/security_solution/public/app/routes.tsx
@@ -50,9 +50,7 @@ const PageRouterComponent: FC<RouterProps> = ({
         <RouteCapture>
           <Switch>
             <Route path="/">
-              <HomePage onAppLeave={onAppLeave} setHeaderActionMenu={setHeaderActionMenu}>
-                {children}
-              </HomePage>
+              <HomePage setHeaderActionMenu={setHeaderActionMenu}>{children}</HomePage>
             </Route>
             <Route>
               <NotFoundPage />

--- a/x-pack/plugins/security_solution/public/cases/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cases/routes.tsx
@@ -11,16 +11,21 @@ import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { CASES_PATH } from '../../common/constants';
 import { Cases } from './pages';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
-export const CasesRoutes = () => (
-  <TrackApplicationView viewId="case">
-    <Cases />
-  </TrackApplicationView>
-);
+export const CasesRoutes = () => {
+  return (
+    <PluginTemplateWrapper>
+      <TrackApplicationView viewId="case">
+        <Cases />
+      </TrackApplicationView>
+    </PluginTemplateWrapper>
+  );
+};
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: CASES_PATH,
-    render: CasesRoutes,
+    component: CasesRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
@@ -20,6 +20,7 @@ import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
 import { SpyRoute } from '../common/utils/route/spy_routes';
 import { FiltersGlobal } from '../common/components/filters_global';
 import { MANAGE } from '../app/translations';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 // This exists only for the type signature cast
 const CloudPostureSpyRoute = ({ pageName }: { pageName?: CloudSecurityPosturePageId }) => (
@@ -39,11 +40,13 @@ const CloudSecurityPosture = memo(() => {
 
   return (
     // TODO: Finer granularity of this needs to be implemented in the cloud security posture plugin
-    <TrackApplicationView viewId="cloud_security_posture">
-      <SecuritySolutionPageWrapper noPadding noTimeline>
-        <CloudSecurityPostureRouter securitySolutionContext={securitySolutionContext} />
-      </SecuritySolutionPageWrapper>
-    </TrackApplicationView>
+    <PluginTemplateWrapper>
+      <TrackApplicationView viewId="cloud_security_posture">
+        <SecuritySolutionPageWrapper noPadding noTimeline>
+          <CloudSecurityPostureRouter securitySolutionContext={securitySolutionContext} />
+        </SecuritySolutionPageWrapper>
+      </TrackApplicationView>
+    </PluginTemplateWrapper>
   );
 });
 

--- a/x-pack/plugins/security_solution/public/common/components/plugin_template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/plugin_template_wrapper/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './plugin_template_wrapper';

--- a/x-pack/plugins/security_solution/public/common/components/plugin_template_wrapper/plugin_template_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/plugin_template_wrapper/plugin_template_wrapper.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { FC } from 'react';
+import type { KibanaPageTemplateProps } from '@kbn/shared-ux-page-kibana-template';
+import { useKibana } from '../../lib/kibana';
+
+interface PluginTemplateWrapperProps {
+  /**
+   * Accepts all the values from KibanaPageTemplate, as well as `noData` which centers the page contents.
+   */
+  template?: KibanaPageTemplateProps['template'] | 'noData';
+}
+
+/**
+ * Uses securityLayout service to retrieve shared plugin wrapper component and renders plugin routes / children inside of it.
+ *
+ * The `template` prop can be used to alter the page layout for a given plugin route / all routes within a plugin - depending on the nesting.
+ */
+export const PluginTemplateWrapper: FC<PluginTemplateWrapperProps> = ({ children, template }) => {
+  const {
+    services: {
+      securityLayout: { getPluginWrapper },
+    },
+  } = useKibana();
+
+  const Wrapper = getPluginWrapper();
+
+  return <Wrapper template={template}>{children}</Wrapper>;
+};

--- a/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.test.tsx
@@ -13,9 +13,8 @@ jest.mock('../route/use_route_spy', () => ({
     .fn()
     .mockImplementationOnce(() => [{ pageName: 'hosts' }])
     .mockImplementationOnce(() => [{ pageName: 'rules' }])
-    .mockImplementationOnce(() => [{ pageName: 'network' }])
-    .mockImplementationOnce(() => [{ pageName: 'get_started' }])
-    .mockImplementationOnce(() => [{ pageName: 'get_started' }]),
+    .mockImplementationOnce(() => [{ pageName: 'network' }]),
+
 }));
 jest.mock('../../containers/sourcerer', () => ({
   useSourcererDataView: jest
@@ -45,24 +44,6 @@ describe('use show pages with empty view', () => {
     });
   });
   it('shows empty view when on an elligible page and indices do exist', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useShowPagesWithEmptyView());
-      await waitForNextUpdate();
-      const emptyResult = result.current;
-      expect(emptyResult).toEqual(true);
-    });
-  });
-
-  it('apply empty view for the landing page if indices do not exist', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useShowPagesWithEmptyView());
-      await waitForNextUpdate();
-      const emptyResult = result.current;
-      expect(emptyResult).toEqual(true);
-    });
-  });
-
-  it('apply empty view for the landing page if indices exist', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook(() => useShowPagesWithEmptyView());
       await waitForNextUpdate();

--- a/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.test.tsx
@@ -14,7 +14,6 @@ jest.mock('../route/use_route_spy', () => ({
     .mockImplementationOnce(() => [{ pageName: 'hosts' }])
     .mockImplementationOnce(() => [{ pageName: 'rules' }])
     .mockImplementationOnce(() => [{ pageName: 'network' }]),
-
 }));
 jest.mock('../../containers/sourcerer', () => ({
   useSourcererDataView: jest

--- a/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/empty_view/use_show_pages_with_empty_view.tsx
@@ -27,8 +27,7 @@ export const useShowPagesWithEmptyView = () => {
   const [{ pageName }] = useRouteSpy();
   const { indicesExist } = useSourcererDataView();
 
-  const shouldShowEmptyState =
-    (isPageNameWithEmptyView(pageName) && !indicesExist) || pageName === SecurityPageName.landing;
+  const shouldShowEmptyState = isPageNameWithEmptyView(pageName) && !indicesExist;
 
   const [showEmptyState, setShowEmptyState] = useState(shouldShowEmptyState);
 

--- a/x-pack/plugins/security_solution/public/detections/routes.tsx
+++ b/x-pack/plugins/security_solution/public/detections/routes.tsx
@@ -9,9 +9,14 @@ import React from 'react';
 import type { RouteProps, RouteComponentProps } from 'react-router-dom';
 import { Redirect } from 'react-router-dom';
 import { ALERTS_PATH, DETECTIONS_PATH } from '../../common/constants';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { Alerts } from './pages/alerts';
 
-const renderAlertsRoutes = () => <Alerts />;
+const AlertsRoutes = () => (
+  <PluginTemplateWrapper>
+    <Alerts />
+  </PluginTemplateWrapper>
+);
 
 const DetectionsRedirects = ({ location }: RouteComponentProps) =>
   location.pathname === DETECTIONS_PATH ? (
@@ -27,6 +32,6 @@ export const routes: RouteProps[] = [
   },
   {
     path: ALERTS_PATH,
-    render: renderAlertsRoutes,
+    component: AlertsRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/exceptions/routes.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/routes.tsx
@@ -15,15 +15,16 @@ import { ExceptionListsTable } from '../detections/pages/detection_engine/rules/
 import { SpyRoute } from '../common/utils/route/spy_routes';
 import { NotFoundPage } from '../app/404';
 import { useReadonlyHeader } from '../use_readonly_header';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
-const ExceptionsRoutes = () => {
-  return (
+const ExceptionsRoutes = () => (
+  <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.exceptions}>
       <ExceptionListsTable />
       <SpyRoute pageName={SecurityPageName.exceptions} />
     </TrackApplicationView>
-  );
-};
+  </PluginTemplateWrapper>
+);
 
 const ExceptionsContainerComponent: React.FC = () => {
   useReadonlyHeader(i18n.READ_ONLY_BADGE_TOOLTIP);

--- a/x-pack/plugins/security_solution/public/hosts/routes.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/routes.tsx
@@ -11,16 +11,19 @@ import { HostsContainer } from './pages';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
 import { HOSTS_PATH } from '../../common/constants';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const HostsRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.hosts}>
-    <HostsContainer />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.hosts}>
+      <HostsContainer />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: HOSTS_PATH,
-    render: HostsRoutes,
+    component: HostsRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/kubernetes/routes.tsx
+++ b/x-pack/plugins/security_solution/public/kubernetes/routes.tsx
@@ -12,16 +12,19 @@ import { KubernetesContainer } from './pages';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
 import { KUBERNETES_PATH } from '../../common/constants';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const KubernetesRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.kubernetes}>
-    <KubernetesContainer />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.kubernetes}>
+      <KubernetesContainer />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: KUBERNETES_PATH,
-    render: KubernetesRoutes,
+    component: KubernetesRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/landing_pages/routes.tsx
+++ b/x-pack/plugins/security_solution/public/landing_pages/routes.tsx
@@ -14,36 +14,43 @@ import { DASHBOARDS_PATH, MANAGE_PATH, EXPLORE_PATH } from '../../common/constan
 import { ExploreLandingPage } from './pages/explore';
 import { DashboardsLandingPage } from './pages/dashboards';
 import { ManageLandingPage } from './pages/manage';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const ThreatHuntingRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.exploreLanding}>
-    <ExploreLandingPage />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.exploreLanding}>
+      <ExploreLandingPage />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const DashboardRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.dashboardsLanding}>
-    <DashboardsLandingPage />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.dashboardsLanding}>
+      <DashboardsLandingPage />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const ManageRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.administration}>
-    <ManageLandingPage />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.administration}>
+      <ManageLandingPage />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: EXPLORE_PATH,
-    render: ThreatHuntingRoutes,
+    component: ThreatHuntingRoutes,
   },
   {
     path: DASHBOARDS_PATH,
-    render: DashboardRoutes,
+    component: DashboardRoutes,
   },
   {
     path: MANAGE_PATH,
-    render: ManageRoutes,
+    component: ManageRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/management/routes.tsx
+++ b/x-pack/plugins/security_solution/public/management/routes.tsx
@@ -10,19 +10,22 @@ import { MANAGEMENT_PATH } from '../../common/constants';
 import { ManagementContainer } from './pages';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { CurrentLicense } from '../common/components/current_license';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 /**
  * Returns the React Router Routes for the management area
  */
 const ManagementRoutes = () => (
-  <CurrentLicense>
-    <ManagementContainer />
-  </CurrentLicense>
+  <PluginTemplateWrapper>
+    <CurrentLicense>
+      <ManagementContainer />
+    </CurrentLicense>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: MANAGEMENT_PATH,
-    render: ManagementRoutes,
+    component: ManagementRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/network/routes.tsx
+++ b/x-pack/plugins/security_solution/public/network/routes.tsx
@@ -12,16 +12,19 @@ import { NetworkContainer } from './pages';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
 import { NETWORK_PATH } from '../../common/constants';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const NetworkRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.network}>
-    <NetworkContainer />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.network}>
+      <NetworkContainer />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: NETWORK_PATH,
-    render: NetworkRoutes,
+    component: NetworkRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/overview/routes.tsx
+++ b/x-pack/plugins/security_solution/public/overview/routes.tsx
@@ -19,40 +19,49 @@ import type { SecuritySubPluginRoutes } from '../app/types';
 import { LandingPage } from './pages/landing';
 import { StatefulOverview } from './pages/overview';
 import { DetectionResponse } from './pages/detection_response';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { EntityAnalyticsPage } from './pages/entity_analytics';
 
 const OverviewRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.overview}>
-    <StatefulOverview />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.overview}>
+      <StatefulOverview />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 const DetectionResponseRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.detectionAndResponse}>
-    <DetectionResponse />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.detectionAndResponse}>
+      <DetectionResponse />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 const LandingRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.landing}>
-    <LandingPage />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.landing}>
+      <LandingPage />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 const EntityAnalyticsRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.entityAnalytics}>
-    <EntityAnalyticsPage />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.entityAnalytics}>
+      <EntityAnalyticsPage />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: OVERVIEW_PATH,
-    render: OverviewRoutes,
+    component: OverviewRoutes,
   },
   {
     path: DETECTION_RESPONSE_PATH,
-    render: DetectionResponseRoutes,
+    component: DetectionResponseRoutes,
   },
   {
     path: LANDING_PATH,

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -125,9 +125,10 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
      * This is a promise because these aren't available until the `start` lifecycle phase but they are referenced
      * in the `setup` lifecycle phase.
      */
-    const startServices: Promise<StartServices> = (async () => {
+    const startServices = async (params: AppMountParameters<unknown>): Promise<StartServices> => {
       const [coreStart, startPluginsDeps] = await core.getStartServices();
       const { apm } = await import('@elastic/apm-rum');
+      const { SecuritySolutionTemplateWrapper } = await import('./app/home/template_wrapper');
 
       const { savedObjectsTaggingOss, ...startPlugins } = startPluginsDeps;
 
@@ -138,9 +139,13 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         savedObjectsTagging: savedObjectsTaggingOss.getTaggingApi(),
         storage: this.storage,
         security: startPluginsDeps.security,
+        onAppLeave: params.onAppLeave,
+        securityLayout: {
+          getPluginWrapper: () => SecuritySolutionTemplateWrapper,
+        },
       };
       return services;
-    })();
+    };
 
     core.application.register({
       id: APP_UI_ID,
@@ -164,7 +169,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         const { renderApp } = await this.lazyApplicationDependencies();
         return renderApp({
           ...params,
-          services: await startServices,
+          services: await startServices(params),
           store: await this.store(coreStart, startPlugins, subPlugins),
           usageCollection: plugins.usageCollection,
           subPluginRoutes: getSubPluginRoutesByCapabilities(

--- a/x-pack/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/plugins/security_solution/public/rules/routes.tsx
@@ -17,6 +17,7 @@ import { CreateRulePage } from '../detections/pages/detection_engine/rules/creat
 import { RuleDetailsPage } from '../detections/pages/detection_engine/rules/details';
 import { EditRulePage } from '../detections/pages/detection_engine/rules/edit';
 import { useReadonlyHeader } from '../use_readonly_header';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 const RulesSubRoutes = [
   {
@@ -45,16 +46,22 @@ const RulesContainerComponent: React.FC = () => {
   useReadonlyHeader(i18n.READ_ONLY_BADGE_TOOLTIP);
 
   return (
-    <TrackApplicationView viewId={SecurityPageName.rules}>
-      <Switch>
-        {RulesSubRoutes.map((route, index) => (
-          <Route key={`rules-route-${route.path}`} path={route.path} exact={route?.exact ?? false}>
-            <route.main />
-          </Route>
-        ))}
-        <Route component={NotFoundPage} />
-      </Switch>
-    </TrackApplicationView>
+    <PluginTemplateWrapper>
+      <TrackApplicationView viewId={SecurityPageName.rules}>
+        <Switch>
+          {RulesSubRoutes.map((route, index) => (
+            <Route
+              key={`rules-route-${route.path}`}
+              path={route.path}
+              exact={route?.exact ?? false}
+            >
+              <route.main />
+            </Route>
+          ))}
+          <Route component={NotFoundPage} />
+        </Switch>
+      </TrackApplicationView>
+    </PluginTemplateWrapper>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
+++ b/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
@@ -20,6 +20,7 @@ import { licenseService } from '../common/hooks/use_license';
 import { SecurityPageName } from '../app/types';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { useSourcererDataView } from '../common/containers/sourcerer';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 const ThreatIntelligence = memo(() => {
   const { threatIntelligence } = useKibana().services;
@@ -40,10 +41,12 @@ const ThreatIntelligence = memo(() => {
 
   return (
     <TrackApplicationView viewId="threat_intelligence">
-      <SecuritySolutionPageWrapper noPadding>
-        <ThreatIntelligencePlugin securitySolutionContext={securitySolutionContext} />
-        <SpyRoute pageName={SecurityPageName.threatIntelligenceIndicators} />
-      </SecuritySolutionPageWrapper>
+      <PluginTemplateWrapper>
+        <SecuritySolutionPageWrapper noPadding>
+          <ThreatIntelligencePlugin securitySolutionContext={securitySolutionContext} />
+          <SpyRoute pageName={SecurityPageName.threatIntelligenceIndicators} />
+        </SecuritySolutionPageWrapper>
+      </PluginTemplateWrapper>
     </TrackApplicationView>
   );
 });

--- a/x-pack/plugins/security_solution/public/timelines/routes.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/routes.tsx
@@ -12,16 +12,19 @@ import { TIMELINES_PATH } from '../../common/constants';
 
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 const TimelinesRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.timelines}>
-    <Timelines />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.timelines}>
+      <Timelines />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: TIMELINES_PATH,
-    render: TimelinesRoutes,
+    component: TimelinesRoutes,
   },
 ];

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CoreStart } from '@kbn/core/public';
+import type { AppLeaveHandler, CoreStart } from '@kbn/core/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
@@ -56,6 +56,7 @@ import type { Management } from './management';
 import type { LandingPages } from './landing_pages';
 import type { CloudSecurityPosture } from './cloud_security_posture';
 import type { ThreatIntelligence } from './threat_intelligence';
+import type { SecuritySolutionTemplateWrapper } from './app/home/template_wrapper';
 
 export interface SetupPlugins {
   home?: HomePublicPluginSetup;
@@ -101,6 +102,15 @@ export type StartServices = CoreStart &
     storage: Storage;
     apm: ApmBase;
     savedObjectsTagging?: SavedObjectsTaggingApi;
+    onAppLeave: (handler: AppLeaveHandler) => void;
+
+    /**
+     * This component will be exposed to all lazy loaded plugins, via useKibana hook. It should wrap every plugin route.
+     * The goal is to allow page property customization (such as `template`).
+     */
+    securityLayout: {
+      getPluginWrapper: () => typeof SecuritySolutionTemplateWrapper;
+    };
   };
 
 export interface PluginSetup {

--- a/x-pack/plugins/security_solution/public/users/routes.tsx
+++ b/x-pack/plugins/security_solution/public/users/routes.tsx
@@ -12,16 +12,19 @@ import { UsersContainer } from './pages';
 import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
 import { USERS_PATH } from '../../common/constants';
+import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const UsersRoutes = () => (
-  <TrackApplicationView viewId={SecurityPageName.users}>
-    <UsersContainer />
-  </TrackApplicationView>
+  <PluginTemplateWrapper>
+    <TrackApplicationView viewId={SecurityPageName.users}>
+      <UsersContainer />
+    </TrackApplicationView>
+  </PluginTemplateWrapper>
 );
 
 export const routes: SecuritySubPluginRoutes = [
   {
     path: USERS_PATH,
-    render: UsersRoutes,
+    component: UsersRoutes,
   },
 ];


### PR DESCRIPTION
## Summary

Changes in this PR will allow each plugin route to customize `template` mode used to render the contents. 

Please see https://github.com/elastic/security-team/issues/4666 for reference.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
