### PR TITLE
[ML] Transform: Fix `percentiles` and `terms` sub-aggs

### DIFF
--- a/x-pack/plugins/transform/common/types/pivot_aggs.ts
+++ b/x-pack/plugins/transform/common/types/pivot_aggs.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AggName } from './aggregations';
-import { EsFieldName } from './fields';
 
 export const PIVOT_SUPPORTED_AGGS = {
   AVG: 'avg',
@@ -23,11 +23,7 @@ export const PIVOT_SUPPORTED_AGGS = {
 
 export type PivotSupportedAggs = typeof PIVOT_SUPPORTED_AGGS[keyof typeof PIVOT_SUPPORTED_AGGS];
 
-export type PivotAgg = {
-  [key in PivotSupportedAggs]?: {
-    field: EsFieldName;
-  };
-};
+export type PivotAgg = estypes.AggregationsAggregationContainer;
 
 export type PivotAggDict = {
   [key in AggName]: PivotAgg;

--- a/x-pack/plugins/transform/public/app/common/index.ts
+++ b/x-pack/plugins/transform/public/app/common/index.ts
@@ -37,7 +37,7 @@ export type {
 } from './pivot_aggs';
 export {
   getEsAggFromAggConfig,
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   isPivotAggsConfigPercentiles,
   isPivotAggsConfigTerms,
   PERCENTILES_AGG_DEFAULT_PERCENTS,

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
@@ -93,6 +93,9 @@ describe('getAggConfigFromEsAgg', () => {
       dropDownName: 'products.base_price.percentiles',
       field: 'products.base_price',
       parentAgg: result,
+      aggConfig: {
+        percents: '1,5,25,50,75,95,99',
+      },
     });
   });
 

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
@@ -68,7 +68,7 @@ describe('getAggConfigFromEsAgg', () => {
     });
   });
 
