### PR TITLE
Replaces implementation in simple saved object mock with an actual mock

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
@@ -6,15 +6,47 @@
  * Side Public License, v 1.
  */
 
-import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-browser';
-import { SimpleSavedObjectImpl } from '@kbn/core-saved-objects-browser-internal';
+import type {
+  SavedObjectsClientContract,
+  SimpleSavedObject,
+} from '@kbn/core-saved-objects-api-browser';
 import type { SavedObject } from '@kbn/core-saved-objects-common';
 
+type T = unknown;
 const createSimpleSavedObjectMock = (
-  client: SavedObjectsClientContract,
-  savedObject: SavedObject<unknown>
-) => new SimpleSavedObjectImpl(client, savedObject);
+  savedObject: SavedObject
+): jest.Mocked<SimpleSavedObject<T>> => {
+  const mock = {
+    attributes: savedObject.attributes || ({} as T),
+    _version: savedObject.version ?? '',
+    id: savedObject.id ?? 'id',
+    type: savedObject.type ?? 'type',
+    migrationVersion: savedObject.migrationVersion ?? {},
+    coreMigrationVersion: savedObject.coreMigrationVersion ?? '8.0.0',
+    error: undefined,
+    references: savedObject.references ?? [],
+    updatedAt: savedObject.updated_at ?? '',
+    namespaces: savedObject.namespaces ?? undefined,
+    get: jest.fn(),
+    set: jest.fn(),
+    has: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+  mock.get.mockImplementation(
+    (key: string): any => (savedObject.attributes as any)[key] || undefined
+  );
+  mock.set.mockReturnValue((key: string, value: any) => {
+    (savedObject as any)[key] = value;
+    return savedObject;
+  });
+  mock.has.mockReturnValue(true);
+  mock.save.mockImplementation(() => Promise.resolve(mock));
+  mock.delete.mockImplementation(() => Promise.resolve({}));
+  return mock;
+};
 
 export const simpleSavedObjectMock = {
-  create: createSimpleSavedObjectMock,
+  create: (client: SavedObjectsClientContract, savedObject: SavedObject) =>
+    createSimpleSavedObjectMock(savedObject),
 };

--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/src/simple_saved_object.mock.ts
@@ -13,20 +13,35 @@ import type {
 import type { SavedObject } from '@kbn/core-saved-objects-common';
 
 type T = unknown;
+
+const simpleSavedObjectMockDefaults: Partial<SimpleSavedObject<T>> = {
+  attributes: {},
+  _version: '',
+  id: 'id',
+  type: 'type',
+  migrationVersion: {},
+  coreMigrationVersion: '8.0.0',
+  error: undefined,
+  references: [],
+  updatedAt: '',
+  namespaces: undefined,
+};
+
 const createSimpleSavedObjectMock = (
   savedObject: SavedObject
 ): jest.Mocked<SimpleSavedObject<T>> => {
   const mock = {
-    attributes: savedObject.attributes || ({} as T),
-    _version: savedObject.version ?? '',
-    id: savedObject.id ?? 'id',
-    type: savedObject.type ?? 'type',
-    migrationVersion: savedObject.migrationVersion ?? {},
-    coreMigrationVersion: savedObject.coreMigrationVersion ?? '8.0.0',
-    error: undefined,
-    references: savedObject.references ?? [],
-    updatedAt: savedObject.updated_at ?? '',
-    namespaces: savedObject.namespaces ?? undefined,
+    ...simpleSavedObjectMockDefaults,
+    attributes: savedObject.attributes,
+    _version: savedObject.version,
+    id: savedObject.id,
+    type: savedObject.type,
+    migrationVersion: savedObject.migrationVersion,
+    coreMigrationVersion: savedObject.coreMigrationVersion,
+    error: savedObject.error,
+    references: savedObject.references,
+    updatedAt: savedObject.updated_at,
+    namespaces: savedObject.namespaces,
     get: jest.fn(),
     set: jest.fn(),
     has: jest.fn(),


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/138063.

We added a `SimpleSavedObject` pseudo-mock in order to keep the implementation internal to core. This PR replaces the implementation within the mock with an actual mock.