### PR TITLE
update telemetry.optIn for perf tests

### DIFF
--- a/x-pack/test/performance/journeys/base.config.ts
+++ b/x-pack/test/performance/journeys/base.config.ts
@@ -59,6 +59,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
       ...functionalConfig.get('kbnTestServer'),
       serverArgs: [
         ...functionalConfig.get('kbnTestServer.serverArgs'),
+        `--telemetry.optIn=true`,
         `--telemetry.labels=${JSON.stringify(telemetryLabels)}`,
       ],
       env: {


### PR DESCRIPTION
Single user performance journeys are relying on common functional config which include a server arg `--telemetry.optIn=false`. This PR overrides that label to `true` for performance tests in order us to get telemetry data for performance tests.