### PR TITLE
[Enterprise Search] Fix small ui issues on index detail views

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/generate_api_key_modal/modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/generate_api_key_modal/modal.tsx
@@ -113,17 +113,23 @@ export const GenerateApiKeyModal: React.FC<GenerateApiKeyModalProps> = ({ indexN
                       </EuiFlexItem>
                     </>
                   ) : (
-                    <ApiKey
-                      apiKey={apiKey}
-                      label={keyName}
-                      actions={
-                        <EuiButtonIcon
-                          iconType="download"
-                          href={encodeURI(`data:text/csv;charset=utf-8,${apiKey}`)}
-                          download={`${keyName}.csv`}
-                        />
-                      }
-                    />
+                    <EuiFlexItem>
+                      <ApiKey
+                        apiKey={apiKey}
+                        label={keyName}
+                        actions={
+                          <EuiButtonIcon
+                            aria-label={i18n.translate(
+                              'xpack.enterpriseSearch.content.overview.generateApiKeyModal.csvDownloadButton',
+                              { defaultMessage: 'Download API key' }
+                            )}
+                            iconType="download"
+                            href={encodeURI(`data:text/csv;charset=utf-8,${apiKey}`)}
+                            download={`${keyName}.csv`}
+                          />
+                        }
+                      />
+                    </EuiFlexItem>
                   )}
                 </EuiFlexGroup>
               </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/result/result_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/result/result_field.tsx
@@ -74,10 +74,13 @@ export const ResultField: React.FC<ResultFieldProps> = ({
           />
         </span>
       </EuiTableRowCell>
-      <EuiTableRowCell className="resultFieldRowCell" width="25%" valign="middle">
-        <EuiText size="xs" grow={false}>
-          {fieldName}
-        </EuiText>
+      <EuiTableRowCell
+        className="resultFieldRowCell"
+        width="25%"
+        truncateText={!isExpanded}
+        valign="middle"
+      >
+        <EuiText size="xs">{fieldName}</EuiText>
       </EuiTableRowCell>
       <EuiTableRowCell
         className="resultFieldRowCell"
@@ -86,7 +89,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
       >
         <EuiIcon type="sortRight" color="subdued" />
       </EuiTableRowCell>
-      <EuiTableRowCell className="resultFieldRowCell" truncateText valign="middle">
+      <EuiTableRowCell className="resultFieldRowCell" truncateText={!isExpanded} valign="middle">
         {(fieldType === 'object' ||
           fieldType === 'array' ||
           fieldType === 'nested' ||
@@ -96,9 +99,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
             {fieldValue}
           </EuiCodeBlock>
         ) : (
-          <EuiText size="xs" grow={false}>
-            {fieldValue}
-          </EuiText>
+          <EuiText size="xs">{fieldValue}</EuiText>
         )}
       </EuiTableRowCell>
     </EuiTableRow>


### PR DESCRIPTION
## Summary


https://user-images.githubusercontent.com/1410658/183777618-7e9cc3f6-eca4-46bf-a90c-0651dd63a67a.mov


Fixes small ui misalignment on generate API key modal.
When fieldname and fieldvalue are too long, result table will not
truncate the text on expanded view to make all content visible.
Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->