### PR TITLE
[Security Solution] Fix `narrowDateRange` and `updateDateRange` misuse

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/stat_items/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/stat_items/index.test.tsx
@@ -26,7 +26,7 @@ import {
   mockData,
   mockEnableChartsData,
   mockNoChartMappings,
-  mockNarrowDateRange,
+  mockUpdateDateRange,
 } from '../../../network/components/kpi_network/mock';
 import {
   createSecuritySolutionStorageMock,
@@ -75,7 +75,7 @@ describe('Stat Items Component', () => {
     loading: false,
     setQuerySkip: mockSetQuerySkip,
     to,
-    narrowDateRange: mockNarrowDateRange,
+    updateDateRange: mockUpdateDateRange,
   };
   beforeEach(() => {
     jest.clearAllMocks();
@@ -281,7 +281,7 @@ describe('useKpiMatrixStatus', () => {
       'statItem',
       from,
       to,
-      mockNarrowDateRange,
+      mockUpdateDateRange,
       mockSetQuerySkip,
       false
     );

--- a/x-pack/plugins/security_solution/public/common/components/stat_items/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/stat_items/index.tsx
@@ -96,7 +96,7 @@ export interface StatItemsProps extends StatItems {
   barChart?: ChartSeriesData[];
   from: string;
   id: string;
-  narrowDateRange: UpdateDateRange;
+  updateDateRange: UpdateDateRange;
   to: string;
   showInspectButton?: boolean;
   loading: boolean;
@@ -193,7 +193,7 @@ export const useKpiMatrixStatus = (
   id: string,
   from: string,
   to: string,
-  narrowDateRange: UpdateDateRange,
+  updateDateRange: UpdateDateRange,
   setQuerySkip: (skip: boolean) => void,
   loading: boolean
 ): StatItemsProps[] =>
@@ -207,7 +207,7 @@ export const useKpiMatrixStatus = (
     statKey: `${stat.key}`,
     from,
     to,
-    narrowDateRange,
+    updateDateRange,
     setQuerySkip,
     loading,
   }));
@@ -228,7 +228,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(
     loading = false,
     showInspectButton = true,
     index,
-    narrowDateRange,
+    updateDateRange,
     statKey = 'item',
     to,
     barChartLensAttributes,
@@ -373,7 +373,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(
                         areaChart={areaChart}
                         configs={areachartConfigs({
                           xTickFormatter: histogramDateTimeFormatter([from, to]),
-                          onBrushEnd: narrowDateRange,
+                          onBrushEnd: updateDateRange,
                         })}
                         visualizationActionsOptions={{
                           lensAttributes: areaChartLensAttributes,
@@ -403,7 +403,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(
     prevProps.setQuerySkip === nextProps.setQuerySkip &&
     prevProps.id === nextProps.id &&
     prevProps.index === nextProps.index &&
-    prevProps.narrowDateRange === nextProps.narrowDateRange &&
+    prevProps.updateDateRange === nextProps.updateDateRange &&
     prevProps.statKey === nextProps.statKey &&
     prevProps.to === nextProps.to &&
     deepEqual(prevProps.areaChart, nextProps.areaChart) &&

--- a/x-pack/plugins/security_solution/public/common/containers/anomalies/anomalies_query_tab_body/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/anomalies/anomalies_query_tab_body/index.tsx
@@ -24,7 +24,6 @@ const AnomaliesQueryTabBodyComponent: React.FC<AnomaliesQueryTabBodyProps> = ({
   skip,
   startDate,
   type,
-  narrowDateRange,
   filterQuery,
   anomaliesFilterQuery,
   AnomaliesTableComponent,
@@ -71,7 +70,6 @@ const AnomaliesQueryTabBodyComponent: React.FC<AnomaliesQueryTabBodyProps> = ({
         endDate={endDate}
         skip={skip}
         type={type}
-        narrowDateRange={narrowDateRange}
         flowTarget={flowTarget}
         ip={ip}
         hostName={hostName}

--- a/x-pack/plugins/security_solution/public/common/containers/anomalies/anomalies_query_tab_body/types.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/anomalies/anomalies_query_tab_body/types.ts
@@ -6,8 +6,6 @@
  */
 
 import type { ESTermQuery } from '../../../../../common/typed_json';
-import type { NarrowDateRange } from '../../../components/ml/types';
-import type { UpdateDateRange } from '../../../components/charts/common';
 import type { GlobalTimeArgs } from '../../use_global_time';
 import type { HostsType } from '../../../../hosts/store/model';
 import type { NetworkType } from '../../../../network/store/model';
@@ -27,11 +25,9 @@ export type AnomaliesQueryTabBodyProps = QueryTabBodyProps & {
   endDate: GlobalTimeArgs['to'];
   flowTarget?: FlowTargetSourceDest;
   indexNames: string[];
-  narrowDateRange: NarrowDateRange;
   setQuery: GlobalTimeArgs['setQuery'];
   startDate: GlobalTimeArgs['from'];
   skip: boolean;
-  updateDateRange?: UpdateDateRange;
   hideHistogramIfEmpty?: boolean;
   ip?: string;
   hostName?: string;

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/common/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/common/index.tsx
@@ -35,19 +35,19 @@ interface KpiBaseComponentProps {
   id: string;
   from: string;
   to: string;
-  narrowDateRange: UpdateDateRange;
+  updateDateRange: UpdateDateRange;
   setQuerySkip: (skip: boolean) => void;
 }
 
 export const KpiBaseComponent = React.memo<KpiBaseComponentProps>(
-  ({ fieldsMapping, data, id, loading = false, from, to, narrowDateRange, setQuerySkip }) => {
+  ({ fieldsMapping, data, id, loading = false, from, to, updateDateRange, setQuerySkip }) => {
     const statItemsProps: StatItemsProps[] = useKpiMatrixStatus(
       fieldsMapping,
       data,
       id,
       from,
       to,
-      narrowDateRange,
+      updateDateRange,
       setQuerySkip,
       loading
     );
@@ -66,7 +66,7 @@ export const KpiBaseComponent = React.memo<KpiBaseComponentProps>(
     prevProps.loading === nextProps.loading &&
     prevProps.from === nextProps.from &&
     prevProps.to === nextProps.to &&
-    prevProps.narrowDateRange === nextProps.narrowDateRange &&
+    prevProps.updateDateRange === nextProps.updateDateRange &&
     deepEqual(prevProps.data, nextProps.data)
 );
 

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/hosts/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/hosts/index.test.tsx
@@ -25,7 +25,7 @@ describe('Hosts KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/hosts/index.tsx
@@ -40,7 +40,7 @@ const HostsKpiHostsComponent: React.FC<HostsKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -66,7 +66,7 @@ const HostsKpiHostsComponent: React.FC<HostsKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
@@ -17,7 +17,7 @@ import * as i18n from './translations';
 import { useHostRiskScore } from '../../../risk_score/containers';
 
 export const HostsKpiComponent = React.memo<HostsKpiProps>(
-  ({ filterQuery, from, indexNames, to, setQuery, skip, narrowDateRange }) => {
+  ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => {
     const [_, { isModuleEnabled }] = useHostRiskScore({});
 
     return (
@@ -53,7 +53,7 @@ export const HostsKpiComponent = React.memo<HostsKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -64,7 +64,7 @@ export const HostsKpiComponent = React.memo<HostsKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -78,7 +78,7 @@ export const HostsKpiComponent = React.memo<HostsKpiProps>(
 HostsKpiComponent.displayName = 'HostsKpiComponent';
 
 export const HostsDetailsKpiComponent = React.memo<HostsKpiProps>(
-  ({ filterQuery, from, indexNames, to, setQuery, skip, narrowDateRange }) => {
+  ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => {
     return (
       <EuiFlexGroup wrap>
         <EuiFlexItem grow={1}>
@@ -87,7 +87,7 @@ export const HostsDetailsKpiComponent = React.memo<HostsKpiProps>(
             from={from}
             indexNames={indexNames}
             to={to}
-            narrowDateRange={narrowDateRange}
+            updateDateRange={updateDateRange}
             setQuery={setQuery}
             skip={skip}
           />

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/types.ts
@@ -13,7 +13,7 @@ export interface HostsKpiProps {
   from: string;
   to: string;
   indexNames: string[];
-  narrowDateRange: UpdateDateRange;
+  updateDateRange: UpdateDateRange;
   setQuery: GlobalTimeArgs['setQuery'];
   skip: boolean;
 }

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/unique_ips/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/unique_ips/index.test.tsx
@@ -25,7 +25,7 @@ describe('Unique IPs KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/unique_ips/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/unique_ips/index.tsx
@@ -55,7 +55,7 @@ const HostsKpiUniqueIpsComponent: React.FC<HostsKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -81,7 +81,7 @@ const HostsKpiUniqueIpsComponent: React.FC<HostsKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.test.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.test.tsx
@@ -12,7 +12,7 @@ import useResizeObserver from 'use-resize-observer/polyfilled';
 import '../../../common/mock/match_media';
 import { mockIndexPattern, TestProviders } from '../../../common/mock';
 import { HostDetailsTabs } from './details_tabs';
-import type { HostDetailsTabsProps, SetAbsoluteRangeDatePicker } from './types';
+import type { HostDetailsTabsProps } from './types';
 import { hostDetailsPagePath } from '../types';
 import { type } from './utils';
 import { useMountAppended } from '../../../common/utils/use_mount_appended';
@@ -102,7 +102,6 @@ describe('body', () => {
               isInitializing={false}
               detailName={'host-1'}
               setQuery={jest.fn()}
-              setAbsoluteRangeDatePicker={jest.fn() as unknown as SetAbsoluteRangeDatePicker}
               hostDetailsPagePath={hostDetailsPagePath}
               indexNames={[]}
               indexPattern={mockIndexPattern}

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.tsx
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Switch } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
 
-import type { UpdateDateRange } from '../../../common/components/charts/common';
-import { scoreIntervalToDateTime } from '../../../common/components/ml/score/score_interval_to_datetime';
-import type { Anomaly } from '../../../common/components/ml/types';
 import { HostsTableType } from '../../store/model';
 import { AnomaliesQueryTabBody } from '../../../common/containers/anomalies/anomalies_query_tab_body';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
@@ -38,36 +35,9 @@ export const HostDetailsTabs = React.memo<HostDetailsTabsProps>(
     indexNames,
     indexPattern,
     pageFilters = [],
-    setAbsoluteRangeDatePicker,
     hostDetailsPagePath,
   }) => {
     const { from, to, isInitializing, deleteQuery, setQuery } = useGlobalTime();
-    const narrowDateRange = useCallback(
-      (score: Anomaly, interval: string) => {
-        const fromTo = scoreIntervalToDateTime(score, interval);
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: fromTo.from,
-          to: fromTo.to,
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
-    const updateDateRange = useCallback<UpdateDateRange>(
-      ({ x }) => {
-        if (!x) {
-          return;
-        }
-        const [min, max] = x;
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: new Date(min).toISOString(),
-          to: new Date(max).toISOString(),
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
 
     const tabProps = {
       deleteQuery,
@@ -80,8 +50,6 @@ export const HostDetailsTabs = React.memo<HostDetailsTabsProps>(
       indexPattern,
       indexNames,
       hostName: detailName,
-      narrowDateRange,
-      updateDateRange,
     };
 
     const externalAlertPageFilters = useMemo(

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -83,7 +83,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
   );
   const getFilters = () => [...hostDetailsPageFilters, ...filters];
 
-  const narrowDateRange = useCallback<UpdateDateRange>(
+  const updateDateRange = useCallback<UpdateDateRange>(
     ({ x }) => {
       if (!x) {
         return;
@@ -94,6 +94,19 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
           id: 'global',
           from: new Date(min).toISOString(),
           to: new Date(max).toISOString(),
+        })
+      );
+    },
+    [dispatch]
+  );
+  const narrowDateRange = useCallback(
+    (score, interval) => {
+      const fromTo = scoreIntervalToDateTime(score, interval);
+      dispatch(
+        setAbsoluteRangeDatePicker({
+          id: 'global',
+          from: fromTo.from,
+          to: fromTo.to,
         })
       );
     },
@@ -165,14 +178,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
                     loading={loading}
                     startDate={from}
                     endDate={to}
-                    narrowDateRange={(score, interval) => {
-                      const fromTo = scoreIntervalToDateTime(score, interval);
-                      setAbsoluteRangeDatePicker({
-                        id: 'global',
-                        from: fromTo.from,
-                        to: fromTo.to,
-                      });
-                    }}
+                    narrowDateRange={narrowDateRange}
                     setQuery={setQuery}
                     refetch={refetch}
                     inspect={inspect}
@@ -190,7 +196,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
                 indexNames={selectedPatterns}
                 setQuery={setQuery}
                 to={to}
-                narrowDateRange={narrowDateRange}
+                updateDateRange={updateDateRange}
                 skip={isInitializing}
               />
 
@@ -220,7 +226,6 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
               filterQuery={filterQuery}
               hostDetailsPagePath={hostDetailsPagePath}
               indexPattern={indexPattern}
-              setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}
             />
           </SecuritySolutionPageWrapper>
         </>

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/types.ts
@@ -15,11 +15,6 @@ import type { KeyHostsNavTabWithoutMlPermission } from '../navigation/types';
 import type { hostsModel } from '../../store';
 
 interface HostBodyComponentDispatchProps {
-  setAbsoluteRangeDatePicker: ActionCreator<{
-    id: InputsModelId;
-    from: string;
-    to: string;
-  }>;
   detailName: string;
   hostDetailsPagePath: string;
 }

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -108,7 +108,7 @@ const HostsComponent = () => {
     }
     return filters;
   }, [severitySelection, tabName, filters]);
-  const narrowDateRange = useCallback<UpdateDateRange>(
+  const updateDateRange = useCallback<UpdateDateRange>(
     ({ x }) => {
       if (!x) {
         return;
@@ -204,7 +204,7 @@ const HostsComponent = () => {
                 setQuery={setQuery}
                 to={to}
                 skip={isInitializing || !filterQuery}
-                narrowDateRange={narrowDateRange}
+                updateDateRange={updateDateRange}
               />
 
               <EuiSpacer />
@@ -225,7 +225,6 @@ const HostsComponent = () => {
               filterQuery={tabsFilterQuery || ''}
               isInitializing={isInitializing}
               indexNames={selectedPatterns}
-              setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}
               setQuery={setQuery}
               from={from}
               type={hostsModel.HostsType.page}

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
@@ -5,17 +5,14 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { Switch } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
 
 import type { HostsTabsProps } from './types';
-import { scoreIntervalToDateTime } from '../../common/components/ml/score/score_interval_to_datetime';
-import type { Anomaly } from '../../common/components/ml/types';
 import { HostsTableType } from '../store/model';
 import { AnomaliesQueryTabBody } from '../../common/containers/anomalies/anomalies_query_tab_body';
 import { AnomaliesHostTable } from '../../common/components/ml/tables/anomalies_host_table';
-import type { UpdateDateRange } from '../../common/components/charts/common';
 import { EventsQueryTabBody } from '../../common/components/events_tab';
 import { HOSTS_PATH } from '../../../common/constants';
 
@@ -36,38 +33,10 @@ export const HostsTabs = memo<HostsTabsProps>(
     from,
     indexNames,
     isInitializing,
-    setAbsoluteRangeDatePicker,
     setQuery,
     to,
     type,
   }) => {
-    const narrowDateRange = useCallback(
-      (score: Anomaly, interval: string) => {
-        const fromTo = scoreIntervalToDateTime(score, interval);
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: fromTo.from,
-          to: fromTo.to,
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
-    const updateDateRange = useCallback<UpdateDateRange>(
-      ({ x }) => {
-        if (!x) {
-          return;
-        }
-        const [min, max] = x;
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: new Date(min).toISOString(),
-          to: new Date(max).toISOString(),
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
     const tabProps = {
       deleteQuery,
       endDate: to,
@@ -77,8 +46,6 @@ export const HostsTabs = memo<HostsTabsProps>(
       setQuery,
       startDate: from,
       type,
-      narrowDateRange,
-      updateDateRange,
     };
 
     const externalAlertPageFilters = useMemo(

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/types.ts
@@ -8,11 +8,9 @@
 import type { Filter } from '@kbn/es-query';
 import type { ESTermQuery } from '../../../../common/typed_json';
 
-import type { NarrowDateRange } from '../../../common/components/ml/types';
 import type { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 import type { HostsTableType, HostsType } from '../../store/model';
 import type { NavTab } from '../../../common/components/navigation/types';
-import type { UpdateDateRange } from '../../../common/components/charts/common';
 
 export type KeyHostsNavTabWithoutMlPermission = HostsTableType.hosts &
   HostsTableType.authentications &
@@ -38,8 +36,6 @@ export type HostsComponentsQueryProps = QueryTabBodyProps & {
   pageFilters?: Filter[];
   skip: boolean;
   setQuery: GlobalTimeArgs['setQuery'];
-  updateDateRange?: UpdateDateRange;
-  narrowDateRange?: NarrowDateRange;
 };
 
 export type AlertsComponentQueryProps = HostsComponentsQueryProps & {

--- a/x-pack/plugins/security_solution/public/hosts/pages/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/types.ts
@@ -5,12 +5,9 @@
  * 2.0.
  */
 
-import type { ActionCreator } from 'typescript-fsa';
-
 import type { Filter } from '@kbn/es-query';
 import type { hostsModel } from '../store';
 import type { GlobalTimeArgs } from '../../common/containers/use_global_time';
-import type { InputsModelId } from '../../common/store/inputs/constants';
 import { HOSTS_PATH } from '../../../common/constants';
 
 export const hostDetailsPagePath = `${HOSTS_PATH}/name/:detailName`;
@@ -20,11 +17,6 @@ export type HostsTabsProps = GlobalTimeArgs & {
   pageFilters?: Filter[];
   indexNames: string[];
   type: hostsModel.HostsType;
-  setAbsoluteRangeDatePicker: ActionCreator<{
-    id: InputsModelId;
-    from: string;
-    to: string;
-  }>;
 };
 
 export type HostsQueryProps = GlobalTimeArgs;

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/__snapshots__/index.test.tsx.snap
@@ -5,9 +5,9 @@ exports[`NetworkKpiComponent rendering it renders the default widget 1`] = `
   filterQuery=""
   from="2019-06-15T06:00:00.000Z"
   indexNames={Array []}
-  narrowDateRange={[MockFunction]}
   setQuery={[MockFunction]}
   skip={true}
   to="2019-06-18T06:00:00.000Z"
+  updateDateRange={[MockFunction]}
 />
 `;

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/dns/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/dns/index.test.tsx
@@ -25,7 +25,7 @@ describe('DNS KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/dns/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/dns/index.tsx
@@ -35,7 +35,7 @@ const NetworkKpiDnsComponent: React.FC<NetworkKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -61,7 +61,7 @@ const NetworkKpiDnsComponent: React.FC<NetworkKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/index.test.tsx
@@ -26,7 +26,7 @@ describe('NetworkKpiComponent', () => {
     filterQuery: '',
     from: '2019-06-15T06:00:00.000Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: true,
     to: '2019-06-18T06:00:00.000Z',

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/index.tsx
@@ -16,7 +16,7 @@ import { NetworkKpiUniquePrivateIps } from './unique_private_ips';
 import type { NetworkKpiProps } from './types';
 
 export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
-  ({ filterQuery, from, indexNames, to, setQuery, skip, narrowDateRange }) => (
+  ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => (
     <EuiFlexGroup wrap>
       <EuiFlexItem grow={1}>
         <EuiFlexGroup wrap>
@@ -26,7 +26,7 @@ export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -37,7 +37,7 @@ export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -51,7 +51,7 @@ export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -62,7 +62,7 @@ export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -75,7 +75,7 @@ export const NetworkKpiComponent = React.memo<NetworkKpiProps>(
           from={from}
           indexNames={indexNames}
           to={to}
-          narrowDateRange={narrowDateRange}
+          updateDateRange={updateDateRange}
           setQuery={setQuery}
           skip={skip}
         />

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/mock.ts
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/mock.ts
@@ -12,7 +12,7 @@ import { kpiUniquePrivateIpsBarLensAttributes } from '../../../common/components
 import { kpiUniquePrivateIpsDestinationMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_destination_metric';
 import { kpiUniquePrivateIpsSourceMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/network/kpi_unique_private_ips_source_metric';
 
-export const mockNarrowDateRange = jest.fn();
+export const mockUpdateDateRange = jest.fn();
 
 export const mockData: NetworkKpiStrategyResponse = {
   networkEvents: 16,
@@ -152,7 +152,7 @@ export const mockEnableChartsData = {
   statKey: 'UniqueIps',
   setQuerySkip: jest.fn(),
   to: '2019-06-18T06:00:00.000Z',
-  narrowDateRange: mockNarrowDateRange,
+  updateDateRange: mockUpdateDateRange,
   areaChartLensAttributes: kpiUniquePrivateIpsAreaLensAttributes,
   barChartLensAttributes: kpiUniquePrivateIpsBarLensAttributes,
 };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/network_events/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/network_events/index.test.tsx
@@ -25,7 +25,7 @@ describe('Network Events KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/network_events/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/network_events/index.tsx
@@ -39,7 +39,7 @@ const NetworkKpiNetworkEventsComponent: React.FC<NetworkKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -65,7 +65,7 @@ const NetworkKpiNetworkEventsComponent: React.FC<NetworkKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/tls_handshakes/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/tls_handshakes/index.test.tsx
@@ -25,7 +25,7 @@ describe('TLS Handshakes KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/tls_handshakes/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/tls_handshakes/index.tsx
@@ -34,7 +34,7 @@ const NetworkKpiTlsHandshakesComponent: React.FC<NetworkKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -60,7 +60,7 @@ const NetworkKpiTlsHandshakesComponent: React.FC<NetworkKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/types.ts
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/types.ts
@@ -13,7 +13,7 @@ export interface NetworkKpiProps {
   from: string;
   indexNames: string[];
   to: string;
-  narrowDateRange: UpdateDateRange;
+  updateDateRange: UpdateDateRange;
   setQuery: GlobalTimeArgs['setQuery'];
   skip: boolean;
 }

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_flows/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_flows/index.test.tsx
@@ -25,7 +25,7 @@ describe('Unique Flows KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_flows/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_flows/index.tsx
@@ -34,7 +34,7 @@ const NetworkKpiUniqueFlowsComponent: React.FC<NetworkKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -60,7 +60,7 @@ const NetworkKpiUniqueFlowsComponent: React.FC<NetworkKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_private_ips/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_private_ips/index.test.tsx
@@ -25,7 +25,7 @@ describe('Unique Private IPs KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_private_ips/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/unique_private_ips/index.tsx
@@ -62,7 +62,7 @@ const NetworkKpiUniquePrivateIpsComponent: React.FC<NetworkKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -88,7 +88,7 @@ const NetworkKpiUniquePrivateIpsComponent: React.FC<NetworkKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/network/pages/details/details_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/details_tabs.tsx
@@ -41,13 +41,12 @@ interface NetworkDetailTabsProps {
   indexNames: string[];
   skip: boolean;
   setQuery: GlobalTimeArgs['setQuery'];
-  narrowDateRange: (score: unknown, interval: unknown) => void;
   indexPattern: DataViewBase;
   flowTarget: FlowTargetSourceDest;
 }
 
 export const NetworkDetailsTabs = React.memo<NetworkDetailTabsProps>(
-  ({ narrowDateRange, indexPattern, flowTarget, ...rest }) => {
+  ({ indexPattern, flowTarget, ...rest }) => {
     const type = networkModel.NetworkType.details;
 
     const commonProps = { ...rest, type };
@@ -111,7 +110,6 @@ export const NetworkDetailsTabs = React.memo<NetworkDetailTabsProps>(
             {...commonPropsWithFlowTarget}
             hideHistogramIfEmpty={true}
             AnomaliesTableComponent={AnomaliesNetworkTable}
-            narrowDateRange={narrowDateRange}
           />
         </Route>
         <Route

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -188,7 +188,6 @@ const NetworkDetailsComponent: React.FC = () => {
               indexNames={selectedPatterns}
               skip={shouldSkip}
               setQuery={setQuery}
-              narrowDateRange={narrowDateRange}
               indexPattern={indexPattern}
               flowTarget={flowTarget}
             />

--- a/x-pack/plugins/security_solution/public/network/pages/navigation/network_routes.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/navigation/network_routes.tsx
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Switch } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { FlowTargetSourceDest } from '../../../../common/search_strategy/security_solution/network';
-import { scoreIntervalToDateTime } from '../../../common/components/ml/score/score_interval_to_datetime';
 
 import {
   CountriesQueryTabBody,
@@ -28,8 +27,6 @@ import { TimelineId } from '../../../../common/types';
 import { ConditionalFlexGroup } from './conditional_flex_group';
 import type { NetworkRoutesProps } from './types';
 import { NetworkRouteType } from './types';
-import type { Anomaly } from '../../../common/components/ml/types';
-import type { UpdateDateRange } from '../../../common/components/charts/common';
 import { NETWORK_PATH } from '../../../../common/constants';
 
 export const NetworkRoutes = React.memo<NetworkRoutesProps>(
@@ -43,34 +40,7 @@ export const NetworkRoutes = React.memo<NetworkRoutesProps>(
     indexPattern,
     indexNames,
     setQuery,
-    setAbsoluteRangeDatePicker,
   }) => {
-    const narrowDateRange = useCallback(
-      (score: Anomaly, interval: string) => {
-        const fromTo = scoreIntervalToDateTime(score, interval);
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: fromTo.from,
-          to: fromTo.to,
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-    const updateDateRange = useCallback<UpdateDateRange>(
-      ({ x }) => {
-        if (!x) {
-          return;
-        }
-        const [min, max] = x;
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: new Date(min).toISOString(),
-          to: new Date(max).toISOString(),
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
     const networkAnomaliesFilterQuery = {
       bool: {
         should: [
@@ -95,7 +65,6 @@ export const NetworkRoutes = React.memo<NetworkRoutesProps>(
       indexNames,
       skip: isInitializing,
       type,
-      narrowDateRange,
       setQuery,
       filterQuery,
     };
@@ -103,7 +72,6 @@ export const NetworkRoutes = React.memo<NetworkRoutesProps>(
     const tabProps = {
       ...commonProps,
       indexPattern,
-      updateDateRange,
     };
 
     const anomaliesProps = {

--- a/x-pack/plugins/security_solution/public/network/pages/navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/network/pages/navigation/types.ts
@@ -8,7 +8,6 @@
 import type { DataViewBase } from '@kbn/es-query';
 import type { Optional } from 'utility-types';
 
-import type { NarrowDateRange } from '../../../common/components/ml/types';
 import type { ESTermQuery } from '../../../../common/typed_json';
 
 import type { NavTab } from '../../../common/components/navigation/types';
@@ -16,7 +15,6 @@ import type { FlowTargetSourceDest } from '../../../../common/search_strategy/se
 import type { networkModel } from '../../store';
 import type { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 
-import type { SetAbsoluteRangeDatePicker } from '../types';
 import type { DocValueFields } from '../../../common/containers/source';
 
 export interface QueryTabBodyProps extends Pick<GlobalTimeArgs, 'setQuery' | 'deleteQuery'> {
@@ -24,7 +22,6 @@ export interface QueryTabBodyProps extends Pick<GlobalTimeArgs, 'setQuery' | 'de
   filterQuery?: string | ESTermQuery;
   indexNames: string[];
   ip?: string;
-  narrowDateRange?: NarrowDateRange;
   skip: boolean;
   startDate: string;
   type: networkModel.NetworkType;
@@ -55,7 +52,6 @@ export type NetworkRoutesProps = GlobalTimeArgs & {
   filterQuery?: string | ESTermQuery;
   indexPattern: DataViewBase;
   indexNames: string[];
-  setAbsoluteRangeDatePicker: SetAbsoluteRangeDatePicker;
 };
 
 export enum NetworkRouteType {

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -95,7 +95,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       return filters;
     }, [tabName, filters]);
 
-    const narrowDateRange = useCallback<UpdateDateRange>(
+    const updateDateRange = useCallback<UpdateDateRange>(
       ({ x }) => {
         if (!x) {
           return;
@@ -198,7 +198,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                   filterQuery={filterQuery}
                   from={from}
                   indexNames={selectedPatterns}
-                  narrowDateRange={narrowDateRange}
+                  updateDateRange={updateDateRange}
                   setQuery={setQuery}
                   skip={isInitializing || filterQuery === undefined}
                   to={to}
@@ -221,7 +221,6 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                     indexPattern={indexPattern}
                     indexNames={selectedPatterns}
                     setQuery={setQuery}
-                    setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}
                     type={networkModel.NetworkType.page}
                     to={to}
                   />

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/authentications/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/authentications/index.test.tsx
@@ -25,7 +25,7 @@ describe('Authentications KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/authentications/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/authentications/index.tsx
@@ -59,7 +59,7 @@ const UsersKpiAuthenticationsComponent: React.FC<UsersKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -85,7 +85,7 @@ const UsersKpiAuthenticationsComponent: React.FC<UsersKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
@@ -18,7 +18,7 @@ import * as i18n from './translations';
 import { RISKY_USERS_DOC_LINK } from '../constants';
 
 export const UsersKpiComponent = React.memo<UsersKpiProps>(
-  ({ filterQuery, from, indexNames, to, setQuery, skip, narrowDateRange }) => {
+  ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => {
     const [_, { isModuleEnabled }] = useUserRiskScore({});
 
     return (
@@ -54,7 +54,7 @@ export const UsersKpiComponent = React.memo<UsersKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />
@@ -66,7 +66,7 @@ export const UsersKpiComponent = React.memo<UsersKpiProps>(
               from={from}
               indexNames={indexNames}
               to={to}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
               setQuery={setQuery}
               skip={skip}
             />

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/total_users/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/total_users/index.test.tsx
@@ -25,7 +25,7 @@ describe('Total Users KPI', () => {
     from: '2019-06-25T04:31:59.345Z',
     to: '2019-06-25T06:31:59.345Z',
     indexNames: [],
-    narrowDateRange: jest.fn(),
+    updateDateRange: jest.fn(),
     setQuery: jest.fn(),
     skip: false,
   };

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/total_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/total_users/index.tsx
@@ -45,7 +45,7 @@ const TotalUsersKpiComponent: React.FC<UsersKpiProps> = ({
   from,
   indexNames,
   to,
-  narrowDateRange,
+  updateDateRange,
   setQuery,
   skip,
 }) => {
@@ -85,7 +85,7 @@ const TotalUsersKpiComponent: React.FC<UsersKpiProps> = ({
       fieldsMapping={fieldsMapping}
       from={from}
       to={to}
-      narrowDateRange={narrowDateRange}
+      updateDateRange={updateDateRange}
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/types.ts
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/types.ts
@@ -13,7 +13,7 @@ export interface UsersKpiProps {
   from: string;
   to: string;
   indexNames: string[];
-  narrowDateRange: UpdateDateRange;
+  updateDateRange: UpdateDateRange;
   setQuery: GlobalTimeArgs['setQuery'];
   skip: boolean;
 }

--- a/x-pack/plugins/security_solution/public/users/pages/details/details_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/details/details_tabs.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Switch } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
 
@@ -13,9 +13,6 @@ import { UsersTableType } from '../../store/model';
 import { AnomaliesUserTable } from '../../../common/components/ml/tables/anomalies_user_table';
 import type { UsersDetailsTabsProps } from './types';
 import { AnomaliesQueryTabBody } from '../../../common/containers/anomalies/anomalies_query_tab_body';
-import { scoreIntervalToDateTime } from '../../../common/components/ml/score/score_interval_to_datetime';
-import type { UpdateDateRange } from '../../../common/components/charts/common';
-import type { Anomaly } from '../../../common/components/ml/types';
 import { usersDetailsPagePath } from '../constants';
 import { TimelineId } from '../../../../common/types';
 import { EventsQueryTabBody } from '../../../common/components/events_tab';
@@ -33,37 +30,9 @@ export const UsersDetailsTabs = React.memo<UsersDetailsTabsProps>(
     setQuery,
     to,
     type,
-    setAbsoluteRangeDatePicker,
     detailName,
     pageFilters = [],
   }) => {
-    const narrowDateRange = useCallback(
-      (score: Anomaly, interval: string) => {
-        const fromTo = scoreIntervalToDateTime(score, interval);
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: fromTo.from,
-          to: fromTo.to,
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
-    const updateDateRange = useCallback<UpdateDateRange>(
-      ({ x }) => {
-        if (!x) {
-          return;
-        }
-        const [min, max] = x;
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: new Date(min).toISOString(),
-          to: new Date(max).toISOString(),
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
     const tabProps = {
       deleteQuery,
       endDate: to,
@@ -73,8 +42,6 @@ export const UsersDetailsTabs = React.memo<UsersDetailsTabsProps>(
       setQuery,
       startDate: from,
       type,
-      narrowDateRange,
-      updateDateRange,
       userName: detailName,
     };
 

--- a/x-pack/plugins/security_solution/public/users/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/details/index.tsx
@@ -7,7 +7,7 @@
 
 import { EuiSpacer, EuiWindowEvent } from '@elastic/eui';
 import { noop } from 'lodash/fp';
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 import type { Filter } from '@kbn/es-query';
@@ -118,6 +118,20 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
 
   useQueryInspector({ setQuery, deleteQuery, refetch, inspect, loading, queryId: QUERY_ID });
 
+  const narrowDateRange = useCallback(
+    (score, interval) => {
+      const fromTo = scoreIntervalToDateTime(score, interval);
+      dispatch(
+        setAbsoluteRangeDatePicker({
+          id: 'global',
+          from: fromTo.from,
+          to: fromTo.to,
+        })
+      );
+    },
+    [dispatch]
+  );
+
   return (
     <>
       {indicesExist ? (
@@ -156,14 +170,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
                   loading={loading}
                   startDate={from}
                   endDate={to}
-                  narrowDateRange={(score, interval) => {
-                    const fromTo = scoreIntervalToDateTime(score, interval);
-                    setAbsoluteRangeDatePicker({
-                      id: 'global',
-                      from: fromTo.from,
-                      to: fromTo.to,
-                    });
-                  }}
+                  narrowDateRange={narrowDateRange}
                   indexPatterns={selectedPatterns}
                 />
               )}
@@ -190,7 +197,6 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
               indexPattern={indexPattern}
               isInitializing={isInitializing}
               pageFilters={usersDetailsPageFilters}
-              setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}
               setQuery={setQuery}
               to={to}
               type={type}

--- a/x-pack/plugins/security_solution/public/users/pages/details/types.ts
+++ b/x-pack/plugins/security_solution/public/users/pages/details/types.ts
@@ -22,11 +22,6 @@ interface UsersDetailsComponentReduxProps {
 }
 
 interface UserBodyComponentDispatchProps {
-  setAbsoluteRangeDatePicker: ActionCreator<{
-    id: InputsModelId;
-    from: string;
-    to: string;
-  }>;
   detailName: string;
   usersDetailsPagePath: string;
 }

--- a/x-pack/plugins/security_solution/public/users/pages/types.ts
+++ b/x-pack/plugins/security_solution/public/users/pages/types.ts
@@ -4,14 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { ActionCreator } from 'typescript-fsa';
 
 import type { Filter } from '@kbn/es-query';
 import type { DocValueFields } from '@kbn/timelines-plugin/common';
 import type { GlobalTimeArgs } from '../../common/containers/use_global_time';
 
 import type { usersModel } from '../store';
-import type { InputsModelId } from '../../common/store/inputs/constants';
 
 export type UsersTabsProps = GlobalTimeArgs & {
   docValueFields: DocValueFields[];
@@ -19,11 +17,6 @@ export type UsersTabsProps = GlobalTimeArgs & {
   pageFilters?: Filter[];
   indexNames: string[];
   type: usersModel.UsersType;
-  setAbsoluteRangeDatePicker: ActionCreator<{
-    id: InputsModelId;
-    from: string;
-    to: string;
-  }>;
 };
 
 export type UsersQueryProps = GlobalTimeArgs;

--- a/x-pack/plugins/security_solution/public/users/pages/users.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/users.tsx
@@ -150,7 +150,7 @@ const UsersComponent = () => {
     [containerElement, onSkipFocusBeforeEventsTable, onSkipFocusAfterEventsTable]
   );
 
-  const narrowDateRange = useCallback<UpdateDateRange>(
+  const updateDateRange = useCallback<UpdateDateRange>(
     ({ x }) => {
       if (!x) {
         return;
@@ -199,7 +199,7 @@ const UsersComponent = () => {
               setQuery={setQuery}
               to={to}
               skip={isInitializing || !filterQuery}
-              narrowDateRange={narrowDateRange}
+              updateDateRange={updateDateRange}
             />
 
             <EuiSpacer />
@@ -215,7 +215,6 @@ const UsersComponent = () => {
               from={from}
               indexNames={selectedPatterns}
               isInitializing={isInitializing}
-              setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}
               setQuery={setQuery}
               to={to}
               type={usersModel.UsersType.page}

--- a/x-pack/plugins/security_solution/public/users/pages/users_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/users_tabs.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo } from 'react';
 import { Switch } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
 
@@ -15,9 +15,6 @@ import { USERS_PATH } from '../../../common/constants';
 import { AllUsersQueryTabBody, AuthenticationsQueryTabBody } from './navigation';
 import { AnomaliesQueryTabBody } from '../../common/containers/anomalies/anomalies_query_tab_body';
 import { AnomaliesUserTable } from '../../common/components/ml/tables/anomalies_user_table';
-import type { Anomaly } from '../../common/components/ml/types';
-import { scoreIntervalToDateTime } from '../../common/components/ml/score/score_interval_to_datetime';
-import type { UpdateDateRange } from '../../common/components/charts/common';
 
 import { UserRiskScoreQueryTabBody } from './navigation/user_risk_score_tab_body';
 import { EventsQueryTabBody } from '../../common/components/events_tab';
@@ -34,35 +31,7 @@ export const UsersTabs = memo<UsersTabsProps>(
     setQuery,
     to,
     type,
-    setAbsoluteRangeDatePicker,
   }) => {
-    const narrowDateRange = useCallback(
-      (score: Anomaly, interval: string) => {
-        const fromTo = scoreIntervalToDateTime(score, interval);
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: fromTo.from,
-          to: fromTo.to,
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
-    const updateDateRange = useCallback<UpdateDateRange>(
-      ({ x }) => {
-        if (!x) {
-          return;
-        }
-        const [min, max] = x;
-        setAbsoluteRangeDatePicker({
-          id: 'global',
-          from: new Date(min).toISOString(),
-          to: new Date(max).toISOString(),
-        });
-      },
-      [setAbsoluteRangeDatePicker]
-    );
-
     const tabProps = {
       deleteQuery,
       endDate: to,
@@ -72,8 +41,6 @@ export const UsersTabs = memo<UsersTabsProps>(
       setQuery,
       startDate: from,
       type,
-      narrowDateRange,
-      updateDateRange,
     };
 
     return (


### PR DESCRIPTION
## Summary

In a [previous PR](https://github.com/elastic/kibana/pull/138464) I fixed a place where the `dispatch` was missing from `setAbsoluteRangeDatePicker` action calls within `narrowDateRange` and `updateDateRange` functions. [Pablo pointed out](https://github.com/elastic/kibana/pull/138464#issuecomment-1210392313) a few more places where `dispatch` was missing, and we realized that most of these DateRange functions were not ever called. So I deleted it from where it was not used.

There is a difference between `narrowDateRange` and `updateDateRange`. In some types we had `narrowDateRange: UpdateDateRange`. I corrected this to be `updateDateRange: UpdateDateRange`. We can see where this becomes a problem in `x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx` where both `narrowDateRange` and `updateDateRange` are defined, but `updateDateRange` was named `narrowDateRange` and `narrowDateRange` was an anonymous function, lacking the dispatch.
