### PR TITLE
[Enterprise Search]Update default url for elasticsearch host.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
@@ -37,7 +37,7 @@ export const GenerateApiKeyPanel: React.FC = () => {
 
   const cloudContext = useCloudDetails();
 
-  const DEFAULT_URL = '<ELASTICSEARCH-HOST>:<ELASTICSEARCH-PORT>';
+  const DEFAULT_URL = 'https://localhost:9200';
   const searchIndexApiUrl =
     (cloudContext.cloudId && decodeCloudId(cloudContext.cloudId)?.elasticsearchUrl) || DEFAULT_URL;
 


### PR DESCRIPTION
## Summary

Updates example code to show `localhost:9200` instead of a placeholder text. 
![Screenshot 2022-08-16 at 12 05 00](https://user-images.githubusercontent.com/1410658/184853744-da537d9f-826b-4c3c-9ad5-c0eee28885a6.png)




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->