### PR TITLE
[Stack Monitoring] support logstash datastream in standalone query

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/standalone_clusters/has_standalone_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/standalone_clusters/has_standalone_clusters.ts
@@ -47,7 +47,7 @@ export async function hasStandaloneClusters(req: LegacyRequest, ccs: string) {
           },
           {
             terms: {
-              'data_stream.dataset': ['node', 'node_stats', 'stats', 'state'],
+              'data_stream.dataset': ['logstash.node', 'logstash.node_stats'],
             },
           },
         ],


### PR DESCRIPTION
## Summary
We were looking for the wrong datasets. We don't need to look for the beats one since there is no integration