### PR TITLE
Fix broken link to CiStatsReporter

### DIFF
--- a/docs/developer/contributing/development-ci-metrics.asciidoc
+++ b/docs/developer/contributing/development-ci-metrics.asciidoc
@@ -60,7 +60,7 @@ The number of saved object fields broken down by saved object type.
 [[ci-metric-adding-new-metrics]]
 === Adding new metrics
 
-You can report new metrics by using the `CiStatsReporter` class provided by the `@kbn/dev-utils` package. This class is automatically configured on CI and its methods noop when running outside of CI. For more details checkout the {kib-repo}blob/{branch}/packages/kbn-dev-utils/src/ci_stats_reporter[`CiStatsReporter` readme].
+You can report new metrics by using the `CiStatsReporter` class provided by the `@kbn/dev-utils` package. This class is automatically configured on CI and its methods noop when running outside of CI. For more details checkout the {kib-repo}blob/{branch}/packages/kbn-ci-stats-reporter[`CiStatsReporter` readme].
 
 [[ci-metric-resolving-overages]]
 === Resolving `page load bundle size` overages


### PR DESCRIPTION
## Summary

I noticed the link was broken as the CiStatsReporter was moved to a separate package. This PR fixes the link.

I noticed the split happened on 8.3.0 (https://github.com/elastic/kibana/pull/130509), so I'll backport the docs only to the previous minor.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->