### PR TITLE
[TIP] Fix bug indicator barchart not synchronized with KQL bar

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { SecuritySolutionPluginContext } from '../..';
+
+export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext => ({
+  getFiltersGlobalComponent:
+    () =>
+    ({ children }) =>
+      <div>{children}</div>,
+  licenseService: {
+    isEnterprise() {
+      return true;
+    },
+  },
+  sourcererDataView: {
+    browserFields: {},
+    selectedPatterns: [],
+    indexPattern: { fields: [], title: '' },
+  },
+});

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { ReactNode, VFC } from 'react';
+import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
+import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { CoreStart, IUiSettingsClient } from '@kbn/core/public';
+import { SecuritySolutionContext } from '../../containers/security_solution_context';
+import { getSecuritySolutionContextMock } from './mock_security_context';
+
+export interface KibanaContextMock {
+  /**
+   * For the data plugin (see {@link DataPublicPluginStart})
+   */
+  data?: DataPublicPluginStart;
+  /**
+   * For the core ui-settings package (see {@link IUiSettingsClient})
+   */
+  uiSettings?: IUiSettingsClient;
+}
+
+export interface StoryProvidersComponentProps {
+  /**
+   * Used to generate a new KibanaReactContext (using {@link createKibanaReactContext})
+   */
+  kibana: KibanaContextMock;
+  /**
+   * Component(s) to be displayed inside
+   */
+  children: ReactNode;
+}
+
+/**
+ * Helper functional component used in Storybook stories.
+ * Wraps the story with our {@link SecuritySolutionContext} and KibanaReactContext.
+ */
+export const StoryProvidersComponent: VFC<StoryProvidersComponentProps> = ({
+  children,
+  kibana,
+}) => {
+  const KibanaReactContext = createKibanaReactContext(kibana as CoreStart);
+  const securitySolutionContextMock = getSecuritySolutionContextMock();
+
+  return (
+    <SecuritySolutionContext.Provider value={securitySolutionContextMock}>
+      <KibanaReactContext.Provider>{children}</KibanaReactContext.Provider>
+    </SecuritySolutionContext.Provider>
+  );
+};

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/test_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/test_providers.tsx
@@ -14,6 +14,7 @@ import type { IStorage } from '@kbn/kibana-utils-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { BehaviorSubject } from 'rxjs';
+import { getSecuritySolutionContextMock } from './mock_security_context';
 import { mockUiSetting } from './mock_kibana_ui_setting';
 import { KibanaContext } from '../../hooks/use_kibana';
 import { SecuritySolutionPluginContext } from '../../types';
@@ -95,22 +96,7 @@ const coreServiceMock = {
   uiSettings: { get: jest.fn().mockImplementation(mockUiSetting) },
 };
 
