### PR TITLE
Bump a number of the user profile activation attempts from 3 to 10.

### DIFF
--- a/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
+++ b/x-pack/plugins/security/server/user_profile/user_profile_service.test.ts
@@ -466,21 +466,17 @@ describe('UserProfileService', () => {
         type: 'accessToken',
         accessToken: 'some-token',
       });
-      await nextTick();
-      jest.runAllTimers();
 
-      // The first retry.
-      await nextTick();
-      jest.runAllTimers();
-
-      // The second retry.
-      await nextTick();
-      jest.runAllTimers();
+      // Re-try 9 more times.
+      for (const _ of Array.from({ length: 9 })) {
+        await nextTick();
+        jest.runAllTimers();
+      }
 
       await expect(activatePromise).rejects.toBe(failureReason);
       expect(
         mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
-      ).toHaveBeenCalledTimes(3);
+      ).toHaveBeenCalledTimes(10);
       expect(
         mockStartParams.clusterClient.asInternalUser.security.activateUserProfile
       ).toHaveBeenCalledWith({ grant_type: 'access_token', access_token: 'some-token' });

--- a/x-pack/plugins/security/server/user_profile/user_profile_service.ts
+++ b/x-pack/plugins/security/server/user_profile/user_profile_service.ts
@@ -28,7 +28,7 @@ import { getPrintableSessionId } from '../session_management';
 import type { UserProfileGrant } from './user_profile_grant';
 
 const KIBANA_DATA_ROOT = 'kibana';
-const ACTIVATION_MAX_RETRIES = 3;
+const ACTIVATION_MAX_RETRIES = 10;
 const ACTIVATION_RETRY_SCALE_DURATION_MS = 150;
 const MAX_SUGGESTIONS_COUNT = 100;
 const DEFAULT_SUGGESTIONS_COUNT = 10;


### PR DESCRIPTION
## Summary

In this PR we bump a number of the user profile activation attempts from 3 to 10 to make login process more resilient in various edge cases. The max delay (for the last retry) between consequent retries would be 1350 ms (9 * 150 ms).

While running [Kibana load tests](https://github.com/elastic/kibana-load-testing) (500 simultaneous logins by the same user) we noticed pretty significant failure rate on the login step:

```
# Single-node cluster, 3 activation attempts in Kibana
6800 login attempts with 295 failed ones (~4.35%)

# Three-nodes cluster, 3 activation attempts in Kibana
6685 login attempts with 571 failed ones (~8.54%)
```

The reason is the conflicts that might happen during profile activation since currently Elasticsearch updates profile document on every activation call even if nothing has changed. We reached out to the Elasticsearch team to see if we can have solution on their end and ended up exploring solution that assumes 30 secs delay between user profile document updates if nothing has changed. This solution would significantly decrease the failure rate, but, unfortunately, wouldn't solve the problem completely:

```
# Single-node cluster, 30 sec delay in ES and 3 activation attempts in Kibana
7454 login attempts with 3 failed ones (~0.04%)

# Three-nodes cluster, 30 sec delay in ES and 3 activation attempts in Kibana
6956 login attempts with 58 failed ones (~0.83%)
```

We're still discussing whether or not this change makes sense for Elasticsearch, but in the meantime it'd make sense to bump a number of activation attempts in Kibana that seem to work perfectly well (albeit a bit slower):

```
# Single-node cluster, 10 activation attempts in Kibana
7036 login attempts with 0 failed ones (0.00%)

# Three-nodes cluster, 10 activation attempts in Kibana
6767 login attempts with 0 failed ones (0.00%)

---

# Single-node cluster, 30 sec delay in ES and 10 activation attempts in Kibana
7359 login attempts with 0 failed ones (0.00%, ~4.59% perf increase)

# Three-nodes cluster, 30 sec delay in ES and 10 activation attempts in Kibana
6816 login attempts with 0 failed ones (0.00%, ~0.72% perf increase)
```

## How to test
1. Run `node scripts/functional_tests_server --config x-pack/test/load/config.ts` from the Kibana folder
2. Checkout [kibana-load-testing](https://github.com/elastic/kibana-load-testing) and run `mvn gatling:test -Dgatling.simulationClass=org.kibanaLoadTest.simulation.branch.LensJourney`

The login step shouldn't fail during this test (takes ~8 mins), e.g.:
```
================================================================================
2022-08-23 12:05:02                                         431s elapsed
---- Requests ------------------------------------------------------------------
...
> login                                                    (OK=7477   KO=0     )
...
```

__Note:__ If you'd like to test a multi-node setup, please reach out to me for the corresponding Kibana test package patch.

@dmlemeshko @ywangd

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->