### PR TITLE
[Lens] clear metric visualization state

### DIFF
--- a/src/plugins/chart_expressions/expression_metric/common/expression_functions/metric_vis_function.ts
+++ b/src/plugins/chart_expressions/expression_metric/common/expression_functions/metric_vis_function.ts
@@ -102,6 +102,7 @@ export const metricVisFunction = (): MetricVisExpressionFunctionDefinition => ({
   fn(input, args, handlers) {
     validateAccessor(args.metric, input.columns);
     validateAccessor(args.secondaryMetric, input.columns);
+    validateAccessor(args.max, input.columns);
     validateAccessor(args.breakdownBy, input.columns);
 
     if (handlers?.inspectorAdapters?.tables) {

--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -160,16 +160,11 @@ const getColor = (
   data: Datatable,
   rowNumber: number
 ) => {
-  let minBound = paletteParams.rangeMin;
-  let maxBound = paletteParams.rangeMax;
-
   const { min, max } = getDataBoundsForPalette(accessors, data, rowNumber);
-  minBound = min;
-  maxBound = max;
 
   return getPaletteService().get(CUSTOM_PALETTE)?.getColorForValue?.(value, paletteParams, {
-    min: minBound,
-    max: maxBound,
+    min,
+    max,
   });
 };
 

--- a/x-pack/plugins/lens/public/visualizations/metric/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/metric/visualization.test.ts
@@ -517,12 +517,8 @@ describe('metric visualization', () => {
   it('clears a layer', () => {
     expect(visualization.clearLayer(fullState, 'some-id')).toMatchInlineSnapshot(`
       Object {
-        "color": "static-color",
         "layerId": "first",
         "layerType": "data",
-        "maxCols": 5,
-        "progressDirection": "vertical",
-        "subtitle": "subtitle",
       }
     `);
   });
@@ -634,6 +630,7 @@ describe('metric visualization', () => {
 
       expect(removed).not.toHaveProperty('metricAccessor');
       expect(removed).not.toHaveProperty('palette');
+      expect(removed).not.toHaveProperty('color');
     });
     it('removes secondary metric dimension', () => {
       const removed = visualization.removeDimension({
@@ -651,6 +648,7 @@ describe('metric visualization', () => {
       });
 
       expect(removed).not.toHaveProperty('maxAccessor');
+      expect(removed).not.toHaveProperty('progressDirection');
     });
     it('removes breakdown-by dimension', () => {
       const removed = visualization.removeDimension({
@@ -660,6 +658,7 @@ describe('metric visualization', () => {
 
       expect(removed).not.toHaveProperty('breakdownByAccessor');
       expect(removed).not.toHaveProperty('collapseFn');
+      expect(removed).not.toHaveProperty('maxCols');
     });
   });
 

--- a/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
@@ -155,6 +155,28 @@ const metricGroupLabel = i18n.translate('xpack.lens.metric.groupLabel', {
   defaultMessage: 'Goal and single value',
 });
 
+const removeMetricDimension = (state: MetricVisualizationState) => {
+  delete state.metricAccessor;
+  delete state.palette;
+  delete state.color;
+};
+
+const removeSecondaryMetricDimension = (state: MetricVisualizationState) => {
+  delete state.secondaryMetricAccessor;
+  delete state.secondaryPrefix;
+};
+
+const removeMaxDimension = (state: MetricVisualizationState) => {
+  delete state.maxAccessor;
+  delete state.progressDirection;
+};
+
+const removeBreakdownByDimension = (state: MetricVisualizationState) => {
+  delete state.breakdownByAccessor;
+  delete state.collapseFn;
+  delete state.maxCols;
+};
+
 export const getMetricVisualization = ({
   paletteService,
   theme,
@@ -181,14 +203,13 @@ export const getMetricVisualization = ({
 
   clearLayer(state) {
     const newState = { ...state };
-    delete newState.metricAccessor;
-    delete newState.secondaryMetricAccessor;
-    delete newState.secondaryPrefix;
-    delete newState.breakdownByAccessor;
-    delete newState.collapseFn;
-    delete newState.maxAccessor;
-    delete newState.palette;
-    // TODO - clear more?
+    delete newState.subtitle;
+
+    removeMetricDimension(newState);
+    removeSecondaryMetricDimension(newState);
+    removeMaxDimension(newState);
+    removeBreakdownByDimension(newState);
+
     return newState;
   },
 
@@ -405,20 +426,16 @@ export const getMetricVisualization = ({
     const updated = { ...prevState };
 
     if (prevState.metricAccessor === columnId) {
-      delete updated.metricAccessor;
-      delete updated.palette;
-      delete updated.color;
+      removeMetricDimension(updated);
     }
     if (prevState.secondaryMetricAccessor === columnId) {
-      delete updated.secondaryMetricAccessor;
-      delete updated.secondaryPrefix;
+      removeSecondaryMetricDimension(updated);
     }
     if (prevState.maxAccessor === columnId) {
-      delete updated.maxAccessor;
+      removeMaxDimension(updated);
     }
     if (prevState.breakdownByAccessor === columnId) {
-      delete updated.breakdownByAccessor;
-      delete updated.collapseFn;
+      removeBreakdownByDimension(updated);
     }
 
     return updated;


### PR DESCRIPTION
## Summary

Visualization state is now properly cleared when 
- a dimension is removed whose editor contained the extra settings
- the layer is cleared

Also, adding missing validation for the max accessor.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
