### PR TITLE
[Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -218,7 +218,10 @@ describe('Custom query rules', () => {
             const initialNumberOfRules = rules.length;
             const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-            cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing 1-${initialNumberOfRules} of ${initialNumberOfRules} rules`);
+            cy.get(SHOWING_RULES_TEXT).should(
+              'have.text',
+              `Showing 1-${initialNumberOfRules} of ${initialNumberOfRules} rules`
+            );
 
             deleteFirstRule();
             waitForRulesTableToBeRefreshed();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -23,7 +23,6 @@ import {
   RULES_TABLE,
   RULE_SWITCH,
   SEVERITY,
-  SHOWING_RULES_TEXT,
 } from '../../screens/alerts_detection_rules';
 import {
   ABOUT_CONTINUE_BTN,
@@ -218,10 +217,10 @@ describe('Custom query rules', () => {
             const initialNumberOfRules = rules.length;
             const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-            cy.get(SHOWING_RULES_TEXT).should(
-              'have.text',
-              `Showing 1-${initialNumberOfRules} of ${initialNumberOfRules} rules`
-            );
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(initialNumberOfRules);
+            });
 
             deleteFirstRule();
             waitForRulesTableToBeRefreshed();
@@ -229,10 +228,10 @@ describe('Custom query rules', () => {
             cy.get(RULES_TABLE)
               .find(RULES_ROW)
               .should('have.length', expectedNumberOfRulesAfterDeletion);
-            cy.get(SHOWING_RULES_TEXT).should(
-              'have.text',
-              `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rules`
-            );
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+            });
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
               `Custom rules (${expectedNumberOfRulesAfterDeletion})`
@@ -256,10 +255,10 @@ describe('Custom query rules', () => {
             cy.get(RULES_TABLE)
               .find(RULES_ROW)
               .should('have.length', expectedNumberOfRulesAfterDeletion);
-            cy.get(SHOWING_RULES_TEXT).should(
-              'have.text',
-              `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rule`
-            );
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+            });
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
               `Custom rules (${expectedNumberOfRulesAfterDeletion})`
@@ -284,10 +283,10 @@ describe('Custom query rules', () => {
               cy.get(RULES_TABLE)
                 .find(RULES_ROW)
                 .should('have.length', expectedNumberOfRulesAfterDeletion);
-              cy.get(SHOWING_RULES_TEXT).should(
-                'have.text',
-                `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rules`
-              );
+              cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+                const numberOfRules = body.data.length;
+                expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+              });
               cy.get(CUSTOM_RULES_BTN).should(
                 'have.text',
                 `Custom rules (${expectedNumberOfRulesAfterDeletion})`

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -218,7 +218,7 @@ describe('Custom query rules', () => {
             const initialNumberOfRules = rules.length;
             const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-            cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing ${initialNumberOfRules} rules`);
+            cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing 1-${initialNumberOfRules} of ${initialNumberOfRules} rules`);
 
             deleteFirstRule();
             waitForRulesTableToBeRefreshed();
@@ -228,7 +228,7 @@ describe('Custom query rules', () => {
               .should('have.length', expectedNumberOfRulesAfterDeletion);
             cy.get(SHOWING_RULES_TEXT).should(
               'have.text',
-              `Showing ${expectedNumberOfRulesAfterDeletion} rules`
+              `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rules`
             );
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
@@ -255,7 +255,7 @@ describe('Custom query rules', () => {
               .should('have.length', expectedNumberOfRulesAfterDeletion);
             cy.get(SHOWING_RULES_TEXT).should(
               'have.text',
-              `Showing ${expectedNumberOfRulesAfterDeletion} rule`
+              `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rule`
             );
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
@@ -283,7 +283,7 @@ describe('Custom query rules', () => {
                 .should('have.length', expectedNumberOfRulesAfterDeletion);
               cy.get(SHOWING_RULES_TEXT).should(
                 'have.text',
-                `Showing ${expectedNumberOfRulesAfterDeletion} rules`
+                `Showing 1-${expectedNumberOfRulesAfterDeletion} of ${expectedNumberOfRulesAfterDeletion} rules`
               );
               cy.get(CUSTOM_RULES_BTN).should(
                 'have.text',

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -59,7 +59,10 @@ describe('Prebuilt rules', () => {
 
       changeRowsPerPageTo(rowsPerPage);
 
-      cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing 1-${rowsPerPage} of ${expectedNumberOfRules} rules`);
+      cy.get(SHOWING_RULES_TEXT).should(
+        'have.text',
+        `Showing 1-${rowsPerPage} of ${expectedNumberOfRules} rules`
+      );
       cy.get(pageSelector(expectedNumberOfPages)).should('exist');
     });
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -59,7 +59,7 @@ describe('Prebuilt rules', () => {
 
       changeRowsPerPageTo(rowsPerPage);
 
-      cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing ${expectedNumberOfRules} rules`);
+      cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing 1-${rowsPerPage} of ${expectedNumberOfRules} rules`);
       cy.get(pageSelector(expectedNumberOfPages)).should('exist');
     });
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -26,7 +26,7 @@ import { useFormatUrl } from '../../../../../../common/components/link_to';
 import { Loader } from '../../../../../../common/components/loader';
 
 import * as i18n from './translations';
-import { AllRulesUtilityBar } from '../utility_bar';
+import { ExceptionsTableUtilityBar } from './exceptions_table_utility_bar';
 import type { AllExceptionListsColumns } from './columns';
 import { getAllExceptionListsColumns } from './columns';
 import { useAllExceptionLists } from './use_all_exception_lists';
