### PR TITLE
[Fleet Synthetics] Upgrade to 0.10.2

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -31,6 +31,6 @@
   },
   {
     "name": "synthetics",
-    "version": "0.10.1"
+    "version": "0.10.2"
   }
 ]

--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -18,7 +18,7 @@ import pRetry from 'p-retry';
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
 const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:433d99a96f3289c5013ae35826877adf408eb9c9`;
+const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:d32582b3bbeef5283e4450a9403f26c2a5e415f4`;
 
 function firstWithTimeout(source$: Rx.Observable<any>, errorMsg: string, ms = 30 * 1000) {
   return Rx.race(

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -15,7 +15,7 @@ import { pageObjects } from './page_objects';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:433d99a96f3289c5013ae35826877adf408eb9c9';
+  'docker.elastic.co/package-registry/distribution:d32582b3bbeef5283e4450a9403f26c2a5e415f4';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values


### PR DESCRIPTION

## Summary

Upgrading synthetics package to 0.10.2 for kibana v^8.4.0

Release Note - Breaking
---
The Elastic Synthetics Integration package 0.10.1 will segment ILM policies for the `synthetics-*` datastreams by dataset. These changes will **automatically apply** these ILM policy settings to all existing `synthetics-*` datastreams. This includes:
* `synthetics-browser.network-*`
* `synthetics-browser.network-*`
* `synthetics-browser.network-*`
* `synthetics-http-*`
* `synthetics-tcp-*`
* `synthetics-icmp-*`

This change will dramatically reduce the data retention period for the `synthetics-browser.screenshot-*` and `synthetics-browser-network` in particular. We've found that that data tends to be quite large in these datasets, with our customers desiring to store this costly data for a period.

The new ILM settings will be

Hot phase
--
|       | HTTP | TCP | ICMP | Browser core | Browser screenshot | Browser network |
| --- | -----  | ---- | ----- | ---------------- | -------------------- | -------- |
| Max age | 30 days | 30 days | 30 days | 30 days | 1 day | 1 day |
| Max size | 50gb | 50gb | 50gb | 50gb | | | 

Delete phase
--
|       | HTTP | TCP | ICMP | Browser core | Browser screenshot | Browser network |
| --- | -----  | ---- | ----- | ---------------- | -------------------- | -------- |
| Min age | 365 days | 365 days | 365 days | 365 days | 14 days | 14 days |

TLDR
--
The important thing to note is that screenshots and network data for browser monitors run via Uptime Monitor Management, Elastic Synthetics Integration, and Heartbeat 8.4.0 will now be deleted after 14 days by default.

More information https://github.com/elastic/uptime/issues/462

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->


As part of https://github.com/elastic/kibana/issues/138708 promoting bundle to 0.10.2


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->