### PR TITLE
[ci/on-merge] Use n2-16 for populating bazel cache

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -134,7 +134,7 @@ steps:
   - command: .buildkite/scripts/steps/bazel_cache/bootstrap_linux.sh
     label: 'Populate local dev bazel cache (Linux)'
     agents:
-      queue: n2-4-spot
+      queue: n2-16-spot
     timeout_in_minutes: 15
     retry:
       automatic:


### PR DESCRIPTION
Bazel seems to make use of extra CPU - thoughts on more cores to populate caches faster?