### PR TITLE
[Cloud Posture] Title beta tag alignment

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page_title.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { css } from '@emotion/react';
 
 export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta: boolean }) => (
   <EuiFlexGroup alignItems="center" gutterSize="s">
@@ -17,7 +18,15 @@ export const CloudPosturePageTitle = ({ title, isBeta }: { title: string; isBeta
       </EuiTitle>
     </EuiFlexItem>
     {isBeta && (
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem
+        grow={false}
+        css={css`
+          // tooltipContent wraps EuiBetaBadge with a span element which breaks alignment
+          .euiToolTipAnchor {
+            display: flex;
+          }
+        `}
+      >
         <EuiBetaBadge
           label={i18n.translate('xpack.csp.common.cloudPosturePageTitle.BetaBadgeLabel', {
             defaultMessage: 'Beta',


### PR DESCRIPTION
## Summary

`tooltipContent` property of `EuiBetaBadge` adds a span element which breaks the flexbox alignment of `EuiFlexGroup`

## Before
![image](https://user-images.githubusercontent.com/51442161/183680011-300077bc-b20a-4245-a490-9335ae188393.png)

![image](https://user-images.githubusercontent.com/51442161/183683360-7c1dfd20-1f06-40dd-8c59-a13328133441.png)


## After
![image](https://user-images.githubusercontent.com/51442161/183679906-87add174-67dc-484f-914c-568b2593f584.png)

![image](https://user-images.githubusercontent.com/51442161/183683119-857d4df9-a657-415b-84ba-c82f64c9d29b.png)