-const mockSecurityContext: SecuritySolutionPluginContext = {
-  getFiltersGlobalComponent:
-    () =>
-    ({ children }) =>
-      <div>{children}</div>,
-  licenseService: {
-    isEnterprise() {
-      return true;
-    },
-  },
-  sourcererDataView: {
-    browserFields: {},
-    selectedPatterns: [],
-    indexPattern: { fields: [], title: '' },
-  },
-};
+const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
 
 export const mockedServices = {
   ...coreServiceMock,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.stories.tsx
@@ -7,12 +7,14 @@
 
 import moment from 'moment';
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { of } from 'rxjs';
 import { Story } from '@storybook/react';
 import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
-import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
-import { CoreStart } from '@kbn/core/public';
 import { TimeRange } from '@kbn/es-query';
+import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { IUiSettingsClient } from '@kbn/core/public';
+import { StoryProvidersComponent } from '../../../../common/mocks/story_providers';
 import { Aggregation, AGGREGATION_NAME } from '../../hooks/use_aggregated_indicators';
 import { DEFAULT_TIME_RANGE } from '../../hooks/use_filters/utils';
 import { IndicatorsBarChartWrapper } from './indicators_barchart_wrapper';
@@ -74,38 +76,43 @@ const aggregation2: Aggregation = {
   doc_count: 0,
   key: '[Filebeat] AbuseCH MalwareBazaar',
 };
-const KibanaReactContext = createKibanaReactContext({
-  data: {
-    search: {
-      search: () =>
-        of({
-          rawResponse: {
-            aggregations: {
-              [AGGREGATION_NAME]: {
-                buckets: [aggregation1, aggregation2],
-              },
+const mockData = {
+  search: {
+    search: () =>
+      of({
+        rawResponse: {
+          aggregations: {
+            [AGGREGATION_NAME]: {
+              buckets: [aggregation1, aggregation2],
             },
           },
-        }),
-    },
-    query: {
-      timefilter: {
-        timefilter: {
-          calculateBounds: () => ({
-            min: moment(validDate),
-            max: moment(validDate).add(numberOfDays, 'days'),
-          }),
         },
+      }),
+  },
+  query: {
+    timefilter: {
+      timefilter: {
+        calculateBounds: () => ({
+          min: moment(validDate),
+          max: moment(validDate).add(numberOfDays, 'days'),
+        }),
       },
     },
+    filterManager: {
+      getFilters: () => {},
+      setFilters: () => {},
+      getUpdates$: () => of(),
+    },
   },
-  uiSettings: { get: () => {} },
-} as unknown as Partial<CoreStart>);
+} as unknown as DataPublicPluginStart;
+
+const mockUiSettings = { get: () => {} } as unknown as IUiSettingsClient;
 
 export const Default: Story<void> = () => {
   return (
-    <KibanaReactContext.Provider>
+    <StoryProvidersComponent kibana={{ data: mockData, uiSettings: mockUiSettings }}>
       <IndicatorsBarChartWrapper timeRange={mockTimeRange} indexPattern={mockIndexPattern} />
-    </KibanaReactContext.Provider>
+    </StoryProvidersComponent>
   );
 };
+Default.decorators = [(story) => <MemoryRouter>{story()}</MemoryRouter>];

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.test.tsx
@@ -12,8 +12,11 @@ import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 import { IndicatorsBarChartWrapper } from './indicators_barchart_wrapper';
 import { DEFAULT_TIME_RANGE } from '../../hooks/use_filters/utils';
+import { useFilters } from '../../hooks/use_filters';
 
-const mockIndexPatterns: DataView = {
+jest.mock('../../hooks/use_filters');
+
+const mockIndexPattern: DataView = {
   fields: [
     {
       name: '@timestamp',
@@ -25,13 +28,26 @@ const mockIndexPatterns: DataView = {
     } as DataViewField,
   ],
 } as DataView;
+
 const mockTimeRange: TimeRange = DEFAULT_TIME_RANGE;
 
+const stub = () => {};
+
 describe('<IndicatorsBarChartWrapper />', () => {
+  beforeEach(() => {
+    (useFilters as jest.MockedFunction<typeof useFilters>).mockReturnValue({
+      filters: [],
+      filterQuery: { language: 'kuery', query: '' },
+      filterManager: {} as any,
+      handleSavedQuery: stub,
+      handleSubmitQuery: stub,
+      handleSubmitTimeRange: stub,
+    });
+  });
   it('should render barchart and field selector dropdown', () => {
     const component = render(
       <TestProvidersComponent>
-        <IndicatorsBarChartWrapper indexPattern={mockIndexPatterns} timeRange={mockTimeRange} />
+        <IndicatorsBarChartWrapper indexPattern={mockIndexPattern} timeRange={mockTimeRange} />
       </TestProvidersComponent>
     );
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 const indicatorsFixture: Indicator[] = Array(10).fill(generateMockIndicator());
-const mockIndexPattern: DataView = {} as DataView;
+const mockIndexPattern: DataView = undefined as unknown as DataView;
 
 const stub = () => void 0;
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
@@ -21,6 +21,9 @@ import {
   mockedSearchService,
   mockedTimefilterService,
 } from '../../../common/mocks/test_providers';
+import { useFilters } from './use_filters';
+
+jest.mock('./use_filters/use_filters');
 
 const aggregationResponse = {
   rawResponse: { aggregations: { [AGGREGATION_NAME]: { buckets: [] } } },
@@ -35,6 +38,8 @@ const useAggregatedIndicatorsParams: UseAggregatedIndicatorsParam = {
   timeRange: DEFAULT_TIME_RANGE,
 };
 
+const stub = () => {};
+
 describe('useAggregatedIndicators()', () => {
   beforeEach(jest.clearAllMocks);
 
@@ -45,6 +50,15 @@ describe('useAggregatedIndicators()', () => {
 
   describe('when mounted', () => {
     beforeEach(() => {
+      (useFilters as jest.MockedFunction<typeof useFilters>).mockReturnValue({
+        filters: [],
+        filterQuery: { language: 'kuery', query: '' },
+        filterManager: {} as any,
+        handleSavedQuery: stub,
+        handleSubmitQuery: stub,
+        handleSubmitTimeRange: stub,
+      });
+
       renderHook(() => useAggregatedIndicators(useAggregatedIndicatorsParams), {
         wrapper: TestProvidersComponent,
       });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.ts
@@ -15,6 +15,7 @@ import {
   isErrorResponse,
   TimeRangeBounds,
 } from '@kbn/data-plugin/common';
+import { useFilters } from './use_filters';
 import { convertAggregationToChartSeries } from '../../../common/utils/barchart';
 import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 import { THREAT_QUERY_BASE } from '../../../../common/constants';
@@ -87,6 +88,8 @@ export const useAggregatedIndicators = ({
     [queryService, timeRange]
   );
 
+  const { filters, filterQuery } = useFilters();
+
   const loadData = useCallback(async () => {
     const dateFrom: number = (dateRange.min as moment.Moment).toDate().getTime();
     const dateTo: number = (dateRange.max as moment.Moment).toDate().getTime();
@@ -101,8 +104,13 @@ export const useAggregatedIndicators = ({
           query: THREAT_QUERY_BASE,
           language: 'kuery',
         },
+        {
+          query: filterQuery.query as string,
+          language: 'kuery',
+        },
       ],
       [
+        ...filters,
         {
           query: {
             range: {
@@ -175,6 +183,8 @@ export const useAggregatedIndicators = ({
     dateRange.max,
     dateRange.min,
     field,
+    filterQuery,
+    filters,
     searchService,
     selectedPatterns,
     timeRange.from,


### PR DESCRIPTION
## Summary

This PR fixes the bug where the indicator barchart and table data were not in sync. When the KQL bar was added, the filters and filterQuery retrieved from the KQL bar were added to the `useIndicators` hook used by the table, but not to the `useAggregatedIndicators` hook used by the barchart. Therefore the barchart was always querying everything.

The PR also fixes a couple of Storybook stories that were broken in the previous field browser PR.

https://github.com/elastic/security-team/issues/4757


https://user-images.githubusercontent.com/17276605/185445458-7eada832-83c0-424a-be1c-2747c283ee0f.mov



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios