### PR TITLE
[Fleet] tests - update package registry image

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -18,7 +18,7 @@ import pRetry from 'p-retry';
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
 const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:d32582b3bbeef5283e4450a9403f26c2a5e415f4`;
+const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:390966a60feb5c3a2a8be7987feaa9411206bf69`;
 
 function firstWithTimeout(source$: Rx.Observable<any>, errorMsg: string, ms = 30 * 1000) {
   return Rx.race(

--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -18,7 +18,7 @@ import pRetry from 'p-retry';
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
 const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:390966a60feb5c3a2a8be7987feaa9411206bf69`;
+const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:c9f9a83da2c00118d5451cc69c680ade74494d4e`;
 
 function firstWithTimeout(source$: Rx.Observable<any>, errorMsg: string, ms = 30 * 1000) {
   return Rx.race(

--- a/x-pack/plugins/fleet/server/integration_tests/validate_bundled_packages.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/validate_bundled_packages.test.ts
@@ -19,8 +19,7 @@ import { appContextService } from '../services';
 
 import { useDockerRegistry } from './helpers';
 
-// Failing: https://github.com/elastic/kibana/issues/138905
-describe.skip('validate bundled packages', () => {
+describe('validate bundled packages', () => {
   const registryUrl = useDockerRegistry();
   let mockContract: ReturnType<typeof createAppContextStartContractMock>;
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/138905

Updates the package registry docker image uses in Fleet tests to the one from this build: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/production/412/pipeline/290

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->