### PR TITLE
[Security Solution] Fix Event Filter OS selection when creating filter from Event List

### DIFF
--- a/x-pack/plugins/timelines/server/search_strategy/timeline/eql/helpers.test.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/eql/helpers.test.ts
@@ -282,6 +282,9 @@ describe('Search Strategy EQL helper', () => {
                     "family": Array [
                       "windows",
                     ],
+                    "name": Array [
+                      "Windows",
+                    ],
                   },
                 },
                 "message": Array [
@@ -411,6 +414,9 @@ describe('Search Strategy EQL helper', () => {
                   "os": Object {
                     "family": Array [
                       "windows",
+                    ],
+                    "name": Array [
+                      "Windows",
                     ],
                   },
                 },
@@ -549,6 +555,9 @@ describe('Search Strategy EQL helper', () => {
                     "family": Array [
                       "windows",
                     ],
+                    "name": Array [
+                      "Windows",
+                    ],
                   },
                 },
                 "message": Array [
@@ -674,6 +683,9 @@ describe('Search Strategy EQL helper', () => {
                   "os": Object {
                     "family": Array [
                       "windows",
+                    ],
+                    "name": Array [
+                      "Windows",
                     ],
                   },
                 },

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/constants.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/constants.ts
@@ -130,6 +130,7 @@ export const TIMELINE_EVENTS_FIELDS = [
   'file.Ext.code_signature.trusted',
   'file.hash.sha256',
   'host.os.family',
+  'host.os.name',
   'host.id',
   'host.ip',
   'registry.key',


### PR DESCRIPTION
## Summary

Fixes a bug where the Event Filters OS selection wasn't working because we weren't getting the `host.os.name` field from the corresponding API response.

Before when we create the Event filter from the list:
![image](https://user-images.githubusercontent.com/56395104/183917385-ae085f4d-8e43-40ed-b242-d1228512a7e2.png)

![image](https://user-images.githubusercontent.com/56395104/183917428-d867778d-e04c-4019-ab76-6f410c33964c.png)

After:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/183919198-85172ce0-4b4f-4320-bcc7-5605e331087f.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/183919251-451a02c6-c7a5-4704-9727-cee32d31b3f0.png">
