### PR TITLE
[7.17] [ML] Functional tests - adjust version range for anomaly explorer suite

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -66,6 +66,8 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('anomaly explorer', function () {
     this.tags(['mlqa']);
+    this.onlyEsVersion('<=7 || >=8.4');
+
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');


### PR DESCRIPTION
## Summary

This PR adds version information to the anomaly explorer suite so it won't run in forward compatibility tests against 8.3

### Details

There was a recent backend change that went into 7.17 and 8.4, which required test adjustments. As a result, the 7.17 tests are no longer forward compatible with versions in [8.0, 8.3].  The version limitation is only added to the 7.17 branch as it's only relevant for forward compatibility tests and we don't want to skip the 8.3 tests completely (they're still valid for 8.3, just not compatible with 7.17 anymore).