### PR TITLE
[Lens] pagination filtering bug workaround

### DIFF
--- a/src/plugins/vis_types/table/public/components/table_vis_basic.test.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_basic.test.tsx
@@ -65,7 +65,7 @@ describe('TableVisBasic', () => {
     );
     expect(comp).toMatchSnapshot();
   });
- 
+
   it('should sort rows by column and pass the sorted rows for consumers', () => {
     (createTableVisCell as jest.Mock).mockClear();
     const uiStateProps = {

--- a/src/plugins/vis_types/table/public/components/table_vis_basic.test.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_basic.test.tsx
@@ -65,7 +65,7 @@ describe('TableVisBasic', () => {
     );
     expect(comp).toMatchSnapshot();
   });
-
+ 
   it('should sort rows by column and pass the sorted rows for consumers', () => {
     (createTableVisCell as jest.Mock).mockClear();
     const uiStateProps = {

--- a/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
@@ -78,7 +78,7 @@ export const TableVisBasic = memo(
       columnsWidth,
       fireEvent,
       dataGridRef.current?.closeCellPopover,
-      pagination?.onChangePage,
+      pagination?.onChangePage
     );
 
     // Sorting config

--- a/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
@@ -67,6 +67,9 @@ export const TableVisBasic = memo(
       [visConfig.autoFitRowToContent]
     );
 
+    // Pagination config
+    const pagination = usePagination(visConfig, rows.length);
+
     // Columns config
     const gridColumns = createGridColumns(
       columns,
@@ -74,11 +77,10 @@ export const TableVisBasic = memo(
       formattedColumns,
       columnsWidth,
       fireEvent,
-      dataGridRef.current?.closeCellPopover
+      dataGridRef.current?.closeCellPopover,
+      pagination?.onChangePage,
     );
 
-    // Pagination config
-    const pagination = usePagination(visConfig, rows.length);
     // Sorting config
     const sortingColumns = useMemo(
       () =>

--- a/src/plugins/vis_types/table/public/components/table_vis_columns.test.ts
+++ b/src/plugins/vis_types/table/public/components/table_vis_columns.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import  { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
 
 import { createGridColumns } from './table_vis_columns';

--- a/src/plugins/vis_types/table/public/components/table_vis_columns.test.ts
+++ b/src/plugins/vis_types/table/public/components/table_vis_columns.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import  { ReactNode } from 'react';
+import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
+
+import { createGridColumns } from './table_vis_columns';
+import { FieldFormat } from '@kbn/field-formats-plugin/common';
+
+describe('table vis columns', () => {
+  describe('filtering', () => {
+    it('should fire filter event and reset page on filter click', () => {
+      const fireEvent = jest.fn();
+      const closeCellPopover = jest.fn();
+      const changePage = jest.fn();
+      const columns = createGridColumns(
+        [
+          {
+            name: 'a',
+            meta: { type: 'number' },
+            id: 'a',
+          },
+        ],
+        [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }],
+        {
+          a: {
+            title: 'Test',
+            formatter: { convert: (x: unknown) => x } as unknown as FieldFormat,
+            filterable: true,
+          },
+        },
+        [],
+        fireEvent,
+        closeCellPopover,
+        changePage
+      );
+
+      // call `onClick` of passed down react component of first cell action
+      (
+        (
+          columns[0].cellActions![0] as unknown as (
+            props: EuiDataGridColumnCellActionProps
+          ) => ReactNode
+        )({
+          rowIndex: 0,
+          columnId: 'a',
+          colIndex: 0,
+          isExpanded: true,
+          Component: () => null,
+        }) as unknown as { props: { onClick: () => void } }
+      ).props!.onClick();
+      expect(fireEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'filter',
+        })
+      );
+      expect(changePage).toHaveBeenCalledWith(0);
+      expect(closeCellPopover).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/vis_types/table/public/components/table_vis_columns.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_columns.tsx
@@ -35,9 +35,12 @@ export const createGridColumns = (
   formattedColumns: FormattedColumns,
   columnsWidth: TableVisUiState['colWidth'],
   fireEvent: IInterpreterRenderHandlers['event'],
-  closeCellPopover?: Function
+  closeCellPopover?: Function,
+  onChangePage?: (pageIndex: number) => void,
 ) => {
   const onFilterClick = (data: FilterCellData, negate: boolean) => {
+    // switch back to first page on filtering so we don't render an empty page
+    onChangePage?.(0);
     fireEvent({
       name: 'filter',
       data: {

--- a/src/plugins/vis_types/table/public/components/table_vis_columns.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_columns.tsx
@@ -36,7 +36,7 @@ export const createGridColumns = (
   columnsWidth: TableVisUiState['colWidth'],
   fireEvent: IInterpreterRenderHandlers['event'],
   closeCellPopover?: Function,
-  onChangePage?: (pageIndex: number) => void,
+  onChangePage?: (pageIndex: number) => void
 ) => {
   const onFilterClick = (data: FilterCellData, negate: boolean) => {
     // switch back to first page on filtering so we don't render an empty page

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.test.tsx
@@ -783,7 +783,7 @@ describe('DatatableComponent', () => {
         { a: 'shoes', b: 1588024800000, c: 3 },
         { a: 'shoes', b: 1588024800000, c: 3 },
         { a: 'shoes', b: 1588024800000, c: 3 },
-      ]
+      ];
 
       const wrapper = mount(
         <DatatableComponent

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -177,10 +177,19 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
     [dispatchEvent]
   );
 
-  const handleFilterClick = useMemo(
-    () => (isInteractive ? createGridFilterHandler(firstTableRef, onClickValue) : undefined),
-    [firstTableRef, onClickValue, isInteractive]
-  );
+  const handleFilterClick = useMemo(() => {
+    const handler = isInteractive
+      ? createGridFilterHandler(firstTableRef, onClickValue)
+      : undefined;
+    if (handler) {
+      const wrappedHandler: typeof handler = (...args) => {
+        // update pagination
+        onChangePage(0);
+        return handler(...args);
+      };
+      return wrappedHandler;
+    }
+  }, [firstTableRef, onClickValue, isInteractive, onChangePage]);
 
   const handleTransposedColumnClick = useMemo(
     () =>

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -183,7 +183,7 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
       : undefined;
     if (handler) {
       const wrappedHandler: typeof handler = (...args) => {
-        // update pagination
+        // switch to first page before filtering to work around EuiDataGrid bug (see https://github.com/elastic/kibana/issues/139126)
         onChangePage(0);
         return handler(...args);
       };


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/139126

This is a quick workaround for the EUI bug where the `EuiDataGrid` treats cell actions differently when they aren't on the first page. We should still nail down the details on this, but this PR is available if we need it for 8.4.

This isn't perfect since the user loses their place in the table when they filter by a cell value and then remove that filter.

https://user-images.githubusercontent.com/315764/185521072-1e58f024-401b-4625-85b3-2637097e8bb0.mov



### Checklist

Delete any items that are not applicable to this PR.
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
