### PR TITLE
[Enterprise Search] make enterprise search nav link to overview

### DIFF
--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -93,6 +93,7 @@ const overviewIDs = [
   'observability-overview',
   'securitySolutionUI:get_started',
   'management',
+  'enterpriseSearch',
 ];
 
 export function CollapsibleNav({


### PR DESCRIPTION
## Summary

Added the `enterpriseSearch` link id to the `overviewIDs` so that the
Enterprise Search accordion button in the collapsible nav is a link to
the overview page. This brings the Enterprise Search section in line
with the other overview sections in Nav by linking out to the app
instead of just controlling the accordion.

Closes [elastic/enterprise-search-team#2470](https://github.com/elastic/enterprise-search-team/issues/2470)

### Screenshots 
After:
https://user-images.githubusercontent.com/1972968/184964264-3aa06304-575c-48de-b28a-82e96fe9ef0a.mov

Before:
https://user-images.githubusercontent.com/1972968/184964544-8d8e6e2e-22e2-47a9-950f-6301fa907d40.mov

### Checklist

N/A