### PR TITLE
Focusing on input box on render

### DIFF
--- a/packages/kbn-user-profile-components/src/user_profiles_popover.test.tsx
+++ b/packages/kbn-user-profile-components/src/user_profiles_popover.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 
 import { UserProfilesPopover } from './user_profiles_popover';
@@ -102,6 +102,7 @@ describe('UserProfilesPopover', () => {
                 },
               ]
             }
+            inputRef={[Function]}
             selectedOptions={
               Array [
                 Object {
@@ -120,5 +121,23 @@ describe('UserProfilesPopover', () => {
         </EuiContextMenuPanel>
       </EuiPopover>
     `);
+  });
+
+  it('gives focus to the input box', async () => {
+    const [firstOption, secondOption] = userProfiles;
+    const wrapper = mount(
+      <UserProfilesPopover
+        title="Title"
+        button={<button>Toggle</button>}
+        closePopover={jest.fn()}
+        isOpen
+        selectableProps={{
+          selectedOptions: [firstOption],
+          defaultOptions: [secondOption],
+        }}
+      />
+    );
+
+    expect(wrapper.find('input[type="search"]').is(':focus')).toBe(true);
   });
 });

--- a/packages/kbn-user-profile-components/src/user_profiles_popover.tsx
+++ b/packages/kbn-user-profile-components/src/user_profiles_popover.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { EuiPopoverProps, EuiContextMenuPanelProps } from '@elastic/eui';
-import type { FunctionComponent } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import React from 'react';
 import { EuiPopover, EuiContextMenuPanel } from '@elastic/eui';
 
@@ -38,10 +38,22 @@ export const UserProfilesPopover: FunctionComponent<UserProfilesPopoverProps> = 
   selectableProps,
   ...popoverProps
 }) => {
+  const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null);
+
+  const setInputRef = useCallback((node: HTMLInputElement | null) => {
+    setInputElement(node);
+  }, []);
+
+  useEffect(() => {
+    inputElement?.focus();
+  }, [inputElement]);
+
+  const initialFocus = inputElement ? inputElement : undefined;
+
   return (
-    <EuiPopover panelPaddingSize="none" {...popoverProps}>
+    <EuiPopover panelPaddingSize="none" initialFocus={initialFocus} {...popoverProps}>
       <EuiContextMenuPanel title={title}>
-        <UserProfilesSelectable {...selectableProps} />
+        <UserProfilesSelectable inputRef={setInputRef} {...selectableProps} />
       </EuiContextMenuPanel>
     </EuiPopover>
   );

--- a/packages/kbn-user-profile-components/src/user_profiles_selectable.tsx
+++ b/packages/kbn-user-profile-components/src/user_profiles_selectable.tsx
@@ -6,7 +6,11 @@
  * Side Public License, v 1.
  */
 
-import type { EuiSelectableOption, EuiSelectableProps } from '@elastic/eui';
+import type {
+  EuiSelectableOption,
+  EuiSelectableProps,
+  EuiSelectableSearchProps,
+} from '@elastic/eui';
 import {
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -33,14 +37,15 @@ import { UserAvatar } from './user_avatar';
  */
 export interface UserProfilesSelectableProps
   extends Pick<
-    EuiSelectableProps,
-    | 'height'
-    | 'singleSelection'
-    | 'loadingMessage'
-    | 'noMatchesMessage'
-    | 'emptyMessage'
-    | 'errorMessage'
-  > {
+      EuiSelectableProps,
+      | 'height'
+      | 'singleSelection'
+      | 'loadingMessage'
+      | 'noMatchesMessage'
+      | 'emptyMessage'
+      | 'errorMessage'
+    >,
+    Pick<EuiSelectableSearchProps<{}>, 'inputRef'> {
   /**
    * List of users to be rendered as suggestions.
    */
@@ -109,6 +114,7 @@ export const UserProfilesSelectable: FunctionComponent<UserProfilesSelectablePro
   searchPlaceholder,
   selectedStatusMessage,
   clearButtonLabel,
+  inputRef,
 }) => {
   const [displayedOptions, setDisplayedOptions] = useState<SelectableOption[]>([]);
 
@@ -243,6 +249,7 @@ export const UserProfilesSelectable: FunctionComponent<UserProfilesSelectablePro
         onChange: onSearchChange,
         isLoading,
         isClearable: !isLoading,
+        inputRef,
       }}
       isPreFiltered
       listProps={{ onFocusBadge: false }}


### PR DESCRIPTION
This PR modifies the popover component such that the search input element is focused on when the popover is displayed. This is to better align with the design.