### PR TITLE
[DOCS] Removes tags from 8.4.0 release docs

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -36,8 +36,6 @@ Review important information about the {kib} 8.4.x releases.
 [[release-notes-8.4.0]]
 == {kib} 8.4.0
 
-coming::[8.4.0]
-
 Review the following information about the {kib} 8.4.0 release.
 
 [float]

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -12,8 +12,6 @@ Previous versions: {kibana-ref-all}/8.3/whats-new.html[8.3] | {kibana-ref-all}/8
 
 // tag::notable-highlights[]
 
-coming::[8.4.0]
-
 [discrete]
 [[highlights-8.4-release-docs]]
 === Elastic release docs now in one place


### PR DESCRIPTION
## Summary

Removes the coming tags from the 8.4.0 release notes and what's new. 

