### PR TITLE
[Discover] Remove usage of savedObjects API

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -145,6 +145,10 @@ export class DataView implements DataViewBase {
    * Name of the data view. Human readable name used to differentiate data view.
    */
   public name: string = '';
+  /**
+   * Timestamp of the last time this data view was updated.
+   */
+  public updatedAt: string | undefined;
 
   /**
    * constructor
@@ -181,6 +185,7 @@ export class DataView implements DataViewBase {
     this.runtimeFieldMap = cloneDeep(spec.runtimeFieldMap) || {};
     this.namespaces = spec.namespaces || [];
     this.name = spec.name || '';
+    this.updatedAt = spec.updatedAt;
   }
 
   /**
@@ -304,6 +309,7 @@ export class DataView implements DataViewBase {
       fieldAttrs: cloneDeep(this.fieldAttrs),
       allowNoIndex: this.allowNoIndex,
       name: this.name,
+      updatedAt: this.updatedAt,
     };
 
     // Filter undefined values from the spec

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -309,7 +309,6 @@ export class DataView implements DataViewBase {
       fieldAttrs: cloneDeep(this.fieldAttrs),
       allowNoIndex: this.allowNoIndex,
       name: this.name,
-      updatedAt: this.updatedAt,
     };
 
     // Filter undefined values from the spec

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -625,6 +625,7 @@ export class DataViewsService {
    */
 
   savedObjectToSpec = (savedObject: SavedObject<DataViewAttributes>): DataViewSpec => {
+    // @ts-ignore
     const {
       id,
       version,
@@ -642,6 +643,8 @@ export class DataViewsService {
         allowNoIndex,
         name,
       },
+      // @ts-ignore
+      updatedAt,
     } = savedObject;
 
     const parsedSourceFilters = sourceFilters ? JSON.parse(sourceFilters) : undefined;
@@ -668,6 +671,7 @@ export class DataViewsService {
       allowNoIndex,
       runtimeFieldMap: parsedRuntimeFieldMap,
       name,
+      updatedAt,
     };
   };
 

--- a/src/plugins/data_views/common/types.ts
+++ b/src/plugins/data_views/common/types.ts
@@ -506,6 +506,10 @@ export type DataViewSpec = {
    * Name of the data view. Human readable name used to differentiate data view.
    */
   name?: string;
+  /**
+   * Timestamp of the last time this data view was updated.
+   */
+  updatedAt?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/src/plugins/discover/public/application/view_alert/view_alert_route.tsx
+++ b/src/plugins/discover/public/application/view_alert/view_alert_route.tsx
@@ -104,9 +104,8 @@ export function ViewAlertRoute() {
         return;
       }
 
-      const dataViewSavedObject = await core.savedObjects.client.get('index-pattern', dataView.id!);
       const alertUpdatedAt = fetchedAlert.updatedAt;
-      const dataViewUpdatedAt = dataViewSavedObject.updatedAt!;
+      const dataViewUpdatedAt = dataView.updatedAt!;
       // data view updated after the last update of the alert rule
       if (
         openActualAlert &&


### PR DESCRIPTION
Addresses #91715 

Steps to test it:
- On Discover page create a new rule via "Alert" top menu item
- Navigate to Stack Management > Rules and Connectors
- Open your rule
- Press on "Open in app" link at the top => it will redirect you back to Discover