### PR TITLE
Upgrade `lazystream` dependency (`1.0.0` → `1.0.1`).

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19448,9 +19448,9 @@ lazy-universal-dotenv@^3.0.1:
     dotenv-expand "^5.1.0"
 
 lazystream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
-  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"
+  integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
   dependencies:
     readable-stream "^2.0.5"
 


### PR DESCRIPTION
## Summary

Upgrade `lazystream` dependency (`1.0.0` → `1.0.1`).

Change log: https://github.com/jpommerening/node-lazystream#changelog
Code diff: https://github.com/jpommerening/node-lazystream/compare/1.0.0...1.0.1

<!--ONMERGE {"backportTargets":["7.17","8.3","8.4"]} ONMERGE-->