### PR TITLE
[Security Solution] [Endpoint] Fixes long command names truncation in help command response

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_list.tsx
@@ -57,7 +57,12 @@ const StyledEuiFlexGroup = styled(EuiFlexGroup)`
 `;
 
 const StyledEuiFlexGrid = styled(EuiFlexGrid)`
-  max-width: 50%;
+  @media only screen and (min-width: ${(props) => props.theme.eui.euiBreakpoints.l}) {
+    max-width: 75%;
+  }
+  @media only screen and (min-width: ${(props) => props.theme.eui.euiBreakpoints.xl}) {
+    max-width: 50%;
+  }
 `;
 
 const StyledEuiBadge = styled(EuiBadge)`
@@ -304,6 +309,7 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
             direction="column"
           >
             {filteredCommands.map((command) => {
+              const commandNameWithArgs = getCommandNameWithArgs(command);
               return (
                 <EuiFlexItem key={command.name}>
                   <EuiDescriptionList
@@ -311,11 +317,13 @@ export const CommandList = memo<CommandListProps>(({ commands, display = 'defaul
                     listItems={[
                       {
                         title: (
-                          <StyledEuiBadge>
-                            <ConsoleCodeBlock inline bold>
-                              {getCommandNameWithArgs(command)}{' '}
-                            </ConsoleCodeBlock>
-                          </StyledEuiBadge>
+                          <EuiToolTip content={commandNameWithArgs}>
+                            <StyledEuiBadge>
+                              <ConsoleCodeBlock inline bold>
+                                {commandNameWithArgs}
+                              </ConsoleCodeBlock>
+                            </StyledEuiBadge>
+                          </EuiToolTip>
                         ),
                         description: (
                           <EuiText color="subdued" size="xs">


### PR DESCRIPTION
## Summary

Fixes min width depending on screen size and adds tooltip.

Width: 1791px:
<img width="1791" alt="Screenshot 2022-08-23 at 12 42 23" src="https://user-images.githubusercontent.com/15727784/186138552-c2053636-9675-4105-b3ba-827becc2853e.png">

Width: 1033px:
<img width="1033" alt="Screenshot 2022-08-23 at 12 42 56" src="https://user-images.githubusercontent.com/15727784/186138663-6a66f262-e83e-4cdd-a75a-18a43ad27322.png">

Width: 800px:
<img width="800" alt="Screenshot 2022-08-23 at 12 43 23" src="https://user-images.githubusercontent.com/15727784/186138738-611ccb44-69e7-4cac-902d-1472dec58ef2.png">


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
