### PR TITLE
[Profiling] Right-align stats in functions table

### DIFF
--- a/x-pack/plugins/profiling/public/components/topn_functions.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions.tsx
@@ -154,6 +154,7 @@ export const TopNFunctionsTable = ({
       name: i18n.translate('xpack.profiling.functionsView.samplesColumnLabel', {
         defaultMessage: 'Samples',
       }),
+      align: 'right',
     },
     {
       field: TopNFunctionSortField.ExclusiveCPU,
@@ -163,6 +164,7 @@ export const TopNFunctionsTable = ({
       render: (_, { exclusiveCPU, diff }) => {
         return <CPUStat cpu={exclusiveCPU} diffCPU={diff?.exclusiveCPU} />;
       },
+      align: 'right',
     },
     {
       field: TopNFunctionSortField.InclusiveCPU,
@@ -172,6 +174,7 @@ export const TopNFunctionsTable = ({
       render: (_, { inclusiveCPU, diff }) => {
         return <CPUStat cpu={inclusiveCPU} diffCPU={diff?.inclusiveCPU} />;
       },
+      align: 'right',
     },
   ];
 

--- a/x-pack/plugins/profiling/public/components/topn_functions.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions.tsx
@@ -127,6 +127,7 @@ export const TopNFunctionsTable = ({
       name: i18n.translate('xpack.profiling.functionsView.rankColumnLabel', {
         defaultMessage: 'Rank',
       }),
+      align: 'right',
     },
     {
       field: TopNFunctionSortField.Frame,


### PR DESCRIPTION
Before:
<img width="1357" alt="CleanShot 2022-08-17 at 13 25 26@2x" src="https://user-images.githubusercontent.com/352732/185107004-5fd1f82b-6912-446e-b240-97da996336ee.png">

After:
<img width="1361" alt="CleanShot 2022-08-17 at 13 24 43@2x" src="https://user-images.githubusercontent.com/352732/185106876-89601eb9-3684-4993-9765-b3f195f6d61f.png">
