### PR TITLE
[VisEditors] Remove usage of `SavedObject` from `Lens`

### DIFF
--- a/src/plugins/embeddable/public/lib/attribute_service/attribute_service.tsx
+++ b/src/plugins/embeddable/public/lib/attribute_service/attribute_service.tsx
@@ -45,7 +45,7 @@ export interface AttributeServiceOptions<
     attributes: SavedObjectAttributes,
     savedObjectId?: string
   ) => Promise<{ id?: string } | { error: Error }>;
-  checkForDuplicateTitle: (props: OnSaveProps) => Promise<true>;
+  checkForDuplicateTitle: (props: OnSaveProps) => Promise<boolean>;
   unwrapMethod?: (
     savedObjectId: string
   ) => Promise<AttributeServiceUnwrapResult<SavedObjectAttributes, MetaInfo>>;

--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -882,8 +882,7 @@ describe('Lens App', () => {
           });
         });
         expect(checkForDuplicateTitle).toHaveBeenCalledWith(
-          expect.objectContaining({ id: '123' }),
-          false,
+          expect.objectContaining({ id: '123', isTitleDuplicateConfirmed: false }),
           onTitleDuplicate,
           expect.anything()
         );

--- a/x-pack/plugins/lens/public/app_plugin/save_modal_container.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/save_modal_container.tsx
@@ -251,15 +251,13 @@ export const runSaveLensVisualization = async (
         {
           id: originalSavedObjectId,
           title: docToSave.title,
-          copyOnSave: saveProps.newCopyOnSave,
+          displayName: i18n.translate('xpack.lens.app.saveModalType', {
+            defaultMessage: 'Lens visualization',
+          }),
           lastSavedTitle: lastKnownDoc.title,
-          getEsType: () => 'lens',
-          getDisplayName: () =>
-            i18n.translate('xpack.lens.app.saveModalType', {
-              defaultMessage: 'Lens visualization',
-            }),
+          copyOnSave: saveProps.newCopyOnSave,
+          isTitleDuplicateConfirmed: saveProps.isTitleDuplicateConfirmed,
         },
-        saveProps.isTitleDuplicateConfirmed,
         saveProps.onTitleDuplicate,
         {
           savedObjectsClient,

--- a/x-pack/plugins/lens/public/lens_attribute_service.ts
+++ b/x-pack/plugins/lens/public/lens_attribute_service.ts
@@ -80,12 +80,11 @@ export function getLensAttributeService(
       return checkForDuplicateTitle(
         {
           title: props.newTitle,
-          copyOnSave: false,
+          displayName: DOC_TYPE,
+          isTitleDuplicateConfirmed: props.isTitleDuplicateConfirmed,
           lastSavedTitle: '',
-          getEsType: () => DOC_TYPE,
-          getDisplayName: () => DOC_TYPE,
+          copyOnSave: false,
         },
-        props.isTitleDuplicateConfirmed,
         props.onTitleDuplicate,
         {
           savedObjectsClient,

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/check_for_duplicate_title.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/check_for_duplicate_title.ts
@@ -6,26 +6,24 @@
  */
 
 import type { OverlayStart, SavedObjectsClientContract } from '@kbn/core/public';
-import type { SavedObject } from '@kbn/saved-objects-plugin/public';
+import { DOC_TYPE } from '../../../common';
 import { SAVE_DUPLICATE_REJECTED } from './constants';
 import { findObjectByTitle } from './find_object_by_title';
 import { displayDuplicateTitleConfirmModal } from './display_duplicate_title_confirm_modal';
+import type { ConfirmModalSavedObjectMeta } from './types';
 
 /**
- * check for an existing SavedObject with the same title in ES
+ * check for an existing saved object with the same title in ES
  * returns Promise<true> when it's no duplicate, or the modal displaying the warning
  * that's there's a duplicate is confirmed, else it returns a rejected Promise<ErrorMsg>
  */
 export async function checkForDuplicateTitle(
-  savedObject: Pick<
-    SavedObject,
-    'id' | 'title' | 'getDisplayName' | 'lastSavedTitle' | 'copyOnSave' | 'getEsType'
-  >,
-  isTitleDuplicateConfirmed: boolean,
+  savedObjectMeta: ConfirmModalSavedObjectMeta,
   onTitleDuplicate: (() => void) | undefined,
   services: { savedObjectsClient: SavedObjectsClientContract; overlays: OverlayStart }
-): Promise<true> {
+): Promise<boolean> {
   const { savedObjectsClient, overlays } = services;
+  const { id, title, isTitleDuplicateConfirmed, lastSavedTitle, copyOnSave } = savedObjectMeta;
 
   // Don't check for duplicates if user has already confirmed save with duplicate title
   if (isTitleDuplicateConfirmed) {
@@ -34,17 +32,13 @@ export async function checkForDuplicateTitle(
 
   // Don't check if the user isn't updating the title, otherwise that would become very annoying to have
   // to confirm the save every time, except when copyOnSave is true, then we do want to check.
-  if (savedObject.title === savedObject.lastSavedTitle && !savedObject.copyOnSave) {
+  if (title === lastSavedTitle && !copyOnSave) {
     return true;
   }
 
-  const duplicate = await findObjectByTitle(
-    savedObjectsClient,
-    savedObject.getEsType(),
-    savedObject.title
-  );
+  const duplicate = await findObjectByTitle(savedObjectsClient, DOC_TYPE, title);
 
-  if (!duplicate || duplicate.id === savedObject.id) {
+  if (!duplicate || duplicate.id === id) {
     return true;
   }
 
@@ -55,5 +49,5 @@ export async function checkForDuplicateTitle(
 
   // TODO: make onTitleDuplicate a required prop and remove UI components from this class
   // Need to leave here until all users pass onTitleDuplicate.
-  return displayDuplicateTitleConfirmModal(savedObject, overlays);
+  return displayDuplicateTitleConfirmModal(savedObjectMeta, overlays);
 }

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/confirm_modal_promise.tsx
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/confirm_modal_promise.tsx
@@ -16,7 +16,7 @@ export function confirmModalPromise(
   title = '',
   confirmBtnText = '',
   overlays: OverlayStart
-): Promise<true> {
+): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const cancelButtonText = i18n.translate('xpack.lens.confirmModal.cancelButtonLabel', {
       defaultMessage: 'Cancel',

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/display_duplicate_title_confirm_modal.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/display_duplicate_title_confirm_modal.ts
@@ -7,25 +7,25 @@
 
 import { i18n } from '@kbn/i18n';
 import type { OverlayStart } from '@kbn/core/public';
-import type { SavedObject } from '@kbn/saved-objects-plugin/public';
+import type { ConfirmModalSavedObjectMeta } from './types';
 import { SAVE_DUPLICATE_REJECTED } from './constants';
 import { confirmModalPromise } from './confirm_modal_promise';
 
 export function displayDuplicateTitleConfirmModal(
-  savedObject: Pick<SavedObject, 'title' | 'getDisplayName'>,
+  { title, displayName }: ConfirmModalSavedObjectMeta,
   overlays: OverlayStart
-): Promise<true> {
+): Promise<boolean> {
   const confirmMessage = i18n.translate(
     'xpack.lens.confirmModal.saveDuplicateConfirmationMessage',
     {
       defaultMessage: `A {name} with the title '{title}' already exists. Would you like to save anyway?`,
-      values: { title: savedObject.title, name: savedObject.getDisplayName() },
+      values: { title, name: displayName },
     }
   );
 
   const confirmButtonText = i18n.translate('xpack.lens.confirmModal.saveDuplicateButtonLabel', {
     defaultMessage: 'Save {name}',
-    values: { name: savedObject.getDisplayName() },
+    values: { name: displayName },
   });
   try {
     return confirmModalPromise(confirmMessage, '', confirmButtonText, overlays);

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/find_object_by_title.test.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/find_object_by_title.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { findObjectByTitle } from './find_object_by_title';
-import { SavedObjectsClientContract, SavedObject } from '@kbn/core/public';
+import { SavedObjectsClientContract, SimpleSavedObject } from '@kbn/core/public';
 import { simpleSavedObjectMock } from '@kbn/core/public/mocks';
 
 describe('findObjectByTitle', () => {
@@ -24,7 +24,8 @@ describe('findObjectByTitle', () => {
   it('matches any case', async () => {
     const indexPattern = simpleSavedObjectMock.create(savedObjectsClient, {
       attributes: { title: 'foo' },
-    } as SavedObject);
+    } as SimpleSavedObject);
+
     savedObjectsClient.find = jest.fn().mockImplementation(() =>
       Promise.resolve({
         savedObjects: [indexPattern],

--- a/x-pack/plugins/lens/public/persistence/saved_objects_utils/types.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_objects_utils/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** @internal */
+export interface ConfirmModalSavedObjectMeta {
+  id?: string;
+  title: string;
+  displayName: string;
+  lastSavedTitle: string;
+  copyOnSave: boolean;
+  isTitleDuplicateConfirmed: boolean;
+}


### PR DESCRIPTION
Part of  #137735

## Summary

[VisEditors] Remove usage of SavedObject from Lens


