### PR TITLE
[Canvas] Use index pattern service to load index patterns

### DIFF
--- a/x-pack/plugins/canvas/kibana.json
+++ b/x-pack/plugins/canvas/kibana.json
@@ -14,6 +14,7 @@
     "bfetch",
     "charts",
     "data",
+    "dataViews",
     "embeddable",
     "expressionError",
     "expressionImage",

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -21,6 +21,7 @@ import {
 } from '@kbn/core/public';
 import { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import { DataViewsService } from '@kbn/data-views-plugin/public';
 import { ExpressionsSetup, ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
@@ -62,6 +63,7 @@ export interface CanvasStartDeps {
   uiActions: UiActionsStart;
   charts: ChartsPluginStart;
   data: DataPublicPluginStart;
+  dataViews: DataViewsService;
   presentationUtil: PresentationUtilPluginStart;
   visualizations: VisualizationsStart;
   spaces?: SpacesPluginStart;

--- a/x-pack/plugins/canvas/public/services/data_views.ts
+++ b/x-pack/plugins/canvas/public/services/data_views.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+
+export interface DataViewsService {
+  getIdsWithTitle: DataViewsPublicPluginStart['getIdsWithTitle'];
+  getDefaultDataView: DataViewsPublicPluginStart['getDefaultDataView'];
+}

--- a/x-pack/plugins/canvas/public/services/index.ts
+++ b/x-pack/plugins/canvas/public/services/index.ts
@@ -9,17 +9,18 @@ export * from './legacy';
 
 import { PluginServices } from '@kbn/presentation-util-plugin/public';
 
-import { CanvasCustomElementService } from './custom_element';
-import { CanvasEmbeddablesService } from './embeddables';
-import { CanvasExpressionsService } from './expressions';
-import { CanvasFiltersService } from './filters';
-import { CanvasLabsService } from './labs';
-import { CanvasNavLinkService } from './nav_link';
-import { CanvasNotifyService } from './notify';
-import { CanvasPlatformService } from './platform';
-import { CanvasReportingService } from './reporting';
-import { CanvasVisualizationsService } from './visualizations';
-import { CanvasWorkpadService } from './workpad';
+import type { CanvasCustomElementService } from './custom_element';
+import type { CanvasEmbeddablesService } from './embeddables';
+import type { CanvasExpressionsService } from './expressions';
+import type { CanvasFiltersService } from './filters';
+import type { CanvasLabsService } from './labs';
+import type { CanvasNavLinkService } from './nav_link';
+import type { CanvasNotifyService } from './notify';
+import type { CanvasPlatformService } from './platform';
+import type { CanvasReportingService } from './reporting';
+import type { CanvasVisualizationsService } from './visualizations';
+import type { CanvasWorkpadService } from './workpad';
+import type { DataViewsService } from './data_views';
 
 export interface CanvasPluginServices {
   customElement: CanvasCustomElementService;
@@ -33,6 +34,7 @@ export interface CanvasPluginServices {
   reporting: CanvasReportingService;
   visualizations: CanvasVisualizationsService;
   workpad: CanvasWorkpadService;
+  dataViews: DataViewsService;
 }
 
 export const pluginServices = new PluginServices<CanvasPluginServices>();

--- a/x-pack/plugins/canvas/public/services/kibana/data_views.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/data_views.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaPluginServiceFactory } from '@kbn/presentation-util-plugin/public';
+import type { CanvasStartDeps } from '../../plugin';
+import type { DataViewsService } from '../data_views';
+
+export type DataViewsServiceFactory = KibanaPluginServiceFactory<DataViewsService, CanvasStartDeps>;
+
+export const dataViewsServiceFactory: DataViewsServiceFactory = ({ startPlugins }) => ({
+  getDefaultDataView: () => startPlugins.dataViews.getDefaultDataView(),
+  getIdsWithTitle: () => startPlugins.dataViews.getIdsWithTitle(),
+});

--- a/x-pack/plugins/canvas/public/services/kibana/index.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/index.ts
@@ -25,6 +25,7 @@ import { reportingServiceFactory } from './reporting';
 import { visualizationsServiceFactory } from './visualizations';
 import { workpadServiceFactory } from './workpad';
 import { filtersServiceFactory } from './filters';
+import { dataViewsServiceFactory } from './data_views';
 
 export { customElementServiceFactory } from './custom_element';
 export { embeddablesServiceFactory } from './embeddables';
@@ -52,6 +53,7 @@ export const pluginServiceProviders: PluginServiceProviders<
   reporting: new PluginServiceProvider(reportingServiceFactory),
   visualizations: new PluginServiceProvider(visualizationsServiceFactory),
   workpad: new PluginServiceProvider(workpadServiceFactory),
+  dataViews: new PluginServiceProvider(dataViewsServiceFactory),
 };
 
 export const pluginServiceRegistry = new PluginServiceRegistry<

--- a/x-pack/plugins/canvas/public/services/stubs/data_views.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/data_views.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginServiceFactory } from '@kbn/presentation-util-plugin/public';
+import type { DataViewsService } from '../data_views';
+
+type DataViewsFactory = PluginServiceFactory<DataViewsService>;
+
+export const dataViewsServiceFactory: DataViewsFactory = () => ({
+  getIdsWithTitle: async () => [{ id: 'id', title: 'kibana_test_data_view' }],
+  getDefaultDataView: async () => null,
+});

--- a/x-pack/plugins/canvas/public/services/stubs/index.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/index.ts
@@ -25,6 +25,7 @@ import { reportingServiceFactory } from './reporting';
 import { visualizationsServiceFactory } from './visualizations';
 import { workpadServiceFactory } from './workpad';
 import { filtersServiceFactory } from './filters';
+import { dataViewsServiceFactory } from './data_views';
 
 export { customElementServiceFactory } from './custom_element';
 export { expressionsServiceFactory } from './expressions';
@@ -36,6 +37,7 @@ export { platformServiceFactory } from './platform';
 export { reportingServiceFactory } from './reporting';
 export { visualizationsServiceFactory } from './visualizations';
 export { workpadServiceFactory } from './workpad';
+export { dataViewsServiceFactory } from './data_views';
 
 export const pluginServiceProviders: PluginServiceProviders<CanvasPluginServices> = {
   customElement: new PluginServiceProvider(customElementServiceFactory),
@@ -49,6 +51,7 @@ export const pluginServiceProviders: PluginServiceProviders<CanvasPluginServices
   reporting: new PluginServiceProvider(reportingServiceFactory),
   visualizations: new PluginServiceProvider(visualizationsServiceFactory),
   workpad: new PluginServiceProvider(workpadServiceFactory),
+  dataViews: new PluginServiceProvider(dataViewsServiceFactory),
 };
 
 export const pluginServiceRegistry = new PluginServiceRegistry<CanvasPluginServices>(


### PR DESCRIPTION
Part of #91715

## Summary

This PR resolve the following part of #91715
- https://github.com/elastic/kibana/blob/master/x-pack/plugins/canvas/public/lib/es_service.ts
