### PR TITLE
[TIP] Show loading spinner when IndicatorsTable is loading data

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
@@ -42,7 +42,6 @@ export function WithIndicators() {
   return (
     <KibanaReactContext.Provider>
       <IndicatorsTable
-        firstLoad={false}
         loading={false}
         pagination={{
           pageSize: 10,
@@ -62,7 +61,6 @@ export function WithIndicators() {
 export function WithNoIndicators() {
   return (
     <IndicatorsTable
-      firstLoad={false}
       pagination={{
         pageSize: 10,
         pageIndex: 0,
@@ -73,6 +71,24 @@ export function WithNoIndicators() {
       onChangeItemsPerPage={stub}
       indicatorCount={0}
       loading={false}
+      indexPatterns={[]}
+    />
+  );
+}
+
+export function Loading() {
+  return (
+    <IndicatorsTable
+      pagination={{
+        pageSize: 10,
+        pageIndex: 0,
+        pageSizeOptions: [10, 25, 50],
+      }}
+      indicators={[]}
+      onChangePage={stub}
+      onChangeItemsPerPage={stub}
+      indicatorCount={0}
+      loading={true}
       indexPatterns={[]}
     />
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.test.tsx
@@ -21,7 +21,6 @@ const tableProps: IndicatorsTableProps = {
   indicators: [],
   pagination: { pageSize: 10, pageIndex: 0, pageSizeOptions: [10] },
   indicatorCount: 0,
-  firstLoad: false,
   loading: false,
   indexPatterns: [],
 };
@@ -42,11 +41,11 @@ const indicatorsFixture: Indicator[] = [
 ];
 
 describe('<IndicatorsTable />', () => {
-  it('should render loading spinner on first load', async () => {
+  it('should render loading spinner when loading', async () => {
     await act(async () => {
       render(
         <TestProvidersComponent>
-          <IndicatorsTable {...tableProps} firstLoad={true} />
+          <IndicatorsTable {...tableProps} loading={true} />
         </TestProvidersComponent>
       );
     });
@@ -54,13 +53,13 @@ describe('<IndicatorsTable />', () => {
     expect(screen.queryByRole('progressbar')).toBeInTheDocument();
   });
 
-  it('should render datagrid when first load is done', async () => {
+  it('should render datagrid when loading is done', async () => {
     await act(async () => {
       render(
         <TestProvidersComponent>
           <IndicatorsTable
             {...tableProps}
-            firstLoad={false}
+            loading={false}
             indicatorCount={indicatorsFixture.length}
             indicators={indicatorsFixture}
           />

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { VFC, useState, useMemo } from 'react';
-import { EuiDataGrid, EuiLoadingSpinner, EuiText } from '@elastic/eui';
+import {
+  EuiDataGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -80,7 +87,6 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
   onChangePage,
   onChangeItemsPerPage,
   pagination,
-  firstLoad,
   loading,
   indexPatterns,
 }) => {
@@ -141,11 +147,19 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
     [renderCellValue]
   );
 
-  if (firstLoad) {
-    return <EuiLoadingSpinner size="m" />;
+  if (loading) {
+    return (
+      <EuiFlexGroup justifyContent="spaceAround">
+        <EuiFlexItem grow={false}>
+          <EuiPanel hasShadow={false} hasBorder={false} paddingSize="xl">
+            <EuiLoadingSpinner size="xl" />
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
   }
 
-  if (!loading && !indicatorCount) {
+  if (!indicatorCount) {
     return <EmptyState />;
   }
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
@@ -35,7 +35,6 @@ export interface UseIndicatorsValue {
   pagination: Pagination;
   onChangeItemsPerPage: (value: number) => void;
   onChangePage: (value: number) => void;
-  firstLoad: boolean;
   loading: boolean;
 }
 
@@ -73,7 +72,6 @@ export const useIndicators = ({
 
   const [indicators, setIndicators] = useState<Indicator[]>([]);
   const [indicatorCount, setIndicatorCount] = useState<number>(0);
-  const [firstLoad, setFirstLoad] = useState(true);
   const [loading, setLoading] = useState(true);
 
   const [pagination, setPagination] = useState({
@@ -148,14 +146,12 @@ export const useIndicators = ({
               searchSubscription$.current?.unsubscribe();
             }
 
-            setFirstLoad(false);
             setLoading(false);
           },
           error: (msg) => {
             searchService.showError(msg);
             searchSubscription$.current?.unsubscribe();
 
-            setFirstLoad(false);
             setLoading(false);
           },
         });
@@ -201,7 +197,6 @@ export const useIndicators = ({
     pagination,
     onChangePage,
     onChangeItemsPerPage,
-    firstLoad,
     loading,
     handleRefresh,
   };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
@@ -32,10 +32,9 @@ const stub = () => {};
 describe('<IndicatorsPage />', () => {
   beforeAll(() => {
     (useIndicators as jest.MockedFunction<typeof useIndicators>).mockReturnValue({
-      indicators: [],
-      indicatorCount: 0,
-      firstLoad: false,
-      loading: true,
+      indicators: [{ fields: {} }],
+      indicatorCount: 1,
+      loading: false,
       pagination: { pageIndex: 0, pageSize: 10, pageSizeOptions: [10] },
       onChangeItemsPerPage: stub,
       onChangePage: stub,


### PR DESCRIPTION
## Summary

This PR adds large spinner rendered whenever indicators table is fetching data.

![image](https://user-images.githubusercontent.com/11671118/185065553-bc8a860d-0ffc-48b7-a466-620f06b930ad.png)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->