### PR TITLE
[DOCS] Add missing collapsible sections in case APIs

### DIFF
--- a/docs/api/cases/cases-api-add-comment.asciidoc
+++ b/docs/api/cases/cases-api-add-comment.asciidoc
@@ -29,6 +29,7 @@ You must have `all` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === {api-request-body-title}
 
 `alertId`::

--- a/docs/api/cases/cases-api-create.asciidoc
+++ b/docs/api/cases/cases-api-create.asciidoc
@@ -25,6 +25,7 @@ You must have `all` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === {api-request-body-title}
 
 `connector`::
@@ -34,12 +35,13 @@ default space is used.
 [%collapsible%open]
 ====
 `fields`::
-(Required, object) An object containing the connector fields.
+(Required, object) An object containing the connector fields. To create a case
+without a connector, specify `null`. If you want to omit any individual field,
+specify `null` as its value.
 +
---
-To create a case without a connector, specify `null`. If you want to omit any
-individual field, specify `null` as its value.
-
+.Properties of `fields`
+[%collapsible%open]
+=====
 For {ibm-r} connectors, specify:
 
 `issueTypes`:::
@@ -103,7 +105,7 @@ For {swimlane} connectors, specify:
 
 `caseId`:::
 (Required, string) The case ID.
---
+=====
 
 `id`::
 (Required, string) The identifier for the connector. To create a case without a

--- a/docs/api/cases/cases-api-set-configuration.asciidoc
+++ b/docs/api/cases/cases-api-set-configuration.asciidoc
@@ -35,6 +35,7 @@ you must still specify all of the connector details.
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === {api-request-body-title}
 
 `closure_type`::

--- a/docs/api/cases/cases-api-update-comment.asciidoc
+++ b/docs/api/cases/cases-api-update-comment.asciidoc
@@ -29,6 +29,7 @@ The identifier for the case. To retrieve case IDs, use
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === {api-request-body-title}
 
 `alertId`::

--- a/docs/api/cases/cases-api-update-configuration.asciidoc
+++ b/docs/api/cases/cases-api-update-configuration.asciidoc
@@ -35,6 +35,7 @@ The identifier for the configuration. To retrieve the configuration IDs, use
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === Request body
 
 `closure_type`::

--- a/docs/api/cases/cases-api-update.asciidoc
+++ b/docs/api/cases/cases-api-update.asciidoc
@@ -47,7 +47,7 @@ connector, specify `null`. If you want to omit any individual field, specify
 +
 .Properties of `fields`
 [%collapsible%open]
-===
+=======
 For {ibm-r} connectors, specify:
 
 `issueTypes`:::
@@ -112,7 +112,7 @@ For {swimlane} connectors, specify:
 
 `caseId`:::
 (Required, string) The identifier for the case.
-===
+=======
 
 `id`::
 (Required, string) The identifier for the connector. To remove the connector,

--- a/docs/api/cases/cases-api-update.asciidoc
+++ b/docs/api/cases/cases-api-update.asciidoc
@@ -25,6 +25,7 @@ You must have `all` privileges for the *Cases* feature in the *Management*,
 (Optional, string) An identifier for the space. If it is not specified, the
 default space is used.
 
+[role="child_attributes"]
 === {api-request-body-title}
 
 `cases`::
@@ -40,12 +41,13 @@ default space is used.
 [%collapsible%open]
 =====
 `fields`::
-(Required, object) An object containing the connector fields.
+(Required, object) An object containing the connector fields. To remove the
+connector, specify `null`. If you want to omit any individual field, specify
+`null` as its value.
 +
---
-To remove the connector, specify `null`. If you want to omit any individual
-field, specify `null` as its value.
-
+.Properties of `fields`
+[%collapsible%open]
+===
 For {ibm-r} connectors, specify:
 
 `issueTypes`:::
@@ -110,7 +112,7 @@ For {swimlane} connectors, specify:
 
 `caseId`:::
 (Required, string) The identifier for the case.
---
+===
 
 `id`::
 (Required, string) The identifier for the connector. To remove the connector,


### PR DESCRIPTION
## Summary

The case API documentation is missing some `[role="child_attributes"]`, which makes the nested properties easier to read.

### Preview

* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-add-comment.html
* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-create.html
* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-set-configuration.html
* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-update-comment.html
* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-update-configuration.html
* https://kibana_138588.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-update.html