### PR TITLE
redirect with toast draft

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/index.ts
@@ -1,0 +1,1 @@
+export { SecuritySolutionRedirect } from './security_solution_redirect';

--- a/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/index.ts
@@ -1,1 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 export { SecuritySolutionRedirect } from './security_solution_redirect';

--- a/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/security_solution_redirect.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/security_solution_redirect.tsx
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 import { useEffect } from 'react';
 import { useKibana } from '../../lib/kibana';
 

--- a/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/security_solution_redirect.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/security_solution_redirect.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useKibana } from '../../lib/kibana';
+
+export const SecuritySolutionRedirect = ({ path }: { path: string }) => {
+  const spacesApi = useKibana().services.spaces;
+
+  useEffect(() => {
+    if (spacesApi) {
+      spacesApi.ui.redirectLegacyUrl({
+        path,
+        useToast: true,
+        objectNoun: 'path',
+      });
+    }
+  }, [spacesApi]);
+
+  return null;
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -320,7 +320,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
         const path = `rules/id/${rule.id}${window.location.search}${window.location.hash}`;
         spacesApi.ui.redirectLegacyUrl({
           path,
-          aliasPurpose: rule.alias_purpose,
+          useToast: rule.alias_purpose === 'savedObjectConversion',
           objectNoun: i18nTranslate.translate(
             'xpack.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
             { defaultMessage: 'rule' }

--- a/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/index.tsx
@@ -15,6 +15,7 @@ import { HostsTableType } from '../store/model';
 import { MlHostConditionalContainer } from '../../common/components/ml/conditional_links/ml_host_conditional_container';
 import { Hosts } from './hosts';
 import { hostDetailsPagePath } from './types';
+import { SecuritySolutionRedirect } from '../../common/components/security_solution_redirect';
 
 const getHostsTabPath = () =>
   `${HOSTS_PATH}/:tabName(` +
@@ -78,14 +79,7 @@ export const HostsContainer = React.memo(() => (
           params: { detailName, tabName = HostsTableType.authentications },
         },
         location: { search = '' },
-      }) => (
-        <Redirect
-          to={{
-            pathname: `${HOSTS_PATH}/name/${detailName}/${tabName}`,
-            search,
-          }}
-        />
-      )}
+      }) => <SecuritySolutionRedirect path={`${HOSTS_PATH}/name/${detailName}/${tabName}`} />}
     />
     <Route // Redirect to the first tab when tabName is not present.
       path={HOSTS_PATH}

--- a/x-pack/plugins/security_solution/public/users/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/index.tsx
@@ -13,6 +13,7 @@ import { UsersTableType } from '../store/model';
 import { Users } from './users';
 import { UsersDetails } from './details';
 import { usersDetailsPagePath, usersDetailsTabPath, usersTabPath } from './constants';
+import { SecuritySolutionRedirect } from '../../common/components/security_solution_redirect';
 
 export const UsersContainer = React.memo(() => {
   return (
@@ -58,14 +59,10 @@ export const UsersContainer = React.memo(() => {
             params: { detailName, tabName = UsersTableType.authentications },
           },
           location: { search = '' },
-        }) => (
-          <Redirect
-            to={{
-              pathname: `${USERS_PATH}/name/${detailName}/${tabName}`,
-              search,
-            }}
-          />
-        )}
+        }) => {
+          console.log({ search });
+          return <SecuritySolutionRedirect path={`${USERS_PATH}/name/${detailName}/${tabName}`} />;
+        }}
       />
       <Route // Redirect to the first tab when tabName is not present.
         path={USERS_PATH}

--- a/x-pack/plugins/spaces/public/legacy_urls/redirect_legacy_url.ts
+++ b/x-pack/plugins/spaces/public/legacy_urls/redirect_legacy_url.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { first } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 import type { StartServicesAccessor } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
@@ -20,14 +20,15 @@ export function createRedirectLegacyUrl(
 ): SpacesApiUi['redirectLegacyUrl'] {
   return async function ({
     path,
+    useToast,
     aliasPurpose,
     objectNoun = DEFAULT_OBJECT_NOUN,
   }: RedirectLegacyUrlParams) {
     const [{ notifications, application }] = await getStartServices();
     const { currentAppId$, navigateToApp } = application;
-    const appId = await currentAppId$.pipe(first()).toPromise(); // retrieve the most recent value from the BehaviorSubject
+    const appId = await firstValueFrom(currentAppId$); // retrieve the most recent value from the BehaviorSubject
 
-    if (aliasPurpose === 'savedObjectConversion') {
+    if (aliasPurpose === 'savedObjectConversion' || useToast) {
       const title = i18n.translate('xpack.spaces.redirectLegacyUrlToast.title', {
         defaultMessage: `We redirected you to a new URL`,
       });
@@ -37,7 +38,6 @@ export function createRedirectLegacyUrl(
       });
       notifications.toasts.addInfo({ title, text });
     }
-
     await navigateToApp(appId!, { replace: true, path });
   };
 }

