### PR TITLE
[Security Solution][Detections] fixes tests related to prebuilt rules update

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
@@ -34,7 +34,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const log = getService('log');
 
-  describe('update_actions', () => {
+  describe.only('update_actions', () => {
     describe('updating actions', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
@@ -104,7 +104,7 @@ export default ({ getService }: FtrProviderContext) => {
         await waitForRuleSuccessOrStatus(supertest, log, updatedRule.id);
       });
 
-      it('should be able to create a new webhook action and attach it to an immutable rule', async () => {
+      it('should not change properties of immutable rule when applying actions to it', async () => {
         await installPrePackagedRules(supertest, log);
         // Rule id of "9a1a2dae-0b5f-4c3d-8305-a268d404c306" is from the file:
         // x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/elastic_endpoint.json
@@ -120,8 +120,25 @@ export default ({ getService }: FtrProviderContext) => {
           rule_id: immutableRule.rule_id, // Rule id should match the same as the immutable rule
           version: immutableRule.version, // This version number should not change when an immutable rule is updated
           immutable: true, // It should stay immutable true when returning
+          required_fields: bodyToCompare.required_fields, // required_fields cannot be modified, so newRuleToUpdate will have required_fields from immutable rule
         };
         expect(bodyToCompare).to.eql(expected);
+      });
+
+      it('should be able to create a new webhook action and attach it to an immutable rule', async () => {
+        await installPrePackagedRules(supertest, log);
+        // Rule id of "9a1a2dae-0b5f-4c3d-8305-a268d404c306" is from the file:
+        // x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/elastic_endpoint.json
+        const immutableRule = await getRule(supertest, log, '9a1a2dae-0b5f-4c3d-8305-a268d404c306');
+        const hookAction = await createNewAction(supertest, log);
+        const newRuleToUpdate = getSimpleRule(immutableRule.rule_id);
+        const ruleToUpdate = getRuleWithWebHookAction(hookAction.id, false, newRuleToUpdate);
+        const updatedRule = await updateRule(supertest, log, ruleToUpdate);
+        const bodyToCompare = removeServerGeneratedProperties(updatedRule);
+
+        const expected = getSimpleRuleOutputWithWebHookAction(`${bodyToCompare.actions?.[0].id}`);
+
+        expect(bodyToCompare.actions).to.eql(expected.actions);
       });
 
       it('should be able to create a new webhook action, attach it to an immutable rule and the count of prepackaged rules should not increase. If this fails, suspect the immutable tags are not staying on the rule correctly.', async () => {
@@ -155,13 +172,10 @@ export default ({ getService }: FtrProviderContext) => {
 
         expect(body.data.length).to.eql(1); // should have only one length to the data set, otherwise we have duplicates or the tags were removed and that is incredibly bad.
         const bodyToCompare = removeServerGeneratedProperties(body.data[0]);
-        const expected = {
-          ...getSimpleRuleOutputWithWebHookAction(`${bodyToCompare.actions?.[0].id}`),
-          rule_id: immutableRule.rule_id, // Rule id should match the same as the immutable rule
-          version: immutableRule.version, // This version number should not change when an immutable rule is updated
-          immutable: true, // It should stay immutable true when returning
-        };
-        expect(bodyToCompare).to.eql(expected);
+        const expected = getSimpleRuleOutputWithWebHookAction(`${bodyToCompare.actions?.[0].id}`);
+
+        expect(bodyToCompare.actions).to.eql(expected.actions);
+        expect(bodyToCompare.immutable).to.be(true);
       });
     });
   });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
@@ -34,7 +34,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const log = getService('log');
 
-  describe.only('update_actions', () => {
+  describe('update_actions', () => {
     describe('updating actions', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/update_actions.ts
@@ -120,7 +120,7 @@ export default ({ getService }: FtrProviderContext) => {
           rule_id: immutableRule.rule_id, // Rule id should match the same as the immutable rule
           version: immutableRule.version, // This version number should not change when an immutable rule is updated
           immutable: true, // It should stay immutable true when returning
-          required_fields: bodyToCompare.required_fields, // required_fields cannot be modified, so newRuleToUpdate will have required_fields from immutable rule
+          required_fields: immutableRule.required_fields, // required_fields cannot be modified, so newRuleToUpdate will have required_fields from immutable rule
         };
         expect(bodyToCompare).to.eql(expected);
       });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -1298,7 +1298,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
+      it.only('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
         await installPrePackagedRules(supertest, log);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -1298,7 +1298,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
+      it.only('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
         await installPrePackagedRules(supertest, log);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
@@ -1315,12 +1315,12 @@ export default ({ getService }: FtrProviderContext) => {
             created_on: createdOn,
             updated_on: updatedOn,
             rule_id: ruleId,
+            rule_version: ruleVersion,
             ...omittedFields
           } = foundRule;
           expect(omittedFields).to.eql({
             rule_name: 'Endpoint Security',
             rule_type: 'query',
-            rule_version: 3,
             enabled: true,
             elastic_rule: true,
             alert_count_daily: 0,

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -1298,7 +1298,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it.only('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
+      it('should show stats for the detection_rule_details for a specific pre-packaged rule', async () => {
         await installPrePackagedRules(supertest, log);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);

--- a/x-pack/test/detection_engine_api_integration/utils/remove_server_generated_properties.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/remove_server_generated_properties.ts
@@ -20,6 +20,7 @@ export const removeServerGeneratedProperties = (
     created_at,
     updated_at,
     execution_summary,
+    required_fields,
     ...removedProperties
   } = rule;
   return removedProperties;

--- a/x-pack/test/detection_engine_api_integration/utils/remove_server_generated_properties.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/remove_server_generated_properties.ts
@@ -20,7 +20,6 @@ export const removeServerGeneratedProperties = (
     created_at,
     updated_at,
     execution_summary,
-    required_fields,
     ...removedProperties
   } = rule;
   return removedProperties;


### PR DESCRIPTION
## Summary

fixes tests related to prebuilt rules update tests failures(https://github.com/elastic/kibana/pull/138574#issuecomment-1211348195):
- removed hardcoded rule version value
- required_fields are not tested agains empty array, but agains actual immutable rule value



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->