### PR TITLE
[Security Solution] Update text and Response Console product name

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -359,6 +359,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
         macos_system_ext: `${SECURITY_SOLUTION_DOCS}deploy-elastic-endpoint.html#system-extension-endpoint`,
         linux_deadlock: `${SECURITY_SOLUTION_DOCS}ts-management.html`,
       },
+      responseActions: `${SECURITY_SOLUTION_DOCS}response-actions.html`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -264,6 +264,7 @@ export interface DocLinks {
       linux_deadlock: string;
     };
     readonly threatIntelInt: string;
+    readonly responseActions: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/responder_context_menu_item.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/responder_context_menu_item.tsx
@@ -100,7 +100,7 @@ export const ResponderContextMenuItem = memo<ResponderContextMenuItemProps>(
       >
         <FormattedMessage
           id="xpack.securitySolution.endpoint.detections.takeAction.responseActionConsole.buttonLabel"
-          defaultMessage="Launch responder"
+          defaultMessage="Respond"
         />
       </EuiContextMenuItem>
     );

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
@@ -234,11 +234,11 @@ describe('take action dropdown', () => {
         );
       });
     });
-    test('should render "Launch responder"', async () => {
+    test('should render "Respond"', async () => {
       await waitFor(() => {
         expect(
           wrapper.find('[data-test-subj="endpointResponseActions-action-item"]').first().text()
-        ).toEqual('Launch responder');
+        ).toEqual('Respond');
       });
     });
   });
@@ -366,7 +366,7 @@ describe('take action dropdown', () => {
       });
     });
 