--- a/x-pack/plugins/spaces/public/legacy_urls/types.ts
+++ b/x-pack/plugins/spaces/public/legacy_urls/types.ts
@@ -56,12 +56,18 @@ export interface RedirectLegacyUrlParams {
    */
   path: string;
   /**
+   * Determines whether the user should be shown a toast message, for eg. if an object alias was created
+   * because of saved object conversion.
+   */
+  useToast?: boolean;
+  /**
+   * @deprecated
    * The reason the resolved alias was created.
    *
    * This is used to determine whether or not a toast should be shown when a user is redirected from a legacy URL; if the alias was created
    * because of saved object conversion, then we will display a toast telling the user that the object has a new URL.
    */
-  aliasPurpose: ResolvedSimpleSavedObject['alias_purpose'];
+  aliasPurpose?: ResolvedSimpleSavedObject['alias_purpose'];
   /**
    * The string that is used to describe the object in the toast, e.g., _The **object** you're looking for has a new location_.
    * Default value is 'object'.


### PR DESCRIPTION
## Summary

Our app has a couple legacy URLs that redirect to their new counterpart. In an effort to provide a notifcation to the end user to update their bookmarks, we want to show them a toast pointing out the change. 

In researching[ this ticket ](https://elastic.slack.com/archives/C9097ABGC/p1660834261783699)I came across redirectLegacyUrl that was used to handle the saved object migration from 7.x to 8.x. I want to repurpose this component to allow for usage beyond just saved objects. 

This would require very minimal changes, and allow for it to be used as it currently is for the most part, with the added benefit of working with regular URL redirects.

It's current interface is 
```
export interface RedirectLegacyUrlParams {
  /**
   * The path to use for the new URL, optionally including `search` and/or `hash` URL components.
   */
  path: string;
  /**
   * The reason the resolved alias was created.
   *
   * This is used to determine whether or not a toast should be shown when a user is redirected from a legacy URL; if the alias was created
   * because of saved object conversion, then we will display a toast telling the user that the object has a new URL.
   */
  aliasPurpose: ResolvedSimpleSavedObject['alias_purpose'];
  /**
   * The string that is used to describe the object in the toast, e.g., _The **object** you're looking for has a new location_.
   * Default value is 'object'.
   */
  objectNoun?: string;
}
```

What I would like to do is add a prop: `useToast?: boolean`, that preferably takes the place of `aliasPurpose` and logic determining whether to show the toast happen in the parent component.

For eg instead of:

```
spacesApi.ui.redirectLegacyUrl({
          path,
          aliasPurpose: rule.alias_purpose,
          objectNoun: i18nTranslate.translate(
            'xpack.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
            { defaultMessage: 'rule' }
```

it would be:
```
spacesApi.ui.redirectLegacyUrl({
          path,
          useToast: rule.alias_purpose === 'savedObjectConversion', <----
          objectNoun: i18nTranslate.translate(
            'xpack.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
            { defaultMessage: 'rule' }
```
By making it a boolean instead of locking it to an aliasPurpose, the component can be used anywhere. Of course, doing so means I will need to update it's usage everywhere, (really there are not that many places, and its a straightforward fix of doing: `useToast: rule.alias_purpose === 'savedObjectConversion'` or something similar.

Alternatively, I could keep the `aliasPurpose` prop, still add the `useToast` property and have them work together for the same purpose as this draft PR outlines. I prefer the former method but would like some input from @elastic/kibana-security , to see if they would be on board for either change, if not I will duplicate the code into security solution for our own version, but that seems clunky to me.

Thanks for condsidering!

Here it is working in security solution
![Recording 2022-08-18 at 09 44 27](https://user-images.githubusercontent.com/28942857/185423991-e06dda1b-01f9-4dce-9dc8-8d2695a7b4b5.gif)

Sidenote: It may also require the creation of a sister component for places where we cant functionally navigate but instead use a react component. In a `<Switch>` for eg. an eg of what I mean can be found here:

https://github.com/elastic/kibana/blob/15c67e0adaf78f5f674af56e2a90acf96ed9ad1a/x-pack/plugins/security_solution/public/common/components/security_solution_redirect/security_solution_redirect.tsx

With an implementation like:

```
import { SecuritySolutionRedirect } from '../../common/components/security_solution_redirect';
...
<Switch>
...
<Route // Compatibility redirect for the old user detail path.
      path={`${HOSTS_PATH}/:detailName/:tabName?`}
      render={({
        match: {
          params: { detailName, tabName = HostsTableType.authentications },
        },
      }) => <SecuritySolutionRedirect path={`${HOSTS_PATH}/name/${detailName}/${tabName}`} />}
/>
...
```