-  test('should resolve percentiles agg in sub-aggregations', () => {
+  test('should resolve percentiles and terms agg in sub-aggregations', () => {
     const esConfig = {
       filter: {
         exists: {
@@ -80,6 +80,12 @@ describe('getAggConfigFromEsAgg', () => {
           percentiles: {
             field: 'products.base_price',
             percents: [1, 5, 25, 50, 75, 95, 99],
+          },
+        },
+        check_terms: {
+          terms: {
+            field: 'products.base_price',
+            size: 3,
           },
         },
       },
@@ -95,6 +101,17 @@ describe('getAggConfigFromEsAgg', () => {
       parentAgg: result,
       aggConfig: {
         percents: '1,5,25,50,75,95,99',
+      },
+    });
+
+    expect(result.subAggs!.check_terms).toMatchObject({
+      agg: 'terms',
+      aggName: 'check_terms',
+      dropDownName: 'check_terms',
+      field: 'products.base_price',
+      parentAgg: result,
+      aggConfig: {
+        size: 3,
       },
     });
   });

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
@@ -10,13 +10,11 @@ import { FC } from 'react';
 import { ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/data-plugin/common';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-
 import type { AggName } from '../../../common/types/aggregations';
 import type { Dictionary } from '../../../common/types/common';
 import type { EsFieldName } from '../../../common/types/fields';
 import type { PivotSupportedAggs } from '../../../common/types/pivot_aggs';
-import { PIVOT_SUPPORTED_AGGS } from '../../../common/types/pivot_aggs';
+import { PIVOT_SUPPORTED_AGGS, PivotAgg } from '../../../common/types/pivot_aggs';
 
 import { getAggFormConfig } from '../sections/create_transform/components/step_define/common/get_agg_form_config';
 import { PivotAggsConfigFilter } from '../sections/create_transform/components/step_define/common/filter_agg/types';
@@ -117,7 +115,7 @@ export const TOP_METRICS_SPECIAL_SORT_FIELDS = {
   _SCORE: '_score',
 } as const;
 
-export const isSpecialSortField = (sortField: unknown) => {
+export const isSpecialSortField = (sortField: unknown): sortField is string => {
   return Object.values(TOP_METRICS_SPECIAL_SORT_FIELDS).some((v) => v === sortField);
 };
 
@@ -290,7 +288,7 @@ export type PivotAggsConfigDict = Dictionary<PivotAggsConfig>;
  */
 export function getEsAggFromAggConfig(
   pivotAggsConfig: PivotAggsConfigBase | PivotAggsConfigWithExtendedForm
-): estypes.TransformPivot | null {
+): PivotAgg | null {
   let esAgg: { [key: string]: any } = { ...pivotAggsConfig };
 
   delete esAgg.agg;
@@ -299,7 +297,7 @@ export function getEsAggFromAggConfig(
   delete esAgg.parentAgg;
 
   if (isPivotAggsWithExtendedForm(pivotAggsConfig)) {
-    esAgg = pivotAggsConfig.getEsAggConfig();
+    esAgg = pivotAggsConfig.getEsAggConfig() as PivotAgg;
 
     if (esAgg === null) {
       return null;
@@ -308,7 +306,7 @@ export function getEsAggFromAggConfig(
 
   const result = {
     [pivotAggsConfig.agg]: esAgg,
-  } as estypes.TransformPivot;
+  } as PivotAgg;
 
   if (
     isPivotAggsConfigWithUiSupport(pivotAggsConfig) &&
@@ -317,9 +315,7 @@ export function getEsAggFromAggConfig(
   ) {
     result.aggs = {};
     for (const subAggConfig of Object.values(pivotAggsConfig.subAggs)) {
-      result.aggs[subAggConfig.aggName] = getEsAggFromAggConfig(
-        subAggConfig
-      ) as estypes.TransformPivot;
+      result.aggs[subAggConfig.aggName] = getEsAggFromAggConfig(subAggConfig) as PivotAgg;
     }
   }
 

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
@@ -244,7 +244,7 @@ export type PivotAggsConfigWithUiSupport =
   | PivotAggsConfigTerms
   | PivotAggsConfigWithExtendedForm;
 
-export function isPivotAggsConfigWithUiSupport(arg: unknown): arg is PivotAggsConfigWithUiBase {
+export function isPivotAggsConfigWithUiBase(arg: unknown): arg is PivotAggsConfigWithUiBase {
   return (
     isPopulatedObject(arg, ['agg', 'aggName', 'dropDownName', 'field']) &&
     isPivotSupportedAggs(arg.agg)
@@ -309,7 +309,7 @@ export function getEsAggFromAggConfig(
   } as PivotAgg;
 
   if (
-    isPivotAggsConfigWithUiSupport(pivotAggsConfig) &&
+    isPivotAggsConfigWithUiBase(pivotAggsConfig) &&
     pivotAggsConfig.subAggs !== undefined &&
     Object.keys(pivotAggsConfig.subAggs).length > 0
   ) {

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.ts
@@ -212,7 +212,7 @@ export interface PivotAggsConfigWithExtra<T, ESConfig extends { [key: string]: a
     aggConfig: Partial<T>;
     onChange: (arg: Partial<T>) => void;
     selectedField: string;
-    isValid: boolean;
+    isValid?: boolean;
   }>;
   /** Aggregation specific configuration */
   aggConfig: Partial<T>;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
@@ -14,7 +14,7 @@ import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiTextColor } fr
 import { AggName } from '../../../../../../common/types/aggregations';
 
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PivotAggsConfig,
   PivotAggsConfigWithUiSupportDict,
 } from '../../../../common';
@@ -50,7 +50,7 @@ export const AggLabelForm: React.FC<Props> = ({
   const helperText = isPivotAggsWithExtendedForm(item) && item.helperText && item.helperText();
 
   const isSubAggSupported =
-    isPivotAggsConfigWithUiSupport(item) &&
+    isPivotAggsConfigWithUiBase(item) &&
     item.isSubAggsSupported &&
     (isPivotAggsWithExtendedForm(item) ? item.isValid() : true);
 

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -28,7 +28,7 @@ import { PivotSupportedAggs } from '../../../../../../common/types/pivot_aggs';
 
 import {
   isAggName,
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   getEsAggFromAggConfig,
   PivotAggsConfig,
   PivotAggsConfigWithUiSupportDict,
@@ -49,10 +49,10 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
   const [aggName, setAggName] = useState(defaultData.aggName);
   const [agg, setAgg] = useState(defaultData.agg);
   const [field, setField] = useState<string | string[] | null>(
-    isPivotAggsConfigWithUiSupport(defaultData) ? defaultData.field : ''
+    isPivotAggsConfigWithUiBase(defaultData) ? defaultData.field : ''
   );
 
-  const isUnsupportedAgg = !isPivotAggsConfigWithUiSupport(defaultData);
+  const isUnsupportedAgg = !isPivotAggsConfigWithUiBase(defaultData);
 
   // Update configuration based on the aggregation type
   useEffect(() => {
@@ -88,7 +88,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
   function getUpdatedItem(): PivotAggsConfig {
     let resultField = field;
     if (
-      isPivotAggsConfigWithUiSupport(aggConfigDef) &&
+      isPivotAggsConfigWithUiBase(aggConfigDef) &&
       !aggConfigDef.isMultiField &&
       Array.isArray(field)
     ) {
@@ -119,7 +119,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
     optionsArr
       .filter(
         (o) =>
-          isPivotAggsConfigWithUiSupport(defaultData) &&
+          isPivotAggsConfigWithUiBase(defaultData) &&
           (Array.isArray(defaultData.field)
             ? defaultData.field.includes(o.field as string)
             : o.field === defaultData.field)

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
@@ -9,6 +9,7 @@ import { getPivotDropdownOptions } from '.';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { FilterAggForm } from './filter_agg/components';
 import type { RuntimeField } from '@kbn/data-views-plugin/common';
+import { PercentilesAggForm } from './percentiles_agg/percentiles_form_component';
 
 describe('Transform: Define Pivot Common', () => {
   test('getPivotDropdownOptions()', () => {
@@ -78,7 +79,8 @@ describe('Transform: Define Pivot Common', () => {
           field: ' the-f[i]e>ld ',
           aggName: 'the-field.percentiles',
           dropDownName: 'percentiles( the-f[i]e>ld )',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'filter( the-f[i]e>ld )': {
           agg: 'filter',
@@ -182,7 +184,8 @@ describe('Transform: Define Pivot Common', () => {
           aggName: 'the-field.percentiles',
           dropDownName: 'percentiles( the-f[i]e>ld )',
           field: ' the-f[i]e>ld ',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'sum( the-f[i]e>ld )': {
           agg: 'sum',
@@ -233,7 +236,8 @@ describe('Transform: Define Pivot Common', () => {
           aggName: 'rt_bytes_bigger.percentiles',
           dropDownName: 'percentiles(rt_bytes_bigger)',
           field: 'rt_bytes_bigger',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'sum(rt_bytes_bigger)': {
           agg: 'sum',

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
@@ -50,6 +50,7 @@ export function getFilterAggConfig(
     },
     setUiConfigFromEs(esAggDefinition) {
       const filterAgg = Object.keys(esAggDefinition)[0] as FilterAggType;
+      // @ts-ignore conflicts with a union type
       const filterAggConfig = esAggDefinition[filterAgg];
 
       const aggTypeConfig = getFilterAggTypeConfig(filterAgg, field as string, filterAggConfig);

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
@@ -7,7 +7,7 @@
 
 import { jsonStringValidator } from '../../../../../../common/validators';
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PivotAggsConfigBase,
   PivotAggsConfigWithUiBase,
 } from '../../../../../../common/pivot_aggs';
@@ -29,7 +29,7 @@ import {
 export function getFilterAggConfig(
   commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
 ): PivotAggsConfigFilter {
-  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
 
   return {
     ...commonConfig,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
@@ -40,11 +40,11 @@ interface FilterAggTypeConfig<U, R> {
 }
 
 /** Filter agg type definition */
-interface FilterAggProps<K extends FilterAggType, U, R = { [key: string]: any }> {
+interface FilterAggProps<K extends FilterAggType, U, ESConfig extends { [key: string]: any }> {
   /** Filter aggregation type */
   filterAgg: K;
   /** Definition of the filter agg config */
-  aggTypeConfig: FilterAggTypeConfig<U, R>;
+  aggTypeConfig: FilterAggTypeConfig<U, ESConfig>;
 }
 
 /** Filter term agg */
@@ -62,10 +62,14 @@ export type FilterAggConfigRange = FilterAggProps<
 /** Filter exists agg */
 export type FilterAggConfigExists = FilterAggProps<'exists', undefined, { field: string }>;
 /** Filter bool agg */
-export type FilterAggConfigBool = FilterAggProps<'bool', string>;
+export type FilterAggConfigBool = FilterAggProps<
+  'bool',
+  string,
+  { must?: object[]; must_not?: object[]; should?: object[] }
+>;
 
 /** General type for filter agg */
-export type FilterAggConfigEditor = FilterAggProps<FilterAggType, string>;
+export type FilterAggConfigEditor = FilterAggProps<FilterAggType, string, Record<string, unknown>>;
 
 export type FilterAggConfigUnion =
   | FilterAggConfigTerm
@@ -78,7 +82,7 @@ export type FilterAggConfigUnion =
  * TODO find out if it's possible to use {@link FilterAggConfigUnion} instead of {@link FilterAggConfigBase}.
  * ATM TS is not able to infer a type.
  */
-export type PivotAggsConfigFilter = PivotAggsConfigWithExtra<FilterAggConfigBase>;
+export type PivotAggsConfigFilter = PivotAggsConfigWithExtra<FilterAggConfigBase, {}>;
 
 export interface FilterAggConfigBase {
   filterAgg?: FilterAggType;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { getPercentilesAggConfig } from './percentiles_agg';
 import {
   PivotSupportedAggs,
   PIVOT_SUPPORTED_AGGS,
@@ -26,6 +27,8 @@ export function getAggFormConfig(
       return getFilterAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.TOP_METRICS:
       return getTopMetricsAggConfig(commonConfig);
+    case PIVOT_SUPPORTED_AGGS.PERCENTILES:
+      return getPercentilesAggConfig(commonConfig);
     default:
       return commonConfig;
   }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { getTermsAggConfig } from './terms_agg';
 import { getPercentilesAggConfig } from './percentiles_agg';
 import {
   PivotSupportedAggs,
@@ -29,6 +30,8 @@ export function getAggFormConfig(
       return getTopMetricsAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.PERCENTILES:
       return getPercentilesAggConfig(commonConfig);
+    case PIVOT_SUPPORTED_AGGS.TERMS:
+      return getTermsAggConfig(commonConfig);
     default:
       return commonConfig;
   }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
@@ -13,7 +13,7 @@ import {
 
 import { PivotAggsConfigBase, PivotAggsConfigWithUiBase } from '../../../../../common/pivot_aggs';
 import { getFilterAggConfig } from './filter_agg/config';
-import { getTopMetricsAggConfig } from './top_metrics_agg/config';
+import { getTopMetricsAggConfig } from './top_metrics_agg';
 
 /**
  * Gets form configuration for provided aggregation type.

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { getTermsAggConfig } from './terms_agg';
 import { EsFieldName } from '../../../../../../../common/types/fields';
 import {
   PivotSupportedAggs,
@@ -42,6 +43,8 @@ export function getDefaultAggregationConfig(
         // top_metrics agg has different naming convention by default
         aggName: PIVOT_SUPPORTED_AGGS.TOP_METRICS,
       });
+    case PIVOT_SUPPORTED_AGGS.TERMS:
+      return getTermsAggConfig(commonConfig);
     default:
       return commonConfig;
   }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
@@ -10,11 +10,9 @@ import {
   PivotSupportedAggs,
   PIVOT_SUPPORTED_AGGS,
 } from '../../../../../../../common/types/pivot_aggs';
-import {
-  PERCENTILES_AGG_DEFAULT_PERCENTS,
-  PivotAggsConfigWithUiSupport,
-} from '../../../../../common';
+import { PivotAggsConfigWithUiSupport } from '../../../../../common';
 import { getFilterAggConfig } from './filter_agg/config';
+import { getPercentilesAggConfig } from './percentiles_agg';
 import { getTopMetricsAggConfig } from './top_metrics_agg/config';
 
 /**
@@ -35,11 +33,7 @@ export function getDefaultAggregationConfig(
 
   switch (agg) {
     case PIVOT_SUPPORTED_AGGS.PERCENTILES:
-      return {
-        ...commonConfig,
-        agg,
-        percents: PERCENTILES_AGG_DEFAULT_PERCENTS,
-      };
+      return getPercentilesAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.FILTER:
       return getFilterAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.TOP_METRICS:

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
@@ -13,7 +13,7 @@ import {
 import { PivotAggsConfigWithUiSupport } from '../../../../../common';
 import { getFilterAggConfig } from './filter_agg/config';
 import { getPercentilesAggConfig } from './percentiles_agg';
-import { getTopMetricsAggConfig } from './top_metrics_agg/config';
+import { getTopMetricsAggConfig } from './top_metrics_agg';
 
 /**
  * Provides a configuration based on the aggregation type.

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
@@ -8,7 +8,7 @@
 import { PercentilesAggForm } from './percentiles_form_component';
 import { IPivotAggsConfigPercentiles } from './types';
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PERCENTILES_AGG_DEFAULT_PERCENTS,
   PivotAggsConfigBase,
 } from '../../../../../../common';
@@ -47,7 +47,7 @@ function isValidPercentsInput(inputValue: string) {
 export function getPercentilesAggConfig(
   commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
 ): IPivotAggsConfigPercentiles {
-  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
 
   return {
     ...commonConfig,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PercentilesAggForm } from './percentiles_form_component';
+import { IPivotAggsConfigPercentiles } from './types';
+import {
+  isPivotAggsConfigWithUiSupport,
+  PERCENTILES_AGG_DEFAULT_PERCENTS,
+  PivotAggsConfigBase,
+} from '../../../../../../common';
+import { PivotAggsConfigWithUiBase } from '../../../../../../common/pivot_aggs';
+
+/**
+ * TODO this callback has been moved.
+ * The logic of parsing the string should be improved.
+ */
+function parsePercentsInput(inputValue: string | undefined) {
+  if (inputValue !== undefined) {
+    const strVals: string[] = inputValue.split(',');
+    const percents: number[] = [];
+    for (const str of strVals) {
+      if (str.trim().length > 0 && isNaN(str as any) === false) {
+        const val = Number(str);
+        if (val >= 0 && val <= 100) {
+          percents.push(val);
+        } else {
+          return [];
+        }
+      }
+    }
+
+    return percents;
+  }
+
+  return [];
+}
+
+// Input string should only include comma separated numbers
+function isValidPercentsInput(inputValue: string) {
+  return /^[0-9]+(,[0-9]+)*$/.test(inputValue);
+}
+
+export function getPercentilesAggConfig(
+  commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
+): IPivotAggsConfigPercentiles {
+  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+
+  return {
+    ...commonConfig,
+    isSubAggsSupported: false,
+    isMultiField: false,
+    AggFormComponent: PercentilesAggForm,
+    field,
+    aggConfig: {
+      percents: PERCENTILES_AGG_DEFAULT_PERCENTS.toString(),
+    },
+    setUiConfigFromEs(esAggDefinition) {
+      const { field: esField, percents } = esAggDefinition;
+
+      this.field = esField;
+      this.aggConfig.percents = percents.join(',');
+    },
+    getEsAggConfig() {
+      if (!this.isValid()) {
+        return null;
+      }
+
+      return {
+        field: this.field as string,
+        percents: parsePercentsInput(this.aggConfig.percents),
+      };
+    },
+    isValid() {
+      return (
+        typeof this.aggConfig.percents === 'string' && isValidPercentsInput(this.aggConfig.percents)
+      );
+    },
+  };
+}

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getPercentilesAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/percentiles_form_component.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/percentiles_form_component.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { IPivotAggsConfigPercentiles } from './types';
+
+export const PercentilesAggForm: IPivotAggsConfigPercentiles['AggFormComponent'] = ({
+  aggConfig,
+  onChange,
+  isValid,
+}) => {
+  return (
+    <>
+      <EuiFormRow
+        label={i18n.translate('xpack.transform.agg.popoverForm.percentsLabel', {
+          defaultMessage: 'Percents',
+        })}
+        error={
+          !isValid && [
+            i18n.translate('xpack.transform.groupBy.popoverForm.intervalPercents', {
+              defaultMessage: 'Enter a comma-separated list of percentiles',
+            }),
+          ]
+        }
+        isInvalid={!isValid}
+      >
+        <EuiFieldText
+          value={aggConfig.percents}
+          onChange={(e) => {
+            onChange({
+              percents: e.target.value,
+            });
+          }}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PivotAggsConfigWithExtra } from '../../../../../../common/pivot_aggs';
+
+export interface PercentilesAggConfig {
+  /** Comma separated list */
+  percents: string;
+}
+export type IPivotAggsConfigPercentiles = PivotAggsConfigWithExtra<
+  PercentilesAggConfig,
+  { field: string; percents: number[] }
+>;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TermsAggForm } from './terms_form_component';
+import {
+  isPivotAggsConfigWithUiSupport,
+  PivotAggsConfigBase,
+  PivotAggsConfigWithUiBase,
+  TERMS_AGG_DEFAULT_SIZE,
+} from '../../../../../../common/pivot_aggs';
+import { IPivotAggsConfigTerms } from './types';
+
+export function getTermsAggConfig(
+  commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
+): IPivotAggsConfigTerms {
+  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+
+  return {
+    ...commonConfig,
+    isSubAggsSupported: false,
+    isMultiField: false,
+    AggFormComponent: TermsAggForm,
+    field,
+    aggConfig: {
+      size: TERMS_AGG_DEFAULT_SIZE,
+    },
+    setUiConfigFromEs(esAggDefinition) {
+      const { field: esField, size } = esAggDefinition;
+
+      this.field = esField;
+      this.aggConfig.size = size;
+    },
+    getEsAggConfig() {
+      if (!this.isValid()) {
+        return null;
+      }
+
+      return {
+        field: this.field as string,
+        size: this.aggConfig.size as number,
+      };
+    },
+    isValid() {
+      return typeof this.aggConfig.size === 'number' && this.aggConfig.size > 0;
+    },
+  };
+}

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
@@ -7,7 +7,7 @@
 
 import { TermsAggForm } from './terms_form_component';
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PivotAggsConfigBase,
   PivotAggsConfigWithUiBase,
   TERMS_AGG_DEFAULT_SIZE,
@@ -17,7 +17,7 @@ import { IPivotAggsConfigTerms } from './types';
 export function getTermsAggConfig(
   commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
 ): IPivotAggsConfigTerms {
-  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
 
   return {
     ...commonConfig,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getTermsAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/terms_form_component.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/terms_form_component.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFieldNumber, EuiFormRow } from '@elastic/eui';
+import { IPivotAggsConfigTerms } from './types';
+
+export const TermsAggForm: IPivotAggsConfigTerms['AggFormComponent'] = ({
+  aggConfig,
+  onChange,
+  isValid,
+}) => {
+  return (
+    <>
+      <EuiFormRow
+        label={i18n.translate('xpack.transform.agg.popoverForm.sizeLabel', {
+          defaultMessage: 'Size',
+        })}
+        error={
+          !isValid && [
+            i18n.translate('xpack.transform.groupBy.popoverForm.invalidSizeErrorMessage', {
+              defaultMessage: 'Enter a valid positive number',
+            }),
+          ]
+        }
+        isInvalid={!isValid}
+      >
+        <EuiFieldNumber
+          value={aggConfig.size}
+          onChange={(e) => {
+            onChange({ size: Number(e.target.value) });
+          }}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PivotAggsConfigWithExtra } from '../../../../../../common/pivot_aggs';
+
+export interface TermsAggConfig {
+  size: number;
+}
+export type IPivotAggsConfigTerms = PivotAggsConfigWithExtra<
+  TermsAggConfig,
+  { field: string; size: number }
+>;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/config.ts
@@ -106,13 +106,13 @@ export function getTopMetricsAggConfig(
         this.aggConfig.sortSettings = rest;
 
         if (isValidSortDirection(order)) {
-          this.aggConfig.sortSettings!.order = order;
+          this.aggConfig.sortSettings.order = order;
         }
         if (isValidSortMode(mode)) {
-          this.aggConfig.sortSettings!.mode = mode;
+          this.aggConfig.sortSettings.mode = mode;
         }
         if (isValidSortNumericType(numType)) {
-          this.aggConfig.sortSettings!.numericType = numType;
+          this.aggConfig.sortSettings.numericType = numType;
         }
       }
 

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/config.ts
@@ -9,7 +9,7 @@ import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   isSpecialSortField,
   isValidSortDirection,
   isValidSortMode,
@@ -30,7 +30,7 @@ export function getTopMetricsAggConfig(
     ...commonConfig,
     isSubAggsSupported: false,
     isMultiField: true,
-    field: isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : '',
+    field: isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : '',
     AggFormComponent: TopMetricsAggForm,
     aggConfig: {},
     getEsAggConfig() {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getTopMetricsAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   PivotAggsConfigWithExtra,
   SortDirection,
@@ -18,7 +19,15 @@ export interface TopMetricsAggConfig {
     order?: SortDirection;
     mode?: SortMode;
     numericType?: SortNumericFieldType;
+    [unsupported: string]: unknown;
   };
 }
 
-export type PivotAggsConfigTopMetrics = PivotAggsConfigWithExtra<TopMetricsAggConfig>;
+export type PivotAggsConfigTopMetrics = PivotAggsConfigWithExtra<
+  TopMetricsAggConfig,
+  {
+    metrics?: estypes.AggregationsTopMetricsValue | estypes.AggregationsTopMetricsValue[];
+    size?: estypes.integer;
+    sort?: estypes.SortCombinations;
+  }
+>;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/138715

- Fixes `percentiles` and `terms` aggs when used as sub-aggregations. 
- Improves UI validation 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

