### PR TITLE
Retry click on filter to get popover to remove

### DIFF
--- a/test/functional/services/filter_bar.ts
+++ b/test/functional/services/filter_bar.ts
@@ -56,8 +56,10 @@ export class FilterBarService extends FtrService {
    * @param key field name
    */
   public async removeFilter(key: string): Promise<void> {
-    await this.testSubjects.click(`~filter & ~filter-key-${key}`);
-    await this.testSubjects.click(`deleteFilter`);
+    await this.retry.try(async () => {
+      await this.testSubjects.click(`~filter & ~filter-key-${key}`);
+      await this.testSubjects.click(`deleteFilter`);
+    });
     await this.header.awaitGlobalLoadingIndicatorHidden();
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/139040

Sometimes the click on the filter doesn't open it correctly. This PR retries the click if it didn't work out the first time.