@@ -378,11 +378,8 @@ export const ExceptionListsTable = React.memo(() => {
           <EuiLoadingContent data-test-subj="initialLoadingPanelAllRulesTable" lines={10} />
         ) : (
           <>
-            <AllRulesUtilityBar
-              hasBulkActions={false}
-              canBulkEdit={hasPermissions}
-              totalExceptionLists={exceptionListsWithRuleRefs.length ?? 0}
-              numberSelectedItems={0}
+            <ExceptionsTableUtilityBar
+              totalExceptionLists={exceptionListsWithRuleRefs.length}
               onRefresh={handleRefresh}
             />
             <EuiBasicTable<ExceptionsTableItem>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -381,7 +381,7 @@ export const ExceptionListsTable = React.memo(() => {
             <AllRulesUtilityBar
               hasBulkActions={false}
               canBulkEdit={hasPermissions}
-              paginationTotal={exceptionListsWithRuleRefs.length ?? 0}
+              totalExceptionLists={exceptionListsWithRuleRefs.length ?? 0}
               numberSelectedItems={0}
               onRefresh={handleRefresh}
             />

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { TestProviders } from '../../../../../../common/mock';
+import { render, screen, within } from '@testing-library/react';
+import { ExceptionsTableUtilityBar } from './exceptions_table_utility_bar';
+
+describe('ExceptionsTableUtilityBar', () => {
+  it('displays correct exception lists label and refresh rules action button', () => {
+    const EXCEPTION_LISTS_NUMBER = 25;
+    render(
+      <TestProviders>
+        <ExceptionsTableUtilityBar
+          onRefresh={jest.fn()}
+          totalExceptionLists={EXCEPTION_LISTS_NUMBER}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('showingExceptionLists')).toBeInTheDocument();
+    expect(screen.getByTestId('refreshRulesAction')).toBeInTheDocument();
+    expect(screen.getByText(`Showing ${EXCEPTION_LISTS_NUMBER} lists`)).toBeInTheDocument();
+  });
+
+  it('invokes refresh on refresh action click', () => {
+    const mockRefresh = jest.fn();
+    render(
+      <TestProviders>
+        <ExceptionsTableUtilityBar onRefresh={mockRefresh} totalExceptionLists={1} />
+      </TestProviders>
+    );
+
+    const buttonWrapper = screen.getByTestId('refreshRulesAction');
+    within(buttonWrapper).getByRole('button').click();
+
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
@@ -14,7 +14,7 @@ import {
   UtilityBarSection,
   UtilityBarText,
 } from '../../../../../../common/components/utility_bar';
-import * as i18n from '../../translations';
+import * as i18n from './translations';
 
 interface ExceptionsTableUtilityBarProps {
   onRefresh?: () => void;
@@ -40,7 +40,7 @@ export const ExceptionsTableUtilityBar: React.FC<ExceptionsTableUtilityBarProps>
             iconType="refresh"
             onClick={onRefresh}
           >
-            {i18n.REFRESH}
+            {i18n.REFRESH_EXCEPTIONS_TABLE}
           </UtilityBarAction>
         </UtilityBarGroup>
       </UtilityBarSection>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import {
+  UtilityBar,
+  UtilityBarAction,
+  UtilityBarGroup,
+  UtilityBarSection,
+  UtilityBarText,
+} from '../../../../../../common/components/utility_bar';
+import * as i18n from '../../translations';
+
+interface ExceptionsTableUtilityBarProps {
+  onRefresh?: () => void;
+  totalExceptionLists: number;
+}
+
+export const ExceptionsTableUtilityBar: React.FC<ExceptionsTableUtilityBarProps> = ({
+  onRefresh,
+  totalExceptionLists,
+}) => {
+  return (
+    <UtilityBar border>
+      <UtilityBarSection>
+        <UtilityBarGroup>
+          <UtilityBarText dataTestSubj="showingExceptionLists">
+            {i18n.SHOWING_EXCEPTION_LISTS(totalExceptionLists)}
+          </UtilityBarText>
+        </UtilityBarGroup>
+        <UtilityBarGroup>
+          <UtilityBarAction
+            dataTestSubj="refreshRulesAction"
+            iconSide="left"
+            iconType="refresh"
+            onClick={onRefresh}
+          >
+            {i18n.REFRESH}
+          </UtilityBarAction>
+        </UtilityBarGroup>
+      </UtilityBarSection>
+    </UtilityBar>
+  );
+};
+
+ExceptionsTableUtilityBar.displayName = 'ExceptionsTableUtilityBar';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
@@ -28,6 +28,15 @@ export const EXCEPTION_LIST_ACTIONS = i18n.translate(
   }
 );
 
+export const SHOWING_EXCEPTION_LISTS = (totalLists: number) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.all.exceptions.showingExceptionLists',
+    {
+      values: { totalLists },
+      defaultMessage: 'Showing {totalLists} {totalLists, plural, =1 {list} other {lists}}',
+    }
+  );
+
 export const RULES_ASSIGNED_TO_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.all.exceptions.rulesAssignedTitle',
   {
@@ -149,5 +158,12 @@ export const EXCEPTION_LIST_SEARCH_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.exceptions.searchPlaceholder',
   {
     defaultMessage: 'e.g. Example List Name',
+  }
+);
+
+export const REFRESH_EXCEPTIONS_TABLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.all.exceptions.refresh',
+  {
+    defaultMessage: 'Refresh',
   }
 );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -9,8 +9,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { AllRulesUtilityBar } from './utility_bar';
+import { AllRulesUtilityBar } from './rules_table_utility_bar';
 import { TestProviders } from '../../../../../common/mock';
+
+jest.mock('./rules_table/rules_table_context');
 
 describe('AllRules', () => {
   it('renders AllRulesUtilityBar total rules and selected rules', () => {
@@ -28,7 +30,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
         />
       </TestProviders>
     );
@@ -43,6 +44,7 @@ describe('AllRules', () => {
 
   describe('renders correct pagination label when', () => {
     it.each([
+      [0, 0, 0, 'Showing 0-0 of 0 rules'],
       [1, 1, 1, 'Showing 1-1 of 1 rule'],
       [1, 10, 21, 'Showing 1-10 of 21 rules'],
       [1, 10, 8, 'Showing 1-8 of 8 rules'],
@@ -68,35 +70,11 @@ describe('AllRules', () => {
               onGetBulkItemsPopoverContent={jest.fn()}
               isAutoRefreshOn={true}
               onRefreshSwitch={jest.fn()}
-              hasBulkActions
             />
           </TestProviders>
         );
         expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(label);
       }
-    );
-  });
-
-  it('does not render total selected and bulk actions when "hasBulkActions" is false', () => {
-    const wrapper = mount(
-      <TestProviders>
-        <AllRulesUtilityBar
-          canBulkEdit
-          onRefresh={jest.fn()}
-          totalExceptionLists={7}
-          numberSelectedItems={1}
-          onGetBulkItemsPopoverContent={jest.fn()}
-          isAutoRefreshOn={true}
-          onRefreshSwitch={jest.fn()}
-          hasBulkActions={false}
-        />
-      </TestProviders>
-    );
-
-    expect(wrapper.find('[data-test-subj="showingRules"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-subj="tableBulkActions"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-subj="showingExceptionLists"]').at(0).text()).toEqual(
-      'Showing 7 lists'
     );
   });
 
@@ -115,7 +93,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
         />
       </TestProviders>
     );
@@ -138,7 +115,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
         />
       </TestProviders>
     );
@@ -162,7 +138,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
         />
       </TestProviders>
     );
@@ -188,7 +163,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
-          hasBulkActions
         />
       </TestProviders>
     );
@@ -216,7 +190,6 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
-          hasBulkActions
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -44,26 +44,26 @@ describe('RulesTableUtilityBar', () => {
   });
 
   it('renders correct pagination label according to pagination data', () => {
-        const wrapper = mount(
-          <TestProviders>
-            <RulesTableUtilityBar
-              canBulkEdit
-              onRefresh={jest.fn()}
-              pagination={{
-                page: 1,
-                perPage: 10,
-                total: 21,
-              }}
-              numberSelectedItems={1}
-              onGetBulkItemsPopoverContent={jest.fn()}
-              isAutoRefreshOn={true}
-              onRefreshSwitch={jest.fn()}
-              onToggleSelectAll={jest.fn()}
-            />
-          </TestProviders>
-        );
-        expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual("Showing 1-10 of 21 rules");
-      }
+    const wrapper = mount(
+      <TestProviders>
+        <RulesTableUtilityBar
+          canBulkEdit
+          onRefresh={jest.fn()}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
+          numberSelectedItems={1}
+          onGetBulkItemsPopoverContent={jest.fn()}
+          isAutoRefreshOn={true}
+          onRefreshSwitch={jest.fn()}
+          onToggleSelectAll={jest.fn()}
+        />
+      </TestProviders>
+    );
+    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(
+      'Showing 1-10 of 21 rules'
     );
   });
 
@@ -194,72 +194,72 @@ describe('RulesTableUtilityBar', () => {
       expect(mockSwitch).not.toHaveBeenCalled();
     });
   });
-});
 
-describe('getShowingRulesParams creates correct label when', () => {
-  it('there are 0 rules to display', () => {
-    const pagination = {
-      page: 1,
-      perPage: 10,
-      total: 0,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(0);
-    expect(lastInPage).toEqual(0);
-  });
+  describe('getShowingRulesParams creates correct label when', () => {
+    it('there are 0 rules to display', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 0,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(0);
+      expect(lastInPage).toEqual(0);
+    });
 
-  it('there is 1 rule to display', () => {
-    const pagination = {
-      page: 1,
-      perPage: 10,
-      total: 1,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(1);
-    expect(lastInPage).toEqual(1);
-  });
+    it('there is 1 rule to display', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 1,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(1);
+    });
 
-  it('the table displays the first page, and rules per page is less than total rules', () => {
-    const pagination = {
-      page: 1,
-      perPage: 10,
-      total: 21,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(1);
-    expect(lastInPage).toEqual(10);
-  });
+    it('the table displays the first page, and rules per page is less than total rules', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 21,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(10);
+    });
 
-  it('the table displays the first page, and rules per page is greater than total rules', () => {
-    const pagination = {
-      page: 1,
-      perPage: 10,
-      total: 8,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(1);
-    expect(lastInPage).toEqual(8);
-  });
+    it('the table displays the first page, and rules per page is greater than total rules', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 8,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(8);
+    });
 
-  it('the table displays the second page, and rules per page is less than total rules', () => {
-    const pagination = {
-      page: 2,
-      perPage: 10,
-      total: 31,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(11);
-    expect(lastInPage).toEqual(20);
-  });
+    it('the table displays the second page, and rules per page is less than total rules', () => {
+      const pagination = {
+        page: 2,
+        perPage: 10,
+        total: 31,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(11);
+      expect(lastInPage).toEqual(20);
+    });
 
-  it('the table displays the last page, displaying the remaining rules', () => {
-    const pagination = {
-      page: 2,
-      perPage: 100,
-      total: 101,
-    };
-    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
-    expect(firstInPage).toEqual(101);
-    expect(lastInPage).toEqual(101);
+    it('the table displays the last page, displaying the remaining rules', () => {
+      const pagination = {
+        page: 2,
+        perPage: 100,
+        total: 101,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(101);
+      expect(lastInPage).toEqual(101);
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -9,16 +9,16 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { AllRulesUtilityBar } from './rules_table_utility_bar';
+import { RulesTableUtilityBar } from './rules_table_utility_bar';
 import { TestProviders } from '../../../../../common/mock';
 
 jest.mock('./rules_table/rules_table_context');
 
-describe('AllRules', () => {
-  it('renders AllRulesUtilityBar total rules and selected rules', () => {
+describe('RulesTableUtilityBar', () => {
+  it('renders RulesTableUtilityBar total rules and selected rules', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
           pagination={{
@@ -30,6 +30,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -58,7 +59,7 @@ describe('AllRules', () => {
       (page, perPage, total, label) => {
         const wrapper = mount(
           <TestProviders>
-            <AllRulesUtilityBar
+            <RulesTableUtilityBar
               canBulkEdit
               onRefresh={jest.fn()}
               pagination={{
@@ -70,6 +71,7 @@ describe('AllRules', () => {
               onGetBulkItemsPopoverContent={jest.fn()}
               isAutoRefreshOn={true}
               onRefreshSwitch={jest.fn()}
+              onToggleSelectAll={jest.fn()}
             />
           </TestProviders>
         );
@@ -81,7 +83,7 @@ describe('AllRules', () => {
   it('renders utility actions if user has permissions', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
           pagination={{
@@ -93,6 +95,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -103,7 +106,7 @@ describe('AllRules', () => {
   it('renders no utility actions if user has no permissions', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit={false}
           onRefresh={jest.fn()}
           pagination={{
@@ -115,6 +118,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -126,7 +130,7 @@ describe('AllRules', () => {
     const mockRefresh = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={mockRefresh}
           pagination={{
@@ -138,6 +142,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -151,7 +156,7 @@ describe('AllRules', () => {
     const mockSwitch = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
           pagination={{
@@ -163,6 +168,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -178,7 +184,7 @@ describe('AllRules', () => {
     const mockSwitch = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
           pagination={{
@@ -190,6 +196,7 @@ describe('AllRules', () => {
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -43,29 +43,16 @@ describe('RulesTableUtilityBar', () => {
     );
   });
 
-  describe('renders correct pagination label when', () => {
-    it.each([
-      [0, 0, 0, 'Showing 0-0 of 0 rules'],
-      [1, 1, 1, 'Showing 1-1 of 1 rule'],
-      [1, 10, 21, 'Showing 1-10 of 21 rules'],
-      [1, 10, 8, 'Showing 1-8 of 8 rules'],
-      [2, 10, 31, 'Showing 11-20 of 31 rules'],
-      [4, 10, 31, 'Showing 31-31 of 31 rules'],
-      [1, 5, 4, 'Showing 1-4 of 4 rules'],
-      [1, 100, 100, 'Showing 1-100 of 100 rules'],
-      [2, 100, 101, 'Showing 101-101 of 101 rules'],
-    ])(
-      'current page is %s, showing %s rules per page and total rules is %s',
-      (page, perPage, total, label) => {
+  it('renders correct pagination label according to pagination data', () => {
         const wrapper = mount(
           <TestProviders>
             <RulesTableUtilityBar
               canBulkEdit
               onRefresh={jest.fn()}
               pagination={{
-                page,
-                perPage,
-                total,
+                page: 1,
+                perPage: 10,
+                total: 21,
               }}
               numberSelectedItems={1}
               onGetBulkItemsPopoverContent={jest.fn()}
@@ -75,7 +62,7 @@ describe('RulesTableUtilityBar', () => {
             />
           </TestProviders>
         );
-        expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(label);
+        expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual("Showing 1-10 of 21 rules");
       }
     );
   });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { RulesTableUtilityBar } from './rules_table_utility_bar';
+import { getShowingRulesParams, RulesTableUtilityBar } from './rules_table_utility_bar';
 import { TestProviders } from '../../../../../common/mock';
 
 jest.mock('./rules_table/rules_table_context');
@@ -206,5 +206,73 @@ describe('RulesTableUtilityBar', () => {
       wrapper.find('[data-test-subj="refreshSettingsSwitch"] button').first().simulate('click');
       expect(mockSwitch).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('getShowingRulesParams creates correct label when', () => {
+  it('there are 0 rules to display', () => {
+    const pagination = {
+      page: 1,
+      perPage: 10,
+      total: 0,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(0);
+    expect(lastInPage).toEqual(0);
+  });
+
+  it('there is 1 rule to display', () => {
+    const pagination = {
+      page: 1,
+      perPage: 10,
+      total: 1,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(1);
+    expect(lastInPage).toEqual(1);
+  });
+
+  it('the table displays the first page, and rules per page is less than total rules', () => {
+    const pagination = {
+      page: 1,
+      perPage: 10,
+      total: 21,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(1);
+    expect(lastInPage).toEqual(10);
+  });
+
+  it('the table displays the first page, and rules per page is greater than total rules', () => {
+    const pagination = {
+      page: 1,
+      perPage: 10,
+      total: 8,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(1);
+    expect(lastInPage).toEqual(8);
+  });
+
+  it('the table displays the second page, and rules per page is less than total rules', () => {
+    const pagination = {
+      page: 2,
+      perPage: 10,
+      total: 31,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(11);
+    expect(lastInPage).toEqual(20);
+  });
+
+  it('the table displays the last page, displaying the remaining rules', () => {
+    const pagination = {
+      page: 2,
+      perPage: 100,
+      total: 101,
+    };
+    const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+    expect(firstInPage).toEqual(101);
+    expect(lastInPage).toEqual(101);
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.tsx
@@ -29,21 +29,21 @@ import { useRulesTableContext } from './rules_table/rules_table_context';
 import { getShowingRulesParams } from '../utils';
 import type { Pagination } from '../types';
 
-interface AllRulesUtilityBarProps {
+interface RulesTableUtilityBarProps {
   canBulkEdit: boolean;
   isAllSelected?: boolean;
   isAutoRefreshOn?: boolean;
   numberSelectedItems: number;
   onGetBulkItemsPopoverContent?: (closePopover: () => void) => EuiContextMenuPanelDescriptor[];
-  onRefresh?: () => void;
-  onRefreshSwitch?: (checked: boolean) => void;
-  onToggleSelectAll?: () => void;
+  onRefresh: () => void;
+  onRefreshSwitch: (checked: boolean) => void;
+  onToggleSelectAll: () => void;
   pagination: Pagination;
   isBulkActionInProgress?: boolean;
   hasDisabledActions?: boolean;
 }
 
-export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
+export const RulesTableUtilityBar = React.memo<RulesTableUtilityBarProps>(
   ({
     canBulkEdit,
     isAllSelected,
@@ -133,7 +133,7 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
                 {i18n.SELECTED_RULES(numberSelectedItems)}
               </UtilityBarText>
 
-              {canBulkEdit && onToggleSelectAll && (
+              {canBulkEdit && (
                 <UtilityBarAction
                   disabled={hasDisabledActions}
                   dataTestSubj="selectAllRules"
@@ -191,4 +191,4 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
   }
 );
 
-AllRulesUtilityBar.displayName = 'AllRulesUtilityBar';
+RulesTableUtilityBar.displayName = 'RulesTableUtilityBar';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.tsx
@@ -26,8 +26,14 @@ import {
 import * as i18n from '../translations';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useRulesTableContext } from './rules_table/rules_table_context';
-import { getShowingRulesParams } from '../utils';
-import type { Pagination } from '../types';
+import type { PaginationOptions } from '../../../../containers/detection_engine/rules/types';
+
+export const getShowingRulesParams = ({ page, perPage, total: totalRules }: PaginationOptions) => {
+  const firstInPage = totalRules === 0 ? 0 : (page - 1) * perPage + 1;
+  const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
+
+  return [firstInPage, lastInPage, totalRules] as const;
+};
 
 interface RulesTableUtilityBarProps {
   canBulkEdit: boolean;
@@ -38,7 +44,7 @@ interface RulesTableUtilityBarProps {
   onRefresh: () => void;
   onRefreshSwitch: (checked: boolean) => void;
   onToggleSelectAll: () => void;
-  pagination: Pagination;
+  pagination: PaginationOptions;
   isBulkActionInProgress?: boolean;
   hasDisabledActions?: boolean;
 }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -31,7 +31,7 @@ import { showRulesTable } from './helpers';
 import { useRulesTableContext } from './rules_table/rules_table_context';
 import { useAsyncConfirmation } from './rules_table/use_async_confirmation';
 import { RulesTableFilters } from './rules_table_filters/rules_table_filters';
-import { AllRulesUtilityBar } from './rules_table_utility_bar';
+import { RulesTableUtilityBar } from './rules_table_utility_bar';
 import { useBulkActionsDryRun } from './bulk_actions/use_bulk_actions_dry_run';
 import { useBulkActionsConfirmation } from './bulk_actions/use_bulk_actions_confirmation';
 import { useBulkEditFormFlyout } from './bulk_actions/use_bulk_edit_form_flyout';
@@ -331,7 +331,7 @@ export const RulesTables = React.memo<RulesTableProps>(
         )}
         {shouldShowRulesTable && (
           <>
-            <AllRulesUtilityBar
+            <RulesTableUtilityBar
               canBulkEdit={hasPermissions}
               pagination={pagination}
               numberSelectedItems={selectedItemsCount}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -107,7 +107,7 @@ export const RulesTables = React.memo<RulesTableProps>(
         setSortingOptions,
       },
     } = rulesTableContext;
-    debugger;
+
     const prePackagedRuleStatus = getPrePackagedRuleStatus(
       rulesInstalled,
       rulesNotInstalled,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable complexity */
-
 import {
   EuiBasicTable,
   EuiConfirmModal,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -31,7 +31,7 @@ import { showRulesTable } from './helpers';
 import { useRulesTableContext } from './rules_table/rules_table_context';
 import { useAsyncConfirmation } from './rules_table/use_async_confirmation';
 import { RulesTableFilters } from './rules_table_filters/rules_table_filters';
-import { AllRulesUtilityBar } from './utility_bar';
+import { AllRulesUtilityBar } from './rules_table_utility_bar';
 import { useBulkActionsDryRun } from './bulk_actions/use_bulk_actions_dry_run';
 import { useBulkActionsConfirmation } from './bulk_actions/use_bulk_actions_confirmation';
 import { useBulkEditFormFlyout } from './bulk_actions/use_bulk_edit_form_flyout';
@@ -145,7 +145,6 @@ export const RulesTables = React.memo<RulesTableProps>(
     } = useBulkEditFormFlyout();
 
     const selectedItemsCount = isAllSelected ? pagination.total : selectedRuleIds.length;
-    const hasPagination = pagination.total > pagination.perPage;
 
     const { isBulkActionsDryRunLoading, executeBulkActionsDryRun } = useBulkActionsDryRun();
 
@@ -334,7 +333,6 @@ export const RulesTables = React.memo<RulesTableProps>(
           <>
             <AllRulesUtilityBar
               canBulkEdit={hasPermissions}
-              hasPagination={hasPagination}
               pagination={pagination}
               numberSelectedItems={selectedItemsCount}
               onGetBulkItemsPopoverContent={getBulkItemsPopoverContent}
@@ -345,7 +343,6 @@ export const RulesTables = React.memo<RulesTableProps>(
               onToggleSelectAll={toggleSelectAll}
               isBulkActionInProgress={isBulkActionsDryRunLoading || loadingRulesAction != null}
               hasDisabledActions={loadingRulesAction != null}
-              hasBulkActions
             />
             <EuiBasicTable
               itemId="id"

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -107,7 +107,7 @@ export const RulesTables = React.memo<RulesTableProps>(
         setSortingOptions,
       },
     } = rulesTableContext;
-
+    debugger;
     const prePackagedRuleStatus = getPrePackagedRuleStatus(
       rulesInstalled,
       rulesNotInstalled,
@@ -337,7 +337,7 @@ export const RulesTables = React.memo<RulesTableProps>(
             <AllRulesUtilityBar
               canBulkEdit={hasPermissions}
               hasPagination={hasPagination}
-              paginationTotal={pagination.total ?? 0}
+              pagination={pagination}
               numberSelectedItems={selectedItemsCount}
               onGetBulkItemsPopoverContent={getBulkItemsPopoverContent}
               onRefresh={handleRefreshRules}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
@@ -19,7 +19,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -29,11 +33,45 @@ describe('AllRules', () => {
       </TestProviders>
     );
 
-    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual('Showing 4 rules');
+    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual('Showing 1-10 of 21 rules');
     expect(wrapper.find('[data-test-subj="selectedRules"]').at(0).text()).toEqual(
       'Selected 1 rule'
     );
   });
+
+  describe("renders correct pagination label when", () => {
+    it.each([
+      [1, 1, 1, "Showing 1-1 of 1 rule"],
+      [1, 10, 21, "Showing 1-10 of 21 rules"],
+      [1, 10, 8, "Showing 1-8 of 8 rules"],
+      [2, 10, 31, "Showing 11-20 of 31 rules"],
+      [4, 10, 31, "Showing 31-31 of 31 rules"],
+      [1, 5, 4, "Showing 1-4 of 4 rules"],
+      [1, 100, 100, "Showing 1-100 of 100 rules"],
+      [2, 100, 101, "Showing 101-101 of 101 rules"],
+    ])("current page is %s, showing %s rules per page and total rules is %s", (page, perPage, total, label) => {
+      const wrapper = mount(
+        <TestProviders>
+          <AllRulesUtilityBar
+            canBulkEdit
+            onRefresh={jest.fn()}
+            pagination={{
+              page,
+              perPage,
+              total
+            }}
+            numberSelectedItems={1}
+            onGetBulkItemsPopoverContent={jest.fn()}
+            isAutoRefreshOn={true}
+            onRefreshSwitch={jest.fn()}
+            hasBulkActions
+          />
+        </TestProviders>
+      );
+      expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(label);
+    })
+  })
+
 
   it('does not render total selected and bulk actions when "hasBulkActions" is false', () => {
     const wrapper = mount(
@@ -41,7 +79,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 4
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -64,7 +106,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -83,7 +129,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit={false}
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -103,7 +153,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={mockRefresh}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -125,7 +179,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={0}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -149,7 +207,11 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
@@ -83,11 +83,7 @@ describe('AllRules', () => {
         <AllRulesUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          pagination={{
-            page: 1,
-            perPage: 10,
-            total: 4,
-          }}
+          totalExceptionLists={7}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
@@ -100,7 +96,7 @@ describe('AllRules', () => {
     expect(wrapper.find('[data-test-subj="showingRules"]').exists()).toBeFalsy();
     expect(wrapper.find('[data-test-subj="tableBulkActions"]').exists()).toBeFalsy();
     expect(wrapper.find('[data-test-subj="showingExceptionLists"]').at(0).text()).toEqual(
-      'Showing 4 lists'
+      'Showing 7 lists'
     );
   });
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.test.tsx
@@ -22,7 +22,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -33,45 +33,49 @@ describe('AllRules', () => {
       </TestProviders>
     );
 
-    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual('Showing 1-10 of 21 rules');
+    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(
+      'Showing 1-10 of 21 rules'
+    );
     expect(wrapper.find('[data-test-subj="selectedRules"]').at(0).text()).toEqual(
       'Selected 1 rule'
     );
   });
 
-  describe("renders correct pagination label when", () => {
+  describe('renders correct pagination label when', () => {
     it.each([
-      [1, 1, 1, "Showing 1-1 of 1 rule"],
-      [1, 10, 21, "Showing 1-10 of 21 rules"],
-      [1, 10, 8, "Showing 1-8 of 8 rules"],
-      [2, 10, 31, "Showing 11-20 of 31 rules"],
-      [4, 10, 31, "Showing 31-31 of 31 rules"],
-      [1, 5, 4, "Showing 1-4 of 4 rules"],
-      [1, 100, 100, "Showing 1-100 of 100 rules"],
-      [2, 100, 101, "Showing 101-101 of 101 rules"],
-    ])("current page is %s, showing %s rules per page and total rules is %s", (page, perPage, total, label) => {
-      const wrapper = mount(
-        <TestProviders>
-          <AllRulesUtilityBar
-            canBulkEdit
-            onRefresh={jest.fn()}
-            pagination={{
-              page,
-              perPage,
-              total
-            }}
-            numberSelectedItems={1}
-            onGetBulkItemsPopoverContent={jest.fn()}
-            isAutoRefreshOn={true}
-            onRefreshSwitch={jest.fn()}
-            hasBulkActions
-          />
-        </TestProviders>
-      );
-      expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(label);
-    })
-  })
-
+      [1, 1, 1, 'Showing 1-1 of 1 rule'],
+      [1, 10, 21, 'Showing 1-10 of 21 rules'],
+      [1, 10, 8, 'Showing 1-8 of 8 rules'],
+      [2, 10, 31, 'Showing 11-20 of 31 rules'],
+      [4, 10, 31, 'Showing 31-31 of 31 rules'],
+      [1, 5, 4, 'Showing 1-4 of 4 rules'],
+      [1, 100, 100, 'Showing 1-100 of 100 rules'],
+      [2, 100, 101, 'Showing 101-101 of 101 rules'],
+    ])(
+      'current page is %s, showing %s rules per page and total rules is %s',
+      (page, perPage, total, label) => {
+        const wrapper = mount(
+          <TestProviders>
+            <AllRulesUtilityBar
+              canBulkEdit
+              onRefresh={jest.fn()}
+              pagination={{
+                page,
+                perPage,
+                total,
+              }}
+              numberSelectedItems={1}
+              onGetBulkItemsPopoverContent={jest.fn()}
+              isAutoRefreshOn={true}
+              onRefreshSwitch={jest.fn()}
+              hasBulkActions
+            />
+          </TestProviders>
+        );
+        expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(label);
+      }
+    );
+  });
 
   it('does not render total selected and bulk actions when "hasBulkActions" is false', () => {
     const wrapper = mount(
@@ -82,7 +86,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 4
+            total: 4,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -109,7 +113,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -132,7 +136,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -156,7 +160,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -182,7 +186,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={0}
           onGetBulkItemsPopoverContent={jest.fn()}
@@ -210,7 +214,7 @@ describe('AllRules', () => {
           pagination={{
             page: 1,
             perPage: 10,
-            total: 21
+            total: 21,
           }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
@@ -38,7 +38,8 @@ interface AllRulesUtilityBarProps {
   onRefresh?: () => void;
   onRefreshSwitch?: (checked: boolean) => void;
   onToggleSelectAll?: () => void;
-  pagination: Pagination;
+  pagination?: Pagination;
+  totalExceptionLists?: number;
   hasBulkActions: boolean;
   hasPagination?: boolean;
   isBulkActionInProgress?: boolean;
@@ -56,6 +57,7 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
     onRefreshSwitch,
     onToggleSelectAll,
     pagination,
+    totalExceptionLists,
     hasBulkActions = true,
     hasPagination,
     isBulkActionInProgress,
@@ -123,19 +125,17 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
       [isAutoRefreshOn, handleAutoRefreshSwitch, isAnyRuleSelected]
     );
 
-    const showingRulesParams = getShowingRulesParams(pagination);
-
     return (
       <UtilityBar border>
         <UtilityBarSection>
           <UtilityBarGroup>
-            {hasBulkActions ? (
+            {hasBulkActions && pagination ? (
               <UtilityBarText dataTestSubj="showingRules">
-                {i18n.SHOWING_RULES(...showingRulesParams)}
+                {i18n.SHOWING_RULES(...getShowingRulesParams(pagination))}
               </UtilityBarText>
             ) : (
               <UtilityBarText dataTestSubj="showingExceptionLists">
-                {i18n.SHOWING_EXCEPTION_LISTS(pagination.total)}
+                {i18n.SHOWING_EXCEPTION_LISTS(totalExceptionLists ?? 0)}
               </UtilityBarText>
             )}
           </UtilityBarGroup>
@@ -147,7 +147,7 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
                   {i18n.SELECTED_RULES(numberSelectedItems)}
                 </UtilityBarText>
 
-                {canBulkEdit && onToggleSelectAll && hasPagination && (
+                {canBulkEdit && onToggleSelectAll && hasPagination && pagination && (
                   <UtilityBarAction
                     disabled={hasDisabledActions}
                     dataTestSubj="selectAllRules"

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
@@ -27,7 +27,7 @@ import * as i18n from '../translations';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useRulesTableContextOptional } from './rules_table/rules_table_context';
 import { getShowingRulesParams } from '../utils';
-import { Pagination } from '../types';
+import type { Pagination } from '../types';
 
 interface AllRulesUtilityBarProps {
   canBulkEdit: boolean;

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/utility_bar.tsx
@@ -26,6 +26,8 @@ import {
 import * as i18n from '../translations';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useRulesTableContextOptional } from './rules_table/rules_table_context';
+import { getShowingRulesParams } from '../utils';
+import { Pagination } from '../types';
 
 interface AllRulesUtilityBarProps {
   canBulkEdit: boolean;
@@ -36,7 +38,7 @@ interface AllRulesUtilityBarProps {
   onRefresh?: () => void;
   onRefreshSwitch?: (checked: boolean) => void;
   onToggleSelectAll?: () => void;
-  paginationTotal: number;
+  pagination: Pagination;
   hasBulkActions: boolean;
   hasPagination?: boolean;
   isBulkActionInProgress?: boolean;
@@ -53,7 +55,7 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
     onRefresh,
     onRefreshSwitch,
     onToggleSelectAll,
-    paginationTotal,
+    pagination,
     hasBulkActions = true,
     hasPagination,
     isBulkActionInProgress,
@@ -121,17 +123,19 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
       [isAutoRefreshOn, handleAutoRefreshSwitch, isAnyRuleSelected]
     );
 
+    const showingRulesParams = getShowingRulesParams(pagination);
+
     return (
       <UtilityBar border>
         <UtilityBarSection>
           <UtilityBarGroup>
             {hasBulkActions ? (
               <UtilityBarText dataTestSubj="showingRules">
-                {i18n.SHOWING_RULES(paginationTotal)}
+                {i18n.SHOWING_RULES(...showingRulesParams)}
               </UtilityBarText>
             ) : (
               <UtilityBarText dataTestSubj="showingExceptionLists">
-                {i18n.SHOWING_EXCEPTION_LISTS(paginationTotal)}
+                {i18n.SHOWING_EXCEPTION_LISTS(pagination.total)}
               </UtilityBarText>
             )}
           </UtilityBarGroup>
@@ -151,7 +155,7 @@ export const AllRulesUtilityBar = React.memo<AllRulesUtilityBarProps>(
                     iconSide="left"
                     onClick={onToggleSelectAll}
                   >
-                    {isAllSelected ? i18n.CLEAR_SELECTION : i18n.SELECT_ALL_RULES(paginationTotal)}
+                    {isAllSelected ? i18n.CLEAR_SELECTION : i18n.SELECT_ALL_RULES(pagination.total)}
                   </UtilityBarAction>
                 )}
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -437,10 +437,10 @@ export const SEARCH_PLACEHOLDER = i18n.translate(
   }
 );
 
-export const SHOWING_RULES = (totalRules: number) =>
+export const SHOWING_RULES = (firstInPage: number, lastOfPage: number, totalRules: number) =>
   i18n.translate('xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle', {
-    values: { totalRules },
-    defaultMessage: 'Showing {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
+    values: { firstInPage, lastOfPage, totalRules },
+    defaultMessage: 'Showing {firstInPage}-{lastOfPage} of {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
   });
 
 export const SELECT_ALL_RULES = (totalRules: number) =>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -840,12 +840,6 @@ export const REFRESH_RULE_POPOVER_LABEL = i18n.translate(
   }
 );
 
-export const SHOWING_EXCEPTION_LISTS = (totalLists: number) =>
-  i18n.translate('xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists', {
-    values: { totalLists },
-    defaultMessage: 'Showing {totalLists} {totalLists, plural, =1 {list} other {lists}}',
-  });
-
 /**
  * Bulk Export
  */

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -440,7 +440,8 @@ export const SEARCH_PLACEHOLDER = i18n.translate(
 export const SHOWING_RULES = (firstInPage: number, lastOfPage: number, totalRules: number) =>
   i18n.translate('xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle', {
     values: { firstInPage, lastOfPage, totalRules },
-    defaultMessage: 'Showing {firstInPage}-{lastOfPage} of {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
+    defaultMessage:
+      'Showing {firstInPage}-{lastOfPage} of {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
   });
 
 export const SELECT_ALL_RULES = (totalRules: number) =>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
@@ -51,6 +51,12 @@ export interface EuiBasicTableOnChange {
   sort?: EuiBasicTableSortTypes;
 }
 
+export type Pagination = {
+  page: number,
+  perPage: number,
+  total: number,
+}
+
 export type RuleStatusType = 'passive' | 'active' | 'valid';
 
 export enum RuleStep {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
@@ -51,12 +51,6 @@ export interface EuiBasicTableOnChange {
   sort?: EuiBasicTableSortTypes;
 }
 
-export interface Pagination {
-  page: number;
-  perPage: number;
-  total: number;
-}
-
 export type RuleStatusType = 'passive' | 'active' | 'valid';
 
 export enum RuleStep {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
@@ -51,10 +51,10 @@ export interface EuiBasicTableOnChange {
   sort?: EuiBasicTableSortTypes;
 }
 
-export type Pagination = {
-  page: number,
-  perPage: number,
-  total: number,
+export interface Pagination {
+  page: number;
+  perPage: number;
+  total: number;
 }
 
 export type RuleStatusType = 'passive' | 'active' | 'valid';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -73,6 +73,6 @@ export const getTrailingBreadcrumbs = (
 export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination)  => {
   const firstInPage = (page - 1) * perPage + 1;
   const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
-
+  
   return [firstInPage, lastInPage, totalRules] as const;
 }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -11,7 +11,7 @@ import * as i18nRules from './translations';
 import type { RouteSpyState } from '../../../../common/utils/route/types';
 import { SecurityPageName } from '../../../../app/types';
 import { RULES_PATH } from '../../../../../common/constants';
-import type { Pagination, RuleStepsOrder } from './types';
+import type { RuleStepsOrder } from './types';
 import { RuleStep } from './types';
 import type { GetSecuritySolutionUrl } from '../../../../common/components/link_to';
 
@@ -68,11 +68,4 @@ export const getTrailingBreadcrumbs = (
   }
 
   return breadcrumb;
-};
-
-export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination) => {
-  const firstInPage = totalRules === 0 ? 0 : (page - 1) * perPage + 1;
-  const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
-
-  return [firstInPage, lastInPage, totalRules] as const;
 };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -11,7 +11,7 @@ import * as i18nRules from './translations';
 import type { RouteSpyState } from '../../../../common/utils/route/types';
 import { SecurityPageName } from '../../../../app/types';
 import { RULES_PATH } from '../../../../../common/constants';
-import type { RuleStepsOrder } from './types';
+import type { Pagination, RuleStepsOrder } from './types';
 import { RuleStep } from './types';
 import type { GetSecuritySolutionUrl } from '../../../../common/components/link_to';
 
@@ -69,3 +69,10 @@ export const getTrailingBreadcrumbs = (
 
   return breadcrumb;
 };
+
+export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination)  => {
+  const firstInPage = (page - 1) * perPage + 1;
+  const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
+
+  return [firstInPage, lastInPage, totalRules] as const;
+}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -70,9 +70,9 @@ export const getTrailingBreadcrumbs = (
   return breadcrumb;
 };
 
-export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination)  => {
+export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination) => {
   const firstInPage = (page - 1) * perPage + 1;
   const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
-  
+
   return [firstInPage, lastInPage, totalRules] as const;
-}
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -71,7 +71,7 @@ export const getTrailingBreadcrumbs = (
 };
 
 export const getShowingRulesParams = ({ page, perPage, total: totalRules }: Pagination) => {
-  const firstInPage = (page - 1) * perPage + 1;
+  const firstInPage = totalRules === 0 ? 0 : (page - 1) * perPage + 1;
   const lastInPage = page * perPage > totalRules ? totalRules : page * perPage;
 
   return [firstInPage, lastInPage, totalRules] as const;

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -25369,7 +25369,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "Durée de l'écart le plus récent dans l'exécution de la règle. Ajustez l'historique des règles ou {seeDocs} pour réduire les écarts.",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "Sélection totale de {totalRules} {totalRules, plural, =1 {règle} other {règles}} effectuée",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "Sélection de {selectedRules} {selectedRules, plural, =1 {règle} other {règles}} effectuée",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "Affichage de {totalLists} {totalLists, plural, =1 {liste} other {listes}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} a été créé",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "Infobulle pour la colonne : {columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "Installez {missingRules} {missingRules, plural, =1 {règle prédéfinie} other {règles prédéfinies}} d'Elastic et {missingTimelines} {missingTimelines, plural, =1 {chronologie prédéfinie} other {chronologies prédéfinies}} d'Elastic ",

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -25370,7 +25370,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "Sélection totale de {totalRules} {totalRules, plural, =1 {règle} other {règles}} effectuée",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "Sélection de {selectedRules} {selectedRules, plural, =1 {règle} other {règles}} effectuée",
     "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "Affichage de {totalLists} {totalLists, plural, =1 {liste} other {listes}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "Affichage de {totalRules} {totalRules, plural, =1 {règle} other {règles}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} a été créé",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "Infobulle pour la colonne : {columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "Installez {missingRules} {missingRules, plural, =1 {règle prédéfinie} other {règles prédéfinies}} d'Elastic et {missingTimelines} {missingTimelines, plural, =1 {chronologie prédéfinie} other {chronologies prédéfinies}} d'Elastic ",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -25348,7 +25348,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "すべての{totalRules} {totalRules, plural, other  {個のルール}}を選択",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "{selectedRules} {selectedRules, plural, other  {ルール}}を選択しました",
     "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "{totalLists} {totalLists, plural, other  {件のリスト}}を表示しています。",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "{totalRules} {totalRules, plural, other  {ルール}}を表示中",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName}が作成されました",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列のツールチップ：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "{missingRules} Elastic事前構築済み{missingRules, plural, other  {ルール}}と{missingTimelines} Elastic事前構築済み{missingTimelines, plural, other  {タイムライン}}をインストール ",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -25347,7 +25347,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "ルール実行の最新のギャップの期間。ルールルックバックを調整するか、ギャップの軽減については{seeDocs}してください。",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "すべての{totalRules} {totalRules, plural, other  {個のルール}}を選択",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "{selectedRules} {selectedRules, plural, other  {ルール}}を選択しました",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "{totalLists} {totalLists, plural, other  {件のリスト}}を表示しています。",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName}が作成されました",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列のツールチップ：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "{missingRules} Elastic事前構築済み{missingRules, plural, other  {ルール}}と{missingTimelines} Elastic事前構築済み{missingTimelines, plural, other  {タイムライン}}をインストール ",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25378,7 +25378,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "选择所有 {totalRules} 个{totalRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "已选择 {selectedRules} 个{selectedRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "正在显示 {totalLists} 个{totalLists, plural, other {列表}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "正在显示 {totalRules} 个{totalRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} 已创建",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列的工具提示：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "安装 {missingRules} 个 Elastic 预构建{missingRules, plural, other {规则}}以及 {missingTimelines} 个 Elastic 预构建{missingTimelines, plural, other {时间线}} ",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25377,7 +25377,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "规则执行中最近缺口的持续时间。调整规则回查或{seeDocs}以缩小缺口。",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "选择所有 {totalRules} 个{totalRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "已选择 {selectedRules} 个{selectedRules, plural, other {规则}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "正在显示 {totalLists} 个{totalLists, plural, other {列表}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} 已创建",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列的工具提示：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "安装 {missingRules} 个 Elastic 预构建{missingRules, plural, other {规则}}以及 {missingTimelines} 个 Elastic 预构建{missingTimelines, plural, other {时间线}} ",


### PR DESCRIPTION
**Fixes:** https://github.com/elastic/kibana/issues/121754

## Summary

Changes rules count pagination count to format:

**"Showing 1-10 of 596 rules"** -> when page 1, rules per page is 10 and total rules is 596
**"Showing 6-6 of 6 rules"** -> when page 2, rules per page is 5 and total rules is 6
See other cases in tests.

**Before changes**
![image](https://user-images.githubusercontent.com/5354282/184883106-118f0041-5567-4cf8-bfd5-8383e8146018.png)
![image](https://user-images.githubusercontent.com/5354282/184884145-22d30482-cc2d-4796-8f84-d809a8ca6d8a.png)


**After changes**
![image](https://user-images.githubusercontent.com/5354282/184882149-d6c55dff-39a0-4a72-94a9-217b2e5ca7ac.png)
![image](https://user-images.githubusercontent.com/5354282/184886334-a107a2c5-31dc-4a7b-9e70-54c87c1630e0.png)

## Codebase changes

- Refactors `AllRulesUtilityBar` component to separate usage of the utility bar between the all-rules table use-case and the Exceptions table use-case, by creating a new `ExceptionsTableUtilityBar` component. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->