### PR TITLE
[Maps] support Vector tile runtime geo_point fields

### DIFF
--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
@@ -360,14 +360,6 @@ describe('geoPointToGeometry', () => {
     expect(points[0].coordinates).toEqual([lon, lat]);
   });
 
-  it('Should convert runtime geo_point value', () => {
-    const points = [];
-    geoPointToGeometry(`${lat},${lon}`, points);
-    expect(points.length).toBe(1);
-    expect(points[0].type).toBe('Point');
-    expect(points[0].coordinates).toEqual([lon, lat]);
-  });
-
   it('Should convert array of values', () => {
     const lat2 = 30;
     const lon2 = -60;

--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
@@ -129,7 +129,7 @@ export function hitsToGeoJson(
 
 // Parse geo_point fields API response
 export function geoPointToGeometry(
-  value: Point[] | Point | string | undefined,
+  value: Point[] | Point | undefined,
   accumulator: Geometry[]
 ): void {
   if (!value) {
@@ -140,19 +140,6 @@ export function geoPointToGeometry(
     for (let i = 0; i < value.length; i++) {
       geoPointToGeometry(value[i], accumulator);
     }
-    return;
-  }
-
-  // runtime geo_point field returns value as "lat,lon" string instead of GeoJSON
-  // This is a workaround for a bug - https://github.com/elastic/elasticsearch/issues/85245
-  if (typeof value === 'string') {
-    const commaSplit = value.split(',');
-    const lat = parseFloat(commaSplit[0]);
-    const lon = parseFloat(commaSplit[1]);
-    accumulator.push({
-      type: GEO_JSON_TYPE.POINT,
-      coordinates: [lon, lat],
-    } as Point);
     return;
   }
 

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/__snapshots__/update_source_editor.test.js.snap
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/__snapshots__/update_source_editor.test.js.snap
@@ -94,12 +94,10 @@ exports[`should enable sort order select when sort field provided 1`] = `
       clusteringDisabledReason={null}
       filterByMapBounds={true}
       indexPatternId="indexPattern1"
-      mvtDisabledReason={null}
       numberOfJoins={0}
       onChange={[Function]}
       scalingType="LIMIT"
       supportsClustering={false}
-      supportsMvt={true}
     />
   </EuiPanel>
   <EuiSpacer
@@ -201,12 +199,10 @@ exports[`should render update source editor 1`] = `
       clusteringDisabledReason={null}
       filterByMapBounds={true}
       indexPatternId="indexPattern1"
-      mvtDisabledReason={null}
       numberOfJoins={0}
       onChange={[Function]}
       scalingType="LIMIT"
       supportsClustering={false}
-      supportsMvt={true}
     />
   </EuiPanel>
   <EuiSpacer

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/create_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/create_source_editor.tsx
@@ -84,7 +84,7 @@ export class CreateSourceEditor extends Component<Props, State> {
         ? {
             indexPatternId: indexPattern.id,
             geoField: geoFieldName,
-            scalingType: field && field.isRuntimeField ? SCALING_TYPES.LIMIT : SCALING_TYPES.MVT,
+            scalingType: SCALING_TYPES.MVT,
           }
         : null;
     const isPointsOnly = field ? field.type === 'geo_point' : false;

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/update_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/update_source_editor.tsx
@@ -47,8 +47,6 @@ interface State {
   sortFields: DataViewField[] | undefined;
   supportsClustering: boolean;
   clusteringDisabledReason: string | null;
-  supportsMvt: boolean;
-  mvtDisabledReason: string | null;
 }
 
 export class UpdateSourceEditor extends Component<Props, State> {
@@ -58,8 +56,6 @@ export class UpdateSourceEditor extends Component<Props, State> {
     sortFields: undefined,
     supportsClustering: false,
     clusteringDisabledReason: null,
-    supportsMvt: true,
-    mvtDisabledReason: null,
   };
 
   componentDidMount() {
@@ -111,13 +107,6 @@ export class UpdateSourceEditor extends Component<Props, State> {
     this.setState({
       supportsClustering: supportsGeoTileAgg(geoField),
       clusteringDisabledReason: getGeoTileAggNotSupportedReason(geoField),
-      supportsMvt: !geoField.isRuntimeField,
-      mvtDisabledReason: geoField.isRuntimeField
-        ? i18n.translate('xpack.maps.source.esSearch.mvtDisableReason', {
-            defaultMessage: 'Vector tile API does not support runtime {type} field',
-            values: { type: geoField.type },
-          })
-        : null,
       sourceFields,
       sortFields: indexPattern.fields.filter(
         (field) => field.sortable && !indexPatterns.isNestedField(field)
@@ -228,8 +217,6 @@ export class UpdateSourceEditor extends Component<Props, State> {
           scalingType={this.props.scalingType}
           supportsClustering={this.state.supportsClustering}
           clusteringDisabledReason={this.state.clusteringDisabledReason}
-          supportsMvt={this.state.supportsMvt}
-          mvtDisabledReason={this.state.mvtDisabledReason}
           numberOfJoins={this.props.numberOfJoins}
         />
       </EuiPanel>

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`scaling form should disable clusters option when clustering is not supp
     <div>
       <EuiRadio
         checked={false}
-        disabled={false}
         id="MVT"
         label="Use vector tiles"
         onChange={[Function]}
@@ -113,7 +112,6 @@ exports[`scaling form should render 1`] = `
     <div>
       <EuiRadio
         checked={false}
-        disabled={false}
         id="MVT"
         label="Use vector tiles"
         onChange={[Function]}

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.test.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.test.tsx
@@ -25,7 +25,6 @@ const defaultProps = {
   onChange: () => {},
   scalingType: SCALING_TYPES.LIMIT,
   supportsClustering: true,
-  supportsMvt: true,
   termFields: [],
   numberOfJoins: 0,
 };

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
@@ -35,8 +35,6 @@ interface Props {
   scalingType: SCALING_TYPES;
   supportsClustering: boolean;
   clusteringDisabledReason?: string | null;
-  supportsMvt: boolean;
-  mvtDisabledReason?: string | null;
   numberOfJoins: number;
 }
 
@@ -188,26 +186,6 @@ export class ScalingForm extends Component<Props, State> {
     );
   }
 
-  _renderMvtRadio() {
-    const radio = (
-      <EuiRadio
-        id={SCALING_TYPES.MVT}
-        label={this._getMvtOptionLabel()}
-        checked={this.props.scalingType === SCALING_TYPES.MVT}
-        onChange={() => this._onScalingTypeSelect(SCALING_TYPES.MVT)}
-        disabled={!this.props.supportsMvt}
-      />
-    );
-
-    return this.props.mvtDisabledReason ? (
-      <EuiToolTip position="left" content={this.props.mvtDisabledReason}>
-        {radio}
-      </EuiToolTip>
-    ) : (
-      radio
-    );
-  }
-
   _renderClusteringRadio() {
     const clusteringRadio = (
       <EuiRadio
@@ -264,7 +242,12 @@ export class ScalingForm extends Component<Props, State> {
 
         <EuiFormRow>
           <div>
-            {this._renderMvtRadio()}
+            <EuiRadio
+              id={SCALING_TYPES.MVT}
+              label={this._getMvtOptionLabel()}
+              checked={this.props.scalingType === SCALING_TYPES.MVT}
+              onChange={() => this._onScalingTypeSelect(SCALING_TYPES.MVT)}
+            />
             {this._renderClusteringRadio()}
             <EuiRadio
               id={SCALING_TYPES.LIMIT}

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -18354,7 +18354,6 @@
     "xpack.maps.source.esSearch.convertToGeoJsonErrorMsg": "Impossible de convertir la réponse de la recherche à la collecte de fonctionnalités geoJson, erreur : {errorMsg}",
     "xpack.maps.source.esSearch.limitScalingLabel": "Limiter les résultats à {maxResultWindow}",
     "xpack.maps.source.esSearch.loadTooltipPropertiesErrorMsg": "Document introuvable, _id : {docId}",
-    "xpack.maps.source.esSearch.mvtDisableReason": "L'API de tuile vectorielle ne prend pas en charge le champ de runtime {type}",
     "xpack.maps.source.esSearch.mvtScalingJoinMsg": "Les tuiles vectorielles prennent en charge une seule liaison de terme. Votre calque comporte {numberOfJoins} liaisons de terme. Le passage aux tuiles vectorielles conservera la première liaison de terme et supprimera toutes les autres liaisons de terme de votre configuration de calque.",
     "xpack.maps.source.esSource.noGeoFieldErrorMessage": "La vue de données {indexPatternTitle} ne contient plus le champ géographique {geoField}.",
     "xpack.maps.source.esSource.requestFailedErrorMessage": "Échec de la demande de recherche Elasticsearch, erreur : {message}",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -18339,7 +18339,6 @@
     "xpack.maps.source.esSearch.convertToGeoJsonErrorMsg": "検索への応答を geoJson 機能コレクションに変換できません。エラー：{errorMsg}",
     "xpack.maps.source.esSearch.limitScalingLabel": "結果を{maxResultWindow}に限定",
     "xpack.maps.source.esSearch.loadTooltipPropertiesErrorMsg": "ドキュメントが見つかりません。_id：{docId}",
-    "xpack.maps.source.esSearch.mvtDisableReason": "ベクトルタイルAPIは、ランタイム{type}フィールドをサポートしません",
     "xpack.maps.source.esSearch.mvtScalingJoinMsg": "ベクトルタイルは1つの用語結合をサポートします。レイヤーには{numberOfJoins}個の用語結合があります。ベクトルタイルに切り替えると、最初の用語結合が保持され、すべての他の用語結合がレイヤー構成から削除されます。",
     "xpack.maps.source.esSource.noGeoFieldErrorMessage": "データビュー{indexPatternTitle}には現在ジオフィールド{geoField}が含まれていません",
     "xpack.maps.source.esSource.requestFailedErrorMessage": "Elasticsearch 検索リクエストに失敗。エラー：{message}",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -18361,7 +18361,6 @@
     "xpack.maps.source.esSearch.convertToGeoJsonErrorMsg": "无法将搜索响应转换成 geoJson 功能集合，错误：{errorMsg}",
     "xpack.maps.source.esSearch.limitScalingLabel": "将结果数限制到 {maxResultWindow}",
     "xpack.maps.source.esSearch.loadTooltipPropertiesErrorMsg": "找不到文档，_id：{docId}",
-    "xpack.maps.source.esSearch.mvtDisableReason": "矢量磁帖 API 不支持运行时 {type} 字段",
     "xpack.maps.source.esSearch.mvtScalingJoinMsg": "矢量磁贴支持一个词联接。您的图层具有 {numberOfJoins} 个词联接。切换到矢量磁贴会保留第一个词联接，并从图层配置中移除所有其他词联接。",
     "xpack.maps.source.esSource.noGeoFieldErrorMessage": "数据视图 {indexPatternTitle} 不再包含地理字段 {geoField}",
     "xpack.maps.source.esSource.requestFailedErrorMessage": "Elasticsearch 搜索请求失败，错误：{message}",


### PR DESCRIPTION
In 8.4 and prior version, Elasticsearch vector tile search API did not support runtime geo_point fields. https://github.com/elastic/kibana/pull/136675 updated Documents source to fallback to GeoJSON when geospatial field is runtime field. Vector tiles option is disabled in the scaling form.

https://github.com/elastic/elasticsearch/issues/85245 is resolved and Elasticsearch 8.5 and forward supports runtime geo_point fields. This PR rolls back changes made by https://github.com/elastic/kibana/pull/136675. 

To test:
* Create a simple index with lat/lon data
    ```
    DELETE runtime_geo_example

    PUT runtime_geo_example
    {
      "mappings": {
        "properties": {
          "latitude": {"type": "float"},
          "longitude": {"type": "float"}
        }
      }
    }

    PUT runtime_geo_example/_bulk
    { "index": {} }
    { "longitude": 0.5, "latitude": 40}
    { "index": {} }
    { "longitude": 0, "latitude": 41}
    { "index": {} }
    { "longitude": -0.5, "latitude": 39}

    ```
* Create data view for `runtime_geo_example` index
* Add geo_point runtime field to data view. Set value to `emit(doc['longitude'].value,doc['latitude'].value)`
* Create a new map.
* Add a document layer and select `runtime_geo_example` data view. Verify results are displayed and "Vector tile" scaling option is selected.