### PR TITLE
Fix management test to run against cloud

### DIFF
--- a/test/functional/apps/management/_exclude_index_pattern.ts
+++ b/test/functional/apps/management/_exclude_index_pattern.ts
@@ -12,27 +12,43 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['settings']);
   const es = getService('es');
+  const security = getService('security');
 
   describe('creating and deleting default index', function describeIndexTests() {
-    it('data view creation with exclusion', async () => {
+    before(async function () {
+      await security.testUser.setRoles(['kibana_admin', 'index_a', 'index_b']);
+      await PageObjects.settings.navigateTo();
       await es.transport.request({
-        path: '/index-a/_doc',
+        path: '/index_a/_doc',
         method: 'POST',
         body: { user: 'matt' },
       });
 
       await es.transport.request({
-        path: '/index-b/_doc',
+        path: '/index_b/_doc',
         method: 'POST',
         body: { title: 'hello' },
       });
+      await PageObjects.settings.createIndexPattern('index_*,-index_b');
+    });
 
-      await PageObjects.settings.createIndexPattern('index-*,-index-b');
-
+    it('data view creation with exclusion', async () => {
       const fieldCount = await PageObjects.settings.getFieldsTabCount();
-
       // five metafields plus keyword and text version of 'user' field
       expect(parseInt(fieldCount, 10)).to.be(6);
+    });
+
+    after(async () => {
+      await es.transport.request({
+        path: '/index_a',
+        method: 'DELETE',
+      });
+      await es.transport.request({
+        path: '/index_b',
+        method: 'DELETE',
+      });
+      await PageObjects.settings.removeIndexPattern();
+      await security.testUser.restoreDefaults();
     });
   });
 }

--- a/test/functional/apps/management/_exclude_index_pattern.ts
+++ b/test/functional/apps/management/_exclude_index_pattern.ts
@@ -19,17 +19,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await security.testUser.setRoles(['kibana_admin', 'index_a', 'index_b']);
       await PageObjects.settings.navigateTo();
       await es.transport.request({
-        path: '/index_a/_doc',
+        path: '/index-a/_doc',
         method: 'POST',
         body: { user: 'matt' },
       });
 
       await es.transport.request({
-        path: '/index_b/_doc',
+        path: '/index-b/_doc',
         method: 'POST',
         body: { title: 'hello' },
       });
-      await PageObjects.settings.createIndexPattern('index_*,-index_b');
+      await PageObjects.settings.createIndexPattern('index-*,-index-b');
     });
 
     it('data view creation with exclusion', async () => {
@@ -40,11 +40,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await es.transport.request({
-        path: '/index_a',
+        path: '/index-a',
         method: 'DELETE',
       });
       await es.transport.request({
-        path: '/index_b',
+        path: '/index-b',
         method: 'DELETE',
       });
       await PageObjects.settings.removeIndexPattern();

--- a/test/functional/config.base.js
+++ b/test/functional/config.base.js
@@ -249,6 +249,36 @@ export default async function ({ readConfigFile }) {
           kibana: [],
         },
 
+        index_a: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['index_a'],
+                privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        index_b: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['index_b'],
+                privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
         kibana_sample_read: {
           elasticsearch: {
             cluster: [],

--- a/test/functional/config.base.js
+++ b/test/functional/config.base.js
@@ -254,7 +254,7 @@ export default async function ({ readConfigFile }) {
             cluster: [],
             indices: [
               {
-                names: ['index_a'],
+                names: ['index-a'],
                 privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
                 field_security: { grant: ['*'], except: [] },
               },
@@ -269,7 +269,7 @@ export default async function ({ readConfigFile }) {
             cluster: [],
             indices: [
               {
-                names: ['index_b'],
+                names: ['index-b'],
                 privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
                 field_security: { grant: ['*'], except: [] },
               },


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/126369

Test: ```_exclude_index_pattern``` 

1. Added setup security role access to the indices being used to avoid another test overwriting those permissions and causing this test to fail.
2. Added navigate function, so this test logins in when run individually, otherwise it was dependent on another being logged in.  
3. Added cleanup to remove data, index patterns and restore security role access.
