### PR TITLE
[Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
@@ -13,8 +13,7 @@ import { act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDeferred } from '../../mocks';
 
-// FLAKY: https://github.com/elastic/kibana/issues/137590
-describe.skip('When displaying the Delete artfifact modal in the Artifact List Page', () => {
+describe('When displaying the Delete artifact modal in the Artifact List Page', () => {
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let history: AppContextTestRender['history'];
   let coreStart: AppContextTestRender['coreStart'];
@@ -55,9 +54,17 @@ describe.skip('When displaying the Delete artfifact modal in the Artifact List P
 
     await clickCardAction('delete');
 
+    // Wait for the dialog to be present
+    await act(async () => {
+      await waitFor(() => {
+        expect(renderResult.getByTestId('testPage-deleteModal')).not.toBeNull();
+      });
+    });
+
     cancelButton = renderResult.getByTestId(
       'testPage-deleteModal-cancelButton'
     ) as HTMLButtonElement;
+
     submitButton = renderResult.getByTestId(
       'testPage-deleteModal-submitButton'
     ) as HTMLButtonElement;

--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
@@ -37,38 +37,45 @@ describe('When displaying the Delete artifact modal in the Artifact List Page', 
     });
   };
 
-  beforeEach(async () => {
-    const renderSetup = getArtifactListPageRenderingSetup();
+  beforeEach(
+    async () => {
+      const renderSetup = getArtifactListPageRenderingSetup();
 
-    ({ history, coreStart, mockedApi, getFirstCard } = renderSetup);
+      ({ history, coreStart, mockedApi, getFirstCard } = renderSetup);
 
-    history.push('somepage?show=create');
+      history.push('somepage?show=create');
 
-    renderResult = renderSetup.renderArtifactListPage();
+      renderResult = renderSetup.renderArtifactListPage();
 
-    await act(async () => {
-      await waitFor(() => {
-        expect(renderResult.getByTestId('testPage-list')).toBeTruthy();
+      await act(async () => {
+        await waitFor(() => {
+          expect(renderResult.getByTestId('testPage-list')).toBeTruthy();
+        });
       });
-    });
 
-    await clickCardAction('delete');
+      await clickCardAction('delete');
 
-    // Wait for the dialog to be present
-    await act(async () => {
-      await waitFor(() => {
-        expect(renderResult.getByTestId('testPage-deleteModal')).not.toBeNull();
+      // Wait for the dialog to be present
+      await act(async () => {
+        await waitFor(() => {
+          expect(renderResult.getByTestId('testPage-deleteModal')).not.toBeNull();
+        });
       });
-    });
 
-    cancelButton = renderResult.getByTestId(
-      'testPage-deleteModal-cancelButton'
-    ) as HTMLButtonElement;
+      cancelButton = renderResult.getByTestId(
+        'testPage-deleteModal-cancelButton'
+      ) as HTMLButtonElement;
 
-    submitButton = renderResult.getByTestId(
-      'testPage-deleteModal-submitButton'
-    ) as HTMLButtonElement;
-  });
+      submitButton = renderResult.getByTestId(
+        'testPage-deleteModal-submitButton'
+      ) as HTMLButtonElement;
+    },
+    // Timeout set to 10s
+    // In some cases, whose causes are unknown, a test will timeout and will point
+    // to this setup as the culprid. It rarely happens, but in order to avoid it,
+    // the timeout below is being set to 10s
+    10000
+  );
 
   it('should show Cancel and Delete buttons enabled', async () => {
     expect(cancelButton).toBeEnabled();


### PR DESCRIPTION
## Summary

Fixes #135794
Fixes #135795

🤞 

Changes: 

- Un-skipped tests for the Artifact Delete Modal
- Added additional `waitFor()` to the `beforeEach()` setup to ensure Modal is present before getting references to the dialog buttons
- increase the timeout for the test setup to 10s to avoid occasional timeouts



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->