### PR TITLE
[Profiling] Improve performance of frame group operations for the flamegraph and Top N functions APIs

### DIFF
--- a/x-pack/plugins/profiling/common/callercallee.test.ts
+++ b/x-pack/plugins/profiling/common/callercallee.test.ts
@@ -10,7 +10,7 @@ import {
   createCallerCalleeIntermediateNode,
   fromCallerCalleeIntermediateNode,
 } from './callercallee';
-import { hashFrameGroup } from './frame_group';
+import { createFrameGroupID } from './frame_group';
 import { createStackFrameMetadata } from './profiling';
 
 import { events, stackTraces, stackFrames, executables } from './__fixtures__/stacktraces';
@@ -40,8 +40,8 @@ describe('Caller-callee operations', () => {
     const child = createCallerCalleeIntermediateNode(childFrame, 10, 'child');
 
     const root = createCallerCalleeIntermediateNode(createStackFrameMetadata(), 10, 'root');
-    root.callees.set(hashFrameGroup(child.frameGroup), child);
-    root.callees.set(hashFrameGroup(parent.frameGroup), parent);
+    root.callees.set(createFrameGroupID(child.frameGroup), child);
+    root.callees.set(createFrameGroupID(parent.frameGroup), parent);
 
     const graph = fromCallerCalleeIntermediateNode(root);
 

--- a/x-pack/plugins/profiling/common/callercallee.test.ts
+++ b/x-pack/plugins/profiling/common/callercallee.test.ts
@@ -10,7 +10,8 @@ import {
   createCallerCalleeIntermediateNode,
   fromCallerCalleeIntermediateNode,
 } from './callercallee';
-import { createStackFrameMetadata, hashFrameGroup } from './profiling';
+import { hashFrameGroup } from './frame_group';
+import { createStackFrameMetadata } from './profiling';
 
 import { events, stackTraces, stackFrames, executables } from './__fixtures__/stacktraces';
 

--- a/x-pack/plugins/profiling/common/callercallee.ts
+++ b/x-pack/plugins/profiling/common/callercallee.ts
@@ -8,10 +8,10 @@
 import { clone } from 'lodash';
 import {
   compareFrameGroup,
-  defaultGroupBy,
+  createFrameGroup,
+  createFrameGroupID,
   FrameGroup,
   FrameGroupID,
-  hashFrameGroup,
 } from './frame_group';
 import {
   createStackFrameMetadata,
@@ -42,7 +42,7 @@ export function createCallerCalleeIntermediateNode(
   frameGroupID: string
 ): CallerCalleeIntermediateNode {
   return {
-    frameGroup: defaultGroupBy(frameMetadata),
+    frameGroup: createFrameGroup(frameMetadata),
     callers: new Map<FrameGroupID, CallerCalleeIntermediateNode>(),
     callees: new Map<FrameGroupID, CallerCalleeIntermediateNode>(),
     frameMetadata: new Set<StackFrameMetadata>([frameMetadata]),
@@ -72,7 +72,7 @@ function selectRelevantTraces(
   frames: Map<StackTraceID, StackFrameMetadata[]>
 ): Map<StackTraceID, RelevantTrace> {
   const result = new Map<StackTraceID, RelevantTrace>();
-  const rootString = hashFrameGroup(defaultGroupBy(rootFrame));
+  const rootString = createFrameGroupID(createFrameGroup(rootFrame));
   for (const [stackTraceID, frameMetadata] of frames) {
     if (rootFrame.FileID === '' && rootFrame.AddressOrLine === 0) {
       // If the root frame is empty, every trace is relevant, and all elements
@@ -87,7 +87,7 @@ function selectRelevantTraces(
       // Search for the right index of the root frame in the frameMetadata, and
       // set it in the result.
       for (let i = 0; i < frameMetadata.length; i++) {
-        if (rootString === hashFrameGroup(defaultGroupBy(frameMetadata[i]))) {
+        if (rootString === createFrameGroupID(createFrameGroup(frameMetadata[i]))) {
           result.set(stackTraceID, {
             frames: frameMetadata,
             index: i,
@@ -158,7 +158,7 @@ export function createCallerCalleeIntermediateRoot(
 
     for (let i = callees.length - 1; i >= 0; i--) {
       const callee = callees[i];
-      const calleeName = hashFrameGroup(defaultGroupBy(callee));
+      const calleeName = createFrameGroupID(createFrameGroup(callee));
       let node = currentNode.callees.get(calleeName);
       if (node === undefined) {
         node = createCallerCalleeIntermediateNode(callee, samples, calleeName);

--- a/x-pack/plugins/profiling/common/callercallee.ts
+++ b/x-pack/plugins/profiling/common/callercallee.ts
@@ -8,14 +8,16 @@
 import { clone } from 'lodash';
 import {
   compareFrameGroup,
-  createStackFrameMetadata,
   defaultGroupBy,
-  Executable,
-  FileID,
   FrameGroup,
   FrameGroupID,
-  groupStackFrameMetadataByStackTrace,
   hashFrameGroup,
+} from './frame_group';
+import {
+  createStackFrameMetadata,
+  Executable,
+  FileID,
+  groupStackFrameMetadataByStackTrace,
   StackFrame,
   StackFrameID,
   StackFrameMetadata,

--- a/x-pack/plugins/profiling/common/frame_group.test.ts
+++ b/x-pack/plugins/profiling/common/frame_group.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { compareFrameGroup, createFrameGroup, defaultGroupBy, hashFrameGroup } from './frame_group';
+import { createStackFrameMetadata } from './profiling';
+
+describe('Frame group operations', () => {
+  test('check if a frame group is less than another', () => {
+    const a = createFrameGroup({ ExeFileName: 'chrome' });
+    const b = createFrameGroup({ ExeFileName: 'dockerd' });
+    expect(compareFrameGroup(a, b)).toEqual(-1);
+  });
+
+  test('check if a frame group is greater than another', () => {
+    const a = createFrameGroup({ ExeFileName: 'oom_reaper' });
+    const b = createFrameGroup({ ExeFileName: 'dockerd' });
+    expect(compareFrameGroup(a, b)).toEqual(1);
+  });
+
+  test('check if frame groups are equal', () => {
+    const a = createFrameGroup({ AddressOrLine: 1234 });
+    const b = createFrameGroup({ AddressOrLine: 1234 });
+    expect(compareFrameGroup(a, b)).toEqual(0);
+  });
+
+  test('check serialized non-symbolized frame', () => {
+    const metadata = createStackFrameMetadata({
+      FileID: '0x0123456789ABCDEF',
+      AddressOrLine: 102938,
+    });
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
+      '{"AddressOrLine":102938,"ExeFileName":"","FileID":"0x0123456789ABCDEF","FunctionName":"","SourceFilename":""}'
+    );
+  });
+
+  test('check serialized non-symbolized ELF frame', () => {
+    const metadata = createStackFrameMetadata({
+      FunctionName: 'strlen()',
+      FileID: '0x0123456789ABCDEF',
+    });
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
+      '{"AddressOrLine":0,"ExeFileName":"","FileID":"0x0123456789ABCDEF","FunctionName":"strlen()","SourceFilename":""}'
+    );
+  });
+
+  test('check serialized symbolized frame', () => {
+    const metadata = createStackFrameMetadata({
+      ExeFileName: 'chrome',
+      SourceFilename: 'strlen()',
+      FunctionName: 'strlen()',
+    });
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
+      '{"AddressOrLine":0,"ExeFileName":"chrome","FileID":"","FunctionName":"strlen()","SourceFilename":"strlen()"}'
+    );
+  });
+});

--- a/x-pack/plugins/profiling/common/frame_group.test.ts
+++ b/x-pack/plugins/profiling/common/frame_group.test.ts
@@ -160,18 +160,18 @@ describe('Frame group operations', () => {
   describe('check serialization for', () => {
     test('non-symbolized frame', () => {
       expect(createFrameGroupID(nonSymbolizedFrameGroups[0])).toEqual(
-        'empty:0x0123456789ABCDEF:102938'
+        'empty;0x0123456789ABCDEF;102938'
       );
     });
 
     test('non-symbolized ELF frame', () => {
       expect(createFrameGroupID(elfSymbolizedFrameGroups[0])).toEqual(
-        'elf:0x0123456789ABCDEF:strlen()'
+        'elf;0x0123456789ABCDEF;strlen()'
       );
     });
 
     test('symbolized frame', () => {
-      expect(createFrameGroupID(symbolizedFrameGroups[0])).toEqual('full:chrome:strlen():strlen()');
+      expect(createFrameGroupID(symbolizedFrameGroups[0])).toEqual('full;chrome;strlen();strlen()');
     });
   });
 });

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -151,13 +151,13 @@ export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
 export function createFrameGroupID(frameGroup: FrameGroup): FrameGroupID {
   switch (frameGroup.name) {
     case FrameGroupName.EMPTY:
-      return `${frameGroup.name}:${frameGroup.fileID}:${frameGroup.addressOrLine}`;
+      return `${frameGroup.name};${frameGroup.fileID};${frameGroup.addressOrLine}`;
       break;
     case FrameGroupName.ELF:
-      return `${frameGroup.name}:${frameGroup.fileID}:${frameGroup.functionName}`;
+      return `${frameGroup.name};${frameGroup.fileID};${frameGroup.functionName}`;
       break;
     case FrameGroupName.FULL:
-      return `${frameGroup.name}:${frameGroup.exeFilename}:${frameGroup.functionName}:${frameGroup.sourceFilename}`;
+      return `${frameGroup.name};${frameGroup.exeFilename};${frameGroup.functionName};${frameGroup.sourceFilename}`;
       break;
   }
 }

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import jsonStableStringify from 'json-stable-stringify';
+
+import { StackFrameMetadata } from './profiling';
+
+export type FrameGroup = Pick<
+  StackFrameMetadata,
+  'FileID' | 'ExeFileName' | 'FunctionName' | 'AddressOrLine' | 'SourceFilename'
+>;
+
+// This is a convenience function to create a FrameGroup value with
+// defaults for missing fields
+export function createFrameGroup(options: Partial<FrameGroup> = {}): FrameGroup {
+  const frameGroup = {} as FrameGroup;
+
+  frameGroup.FileID = options.FileID ?? '';
+  frameGroup.ExeFileName = options.ExeFileName ?? '';
+  frameGroup.FunctionName = options.FunctionName ?? '';
+  frameGroup.AddressOrLine = options.AddressOrLine ?? 0;
+  frameGroup.SourceFilename = options.SourceFilename ?? '';
+
+  return frameGroup;
+}
+
+export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
+  if (a.ExeFileName < b.ExeFileName) return -1;
+  if (a.ExeFileName > b.ExeFileName) return 1;
+  if (a.SourceFilename < b.SourceFilename) return -1;
+  if (a.SourceFilename > b.SourceFilename) return 1;
+  if (a.FunctionName < b.FunctionName) return -1;
+  if (a.FunctionName > b.FunctionName) return 1;
+  if (a.FileID < b.FileID) return -1;
+  if (a.FileID > b.FileID) return 1;
+  if (a.AddressOrLine < b.AddressOrLine) return -1;
+  if (a.AddressOrLine > b.AddressOrLine) return 1;
+  return 0;
+}
+
+// defaultGroupBy is the "standard" way of grouping frames, by commonly
+// shared group identifiers.
+//
+// For ELF-symbolized frames, group by FunctionName and FileID.
+// For non-symbolized frames, group by FileID and AddressOrLine.
+// Otherwise group by ExeFileName, SourceFilename and FunctionName.
+export function defaultGroupBy(frame: StackFrameMetadata): FrameGroup {
+  const frameGroup = createFrameGroup();
+
+  if (frame.FunctionName === '') {
+    // Non-symbolized frame where we only have FileID and AddressOrLine
+    frameGroup.FileID = frame.FileID;
+    frameGroup.AddressOrLine = frame.AddressOrLine;
+  } else if (frame.SourceFilename === '') {
+    // Non-symbolized frame with FunctionName set from ELF data
+    frameGroup.FunctionName = frame.FunctionName;
+    frameGroup.FileID = frame.FileID;
+  } else {
+    // This is a symbolized frame
+    frameGroup.ExeFileName = frame.ExeFileName;
+    frameGroup.SourceFilename = frame.SourceFilename;
+    frameGroup.FunctionName = frame.FunctionName;
+  }
+
+  return frameGroup;
+}
+
+export type FrameGroupID = string;
+
+export function hashFrameGroup(frameGroup: FrameGroup): FrameGroupID {
+  // We use serialized JSON as the unique value of a frame group for now
+  return jsonStableStringify(frameGroup);
+}

--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -8,12 +8,14 @@ import * as t from 'io-ts';
 import {
   compareFrameGroup,
   defaultGroupBy,
-  Executable,
-  FileID,
   FrameGroup,
   FrameGroupID,
-  groupStackFrameMetadataByStackTrace,
   hashFrameGroup,
+} from './frame_group';
+import {
+  Executable,
+  FileID,
+  groupStackFrameMetadataByStackTrace,
   StackFrame,
   StackFrameID,
   StackFrameMetadata,

--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -7,10 +7,10 @@
 import * as t from 'io-ts';
 import {
   compareFrameGroup,
-  defaultGroupBy,
+  createFrameGroup,
+  createFrameGroupID,
   FrameGroup,
   FrameGroupID,
-  hashFrameGroup,
 } from './frame_group';
 import {
   Executable,
@@ -68,8 +68,8 @@ export function createTopNFunctions(
     // e.g. when stopping the host agent or on network errors.
     const frames = metadata.get(traceHash) ?? [];
     for (let i = 0; i < frames.length; i++) {
-      const frameGroup = defaultGroupBy(frames[i]);
-      const frameGroupID = hashFrameGroup(frameGroup);
+      const frameGroup = createFrameGroup(frames[i]);
+      const frameGroupID = createFrameGroupID(frameGroup);
 
       if (!topNFunctions.has(frameGroupID)) {
         topNFunctions.set(frameGroupID, {
@@ -121,7 +121,7 @@ export function createTopNFunctions(
     Frame: frameAndCount.Frame,
     CountExclusive: frameAndCount.CountExclusive,
     CountInclusive: frameAndCount.CountInclusive,
-    Id: hashFrameGroup(frameAndCount.FrameGroup),
+    Id: createFrameGroupID(frameAndCount.FrameGroup),
   }));
 
   return {

--- a/x-pack/plugins/profiling/common/profiling.test.ts
+++ b/x-pack/plugins/profiling/common/profiling.test.ts
@@ -6,14 +6,10 @@
  */
 
 import {
-  createFrameGroup,
   createStackFrameMetadata,
-  compareFrameGroup,
-  defaultGroupBy,
   FrameType,
   getCalleeFunction,
   getCalleeSource,
-  hashFrameGroup,
 } from './profiling';
 
 describe('Stack frame metadata operations', () => {
@@ -79,56 +75,5 @@ describe('Stack frame metadata operations', () => {
       SourceFilename: 'runtime/malloc.go',
     });
     expect(getCalleeSource(metadata)).toEqual('runtime/malloc.go');
-  });
-});
-
-describe('Frame group operations', () => {
-  test('check if a frame group is less than another', () => {
-    const a = createFrameGroup({ ExeFileName: 'chrome' });
-    const b = createFrameGroup({ ExeFileName: 'dockerd' });
-    expect(compareFrameGroup(a, b)).toEqual(-1);
-  });
-
-  test('check if a frame group is greater than another', () => {
-    const a = createFrameGroup({ ExeFileName: 'oom_reaper' });
-    const b = createFrameGroup({ ExeFileName: 'dockerd' });
-    expect(compareFrameGroup(a, b)).toEqual(1);
-  });
-
-  test('check if frame groups are equal', () => {
-    const a = createFrameGroup({ AddressOrLine: 1234 });
-    const b = createFrameGroup({ AddressOrLine: 1234 });
-    expect(compareFrameGroup(a, b)).toEqual(0);
-  });
-
-  test('check serialized non-symbolized frame', () => {
-    const metadata = createStackFrameMetadata({
-      FileID: '0x0123456789ABCDEF',
-      AddressOrLine: 102938,
-    });
-    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
-      '{"AddressOrLine":102938,"ExeFileName":"","FileID":"0x0123456789ABCDEF","FunctionName":"","SourceFilename":""}'
-    );
-  });
-
-  test('check serialized non-symbolized ELF frame', () => {
-    const metadata = createStackFrameMetadata({
-      FunctionName: 'strlen()',
-      FileID: '0x0123456789ABCDEF',
-    });
-    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
-      '{"AddressOrLine":0,"ExeFileName":"","FileID":"0x0123456789ABCDEF","FunctionName":"strlen()","SourceFilename":""}'
-    );
-  });
-
-  test('check serialized symbolized frame', () => {
-    const metadata = createStackFrameMetadata({
-      ExeFileName: 'chrome',
-      SourceFilename: 'strlen()',
-      FunctionName: 'strlen()',
-    });
-    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
-      '{"AddressOrLine":0,"ExeFileName":"chrome","FileID":"","FunctionName":"strlen()","SourceFilename":"strlen()"}'
-    );
   });
 });

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import jsonStableStringify from 'json-stable-stringify';
 
 export type StackTraceID = string;
 export type StackFrameID = string;
@@ -181,71 +180,4 @@ export function groupStackFrameMetadataByStackTrace(
     frameMetadataForTraces.set(stackTraceID, frameMetadata);
   }
   return frameMetadataForTraces;
-}
-
-export type FrameGroup = Pick<
-  StackFrameMetadata,
-  'FileID' | 'ExeFileName' | 'FunctionName' | 'AddressOrLine' | 'SourceFilename'
->;
-
-// This is a convenience function to create a FrameGroup value with
-// defaults for missing fields
-export function createFrameGroup(options: Partial<FrameGroup> = {}): FrameGroup {
-  const frameGroup = {} as FrameGroup;
-
-  frameGroup.FileID = options.FileID ?? '';
-  frameGroup.ExeFileName = options.ExeFileName ?? '';
-  frameGroup.FunctionName = options.FunctionName ?? '';
-  frameGroup.AddressOrLine = options.AddressOrLine ?? 0;
-  frameGroup.SourceFilename = options.SourceFilename ?? '';
-
-  return frameGroup;
-}
-
-export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
-  if (a.ExeFileName < b.ExeFileName) return -1;
-  if (a.ExeFileName > b.ExeFileName) return 1;
-  if (a.SourceFilename < b.SourceFilename) return -1;
-  if (a.SourceFilename > b.SourceFilename) return 1;
-  if (a.FunctionName < b.FunctionName) return -1;
-  if (a.FunctionName > b.FunctionName) return 1;
-  if (a.FileID < b.FileID) return -1;
-  if (a.FileID > b.FileID) return 1;
-  if (a.AddressOrLine < b.AddressOrLine) return -1;
-  if (a.AddressOrLine > b.AddressOrLine) return 1;
-  return 0;
-}
-
-// defaultGroupBy is the "standard" way of grouping frames, by commonly
-// shared group identifiers.
-//
-// For ELF-symbolized frames, group by FunctionName and FileID.
-// For non-symbolized frames, group by FileID and AddressOrLine.
-// Otherwise group by ExeFileName, SourceFilename and FunctionName.
-export function defaultGroupBy(frame: StackFrameMetadata): FrameGroup {
-  const frameGroup = createFrameGroup();
-
-  if (frame.FunctionName === '') {
-    // Non-symbolized frame where we only have FileID and AddressOrLine
-    frameGroup.FileID = frame.FileID;
-    frameGroup.AddressOrLine = frame.AddressOrLine;
-  } else if (frame.SourceFilename === '') {
-    // Non-symbolized frame with FunctionName set from ELF data
-    frameGroup.FunctionName = frame.FunctionName;
-    frameGroup.FileID = frame.FileID;
-  } else {
-    // This is a symbolized frame
-    frameGroup.ExeFileName = frame.ExeFileName;
-    frameGroup.SourceFilename = frame.SourceFilename;
-    frameGroup.FunctionName = frame.FunctionName;
-  }
-
-  return frameGroup;
-}
-
-export type FrameGroupID = string;
-
-export function hashFrameGroup(frameGroup: FrameGroup): FrameGroupID {
-  // We use serialized JSON as the unique value of a frame group for now
-  return jsonStableStringify(frameGroup);
 }


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2479

This PR refactors the internal data structure used to group stack frames so that the performance of the flamegraph and Top N function APIs is improved.

This PR also has smaller updates:
* moved frame groups methods into separate file
* renamed `defaultGroupBy` to `createFrameGroup`
* renamed `hashFrameGroup` to `createFrameGroupID`

### Background

I profiled the flamegraph and TopN function endpoints and narrowed in on `hashFrameGroup` as a costly function. For background, `hashFrameGroup` is responsible for creating a serialized representation of a stackframe so that sibling frames can be grouped together. According to local measurements, `hashFrameGroup` is called about ~260k times per request and this value is consistent across different time ranges.

The original implementation for `hashFrameGroup` used `JSON.stringify`, but the latest implementation uses `jsonStableStringify` to obtain deterministic results. I experimented with a new implementation using an interface for each specific frame group combined with string concatenation (see `subclass+concat` in the charts below). This new implementation has the same deterministic properties as `jsonStableStringify`.

Each implementation was measured several times and the average of each respective metric was taken. The charts below show the preliminary results for the optimized implementation.

#### Cumulative time spent in `hashFrameGroup` for one request

![cumulative](https://user-images.githubusercontent.com/6038/183541861-ae64ecb0-b441-41da-8e90-c934db891e2f.png)

#### Request latency for one request

![latency](https://user-images.githubusercontent.com/6038/183541854-0cdf5767-b34a-4704-9ba5-0e525977888e.png)