### PR TITLE
[Security Solution][Detections] Unskip tests for bulk editing index patterns

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
@@ -50,8 +50,7 @@ describe('ruleParamsModifier', () => {
     expect(editedRuleParams).toHaveProperty('version', ruleParamsMock.version + 1);
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/138409
-  describe.skip('index_patterns', () => {
+  describe('index_patterns', () => {
     test('should add new index pattern to rule', () => {
       const editedRuleParams = ruleParamsModifier(ruleParamsMock, [
         {


### PR DESCRIPTION
**Ticket:** https://github.com/elastic/kibana/issues/138409
**Caused by:** https://github.com/elastic/kibana/pull/138304#issuecomment-1209490032

## Summary

The merge of https://github.com/elastic/kibana/pull/138304 caused unit tests for bulk editing index patterns to start failing. This PR was reverted by https://github.com/elastic/kibana/commit/0bc8cf7f49fe8b9e7bf8c3ebc0f30794472aba84. The tests were skipped in https://github.com/elastic/kibana/commit/26a478355384e010af5bda35c029b2defa9b49e6.

These tests are fully functional in `main`. Unskipping them.