### PR TITLE
[Enterprise Search] Change document search endpoint to post

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_api_logic.test.ts
@@ -19,7 +19,7 @@ describe('SearchDocumentsApiLogic', () => {
   describe('searchDocuments', () => {
     it('calls correct api', async () => {
       const promise = Promise.resolve('result');
-      http.get.mockReturnValue(promise);
+      http.post.mockReturnValue(promise);
       const result = searchDocuments({
         indexName: 'indexName',
         pagination: {
@@ -28,15 +28,18 @@ describe('SearchDocumentsApiLogic', () => {
         },
       });
       await nextTick();
-      expect(http.get).toHaveBeenCalledWith(
+      expect(http.post).toHaveBeenCalledWith(
         '/internal/enterprise_search/indices/indexName/search',
-        { query: { page: 0, size: 10 } }
+        {
+          body: JSON.stringify({}),
+          query: { page: 0, size: 10 },
+        }
       );
       await expect(result).resolves.toEqual('result');
     });
     it('calls correct api with query set', async () => {
       const promise = Promise.resolve('result');
-      http.get.mockReturnValue(promise);
+      http.post.mockReturnValue(promise);
       const result = searchDocuments({
         indexName: 'düsseldorf',
         pagination: {
@@ -46,15 +49,20 @@ describe('SearchDocumentsApiLogic', () => {
         query: 'abcd',
       });
       await nextTick();
-      expect(http.get).toHaveBeenCalledWith(
-        '/internal/enterprise_search/indices/d%C3%BCsseldorf/search/abcd',
-        { query: { page: 0, size: 10 } }
+      expect(http.post).toHaveBeenCalledWith(
+        '/internal/enterprise_search/indices/d%C3%BCsseldorf/search',
+        {
+          body: JSON.stringify({
+            searchQuery: 'abcd',
+          }),
+          query: { page: 0, size: 10 },
+        }
       );
       await expect(result).resolves.toEqual('result');
     });
     it('calls with correct pageSize with docsPerPage set', async () => {
       const promise = Promise.resolve('result');
-      http.get.mockReturnValue(promise);
+      http.post.mockReturnValue(promise);
       const result = searchDocuments({
         docsPerPage: 25,
         indexName: 'indexName',
@@ -64,9 +72,12 @@ describe('SearchDocumentsApiLogic', () => {
         },
       });
       await nextTick();
-      expect(http.get).toHaveBeenCalledWith(
+      expect(http.post).toHaveBeenCalledWith(
         '/internal/enterprise_search/indices/indexName/search',
-        { query: { page: 0, size: 25 } }
+        {
+          body: JSON.stringify({}),
+          query: { page: 0, size: 25 },
+        }
       );
       await expect(result).resolves.toEqual('result');
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/search_documents/search_documents_api_logic.ts
@@ -24,15 +24,16 @@ export const searchDocuments = async ({
   query?: string;
 }) => {
   const newIndexName = encodeURIComponent(indexName);
-  const route = `/internal/enterprise_search/indices/${newIndexName}/search${
-    searchQuery ? `/${searchQuery}` : ''
-  }`;
+  const route = `/internal/enterprise_search/indices/${newIndexName}/search`;
   const query = {
     page: pagination.pageIndex,
     size: docsPerPage || pagination.pageSize,
   };
 
-  return await HttpLogic.values.http.get<{ meta: Meta; results: SearchResponseBody }>(route, {
+  return await HttpLogic.values.http.post<{ meta: Meta; results: SearchResponseBody }>(route, {
+    body: JSON.stringify({
+      searchQuery,
+    }),
     query,
   });
 };

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.test.ts
@@ -87,7 +87,7 @@ describe('fetchSearchResults lib function', () => {
     expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
       from: DEFAULT_FROM_VALUE,
       index: indexName,
-      q: query,
+      q: JSON.stringify(query),
       size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
     });
   });
@@ -120,7 +120,7 @@ describe('fetchSearchResults lib function', () => {
     expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
       from: DEFAULT_FROM_VALUE,
       index: indexName,
-      q: query,
+      q: JSON.stringify(query),
       size: ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
     });
   });

--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
@@ -21,7 +21,7 @@ export const fetchSearchResults = async (
     from,
     index: indexName,
     size,
-    ...(!!query ? { q: query } : {}),
+    ...(!!query ? { q: JSON.stringify(query) } : {}),
   });
   return results;
 };

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search.test.ts
@@ -27,8 +27,8 @@ describe('Elasticsearch Search', () => {
 
     mockRouter = new MockRouter({
       context,
-      method: 'get',
-      path: '/internal/enterprise_search/indices/{index_name}/search/{query}',
+      method: 'post',
+      path: '/internal/enterprise_search/indices/{index_name}/search',
     });
 
     registerSearchRoute({
@@ -37,14 +37,9 @@ describe('Elasticsearch Search', () => {
     });
   });
 
-  describe('GET /internal/enterprise_search/indices/{index_name}/search/{query}', () => {
+  describe('POST /internal/enterprise_search/indices/{index_name}/search with query on request body', () => {
     it('fails validation without index_name', () => {
-      const request = { params: { query: 'banana' } };
-      mockRouter.shouldThrow(request);
-    });
-
-    it('fails validation without query', () => {
-      const request = { params: { index_name: 'search-banana' } };
+      const request = { body: { searchQuery: '' }, params: {} };
       mockRouter.shouldThrow(request);
     });
 
@@ -73,7 +68,10 @@ describe('Elasticsearch Search', () => {
       });
 
       await mockRouter.callRoute({
-        params: { index_name: 'search-index-name', query: 'banana' },
+        body: {
+          searchQuery: 'banana',
+        },
+        params: { index_name: 'search-index-name' },
       });
 
       expect(fetchSearchResults).toHaveBeenCalledWith(
@@ -102,7 +100,7 @@ describe('Elasticsearch Search', () => {
     });
   });
 
-  describe('GET /internal/enterprise_search/indices/{index_name}/search', () => {
+  describe('POST /internal/enterprise_search/indices/{index_name}/search', () => {
     let mockRouterNoQuery: MockRouter;
     beforeEach(() => {
       const context = {
@@ -111,7 +109,7 @@ describe('Elasticsearch Search', () => {
 
       mockRouterNoQuery = new MockRouter({
         context,
-        method: 'get',
+        method: 'post',
         path: '/internal/enterprise_search/indices/{index_name}/search',
       });
 


### PR DESCRIPTION

## Summary

Change search endpoint to POST and stringify query while passing to the Search API.

https://user-images.githubusercontent.com/1410658/184716106-40a1744c-4e8e-415b-b637-176321607dec.mov



### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->