### PR TITLE
[Lens] migrate metric visualization IDs

### DIFF
--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -88,7 +88,7 @@ export interface PieVisualizationState {
   layers: PieLayerState[];
   palette?: PaletteOutput;
 }
-export interface MetricState {
+export interface LegacyMetricState {
   layerId: string;
   accessor?: string;
   layerType: LayerType;

--- a/x-pack/plugins/lens/public/embeddable/embeddable_component.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable_component.tsx
@@ -24,8 +24,9 @@ import type { LensByReferenceInput, LensByValueInput } from './embeddable';
 import type { Document } from '../persistence';
 import type { IndexPatternPersistedState } from '../indexpattern_datasource/types';
 import type { XYState } from '../visualizations/xy/types';
-import type { PieVisualizationState, MetricState } from '../../common';
+import type { PieVisualizationState, LegacyMetricState } from '../../common';
 import type { DatatableVisualizationState } from '../visualizations/datatable/visualization';
+import type { MetricVisualizationState } from '../visualizations/metric/visualization';
 import type { HeatmapVisualizationState } from '../visualizations/heatmap/types';
 import type { GaugeVisualizationState } from '../visualizations/gauge/constants';
 
@@ -51,7 +52,8 @@ export type TypedLensByValueInput = Omit<LensByValueInput, 'attributes'> & {
     | LensAttributes<'lnsXY', XYState>
     | LensAttributes<'lnsPie', PieVisualizationState>
     | LensAttributes<'lnsDatatable', DatatableVisualizationState>
-    | LensAttributes<'lnsMetric', MetricState>
+    | LensAttributes<'lnsLegacyMetric', LegacyMetricState>
+    | LensAttributes<'lnsMetric', MetricVisualizationState>
     | LensAttributes<'lnsHeatmap', HeatmapVisualizationState>
     | LensAttributes<'lnsGauge', GaugeVisualizationState>
     | LensAttributes<string, unknown>;

--- a/x-pack/plugins/lens/public/index.ts
+++ b/x-pack/plugins/lens/public/index.ts
@@ -32,7 +32,7 @@ export type {
   VisualizationSuggestion,
 } from './types';
 export type {
-  MetricState,
+  LegacyMetricState as MetricState,
   ValueLabelConfig,
   PieVisualizationState,
   PieLayerState,

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/dimension_editor.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/dimension_editor.test.tsx
@@ -23,7 +23,7 @@ import { act } from 'react-dom/test-utils';
 
 import { PalettePanelContainer } from '../../shared_components';
 import { layerTypes } from '../../../common';
-import type { MetricState } from '../../../common/types';
+import type { LegacyMetricState } from '../../../common/types';
 
 // mocking random id generator function
 jest.mock('@elastic/eui', () => {
@@ -48,13 +48,13 @@ function paletteParamsContaining(paramsToCheck: PaletteOutput<CustomPaletteParam
 
 describe('metric dimension editor', () => {
   let frame: FramePublicAPI;
-  let state: MetricState;
-  let setState: (newState: MetricState) => void;
-  let props: VisualizationDimensionEditorProps<MetricState> & {
+  let state: LegacyMetricState;
+  let setState: (newState: LegacyMetricState) => void;
+  let props: VisualizationDimensionEditorProps<LegacyMetricState> & {
     paletteService: PaletteRegistry;
   };
 
-  function testState(): MetricState {
+  function testState(): LegacyMetricState {
     return {
       layerId: 'first',
       layerType: layerTypes.DATA,

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/dimension_editor.tsx
@@ -22,7 +22,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useState } from 'react';
 import { ColorMode } from '@kbn/charts-plugin/common';
-import type { MetricState } from '../../../common/types';
+import type { LegacyMetricState } from '../../../common/types';
 import { isNumericFieldForDatatable } from '../../../common/expressions';
 import { applyPaletteParams, PalettePanelContainer } from '../../shared_components';
 import type { VisualizationDimensionEditorProps } from '../../types';
@@ -33,7 +33,7 @@ import './dimension_editor.scss';
 const idPrefix = htmlIdGenerator()();
 
 export function MetricDimensionEditor(
-  props: VisualizationDimensionEditorProps<MetricState> & {
+  props: VisualizationDimensionEditorProps<LegacyMetricState> & {
     paletteService: PaletteRegistry;
   }
 ) {
@@ -117,7 +117,7 @@ export function MetricDimensionEditor(
           idSelected={`${idPrefix}${currentColorMode}`}
           onChange={(id) => {
             const newMode = id.replace(idPrefix, '') as ColorMode;
-            const params: Partial<MetricState> = {
+            const params: Partial<LegacyMetricState> = {
               colorMode: newMode,
             };
             if (!state?.palette && newMode !== ColorMode.None) {

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/align_options.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/align_options.tsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonGroup } from '@elastic/eui';
-import { MetricState } from '../../../../common/types';
+import { LegacyMetricState } from '../../../../common/types';
 
 export interface TitlePositionProps {
-  state: MetricState;
-  setState: (newState: MetricState) => void;
+  state: LegacyMetricState;
+  setState: (newState: LegacyMetricState) => void;
 }
 
 export const DEFAULT_TEXT_ALIGNMENT = 'left';
@@ -50,7 +50,7 @@ export const AlignOptions: React.FC<TitlePositionProps> = ({ state, setState }) 
       options={alignButtonIcons}
       idSelected={state.textAlign ?? DEFAULT_TEXT_ALIGNMENT}
       onChange={(id) => {
-        setState({ ...state, textAlign: id as MetricState['textAlign'] });
+        setState({ ...state, textAlign: id as LegacyMetricState['textAlign'] });
       }}
       isIconOnly
       buttonSize="compressed"

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/appearance_options_popover.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/appearance_options_popover.tsx
@@ -10,12 +10,12 @@ import { i18n } from '@kbn/i18n';
 import { ToolbarPopover, TooltipWrapper } from '../../../shared_components';
 import { TitlePositionOptions } from './title_position_option';
 import { FramePublicAPI } from '../../../types';
-import type { MetricState } from '../../../../common/types';
+import type { LegacyMetricState } from '../../../../common/types';
 import { TextFormattingOptions } from './text_formatting_options';
 
 export interface VisualOptionsPopoverProps {
-  state: MetricState;
-  setState: (newState: MetricState) => void;
+  state: LegacyMetricState;
+  setState: (newState: LegacyMetricState) => void;
   datasourceLayers: FramePublicAPI['datasourceLayers'];
 }
 

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/index.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/index.tsx
@@ -8,12 +8,12 @@
 import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, htmlIdGenerator } from '@elastic/eui';
 import type { VisualizationToolbarProps } from '../../../types';
-import type { MetricState } from '../../../../common/types';
+import type { LegacyMetricState } from '../../../../common/types';
 
 import { AppearanceOptionsPopover } from './appearance_options_popover';
 
 export const MetricToolbar = memo(function MetricToolbar(
-  props: VisualizationToolbarProps<MetricState>
+  props: VisualizationToolbarProps<LegacyMetricState>
 ) {
   const { state, setState, frame } = props;
 

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/size_options.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/size_options.tsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonIcon, EuiSuperSelect } from '@elastic/eui';
-import type { MetricState } from '../../../../common/types';
+import type { LegacyMetricState } from '../../../../common/types';
 
 export interface TitlePositionProps {
-  state: MetricState;
-  setState: (newState: MetricState) => void;
+  state: LegacyMetricState;
+  setState: (newState: LegacyMetricState) => void;
 }
 
 export const DEFAULT_TITLE_SIZE = 'm';

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/text_formatting_options.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/text_formatting_options.tsx
@@ -8,13 +8,13 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import type { MetricState } from '../../../../common/types';
+import type { LegacyMetricState } from '../../../../common/types';
 import { SizeOptions } from './size_options';
 import { AlignOptions } from './align_options';
 
 export interface TitlePositionProps {
-  state: MetricState;
-  setState: (newState: MetricState) => void;
+  state: LegacyMetricState;
+  setState: (newState: LegacyMetricState) => void;
 }
 
 export const TextFormattingOptions: React.FC<TitlePositionProps> = ({ state, setState }) => {

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/title_position_option.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_config_panel/title_position_option.tsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonGroup, EuiFormRow } from '@elastic/eui';
-import type { MetricState } from '../../../../common/types';
+import type { LegacyMetricState } from '../../../../common/types';
 
 export interface TitlePositionProps {
-  state: MetricState;
-  setState: (newState: MetricState) => void;
+  state: LegacyMetricState;
+  setState: (newState: LegacyMetricState) => void;
 }
 
 export const DEFAULT_TITLE_POSITION = 'top';
@@ -52,7 +52,7 @@ export const TitlePositionOptions: React.FC<TitlePositionProps> = ({ state, setS
         options={titlePositions}
         idSelected={state.titlePosition ?? DEFAULT_TITLE_POSITION}
         onChange={(value) => {
-          setState({ ...state, titlePosition: value as MetricState['titlePosition'] });
+          setState({ ...state, titlePosition: value as LegacyMetricState['titlePosition'] });
         }}
         buttonSize="compressed"
       />

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
@@ -7,7 +7,7 @@
 
 import { IconChartMetric } from '@kbn/chart-icons';
 import { SuggestionRequest, VisualizationSuggestion, TableSuggestion } from '../../types';
-import type { MetricState } from '../../../common/types';
+import type { LegacyMetricState } from '../../../common/types';
 import { layerTypes } from '../../../common';
 import { legacyMetricSupportedTypes } from './visualization';
 
@@ -20,7 +20,7 @@ export function getSuggestions({
   table,
   state,
   keptLayerIds,
-}: SuggestionRequest<MetricState>): Array<VisualizationSuggestion<MetricState>> {
+}: SuggestionRequest<LegacyMetricState>): Array<VisualizationSuggestion<LegacyMetricState>> {
   // We only render metric charts for single-row queries. We require a single, numeric column.
   if (
     table.isMultiRow ||
@@ -42,7 +42,7 @@ export function getSuggestions({
   return [getSuggestion(table)];
 }
 
-function getSuggestion(table: TableSuggestion): VisualizationSuggestion<MetricState> {
+function getSuggestion(table: TableSuggestion): VisualizationSuggestion<LegacyMetricState> {
   const col = table.columns[0];
   const title = table.label || col.operation.label;
 

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { getLegacyMetricVisualization } from './visualization';
-import type { MetricState } from '../../../common/types';
+import type { LegacyMetricState } from '../../../common/types';
 import { layerTypes } from '../../../common';
 import { createMockDatasource, createMockFramePublicAPI } from '../../mocks';
 import { generateId } from '../../id_generator';
@@ -17,7 +17,7 @@ import { themeServiceMock } from '@kbn/core/public/mocks';
 
 jest.mock('../../id_generator');
 
-function exampleState(): MetricState {
+function exampleState(): LegacyMetricState {
   return {
     accessor: 'a',
     layerId: 'l1',

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -240,7 +240,7 @@ export const getLegacyMetricVisualization = ({
               defaultMessage: 'Value',
             }),
           },
-          groupLabel: i18n.translate('xpack.lens.legacyMetric.label', {
+          groupLabel: i18n.translate('xpack.lens.metric.label', {
             defaultMessage: 'Metric',
           }),
           layerId: props.state.layerId,

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -17,7 +17,7 @@ import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { IconChartMetric } from '@kbn/chart-icons';
 import { getSuggestions } from './metric_suggestions';
 import { Visualization, OperationMetadata, DatasourceLayers } from '../../types';
-import type { MetricState } from '../../../common/types';
+import type { LegacyMetricState } from '../../../common/types';
 import { layerTypes } from '../../../common';
 import { MetricDimensionEditor } from './dimension_editor';
 import { MetricToolbar } from './metric_config_panel';
@@ -25,7 +25,7 @@ import { DEFAULT_TITLE_POSITION } from './metric_config_panel/title_position_opt
 import { DEFAULT_TITLE_SIZE } from './metric_config_panel/size_options';
 import { DEFAULT_TEXT_ALIGNMENT } from './metric_config_panel/align_options';
 
-interface MetricConfig extends Omit<MetricState, 'palette' | 'colorMode'> {
+interface MetricConfig extends Omit<LegacyMetricState, 'palette' | 'colorMode'> {
   title: string;
   description: string;
   metricTitle: string;
@@ -46,9 +46,9 @@ const getFontSizeAndUnit = (fontSize: string) => {
 
 const toExpression = (
   paletteService: PaletteRegistry,
-  state: MetricState,
+  state: LegacyMetricState,
   datasourceLayers: DatasourceLayers,
-  attributes?: Partial<Omit<MetricConfig, keyof MetricState>>,
+  attributes?: Partial<Omit<MetricConfig, keyof LegacyMetricState>>,
   datasourceExpressionsByLayers: Record<string, Ast> | undefined = {}
 ): Ast | null => {
   if (!state.accessor) {
@@ -175,7 +175,7 @@ export const getLegacyMetricVisualization = ({
 }: {
   paletteService: PaletteRegistry;
   theme: ThemeServiceStart;
-}): Visualization<MetricState> => ({
+}): Visualization<LegacyMetricState> => ({
   id: 'lnsLegacyMetric',
 
   visualizationTypes: [
@@ -192,7 +192,7 @@ export const getLegacyMetricVisualization = ({
   ],
 
   getVisualizationTypeId() {
-    return 'lnsMetric';
+    return 'lnsLegacyMetric';
   },
 
   clearLayer(state) {

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -176,11 +176,11 @@ export const getLegacyMetricVisualization = ({
   paletteService: PaletteRegistry;
   theme: ThemeServiceStart;
 }): Visualization<MetricState> => ({
-  id: 'lnsMetric',
+  id: 'lnsLegacyMetric',
 
   visualizationTypes: [
     {
-      id: 'lnsMetric',
+      id: 'lnsLegacyMetric',
       icon: IconChartMetric,
       label: i18n.translate('xpack.lens.legacyMetric.label', {
         defaultMessage: 'Legacy Metric',

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -241,7 +241,7 @@ export const getLegacyMetricVisualization = ({
             }),
           },
           groupLabel: i18n.translate('xpack.lens.legacyMetric.label', {
-            defaultMessage: 'Legacy Metric',
+            defaultMessage: 'Metric',
           }),
           layerId: props.state.layerId,
           accessors: props.state.accessor

--- a/x-pack/plugins/lens/public/visualizations/metric/constants.ts
+++ b/x-pack/plugins/lens/public/visualizations/metric/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const LENS_METRIC_ID = 'lnsMetricNew'; // TODO - rename old one to "legacy"
+export const LENS_METRIC_ID = 'lnsMetric';
 
 export const GROUP_ID = {
   METRIC: 'metric',

--- a/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
+++ b/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
@@ -127,7 +127,7 @@ export const makeLensEmbeddableFactory =
                 attributes: migratedLensState,
               } as unknown as SerializableRecord;
             },
-            '8.4.0': (state) => {
+            '8.5.0': (state) => {
               const lensState = state as unknown as { attributes: LensDocShape840<VisState840> };
               const migratedLensState = commonMigrateMetricIds(lensState.attributes);
               return {

--- a/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
+++ b/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
@@ -27,15 +27,18 @@ import {
   commonUpdateVisLayerType,
   getLensCustomVisualizationMigrations,
   getLensFilterMigrations,
+  commonMigrateMetricIds,
 } from '../migrations/common_migrations';
 import {
   CustomVisualizationMigrations,
   LensDocShape713,
   LensDocShape715,
   LensDocShape810,
+  LensDocShape840,
   LensDocShapePre712,
   VisState716,
   VisState810,
+  VisState840,
   VisStatePre715,
   VisStatePre830,
 } from '../migrations/types';
@@ -119,6 +122,14 @@ export const makeLensEmbeddableFactory =
               migratedLensState = commonFixValueLabelsInXY(
                 migratedLensState as LensDocShape810<VisStatePre830>
               );
+              return {
+                ...lensState,
+                attributes: migratedLensState,
+              } as unknown as SerializableRecord;
+            },
+            '8.4.0': (state) => {
+              const lensState = state as unknown as { attributes: LensDocShape840<VisState840> };
+              const migratedLensState = commonMigrateMetricIds(lensState.attributes);
               return {
                 ...lensState,
                 attributes: migratedLensState,

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -32,7 +32,7 @@ import {
   VisStatePre830,
   LensDocShape840,
 } from './types';
-import { DOCUMENT_FIELD_NAME, layerTypes, MetricState } from '../../common';
+import { DOCUMENT_FIELD_NAME, layerTypes, LegacyMetricState } from '../../common';
 import { LensDocShape } from './saved_object_migrations';
 
 export const commonRenameOperationsForFormula = (
@@ -249,7 +249,7 @@ export const commonLockOldMetricVisSettings = (
     return newAttributes as LensDocShape830<VisState830>;
   }
 
-  const visState = newAttributes.state.visualization as MetricState;
+  const visState = newAttributes.state.visualization as LegacyMetricState;
   visState.textAlign = visState.textAlign ?? 'center';
   visState.titlePosition = visState.titlePosition ?? 'bottom';
   visState.size = visState.size ?? 'xl';

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -30,6 +30,8 @@ import {
   LensDocShape810,
   LensDocShape830,
   VisStatePre830,
+  LensDocShape840,
+  VisState840,
 } from './types';
 import { DOCUMENT_FIELD_NAME, layerTypes, MetricState } from '../../common';
 import { LensDocShape } from './saved_object_migrations';
@@ -397,4 +399,22 @@ export const commonFixValueLabelsInXY = (
       },
     },
   };
+};
+
+export const commonMigrateMetricIds = (
+  attributes: LensDocShape840<VisState840>
+): LensDocShape840<VisState840> => {
+  const typeMappings = {
+    lnsMetric: 'lnsLegacyMetric',
+    lnsMetricNew: 'lnsMetric',
+  } as Record<string, string>;
+
+  if (!attributes.visualizationType || !(attributes.visualizationType in typeMappings)) {
+    return attributes as LensDocShape840<VisState840>;
+  }
+
+  const newAttributes = cloneDeep(attributes);
+  newAttributes.visualizationType = typeMappings[attributes.visualizationType];
+
+  return newAttributes;
 };

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -31,7 +31,6 @@ import {
   LensDocShape830,
   VisStatePre830,
   LensDocShape840,
-  VisState840,
 } from './types';
 import { DOCUMENT_FIELD_NAME, layerTypes, MetricState } from '../../common';
 import { LensDocShape } from './saved_object_migrations';
@@ -402,15 +401,15 @@ export const commonFixValueLabelsInXY = (
 };
 
 export const commonMigrateMetricIds = (
-  attributes: LensDocShape840<VisState840>
-): LensDocShape840<VisState840> => {
+  attributes: LensDocShape840<unknown>
+): LensDocShape840<unknown> => {
   const typeMappings = {
     lnsMetric: 'lnsLegacyMetric',
     lnsMetricNew: 'lnsMetric',
   } as Record<string, string>;
 
   if (!attributes.visualizationType || !(attributes.visualizationType in typeMappings)) {
-    return attributes as LensDocShape840<VisState840>;
+    return attributes as LensDocShape840<unknown>;
   }
 
   const newAttributes = cloneDeep(attributes);

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
@@ -2232,4 +2232,34 @@ describe('Lens migrations', () => {
       expect(visState.valueLabels).toBe('hide');
     });
   });
+
+  describe('8.5.0 migrates metric IDs', () => {
+    const context = { log: { warn: () => {} } } as unknown as SavedObjectMigrationContext;
+    const example = {
+      type: 'lens',
+      id: 'mocked-saved-object-id',
+      attributes: {
+        savedObjectId: '1',
+        title: 'MyRenamedOps',
+        description: '',
+        visualizationType: 'lnsMetric',
+        state: {},
+      },
+    } as unknown as SavedObjectUnsanitizedDoc<LensDocShape810>;
+
+    it('lnsMetric => lnsLegacyMetric', () => {
+      const result = migrations['8.5.0'](example, context) as ReturnType<
+        SavedObjectMigrationFn<LensDocShape, LensDocShape>
+      >;
+      expect(result.attributes.visualizationType).toBe('lnsLegacyMetric');
+    });
+
+    it('lnsMetricNew => lnsMetric', () => {
+      const result = migrations['8.5.0'](
+        { ...example, attributes: { ...example.attributes, visualizationType: 'lnsMetricNew' } },
+        context
+      ) as ReturnType<SavedObjectMigrationFn<LensDocShape, LensDocShape>>;
+      expect(result.attributes.visualizationType).toBe('lnsMetric');
+    });
+  });
 });

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.test.ts
@@ -23,7 +23,7 @@ import {
   VisState820,
   VisState830,
 } from './types';
-import { layerTypes, MetricState } from '../../common';
+import { layerTypes, LegacyMetricState } from '../../common';
 import { Filter } from '@kbn/es-query';
 
 describe('Lens migrations', () => {
@@ -2086,7 +2086,7 @@ describe('Lens migrations', () => {
       const result = migrations['8.3.0'](example, context) as ReturnType<
         SavedObjectMigrationFn<LensDocShape, LensDocShape>
       >;
-      const visState = result.attributes.state.visualization as MetricState;
+      const visState = result.attributes.state.visualization as LegacyMetricState;
       expect(visState.textAlign).toBe('center');
       expect(visState.titlePosition).toBe('bottom');
       expect(visState.size).toBe('xl');
@@ -2109,7 +2109,7 @@ describe('Lens migrations', () => {
         },
         context
       ) as ReturnType<SavedObjectMigrationFn<LensDocShape, LensDocShape>>;
-      const visState = result.attributes.state.visualization as MetricState;
+      const visState = result.attributes.state.visualization as LegacyMetricState;
       expect(visState.textAlign).toBe('right');
       expect(visState.titlePosition).toBe('top');
       expect(visState.size).toBe('s');

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
@@ -50,6 +50,7 @@ import {
   commonFixValueLabelsInXY,
   commonLockOldMetricVisSettings,
   commonPreserveOldLegendSizeDefault,
+  commonMigrateMetricIds,
 } from './common_migrations';
 
 interface LensDocShapePre710<VisualizationState = unknown> {
@@ -530,6 +531,7 @@ const lensMigrations: SavedObjectMigrationMap = {
     enhanceTableRowHeight
   ),
   '8.3.0': flow(lockOldMetricVisSettings, preserveOldLegendSizeDefault, fixValueLabelsInXY),
+  '8.4.0': flow(commonMigrateMetricIds),
 };
 
 export const getAllMigrations = (

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
@@ -33,6 +33,7 @@ import {
   XYVisualizationState830,
   VisState810,
   VisState820,
+  LensDocShape840,
 } from './types';
 import {
   commonRenameOperationsForFormula,
@@ -511,6 +512,11 @@ const preserveOldLegendSizeDefault: SavedObjectMigrationFn<LensDocShape810, Lens
   doc
 ) => ({ ...doc, attributes: commonPreserveOldLegendSizeDefault(doc.attributes) });
 
+const migrateMetricIds: SavedObjectMigrationFn<LensDocShape840, LensDocShape840> = (doc) => ({
+  ...doc,
+  attributes: commonMigrateMetricIds(doc.attributes),
+});
+
 const lensMigrations: SavedObjectMigrationMap = {
   '7.7.0': removeInvalidAccessors,
   // The order of these migrations matter, since the timefield migration relies on the aggConfigs
@@ -531,7 +537,7 @@ const lensMigrations: SavedObjectMigrationMap = {
     enhanceTableRowHeight
   ),
   '8.3.0': flow(lockOldMetricVisSettings, preserveOldLegendSizeDefault, fixValueLabelsInXY),
-  '8.4.0': flow(commonMigrateMetricIds),
+  '8.5.0': flow(migrateMetricIds),
 };
 
 export const getAllMigrations = (

--- a/x-pack/plugins/lens/server/migrations/types.ts
+++ b/x-pack/plugins/lens/server/migrations/types.ts
@@ -269,3 +269,6 @@ export interface XYVisualizationState830 extends VisState820 {
 
 export type VisStatePre830 = XYVisualizationStatePre830;
 export type VisState830 = XYVisualizationState830;
+
+export type VisState840 = VisState830;
+export type LensDocShape840<VisualizationState = unknown> = LensDocShape830<VisualizationState>;

--- a/x-pack/test/accessibility/apps/lens.ts
+++ b/x-pack/test/accessibility/apps/lens.ts
@@ -98,7 +98,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('lens metric chart', async () => {
-      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
       await a11y.testAppSnapshot();
     });
 

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/time_to_visualize_security.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/time_to_visualize_security.ts
@@ -128,7 +128,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           field: 'bytes',
         });
 
-        await PageObjects.lens.switchToVisualization('lnsMetric');
+        await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
 
         await PageObjects.lens.waitForVisualization('legacyMtrVis');
         await PageObjects.lens.assertLegacyMetric('Average of bytes', '5,727.322');

--- a/x-pack/test/functional/apps/lens/group1/persistent_context.ts
+++ b/x-pack/test/functional/apps/lens/group1/persistent_context.ts
@@ -83,7 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await PageObjects.navigationalSearch.searchFor('type:application lens');
           await PageObjects.navigationalSearch.clickOnOption(0);
           await PageObjects.lens.waitForEmptyWorkspace();
-          await PageObjects.lens.switchToVisualization('lnsMetric');
+          await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
           await PageObjects.lens.dragFieldToWorkspace('@timestamp', 'legacyMtrVis');
         });
         it('preserves time range', async () => {
@@ -120,7 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visualize.waitForGroupsSelectPage();
         await PageObjects.visualize.clickVisType('lens');
         await PageObjects.lens.waitForEmptyWorkspace();
-        await PageObjects.lens.switchToVisualization('lnsMetric');
+        await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
         await PageObjects.lens.dragFieldToWorkspace('@timestamp', 'legacyMtrVis');
 
         const timePickerValues = await PageObjects.timePicker.getTimeConfigAsAbsoluteTimes();

--- a/x-pack/test/functional/apps/lens/group1/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/group1/smokescreen.ts
@@ -99,7 +99,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.switchToVisualization('lnsDatatable');
       expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('Maximum of bytes');
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('19,986');
-      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
       await PageObjects.lens.assertLegacyMetric('Maximum of bytes', '19,986');
     });
 

--- a/x-pack/test/functional/apps/lens/group2/add_to_dashboard.ts
+++ b/x-pack/test/functional/apps/lens/group2/add_to_dashboard.ts
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       field: 'bytes',
     });
 
-    await PageObjects.lens.switchToVisualization('lnsMetric');
+    await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
 
     await PageObjects.lens.waitForVisualization('legacyMtrVis');
     await PageObjects.lens.assertLegacyMetric('Average of bytes', '5,727.322');

--- a/x-pack/test/functional/apps/lens/group2/add_to_dashboard.ts
+++ b/x-pack/test/functional/apps/lens/group2/add_to_dashboard.ts
@@ -301,7 +301,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             field: 'bytes',
           });
 
-          await PageObjects.lens.switchToVisualization('lnsMetric');
+          await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
 
           await PageObjects.lens.waitForVisualization('legacyMtrVis');
           await PageObjects.lens.assertLegacyMetric('Average of bytes', '5,727.322');
@@ -347,7 +347,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             field: 'bytes',
           });
 
-          await PageObjects.lens.switchToVisualization('lnsMetric');
+          await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
 
           await PageObjects.lens.waitForVisualization('legacyMtrVis');
           await PageObjects.lens.assertLegacyMetric('Average of bytes', '5,727.322');

--- a/x-pack/test/functional/apps/lens/group3/chart_data.ts
+++ b/x-pack/test/functional/apps/lens/group3/chart_data.ts
@@ -143,7 +143,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should render metric', async () => {
-      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
       await PageObjects.lens.waitForVisualization('legacyMtrVis');
       await PageObjects.lens.assertLegacyMetric('Average of bytes', '5,727.322');
     });

--- a/x-pack/test/functional/apps/lens/group3/metric.ts
+++ b/x-pack/test/functional/apps/lens/group3/metric.ts
@@ -65,7 +65,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.visualize.clickVisType('lens');
       await PageObjects.lens.goToTimeRange();
 
-      await PageObjects.lens.switchToVisualization('lnsMetricNew', 'Metric');
+      await PageObjects.lens.switchToVisualization('lnsMetric', 'Metric');
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsMetric_primaryMetricDimensionPanel > lns-empty-dimension',

--- a/x-pack/test/functional/apps/lens/group3/rollup.ts
+++ b/x-pack/test/functional/apps/lens/group3/rollup.ts
@@ -72,7 +72,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should allow seamless transition to and from table view', async () => {
-      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
       await PageObjects.lens.assertLegacyMetric('Sum of bytes', '16,788');
       await PageObjects.lens.switchToVisualization('lnsDatatable');
       expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('Sum of bytes');
@@ -84,7 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.visualize.clickVisType('lens');
       await PageObjects.lens.goToTimeRange();
       await PageObjects.lens.switchDataPanelIndexPattern('lens_regular_data');
-      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsLegacyMetric');
       await PageObjects.lens.configureDimension({
         dimension: 'lns-empty-dimension',
         operation: 'sum',

--- a/x-pack/test/functional/fixtures/kbn_archiver/canvas/lens.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/canvas/lens.json
@@ -50,7 +50,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsLegacyMetric"
+    "visualizationType": "lnsMetric"
   },
   "coreMigrationVersion": "7.15.0",
   "id": "my-lens-vis",

--- a/x-pack/test/functional/fixtures/kbn_archiver/canvas/lens.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/canvas/lens.json
@@ -50,7 +50,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsMetric"
+    "visualizationType": "lnsLegacyMetric"
   },
   "coreMigrationVersion": "7.15.0",
   "id": "my-lens-vis",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/lens_basic.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/lens_basic.json
@@ -68,7 +68,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsMetric"
+    "visualizationType": "lnsLegacyMetric"
   },
   "coreMigrationVersion": "8.0.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/lens_basic.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/lens_basic.json
@@ -68,7 +68,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsLegacyMetric"
+    "visualizationType": "lnsMetric"
   },
   "coreMigrationVersion": "8.0.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json
@@ -68,7 +68,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsMetric"
+    "visualizationType": "lnsLegacyMetric"
   },
   "coreMigrationVersion": "8.0.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json
@@ -68,7 +68,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsLegacyMetric"
+    "visualizationType": "lnsMetric"
   },
   "coreMigrationVersion": "8.0.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/reporting.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/reporting.json
@@ -181,7 +181,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsMetric"
+    "visualizationType": "lnsLegacyMetric"
   },
   "coreMigrationVersion": "8.4.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/reporting.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/reporting.json
@@ -181,7 +181,7 @@
       }
     },
     "title": "Artistpreviouslyknownaslens",
-    "visualizationType": "lnsLegacyMetric"
+    "visualizationType": "lnsMetric"
   },
   "coreMigrationVersion": "8.4.0",
   "id": "76fc4200-cf44-11e9-b933-fd84270f3ac1",


### PR DESCRIPTION
## Summary

Shuffles the metric visualization IDs.

- `lnsMetric` => `lnsLegacyMetric`
- `lnsMetricNew` => `lnsMetric`


[Here](https://upload.elastic.co/d/aaee35cb17dfec086a98c2bebaedfde3911f8902089a866913449d9d4d98c314) is a dashboard that can be imported to test the migrations.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
