### PR TITLE
[Lens] Stabilize legacy metric test

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -70,7 +70,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async assertExpectedText(selector: string, test: (value?: string) => boolean) {
       let actualText: string | undefined;
 
-      await retry.waitForWithTimeout('assertExpectedText', 1000, async () => {
+      await retry.waitForWithTimeout('assertExpectedText', 5000, async () => {
         actualText = await find.byCssSelector(selector).then((el) => el.getVisibleText());
         return test(actualText);
       });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/138502

In the test the metric is actually showing the right value:
<img width="501" alt="Screenshot 2022-08-10 at 18 13 41" src="https://user-images.githubusercontent.com/1508364/183960773-f2d28b0e-ee7b-474f-8a0f-92e7f037b3f2.png">

This PR increases the timeout as it was pretty tight with just a single second