### PR TITLE
Change debug message when security is disabled

### DIFF
--- a/x-pack/plugins/security/server/authentication/authentication_service.ts
+++ b/x-pack/plugins/security/server/authentication/authentication_service.ts
@@ -121,7 +121,7 @@ export class AuthenticationService {
       // If security is disabled, then continue with no user credentials.
       if (!license.isEnabled()) {
         this.logger.debug(
-          'Current license does not support any security features, authentication is not needed.'
+          'Authentication is not required, as security features are disabled in Elasticsearch.'
         );
         return t.authenticated();
       }


### PR DESCRIPTION
## Summary

Resolves #108943.

Changes our debug log message when security is disabled in Elasticsearch.

<!--ONMERGE {"backportTargets":["7.17","8.3","8.4"]} ONMERGE-->