### PR TITLE
[ML] Transforms: Fix restoring a field name with the `exists` filter aggregation

### DIFF
--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
@@ -68,6 +68,34 @@ describe('getAggConfigFromEsAgg', () => {
     });
   });
 
+  test('should resolve percentiles agg in sub-aggregations', () => {
+    const esConfig = {
+      filter: {
+        exists: {
+          field: 'customer_phone',
+        },
+      },
+      aggs: {
+        'products.base_price.percentiles': {
+          percentiles: {
+            field: 'products.base_price',
+            percents: [1, 5, 25, 50, 75, 95, 99],
+          },
+        },
+      },
+    };
+
+    const result = getAggConfigFromEsAgg(esConfig, 'test_sub_percentiles');
+
+    expect(result.subAggs!['products.base_price.percentiles']).toMatchObject({
+      agg: 'percentiles',
+      aggName: 'products.base_price.percentiles',
+      dropDownName: 'products.base_price.percentiles',
+      field: 'products.base_price',
+      parentAgg: result,
+    });
+  });
+
   test('restore config for the exists filter', () => {
     expect(
       getAggConfigFromEsAgg({ filter: { exists: { field: 'instance' } } }, 'test_3')

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
@@ -33,6 +33,7 @@ describe('getAggConfigFromEsAgg', () => {
       aggConfig: {
         filterAgg: 'term',
         aggTypeConfig: {
+          fieldName: 'region',
           FilterAggFormComponent: FilterTermForm,
           filterAggConfig: {
             value: 'sa-west-1',
@@ -64,6 +65,58 @@ describe('getAggConfigFromEsAgg', () => {
       dropDownName: 'test_avg',
       field: 'test_field',
       parentAgg: result,
+    });
+  });
+
+  test('restore config for the exists filter', () => {
+    expect(
+      getAggConfigFromEsAgg({ filter: { exists: { field: 'instance' } } }, 'test_3')
+    ).toMatchObject({
+      agg: 'filter',
+      aggName: 'test_3',
+      dropDownName: 'test_3',
+      field: 'instance',
+      aggConfig: {
+        filterAgg: 'exists',
+        aggTypeConfig: {
+          fieldName: 'instance',
+        },
+      },
+    });
+  });
+
+  test('restore config for the range filter', () => {
+    expect(
+      getAggConfigFromEsAgg(
+        {
+          filter: {
+            range: {
+              'products.base_price': {
+                gte: 11,
+                lt: 20,
+              },
+            },
+          },
+        },
+        'test_4'
+      )
+    ).toMatchObject({
+      agg: 'filter',
+      aggName: 'test_4',
+      dropDownName: 'test_4',
+      field: 'products.base_price',
+      aggConfig: {
+        filterAgg: 'range',
+        aggTypeConfig: {
+          fieldName: 'products.base_price',
+          filterAggConfig: {
+            from: 11,
+            to: 20,
+            includeFrom: true,
+            includeTo: false,
+          },
+        },
+      },
     });
   });
 });

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
@@ -171,6 +171,8 @@ export function getAggConfigFromEsAgg(
   }
 
   const commonConfig: PivotAggsConfigBase = {
+    // FIXME this spread operator set the field property
+    // Check if there are some extra props involved
     ...esAggDefinition[agg],
     agg,
     aggName,
@@ -200,7 +202,7 @@ export function getAggConfigFromEsAgg(
 }
 
 export interface PivotAggsConfigWithUiBase extends PivotAggsConfigBase {
-  field: EsFieldName | EsFieldName[];
+  field: EsFieldName | EsFieldName[] | null;
 }
 
 export interface PivotAggsConfigWithExtra<T> extends PivotAggsConfigWithUiBase {
@@ -253,7 +255,10 @@ export function isPivotAggsConfigWithUiSupport(arg: unknown): arg is PivotAggsCo
 type PivotAggsConfigWithExtendedForm = PivotAggsConfigFilter | PivotAggsConfigTopMetrics;
 
 export function isPivotAggsWithExtendedForm(arg: unknown): arg is PivotAggsConfigWithExtendedForm {
-  return isPopulatedObject(arg, ['AggFormComponent']);
+  return (
+    (isPopulatedObject(arg) && arg.hasOwnProperty('setUiConfigFromEs')) ||
+    isPopulatedObject(arg, ['AggFormComponent'])
+  );
 }
 
 export function isPivotAggConfigTopMetric(arg: unknown): arg is PivotAggsConfigTopMetrics {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_settings/advanced_runtime_mappings_settings.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_settings/advanced_runtime_mappings_settings.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { isDefined } from '../../../../../../common/types/common';
 import { StepDefineFormHook } from '../step_define';
 import { AdvancedRuntimeMappingsEditor } from '../advanced_runtime_mappings_editor/advanced_runtime_mappings_editor';
 import { AdvancedRuntimeMappingsEditorSwitch } from '../advanced_runtime_mappings_editor_switch';
@@ -80,7 +81,7 @@ export const AdvancedRuntimeMappingsSettings: FC<StepDefineFormHook> = (props) =
           const newFields = agg.field.filter((f) => !isFieldDeleted(f));
           updateAggregation(aggName, { ...agg, field: newFields });
         } else {
-          if (agg.field !== undefined && isFieldDeleted(agg.field)) {
+          if (isDefined(agg.field) && isFieldDeleted(agg.field)) {
             deleteAggregation(aggName);
           }
         }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -107,7 +107,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
 
   const [aggName, setAggName] = useState(defaultData.aggName);
   const [agg, setAgg] = useState(defaultData.agg);
-  const [field, setField] = useState<string | string[]>(
+  const [field, setField] = useState<string | string[] | null>(
     isPivotAggsConfigWithUiSupport(defaultData) ? defaultData.field : ''
   );
 
@@ -304,10 +304,14 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
                   label: v.text as string,
                 };
               })}
-              selectedOptions={(typeof field === 'string' ? [field] : field).map((v) => ({
-                value: v,
-                label: v,
-              }))}
+              selectedOptions={
+                !!field
+                  ? (typeof field === 'string' ? [field] : field).map((v) => ({
+                      value: v,
+                      label: v,
+                    }))
+                  : []
+              }
               onChange={(e) => {
                 const res = e.map((v) => v.value as string);
                 setField(res);

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -178,6 +178,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
 
     if (agg === PIVOT_SUPPORTED_AGGS.PERCENTILES) {
       updatedItem = {
+        ...aggConfigDef,
         agg,
         aggName,
         field: resultField,
@@ -186,6 +187,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
       };
     } else if (agg === PIVOT_SUPPORTED_AGGS.TERMS) {
       updatedItem = {
+        ...aggConfigDef,
         agg,
         aggName,
         field: resultField,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/filter_agg_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/filter_agg_form.tsx
@@ -63,10 +63,13 @@ export const FilterAggForm: PivotAggsConfigFilter['AggFormComponent'] = ({
     [dataView, selectedField, runtimeMappings]
   );
 
-  useUpdateEffect(() => {
-    // reset filter agg on field change
-    onChange({});
-  }, [selectedField]);
+  useUpdateEffect(
+    function resetConfigOnFieldChange() {
+      // reset filter agg on field change
+      onChange({});
+    },
+    [selectedField]
+  );
 
   const filterAggTypeConfig = aggConfig?.aggTypeConfig;
   const filterAgg = aggConfig?.filterAgg ?? '';
@@ -109,7 +112,7 @@ export const FilterAggForm: PivotAggsConfigFilter['AggFormComponent'] = ({
               const filterAggUpdate = e.target.value as FilterAggType;
               onChange({
                 filterAgg: filterAggUpdate,
-                aggTypeConfig: getFilterAggTypeConfig(filterAggUpdate),
+                aggTypeConfig: getFilterAggTypeConfig(filterAggUpdate, selectedField),
               });
             }}
             data-test-subj="transformFilterAggTypeSelector"

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
@@ -88,9 +88,13 @@ export function getFilterAggTypeConfig(
   fieldName?: string,
   esConfig?: { [key: string]: any }
 ): FilterAggConfigUnion['aggTypeConfig'] {
+  let resultField = fieldName;
+
   switch (filterAggType) {
     case FILTERS.TERM:
       const value = typeof esConfig === 'object' ? Object.values(esConfig)[0] : undefined;
+
+      resultField = esConfig ? Object.keys(esConfig)[0] : resultField;
 
       return {
         FilterAggFormComponent: FilterTermForm,
@@ -111,12 +115,15 @@ export function getFilterAggTypeConfig(
         getAggName() {
           return this.filterAggConfig?.value ? this.filterAggConfig.value : undefined;
         },
-        fieldName,
+        fieldName: resultField,
       } as FilterAggConfigTerm['aggTypeConfig'];
     case FILTERS.RANGE:
+      resultField = esConfig ? Object.keys(esConfig)[0] : resultField;
+
       const esFilterRange = typeof esConfig === 'object' ? Object.values(esConfig)[0] : undefined;
 
       return {
+        fieldName: resultField,
         FilterAggFormComponent: FilterRangeForm,
         filterAggConfig:
           typeof esFilterRange === 'object'
@@ -124,7 +131,7 @@ export function getFilterAggTypeConfig(
                 from: esFilterRange.gte ?? esFilterRange.gt,
                 to: esFilterRange.lte ?? esFilterRange.lt,
                 includeFrom: esFilterRange.gte !== undefined,
-                includeTo: esFilterRange.lts !== undefined,
+                includeTo: esFilterRange.lte !== undefined,
               }
             : undefined,
         getEsAggConfig() {
@@ -162,7 +169,6 @@ export function getFilterAggTypeConfig(
 
           return true;
         },
-        fieldName,
         helperText() {
           if (!this.isValid!()) return;
           const { from, to, includeFrom, includeTo } = this.filterAggConfig!;
@@ -173,7 +179,7 @@ export function getFilterAggTypeConfig(
         },
       } as FilterAggConfigRange['aggTypeConfig'];
     case FILTERS.EXISTS:
-      const resultField = esConfig ? esConfig.field : fieldName;
+      resultField = esConfig ? esConfig.field : resultField;
 
       return {
         fieldName: resultField,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
@@ -29,11 +29,14 @@ interface FilterAggTypeConfig<U, R> {
   filterAggConfig?: U extends undefined ? undefined : U;
   /** Converts UI agg config form to ES agg request object */
   getEsAggConfig: (field?: string) => R;
+  /** Validation result of the filter agg config */
   isValid?: () => boolean;
   /** Provides aggregation name generated based on the configuration */
   getAggName?: () => string | undefined;
   /** Helper text for the aggregation reflecting some configuration info */
   helperText?: () => string | undefined;
+  /** Field name. In some cases, e.g. `exists` filter, it's resolved from the filter agg definition */
+  fieldName?: string;
 }
 
 /** Filter agg type definition */

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/hooks/use_pivot_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/hooks/use_pivot_config.ts
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 
 import { KBN_FIELD_TYPES } from '@kbn/data-plugin/common';
 import { AggName } from '../../../../../../../common/types/aggregations';
-import { dictionaryToArray } from '../../../../../../../common/types/common';
+import { dictionaryToArray, isDefined } from '../../../../../../../common/types/common';
 
 import { useToastNotifications } from '../../../../../app_dependencies';
 import {
@@ -190,6 +190,7 @@ export const usePivotConfig = (
               Object.values(aggList)
                 .map((v) => (isPivotAggConfigWithUiSupport(v) ? v.field : undefined))
                 .flat()
+                .filter(isDefined)
             ),
           ].find((v) => fields.find((x) => x.name === v)?.type === KBN_FIELD_TYPES.DATE);
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/132533

- Correctly saves and restored the `exists` filter aggregation. 
- Fixes `percentiles` and `terms` aggregations used as sub-aggretations.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->