-    describe('should correctly enable/disable the "Launch responder" button', () => {
+    describe('should correctly enable/disable the "Respond" button', () => {
       let wrapper: ReactWrapper;
       let apiMocks: ReturnType<typeof endpointMetadataHttpMocks>;
 

--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
@@ -31,6 +31,7 @@ import { useConsoleStateDispatch } from '../hooks/state_selectors/use_console_st
 import { COMMON_ARGS, HELP_GROUPS } from '../service/builtin_commands';
 import { getCommandNameWithArgs } from '../service/utils';
 import { ConsoleCodeBlock } from './console_code_block';
+import { useKibana } from '../../../../common/lib/kibana';
 
 // @ts-expect-error TS2769
 const StyledEuiBasicTable = styled(EuiBasicTable)`
@@ -74,6 +75,7 @@ export interface CommandListProps {
 export const CommandList = memo<CommandListProps>(({ commands, display = 'default' }) => {
   const getTestId = useTestIdGenerator(useDataTestSubj());
   const dispatch = useConsoleStateDispatch();
+  const { docLinks } = useKibana().services;
 
   const footerMessage = useMemo(() => {
     return (
@@ -228,21 +230,21 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
     const calloutItems = [
       <FormattedMessage
         id="xpack.securitySolution.console.commandList.callout.multipleResponses"
-        defaultMessage="You may enter multiple response actions at the same time."
+        defaultMessage="You can enter consecutive response actions — no need to wait for previous actions to complete."
       />,
       <FormattedMessage
         id="xpack.securitySolution.console.commandList.callout.leavingResponder"
-        defaultMessage="Leaving the responder does not abort the actions."
+        defaultMessage="Leaving the response console does not terminate any actions that have been submitted."
       />,
       <FormattedMessage
         id="xpack.securitySolution.console.commandList.callout.visitSupportSections"
-        defaultMessage="{readMore} about manual response actions."
+        defaultMessage="{learnMore} about response actions and using the console."
         values={{
-          readMore: (
-            <EuiLink>
+          learnMore: (
+            <EuiLink href={docLinks.links.securitySolution.responseActions} target="_blank">
               <FormattedMessage
                 id="xpack.securitySolution.console.commandList.callout.readMoreLink"
-                defaultMessage="Read more"
+                defaultMessage="Learn more"
               />
             </EuiLink>
           ),
@@ -255,17 +257,17 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
         title={
           <FormattedMessage
             id="xpack.securitySolution.console.commandList.callout.title"
-            defaultMessage="Do you know?"
+            defaultMessage="Helpful tips:"
           />
         }
       >
-        <ol>
+        <ul>
           {calloutItems.map((item, index) => (
             <li key={index}>
               <EuiText size="s">{item}</EuiText>
             </li>
           ))}
-        </ol>
+        </ul>
       </StyledEuiCallOut>
     );
 

--- a/x-pack/plugins/security_solution/public/management/components/console/components/side_panel/side_panel_content_manager.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/side_panel/side_panel_content_manager.tsx
@@ -70,17 +70,9 @@ export const SidePanelContentManager = memo(() => {
           <EuiText size="s">
             <FormattedMessage
               id="xpack.securitySolution.console.sidePanel.helpDescription"
-              defaultMessage="To execute response actions {addText} ({icon}) use a comment or a parameter if necessary."
+              defaultMessage="Use the add ({icon}) button to populate a response action to the text bar. Add additional parameters or comments as necessary."
               values={{
                 icon: <EuiIcon type="plusInCircle" />,
-                addText: (
-                  <strong>
-                    <FormattedMessage
-                      id="xpack.securitySolution.console.sidePanel.helpDescription.addText"
-                      defaultMessage="add to main text bar"
-                    />
-                  </strong>
-                ),
               }}
             />
           </EuiText>

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/action_log_button.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/action_log_button.tsx
@@ -30,7 +30,7 @@ export const ActionLogButton = memo<EndpointResponderExtensionComponentProps>((p
       >
         <FormattedMessage
           id="xpack.securitySolution.actionLogButton.label"
-          defaultMessage="Action log"
+          defaultMessage="Actions log"
         />
       </EuiButton>
       {showActionLogFlyout && (

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
@@ -92,7 +92,7 @@ export const TABLE_COLUMN_NAMES = Object.freeze({
 export const UX_MESSAGES = Object.freeze({
   flyoutTitle: (hostname: string) =>
     i18n.translate('xpack.securitySolution.responseActionsList.flyout.title', {
-      defaultMessage: `Action log : {hostname}`,
+      defaultMessage: `Actions log : {hostname}`,
       values: { hostname },
     }),
   pageTitle: i18n.translate('xpack.securitySolution.responseActionsList.list.title', {

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_with_show_endpoint_responder.tsx
@@ -20,7 +20,7 @@ import { OfflineCallout } from '../../components/endpoint_responder/offline_call
 type ShowEndpointResponseActionsConsole = (endpointMetadata: HostMetadata) => void;
 
 const RESPONDER_PAGE_TITLE = i18n.translate('xpack.securitySolution.responder_overlay.pageTitle', {
-  defaultMessage: 'Responder',
+  defaultMessage: 'Response console',
 });
 
 export const useWithShowEndpointResponder = (): ShowEndpointResponseActionsConsole => {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -136,7 +136,7 @@ export const useEndpointActionItems = (
                 children: (
                   <FormattedMessage
                     id="xpack.securitySolution.endpoint.actions.console"
-                    defaultMessage="Launch responder"
+                    defaultMessage="Respond"
                   />
                 ),
                 toolTipContent: !isResponderCapabilitiesEnabled


### PR DESCRIPTION
## Summary

This PR adds some text updates, a docs link, and the Response Console product naming according to the marketing and product teams.

![image](https://user-images.githubusercontent.com/56395104/183988400-916ff71d-47ef-4808-87c9-d838cf654c1f.png)

![image](https://user-images.githubusercontent.com/56395104/183988550-d07804b2-4820-437d-984b-9868df71cfc1.png)

![image](https://user-images.githubusercontent.com/56395104/183988576-1e65ac71-81ae-40cd-ae20-71f7f1c0bba5.png)

![image](https://user-images.githubusercontent.com/56395104/183988601-677f16e3-7875-4710-8d01-9af9528af403.png)

![image](https://user-images.githubusercontent.com/56395104/183988625-8f7eb345-8e06-42ee-a63d-5830ea7e6c69.png)

![image](https://user-images.githubusercontent.com/56395104/183988650-2a56393b-c0a2-4b4c-95ec-f7727d0839e0.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
