### PR TITLE
Adding a note about skipped a11y test for upgrade assistant

### DIFF
--- a/x-pack/test/accessibility/apps/upgrade_assistant.ts
+++ b/x-pack/test/accessibility/apps/upgrade_assistant.ts
@@ -5,6 +5,11 @@
  * 2.0.
  */
 
+/* This test expects a deprecation which is valid only on 7.x. So, this is enabled on 7.x
+ * and disabled on 8.x. Should be enabled again when 8.x to next major upgrade happens with
+ * valid deprecations
+ */
+
 import type { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { FtrProviderContext } from '../ftr_provider_context';
 


### PR DESCRIPTION
Upgrade assistant is on UI when user is either performing a major version upgrade or getting ready for an upgrade. So the upgrade assistant a11y test is skipped on 8.x but enabled on 7.x. 

This test will have to be enabled again during next major upgrade. 

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->