### PR TITLE
[TIP] Add paywall component to enterprise guard

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/components/paywall/index.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/paywall/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './paywall';

--- a/x-pack/plugins/threat_intelligence/public/components/paywall/paywall.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/paywall/paywall.stories.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Paywall } from './paywall';
+
+export default {
+  component: BasicPaywall,
+  title: 'Paywall',
+};
+
+export function BasicPaywall() {
+  return <Paywall licenseManagementHref="https://elastic.co" />;
+}

--- a/x-pack/plugins/threat_intelligence/public/components/paywall/paywall.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/paywall/paywall.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { VFC } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+interface PaywallProps {
+  /**
+   * Can be obtained using `http.basePath.prepend('/app/management/stack/license_management')`
+   */
+  licenseManagementHref: string;
+}
+
+export const Paywall: VFC<PaywallProps> = ({ licenseManagementHref }) => {
+  return (
+    <EuiEmptyPrompt
+      icon={<EuiIcon type="logoSecurity" size="xl" />}
+      color="subdued"
+      data-test-subj="tiPaywall"
+      title={
+        <h2>
+          <FormattedMessage
+            id="xpack.threatIntelligence.paywall.title"
+            defaultMessage="Do more with Security!"
+          />
+        </h2>
+      }
+      body={
+        <p>
+          <FormattedMessage
+            id="xpack.threatIntelligence.paywall.body"
+            defaultMessage="Start a free trial or upgrade your license to Enterprise to use threat intelligence."
+          />
+        </p>
+      }
+      actions={
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <div>
+              <EuiButton color="primary" fill href="https://www.elastic.co/subscriptions">
+                <FormattedMessage
+                  id="xpack.threatIntelligence.paywall.upgrade"
+                  defaultMessage="Upgrade"
+                />
+              </EuiButton>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <div>
+              <EuiButtonEmpty href={licenseManagementHref}>
+                <FormattedMessage
+                  id="xpack.threatIntelligence.paywall.trial"
+                  defaultMessage="Start a free trial"
+                />
+              </EuiButtonEmpty>
+            </div>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    />
+  );
+};

--- a/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard/enterprise_guard.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard/enterprise_guard.test.tsx
@@ -7,6 +7,7 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { TestProvidersComponent } from '../../common/mocks/test_providers';
 import { SecuritySolutionPluginContext } from '../../types';
 import { SecuritySolutionContext } from '../security_solution_context';
 import { EnterpriseGuard } from './enterprise_guard';
@@ -15,17 +16,19 @@ describe('<EnterpriseGuard />', () => {
   describe('when on enterprise plan', () => {
     it('should render specified children', () => {
       render(
-        <SecuritySolutionContext.Provider
-          value={
-            {
-              licenseService: { isEnterprise: jest.fn().mockReturnValue(true) },
-            } as unknown as SecuritySolutionPluginContext
-          }
-        >
-          <EnterpriseGuard>
-            <div>enterprise only content</div>
-          </EnterpriseGuard>
-        </SecuritySolutionContext.Provider>
+        <TestProvidersComponent>
+          <SecuritySolutionContext.Provider
+            value={
+              {
+                licenseService: { isEnterprise: jest.fn().mockReturnValue(true) },
+              } as unknown as SecuritySolutionPluginContext
+            }
+          >
+            <EnterpriseGuard>
+              <div>enterprise only content</div>
+            </EnterpriseGuard>
+          </SecuritySolutionContext.Provider>
+        </TestProvidersComponent>
       );
 
       expect(screen.queryByText('enterprise only content')).toBeInTheDocument();
@@ -35,21 +38,23 @@ describe('<EnterpriseGuard />', () => {
   describe('when not on enterprise plan', () => {
     it('should render specified children', () => {
       render(
-        <SecuritySolutionContext.Provider
-          value={
-            {
-              licenseService: { isEnterprise: jest.fn().mockReturnValue(false) },
-            } as unknown as SecuritySolutionPluginContext
-          }
-        >
-          <EnterpriseGuard fallback={<div>fallback for non enterprise</div>}>
-            <div>enterprise only content</div>
-          </EnterpriseGuard>
-        </SecuritySolutionContext.Provider>
+        <TestProvidersComponent>
+          <SecuritySolutionContext.Provider
+            value={
+              {
+                licenseService: { isEnterprise: jest.fn().mockReturnValue(false) },
+              } as unknown as SecuritySolutionPluginContext
+            }
+          >
+            <EnterpriseGuard>
+              <div>enterprise only content</div>
+            </EnterpriseGuard>
+          </SecuritySolutionContext.Provider>
+        </TestProvidersComponent>
       );
 
       expect(screen.queryByText('enterprise only content')).not.toBeInTheDocument();
-      expect(screen.queryByText('fallback for non enterprise')).toBeInTheDocument();
+      expect(screen.queryByTestId('tiPaywall')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard/enterprise_guard.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard/enterprise_guard.tsx
@@ -5,20 +5,25 @@
  * 2.0.
  */
 
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { FC } from 'react';
+import { Paywall } from '../../components/paywall';
+import { useKibana } from '../../hooks/use_kibana';
 import { useSecurityContext } from '../../hooks/use_security_context';
 
-interface EnterpriseGuardProps {
-  fallback?: ReactElement;
-}
-
-export const EnterpriseGuard: FC<EnterpriseGuardProps> = ({ children, fallback = null }) => {
+export const EnterpriseGuard: FC = ({ children }) => {
   const { licenseService } = useSecurityContext();
+  const {
+    services: { http },
+  } = useKibana();
 
   if (licenseService.isEnterprise()) {
     return <>{children}</>;
   }
 
-  return fallback;
+  return (
+    <Paywall
+      licenseManagementHref={http.basePath.prepend('/app/management/stack/license_management')}
+    />
+  );
 };


### PR DESCRIPTION
## Summary

This PR introduces Paywall Component, rendered when user does not have a subscription eligible for Threat Intel features.

![paywall](https://user-images.githubusercontent.com/11671118/185901161-e72754bc-40ee-4b40-8cf3-c921acfe0a6c.png)



### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

