### PR TITLE
[Graph] Fix how the field picker popover can be closed

### DIFF
--- a/x-pack/plugins/graph/public/components/field_manager/field_picker.tsx
+++ b/x-pack/plugins/graph/public/components/field_manager/field_picker.tsx
@@ -63,7 +63,7 @@ export function FieldPicker({
           aria-disabled={!hasFields}
           onClick={() => {
             if (hasFields) {
-              setOpen(true);
+              setOpen(!open);
             }
           }}
           onClickAriaLabel={badgeDescription}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/138504

## Summary

This PR makes the field picker popover close when user toggles "Add fields" button on Graph page.


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->