### PR TITLE
[ui-shared-deps-npm] Less chunks

### DIFF
--- a/packages/kbn-ui-shared-deps-npm/BUILD.bazel
+++ b/packages/kbn-ui-shared-deps-npm/BUILD.bazel
@@ -37,6 +37,7 @@ RUNTIME_DEPS = [
   "@npm//core-js",
   "@npm//css-loader",
   "@npm//fflate",
+  "@npm//globby",
   "@npm//jquery",
   "@npm//loader-utils",
   "@npm//mini-css-extract-plugin",

--- a/packages/kbn-ui-shared-deps-npm/webpack.config.js
+++ b/packages/kbn-ui-shared-deps-npm/webpack.config.js
@@ -10,16 +10,23 @@ const Path = require('path');
 const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const globby = require('globby');
 
 const UiSharedDepsNpm = require('./src');
 
+const REPO_ROOT = Path.resolve(__dirname, '..', '..');
+
 const MOMENT_SRC = require.resolve('moment/min/moment-with-locales.js');
 const WEBPACK_SRC = require.resolve('webpack');
-
-const REPO_ROOT = Path.resolve(__dirname, '..', '..');
+const EUI_ICON_ASSETS = Path.resolve(
+  REPO_ROOT,
+  'node_modules/@elastic/eui',
+  'optimize/es/components/icon/assets'
+);
 
 module.exports = (_, argv) => {
   const outputPath = argv.outputPath ? Path.resolve(argv.outputPath) : UiSharedDepsNpm.distDir;
+  const euiIconEntries = globby.sync(`${EUI_ICON_ASSETS}/**`);
 
   return {
     node: {
@@ -103,6 +110,7 @@ module.exports = (_, argv) => {
         'rxjs/operators',
         'styled-components',
         'tslib',
+        ...euiIconEntries,
       ],
       'kbn-ui-shared-deps-npm.v8.dark': ['@elastic/eui/dist/eui_theme_dark.css'],
       'kbn-ui-shared-deps-npm.v8.light': ['@elastic/eui/dist/eui_theme_light.css'],


### PR DESCRIPTION
Currently the ui-shared-deps-npm dll has ~450 import() chunks, all of which are 1-3 kb icons.

https://github.com/elastic/eui/blob/f048a2f03adc14b74002a93dacadc84222904e11/src/components/icon/icon.tsx#L204

The brotli compressed versions are often larger than the minified version, each file comes with runtime boilerplate, and in total it adds 900 files to distribution.  With our http version still on 1.1, I don't think it's ideal to split these out of our vendor file.

This combines all the icons into the dll.  I hope there's a better way to do it, but I'm coming up short on fixes.