### PR TITLE
Upgrade micromatch from v3.1.10 to v4.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1233,7 +1233,7 @@
     "lmdb-store": "^1.6.11",
     "loader-utils": "^1.2.3",
     "marge": "^1.0.1",
-    "micromatch": "3.1.10",
+    "micromatch": "^4.0.5",
     "mini-css-extract-plugin": "1.1.0",
     "minimist": "^1.2.6",
     "mocha": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20249,7 +20249,7 @@ micromark@~2.11.0:
     debug "^4.0.0"
     parse-entities "^2.0.0"
 
-micromatch@3.1.10, micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==


### PR DESCRIPTION
We only use the direct `micromatch` dependency in one location:

https://github.com/elastic/kibana/blob/f7c0a0cd8e285b399ca77c670b45e5d85b20c0bd/packages/kbn-generate/src/commands/package_command.ts#L61

Here we use the `isMatch` function which is not [listed](https://github.com/micromatch/micromatch/blob/master/CHANGELOG.md#400---2019-03-20) as containing any breaking changes between the 3.x and the 4.x major.

<!--ONMERGE {"backportTargets":["7.17","8.3","8.4"]} ONMERGE-->