### PR TITLE
Bump saved objects index fields limit to 1.5k to prevent upgrade failures

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/actions/actions.test.ts
@@ -475,7 +475,7 @@ describe('migration actions', () => {
         source: 'existing_index_with_write_block',
         target: 'clone_target_1',
       });
-      expect.assertions(1);
+      expect.assertions(3);
       await expect(task()).resolves.toMatchInlineSnapshot(`
         Object {
           "_tag": "Right",
@@ -485,6 +485,12 @@ describe('migration actions', () => {
           },
         }
       `);
+      const { clone_target_1: cloneTarget1 } = await client.indices.getSettings({
+        index: 'clone_target_1',
+      });
+      // @ts-expect-error https://github.com/elastic/elasticsearch/issues/89381
+      expect(cloneTarget1.settings?.index.mapping?.total_fields.limit).toBe('1500');
+      expect(cloneTarget1.settings?.blocks?.write).toBeUndefined();
     });
     it('resolves right if clone target already existed after waiting for index status to be green ', async () => {
       expect.assertions(2);
@@ -1612,6 +1618,11 @@ describe('migration actions', () => {
         _tag: 'Right',
         right: 'create_index_succeeded',
       });
+      const { create_new_index: createNewIndex } = await client.indices.getSettings({
+        index: 'create_new_index',
+      });
+      // @ts-expect-error https://github.com/elastic/elasticsearch/issues/89381
+      expect(createNewIndex.settings?.index?.mapping.total_fields.limit).toBe('1500');
     });
     it('resolves left if an existing index status does not become green', async () => {
       expect.assertions(2);

--- a/src/core/server/saved_objects/migrations/actions/clone_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/clone_index.ts
@@ -64,20 +64,25 @@ export const cloneIndex = ({
         index: source,
         target,
         wait_for_active_shards: WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
-        body: {
-          settings: {
-            index: {
-              // The source we're cloning from will have a write block set, so
-              // we need to remove it to allow writes to our newly cloned index
-              'blocks.write': false,
-              number_of_shards: INDEX_NUMBER_OF_SHARDS,
-              auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
-              // Set an explicit refresh interval so that we don't inherit the
-              // value from incorrectly configured index templates (not required
-              // after we adopt system indices)
-              refresh_interval: '1s',
-              // Bump priority so that recovery happens before newer indices
-              priority: 10,
+        settings: {
+          index: {
+            // The source we're cloning from will have a write block set, so
+            // we need to remove it to allow writes to our newly cloned index
+            'blocks.write': false,
+            // The rest of the index settings should have already been applied
+            // to the source index and will be copied to the clone target. But
+            // we repeat it here for explicitness.
+            number_of_shards: INDEX_NUMBER_OF_SHARDS,
+            auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
+            // Set an explicit refresh interval so that we don't inherit the
+            // value from incorrectly configured index templates (not required
+            // after we adopt system indices)
+            refresh_interval: '1s',
+            // Bump priority so that recovery happens before newer indices
+            priority: 10,
+            // Increase the fields limit beyond the default of 1000
+            mapping: {
+              total_fields: { limit: 1500 },
             },
           },
         },

--- a/src/core/server/saved_objects/migrations/actions/create_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/create_index.ts
@@ -82,21 +82,24 @@ export const createIndex = ({
         // available. If the request doesn't complete within timeout,
         // acknowledged or shards_acknowledged would be false.
         timeout,
-        body: {
-          mappings,
-          aliases: aliasesObject,
-          settings: {
-            index: {
-              // ES rule of thumb: shards should be several GB to 10's of GB, so
-              // Kibana is unlikely to cross that limit.
-              number_of_shards: 1,
-              auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
-              // Set an explicit refresh interval so that we don't inherit the
-              // value from incorrectly configured index templates (not required
-              // after we adopt system indices)
-              refresh_interval: '1s',
-              // Bump priority so that recovery happens before newer indices
-              priority: 10,
+        mappings,
+        aliases: aliasesObject,
+        settings: {
+          index: {
+            // ES rule of thumb: shards should be several GB to 10's of GB, so
+            // Kibana is unlikely to cross that limit.
+            number_of_shards: 1,
+            auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
+            // Set an explicit refresh interval so that we don't inherit the
+            // value from incorrectly configured index templates (not required
+            // after we adopt system indices)
+            refresh_interval: '1s',
+            // Bump priority so that recovery happens before newer indices
+            priority: 10,
+            // Increase the fields limit beyond the default of 1000
+            // @ts-expect-error
+            mapping: {
+              total_fields: { limit: 1500 },
             },
           },
         },

--- a/src/core/server/saved_objects/migrations/actions/create_index.ts
+++ b/src/core/server/saved_objects/migrations/actions/create_index.ts
@@ -97,7 +97,7 @@ export const createIndex = ({
             // Bump priority so that recovery happens before newer indices
             priority: 10,
             // Increase the fields limit beyond the default of 1000
-            // @ts-expect-error
+            // @ts-expect-error https://github.com/elastic/elasticsearch/issues/89381
             mapping: {
               total_fields: { limit: 1500 },
             },


### PR DESCRIPTION
## Summary

Clusters with a big diversity in the different saved object types could fail to upgrade to 8.4.0 because of Elasticsearch's default field limit of 1000. This fix increases the field limit of the saved object indices to 1500.

Because the `migrationVersion` field type is `dynamic: true` the actual field count varies with the data stored in the index. But even when counting the fields on an index that's known to have bumped into the limit using an approach similar to `x-pack/test/saved_objects_field_count/test.ts` but with no ignored fields, we still only count 984 fields. So it might not be possible to arrive at the exact same field count that ES uses, but we should work to reduce the risk of this surprising us in production by adding a safe limit.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->