### PR TITLE
[Security Solution] Adds read only prop to preview table details flyout threat summary

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_summary.tsx
@@ -33,6 +33,7 @@ export interface ThreatSummaryDescription {
   timelineId: string;
   value: string | undefined;
   isDraggable?: boolean;
+  isReadOnly?: boolean;
 }
 
 const EnrichmentFieldFeedName = styled.span`
@@ -65,6 +66,7 @@ const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
   timelineId,
   value,
   isDraggable,
+  isReadOnly,
 }) => {
   if (!data || !value) return null;
   const key = `alert-details-value-formatted-field-value-${timelineId}-${eventId}-${data.field}-${value}-${index}-${feedName}`;
@@ -92,7 +94,7 @@ const EnrichmentDescription: React.FC<ThreatSummaryDescription> = ({
         </div>
       </EuiFlexItem>
       <EuiFlexItem>
-        {value && (
+        {value && !isReadOnly && (
           <ActionCell
             data={data}
             contextId={timelineId}
@@ -115,7 +117,8 @@ const EnrichmentSummaryComponent: React.FC<{
   timelineId: string;
   eventId: string;
   isDraggable?: boolean;
-}> = ({ browserFields, data, enrichments, timelineId, eventId, isDraggable }) => {
+  isReadOnly?: boolean;
+}> = ({ browserFields, data, enrichments, timelineId, eventId, isDraggable, isReadOnly }) => {
   const parsedEnrichments = enrichments.map((enrichment, index) => {
     const { field, type, feedName, value } = getEnrichmentIdentifiers(enrichment);
     const eventData = data.find((item) => item.field === field);
@@ -168,6 +171,7 @@ const EnrichmentSummaryComponent: React.FC<{
                     data={fieldsData}
                     browserField={browserField}
                     isDraggable={isDraggable}
+                    isReadOnly={isReadOnly}
                   />
                 }
               />
@@ -198,6 +202,7 @@ const EnrichmentSummaryComponent: React.FC<{
                     data={fieldsData}
                     browserField={browserField}
                     isDraggable={isDraggable}
+                    isReadOnly={isReadOnly}
                   />
                 }
               />

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -127,7 +127,17 @@ const ThreatSummaryViewComponent: React.FC<{
   timelineId: string;
   hostRisk: HostRisk | null;
   isDraggable?: boolean;
-}> = ({ browserFields, data, enrichments, eventId, timelineId, hostRisk, isDraggable }) => {
+  isReadOnly?: boolean;
+}> = ({
+  browserFields,
+  data,
+  enrichments,
+  eventId,
+  timelineId,
+  hostRisk,
+  isDraggable,
+  isReadOnly,
+}) => {
   if (!hostRisk && enrichments.length === 0) {
     return null;
   }
@@ -155,6 +165,7 @@ const ThreatSummaryViewComponent: React.FC<{
           timelineId={timelineId}
           eventId={eventId}
           isDraggable={isDraggable}
+          isReadOnly={isReadOnly}
         />
       </EuiFlexGroup>
     </>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -202,6 +202,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                     eventId={id}
                     timelineId={timelineId}
                     enrichments={allEnrichments}
+                    isReadOnly={isReadOnly}
                   />
                 )}
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/131118

Adds a `readOnly` prop to the preview table alert details flyout for the threat summary. Forgotten when the rest of the read only props were added in [this PR](https://github.com/elastic/kibana/pull/127986)

### Screenshots

**No more hover actions displayed**


<img width="945" alt="Screen Shot 2022-08-11 at 3 08 58 PM" src="https://user-images.githubusercontent.com/56367316/184220077-549ee8b4-5baf-41a4-90bc-999891b10cfc.png">



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->