### PR TITLE
[8.4] [Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal (#138672)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
@@ -13,8 +13,7 @@ import { act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDeferred } from '../../mocks';
 
-// FLAKY: https://github.com/elastic/kibana/issues/135794
-describe.skip('When displaying the Delete artfifact modal in the Artifact List Page', () => {
+describe('When displaying the Delete artifact modal in the Artifact List Page', () => {
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let history: AppContextTestRender['history'];
   let coreStart: AppContextTestRender['coreStart'];
@@ -38,30 +37,45 @@ describe.skip('When displaying the Delete artfifact modal in the Artifact List P
     });
   };
 
-  beforeEach(async () => {
-    const renderSetup = getArtifactListPageRenderingSetup();
+  beforeEach(
+    async () => {
+      const renderSetup = getArtifactListPageRenderingSetup();
 
-    ({ history, coreStart, mockedApi, getFirstCard } = renderSetup);
+      ({ history, coreStart, mockedApi, getFirstCard } = renderSetup);
 
-    history.push('somepage?show=create');
+      history.push('somepage?show=create');
 
-    renderResult = renderSetup.renderArtifactListPage();
+      renderResult = renderSetup.renderArtifactListPage();
 
-    await act(async () => {
-      await waitFor(() => {
-        expect(renderResult.getByTestId('testPage-list')).toBeTruthy();
+      await act(async () => {
+        await waitFor(() => {
+          expect(renderResult.getByTestId('testPage-list')).toBeTruthy();
+        });
       });
-    });
 
-    await clickCardAction('delete');
+      await clickCardAction('delete');
 
-    cancelButton = renderResult.getByTestId(
-      'testPage-deleteModal-cancelButton'
-    ) as HTMLButtonElement;
-    submitButton = renderResult.getByTestId(
-      'testPage-deleteModal-submitButton'
-    ) as HTMLButtonElement;
-  });
+      // Wait for the dialog to be present
+      await act(async () => {
+        await waitFor(() => {
+          expect(renderResult.getByTestId('testPage-deleteModal')).not.toBeNull();
+        });
+      });
+
+      cancelButton = renderResult.getByTestId(
+        'testPage-deleteModal-cancelButton'
+      ) as HTMLButtonElement;
+
+      submitButton = renderResult.getByTestId(
+        'testPage-deleteModal-submitButton'
+      ) as HTMLButtonElement;
+    },
+    // Timeout set to 10s
+    // In some cases, whose causes are unknown, a test will timeout and will point
+    // to this setup as the culprid. It rarely happens, but in order to avoid it,
+    // the timeout below is being set to 10s
+    10000
+  );
 
   it('should show Cancel and Delete buttons enabled', async () => {
     expect(cancelButton).toBeEnabled();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal (#138672)](https://github.com/elastic/kibana/pull/138672)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-08-11T21:29:34Z","message":"[Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal (#138672)\n\n* Add an `waitFor` before selecting dialog buttons\r\n* increase `beforeEach()` timeout to 10s","sha":"af9e2d9569b1c8c6185ae71cbfab7cbbb67a5583","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Onboarding and Lifecycle Mgt","v8.4.0","v8.5.0"],"number":138672,"url":"https://github.com/elastic/kibana/pull/138672","mergeCommit":{"message":"[Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal (#138672)\n\n* Add an `waitFor` before selecting dialog buttons\r\n* increase `beforeEach()` timeout to 10s","sha":"af9e2d9569b1c8c6185ae71cbfab7cbbb67a5583"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/138672","number":138672,"mergeCommit":{"message":"[Security Solution][Endpoint] Un-skip Jest tests for artifact list page delete modal (#138672)\n\n* Add an `waitFor` before selecting dialog buttons\r\n* increase `beforeEach()` timeout to 10s","sha":"af9e2d9569b1c8c6185ae71cbfab7cbbb67a5583"}}]}] BACKPORT-->