### PR TITLE
[8.4] Update dependency @elastic/charts to v47.2.0 (#138093)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "47.1.1",
+    "@elastic/charts": "47.2.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.3.0-canary.1",
     "@elastic/ems-client": "8.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,10 +1443,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@47.1.1":
-  version "47.1.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-47.1.1.tgz#0ee237c616323112887a7bf7529601dc6f1d65eb"
-  integrity sha512-kPIPUtUcO3wCkp4TkgiFXqfT9jmrJtdhAnmKGOzgDH4Ku5j8mJ2caimdYZhEIGNW1tSqmbjjSYlGH0N+iG6CLw==
+"@elastic/charts@47.2.0":
+  version "47.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-47.2.0.tgz#829235fa133210faf680480ab73ac6a9aa3affa4"
+  integrity sha512-oZM9hH5eMYg8jkQi/Gwr4v7x9qjmUN919dLhflbq9rae49xi5GANXv0zpw8V75xQFt+W0TkuyUisf/OYL2ycCQ==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Update dependency @elastic/charts to v47.2.0 (#138093)](https://github.com/elastic/kibana/pull/138093)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"renovate[bot]","email":"29139614+renovate[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-08-18T20:10:11Z","message":"Update dependency @elastic/charts to v47.2.0 (#138093)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\r\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"20be5a8782dce611b4c4e53f79a39a51c0fba49c","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:DataVis","auto-backport"],"number":138093,"url":"https://github.com/elastic/kibana/pull/138093","mergeCommit":{"message":"Update dependency @elastic/charts to v47.2.0 (#138093)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\r\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"20be5a8782dce611b4c4e53f79a39a51c0fba49c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->