### PR TITLE
[DataViews] deprecate dataViews.title

### DIFF
--- a/dev_docs/tutorials/data_views.mdx
+++ b/dev_docs/tutorials/data_views.mdx
@@ -23,7 +23,7 @@ tags: ['kibana', 'onboarding', 'dev', 'architecture']
 #### Get list of data view titles and ids
 
 ```
-const idsAndTitles = await data.indexPatterns.getIdsWithTitle();
+const idsAndTitles = await data.indexPatterns.getIdsWithIndexPattern();
 idsAndTitles.forEach(({id, title}) => console.log(`Data view id: ${id} title: ${title}`));
 ```
 

--- a/packages/kbn-es-query/src/es_query/types.ts
+++ b/packages/kbn-es-query/src/es_query/types.ts
@@ -64,7 +64,8 @@ export type DataViewFieldBase = {
 export type DataViewBase = {
   fields: DataViewFieldBase[];
   id?: string;
-  title: string;
+  title?: string;
+  indexPattern?: string;
 };
 
 export interface BoolQuery {

--- a/packages/kbn-es-query/src/es_query/types.ts
+++ b/packages/kbn-es-query/src/es_query/types.ts
@@ -64,8 +64,14 @@ export type DataViewFieldBase = {
 export type DataViewBase = {
   fields: DataViewFieldBase[];
   id?: string;
-  title?: string;
+  /**
+   * Contains the string of ES indices to match when searching against the data view
+   */
   indexPattern?: string;
+  /**
+   * @deprecated use {@link indexPattern} instead
+   */
+  title: string;
 };
 
 export interface BoolQuery {

--- a/src/plugins/data/common/query/to_expression_ast.test.ts
+++ b/src/plugins/data/common/query/to_expression_ast.test.ts
@@ -34,7 +34,7 @@ describe('queryStateToExpressionAst', () => {
 
   it('returns an object with the correct structure for an SQL query', async () => {
     const dataViewsService = {
-      getIdsWithTitle: jest.fn(() => {
+      getIdsWithIndexPattern: jest.fn(() => {
         return [
           {
             title: 'foo',

--- a/src/plugins/data/common/query/to_expression_ast.ts
+++ b/src/plugins/data/common/query/to_expression_ast.ts
@@ -58,7 +58,7 @@ export async function queryStateToExpressionAst({
     // sql query
     if (mode === 'sql' && 'sql' in query) {
       const idxPattern = getIndexPatternFromSQLQuery(query.sql);
-      const idsTitles = await dataViewsService.getIdsWithTitle();
+      const idsTitles = await dataViewsService.getIdsWithIndexPattern();
       const dataViewIdTitle = idsTitles.find(({ title }) => title === idxPattern);
       if (dataViewIdTitle) {
         const dataView = await dataViewsService.get(dataViewIdTitle.id);

--- a/src/plugins/data/common/search/expressions/kibana_context.test.ts
+++ b/src/plugins/data/common/search/expressions/kibana_context.test.ts
@@ -227,7 +227,7 @@ describe('kibanaContextFn', () => {
   it('deduplicates duplicated filters and keeps the first enabled filter', async () => {
     const { fn } = kibanaContextFn;
     const filter1 = buildFilter(
-      { fields: [], title: 'dataView' },
+      { fields: [], indexPattern: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -239,7 +239,7 @@ describe('kibanaContextFn', () => {
       FilterStateStore.APP_STATE
     );
     const filter2 = buildFilter(
-      { fields: [], title: 'dataView' },
+      { fields: [], indexPattern: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -252,7 +252,7 @@ describe('kibanaContextFn', () => {
     );
 
     const filter3 = buildFilter(
-      { fields: [], title: 'dataView' },
+      { fields: [], indexPattern: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,

--- a/src/plugins/data/common/search/expressions/kibana_context.test.ts
+++ b/src/plugins/data/common/search/expressions/kibana_context.test.ts
@@ -227,7 +227,7 @@ describe('kibanaContextFn', () => {
   it('deduplicates duplicated filters and keeps the first enabled filter', async () => {
     const { fn } = kibanaContextFn;
     const filter1 = buildFilter(
-      { fields: [], indexPattern: 'dataView' },
+      { fields: [], indexPattern: 'dataView', title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -239,7 +239,7 @@ describe('kibanaContextFn', () => {
       FilterStateStore.APP_STATE
     );
     const filter2 = buildFilter(
-      { fields: [], indexPattern: 'dataView' },
+      { fields: [], indexPattern: 'dataView', title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -252,7 +252,7 @@ describe('kibanaContextFn', () => {
     );
 
     const filter3 = buildFilter(
-      { fields: [], indexPattern: 'dataView' },
+      { fields: [], indexPattern: 'dataView', title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,

--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -38,6 +38,7 @@ const createStartContract = (): Start => {
     }),
     get: jest.fn().mockReturnValue(Promise.resolve({})),
     clearCache: jest.fn(),
+    getIdsWithIndexPattern: jest.fn(),
     getIdsWithTitle: jest.fn(),
   } as unknown as DataViewsContract;
 

--- a/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -94,7 +94,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
       isAdHoc: false,
       ...(editData
         ? {
-            title: editData.title,
+            title: editData.indexPattern,
             id: editData.id,
             name: editData.name,
             ...(editData.timeFieldName
@@ -112,7 +112,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
       }
 
       const indexPatternStub: DataViewSpec = {
-        title: removeSpaces(formData.title),
+        indexPattern: removeSpaces(formData.title),
         timeFieldName: formData.timestampField?.value,
         id: formData.id,
         name: formData.name,
@@ -128,16 +128,16 @@ const IndexPatternEditorFlyoutContentComponent = ({
         };
       }
 
-      if (editData && editData.title !== formData.title) {
+      if (editData && editData.indexPattern !== formData.title) {
         editDataViewModal({
           dataViewName: formData.name || formData.title,
           overlays,
           onEdit: async () => {
-            await onSave(indexPatternStub, !formData.isAdHoc);
+            onSave(indexPatternStub, !formData.isAdHoc);
           },
         });
       } else {
-        await onSave(indexPatternStub, !formData.isAdHoc);
+        onSave(indexPatternStub, !formData.isAdHoc);
       }
     },
   });
@@ -193,7 +193,7 @@ const IndexPatternEditorFlyoutContentComponent = ({
   useEffect(() => {
     loadSources();
     const getTitles = async () => {
-      const dataViewListItems = await dataViews.getIdsWithTitle(editData ? true : false);
+      const dataViewListItems = await dataViews.getIdsWithIndexPattern(editData ? true : false);
       const indexPatternNames = dataViewListItems.map((item) => item.name || item.title);
 
       setExistingIndexPatterns(
@@ -309,14 +309,14 @@ const IndexPatternEditorFlyoutContentComponent = ({
   useEffect(() => {
     if (editData) {
       loadSources();
-      reloadMatchedIndices(removeSpaces(editData.title));
+      reloadMatchedIndices(removeSpaces(editData.indexPattern));
     }
     // We use the below eslint-disable as adding 'loadSources' and 'reloadMatchedIndices' as a dependency creates an infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editData]);
 
   useEffect(() => {
-    const timeFieldQuery = editData ? editData.title : title;
+    const timeFieldQuery = editData ? editData.indexPattern ?? editData.indexPattern : title;
     loadTimestampFieldOptions(removeSpaces(timeFieldQuery));
     if (!editData) getFields().timestampField?.setValue('');
     // We use the below eslint-disable as adding editData as a dependency create an infinite loop

--- a/src/plugins/data_view_management/public/components/utils.test.ts
+++ b/src/plugins/data_view_management/public/components/utils.test.ts
@@ -10,7 +10,7 @@ import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { getIndexPatterns } from './utils';
 
 const indexPatternContractMock = {
-  getIdsWithTitle: jest.fn().mockReturnValue(
+  getIdsWithIndexPattern: jest.fn().mockReturnValue(
     Promise.resolve([
       {
         id: 'test',

--- a/src/plugins/data_view_management/public/components/utils.ts
+++ b/src/plugins/data_view_management/public/components/utils.ts
@@ -33,7 +33,7 @@ const isRollup = (indexPatternType: string = '') => {
 };
 
 export async function getIndexPatterns(defaultIndex: string, dataViewsService: DataViewsContract) {
-  const existingIndexPatterns = await dataViewsService.getIdsWithTitle(true);
+  const existingIndexPatterns = await dataViewsService.getIdsWithIndexPattern(true);
   const indexPatternsListItems = existingIndexPatterns.map((idxPattern) => {
     const { id, title, namespaces, name } = idxPattern;
     const isDefault = defaultIndex === id;

--- a/src/plugins/data_views/common/data_view.stub.ts
+++ b/src/plugins/data_views/common/data_view.stub.ts
@@ -52,6 +52,7 @@ export function stubbedSavedObjectDataView(
     attributes: {
       timeFieldName: 'time',
       fields: JSON.stringify(stubLogstashFieldSpecMap),
+      indexPattern: 'index-pattern',
       title: 'title',
       name: 'Name',
     },

--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -32,6 +32,7 @@ Object {
   "fieldAttrs": Object {},
   "fieldFormats": Object {},
   "id": "test-pattern",
+  "indexPattern": "title",
   "name": "Name",
   "runtimeFieldMap": Object {
     "runtime_field": Object {
@@ -660,6 +661,7 @@ Object {
     },
   },
   "id": "test-pattern",
+  "indexPattern": "title",
   "name": "Name",
   "runtimeFieldMap": Object {
     "runtime_field": Object {

--- a/src/plugins/data_views/common/data_views/__snapshots__/data_views.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_views.test.ts.snap
@@ -40,6 +40,7 @@ Object {
   },
   "fields": Object {},
   "id": "id",
+  "indexPattern": "kibana-*",
   "name": "Kibana *",
   "namespaces": undefined,
   "runtimeFieldMap": Object {

--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -217,7 +217,7 @@ describe('IndexPattern', () => {
       const oldCount = scriptedFields.length;
       const scriptedField = last(scriptedFields)!;
 
-      await indexPattern.removeScriptedField(scriptedField.name);
+      indexPattern.removeScriptedField(scriptedField.name);
 
       expect(indexPattern.getScriptedFields().length).toEqual(oldCount - 1);
       expect(indexPattern.fields.getByName(scriptedField.name)).toEqual(undefined);

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -35,7 +35,7 @@ const savedObject = {
   id: 'id',
   version: 'version',
   attributes: {
-    title: 'kibana-*',
+    indexPattern: 'kibana-*',
     name: 'Kibana *',
     timeFieldName: '@timestamp',
     fields: '[]',
@@ -183,13 +183,13 @@ describe('IndexPatterns', () => {
 
   test('caches saved objects', async () => {
     await indexPatterns.getIds();
-    await indexPatterns.getTitles();
+    await indexPatterns.getIndexPatterns();
     expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
   });
 
   test('can refresh the saved objects caches', async () => {
     await indexPatterns.getIds();
-    await indexPatterns.getTitles(true);
+    await indexPatterns.getIndexPatterns(true);
     expect(savedObjectsClient.find).toHaveBeenCalledTimes(2);
   });
 

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -36,6 +36,7 @@ const savedObject = {
   version: 'version',
   attributes: {
     indexPattern: 'kibana-*',
+    title: 'kibana-*',
     name: 'Kibana *',
     timeFieldName: '@timestamp',
     fields: '[]',
@@ -176,7 +177,7 @@ describe('IndexPatterns', () => {
     expect(await indexPatterns.getIds()).toEqual(['id']);
     expect(savedObjectsClient.find).toHaveBeenCalledWith({
       type: 'index-pattern',
-      fields: ['title', 'type', 'typeMeta', 'name'],
+      fields: ['indexPattern', 'title', 'type', 'typeMeta', 'name'],
       perPage: 10000,
     });
   });
@@ -285,9 +286,9 @@ describe('IndexPatterns', () => {
 
     expect(savedObjectsClient.find).lastCalledWith({
       type: 'index-pattern',
-      fields: ['title'],
+      fields: ['title', 'indexPattern'],
       search,
-      searchFields: ['title'],
+      searchFields: ['title', 'indexPattern'],
       perPage: size,
     });
   });

--- a/src/plugins/data_views/common/lib/get_title.ts
+++ b/src/plugins/data_views/common/lib/get_title.ts
@@ -23,5 +23,5 @@ export async function getTitle(
     throw new Error(`Unable to get index-pattern title: ${savedObject.error.message}`);
   }
 
-  return savedObject.attributes.title;
+  return savedObject.attributes.indexPattern ?? savedObject.attributes.title;
 }

--- a/src/plugins/data_views/common/lib/get_title.ts
+++ b/src/plugins/data_views/common/lib/get_title.ts
@@ -19,9 +19,10 @@ export async function getTitle(
     indexPatternId
   );
 
-  if (savedObject.error) {
-    throw new Error(`Unable to get index-pattern title: ${savedObject.error.message}`);
+  const { error, attributes } = savedObject;
+  if (error) {
+    throw new Error(`Unable to get index-pattern title: ${error.message}`);
   }
 
-  return savedObject.attributes.indexPattern ?? savedObject.attributes.title;
+  return attributes.indexPattern ?? attributes.title;
 }

--- a/src/plugins/data_views/common/types.ts
+++ b/src/plugins/data_views/common/types.ts
@@ -123,8 +123,15 @@ export interface DataViewAttributes {
   fields: string;
   /**
    * Data view title
+   * Contains the string of ES indices to match when searching against the data view
+   * @deprecated use indexPattern instead
    */
-  title: string;
+  title?: string;
+  /**
+   * Data view index pattern
+   * Contains the string of ES indices to match when searching against the data view
+   */
+  indexPattern: string;
   /**
    * Data view type, default or rollup
    */
@@ -460,8 +467,17 @@ export type DataViewSpec = {
   version?: string;
   /**
    * Data view title
+   * Contains the string of ES indices to match when searching against the data view
+   * @deprecated use indexPattern instead
+   *
    */
   title?: string;
+  /**
+   * Data view index pattern
+   * Contains the string of ES indices to match when searching against the data view
+   *
+   */
+  indexPattern?: string;
   /**
    * Name of timestamp field
    */

--- a/src/plugins/data_views/public/mocks.ts
+++ b/src/plugins/data_views/public/mocks.ts
@@ -34,6 +34,7 @@ const createStartContract = (): Start => {
     get: jest.fn().mockReturnValue(Promise.resolve({})),
     clearCache: jest.fn(),
     getCanSaveSync: jest.fn(),
+    getIdsWithIndexPattern: jest.fn(),
     getIdsWithTitle: jest.fn(),
   } as unknown as jest.Mocked<DataViewsContract>;
 };

--- a/src/plugins/data_views/server/has_user_data_view.test.ts
+++ b/src/plugins/data_views/server/has_user_data_view.test.ts
@@ -36,7 +36,7 @@ describe('hasUserDataView', () => {
           references: [],
           type: 'index-pattern',
           score: 99,
-          attributes: { title: 'my-pattern-*' },
+          attributes: { indexPattern: 'my-pattern-*', title: 'my-pattern-*' },
         },
       ],
     });
@@ -54,7 +54,7 @@ describe('hasUserDataView', () => {
           references: [],
           type: 'index-pattern',
           score: 99,
-          attributes: { title: 'my-pattern-*' },
+          attributes: { indexPattern: 'my-pattern-*', title: 'my-pattern-*' },
         },
       ],
     };

--- a/src/plugins/data_views/server/mocks.ts
+++ b/src/plugins/data_views/server/mocks.ts
@@ -28,5 +28,6 @@ export const dataViewsService = {
   getDefaultId: jest.fn(),
   updateSavedObject: jest.fn(),
   refreshFields: jest.fn(),
+  getIdsWithIndexPattern: jest.fn(),
   getIdsWithTitle: jest.fn(),
 } as unknown as jest.Mocked<DataViewsService>;

--- a/src/plugins/data_views/server/rest_api_routes/get_data_views.ts
+++ b/src/plugins/data_views/server/rest_api_routes/get_data_views.ts
@@ -25,7 +25,7 @@ export const getDataViews = async ({
   counterName,
 }: GetDataViewsArgs) => {
   usageCollection?.incrementCounter({ counterName });
-  return dataViewsService.getIdsWithTitle();
+  return dataViewsService.getIdsWithIndexPattern();
 };
 
 const getDataViewsRouteFactory =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/135451

1. Deprecate dataViews.title, dataViews.getTitles, dataviews.getIdsWithTitle
2. Stop using deprecated references in the data_view* plugins

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
