### PR TITLE
[Maps] fix scaling and term join in product help popover width

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
@@ -41,7 +41,7 @@ export class ScalingDocumenationPopover extends Component<Props, State> {
   _renderContent() {
     return (
       <div>
-        <EuiText grow={false}>
+        <EuiText style={{ maxWidth: '36em' }}>
           <dl>
             <dt>{this.props.mvtOptionLabel} (Default)</dt>
             <dd>

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
@@ -34,7 +34,7 @@ export class JoinDocumentationPopover extends Component<{}, State> {
   _renderContent() {
     return (
       <div>
-        <EuiText grow={false}>
+        <EuiText style={{ maxWidth: '36em' }}>
           <p>
             <FormattedMessage
               id="xpack.maps.joinDocs.intro"


### PR DESCRIPTION
https://github.com/elastic/eui/pull/5895 converted EuiText from CSS to Emotion. This change removed `max-width: '36em'` style from EuiText.

Scaling form and Term join in product help relied on this max-width setting to determine popover width. Without these, popovers look terrible as seen in image below
<img width="600" alt="Screen Shot 2022-08-17 at 9 31 31 AM" src="https://user-images.githubusercontent.com/373691/185457079-5e674046-91c9-475d-b15d-9f1f872bbabe.png">

Chatted with EUI team about problem and they tried to solve problem in EUI, https://github.com/elastic/eui/pull/6146. However, EUI determined the old behavior was a bug and Maps should set max-width

PR restores original popover look by setting max-width to what was previously set in EuiText CSS.
<img width="600" alt="Screen Shot 2022-08-17 at 9 31 20 AM" src="https://user-images.githubusercontent.com/373691/185457366-ca2020dd-89ca-4d02-8aeb-0989d10f38ab.png">

To test
1) install sample web logs data set
2) create new map
3) click add layer
4) add documents layer, select web logs index pattern, click add layer
5) open popover for scaling and term joins. Verify width is not over sized.
