### PR TITLE
ENT 2433 | Fix product access in navigation menu in Enterprise Search pages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
@@ -25,14 +25,14 @@ import { i18n } from '@kbn/i18n';
 import { docLinks } from '../../../shared/doc_links';
 import { ElasticsearchResources } from '../../../shared/elasticsearch_resources';
 import { SetElasticsearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { ElasticsearchClientInstructions } from '../elasticsearch_client_instructions';
 import { ElasticsearchCloudId } from '../elasticsearch_cloud_id';
 import { EnterpriseSearchElasticsearchPageTemplate } from '../layout';
 
 // Replace FormattedMessage with i18n strings
 
-export const ElasticsearchGuide: React.FC<AccessProps> = ({ access }) => {
+export const ElasticsearchGuide: React.FC<ProductAccessProps> = ({ access }) => {
   const languages = [
     { value: 'dotnet', text: '.Net' },
     { value: 'go', text: 'Go' },

--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
@@ -25,13 +25,14 @@ import { i18n } from '@kbn/i18n';
 import { docLinks } from '../../../shared/doc_links';
 import { ElasticsearchResources } from '../../../shared/elasticsearch_resources';
 import { SetElasticsearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { AccessProps } from '../../../shared/types';
 import { ElasticsearchClientInstructions } from '../elasticsearch_client_instructions';
 import { ElasticsearchCloudId } from '../elasticsearch_cloud_id';
 import { EnterpriseSearchElasticsearchPageTemplate } from '../layout';
 
 // Replace FormattedMessage with i18n strings
 
-export const ElasticsearchGuide: React.FC = () => {
+export const ElasticsearchGuide: React.FC<AccessProps> = ({ access }) => {
   const languages = [
     { value: 'dotnet', text: '.Net' },
     { value: 'go', text: 'Go' },
@@ -60,7 +61,7 @@ export const ElasticsearchGuide: React.FC = () => {
   }, []);
 
   return (
-    <EnterpriseSearchElasticsearchPageTemplate>
+    <EnterpriseSearchElasticsearchPageTemplate access={access}>
       <SetPageChrome />
       <EuiFlexGroup alignItems="flexStart" data-test-subj="elasticsearchGuide">
         {/* maxWidth is needed to prevent code blocks with long unbreakable strings (Kibana PR Cloud ID) from stretching the column */}

--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.tsx
@@ -14,6 +14,7 @@ import { useEnterpriseSearchNav } from '../../../shared/layout';
 import { SendEnterpriseSearchTelemetry } from '../../../shared/telemetry';
 
 export const EnterpriseSearchElasticsearchPageTemplate: React.FC<PageTemplateProps> = ({
+  access,
   children,
   pageChrome,
   pageViewTelemetry,
@@ -23,8 +24,8 @@ export const EnterpriseSearchElasticsearchPageTemplate: React.FC<PageTemplatePro
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
+        items: useEnterpriseSearchNav(access),
         name: ELASTICSEARCH_PLUGIN.NAME,
-        items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetElasticsearchChrome trail={pageChrome} />}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/index.tsx
@@ -10,6 +10,7 @@ import { Route, Switch } from 'react-router-dom';
 
 import { isVersionMismatch } from '../../../common/is_version_mismatch';
 import { InitialAppData } from '../../../common/types';
+import { NO_ACCESS } from '../shared/constants';
 import { VersionMismatchPage } from '../shared/version_mismatch';
 
 import { ElasticsearchGuide } from './components/elasticsearch_guide';
@@ -17,7 +18,7 @@ import { ElasticsearchGuide } from './components/elasticsearch_guide';
 import { ROOT_PATH } from './routes';
 
 export const Elasticsearch: React.FC<InitialAppData> = (props) => {
-  const { enterpriseSearchVersion, kibanaVersion } = props;
+  const { access, enterpriseSearchVersion, kibanaVersion } = props;
   const incompatibleVersions = isVersionMismatch(enterpriseSearchVersion, kibanaVersion);
 
   const showView = () => {
@@ -30,7 +31,7 @@ export const Elasticsearch: React.FC<InitialAppData> = (props) => {
       );
     }
 
-    return <ElasticsearchGuide />;
+    return <ElasticsearchGuide access={access || NO_ACCESS} />;
   };
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail.tsx
@@ -17,7 +17,7 @@ import { i18n } from '@kbn/i18n';
 
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { SEARCH_INDEX_TAB_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 import { CrawlCustomSettingsFlyout } from '../search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout';
@@ -35,7 +35,7 @@ import { DeduplicationPanel } from './deduplication_panel/deduplication_panel';
 import { EntryPointsTable } from './entry_points_table';
 import { SitemapsTable } from './sitemaps_table';
 
-export const CrawlerDomainDetail: React.FC<AccessProps> = ({ access }) => {
+export const CrawlerDomainDetail: React.FC<ProductAccessProps> = ({ access }) => {
   const { domainId } = useParams<{
     domainId: string;
   }>();

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/crawler_domain_detail/crawler_domain_detail.tsx
@@ -17,6 +17,7 @@ import { i18n } from '@kbn/i18n';
 
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { AccessProps } from '../../../shared/types';
 import { SEARCH_INDEX_TAB_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 import { CrawlCustomSettingsFlyout } from '../search_index/crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout';
@@ -34,7 +35,7 @@ import { DeduplicationPanel } from './deduplication_panel/deduplication_panel';
 import { EntryPointsTable } from './entry_points_table';
 import { SitemapsTable } from './sitemaps_table';
 
-export const CrawlerDomainDetail: React.FC = () => {
+export const CrawlerDomainDetail: React.FC<AccessProps> = ({ access }) => {
   const { domainId } = useParams<{
     domainId: string;
   }>();
@@ -53,6 +54,7 @@ export const CrawlerDomainDetail: React.FC = () => {
 
   return (
     <EnterpriseSearchContentPageTemplate
+      access={access}
       pageChrome={[...baseBreadcrumbs, indexName, domainUrl]}
       isLoading={getLoading}
       pageHeader={{

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/layout/page_template.tsx
@@ -14,6 +14,7 @@ import { useEnterpriseSearchNav } from '../../../shared/layout';
 import { SendEnterpriseSearchTelemetry } from '../../../shared/telemetry';
 
 export const EnterpriseSearchContentPageTemplate: React.FC<PageTemplateProps> = ({
+  access,
   children,
   pageChrome,
   pageViewTelemetry,
@@ -23,7 +24,7 @@ export const EnterpriseSearchContentPageTemplate: React.FC<PageTemplateProps> = 
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
-        items: useEnterpriseSearchNav(),
+        items: useEnterpriseSearchNav(access),
         name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
       }}
       restrictWidth

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -23,7 +23,7 @@ import { i18n } from '@kbn/i18n';
 import { parseQueryParams } from '../../../shared/query_params';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 import { baseBreadcrumbs } from '../search_indices';
 
@@ -96,7 +96,7 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
   },
 ];
 
-export const NewIndex: React.FC<AccessProps> = ({ access }) => {
+export const NewIndex: React.FC<ProductAccessProps> = ({ access }) => {
   const { search } = useLocation();
   const { method: methodParam } = parseQueryParams(search);
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -23,6 +23,7 @@ import { i18n } from '@kbn/i18n';
 import { parseQueryParams } from '../../../shared/query_params';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
+import { AccessProps } from '../../../shared/types';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 import { baseBreadcrumbs } from '../search_indices';
 
@@ -95,7 +96,7 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
   },
 ];
 
-export const NewIndex: React.FC = () => {
+export const NewIndex: React.FC<AccessProps> = ({ access }) => {
   const { search } = useLocation();
   const { method: methodParam } = parseQueryParams(search);
 
@@ -107,6 +108,7 @@ export const NewIndex: React.FC = () => {
 
   return (
     <EnterpriseSearchContentPageTemplate
+      access={access}
       pageChrome={[
         ...baseBreadcrumbs,
         i18n.translate('xpack.enterpriseSearch.content.newIndex.breadcrumb', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/not_found/not_found.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/not_found/not_found.tsx
@@ -13,9 +13,10 @@ import { NotFoundPrompt } from '../../../shared/not_found';
 import { SendEnterpriseSearchTelemetry } from '../../../shared/telemetry';
 import { EnterpriseSearchContentPageTemplate } from '../layout';
 
-export const NotFound: React.FC<PageTemplateProps> = ({ pageChrome = [] }) => {
+export const NotFound: React.FC<PageTemplateProps> = ({ access, pageChrome = [] }) => {
   return (
     <EnterpriseSearchContentPageTemplate
+      access={access}
       pageChrome={[...pageChrome, '404']}
       template="centeredContent"
     >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { Status } from '../../../../../common/types/api';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../shared/kibana';
+import { AccessProps } from '../../../shared/types';
 import { FetchIndexApiLogic } from '../../api/index/fetch_index_api_logic';
 import { SEARCH_INDEX_PATH, SEARCH_INDEX_TAB_PATH } from '../../routes';
 import { isConnectorIndex, isCrawlerIndex } from '../../utils/indices';
@@ -50,7 +51,7 @@ export enum SearchIndexTabId {
   DOMAIN_MANAGEMENT = 'domain_management',
 }
 
-export const SearchIndex: React.FC = () => {
+export const SearchIndex: React.FC<AccessProps> = ({ access }) => {
   const { data: indexData, status: indexApiStatus } = useValues(FetchIndexApiLogic);
   const { isCalloutVisible } = useValues(IndexCreatedCalloutLogic);
   const { tabId = SearchIndexTabId.OVERVIEW } = useParams<{
@@ -138,6 +139,7 @@ export const SearchIndex: React.FC = () => {
   };
   return (
     <EnterpriseSearchContentPageTemplate
+      access={access}
       pageChrome={[...baseBreadcrumbs, indexName]}
       pageViewTelemetry={tabId}
       isLoading={

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -18,7 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { Status } from '../../../../../common/types/api';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../shared/kibana';
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { FetchIndexApiLogic } from '../../api/index/fetch_index_api_logic';
 import { SEARCH_INDEX_PATH, SEARCH_INDEX_TAB_PATH } from '../../routes';
 import { isConnectorIndex, isCrawlerIndex } from '../../utils/indices';
@@ -51,7 +51,7 @@ export enum SearchIndexTabId {
   DOMAIN_MANAGEMENT = 'domain_management',
 }
 
-export const SearchIndex: React.FC<AccessProps> = ({ access }) => {
+export const SearchIndex: React.FC<ProductAccessProps> = ({ access }) => {
   const { data: indexData, status: indexApiStatus } = useValues(FetchIndexApiLogic);
   const { isCalloutVisible } = useValues(IndexCreatedCalloutLogic);
   const { tabId = SearchIndexTabId.OVERVIEW } = useParams<{

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index_router.tsx
@@ -10,6 +10,7 @@ import { Route, Switch, useParams } from 'react-router-dom';
 
 import { useActions } from 'kea';
 
+import { AccessProps } from '../../../shared/types';
 import {
   SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH,
   SEARCH_INDEX_PATH,
@@ -22,7 +23,7 @@ import { IndexNameLogic } from './index_name_logic';
 import { IndexViewLogic } from './index_view_logic';
 import { SearchIndex } from './search_index';
 
-export const SearchIndexRouter: React.FC = () => {
+export const SearchIndexRouter: React.FC<AccessProps> = ({ access }) => {
   const { indexName } = useParams<{ indexName: string }>();
 
   const indexNameLogic = IndexNameLogic({ indexName });
@@ -46,13 +47,13 @@ export const SearchIndexRouter: React.FC = () => {
   return (
     <Switch>
       <Route path={SEARCH_INDEX_PATH} exact>
-        <SearchIndex />
+        <SearchIndex access={access} />
       </Route>
       <Route path={SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH} exact>
-        <CrawlerDomainDetail />
+        <CrawlerDomainDetail access={access} />
       </Route>
       <Route path={SEARCH_INDEX_TAB_PATH}>
-        <SearchIndex />
+        <SearchIndex access={access} />
       </Route>
     </Switch>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index_router.tsx
@@ -10,7 +10,7 @@ import { Route, Switch, useParams } from 'react-router-dom';
 
 import { useActions } from 'kea';
 
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import {
   SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH,
   SEARCH_INDEX_PATH,
@@ -23,7 +23,7 @@ import { IndexNameLogic } from './index_name_logic';
 import { IndexViewLogic } from './index_view_logic';
 import { SearchIndex } from './search_index';
 
-export const SearchIndexRouter: React.FC<AccessProps> = ({ access }) => {
+export const SearchIndexRouter: React.FC<ProductAccessProps> = ({ access }) => {
   const { indexName } = useParams<{ indexName: string }>();
 
   const indexNameLogic = IndexNameLogic({ indexName });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -30,7 +30,7 @@ import { ElasticsearchResources } from '../../../shared/elasticsearch_resources'
 import { GettingStartedSteps } from '../../../shared/getting_started_steps';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { handlePageChange } from '../../../shared/table_pagination';
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { useLocalStorage } from '../../../shared/use_local_storage';
 import { NEW_INDEX_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
@@ -49,7 +49,7 @@ export const baseBreadcrumbs = [
   }),
 ];
 
-export const SearchIndices: React.FC<AccessProps> = ({ access }) => {
+export const SearchIndices: React.FC<ProductAccessProps> = ({ access }) => {
   const { fetchIndices, onPaginate } = useActions(IndicesLogic);
   const { meta, indices, hasNoIndices, isLoading } = useValues(IndicesLogic);
   const [showHiddenIndices, setShowHiddenIndices] = useState(false);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -30,6 +30,7 @@ import { ElasticsearchResources } from '../../../shared/elasticsearch_resources'
 import { GettingStartedSteps } from '../../../shared/getting_started_steps';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { handlePageChange } from '../../../shared/table_pagination';
+import { AccessProps } from '../../../shared/types';
 import { useLocalStorage } from '../../../shared/use_local_storage';
 import { NEW_INDEX_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
@@ -48,7 +49,7 @@ export const baseBreadcrumbs = [
   }),
 ];
 
-export const SearchIndices: React.FC = () => {
+export const SearchIndices: React.FC<AccessProps> = ({ access }) => {
   const { fetchIndices, onPaginate } = useActions(IndicesLogic);
   const { meta, indices, hasNoIndices, isLoading } = useValues(IndicesLogic);
   const [showHiddenIndices, setShowHiddenIndices] = useState(false);
@@ -75,6 +76,7 @@ export const SearchIndices: React.FC = () => {
   return (
     <>
       <EnterpriseSearchContentPageTemplate
+        access={access}
         pageChrome={baseBreadcrumbs}
         pageViewTelemetry="Search indices"
         isLoading={isLoading}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices_router.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 
 import { SEARCH_INDICES_PATH, SEARCH_INDEX_PATH, NEW_INDEX_PATH } from '../../routes';
 
@@ -17,7 +17,7 @@ import { SearchIndexRouter } from '../search_index/search_index_router';
 
 import { SearchIndices } from './search_indices';
 
-export const SearchIndicesRouter: React.FC<AccessProps> = ({ access }) => {
+export const SearchIndicesRouter: React.FC<ProductAccessProps> = ({ access }) => {
   return (
     <Switch>
       <Route exact path={NEW_INDEX_PATH}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices_router.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { AccessProps } from '../../../shared/types';
+
 import { SEARCH_INDICES_PATH, SEARCH_INDEX_PATH, NEW_INDEX_PATH } from '../../routes';
 
 import { NewIndex } from '../new_index';
@@ -15,17 +17,17 @@ import { SearchIndexRouter } from '../search_index/search_index_router';
 
 import { SearchIndices } from './search_indices';
 
-export const SearchIndicesRouter: React.FC = () => {
+export const SearchIndicesRouter: React.FC<AccessProps> = ({ access }) => {
   return (
     <Switch>
       <Route exact path={NEW_INDEX_PATH}>
-        <NewIndex />
+        <NewIndex access={access} />
       </Route>
       <Route exact path={SEARCH_INDICES_PATH}>
-        <SearchIndices />
+        <SearchIndices access={access} />
       </Route>
       <Route path={SEARCH_INDEX_PATH}>
-        <SearchIndexRouter />
+        <SearchIndexRouter access={access} />
       </Route>
     </Switch>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 
 import { i18n } from '@kbn/i18n';
 
-import { AccessProps } from '../../../shared/types';
+import { ProductAccessProps } from '../../../shared/types';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 
-export const Settings: React.FC<AccessProps> = ({ access }) => {
+export const Settings: React.FC<ProductAccessProps> = ({ access }) => {
   return (
     <EnterpriseSearchContentPageTemplate
       access={access}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
@@ -9,11 +9,13 @@ import React from 'react';
 
 import { i18n } from '@kbn/i18n';
 
+import { AccessProps } from '../../../shared/types';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 
-export const Settings: React.FC = () => {
+export const Settings: React.FC<AccessProps> = ({ access }) => {
   return (
     <EnterpriseSearchContentPageTemplate
+      access={access}
       pageChrome={[
         i18n.translate('xpack.enterpriseSearch.content.searchIndices.content.breadcrumb', {
           defaultMessage: 'Content',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -13,6 +13,7 @@ import { useValues } from 'kea';
 import { isVersionMismatch } from '../../../common/is_version_mismatch';
 import { InitialAppData } from '../../../common/types';
 import { SetupGuide } from '../enterprise_search_overview/components/setup_guide';
+import { NO_ACCESS } from '../shared/constants';
 import { HttpLogic } from '../shared/http';
 import { KibanaLogic } from '../shared/kibana';
 import { VersionMismatchPage } from '../shared/version_mismatch';
@@ -64,18 +65,20 @@ export const EnterpriseSearchContentUnconfigured: React.FC = () => (
   </Switch>
 );
 
-export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData>> = () => {
+export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData>> = ({
+  access,
+}) => {
   return (
     <Switch>
       <Redirect exact from={ROOT_PATH} to={SEARCH_INDICES_PATH} />
       <Route path={SEARCH_INDICES_PATH}>
-        <SearchIndicesRouter />
+        <SearchIndicesRouter access={access || NO_ACCESS} />
       </Route>
       <Route path={SETTINGS_PATH}>
-        <Settings />
+        <Settings access={access || NO_ACCESS} />
       </Route>
       <Route>
-        <NotFound />
+        <NotFound access={access || NO_ACCESS} />
       </Route>
     </Switch>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/layout/page_template.tsx
@@ -14,6 +14,7 @@ import { useEnterpriseSearchNav } from '../../../shared/layout';
 import { SendEnterpriseSearchTelemetry } from '../../../shared/telemetry';
 
 export const EnterpriseSearchOverviewPageTemplate: React.FC<PageTemplateProps> = ({
+  access,
   children,
   pageChrome,
   pageViewTelemetry,
@@ -24,7 +25,7 @@ export const EnterpriseSearchOverviewPageTemplate: React.FC<PageTemplateProps> =
       {...pageTemplateProps}
       solutionNav={{
         name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
-        items: useEnterpriseSearchNav(),
+        items: useEnterpriseSearchNav(access),
       }}
       setPageChrome={pageChrome && <SetEnterpriseSearchChrome trail={pageChrome} />}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
@@ -27,6 +27,8 @@ import {
   ELASTICSEARCH_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
 } from '../../../../../common/constants';
+import { ProductAccess } from '../../../../../common/types';
+
 import { AddContentEmptyPrompt } from '../../../shared/add_content_empty_prompt';
 import { docLinks } from '../../../shared/doc_links';
 import { KibanaLogic } from '../../../shared/kibana';
@@ -41,10 +43,7 @@ import { TrialCallout } from '../trial_callout';
 import illustration from './lock_light.svg';
 
 interface ProductSelectorProps {
-  access: {
-    hasAppSearchAccess?: boolean;
-    hasWorkplaceSearchAccess?: boolean;
-  };
+  access: ProductAccess;
   isWorkplaceSearchAdmin: boolean;
 }
 
@@ -354,6 +353,7 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({
   );
   return (
     <EnterpriseSearchOverviewPageTemplate
+      access={access}
       restrictWidth
       pageHeader={{
         pageTitle: i18n.translate('xpack.enterpriseSearch.overview.pageTitle', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/index.tsx
@@ -12,6 +12,7 @@ import { useValues } from 'kea';
 
 import { isVersionMismatch } from '../../../common/is_version_mismatch';
 import { InitialAppData } from '../../../common/types';
+import { NO_ACCESS } from '../shared/constants';
 import { HttpLogic } from '../shared/http';
 import { KibanaLogic } from '../shared/kibana';
 import { VersionMismatchPage } from '../shared/version_mismatch';
@@ -22,7 +23,7 @@ import { SetupGuide } from './components/setup_guide';
 import { ROOT_PATH, SETUP_GUIDE_PATH } from './routes';
 
 export const EnterpriseSearchOverview: React.FC<InitialAppData> = ({
-  access = {},
+  access,
   workplaceSearch,
   enterpriseSearchVersion,
   kibanaVersion,
@@ -48,7 +49,12 @@ export const EnterpriseSearchOverview: React.FC<InitialAppData> = ({
       return <ErrorConnecting />;
     }
 
-    return <ProductSelector isWorkplaceSearchAdmin={isWorkplaceSearchAdmin} access={access} />;
+    return (
+      <ProductSelector
+        access={access || NO_ACCESS}
+        isWorkplaceSearchAdmin={isWorkplaceSearchAdmin}
+      />
+    );
   };
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/access.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/access.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-export * from './access';
-export * from './actions';
-export * from './labels';
-export * from './tables';
-export * from './units';
-export { DEFAULT_META } from './default_meta';
+export const NO_ACCESS = {
+  hasAppSearchAccess: false,
+  hasWorkplaceSearchAccess: false,
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -15,11 +15,12 @@ import {
   ENTERPRISE_SEARCH_OVERVIEW_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
 } from '../../../../common/constants';
+import { ProductAccess } from '../../../../common/types';
 import { SEARCH_INDICES_PATH } from '../../enterprise_search_content/routes';
 
 import { generateNavLink } from './nav_link_helpers';
 
-export const useEnterpriseSearchNav = () => {
+export const useEnterpriseSearchNav = (access?: ProductAccess) => {
   const navItems: Array<EuiSideNavItemType<unknown>> = [
     {
       id: 'es_overview',
@@ -63,26 +64,34 @@ export const useEnterpriseSearchNav = () => {
             to: ELASTICSEARCH_PLUGIN.URL,
           }),
         },
-        {
-          id: 'app_search',
-          name: i18n.translate('xpack.enterpriseSearch.nav.appSearchTitle', {
-            defaultMessage: 'App Search',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            to: APP_SEARCH_PLUGIN.URL,
-          }),
-        },
-        {
-          id: 'workplace_search',
-          name: i18n.translate('xpack.enterpriseSearch.nav.workplaceSearchTitle', {
-            defaultMessage: 'Workplace Search',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            to: WORKPLACE_SEARCH_PLUGIN.URL,
-          }),
-        },
+        ...(access?.hasAppSearchAccess
+          ? [
+              {
+                id: 'app_search',
+                name: i18n.translate('xpack.enterpriseSearch.nav.appSearchTitle', {
+                  defaultMessage: 'App Search',
+                }),
+                ...generateNavLink({
+                  shouldNotCreateHref: true,
+                  to: APP_SEARCH_PLUGIN.URL,
+                }),
+              },
+            ]
+          : []),
+        ...(access?.hasWorkplaceSearchAccess
+          ? [
+              {
+                id: 'workplace_search',
+                name: i18n.translate('xpack.enterpriseSearch.nav.workplaceSearchTitle', {
+                  defaultMessage: 'Workplace Search',
+                }),
+                ...generateNavLink({
+                  shouldNotCreateHref: true,
+                  to: WORKPLACE_SEARCH_PLUGIN.URL,
+                }),
+              },
+            ]
+          : []),
       ],
       name: i18n.translate('xpack.enterpriseSearch.nav.searchExperiencesTitle', {
         defaultMessage: 'Search',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -15,6 +15,8 @@ import { i18n } from '@kbn/i18n';
 
 import { KibanaPageTemplate, KibanaPageTemplateProps } from '@kbn/kibana-react-plugin/public';
 
+import { ProductAccess } from '../../../../common/types';
+
 import { FlashMessages } from '../flash_messages';
 import { HttpLogic } from '../http';
 import { BreadcrumbTrail } from '../kibana_chrome/generate_breadcrumbs';
@@ -34,6 +36,7 @@ import './page_template.scss';
  */
 
 export type PageTemplateProps = KibanaPageTemplateProps & {
+  access?: ProductAccess;
   hideFlashMessages?: boolean;
   isLoading?: boolean;
   emptyState?: React.ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../common/constants';
+import { ProductAccess } from '../../../common/types';
 
 import { ADD, UPDATE } from './constants/operations';
 
@@ -56,4 +57,8 @@ export interface SingleUserRoleMapping<T> {
   elasticsearchUser: ElasticsearchUser;
   roleMapping: T;
   hasEnterpriseSearchRole?: boolean;
+}
+
+export interface AccessProps {
+  access: ProductAccess;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -59,6 +59,6 @@ export interface SingleUserRoleMapping<T> {
   hasEnterpriseSearchRole?: boolean;
 }
 
-export interface AccessProps {
+export interface ProductAccessProps {
   access: ProductAccess;
 }

--- a/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
@@ -47,7 +47,7 @@ export function elasticsearchErrorHandler<ContextType, RequestType, ResponseType
         log.error(
           i18n.translate('xpack.enterpriseSearch.server.routes.errorLogMessage', {
             defaultMessage:
-              'An error occured while resolving request to {requestUrl}: {errorMessage}',
+              'An error occurred while resolving request to {requestUrl}: {errorMessage}',
             values: {
               errorMessage: enterpriseSearchError.message,
               requestUrl: request.url.toString(),


### PR DESCRIPTION
## Summary

Pass the product access data to the components that render an Enterprise Search-specific navigation menu so they can hide products that the user does not have access to.

Closes https://github.com/elastic/enterprise-search-team/issues/2433.

### Screenshots
Without access to Workplace Search:
<img width="1840" alt="Screen Shot 2022-08-11 at 4 50 12 PM" src="https://user-images.githubusercontent.com/5863039/184260897-87099d4b-9537-4f34-994c-bd217b1cc444.png">

The Content/Indices page is still broken. Not sure how to fix that right at this moment. Might be due to the other error on the page. Would be happy to pair on it with someone (@efegurkan maybe we could use your expertise).
<img width="1840" alt="Screen Shot 2022-08-11 at 4 50 20 PM" src="https://user-images.githubusercontent.com/5863039/184260907-d8d5f929-3f29-4310-a613-c57c91defca0.png">


### Checklist

N/A