### PR TITLE
[build] Update copyAll implementation

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -131,13 +131,6 @@ export async function runDockerGenerator(
     dockerBuildDir
   );
 
-  if (flags.ironbank) {
-    await copyAll(
-      config.resolveFromRepo('src/dev/build/tasks/os_packages/docker_generator/resources/ironbank'),
-      dockerBuildDir
-    );
-  }
-
   // Build docker image into the target folder
   // In order to do this we just call the file we
   // created from the templates/build_docker_sh.template.js


### PR DESCRIPTION
vinyl-fs is not updated frequently and there are more performant options now.  This implementation reduces the copy source files task from ~50s to <10s.

Before: https://buildkite.com/elastic/kibana-on-merge/builds/19797#01828f2a-a628-425f-949d-b680c1f8bca1/198-224
After: https://buildkite.com/elastic/kibana-pull-request/builds/64706#01828fc1-ecd8-4881-9db9-9ae27fd5fa3d/207-233