### PR TITLE
[Synthetics] adjust message for failed stale project monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor_formatter.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor_formatter.ts
@@ -341,7 +341,7 @@ export class ProjectMonitorFormatter {
     } catch (e) {
       this.handleStreamingMessage({ message: `Monitor ${journeyId} could not be deleted` });
       this.failedStaleMonitors.push({
-        id: monitorId,
+        id: journeyId,
         reason: 'Failed to delete stale monitor',
         details: e.message,
       });


### PR DESCRIPTION
## Summary

Adjusts the message for failed stale project monitors, returning journey id instead of monitor saved object id.

<img width="809" alt="Screen Shot 2022-08-18 at 1 35 15 PM" src="https://user-images.githubusercontent.com/11356435/185469276-bf4e966c-81a9-4483-b30c-43a96e11c1f0.png">

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->