### PR TITLE
[8.4] Upgrade micromatch from v3.1.10 to v4.0.5 (#139187)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1147,7 +1147,7 @@
     "lmdb-store": "^1.6.11",
     "loader-utils": "^1.2.3",
     "marge": "^1.0.1",
-    "micromatch": "3.1.10",
+    "micromatch": "^4.0.5",
     "mini-css-extract-plugin": "1.1.0",
     "minimist": "^1.2.6",
     "mocha": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20514,7 +20514,7 @@ microevent.ts@~0.1.1:
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
-micromatch@3.1.10, micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Upgrade micromatch from v3.1.10 to v4.0.5 (#139187)](https://github.com/elastic/kibana/pull/139187)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Thomas Watson","email":"watson@elastic.co"},"sourceCommit":{"committedDate":"2022-08-22T12:48:28Z","message":"Upgrade micromatch from v3.1.10 to v4.0.5 (#139187)","sha":"491a461f3ef136b0c5ca1791ebbfcb1f6ca478c5","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v8.5.0"],"number":139187,"url":"https://github.com/elastic/kibana/pull/139187","mergeCommit":{"message":"Upgrade micromatch from v3.1.10 to v4.0.5 (#139187)","sha":"491a461f3ef136b0c5ca1791ebbfcb1f6ca478c5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/139187","number":139187,"mergeCommit":{"message":"Upgrade micromatch from v3.1.10 to v4.0.5 (#139187)","sha":"491a461f3ef136b0c5ca1791ebbfcb1f6ca478c5"}}]}] BACKPORT-->