### PR TITLE
[Security Solution] [Dashboards] [137956] add regex filter for search queries to remove special characters

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.test.tsx
@@ -110,7 +110,7 @@ describe('Dashboards table', () => {
     expect(result.queryByText(DASHBOARD_TABLE_ITEMS[0].description)).toBeInTheDocument();
   });
 
-  it.only('should filter out special characters except hyphens & underscores', () => {
+  it('should filter out special characters except hyphens & underscores', () => {
     const result = renderDashboardTable();
 
     const input = result.getByRole('searchbox');

--- a/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.test.tsx
@@ -21,13 +21,13 @@ const DASHBOARD_TABLE_ITEMS = [
   },
   {
     id: 'id 2',
-    title: 'second dashboard title',
+    title: 'second dashboard_title',
     description: 'desc 2',
   },
   {
     id: 'id 3',
     title: 'different title',
-    description: 'different desc',
+    description: 'different-desc',
   },
 ];
 
@@ -108,5 +108,22 @@ describe('Dashboards table', () => {
     expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
     expect(result.queryByText(DASHBOARD_TABLE_ITEMS[0].title)).toBeInTheDocument();
     expect(result.queryByText(DASHBOARD_TABLE_ITEMS[0].description)).toBeInTheDocument();
+  });
+
+  it.only('should filter out special characters except hyphens & underscores', () => {
+    const result = renderDashboardTable();
+
+    const input = result.getByRole('searchbox');
+    fireEvent.change(input, { target: { value: '"_title"' } });
+
+    expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
+    expect(result.queryByText(DASHBOARD_TABLE_ITEMS[1].title)).toBeInTheDocument();
+    expect(result.queryByText(DASHBOARD_TABLE_ITEMS[1].description)).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "'-desc'" } });
+
+    expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
+    expect(result.queryByText(DASHBOARD_TABLE_ITEMS[2].title)).toBeInTheDocument();
+    expect(result.queryByText(DASHBOARD_TABLE_ITEMS[2].description)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
@@ -46,7 +46,7 @@ export const DashboardsTable: React.FC = () => {
       setFilteredItems(
         items.filter(({ title, description }) => {
           const normalizedName = `${title} ${description}`.toLowerCase();
-          return normalizedName.includes(searchQuery);
+          return normalizedName.includes(searchQuery.replace(/-_[^\w ]/g, ''));
         })
       );
     }

--- a/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
@@ -30,8 +30,8 @@ export const DashboardsTable: React.FC = () => {
     const debouncedSetSearchQuery = debounce(setSearchQuery, INPUT_TIMEOUT);
 
     return {
-      onChange: ({ query }) => {
-        debouncedSetSearchQuery(query?.text.toLowerCase() ?? '');
+      onChange: ({ queryText }) => {
+        debouncedSetSearchQuery(queryText.toLowerCase() ?? '');
       },
       box: {
         incremental: true,
@@ -46,7 +46,7 @@ export const DashboardsTable: React.FC = () => {
       setFilteredItems(
         items.filter(({ title, description }) => {
           const normalizedName = `${title} ${description}`.toLowerCase();
-          return normalizedName.includes(searchQuery.replace(/-_[^\w ]/g, ''));
+          return normalizedName.includes(searchQuery.replace(/[^\w-]/g, ''));
         })
       );
     }

--- a/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/dashboards/dashboards_table.tsx
@@ -46,7 +46,7 @@ export const DashboardsTable: React.FC = () => {
       setFilteredItems(
         items.filter(({ title, description }) => {
           const normalizedName = `${title} ${description}`.toLowerCase();
-          return normalizedName.includes(searchQuery.replace(/[^\w-]/g, ''));
+          return normalizedName.includes(searchQuery.replace(/[^\w- ]/g, ''));
         })
       );
     }


### PR DESCRIPTION
## Summary

fixes #137956 by adding a regex filter to remove special characters. Hyphens and dashes remain intact.

![Recording 2022-08-09 at 13 57 46](https://user-images.githubusercontent.com/28942857/183739481-4f1d604c-b375-4fa5-9040-9c4a6f5a4b59.gif)

## Checklist

[x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->