### PR TITLE
update language of dashboard descriptions

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/links.ts
+++ b/x-pack/plugins/security_solution/public/overview/links.ts
@@ -23,7 +23,8 @@ export const overviewLinks: LinkItem = {
   title: OVERVIEW,
   landingImage: overviewPageImg,
   description: i18n.translate('xpack.securitySolution.appLinks.overviewDescription', {
-    defaultMessage: 'What is going on in your security environment.',
+    defaultMessage:
+      'Summary of your security environment activity, including alerts, events, recent items, and a news feed!',
   }),
   path: OVERVIEW_PATH,
   capabilities: [`${SERVER_APP_ID}.show`],
@@ -54,7 +55,7 @@ export const detectionResponseLinks: LinkItem = {
   landingImage: detectionResponsePageImg,
   description: i18n.translate('xpack.securitySolution.appLinks.detectionAndResponseDescription', {
     defaultMessage:
-      "Monitor the impact of application and device performance from the end user's point of view.",
+      'Information about your Alerts and Cases within the Security Solution, including Hosts and Users with Alerts.',
   }),
   path: DETECTION_RESPONSE_PATH,
   capabilities: [`${SERVER_APP_ID}.show`],


### PR DESCRIPTION
closes: https://github.com/elastic/kibana/issues/138421

## Summary
We are updating the language used to describe the Overview and Detection & Response dashboards:

<img width="963" alt="image" src="https://user-images.githubusercontent.com/28942857/183693046-5c830df1-6ad9-4e8a-9bf3-8124861628ee.png">

Overview
Current: What is going on in your security environment
Updated: Summary of your security environment activity, including alerts, events, recent items, and a news feed!

Detection & Response
Current: Monitor the impact of application and device performance from the end user’s point of view.
Updated: Information about your Alerts and Cases within the Security Solution, including Hosts and Users with Alerts.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->