### PR TITLE
unskipping the skipped test - in accessibility- discovery test 

### DIFF
--- a/test/accessibility/apps/discover.ts
+++ b/test/accessibility/apps/discover.ts
@@ -155,8 +155,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('discoverChartOptionsToggle');
     });
 
-    // https://github.com/elastic/eui/issues/5900
-    it.skip('a11y test for data grid sort panel', async () => {
+    it('a11y test for data grid sort panel', async () => {
       await testSubjects.click('dataGridColumnSortingButton');
       await a11y.testAppSnapshot();
       await browser.pressKeys(browser.keys.ESCAPE);


### PR DESCRIPTION
Original issue: https://github.com/elastic/eui/issues/5900
 fixed by https://github.com/elastic/eui/pull/5916

But the test was not un-skipped . 