### PR TITLE
[Fleet][Test] Add cypress test for force installing unverified package assets

### DIFF
--- a/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Interception } from 'cypress/types/net-stubbing';
+
+describe('Install unverified package assets', () => {
+  beforeEach(() => {
+    cy.intercept('POST', '/api/fleet/epm/packages/fleet_server/*', (req) => {
+      if (!req.body.force) {
+        return req.reply({
+          statusCode: 400,
+          body: {
+            message: 'Package is not verified.',
+            attributes: {
+              type: 'verification_failed',
+            },
+          },
+        });
+      }
+
+      req.reply({
+        items: [
+          { id: 'nginx-1234', type: 'dashboard' },
+          { id: 'nginx-5678', type: 'dashboard' },
+        ],
+        _meta: { install_source: 'registry' },
+      });
+    }).as('installAssets');
+  });
+
+  it('should show force install modal if package is unverified', () => {
+    cy.visit('app/integrations/detail/fleet_server/settings');
+    cy.getBySel('installAssetsButton').click();
+    // this action will install x assets modal
+    const confirmInstall = cy.getBySel('confirmModalConfirmButton');
+    confirmInstall.click();
+
+    // unverified integration force install modal
+    const installAnyway = cy.getBySel('confirmModalConfirmButton').contains('Install anyway');
+    installAnyway.click();
+
+    // cypress 'hack' to get all requests made to an intercepted request
+    cy.get('@installAssets.all').then((interceptions) => {
+      const castInterceptions = interceptions as unknown as Interception[];
+      // expect latest request to have used force
+      expect(castInterceptions.at(-1)?.request?.body?.force).to.equal(true);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
@@ -30,6 +30,18 @@ describe('Install unverified package assets', () => {
         _meta: { install_source: 'registry' },
       });
     }).as('installAssets');
+
+    // save mocking out the whole package response, but make it so that fleet server is always uninstalled
+    cy.intercept('GET', '/api/fleet/epm/packages/fleet_server', (req) => {
+      req.continue((res) => {
+        if (res.body?.item?.savedObject) {
+          delete res.body.item.savedObject;
+        }
+        if (res.body?.item?.status) {
+          res.body.item.status = 'not_installed';
+        }
+      });
+    });
   });
 
   it('should show force install modal if package is unverified', () => {

--- a/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
+++ b/x-pack/plugins/fleet/cypress/integration/install_assets.spec.ts
@@ -24,8 +24,8 @@ describe('Install unverified package assets', () => {
 
       req.reply({
         items: [
-          { id: 'nginx-1234', type: 'dashboard' },
-          { id: 'nginx-5678', type: 'dashboard' },
+          { id: 'fleet_server-1234', type: 'dashboard' },
+          { id: 'fleet_server-5678', type: 'dashboard' },
         ],
         _meta: { install_source: 'registry' },
       });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/install_button.tsx
@@ -52,7 +52,12 @@ export function InstallButton(props: InstallationButtonProps) {
 
   return canInstallPackages ? (
     <Fragment>
-      <EuiButton iconType={'importAction'} isLoading={isInstalling} onClick={toggleInstallModal}>
+      <EuiButton
+        iconType={'importAction'}
+        isLoading={isInstalling}
+        onClick={toggleInstallModal}
+        data-test-subj="installAssetsButton"
+      >
         {isInstalling ? (
           <FormattedMessage
             id="xpack.fleet.integrations.installPackage.installingPackageButtonLabel"


### PR DESCRIPTION
## Summary

part of #133822

Cypress test to assert that the force install modal appears when trying to install the assets of an unverified package. 

also asserts that the package is force installed if the user elects to continue.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->