### PR TITLE
[APM] Use datastreams for API tests

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
@@ -54,9 +54,8 @@ export class ApmSynthtraceKibanaClient {
     });
   }
   async fetchLatestApmPackageVersion(currentKibanaVersion: string) {
-    const url =
-      'https://epr-snapshot.elastic.co/search?package=apm&prerelease=true&all=true&kibana.version=';
-    const response = await fetch(url + currentKibanaVersion, { method: 'GET' });
+    const url = `https://epr-snapshot.elastic.co/search?package=apm&prerelease=true&all=true&kibana.version=${currentKibanaVersion}`;
+    const response = await fetch(url, { method: 'GET' });
     const json = (await response.json()) as Array<{ version: string }>;
     const packageVersions = (json ?? []).map((item) => item.version).sort(Semver.rcompare);
     const validPackageVersions = packageVersions.filter((v) => Semver.valid(v));
@@ -71,7 +70,7 @@ export class ApmSynthtraceKibanaClient {
 
   async installApmPackage(kibanaUrl: string, version: string, username: string, password: string) {
     const packageVersion = await this.fetchLatestApmPackageVersion(version);
-    const response = await fetch(kibanaUrl + '/api/fleet/epm/packages/apm/' + packageVersion, {
+    const response = await fetch(`${kibanaUrl}/api/fleet/epm/packages/apm/${packageVersion}`, {
       method: 'POST',
       headers: {
         Authorization: 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),

--- a/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
@@ -13,6 +13,7 @@ import { getChromeUserAgentDefaults } from './defaults/get_chrome_user_agent_def
 import { getBreakdownMetrics } from './processors/get_breakdown_metrics';
 import { getApmWriteTargets } from './utils/get_apm_write_targets';
 import { ApmSynthtraceEsClient } from './client/apm_synthtrace_es_client';
+import { ApmSynthtraceKibanaClient } from './client/apm_synthtrace_kibana_client';
 
 import type { ApmException } from './apm_fields';
 
@@ -25,6 +26,7 @@ export const apm = {
   getBreakdownMetrics,
   getApmWriteTargets,
   ApmSynthtraceEsClient,
+  ApmSynthtraceKibanaClient,
 };
 
 export type { ApmSynthtraceEsClient, ApmException };

--- a/x-pack/test/apm_api_integration/common/bootstrap_apm_synthtrace.ts
+++ b/x-pack/test/apm_api_integration/common/bootstrap_apm_synthtrace.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apm, createLogger, LogLevel } from '@kbn/apm-synthtrace';
+import { esTestConfig } from '@kbn/test';
+import { APM_TEST_PASSWORD } from './authentication';
+import { InheritedFtrProviderContext } from './ftr_provider_context';
+
+export async function bootstrapApmSynthtrace(
+  context: InheritedFtrProviderContext,
+  kibanaServerUrl: string
+) {
+  const es = context.getService('es');
+  const kibanaVersion = esTestConfig.getVersion();
+
+  const kibanaClient = new apm.ApmSynthtraceKibanaClient(createLogger(LogLevel.info));
+  await kibanaClient.installApmPackage(
+    kibanaServerUrl,
+    kibanaVersion,
+    'elastic',
+    APM_TEST_PASSWORD
+  );
+
+  const esClient = new apm.ApmSynthtraceEsClient(es, createLogger(LogLevel.info), {
+    forceLegacyIndices: false,
+    refreshAfterIndex: true,
+  });
+
+  return esClient;
+}

--- a/x-pack/test/apm_api_integration/common/registry.ts
+++ b/x-pack/test/apm_api_integration/common/registry.ts
@@ -15,7 +15,6 @@ import { FtrProviderContext } from './ftr_provider_context';
 
 type ArchiveName =
   | 'apm_8.0.0'
-  | 'apm_mappings_only_8.0.0'
   | '8.0.0'
   | 'metrics_8.0.0'
   | 'ml_8.0.0'

--- a/x-pack/test/apm_api_integration/common/utils/create_and_run_apm_ml_job.ts
+++ b/x-pack/test/apm_api_integration/common/utils/create_and_run_apm_ml_job.ts
@@ -10,11 +10,12 @@ import datafeed from '@kbn/ml-plugin/server/models/data_recognizer/modules/apm_t
 import { MlApi } from '../../../functional/services/ml/api';
 
 export function createAndRunApmMlJob({ ml, environment }: { ml: MlApi; environment: string }) {
+  const jobId = `apm-tx-metrics-${environment}`;
   return ml.createAndRunAnomalyDetectionLookbackJob(
     // @ts-expect-error not entire job config
     {
       ...job,
-      job_id: `apm-tx-metrics-${environment}`,
+      job_id: jobId,
       allow_lazy_open: false,
       custom_settings: {
         job_tags: {
@@ -25,8 +26,9 @@ export function createAndRunApmMlJob({ ml, environment }: { ml: MlApi; environme
     },
     {
       ...datafeed,
-      job_id: `apm-tx-metrics-${environment}`,
-      indices: ['apm-*'],
+      indices_options: { allow_no_indices: true },
+      job_id: jobId,
+      indices: ['metrics-apm*', 'apm-*'],
       datafeed_id: `apm-tx-metrics-${environment}-datafeed`,
       query: {
         bool: {

--- a/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
@@ -24,7 +24,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'fetching service anomalies with a trial license',
-    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'trial', archives: [] },
     () => {
       const start = '2021-01-01T00:00:00.000Z';
       const end = '2021-01-08T00:15:00.000Z';

--- a/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
@@ -18,7 +18,6 @@ import { createAndRunApmMlJob } from '../../common/utils/create_and_run_apm_ml_j
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
-
   const apmApiClient = getService('apmApiClient');
   const ml = getService('ml');
 
@@ -70,7 +69,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'fetching service anomalies with a basic license',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       it('returns a 501', async () => {
         const status = await statusOf(
@@ -90,7 +89,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'fetching service anomalies with a trial license',
-    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'trial', archives: [] },
     () => {
       const start = '2021-01-01T00:00:00.000Z';
       const end = '2021-01-08T00:15:00.000Z';

--- a/x-pack/test/apm_api_integration/tests/cold_start/cold_start.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/cold_start/cold_start.spec.ts
@@ -66,139 +66,135 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Cold start rate when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('without comparison', () => {
-        let body: ColdStartRate;
-        let status: number;
+  registry.when('Cold start rate when data is generated', { config: 'basic', archives: [] }, () => {
+    describe('without comparison', () => {
+      let body: ColdStartRate;
+      let status: number;
 
-        before(async () => {
-          await generateData({
-            synthtraceEsClient,
-            start,
-            end,
-            coldStartRate: 10,
-            warmStartRate: 30,
-          });
-          const response = await callApi();
-          body = response.body;
-          status = response.status;
+      before(async () => {
+        await generateData({
+          synthtraceEsClient,
+          start,
+          end,
+          coldStartRate: 10,
+          warmStartRate: 30,
         });
-
-        after(() => synthtraceEsClient.clean());
-
-        it('returns correct HTTP status', () => {
-          expect(status).to.be(200);
-        });
-
-        it('returns an array of transaction cold start rates', () => {
-          expect(body).to.have.property('currentPeriod');
-          expect(body.currentPeriod.transactionColdstartRate).to.have.length(15);
-          expect(body.currentPeriod.transactionColdstartRate.every(({ y }) => y === 0.25)).to.be(
-            true
-          );
-        });
-
-        it('returns correct average rate', () => {
-          expect(body.currentPeriod.average).to.be(0.25);
-        });
-
-        it("doesn't have data for the previous period", () => {
-          expect(body).to.have.property('previousPeriod');
-          expect(body.previousPeriod.transactionColdstartRate).to.have.length(0);
-          expect(body.previousPeriod.average).to.be(null);
-        });
+        const response = await callApi();
+        body = response.body;
+        status = response.status;
       });
 
-      describe('with comparison', () => {
-        let body: ColdStartRate;
-        let status: number;
+      after(() => synthtraceEsClient.clean());
 
-        before(async () => {
-          const startDate = moment(start).add(6, 'minutes');
-          const endDate = moment(start).add(9, 'minutes');
-          const comparisonStartDate = new Date(start);
-          const comparisonEndDate = moment(start).add(3, 'minutes');
-
-          await generateData({
-            synthtraceEsClient,
-            start: startDate.valueOf(),
-            end: endDate.valueOf(),
-            coldStartRate: 10,
-            warmStartRate: 30,
-          });
-          await generateData({
-            synthtraceEsClient,
-            start: comparisonStartDate.getTime(),
-            end: comparisonEndDate.valueOf(),
-            coldStartRate: 20,
-            warmStartRate: 20,
-          });
-
-          const response = await callApi({
-            query: {
-              start: startDate.toISOString(),
-              end: endDate.subtract(1, 'seconds').toISOString(),
-              offset: '6m',
-            },
-          });
-          body = response.body;
-          status = response.status;
-        });
-
-        after(() => synthtraceEsClient.clean());
-
-        it('returns correct HTTP status', () => {
-          expect(status).to.be(200);
-        });
-
-        it('returns some data', () => {
-          expect(body.currentPeriod.average).not.to.be(null);
-          expect(body.currentPeriod.transactionColdstartRate.length).to.be.greaterThan(0);
-          const hasCurrentPeriodData = body.currentPeriod.transactionColdstartRate.some(({ y }) =>
-            isFiniteNumber(y)
-          );
-          expect(hasCurrentPeriodData).to.equal(true);
-
-          expect(body.previousPeriod.average).not.to.be(null);
-          expect(body.previousPeriod.transactionColdstartRate.length).to.be.greaterThan(0);
-          const hasPreviousPeriodData = body.previousPeriod.transactionColdstartRate.some(({ y }) =>
-            isFiniteNumber(y)
-          );
-          expect(hasPreviousPeriodData).to.equal(true);
-        });
-
-        it('has same start time for both periods', () => {
-          expect(first(body.currentPeriod.transactionColdstartRate)?.x).to.equal(
-            first(body.previousPeriod.transactionColdstartRate)?.x
-          );
-        });
-
-        it('has same end time for both periods', () => {
-          expect(last(body.currentPeriod.transactionColdstartRate)?.x).to.equal(
-            last(body.previousPeriod.transactionColdstartRate)?.x
-          );
-        });
-
-        it('returns an array of transaction cold start rates', () => {
-          expect(body.currentPeriod.transactionColdstartRate).to.have.length(3);
-          expect(body.currentPeriod.transactionColdstartRate.every(({ y }) => y === 0.25)).to.be(
-            true
-          );
-
-          expect(body.previousPeriod.transactionColdstartRate).to.have.length(3);
-          expect(body.previousPeriod.transactionColdstartRate.every(({ y }) => y === 0.5)).to.be(
-            true
-          );
-        });
-
-        it('has same average value for both periods', () => {
-          expect(body.currentPeriod.average).to.be(0.25);
-          expect(body.previousPeriod.average).to.be(0.5);
-        });
+      it('returns correct HTTP status', () => {
+        expect(status).to.be(200);
       });
-    }
-  );
+
+      it('returns an array of transaction cold start rates', () => {
+        expect(body).to.have.property('currentPeriod');
+        expect(body.currentPeriod.transactionColdstartRate).to.have.length(15);
+        expect(body.currentPeriod.transactionColdstartRate.every(({ y }) => y === 0.25)).to.be(
+          true
+        );
+      });
+
+      it('returns correct average rate', () => {
+        expect(body.currentPeriod.average).to.be(0.25);
+      });
+
+      it("doesn't have data for the previous period", () => {
+        expect(body).to.have.property('previousPeriod');
+        expect(body.previousPeriod.transactionColdstartRate).to.have.length(0);
+        expect(body.previousPeriod.average).to.be(null);
+      });
+    });
+
+    describe('with comparison', () => {
+      let body: ColdStartRate;
+      let status: number;
+
+      before(async () => {
+        const startDate = moment(start).add(6, 'minutes');
+        const endDate = moment(start).add(9, 'minutes');
+        const comparisonStartDate = new Date(start);
+        const comparisonEndDate = moment(start).add(3, 'minutes');
+
+        await generateData({
+          synthtraceEsClient,
+          start: startDate.valueOf(),
+          end: endDate.valueOf(),
+          coldStartRate: 10,
+          warmStartRate: 30,
+        });
+        await generateData({
+          synthtraceEsClient,
+          start: comparisonStartDate.getTime(),
+          end: comparisonEndDate.valueOf(),
+          coldStartRate: 20,
+          warmStartRate: 20,
+        });
+
+        const response = await callApi({
+          query: {
+            start: startDate.toISOString(),
+            end: endDate.subtract(1, 'seconds').toISOString(),
+            offset: '6m',
+          },
+        });
+        body = response.body;
+        status = response.status;
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      it('returns correct HTTP status', () => {
+        expect(status).to.be(200);
+      });
+
+      it('returns some data', () => {
+        expect(body.currentPeriod.average).not.to.be(null);
+        expect(body.currentPeriod.transactionColdstartRate.length).to.be.greaterThan(0);
+        const hasCurrentPeriodData = body.currentPeriod.transactionColdstartRate.some(({ y }) =>
+          isFiniteNumber(y)
+        );
+        expect(hasCurrentPeriodData).to.equal(true);
+
+        expect(body.previousPeriod.average).not.to.be(null);
+        expect(body.previousPeriod.transactionColdstartRate.length).to.be.greaterThan(0);
+        const hasPreviousPeriodData = body.previousPeriod.transactionColdstartRate.some(({ y }) =>
+          isFiniteNumber(y)
+        );
+        expect(hasPreviousPeriodData).to.equal(true);
+      });
+
+      it('has same start time for both periods', () => {
+        expect(first(body.currentPeriod.transactionColdstartRate)?.x).to.equal(
+          first(body.previousPeriod.transactionColdstartRate)?.x
+        );
+      });
+
+      it('has same end time for both periods', () => {
+        expect(last(body.currentPeriod.transactionColdstartRate)?.x).to.equal(
+          last(body.previousPeriod.transactionColdstartRate)?.x
+        );
+      });
+
+      it('returns an array of transaction cold start rates', () => {
+        expect(body.currentPeriod.transactionColdstartRate).to.have.length(3);
+        expect(body.currentPeriod.transactionColdstartRate.every(({ y }) => y === 0.25)).to.be(
+          true
+        );
+
+        expect(body.previousPeriod.transactionColdstartRate).to.have.length(3);
+        expect(body.previousPeriod.transactionColdstartRate.every(({ y }) => y === 0.5)).to.be(
+          true
+        );
+      });
+
+      it('has same average value for both periods', () => {
+        expect(body.currentPeriod.average).to.be(0.25);
+        expect(body.previousPeriod.average).to.be(0.5);
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/cold_start/cold_start_by_transaction_name/cold_start_by_transaction_name.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/cold_start/cold_start_by_transaction_name/cold_start_by_transaction_name.spec.ts
@@ -70,7 +70,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Cold start rate by transaction name when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       describe('without comparison', () => {
         let body: ColdStartRate;

--- a/x-pack/test/apm_api_integration/tests/dependencies/dependency_metrics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/dependency_metrics.spec.ts
@@ -94,181 +94,28 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Dependency metrics when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      before(async () => {
-        await generateOperationData({
-          synthtraceEsClient,
-          start,
-          end,
-        });
+  registry.when('Dependency metrics when data is loaded', { config: 'basic', archives: [] }, () => {
+    before(async () => {
+      await generateOperationData({
+        synthtraceEsClient,
+        start,
+        end,
       });
+    });
 
-      describe('without spanName', () => {
-        describe('without a kuery or environment', () => {
-          it('returns the correct latency', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'latency',
-            });
-
-            const searchRate =
-              ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
-            const bulkRate = ES_BULK_RATE;
-
-            expect(avg(response.body.currentTimeseries)).to.eql(
-              roundNumber(
-                ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
-                  (searchRate + bulkRate)) *
-                  1000
-              )
-            );
-          });
-
-          it('returns the correct throughput', async () => {
-            const response = await callApi({
-              dependencyName: 'redis',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'throughput',
-            });
-
-            expect(avg(response.body.currentTimeseries)).to.eql(REDIS_SET_RATE);
-          });
-
-          it('returns the correct failure rate', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'error_rate',
-            });
-
-            const expectedErrorRate =
-              ES_SEARCH_FAILURE_RATE / (ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE);
-
-            expect(avg(response.body.currentTimeseries)).to.eql(expectedErrorRate);
-          });
-        });
-
-        describe('with a kuery', () => {
-          it('returns the correct latency', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'latency',
-              kuery: `event.outcome:unknown`,
-            });
-
-            const searchRate = ES_SEARCH_UNKNOWN_RATE;
-            const bulkRate = ES_BULK_RATE;
-
-            expect(avg(response.body.currentTimeseries)).to.eql(
-              roundNumber(
-                ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
-                  (searchRate + bulkRate)) *
-                  1000
-              )
-            );
-          });
-
-          it('returns the correct throughput', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'throughput',
-              kuery: `event.outcome:unknown`,
-            });
-
-            const searchRate = ES_SEARCH_UNKNOWN_RATE;
-            const bulkRate = ES_BULK_RATE;
-
-            expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
-          });
-
-          it('returns the correct failure rate', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'error_rate',
-              kuery: 'event.outcome:success',
-            });
-
-            expect(avg(response.body.currentTimeseries)).to.eql(0);
-          });
-        });
-
-        describe('with an environment', () => {
-          it('returns the correct latency', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'latency',
-              environment: 'production',
-            });
-
-            const searchRate = ES_SEARCH_UNKNOWN_RATE;
-            const bulkRate = 0;
-
-            expect(avg(response.body.currentTimeseries)).to.eql(
-              roundNumber(
-                ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
-                  (searchRate + bulkRate)) *
-                  1000
-              )
-            );
-          });
-
-          it('returns the correct throughput', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'throughput',
-              environment: 'production',
-            });
-
-            const searchRate =
-              ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
-            const bulkRate = 0;
-
-            expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
-          });
-
-          it('returns the correct failure rate', async () => {
-            const response = await callApi({
-              dependencyName: 'elasticsearch',
-              searchServiceDestinationMetrics: true,
-              spanName: '',
-              metric: 'error_rate',
-              environment: 'development',
-            });
-
-            expect(avg(response.body.currentTimeseries)).to.eql(null);
-          });
-        });
-      });
-
-      describe('with spanName', () => {
+    describe('without spanName', () => {
+      describe('without a kuery or environment', () => {
         it('returns the correct latency', async () => {
           const response = await callApi({
             dependencyName: 'elasticsearch',
-            searchServiceDestinationMetrics: false,
-            spanName: '/_search',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
             metric: 'latency',
           });
 
           const searchRate =
             ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
-          const bulkRate = 0;
+          const bulkRate = ES_BULK_RATE;
 
           expect(avg(response.body.currentTimeseries)).to.eql(
             roundNumber(
@@ -282,8 +129,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('returns the correct throughput', async () => {
           const response = await callApi({
             dependencyName: 'redis',
-            searchServiceDestinationMetrics: false,
-            spanName: 'SET',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
             metric: 'throughput',
           });
 
@@ -293,16 +140,164 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('returns the correct failure rate', async () => {
           const response = await callApi({
             dependencyName: 'elasticsearch',
-            searchServiceDestinationMetrics: false,
-            spanName: '/_bulk',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
             metric: 'error_rate',
+          });
+
+          const expectedErrorRate =
+            ES_SEARCH_FAILURE_RATE / (ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE);
+
+          expect(avg(response.body.currentTimeseries)).to.eql(expectedErrorRate);
+        });
+      });
+
+      describe('with a kuery', () => {
+        it('returns the correct latency', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'latency',
+            kuery: `event.outcome:unknown`,
+          });
+
+          const searchRate = ES_SEARCH_UNKNOWN_RATE;
+          const bulkRate = ES_BULK_RATE;
+
+          expect(avg(response.body.currentTimeseries)).to.eql(
+            roundNumber(
+              ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
+                (searchRate + bulkRate)) *
+                1000
+            )
+          );
+        });
+
+        it('returns the correct throughput', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'throughput',
+            kuery: `event.outcome:unknown`,
+          });
+
+          const searchRate = ES_SEARCH_UNKNOWN_RATE;
+          const bulkRate = ES_BULK_RATE;
+
+          expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
+        });
+
+        it('returns the correct failure rate', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'error_rate',
+            kuery: 'event.outcome:success',
+          });
+
+          expect(avg(response.body.currentTimeseries)).to.eql(0);
+        });
+      });
+
+      describe('with an environment', () => {
+        it('returns the correct latency', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'latency',
+            environment: 'production',
+          });
+
+          const searchRate = ES_SEARCH_UNKNOWN_RATE;
+          const bulkRate = 0;
+
+          expect(avg(response.body.currentTimeseries)).to.eql(
+            roundNumber(
+              ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
+                (searchRate + bulkRate)) *
+                1000
+            )
+          );
+        });
+
+        it('returns the correct throughput', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'throughput',
+            environment: 'production',
+          });
+
+          const searchRate =
+            ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
+          const bulkRate = 0;
+
+          expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
+        });
+
+        it('returns the correct failure rate', async () => {
+          const response = await callApi({
+            dependencyName: 'elasticsearch',
+            searchServiceDestinationMetrics: true,
+            spanName: '',
+            metric: 'error_rate',
+            environment: 'development',
           });
 
           expect(avg(response.body.currentTimeseries)).to.eql(null);
         });
       });
+    });
 
-      after(() => synthtraceEsClient.clean());
-    }
-  );
+    describe('with spanName', () => {
+      it('returns the correct latency', async () => {
+        const response = await callApi({
+          dependencyName: 'elasticsearch',
+          searchServiceDestinationMetrics: false,
+          spanName: '/_search',
+          metric: 'latency',
+        });
+
+        const searchRate = ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
+        const bulkRate = 0;
+
+        expect(avg(response.body.currentTimeseries)).to.eql(
+          roundNumber(
+            ((ES_SEARCH_DURATION * searchRate + ES_BULK_DURATION * bulkRate) /
+              (searchRate + bulkRate)) *
+              1000
+          )
+        );
+      });
+
+      it('returns the correct throughput', async () => {
+        const response = await callApi({
+          dependencyName: 'redis',
+          searchServiceDestinationMetrics: false,
+          spanName: 'SET',
+          metric: 'throughput',
+        });
+
+        expect(avg(response.body.currentTimeseries)).to.eql(REDIS_SET_RATE);
+      });
+
+      it('returns the correct failure rate', async () => {
+        const response = await callApi({
+          dependencyName: 'elasticsearch',
+          searchServiceDestinationMetrics: false,
+          spanName: '/_bulk',
+          metric: 'error_rate',
+        });
+
+        expect(avg(response.body.currentTimeseries)).to.eql(null);
+      });
+    });
+
+    after(() => synthtraceEsClient.clean());
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/dependencies/metadata.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/metadata.spec.ts
@@ -44,7 +44,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Dependency metadata when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       after(() => synthtraceEsClient.clean());
 

--- a/x-pack/test/apm_api_integration/tests/dependencies/service_dependencies.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/service_dependencies.spec.ts
@@ -47,33 +47,29 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Dependency for services',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        before(async () => {
-          await generateData({ synthtraceEsClient, start, end });
-        });
-        after(() => synthtraceEsClient.clean());
-
-        it('returns a list of dependencies for a service', async () => {
-          const { status, body } = await callApi();
-
-          expect(status).to.be(200);
-          expect(
-            body.serviceDependencies.map(
-              ({ location }) => (location as DependencyNode).dependencyName
-            )
-          ).to.eql([dependencyName]);
-
-          const currentStatsLatencyValues =
-            body.serviceDependencies[0].currentStats.latency.timeseries;
-          expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
-        });
+  registry.when('Dependency for services', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      before(async () => {
+        await generateData({ synthtraceEsClient, start, end });
       });
-    }
-  );
+      after(() => synthtraceEsClient.clean());
+
+      it('returns a list of dependencies for a service', async () => {
+        const { status, body } = await callApi();
+
+        expect(status).to.be(200);
+        expect(
+          body.serviceDependencies.map(
+            ({ location }) => (location as DependencyNode).dependencyName
+          )
+        ).to.eql([dependencyName]);
+
+        const currentStatsLatencyValues =
+          body.serviceDependencies[0].currentStats.latency.timeseries;
+        expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
+      });
+    });
+  });
 
   registry.when(
     'Dependency for service breakdown when data is not loaded',
@@ -88,31 +84,27 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Dependency for services breakdown',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        before(async () => {
-          await generateData({ synthtraceEsClient, start, end });
-        });
-        after(() => synthtraceEsClient.clean());
-
-        it('returns a list of dependencies for a service', async () => {
-          const { status, body } = await callApi();
-
-          expect(status).to.be(200);
-          expect(
-            body.serviceDependencies.map(
-              ({ location }) => (location as DependencyNode).dependencyName
-            )
-          ).to.eql([dependencyName]);
-
-          const currentStatsLatencyValues =
-            body.serviceDependencies[0].currentStats.latency.timeseries;
-          expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
-        });
+  registry.when('Dependency for services breakdown', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      before(async () => {
+        await generateData({ synthtraceEsClient, start, end });
       });
-    }
-  );
+      after(() => synthtraceEsClient.clean());
+
+      it('returns a list of dependencies for a service', async () => {
+        const { status, body } = await callApi();
+
+        expect(status).to.be(200);
+        expect(
+          body.serviceDependencies.map(
+            ({ location }) => (location as DependencyNode).dependencyName
+          )
+        ).to.eql([dependencyName]);
+
+        const currentStatsLatencyValues =
+          body.serviceDependencies[0].currentStats.latency.timeseries;
+        expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/dependencies/top_operations.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/top_operations.spec.ts
@@ -65,154 +65,150 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when(
-    'Top operations when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      before(() =>
-        generateOperationData({
-          synthtraceEsClient,
-          start,
-          end,
-        })
-      );
+  registry.when('Top operations when data is generated', { config: 'basic', archives: [] }, () => {
+    before(() =>
+      generateOperationData({
+        synthtraceEsClient,
+        start,
+        end,
+      })
+    );
 
-      after(() => synthtraceEsClient.clean());
+    after(() => synthtraceEsClient.clean());
 
-      describe('requested for elasticsearch', () => {
-        let response: TopOperations;
-        let searchOperation: ValuesType<TopOperations>;
-        let bulkOperation: ValuesType<TopOperations>;
+    describe('requested for elasticsearch', () => {
+      let response: TopOperations;
+      let searchOperation: ValuesType<TopOperations>;
+      let bulkOperation: ValuesType<TopOperations>;
 
-        before(async () => {
-          response = await callApi({ dependencyName: 'elasticsearch' });
-          searchOperation = response.find((op) => op.spanName === '/_search')!;
-          bulkOperation = response.find((op) => op.spanName === '/_bulk')!;
-        });
-
-        it('returns the correct operations', () => {
-          expect(response.length).to.eql(2);
-
-          expect(searchOperation).to.be.ok();
-          expect(bulkOperation).to.be.ok();
-        });
-
-        it('returns the correct latency', () => {
-          expect(searchOperation.latency).to.eql(ES_SEARCH_DURATION * 1000);
-          expect(bulkOperation.latency).to.eql(ES_BULK_DURATION * 1000);
-        });
-
-        it('returns the correct throughput', () => {
-          const expectedSearchThroughput = roundNumber(
-            ES_SEARCH_UNKNOWN_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_FAILURE_RATE
-          );
-          const expectedBulkThroughput = ES_BULK_RATE;
-
-          expect(roundNumber(searchOperation.throughput)).to.eql(expectedSearchThroughput);
-          expect(roundNumber(bulkOperation.throughput)).to.eql(expectedBulkThroughput);
-
-          expect(
-            searchOperation.timeseries.throughput
-              .map((bucket) => bucket.y)
-              .every((val) => val === expectedSearchThroughput)
-          );
-        });
-
-        it('returns the correct failure rate', () => {
-          const expectedSearchFailureRate =
-            ES_SEARCH_FAILURE_RATE / (ES_SEARCH_SUCCESS_RATE + ES_SEARCH_FAILURE_RATE);
-          const expectedBulkFailureRate = null;
-
-          expect(searchOperation.failureRate).to.be(expectedSearchFailureRate);
-
-          expect(bulkOperation.failureRate).to.be(expectedBulkFailureRate);
-
-          expect(
-            searchOperation.timeseries.failureRate
-              .map((bucket) => bucket.y)
-              .every((val) => val === expectedSearchFailureRate)
-          );
-
-          expect(
-            bulkOperation.timeseries.failureRate
-              .map((bucket) => bucket.y)
-              .every((val) => val === expectedBulkFailureRate)
-          );
-        });
-
-        it('returns the correct impact', () => {
-          expect(searchOperation.impact).to.eql(0);
-          expect(bulkOperation.impact).to.eql(100);
-        });
+      before(async () => {
+        response = await callApi({ dependencyName: 'elasticsearch' });
+        searchOperation = response.find((op) => op.spanName === '/_search')!;
+        bulkOperation = response.find((op) => op.spanName === '/_bulk')!;
       });
 
-      describe('requested for redis', () => {
-        let response: TopOperations;
-        let setOperation: ValuesType<TopOperations>;
+      it('returns the correct operations', () => {
+        expect(response.length).to.eql(2);
 
-        before(async () => {
-          response = await callApi({ dependencyName: 'redis' });
-          setOperation = response.find((op) => op.spanName === 'SET')!;
-        });
-
-        it('returns the correct operations', () => {
-          expect(response.length).to.eql(1);
-
-          expect(setOperation).to.be.ok();
-        });
-
-        it('returns the correct latency', () => {
-          expect(setOperation.latency).to.eql(REDIS_SET_DURATION * 1000);
-        });
-
-        it('returns the correct throughput', () => {
-          expect(roundNumber(setOperation.throughput)).to.eql(roundNumber(REDIS_SET_RATE));
-        });
+        expect(searchOperation).to.be.ok();
+        expect(bulkOperation).to.be.ok();
       });
 
-      describe('requested for a specific service', () => {
-        let response: TopOperations;
-        let searchOperation: ValuesType<TopOperations>;
-        let bulkOperation: ValuesType<TopOperations> | undefined;
-
-        before(async () => {
-          response = await callApi({
-            dependencyName: 'elasticsearch',
-            kuery: `service.name:"synth-go"`,
-          });
-          searchOperation = response.find((op) => op.spanName === '/_search')!;
-          bulkOperation = response.find((op) => op.spanName === '/_bulk');
-        });
-
-        it('returns the correct operations', () => {
-          expect(response.length).to.eql(1);
-
-          expect(searchOperation).to.be.ok();
-          expect(bulkOperation).not.to.be.ok();
-        });
+      it('returns the correct latency', () => {
+        expect(searchOperation.latency).to.eql(ES_SEARCH_DURATION * 1000);
+        expect(bulkOperation.latency).to.eql(ES_BULK_DURATION * 1000);
       });
 
-      describe('requested for a specific environment', () => {
-        let response: TopOperations;
-        let searchOperation: ValuesType<TopOperations> | undefined;
-        let bulkOperation: ValuesType<TopOperations>;
+      it('returns the correct throughput', () => {
+        const expectedSearchThroughput = roundNumber(
+          ES_SEARCH_UNKNOWN_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_FAILURE_RATE
+        );
+        const expectedBulkThroughput = ES_BULK_RATE;
 
-        before(async () => {
-          response = await callApi({
-            dependencyName: 'elasticsearch',
-            environment: 'development',
-          });
-          searchOperation = response.find((op) => op.spanName === '/_search');
-          bulkOperation = response.find((op) => op.spanName === '/_bulk')!;
-        });
+        expect(roundNumber(searchOperation.throughput)).to.eql(expectedSearchThroughput);
+        expect(roundNumber(bulkOperation.throughput)).to.eql(expectedBulkThroughput);
 
-        it('returns the correct operations', () => {
-          expect(response.length).to.eql(1);
-
-          expect(searchOperation).not.to.be.ok();
-          expect(bulkOperation).to.be.ok();
-        });
+        expect(
+          searchOperation.timeseries.throughput
+            .map((bucket) => bucket.y)
+            .every((val) => val === expectedSearchThroughput)
+        );
       });
-    }
-  );
+
+      it('returns the correct failure rate', () => {
+        const expectedSearchFailureRate =
+          ES_SEARCH_FAILURE_RATE / (ES_SEARCH_SUCCESS_RATE + ES_SEARCH_FAILURE_RATE);
+        const expectedBulkFailureRate = null;
+
+        expect(searchOperation.failureRate).to.be(expectedSearchFailureRate);
+
+        expect(bulkOperation.failureRate).to.be(expectedBulkFailureRate);
+
+        expect(
+          searchOperation.timeseries.failureRate
+            .map((bucket) => bucket.y)
+            .every((val) => val === expectedSearchFailureRate)
+        );
+
+        expect(
+          bulkOperation.timeseries.failureRate
+            .map((bucket) => bucket.y)
+            .every((val) => val === expectedBulkFailureRate)
+        );
+      });
+
+      it('returns the correct impact', () => {
+        expect(searchOperation.impact).to.eql(0);
+        expect(bulkOperation.impact).to.eql(100);
+      });
+    });
+
+    describe('requested for redis', () => {
+      let response: TopOperations;
+      let setOperation: ValuesType<TopOperations>;
+
+      before(async () => {
+        response = await callApi({ dependencyName: 'redis' });
+        setOperation = response.find((op) => op.spanName === 'SET')!;
+      });
+
+      it('returns the correct operations', () => {
+        expect(response.length).to.eql(1);
+
+        expect(setOperation).to.be.ok();
+      });
+
+      it('returns the correct latency', () => {
+        expect(setOperation.latency).to.eql(REDIS_SET_DURATION * 1000);
+      });
+
+      it('returns the correct throughput', () => {
+        expect(roundNumber(setOperation.throughput)).to.eql(roundNumber(REDIS_SET_RATE));
+      });
+    });
+
+    describe('requested for a specific service', () => {
+      let response: TopOperations;
+      let searchOperation: ValuesType<TopOperations>;
+      let bulkOperation: ValuesType<TopOperations> | undefined;
+
+      before(async () => {
+        response = await callApi({
+          dependencyName: 'elasticsearch',
+          kuery: `service.name:"synth-go"`,
+        });
+        searchOperation = response.find((op) => op.spanName === '/_search')!;
+        bulkOperation = response.find((op) => op.spanName === '/_bulk');
+      });
+
+      it('returns the correct operations', () => {
+        expect(response.length).to.eql(1);
+
+        expect(searchOperation).to.be.ok();
+        expect(bulkOperation).not.to.be.ok();
+      });
+    });
+
+    describe('requested for a specific environment', () => {
+      let response: TopOperations;
+      let searchOperation: ValuesType<TopOperations> | undefined;
+      let bulkOperation: ValuesType<TopOperations>;
+
+      before(async () => {
+        response = await callApi({
+          dependencyName: 'elasticsearch',
+          environment: 'development',
+        });
+        searchOperation = response.find((op) => op.spanName === '/_search');
+        bulkOperation = response.find((op) => op.spanName === '/_bulk')!;
+      });
+
+      it('returns the correct operations', () => {
+        expect(response.length).to.eql(1);
+
+        expect(searchOperation).not.to.be.ok();
+        expect(bulkOperation).to.be.ok();
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/dependencies/top_spans.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/top_spans.spec.ts
@@ -68,7 +68,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Top dependency spans when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       const javaInstance = apm.service('java', 'production', 'java').instance('instance-a');
 

--- a/x-pack/test/apm_api_integration/tests/dependencies/upstream_services.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/upstream_services.spec.ts
@@ -47,28 +47,24 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Dependency upstream services',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        before(async () => {
-          await generateData({ synthtraceEsClient, start, end });
-        });
-        after(() => synthtraceEsClient.clean());
-
-        it('returns a list of upstream services for the dependency', async () => {
-          const { status, body } = await callApi();
-
-          expect(status).to.be(200);
-          expect(body.services.map(({ location }) => (location as ServiceNode).serviceName)).to.eql(
-            ['synth-go']
-          );
-
-          const currentStatsLatencyValues = body.services[0].currentStats.latency.timeseries;
-          expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
-        });
+  registry.when('Dependency upstream services', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      before(async () => {
+        await generateData({ synthtraceEsClient, start, end });
       });
-    }
-  );
+      after(() => synthtraceEsClient.clean());
+
+      it('returns a list of upstream services for the dependency', async () => {
+        const { status, body } = await callApi();
+
+        expect(status).to.be(200);
+        expect(body.services.map(({ location }) => (location as ServiceNode).serviceName)).to.eql([
+          'synth-go',
+        ]);
+
+        const currentStatsLatencyValues = body.services[0].currentStats.latency.timeseries;
+        expect(currentStatsLatencyValues.every(({ y }) => y === 1000000)).to.be(true);
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/error_rate/service_apis.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/error_rate/service_apis.spec.ts
@@ -114,7 +114,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   let errorRateMetricValues: Awaited<ReturnType<typeof getErrorRateValues>>;
   let errorTransactionValues: Awaited<ReturnType<typeof getErrorRateValues>>;
 
-  registry.when('Services APIs', { config: 'basic', archives: ['apm_mappings_only_8.0.0'] }, () => {
+  registry.when('Services APIs', { config: 'basic', archives: [] }, () => {
     describe('when data is loaded ', () => {
       const GO_PROD_LIST_RATE = 75;
       const GO_PROD_LIST_ERROR_RATE = 25;

--- a/x-pack/test/apm_api_integration/tests/errors/distribution.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/errors/distribution.spec.ts
@@ -60,128 +60,124 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when(
-    'when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('errors distribution', () => {
-        const { appleTransaction, bananaTransaction } = config;
+  registry.when('when data is loaded', { config: 'basic', archives: [] }, () => {
+    describe('errors distribution', () => {
+      const { appleTransaction, bananaTransaction } = config;
+      before(async () => {
+        await generateData({ serviceName, start, end, synthtraceEsClient });
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('without comparison', () => {
+        let errorsDistribution: ErrorsDistribution;
         before(async () => {
-          await generateData({ serviceName, start, end, synthtraceEsClient });
+          const response = await callApi();
+          errorsDistribution = response.body;
         });
 
-        after(() => synthtraceEsClient.clean());
+        it('displays combined number of occurrences', () => {
+          const countSum = sumBy(errorsDistribution.currentPeriod, 'y');
+          const numberOfBuckets = 15;
+          expect(countSum).to.equal(
+            (appleTransaction.failureRate + bananaTransaction.failureRate) * numberOfBuckets
+          );
+        });
+      });
 
-        describe('without comparison', () => {
+      describe('displays occurrences for type "apple transaction" only', () => {
+        let errorsDistribution: ErrorsDistribution;
+        before(async () => {
+          const response = await callApi({
+            query: { kuery: `error.exception.type:"${appleTransaction.name}"` },
+          });
+          errorsDistribution = response.body;
+        });
+        it('displays combined number of occurrences', () => {
+          const countSum = sumBy(errorsDistribution.currentPeriod, 'y');
+          const numberOfBuckets = 15;
+          expect(countSum).to.equal(appleTransaction.failureRate * numberOfBuckets);
+        });
+      });
+
+      describe('with comparison', () => {
+        describe('when data is returned', () => {
           let errorsDistribution: ErrorsDistribution;
           before(async () => {
-            const response = await callApi();
+            const fiveMinutes = 5 * 60 * 1000;
+            const response = await callApi({
+              query: {
+                start: new Date(end - fiveMinutes).toISOString(),
+                end: new Date(end).toISOString(),
+                offset: '5m',
+              },
+            });
             errorsDistribution = response.body;
           });
+          it('returns some data', () => {
+            const hasCurrentPeriodData = errorsDistribution.currentPeriod.some(({ y }) =>
+              isFiniteNumber(y)
+            );
 
-          it('displays combined number of occurrences', () => {
-            const countSum = sumBy(errorsDistribution.currentPeriod, 'y');
-            const numberOfBuckets = 15;
-            expect(countSum).to.equal(
-              (appleTransaction.failureRate + bananaTransaction.failureRate) * numberOfBuckets
+            const hasPreviousPeriodData = errorsDistribution.previousPeriod.some(({ y }) =>
+              isFiniteNumber(y)
+            );
+
+            expect(hasCurrentPeriodData).to.equal(true);
+            expect(hasPreviousPeriodData).to.equal(true);
+          });
+
+          it('has same start time for both periods', () => {
+            expect(first(errorsDistribution.currentPeriod)?.x).to.equal(
+              first(errorsDistribution.previousPeriod)?.x
+            );
+          });
+
+          it('has same end time for both periods', () => {
+            expect(last(errorsDistribution.currentPeriod)?.x).to.equal(
+              last(errorsDistribution.previousPeriod)?.x
+            );
+          });
+
+          it('returns same number of buckets for both periods', () => {
+            expect(errorsDistribution.currentPeriod.length).to.equal(
+              errorsDistribution.previousPeriod.length
             );
           });
         });
 
-        describe('displays occurrences for type "apple transaction" only', () => {
+        describe('when no data is returned', () => {
           let errorsDistribution: ErrorsDistribution;
           before(async () => {
             const response = await callApi({
-              query: { kuery: `error.exception.type:"${appleTransaction.name}"` },
+              query: {
+                start: '2021-01-03T00:00:00.000Z',
+                end: '2021-01-03T00:15:00.000Z',
+                offset: '1d',
+              },
             });
             errorsDistribution = response.body;
           });
-          it('displays combined number of occurrences', () => {
-            const countSum = sumBy(errorsDistribution.currentPeriod, 'y');
-            const numberOfBuckets = 15;
-            expect(countSum).to.equal(appleTransaction.failureRate * numberOfBuckets);
-          });
-        });
 
-        describe('with comparison', () => {
-          describe('when data is returned', () => {
-            let errorsDistribution: ErrorsDistribution;
-            before(async () => {
-              const fiveMinutes = 5 * 60 * 1000;
-              const response = await callApi({
-                query: {
-                  start: new Date(end - fiveMinutes).toISOString(),
-                  end: new Date(end).toISOString(),
-                  offset: '5m',
-                },
-              });
-              errorsDistribution = response.body;
-            });
-            it('returns some data', () => {
-              const hasCurrentPeriodData = errorsDistribution.currentPeriod.some(({ y }) =>
-                isFiniteNumber(y)
-              );
-
-              const hasPreviousPeriodData = errorsDistribution.previousPeriod.some(({ y }) =>
-                isFiniteNumber(y)
-              );
-
-              expect(hasCurrentPeriodData).to.equal(true);
-              expect(hasPreviousPeriodData).to.equal(true);
-            });
-
-            it('has same start time for both periods', () => {
-              expect(first(errorsDistribution.currentPeriod)?.x).to.equal(
-                first(errorsDistribution.previousPeriod)?.x
-              );
-            });
-
-            it('has same end time for both periods', () => {
-              expect(last(errorsDistribution.currentPeriod)?.x).to.equal(
-                last(errorsDistribution.previousPeriod)?.x
-              );
-            });
-
-            it('returns same number of buckets for both periods', () => {
-              expect(errorsDistribution.currentPeriod.length).to.equal(
-                errorsDistribution.previousPeriod.length
-              );
-            });
+          it('has same start time for both periods', () => {
+            expect(first(errorsDistribution.currentPeriod)?.x).to.equal(
+              first(errorsDistribution.previousPeriod)?.x
+            );
           });
 
-          describe('when no data is returned', () => {
-            let errorsDistribution: ErrorsDistribution;
-            before(async () => {
-              const response = await callApi({
-                query: {
-                  start: '2021-01-03T00:00:00.000Z',
-                  end: '2021-01-03T00:15:00.000Z',
-                  offset: '1d',
-                },
-              });
-              errorsDistribution = response.body;
-            });
+          it('has same end time for both periods', () => {
+            expect(last(errorsDistribution.currentPeriod)?.x).to.equal(
+              last(errorsDistribution.previousPeriod)?.x
+            );
+          });
 
-            it('has same start time for both periods', () => {
-              expect(first(errorsDistribution.currentPeriod)?.x).to.equal(
-                first(errorsDistribution.previousPeriod)?.x
-              );
-            });
-
-            it('has same end time for both periods', () => {
-              expect(last(errorsDistribution.currentPeriod)?.x).to.equal(
-                last(errorsDistribution.previousPeriod)?.x
-              );
-            });
-
-            it('returns same number of buckets for both periods', () => {
-              expect(errorsDistribution.currentPeriod.length).to.equal(
-                errorsDistribution.previousPeriod.length
-              );
-            });
+          it('returns same number of buckets for both periods', () => {
+            expect(errorsDistribution.currentPeriod.length).to.equal(
+              errorsDistribution.previousPeriod.length
+            );
           });
         });
       });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/infrastructure/infrastructure_attributes.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/infrastructure/infrastructure_attributes.spec.ts
@@ -48,39 +48,33 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Infrastructure attributes',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        beforeEach(async () => {
-          await generateData({ start, end, synthtraceEsClient });
-        });
+  registry.when('Infrastructure attributes', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      beforeEach(async () => {
+        await generateData({ start, end, synthtraceEsClient });
+      });
 
-        afterEach(() => synthtraceEsClient.clean());
+      afterEach(() => synthtraceEsClient.clean());
 
-        describe('when service runs in container', () => {
-          it('returns arrays of container ids and pod names', async () => {
-            const response = await callApi('synth-go');
-            expect(response.status).to.be(200);
-            expect(response.body.containerIds.length).to.be(1);
-            // hostNames is always returning empty
-            // we can not test the infra indices api call with synthtrace
-            expect(response.body.hostNames.length).to.be(0);
-            expect(response.body.podNames.length).to.be(1);
-          });
-        });
-
-        describe('when service does NOT run in container', () => {
-          it('returns array of host names', async () => {
-            const response = await callApi('synth-java');
-            expect(response.status).to.be(200);
-            expect(response.body.containerIds.length).to.be(0);
-            expect(response.body.hostNames.length).to.be(1);
-            expect(response.body.podNames.length).to.be(0);
-          });
+      describe('when service runs in container', () => {
+        it('returns arrays of container ids and pod names', async () => {
+          const response = await callApi('synth-go');
+          expect(response.status).to.be(200);
+          expect(response.body.containerIds.length).to.be(1);
+          expect(response.body.hostNames.length).to.be(1);
+          expect(response.body.podNames.length).to.be(1);
         });
       });
-    }
-  );
+
+      describe('when service does NOT run in container', () => {
+        it('returns array of host names', async () => {
+          const response = await callApi('synth-java');
+          expect(response.status).to.be(200);
+          expect(response.body.containerIds.length).to.be(0);
+          expect(response.body.hostNames.length).to.be(1);
+          expect(response.body.podNames.length).to.be(0);
+        });
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/latency/service_apis.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/latency/service_apis.spec.ts
@@ -116,7 +116,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   let latencyMetricValues: Awaited<ReturnType<typeof getLatencyValues>>;
   let latencyTransactionValues: Awaited<ReturnType<typeof getLatencyValues>>;
 
-  registry.when('Services APIs', { config: 'basic', archives: ['apm_mappings_only_8.0.0'] }, () => {
+  registry.when('Services APIs', { config: 'basic', archives: [] }, () => {
     describe('when data is loaded ', () => {
       const GO_PROD_RATE = 80;
       const GO_DEV_RATE = 20;

--- a/x-pack/test/apm_api_integration/tests/latency/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/latency/service_maps.spec.ts
@@ -59,68 +59,63 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   let latencyMetricValues: Awaited<ReturnType<typeof getLatencyValues>>;
   let latencyTransactionValues: Awaited<ReturnType<typeof getLatencyValues>>;
-  registry.when(
-    'Service maps APIs',
-    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded ', () => {
-        const GO_PROD_RATE = 80;
-        const GO_DEV_RATE = 20;
-        const GO_PROD_DURATION = 1000;
-        const GO_DEV_DURATION = 500;
-        before(async () => {
-          const serviceGoProdInstance = apm
-            .service(serviceName, 'production', 'go')
-            .instance('instance-a');
-          const serviceGoDevInstance = apm
-            .service(serviceName, 'development', 'go')
-            .instance('instance-b');
+  registry.when('Service maps APIs', { config: 'trial', archives: [] }, () => {
+    describe('when data is loaded ', () => {
+      const GO_PROD_RATE = 80;
+      const GO_DEV_RATE = 20;
+      const GO_PROD_DURATION = 1000;
+      const GO_DEV_DURATION = 500;
+      before(async () => {
+        const serviceGoProdInstance = apm
+          .service(serviceName, 'production', 'go')
+          .instance('instance-a');
+        const serviceGoDevInstance = apm
+          .service(serviceName, 'development', 'go')
+          .instance('instance-b');
 
-          await synthtraceEsClient.index([
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction('GET /api/product/list', 'Worker')
-                  .duration(GO_PROD_DURATION)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_DEV_RATE)
-              .generator((timestamp) =>
-                serviceGoDevInstance
-                  .transaction('GET /api/product/:id')
-                  .duration(GO_DEV_DURATION)
-                  .timestamp(timestamp)
-              ),
+        await synthtraceEsClient.index([
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction('GET /api/product/list', 'Worker')
+                .duration(GO_PROD_DURATION)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_DEV_RATE)
+            .generator((timestamp) =>
+              serviceGoDevInstance
+                .transaction('GET /api/product/:id')
+                .duration(GO_DEV_DURATION)
+                .timestamp(timestamp)
+            ),
+        ]);
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('compare latency value between service inventory and service maps', () => {
+        before(async () => {
+          [latencyTransactionValues, latencyMetricValues] = await Promise.all([
+            getLatencyValues('transaction'),
+            getLatencyValues('metric'),
           ]);
         });
 
-        after(() => synthtraceEsClient.clean());
+        it('returns same avg latency value for Transaction-based and Metric-based data', () => {
+          const expectedLatencyAvgValueMs = ((GO_DEV_RATE * GO_DEV_DURATION) / GO_DEV_RATE) * 1000;
 
-        describe('compare latency value between service inventory and service maps', () => {
-          before(async () => {
-            [latencyTransactionValues, latencyMetricValues] = await Promise.all([
-              getLatencyValues('transaction'),
-              getLatencyValues('metric'),
-            ]);
-          });
-
-          it('returns same avg latency value for Transaction-based and Metric-based data', () => {
-            const expectedLatencyAvgValueMs =
-              ((GO_DEV_RATE * GO_DEV_DURATION) / GO_DEV_RATE) * 1000;
-
-            [
-              latencyTransactionValues.serviceMapsNodeDetailsLatency,
-              latencyTransactionValues.serviceInventoryLatency,
-              latencyMetricValues.serviceMapsNodeDetailsLatency,
-              latencyMetricValues.serviceInventoryLatency,
-            ].forEach((value) => expect(value).to.be.equal(expectedLatencyAvgValueMs));
-          });
+          [
+            latencyTransactionValues.serviceMapsNodeDetailsLatency,
+            latencyTransactionValues.serviceInventoryLatency,
+            latencyMetricValues.serviceMapsNodeDetailsLatency,
+            latencyMetricValues.serviceInventoryLatency,
+          ].forEach((value) => expect(value).to.be.equal(expectedLatencyAvgValueMs));
         });
       });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.spec.ts
@@ -83,93 +83,87 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('Observability overview api ', () => {
-        const GO_PROD_RATE = 50;
-        const GO_DEV_RATE = 5;
-        const JAVA_PROD_RATE = 45;
+  registry.when('data is loaded', { config: 'basic', archives: [] }, () => {
+    describe('Observability overview api ', () => {
+      const GO_PROD_RATE = 50;
+      const GO_DEV_RATE = 5;
+      const JAVA_PROD_RATE = 45;
+      before(async () => {
+        const serviceGoProdInstance = apm
+          .service('synth-go', 'production', 'go')
+          .instance('instance-a');
+        const serviceGoDevInstance = apm
+          .service('synth-go', 'development', 'go')
+          .instance('instance-b');
+
+        const serviceJavaInstance = apm
+          .service('synth-java', 'production', 'java')
+          .instance('instance-c');
+
+        await synthtraceEsClient.index([
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction('GET /api/product/list')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_DEV_RATE)
+            .generator((timestamp) =>
+              serviceGoDevInstance
+                .transaction('GET /api/product/:id')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(JAVA_PROD_RATE)
+            .generator((timestamp) =>
+              serviceJavaInstance
+                .transaction('POST /api/product/buy')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+        ]);
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('compare throughput values', () => {
+        let throughputValues: Awaited<ReturnType<typeof getThroughputValues>>;
         before(async () => {
-          const serviceGoProdInstance = apm
-            .service('synth-go', 'production', 'go')
-            .instance('instance-a');
-          const serviceGoDevInstance = apm
-            .service('synth-go', 'development', 'go')
-            .instance('instance-b');
-
-          const serviceJavaInstance = apm
-            .service('synth-java', 'production', 'java')
-            .instance('instance-c');
-
-          await synthtraceEsClient.index([
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction('GET /api/product/list')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_DEV_RATE)
-              .generator((timestamp) =>
-                serviceGoDevInstance
-                  .transaction('GET /api/product/:id')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(JAVA_PROD_RATE)
-              .generator((timestamp) =>
-                serviceJavaInstance
-                  .transaction('POST /api/product/buy')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-          ]);
+          throughputValues = await getThroughputValues();
         });
 
-        after(() => synthtraceEsClient.clean());
+        it('returns same number of service as shown on service inventory API', () => {
+          const { serviceInventoryCount, observabilityOverview } = throughputValues;
+          [serviceInventoryCount, observabilityOverview.serviceCount].forEach((value) =>
+            expect(value).to.be.equal(2)
+          );
+        });
 
-        describe('compare throughput values', () => {
-          let throughputValues: Awaited<ReturnType<typeof getThroughputValues>>;
-          before(async () => {
-            throughputValues = await getThroughputValues();
-          });
+        it('returns same throughput value on service inventory and obs throughput count', () => {
+          const { serviceInventoryThroughputSum, observabilityOverview } = throughputValues;
+          const obsThroughputCount = roundNumber(observabilityOverview.transactionPerMinute.value);
+          [serviceInventoryThroughputSum, obsThroughputCount].forEach((value) =>
+            expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE + JAVA_PROD_RATE))
+          );
+        });
 
-          it('returns same number of service as shown on service inventory API', () => {
-            const { serviceInventoryCount, observabilityOverview } = throughputValues;
-            [serviceInventoryCount, observabilityOverview.serviceCount].forEach((value) =>
-              expect(value).to.be.equal(2)
-            );
-          });
-
-          it('returns same throughput value on service inventory and obs throughput count', () => {
-            const { serviceInventoryThroughputSum, observabilityOverview } = throughputValues;
-            const obsThroughputCount = roundNumber(
-              observabilityOverview.transactionPerMinute.value
-            );
-            [serviceInventoryThroughputSum, obsThroughputCount].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE + JAVA_PROD_RATE))
-            );
-          });
-
-          it('returns same throughput value on service inventory and obs mean throughput timeseries', () => {
-            const { serviceInventoryThroughputSum, observabilityOverview } = throughputValues;
-            const obsThroughputMean = roundNumber(
-              meanBy(observabilityOverview.transactionPerMinute.timeseries, 'y')
-            );
-            [serviceInventoryThroughputSum, obsThroughputMean].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE + JAVA_PROD_RATE))
-            );
-          });
+        it('returns same throughput value on service inventory and obs mean throughput timeseries', () => {
+          const { serviceInventoryThroughputSum, observabilityOverview } = throughputValues;
+          const obsThroughputMean = roundNumber(
+            meanBy(observabilityOverview.transactionPerMinute.timeseries, 'y')
+          );
+          [serviceInventoryThroughputSum, obsThroughputMean].forEach((value) =>
+            expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE + JAVA_PROD_RATE))
+          );
         });
       });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/service_nodes/get_service_nodes.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_nodes/get_service_nodes.spec.ts
@@ -48,36 +48,33 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when(
-    'Service nodes when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      before(async () => {
-        const instance = apm.service(serviceName, 'production', 'go').instance(instanceName);
-        await synthtraceEsClient.index(
-          timerange(start, end)
-            .interval('1m')
-            .rate(1)
-            .generator((timestamp) =>
-              instance
-                .appMetrics({
-                  'system.process.cpu.total.norm.pct': 1,
-                  'jvm.memory.heap.used': 1000,
-                  'jvm.memory.non_heap.used': 100,
-                  'jvm.thread.count': 25,
-                })
-                .timestamp(timestamp)
-            )
-        );
-      });
-      after(() => synthtraceEsClient.clean());
+  registry.when('Service nodes when data is loaded', { config: 'basic', archives: [] }, () => {
+    before(async () => {
+      const instance = apm.service(serviceName, 'production', 'go').instance(instanceName);
+      await synthtraceEsClient.index(
+        timerange(start, end)
+          .interval('1m')
+          .rate(1)
+          .generator((timestamp) =>
+            instance
+              .appMetrics({
+                'system.process.cpu.total.norm.pct': 1,
+                'jvm.memory.heap.used': 1000,
+                'jvm.memory.non_heap.used': 100,
+                'jvm.thread.count': 25,
+              })
+              .timestamp(timestamp)
+          )
+      );
+    });
+    after(() => synthtraceEsClient.clean());
 
-      it('returns service nodes', async () => {
-        const response = await callApi();
+    it('returns service nodes', async () => {
+      const response = await callApi();
 
-        expect(response.status).to.be(200);
+      expect(response.status).to.be(200);
 
-        expectSnapshot(response.body).toMatchInline(`
+      expectSnapshot(response.body).toMatchInline(`
           Object {
             "serviceNodes": Array [
               Object {
@@ -91,7 +88,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             ],
           }
         `);
-      });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.spec.ts
@@ -283,7 +283,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Service overview instances main statistics when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       describe('for two go instances and one java instance', () => {
         const GO_A_INSTANCE_RATE_SUCCESS = 10;

--- a/x-pack/test/apm_api_integration/tests/services/error_groups/error_groups_detailed_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/error_groups/error_groups_detailed_statistics.spec.ts
@@ -64,136 +64,130 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Error groups detailed statistics',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        const { PROD_LIST_ERROR_RATE, PROD_ID_ERROR_RATE } = config;
+  registry.when('Error groups detailed statistics', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      const { PROD_LIST_ERROR_RATE, PROD_ID_ERROR_RATE } = config;
+      before(async () => {
+        await generateData({ serviceName, start, end, synthtraceEsClient });
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('without data comparison', () => {
+        let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
+        let errorIds: string[] = [];
         before(async () => {
-          await generateData({ serviceName, start, end, synthtraceEsClient });
+          errorIds = await getErrorGroupIds({ serviceName, start, end, apmApiClient });
+          const response = await callApi({
+            body: {
+              groupIds: JSON.stringify(errorIds),
+            },
+          });
+          errorGroupsDetailedStatistics = response.body;
         });
 
-        after(() => synthtraceEsClient.clean());
-
-        describe('without data comparison', () => {
-          let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
-          let errorIds: string[] = [];
-          before(async () => {
-            errorIds = await getErrorGroupIds({ serviceName, start, end, apmApiClient });
-            const response = await callApi({
-              body: {
-                groupIds: JSON.stringify(errorIds),
-              },
-            });
-            errorGroupsDetailedStatistics = response.body;
-          });
-
-          it('return detailed statistics for all errors found', () => {
-            expect(Object.keys(errorGroupsDetailedStatistics.currentPeriod).sort()).to.eql(
-              errorIds
-            );
-          });
-
-          it('returns correct number of occurrencies', () => {
-            const numberOfBuckets = 15;
-            const detailedStatisticsOccurrenciesSum = Object.values(
-              errorGroupsDetailedStatistics.currentPeriod
-            )
-              .sort()
-              .map(({ timeseries }) => {
-                return sumBy(timeseries, 'y');
-              });
-
-            expect(detailedStatisticsOccurrenciesSum).to.eql([
-              PROD_ID_ERROR_RATE * numberOfBuckets,
-              PROD_LIST_ERROR_RATE * numberOfBuckets,
-            ]);
-          });
+        it('return detailed statistics for all errors found', () => {
+          expect(Object.keys(errorGroupsDetailedStatistics.currentPeriod).sort()).to.eql(errorIds);
         });
 
-        describe('return empty state when invalid group id', () => {
-          let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
-          before(async () => {
-            const response = await callApi({
-              body: {
-                groupIds: JSON.stringify(['foo']),
-              },
+        it('returns correct number of occurrencies', () => {
+          const numberOfBuckets = 15;
+          const detailedStatisticsOccurrenciesSum = Object.values(
+            errorGroupsDetailedStatistics.currentPeriod
+          )
+            .sort()
+            .map(({ timeseries }) => {
+              return sumBy(timeseries, 'y');
             });
-            errorGroupsDetailedStatistics = response.body;
-          });
 
-          it('returns empty state', () => {
-            expect(errorGroupsDetailedStatistics).to.be.eql({
-              currentPeriod: {},
-              previousPeriod: {},
-            });
+          expect(detailedStatisticsOccurrenciesSum).to.eql([
+            PROD_ID_ERROR_RATE * numberOfBuckets,
+            PROD_LIST_ERROR_RATE * numberOfBuckets,
+          ]);
+        });
+      });
+
+      describe('return empty state when invalid group id', () => {
+        let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
+        before(async () => {
+          const response = await callApi({
+            body: {
+              groupIds: JSON.stringify(['foo']),
+            },
           });
+          errorGroupsDetailedStatistics = response.body;
         });
 
-        describe('with comparison', () => {
-          let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
-          let errorIds: string[] = [];
-          before(async () => {
-            errorIds = await getErrorGroupIds({ serviceName, start, end, apmApiClient });
-            const response = await callApi({
-              query: {
-                start: moment(end).subtract(7, 'minutes').toISOString(),
-                end: new Date(end).toISOString(),
-                offset: '7m',
-              },
-              body: {
-                groupIds: JSON.stringify(errorIds),
-              },
-            });
-            errorGroupsDetailedStatistics = response.body;
-          });
-
-          it('returns some data', () => {
-            expect(
-              Object.keys(errorGroupsDetailedStatistics.currentPeriod).length
-            ).to.be.greaterThan(0);
-            expect(
-              Object.keys(errorGroupsDetailedStatistics.previousPeriod).length
-            ).to.be.greaterThan(0);
-
-            const hasCurrentPeriodData = Object.values(
-              errorGroupsDetailedStatistics.currentPeriod
-            )[0].timeseries.some(({ y }) => isFiniteNumber(y));
-
-            const hasPreviousPeriodData = Object.values(
-              errorGroupsDetailedStatistics.previousPeriod
-            )[0].timeseries.some(({ y }) => isFiniteNumber(y));
-
-            expect(hasCurrentPeriodData).to.equal(true);
-            expect(hasPreviousPeriodData).to.equal(true);
-          });
-
-          it('has same start time for both periods', () => {
-            expect(
-              first(Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries)?.x
-            ).to.equal(
-              first(Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries)?.x
-            );
-          });
-
-          it('has same end time for both periods', () => {
-            expect(
-              last(Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries)?.x
-            ).to.equal(
-              last(Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries)?.x
-            );
-          });
-
-          it('returns same number of buckets for both periods', () => {
-            expect(
-              Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries.length
-            ).to.equal(
-              Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries.length
-            );
+        it('returns empty state', () => {
+          expect(errorGroupsDetailedStatistics).to.be.eql({
+            currentPeriod: {},
+            previousPeriod: {},
           });
         });
       });
-    }
-  );
+
+      describe('with comparison', () => {
+        let errorGroupsDetailedStatistics: ErrorGroupsDetailedStatistics;
+        let errorIds: string[] = [];
+        before(async () => {
+          errorIds = await getErrorGroupIds({ serviceName, start, end, apmApiClient });
+          const response = await callApi({
+            query: {
+              start: moment(end).subtract(7, 'minutes').toISOString(),
+              end: new Date(end).toISOString(),
+              offset: '7m',
+            },
+            body: {
+              groupIds: JSON.stringify(errorIds),
+            },
+          });
+          errorGroupsDetailedStatistics = response.body;
+        });
+
+        it('returns some data', () => {
+          expect(Object.keys(errorGroupsDetailedStatistics.currentPeriod).length).to.be.greaterThan(
+            0
+          );
+          expect(
+            Object.keys(errorGroupsDetailedStatistics.previousPeriod).length
+          ).to.be.greaterThan(0);
+
+          const hasCurrentPeriodData = Object.values(
+            errorGroupsDetailedStatistics.currentPeriod
+          )[0].timeseries.some(({ y }) => isFiniteNumber(y));
+
+          const hasPreviousPeriodData = Object.values(
+            errorGroupsDetailedStatistics.previousPeriod
+          )[0].timeseries.some(({ y }) => isFiniteNumber(y));
+
+          expect(hasCurrentPeriodData).to.equal(true);
+          expect(hasPreviousPeriodData).to.equal(true);
+        });
+
+        it('has same start time for both periods', () => {
+          expect(
+            first(Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries)?.x
+          ).to.equal(
+            first(Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries)?.x
+          );
+        });
+
+        it('has same end time for both periods', () => {
+          expect(
+            last(Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries)?.x
+          ).to.equal(
+            last(Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries)?.x
+          );
+        });
+
+        it('returns same number of buckets for both periods', () => {
+          expect(
+            Object.values(errorGroupsDetailedStatistics.currentPeriod)[0].timeseries.length
+          ).to.equal(
+            Object.values(errorGroupsDetailedStatistics.previousPeriod)[0].timeseries.length
+          );
+        });
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/error_groups/error_groups_main_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/error_groups/error_groups_main_statistics.spec.ts
@@ -58,51 +58,44 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Error groups main statistics',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded', () => {
-        const { PROD_LIST_ERROR_RATE, PROD_ID_ERROR_RATE, ERROR_NAME_1, ERROR_NAME_2 } = config;
+  registry.when('Error groups main statistics', { config: 'basic', archives: [] }, () => {
+    describe('when data is loaded', () => {
+      const { PROD_LIST_ERROR_RATE, PROD_ID_ERROR_RATE, ERROR_NAME_1, ERROR_NAME_2 } = config;
 
+      before(async () => {
+        await generateData({ serviceName, start, end, synthtraceEsClient });
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('returns the correct data', () => {
+        let errorGroupMainStatistics: ErrorGroupsMainStatistics;
         before(async () => {
-          await generateData({ serviceName, start, end, synthtraceEsClient });
+          const response = await callApi();
+          errorGroupMainStatistics = response.body;
         });
 
-        after(() => synthtraceEsClient.clean());
+        it('returns correct number of occurrences', () => {
+          expect(errorGroupMainStatistics.errorGroups.length).to.equal(2);
+          expect(errorGroupMainStatistics.errorGroups.map((error) => error.name).sort()).to.eql([
+            ERROR_NAME_1,
+            ERROR_NAME_2,
+          ]);
+        });
 
-        describe('returns the correct data', () => {
-          let errorGroupMainStatistics: ErrorGroupsMainStatistics;
-          before(async () => {
-            const response = await callApi();
-            errorGroupMainStatistics = response.body;
-          });
+        it('returns correct occurences', () => {
+          const numberOfBuckets = 15;
+          expect(
+            errorGroupMainStatistics.errorGroups.map((error) => error.occurrences).sort()
+          ).to.eql([PROD_LIST_ERROR_RATE * numberOfBuckets, PROD_ID_ERROR_RATE * numberOfBuckets]);
+        });
 
-          it('returns correct number of occurrences', () => {
-            expect(errorGroupMainStatistics.errorGroups.length).to.equal(2);
-            expect(errorGroupMainStatistics.errorGroups.map((error) => error.name).sort()).to.eql([
-              ERROR_NAME_1,
-              ERROR_NAME_2,
-            ]);
-          });
-
-          it('returns correct occurences', () => {
-            const numberOfBuckets = 15;
-            expect(
-              errorGroupMainStatistics.errorGroups.map((error) => error.occurrences).sort()
-            ).to.eql([
-              PROD_LIST_ERROR_RATE * numberOfBuckets,
-              PROD_ID_ERROR_RATE * numberOfBuckets,
-            ]);
-          });
-
-          it('has same last seen value as end date', () => {
-            errorGroupMainStatistics.errorGroups.map((error) => {
-              expect(error.lastSeen).to.equal(moment(end).startOf('minute').valueOf());
-            });
+        it('has same last seen value as end date', () => {
+          errorGroupMainStatistics.errorGroups.map((error) => {
+            expect(error.lastSeen).to.equal(moment(end).startOf('minute').valueOf());
           });
         });
       });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
@@ -54,7 +54,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Service node metadata when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       before(async () => {
         const instance = apm.service(serviceName, 'production', 'go').instance(instanceName);

--- a/x-pack/test/apm_api_integration/tests/services/service_details/service_details.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_details/service_details.spec.ts
@@ -50,79 +50,75 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'Service details when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      let body: ServiceDetails;
-      let status: number;
+  registry.when('Service details when data is generated', { config: 'basic', archives: [] }, () => {
+    let body: ServiceDetails;
+    let status: number;
 
-      before(async () => {
-        await generateData({ synthtraceEsClient, start, end });
-        const response = await callApi();
-        body = response.body;
-        status = response.status;
-      });
+    before(async () => {
+      await generateData({ synthtraceEsClient, start, end });
+      const response = await callApi();
+      body = response.body;
+      status = response.status;
+    });
 
-      after(() => synthtraceEsClient.clean());
+    after(() => synthtraceEsClient.clean());
 
-      it('returns correct HTTP status', () => {
-        expect(status).to.be(200);
-      });
+    it('returns correct HTTP status', () => {
+      expect(status).to.be(200);
+    });
 
-      it('returns correct cloud details', () => {
-        const { cloud } = dataConfig;
-        const {
-          provider,
-          availabilityZone,
-          region,
-          machineType,
-          projectName,
-          serviceName: cloudServiceName,
-        } = cloud;
+    it('returns correct cloud details', () => {
+      const { cloud } = dataConfig;
+      const {
+        provider,
+        availabilityZone,
+        region,
+        machineType,
+        projectName,
+        serviceName: cloudServiceName,
+      } = cloud;
 
-        expect(first(body?.cloud?.availabilityZones)).to.be(availabilityZone);
-        expect(first(body?.cloud?.machineTypes)).to.be(machineType);
-        expect(body?.cloud?.provider).to.be(provider);
-        expect(body?.cloud?.projectName).to.be(projectName);
-        expect(body?.cloud?.serviceName).to.be(cloudServiceName);
-        expect(first(body?.cloud?.regions)).to.be(region);
-      });
+      expect(first(body?.cloud?.availabilityZones)).to.be(availabilityZone);
+      expect(first(body?.cloud?.machineTypes)).to.be(machineType);
+      expect(body?.cloud?.provider).to.be(provider);
+      expect(body?.cloud?.projectName).to.be(projectName);
+      expect(body?.cloud?.serviceName).to.be(cloudServiceName);
+      expect(first(body?.cloud?.regions)).to.be(region);
+    });
 
-      it('returns correct container details', () => {
-        const { containerOs } = dataConfig;
+    it('returns correct container details', () => {
+      const { containerOs } = dataConfig;
 
-        expect(body?.container?.isContainerized).to.be(true);
-        expect(body?.container?.os).to.be(containerOs);
-        expect(body?.container?.totalNumberInstances).to.be(1);
-        expect(body?.container?.type).to.be('Kubernetes');
-      });
+      expect(body?.container?.isContainerized).to.be(true);
+      expect(body?.container?.os).to.be(containerOs);
+      expect(body?.container?.totalNumberInstances).to.be(1);
+      expect(body?.container?.type).to.be('Kubernetes');
+    });
 
-      it('returns correct serverless details', () => {
-        const { cloud, serverless } = dataConfig;
-        const { serviceName: cloudServiceName } = cloud;
-        const { faasTriggerType, firstFunctionName, secondFunctionName } = serverless;
+    it('returns correct serverless details', () => {
+      const { cloud, serverless } = dataConfig;
+      const { serviceName: cloudServiceName } = cloud;
+      const { faasTriggerType, firstFunctionName, secondFunctionName } = serverless;
 
-        expect(body?.serverless?.type).to.be(cloudServiceName);
-        expect(body?.serverless?.functionNames).to.have.length(2);
-        expect(body?.serverless?.functionNames).to.contain(firstFunctionName);
-        expect(body?.serverless?.functionNames).to.contain(secondFunctionName);
-        expect(first(body?.serverless?.faasTriggerTypes)).to.be(faasTriggerType);
-      });
+      expect(body?.serverless?.type).to.be(cloudServiceName);
+      expect(body?.serverless?.functionNames).to.have.length(2);
+      expect(body?.serverless?.functionNames).to.contain(firstFunctionName);
+      expect(body?.serverless?.functionNames).to.contain(secondFunctionName);
+      expect(first(body?.serverless?.faasTriggerTypes)).to.be(faasTriggerType);
+    });
 
-      it('returns correct service details', () => {
-        const { service } = dataConfig;
-        const { version, runtime, framework, agent } = service;
-        const { name: runTimeName, version: runTimeVersion } = runtime;
-        const { name: agentName, version: agentVersion } = agent;
+    it('returns correct service details', () => {
+      const { service } = dataConfig;
+      const { version, runtime, framework, agent } = service;
+      const { name: runTimeName, version: runTimeVersion } = runtime;
+      const { name: agentName, version: agentVersion } = agent;
 
-        expect(body?.service?.framework).to.be(framework);
-        expect(body?.service?.agent.name).to.be(agentName);
-        expect(body?.service?.agent.version).to.be(agentVersion);
-        expect(body?.service?.runtime?.name).to.be(runTimeName);
-        expect(body?.service?.runtime?.version).to.be(runTimeVersion);
-        expect(first(body?.service?.versions)).to.be(version);
-      });
-    }
-  );
+      expect(body?.service?.framework).to.be(framework);
+      expect(body?.service?.agent.name).to.be(agentName);
+      expect(body?.service?.agent.version).to.be(agentVersion);
+      expect(body?.service?.runtime?.name).to.be(runTimeName);
+      expect(body?.service?.runtime?.version).to.be(runTimeVersion);
+      expect(first(body?.service?.versions)).to.be(version);
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/service_icons/service_icons.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_icons/service_icons.spec.ts
@@ -43,35 +43,31 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when(
-    'Service icons when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      let body: ServiceIconMetadata;
-      let status: number;
+  registry.when('Service icons when data is generated', { config: 'basic', archives: [] }, () => {
+    let body: ServiceIconMetadata;
+    let status: number;
 
-      before(async () => {
-        await generateData({ synthtraceEsClient, start, end });
-        const response = await callApi();
-        body = response.body;
-        status = response.status;
-      });
+    before(async () => {
+      await generateData({ synthtraceEsClient, start, end });
+      const response = await callApi();
+      body = response.body;
+      status = response.status;
+    });
 
-      after(() => synthtraceEsClient.clean());
+    after(() => synthtraceEsClient.clean());
 
-      it('returns correct HTTP status', () => {
-        expect(status).to.be(200);
-      });
+    it('returns correct HTTP status', () => {
+      expect(status).to.be(200);
+    });
 
-      it('returns correct metadata', () => {
-        const { agentName, cloud } = dataConfig;
-        const { provider, serviceName: cloudServiceName } = cloud;
+    it('returns correct metadata', () => {
+      const { agentName, cloud } = dataConfig;
+      const { provider, serviceName: cloudServiceName } = cloud;
 
-        expect(body.agentName).to.be(agentName);
-        expect(body.cloudProvider).to.be(provider);
-        expect(body.containerType).to.be('Kubernetes');
-        expect(body.serverlessType).to.be(cloudServiceName);
-      });
-    }
-  );
+      expect(body.agentName).to.be(agentName);
+      expect(body.cloudProvider).to.be(provider);
+      expect(body.containerType).to.be('Kubernetes');
+      expect(body.serverlessType).to.be(cloudServiceName);
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/sorted_and_filtered_services.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/sorted_and_filtered_services.spec.ts
@@ -51,102 +51,98 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   type ServiceListItem = ValuesType<Awaited<ReturnType<typeof getSortedAndFilteredServices>>>;
 
   // FLAKY: https://github.com/elastic/kibana/issues/127939
-  registry.when.skip(
-    'Sorted and filtered services',
-    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
+  registry.when.skip('Sorted and filtered services', { config: 'trial', archives: [] }, () => {
+    before(async () => {
+      const serviceA = apm.service(SERVICE_NAME_PREFIX + 'a', 'production', 'java').instance('a');
+
+      const serviceB = apm.service(SERVICE_NAME_PREFIX + 'b', 'development', 'go').instance('b');
+
+      const serviceC = apm.service(SERVICE_NAME_PREFIX + 'c', 'development', 'go').instance('c');
+
+      const spikeStart = new Date('2021-01-07T12:00:00.000Z').getTime();
+      const spikeEnd = new Date('2021-01-07T14:00:00.000Z').getTime();
+
+      const eventsWithinTimerange = timerange(new Date(start).getTime(), new Date(end).getTime())
+        .interval('15m')
+        .rate(1)
+        .generator((timestamp) => {
+          const isInSpike = spikeStart <= timestamp && spikeEnd >= timestamp;
+          return [
+            serviceA
+              .transaction('GET /api')
+              .duration(isInSpike ? 1000 : 1100)
+              .timestamp(timestamp),
+            serviceB
+              .transaction('GET /api')
+              .duration(isInSpike ? 1000 : 4000)
+              .timestamp(timestamp),
+          ];
+        });
+
+      const eventsOutsideOfTimerange = timerange(
+        new Date('2021-01-01T00:00:00.000Z').getTime(),
+        new Date(start).getTime() - 1
+      )
+        .interval('15m')
+        .rate(1)
+        .generator((timestamp) => {
+          return serviceC.transaction('GET /api', 'custom').duration(1000).timestamp(timestamp);
+        });
+
+      await synthtraceClient.index(eventsWithinTimerange.merge(eventsOutsideOfTimerange));
+
+      await Promise.all([
+        createAndRunApmMlJob({ environment: 'production', ml }),
+        createAndRunApmMlJob({ environment: 'development', ml }),
+      ]);
+    });
+
+    after(() => {
+      return Promise.all([synthtraceClient.clean(), ml.cleanMlIndices()]);
+    });
+
+    describe('with no kuery or environment are set', () => {
+      let items: ServiceListItem[];
+
       before(async () => {
-        const serviceA = apm.service(SERVICE_NAME_PREFIX + 'a', 'production', 'java').instance('a');
-
-        const serviceB = apm.service(SERVICE_NAME_PREFIX + 'b', 'development', 'go').instance('b');
-
-        const serviceC = apm.service(SERVICE_NAME_PREFIX + 'c', 'development', 'go').instance('c');
-
-        const spikeStart = new Date('2021-01-07T12:00:00.000Z').getTime();
-        const spikeEnd = new Date('2021-01-07T14:00:00.000Z').getTime();
-
-        const eventsWithinTimerange = timerange(new Date(start).getTime(), new Date(end).getTime())
-          .interval('15m')
-          .rate(1)
-          .generator((timestamp) => {
-            const isInSpike = spikeStart <= timestamp && spikeEnd >= timestamp;
-            return [
-              serviceA
-                .transaction('GET /api')
-                .duration(isInSpike ? 1000 : 1100)
-                .timestamp(timestamp),
-              serviceB
-                .transaction('GET /api')
-                .duration(isInSpike ? 1000 : 4000)
-                .timestamp(timestamp),
-            ];
-          });
-
-        const eventsOutsideOfTimerange = timerange(
-          new Date('2021-01-01T00:00:00.000Z').getTime(),
-          new Date(start).getTime() - 1
-        )
-          .interval('15m')
-          .rate(1)
-          .generator((timestamp) => {
-            return serviceC.transaction('GET /api', 'custom').duration(1000).timestamp(timestamp);
-          });
-
-        await synthtraceClient.index(eventsWithinTimerange.merge(eventsOutsideOfTimerange));
-
-        await Promise.all([
-          createAndRunApmMlJob({ environment: 'production', ml }),
-          createAndRunApmMlJob({ environment: 'development', ml }),
-        ]);
+        items = await getSortedAndFilteredServices();
       });
 
-      after(() => {
-        return Promise.all([synthtraceClient.clean(), ml.cleanMlIndices()]);
+      it('returns services based on the terms enum API and ML data', () => {
+        const serviceNames = items.map((item) => item.serviceName);
+
+        expect(serviceNames.sort()).to.eql(['a', 'b', 'c']);
       });
+    });
 
-      describe('with no kuery or environment are set', () => {
-        let items: ServiceListItem[];
+    describe('with kuery set', () => {
+      let items: ServiceListItem[];
 
-        before(async () => {
-          items = await getSortedAndFilteredServices();
-        });
-
-        it('returns services based on the terms enum API and ML data', () => {
-          const serviceNames = items.map((item) => item.serviceName);
-
-          expect(serviceNames.sort()).to.eql(['a', 'b', 'c']);
+      before(async () => {
+        items = await getSortedAndFilteredServices({
+          kuery: 'service.name:*',
         });
       });
 
-      describe('with kuery set', () => {
-        let items: ServiceListItem[];
+      it('does not return any services', () => {
+        expect(items.length).to.be(0);
+      });
+    });
 
-        before(async () => {
-          items = await getSortedAndFilteredServices({
-            kuery: 'service.name:*',
-          });
-        });
+    describe('with environment set to production', () => {
+      let items: ServiceListItem[];
 
-        it('does not return any services', () => {
-          expect(items.length).to.be(0);
+      before(async () => {
+        items = await getSortedAndFilteredServices({
+          environment: 'production',
         });
       });
 
-      describe('with environment set to production', () => {
-        let items: ServiceListItem[];
+      it('returns services for production only', () => {
+        const serviceNames = items.map((item) => item.serviceName);
 
-        before(async () => {
-          items = await getSortedAndFilteredServices({
-            environment: 'production',
-          });
-        });
-
-        it('returns services for production only', () => {
-          const serviceNames = items.map((item) => item.serviceName);
-
-          expect(serviceNames.sort()).to.eql(['a']);
-        });
+        expect(serviceNames.sort()).to.eql(['a']);
       });
-    }
-  );
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/throughput.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/throughput.spec.ts
@@ -63,219 +63,213 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when(
-    'Throughput when data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('Throughput chart api', () => {
-        const GO_PROD_RATE = 50;
-        const GO_DEV_RATE = 5;
-        const JAVA_PROD_RATE = 45;
+  registry.when('Throughput when data is loaded', { config: 'basic', archives: [] }, () => {
+    describe('Throughput chart api', () => {
+      const GO_PROD_RATE = 50;
+      const GO_DEV_RATE = 5;
+      const JAVA_PROD_RATE = 45;
+
+      before(async () => {
+        const serviceGoProdInstance = apm
+          .service(serviceName, 'production', 'go')
+          .instance('instance-a');
+        const serviceGoDevInstance = apm
+          .service(serviceName, 'development', 'go')
+          .instance('instance-b');
+
+        const serviceJavaInstance = apm
+          .service('synth-java', 'development', 'java')
+          .instance('instance-c');
+
+        await synthtraceEsClient.index([
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction('GET /api/product/list')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_DEV_RATE)
+            .generator((timestamp) =>
+              serviceGoDevInstance
+                .transaction('GET /api/product/:id')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(JAVA_PROD_RATE)
+            .generator((timestamp) =>
+              serviceJavaInstance
+                .transaction('POST /api/product/buy')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+        ]);
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('compare transactions and metrics based throughput', () => {
+        let throughputMetrics: ThroughputReturn;
+        let throughputTransactions: ThroughputReturn;
 
         before(async () => {
-          const serviceGoProdInstance = apm
-            .service(serviceName, 'production', 'go')
-            .instance('instance-a');
-          const serviceGoDevInstance = apm
-            .service(serviceName, 'development', 'go')
-            .instance('instance-b');
-
-          const serviceJavaInstance = apm
-            .service('synth-java', 'development', 'java')
-            .instance('instance-c');
-
-          await synthtraceEsClient.index([
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction('GET /api/product/list')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_DEV_RATE)
-              .generator((timestamp) =>
-                serviceGoDevInstance
-                  .transaction('GET /api/product/:id')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(JAVA_PROD_RATE)
-              .generator((timestamp) =>
-                serviceJavaInstance
-                  .transaction('POST /api/product/buy')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
+          const [throughputMetricsResponse, throughputTransactionsResponse] = await Promise.all([
+            callApi({ query: { kuery: 'processor.event : "metric"' } }),
+            callApi({ query: { kuery: 'processor.event : "transaction"' } }),
           ]);
+          throughputMetrics = throughputMetricsResponse.body;
+          throughputTransactions = throughputTransactionsResponse.body;
         });
 
-        after(() => synthtraceEsClient.clean());
-
-        describe('compare transactions and metrics based throughput', () => {
-          let throughputMetrics: ThroughputReturn;
-          let throughputTransactions: ThroughputReturn;
-
-          before(async () => {
-            const [throughputMetricsResponse, throughputTransactionsResponse] = await Promise.all([
-              callApi({ query: { kuery: 'processor.event : "metric"' } }),
-              callApi({ query: { kuery: 'processor.event : "transaction"' } }),
-            ]);
-            throughputMetrics = throughputMetricsResponse.body;
-            throughputTransactions = throughputTransactionsResponse.body;
-          });
-
-          it('returns some transactions data', () => {
-            expect(throughputTransactions.currentPeriod.length).to.be.greaterThan(0);
-            const hasData = throughputTransactions.currentPeriod.some(({ y }) => isFiniteNumber(y));
-            expect(hasData).to.equal(true);
-          });
-
-          it('returns some metrics data', () => {
-            expect(throughputMetrics.currentPeriod.length).to.be.greaterThan(0);
-            const hasData = throughputMetrics.currentPeriod.some(({ y }) => isFiniteNumber(y));
-            expect(hasData).to.equal(true);
-          });
-
-          it('has same mean value for metrics and transactions data', () => {
-            const transactionsMean = meanBy(throughputTransactions.currentPeriod, 'y');
-            const metricsMean = meanBy(throughputMetrics.currentPeriod, 'y');
-            [transactionsMean, metricsMean].forEach((value) =>
-              expect(roundNumber(value)).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE))
-            );
-          });
-
-          it('has a bucket size of 30 seconds for transactions data', () => {
-            const firstTimerange = throughputTransactions.currentPeriod[0].x;
-            const secondTimerange = throughputTransactions.currentPeriod[1].x;
-            const timeIntervalAsSeconds = (secondTimerange - firstTimerange) / 1000;
-            expect(timeIntervalAsSeconds).to.equal(30);
-          });
-
-          it('has a bucket size of 1 minute for metrics data', () => {
-            const firstTimerange = throughputMetrics.currentPeriod[0].x;
-            const secondTimerange = throughputMetrics.currentPeriod[1].x;
-            const timeIntervalAsMinutes = (secondTimerange - firstTimerange) / 1000 / 60;
-            expect(timeIntervalAsMinutes).to.equal(1);
-          });
+        it('returns some transactions data', () => {
+          expect(throughputTransactions.currentPeriod.length).to.be.greaterThan(0);
+          const hasData = throughputTransactions.currentPeriod.some(({ y }) => isFiniteNumber(y));
+          expect(hasData).to.equal(true);
         });
 
-        describe('production environment', () => {
-          let throughput: ThroughputReturn;
-
-          before(async () => {
-            const throughputResponse = await callApi({ query: { environment: 'production' } });
-            throughput = throughputResponse.body;
-          });
-
-          it('returns some data', () => {
-            expect(throughput.currentPeriod.length).to.be.greaterThan(0);
-            const hasData = throughput.currentPeriod.some(({ y }) => isFiniteNumber(y));
-            expect(hasData).to.equal(true);
-          });
-
-          it('returns correct average throughput', () => {
-            const throughputMean = meanBy(throughput.currentPeriod, 'y');
-            expect(roundNumber(throughputMean)).to.be.equal(roundNumber(GO_PROD_RATE));
-          });
+        it('returns some metrics data', () => {
+          expect(throughputMetrics.currentPeriod.length).to.be.greaterThan(0);
+          const hasData = throughputMetrics.currentPeriod.some(({ y }) => isFiniteNumber(y));
+          expect(hasData).to.equal(true);
         });
 
-        describe('when synth-java is selected', () => {
-          let throughput: ThroughputReturn;
-
-          before(async () => {
-            const throughputResponse = await callApi({ path: { serviceName: 'synth-java' } });
-            throughput = throughputResponse.body;
-          });
-
-          it('returns some data', () => {
-            expect(throughput.currentPeriod.length).to.be.greaterThan(0);
-            const hasData = throughput.currentPeriod.some(({ y }) => isFiniteNumber(y));
-            expect(hasData).to.equal(true);
-          });
-
-          it('returns throughput related to java agent', () => {
-            const throughputMean = meanBy(throughput.currentPeriod, 'y');
-            expect(roundNumber(throughputMean)).to.be.equal(roundNumber(JAVA_PROD_RATE));
-          });
+        it('has same mean value for metrics and transactions data', () => {
+          const transactionsMean = meanBy(throughputTransactions.currentPeriod, 'y');
+          const metricsMean = meanBy(throughputMetrics.currentPeriod, 'y');
+          [transactionsMean, metricsMean].forEach((value) =>
+            expect(roundNumber(value)).to.be.equal(roundNumber(GO_PROD_RATE + GO_DEV_RATE))
+          );
         });
 
-        describe('time comparisons', () => {
-          let throughputResponse: ThroughputReturn;
+        it('has a bucket size of 30 seconds for transactions data', () => {
+          const firstTimerange = throughputTransactions.currentPeriod[0].x;
+          const secondTimerange = throughputTransactions.currentPeriod[1].x;
+          const timeIntervalAsSeconds = (secondTimerange - firstTimerange) / 1000;
+          expect(timeIntervalAsSeconds).to.equal(30);
+        });
 
-          before(async () => {
-            const response = await callApi({
-              query: {
-                start: moment(end).subtract(7, 'minutes').toISOString(),
-                end: new Date(end).toISOString(),
-                offset: '7m',
-              },
-            });
-            throughputResponse = response.body;
-          });
-
-          it('returns some data', () => {
-            expect(throughputResponse.currentPeriod.length).to.be.greaterThan(0);
-            expect(throughputResponse.previousPeriod.length).to.be.greaterThan(0);
-
-            const hasCurrentPeriodData = throughputResponse.currentPeriod.some(({ y }) =>
-              isFiniteNumber(y)
-            );
-            const hasPreviousPeriodData = throughputResponse.previousPeriod.some(({ y }) =>
-              isFiniteNumber(y)
-            );
-
-            expect(hasCurrentPeriodData).to.equal(true);
-            expect(hasPreviousPeriodData).to.equal(true);
-          });
-
-          it('has same start time for both periods', () => {
-            expect(first(throughputResponse.currentPeriod)?.x).to.equal(
-              first(throughputResponse.previousPeriod)?.x
-            );
-          });
-
-          it('has same end time for both periods', () => {
-            expect(last(throughputResponse.currentPeriod)?.x).to.equal(
-              last(throughputResponse.previousPeriod)?.x
-            );
-          });
-
-          it('returns same number of buckets for both periods', () => {
-            expect(throughputResponse.currentPeriod.length).to.be(
-              throughputResponse.previousPeriod.length
-            );
-          });
-
-          it('has same mean value for both periods', () => {
-            const currentPeriodMean = meanBy(
-              throughputResponse.currentPeriod.filter(
-                (item) => isFiniteNumber(item.y) && item.y > 0
-              ),
-              'y'
-            );
-            const previousPeriodMean = meanBy(
-              throughputResponse.previousPeriod.filter(
-                (item) => isFiniteNumber(item.y) && item.y > 0
-              ),
-              'y'
-            );
-            const currentPeriod = throughputResponse.currentPeriod;
-            const bucketSize = currentPeriod[1].x - currentPeriod[0].x;
-            const durationAsMinutes = bucketSize / 1000 / 60;
-            [currentPeriodMean, previousPeriodMean].every((value) =>
-              expect(roundNumber(value)).to.be.equal(
-                roundNumber((GO_PROD_RATE + GO_DEV_RATE) / durationAsMinutes)
-              )
-            );
-          });
+        it('has a bucket size of 1 minute for metrics data', () => {
+          const firstTimerange = throughputMetrics.currentPeriod[0].x;
+          const secondTimerange = throughputMetrics.currentPeriod[1].x;
+          const timeIntervalAsMinutes = (secondTimerange - firstTimerange) / 1000 / 60;
+          expect(timeIntervalAsMinutes).to.equal(1);
         });
       });
-    }
-  );
+
+      describe('production environment', () => {
+        let throughput: ThroughputReturn;
+
+        before(async () => {
+          const throughputResponse = await callApi({ query: { environment: 'production' } });
+          throughput = throughputResponse.body;
+        });
+
+        it('returns some data', () => {
+          expect(throughput.currentPeriod.length).to.be.greaterThan(0);
+          const hasData = throughput.currentPeriod.some(({ y }) => isFiniteNumber(y));
+          expect(hasData).to.equal(true);
+        });
+
+        it('returns correct average throughput', () => {
+          const throughputMean = meanBy(throughput.currentPeriod, 'y');
+          expect(roundNumber(throughputMean)).to.be.equal(roundNumber(GO_PROD_RATE));
+        });
+      });
+
+      describe('when synth-java is selected', () => {
+        let throughput: ThroughputReturn;
+
+        before(async () => {
+          const throughputResponse = await callApi({ path: { serviceName: 'synth-java' } });
+          throughput = throughputResponse.body;
+        });
+
+        it('returns some data', () => {
+          expect(throughput.currentPeriod.length).to.be.greaterThan(0);
+          const hasData = throughput.currentPeriod.some(({ y }) => isFiniteNumber(y));
+          expect(hasData).to.equal(true);
+        });
+
+        it('returns throughput related to java agent', () => {
+          const throughputMean = meanBy(throughput.currentPeriod, 'y');
+          expect(roundNumber(throughputMean)).to.be.equal(roundNumber(JAVA_PROD_RATE));
+        });
+      });
+
+      describe('time comparisons', () => {
+        let throughputResponse: ThroughputReturn;
+
+        before(async () => {
+          const response = await callApi({
+            query: {
+              start: moment(end).subtract(7, 'minutes').toISOString(),
+              end: new Date(end).toISOString(),
+              offset: '7m',
+            },
+          });
+          throughputResponse = response.body;
+        });
+
+        it('returns some data', () => {
+          expect(throughputResponse.currentPeriod.length).to.be.greaterThan(0);
+          expect(throughputResponse.previousPeriod.length).to.be.greaterThan(0);
+
+          const hasCurrentPeriodData = throughputResponse.currentPeriod.some(({ y }) =>
+            isFiniteNumber(y)
+          );
+          const hasPreviousPeriodData = throughputResponse.previousPeriod.some(({ y }) =>
+            isFiniteNumber(y)
+          );
+
+          expect(hasCurrentPeriodData).to.equal(true);
+          expect(hasPreviousPeriodData).to.equal(true);
+        });
+
+        it('has same start time for both periods', () => {
+          expect(first(throughputResponse.currentPeriod)?.x).to.equal(
+            first(throughputResponse.previousPeriod)?.x
+          );
+        });
+
+        it('has same end time for both periods', () => {
+          expect(last(throughputResponse.currentPeriod)?.x).to.equal(
+            last(throughputResponse.previousPeriod)?.x
+          );
+        });
+
+        it('returns same number of buckets for both periods', () => {
+          expect(throughputResponse.currentPeriod.length).to.be(
+            throughputResponse.previousPeriod.length
+          );
+        });
+
+        it('has same mean value for both periods', () => {
+          const currentPeriodMean = meanBy(
+            throughputResponse.currentPeriod.filter((item) => isFiniteNumber(item.y) && item.y > 0),
+            'y'
+          );
+          const previousPeriodMean = meanBy(
+            throughputResponse.previousPeriod.filter(
+              (item) => isFiniteNumber(item.y) && item.y > 0
+            ),
+            'y'
+          );
+          const currentPeriod = throughputResponse.currentPeriod;
+          const bucketSize = currentPeriod[1].x - currentPeriod[0].x;
+          const durationAsMinutes = bucketSize / 1000 / 60;
+          [currentPeriodMean, previousPeriodMean].every((value) =>
+            expect(roundNumber(value)).to.be.equal(
+              roundNumber((GO_PROD_RATE + GO_DEV_RATE) / durationAsMinutes)
+            )
+          );
+        });
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/services/top_services.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/top_services.spec.ts
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'APM Services Overview with a basic license when data is not generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       it('handles the empty state', async () => {
         const response = await apmApiClient.readUser({
@@ -57,7 +57,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'APM Services Overview with a basic license when data is generated',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
+    { config: 'basic', archives: [] },
     () => {
       let response: {
         status: number;

--- a/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
@@ -386,73 +386,69 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
     }
   );
 
-  registry.when(
-    'Agent configurations through fleet',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      const name = 'myservice';
-      const environment = 'development';
-      const testConfig = {
-        service: { name, environment },
-        settings: { transaction_sample_rate: '0.9' },
-      };
+  registry.when('Agent configurations through fleet', { config: 'basic', archives: [] }, () => {
+    const name = 'myservice';
+    const environment = 'development';
+    const testConfig = {
+      service: { name, environment },
+      settings: { transaction_sample_rate: '0.9' },
+    };
 
-      let agentConfiguration:
-        | APIReturnType<'GET /api/apm/settings/agent-configuration/view'>
-        | undefined;
+    let agentConfiguration:
+      | APIReturnType<'GET /api/apm/settings/agent-configuration/view'>
+      | undefined;
 
+    before(async () => {
+      log.debug('creating agent configuration');
+      await createConfiguration(testConfig);
+      const { body } = await findExactConfiguration(name, environment);
+      agentConfiguration = body;
+    });
+
+    after(async () => {
+      await deleteConfiguration(testConfig);
+    });
+
+    it(`should have 'applied_by_agent=false' when there are no agent config metrics for this etag`, async () => {
+      expect(agentConfiguration?.applied_by_agent).to.be(false);
+    });
+
+    describe('when there are agent config metrics for this etag', () => {
       before(async () => {
-        log.debug('creating agent configuration');
-        await createConfiguration(testConfig);
-        const { body } = await findExactConfiguration(name, environment);
-        agentConfiguration = body;
-      });
+        const start = new Date().getTime();
+        const end = moment(start).add(15, 'minutes').valueOf();
 
-      after(async () => {
-        await deleteConfiguration(testConfig);
-      });
-
-      it(`should have 'applied_by_agent=false' when there are no agent config metrics for this etag`, async () => {
-        expect(agentConfiguration?.applied_by_agent).to.be(false);
-      });
-
-      describe('when there are agent config metrics for this etag', () => {
-        before(async () => {
-          const start = new Date().getTime();
-          const end = moment(start).add(15, 'minutes').valueOf();
-
-          await addAgentConfigMetrics({
-            synthtraceEsClient,
-            start,
-            end,
-            etag: agentConfiguration?.etag,
-          });
-        });
-
-        after(() => synthtraceEsClient.clean());
-
-        it(`should have 'applied_by_agent=true' when getting a config from all configurations`, async () => {
-          const {
-            body: { configurations },
-          } = await getAllConfigurations();
-
-          const updatedConfig = configurations.find(
-            (x) => x.service.name === name && x.service.environment === environment
-          );
-
-          expect(updatedConfig?.applied_by_agent).to.be(true);
-        });
-
-        it(`should have 'applied_by_agent=true' when getting a single config`, async () => {
-          const {
-            body: { applied_by_agent: appliedByAgent },
-          } = await findExactConfiguration(name, environment);
-
-          expect(appliedByAgent).to.be(true);
+        await addAgentConfigMetrics({
+          synthtraceEsClient,
+          start,
+          end,
+          etag: agentConfiguration?.etag,
         });
       });
-    }
-  );
+
+      after(() => synthtraceEsClient.clean());
+
+      it(`should have 'applied_by_agent=true' when getting a config from all configurations`, async () => {
+        const {
+          body: { configurations },
+        } = await getAllConfigurations();
+
+        const updatedConfig = configurations.find(
+          (x) => x.service.name === name && x.service.environment === environment
+        );
+
+        expect(updatedConfig?.applied_by_agent).to.be(true);
+      });
+
+      it(`should have 'applied_by_agent=true' when getting a single config`, async () => {
+        const {
+          body: { applied_by_agent: appliedByAgent },
+        } = await findExactConfiguration(name, environment);
+
+        expect(appliedByAgent).to.be(true);
+      });
+    });
+  });
 
   registry.when(
     'agent configuration when data is loaded',

--- a/x-pack/test/apm_api_integration/tests/span_links/span_links.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/span_links/span_links.spec.ts
@@ -18,479 +18,467 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const start = new Date('2022-01-01T00:00:00.000Z').getTime();
   const end = new Date('2022-01-01T00:15:00.000Z').getTime() - 1;
 
-  registry.when(
-    'contains linked children',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      let ids: ReturnType<typeof generateSpanLinksData>['ids'];
+  registry.when('contains linked children', { config: 'basic', archives: [] }, () => {
+    let ids: ReturnType<typeof generateSpanLinksData>['ids'];
 
-      before(async () => {
-        const spanLinksData = generateSpanLinksData();
+    before(async () => {
+      const spanLinksData = generateSpanLinksData();
 
-        ids = spanLinksData.ids;
+      ids = spanLinksData.ids;
 
-        await synthtraceEsClient.index(
-          new EntityArrayIterable(spanLinksData.apmFields.producerInternalOnly).merge(
-            new EntityArrayIterable(spanLinksData.apmFields.producerExternalOnly),
-            new EntityArrayIterable(spanLinksData.apmFields.producerConsumer),
-            new EntityArrayIterable(spanLinksData.apmFields.producerMultiple)
-          )
-        );
+      await synthtraceEsClient.index(
+        new EntityArrayIterable(spanLinksData.apmFields.producerInternalOnly).merge(
+          new EntityArrayIterable(spanLinksData.apmFields.producerExternalOnly),
+          new EntityArrayIterable(spanLinksData.apmFields.producerConsumer),
+          new EntityArrayIterable(spanLinksData.apmFields.producerMultiple)
+        )
+      );
+    });
+
+    after(() => synthtraceEsClient.clean());
+
+    describe('Span links count on traces', () => {
+      async function fetchTraces({ traceId }: { traceId: string }) {
+        return await apmApiClient.readUser({
+          endpoint: `GET /internal/apm/traces/{traceId}`,
+          params: {
+            path: { traceId },
+            query: {
+              start: new Date(start).toISOString(),
+              end: new Date(end).toISOString(),
+            },
+          },
+        });
+      }
+
+      describe('producer-internal-only trace', () => {
+        let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
+        before(async () => {
+          const tracesResponse = await fetchTraces({ traceId: ids.producerInternalOnly.traceId });
+          traces = tracesResponse.body;
+        });
+
+        it('contains two children link on Span A', () => {
+          expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(1);
+          expect(
+            traces.linkedChildrenOfSpanCountBySpanId[ids.producerInternalOnly.spanAId]
+          ).to.equal(2);
+        });
       });
 
-      after(() => synthtraceEsClient.clean());
+      describe('producer-external-only trace', () => {
+        let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
+        before(async () => {
+          const tracesResponse = await fetchTraces({ traceId: ids.producerExternalOnly.traceId });
+          traces = tracesResponse.body;
+        });
 
-      describe('Span links count on traces', () => {
-        async function fetchTraces({ traceId }: { traceId: string }) {
-          return await apmApiClient.readUser({
-            endpoint: `GET /internal/apm/traces/{traceId}`,
+        it('contains two children link on Span B', () => {
+          expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(2);
+          expect(
+            traces.linkedChildrenOfSpanCountBySpanId[ids.producerExternalOnly.spanBId]
+          ).to.equal(1);
+          expect(
+            traces.linkedChildrenOfSpanCountBySpanId[ids.producerExternalOnly.transactionBId]
+          ).to.equal(1);
+        });
+      });
+
+      describe('producer-consumer trace', () => {
+        let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
+        before(async () => {
+          const tracesResponse = await fetchTraces({ traceId: ids.producerConsumer.traceId });
+          traces = tracesResponse.body;
+        });
+
+        it('contains one children link on transaction C and two on span C', () => {
+          expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(2);
+          expect(
+            traces.linkedChildrenOfSpanCountBySpanId[ids.producerConsumer.transactionCId]
+          ).to.equal(1);
+          expect(traces.linkedChildrenOfSpanCountBySpanId[ids.producerConsumer.spanCId]).to.equal(
+            1
+          );
+        });
+      });
+
+      describe('consumer-multiple trace', () => {
+        let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
+        before(async () => {
+          const tracesResponse = await fetchTraces({ traceId: ids.producerMultiple.traceId });
+          traces = tracesResponse.body;
+        });
+
+        it('contains no children', () => {
+          expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(0);
+          expect(
+            traces.linkedChildrenOfSpanCountBySpanId[ids.producerMultiple.transactionDId]
+          ).to.equal(undefined);
+          expect(traces.linkedChildrenOfSpanCountBySpanId[ids.producerMultiple.spanEId]).to.equal(
+            undefined
+          );
+        });
+      });
+    });
+
+    describe('Span links details', () => {
+      async function fetchChildrenAndParentsDetails({
+        kuery,
+        traceId,
+        spanId,
+        processorEvent,
+      }: {
+        kuery: string;
+        traceId: string;
+        spanId: string;
+        processorEvent: ProcessorEvent;
+      }) {
+        const [childrenLinksResponse, parentsLinksResponse] = await Promise.all([
+          await apmApiClient.readUser({
+            endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/children',
             params: {
-              path: { traceId },
+              path: { traceId, spanId },
               query: {
+                kuery,
                 start: new Date(start).toISOString(),
                 end: new Date(end).toISOString(),
               },
             },
-          });
-        }
-
-        describe('producer-internal-only trace', () => {
-          let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
-          before(async () => {
-            const tracesResponse = await fetchTraces({ traceId: ids.producerInternalOnly.traceId });
-            traces = tracesResponse.body;
-          });
-
-          it('contains two children link on Span A', () => {
-            expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(1);
-            expect(
-              traces.linkedChildrenOfSpanCountBySpanId[ids.producerInternalOnly.spanAId]
-            ).to.equal(2);
-          });
-        });
-
-        describe('producer-external-only trace', () => {
-          let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
-          before(async () => {
-            const tracesResponse = await fetchTraces({ traceId: ids.producerExternalOnly.traceId });
-            traces = tracesResponse.body;
-          });
-
-          it('contains two children link on Span B', () => {
-            expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(2);
-            expect(
-              traces.linkedChildrenOfSpanCountBySpanId[ids.producerExternalOnly.spanBId]
-            ).to.equal(1);
-            expect(
-              traces.linkedChildrenOfSpanCountBySpanId[ids.producerExternalOnly.transactionBId]
-            ).to.equal(1);
-          });
-        });
-
-        describe('producer-consumer trace', () => {
-          let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
-          before(async () => {
-            const tracesResponse = await fetchTraces({ traceId: ids.producerConsumer.traceId });
-            traces = tracesResponse.body;
-          });
-
-          it('contains one children link on transaction C and two on span C', () => {
-            expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(2);
-            expect(
-              traces.linkedChildrenOfSpanCountBySpanId[ids.producerConsumer.transactionCId]
-            ).to.equal(1);
-            expect(traces.linkedChildrenOfSpanCountBySpanId[ids.producerConsumer.spanCId]).to.equal(
-              1
-            );
-          });
-        });
-
-        describe('consumer-multiple trace', () => {
-          let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
-          before(async () => {
-            const tracesResponse = await fetchTraces({ traceId: ids.producerMultiple.traceId });
-            traces = tracesResponse.body;
-          });
-
-          it('contains no children', () => {
-            expect(Object.values(traces.linkedChildrenOfSpanCountBySpanId).length).to.equal(0);
-            expect(
-              traces.linkedChildrenOfSpanCountBySpanId[ids.producerMultiple.transactionDId]
-            ).to.equal(undefined);
-            expect(traces.linkedChildrenOfSpanCountBySpanId[ids.producerMultiple.spanEId]).to.equal(
-              undefined
-            );
-          });
-        });
-      });
-
-      describe('Span links details', () => {
-        async function fetchChildrenAndParentsDetails({
-          kuery,
-          traceId,
-          spanId,
-          processorEvent,
-        }: {
-          kuery: string;
-          traceId: string;
-          spanId: string;
-          processorEvent: ProcessorEvent;
-        }) {
-          const [childrenLinksResponse, parentsLinksResponse] = await Promise.all([
-            await apmApiClient.readUser({
-              endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/children',
-              params: {
-                path: { traceId, spanId },
-                query: {
-                  kuery,
-                  start: new Date(start).toISOString(),
-                  end: new Date(end).toISOString(),
-                },
+          }),
+          apmApiClient.readUser({
+            endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/parents',
+            params: {
+              path: { traceId, spanId },
+              query: {
+                kuery,
+                start: new Date(start).toISOString(),
+                end: new Date(end).toISOString(),
+                processorEvent,
               },
+            },
+          }),
+        ]);
+
+        return {
+          childrenLinks: childrenLinksResponse.body,
+          parentsLinks: parentsLinksResponse.body,
+        };
+      }
+
+      describe('producer-internal-only span links details', () => {
+        let transactionALinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        let spanALinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        before(async () => {
+          const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all([
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerInternalOnly.traceId,
+              spanId: ids.producerInternalOnly.transactionAId,
+              processorEvent: ProcessorEvent.transaction,
             }),
-            apmApiClient.readUser({
-              endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/parents',
-              params: {
-                path: { traceId, spanId },
-                query: {
-                  kuery,
-                  start: new Date(start).toISOString(),
-                  end: new Date(end).toISOString(),
-                  processorEvent,
-                },
-              },
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerInternalOnly.traceId,
+              spanId: ids.producerInternalOnly.spanAId,
+              processorEvent: ProcessorEvent.span,
             }),
           ]);
-
-          return {
-            childrenLinks: childrenLinksResponse.body,
-            parentsLinks: parentsLinksResponse.body,
-          };
-        }
-
-        describe('producer-internal-only span links details', () => {
-          let transactionALinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          let spanALinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          before(async () => {
-            const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all(
-              [
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerInternalOnly.traceId,
-                  spanId: ids.producerInternalOnly.transactionAId,
-                  processorEvent: ProcessorEvent.transaction,
-                }),
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerInternalOnly.traceId,
-                  spanId: ids.producerInternalOnly.spanAId,
-                  processorEvent: ProcessorEvent.span,
-                }),
-              ]
-            );
-            transactionALinksDetails = transactionALinksDetailsResponse;
-            spanALinksDetails = spanALinksDetailsResponse;
-          });
-
-          it('returns no links for transaction A', () => {
-            expect(transactionALinksDetails.childrenLinks.spanLinksDetails).to.eql([]);
-            expect(transactionALinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
-          });
-
-          it('returns no parents on Span A', () => {
-            expect(spanALinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
-          });
-
-          it('returns two children on Span A', () => {
-            expect(spanALinksDetails.childrenLinks.spanLinksDetails.length).to.eql(2);
-            const serviceCDetails = spanALinksDetails.childrenLinks.spanLinksDetails.find(
-              (childDetails) => {
-                return (
-                  childDetails.traceId === ids.producerConsumer.traceId &&
-                  childDetails.spanId === ids.producerConsumer.transactionCId
-                );
-              }
-            );
-            expect(serviceCDetails?.details).to.eql({
-              serviceName: 'producer-consumer',
-              agentName: 'ruby',
-              transactionId: ids.producerConsumer.transactionCId,
-              spanName: 'Transaction C',
-              duration: 1000000,
-            });
-
-            const serviceDDetails = spanALinksDetails.childrenLinks.spanLinksDetails.find(
-              (childDetails) => {
-                return (
-                  childDetails.traceId === ids.producerMultiple.traceId &&
-                  childDetails.spanId === ids.producerMultiple.transactionDId
-                );
-              }
-            );
-            expect(serviceDDetails?.details).to.eql({
-              serviceName: 'consumer-multiple',
-              agentName: 'nodejs',
-              transactionId: ids.producerMultiple.transactionDId,
-              spanName: 'Transaction D',
-              duration: 1000000,
-            });
-          });
+          transactionALinksDetails = transactionALinksDetailsResponse;
+          spanALinksDetails = spanALinksDetailsResponse;
         });
 
-        describe('producer-external-only span links details', () => {
-          let transactionBLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          let spanBLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          before(async () => {
-            const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all(
-              [
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerExternalOnly.traceId,
-                  spanId: ids.producerExternalOnly.transactionBId,
-                  processorEvent: ProcessorEvent.transaction,
-                }),
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerExternalOnly.traceId,
-                  spanId: ids.producerExternalOnly.spanBId,
-                  processorEvent: ProcessorEvent.span,
-                }),
-              ]
-            );
-            transactionBLinksDetails = transactionALinksDetailsResponse;
-            spanBLinksDetails = spanALinksDetailsResponse;
-          });
-
-          it('returns producer-consumer as children of transaction B', () => {
-            expect(transactionBLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
-          });
-
-          it('returns no parent for transaction B', () => {
-            expect(transactionBLinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
-          });
-
-          it('returns external parent on Span B', () => {
-            expect(spanBLinksDetails.parentsLinks.spanLinksDetails.length).to.be(1);
-            expect(spanBLinksDetails.parentsLinks.spanLinksDetails).to.eql([
-              { traceId: 'trace#1', spanId: 'span#1' },
-            ]);
-          });
-
-          it('returns consumer-multiple as child on Span B', () => {
-            expect(spanBLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
-            expect(spanBLinksDetails.childrenLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerMultiple.traceId,
-                spanId: ids.producerMultiple.spanEId,
-                details: {
-                  serviceName: 'consumer-multiple',
-                  agentName: 'nodejs',
-                  transactionId: ids.producerMultiple.transactionDId,
-                  spanName: 'Span E',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-            ]);
-          });
+        it('returns no links for transaction A', () => {
+          expect(transactionALinksDetails.childrenLinks.spanLinksDetails).to.eql([]);
+          expect(transactionALinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
         });
 
-        describe('producer-consumer span links details', () => {
-          let transactionCLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          let spanCLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          before(async () => {
-            const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all(
-              [
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerConsumer.traceId,
-                  spanId: ids.producerConsumer.transactionCId,
-                  processorEvent: ProcessorEvent.transaction,
-                }),
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerConsumer.traceId,
-                  spanId: ids.producerConsumer.spanCId,
-                  processorEvent: ProcessorEvent.span,
-                }),
-              ]
-            );
-            transactionCLinksDetails = transactionALinksDetailsResponse;
-            spanCLinksDetails = spanALinksDetailsResponse;
-          });
-
-          it('returns producer-internal-only Span A, producer-external-only Transaction B, and External link as parents of Transaction C', () => {
-            expect(transactionCLinksDetails.parentsLinks.spanLinksDetails.length).to.be(3);
-            expect(transactionCLinksDetails.parentsLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerInternalOnly.traceId,
-                spanId: ids.producerInternalOnly.spanAId,
-                details: {
-                  serviceName: 'producer-internal-only',
-                  agentName: 'go',
-                  transactionId: ids.producerInternalOnly.transactionAId,
-                  spanName: 'Span A',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-              {
-                traceId: ids.producerExternalOnly.traceId,
-                spanId: ids.producerExternalOnly.transactionBId,
-                details: {
-                  serviceName: 'producer-external-only',
-                  agentName: 'java',
-                  transactionId: ids.producerExternalOnly.transactionBId,
-                  duration: 1000000,
-                  spanName: 'Transaction B',
-                },
-              },
-              {
-                traceId: ids.producerConsumer.externalTraceId,
-                spanId: ids.producerExternalOnly.spanBId,
-              },
-            ]);
-          });
-
-          it('returns consumer-multiple Span E as child of Transaction C', () => {
-            expect(transactionCLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
-            expect(transactionCLinksDetails.childrenLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerMultiple.traceId,
-                spanId: ids.producerMultiple.spanEId,
-                details: {
-                  serviceName: 'consumer-multiple',
-                  agentName: 'nodejs',
-                  transactionId: ids.producerMultiple.transactionDId,
-                  spanName: 'Span E',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-            ]);
-          });
-
-          it('returns no child on Span C', () => {
-            expect(spanCLinksDetails.parentsLinks.spanLinksDetails.length).to.be(0);
-          });
-
-          it('returns consumer-multiple as Child on producer-consumer', () => {
-            expect(spanCLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
-            expect(spanCLinksDetails.childrenLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerMultiple.traceId,
-                spanId: ids.producerMultiple.transactionDId,
-                details: {
-                  serviceName: 'consumer-multiple',
-                  agentName: 'nodejs',
-                  transactionId: ids.producerMultiple.transactionDId,
-                  spanName: 'Transaction D',
-                  duration: 1000000,
-                },
-              },
-            ]);
-          });
+        it('returns no parents on Span A', () => {
+          expect(spanALinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
         });
 
-        describe('consumer-multiple span links details', () => {
-          let transactionDLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          let spanELinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
-          before(async () => {
-            const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all(
-              [
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerMultiple.traceId,
-                  spanId: ids.producerMultiple.transactionDId,
-                  processorEvent: ProcessorEvent.transaction,
-                }),
-                fetchChildrenAndParentsDetails({
-                  kuery: '',
-                  traceId: ids.producerMultiple.traceId,
-                  spanId: ids.producerMultiple.spanEId,
-                  processorEvent: ProcessorEvent.span,
-                }),
-              ]
-            );
-            transactionDLinksDetails = transactionALinksDetailsResponse;
-            spanELinksDetails = spanALinksDetailsResponse;
+        it('returns two children on Span A', () => {
+          expect(spanALinksDetails.childrenLinks.spanLinksDetails.length).to.eql(2);
+          const serviceCDetails = spanALinksDetails.childrenLinks.spanLinksDetails.find(
+            (childDetails) => {
+              return (
+                childDetails.traceId === ids.producerConsumer.traceId &&
+                childDetails.spanId === ids.producerConsumer.transactionCId
+              );
+            }
+          );
+          expect(serviceCDetails?.details).to.eql({
+            serviceName: 'producer-consumer',
+            agentName: 'ruby',
+            transactionId: ids.producerConsumer.transactionCId,
+            spanName: 'Transaction C',
+            duration: 1000000,
           });
 
-          it('returns producer-internal-only Span A and producer-consumer Span C as parents of Transaction D', () => {
-            expect(transactionDLinksDetails.parentsLinks.spanLinksDetails.length).to.be(2);
-            expect(transactionDLinksDetails.parentsLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerInternalOnly.traceId,
-                spanId: ids.producerInternalOnly.spanAId,
-                details: {
-                  serviceName: 'producer-internal-only',
-                  agentName: 'go',
-                  transactionId: ids.producerInternalOnly.transactionAId,
-                  spanName: 'Span A',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-              {
-                traceId: ids.producerConsumer.traceId,
-                spanId: ids.producerConsumer.spanCId,
-                details: {
-                  serviceName: 'producer-consumer',
-                  agentName: 'ruby',
-                  transactionId: ids.producerConsumer.transactionCId,
-                  spanName: 'Span C',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-            ]);
-          });
-
-          it('returns no children on Transaction D', () => {
-            expect(transactionDLinksDetails.childrenLinks.spanLinksDetails.length).to.be(0);
-          });
-
-          it('returns producer-external-only Span B and producer-consumer Transaction C as parents of Span E', () => {
-            expect(spanELinksDetails.parentsLinks.spanLinksDetails.length).to.be(2);
-
-            expect(spanELinksDetails.parentsLinks.spanLinksDetails).to.eql([
-              {
-                traceId: ids.producerExternalOnly.traceId,
-                spanId: ids.producerExternalOnly.spanBId,
-                details: {
-                  serviceName: 'producer-external-only',
-                  agentName: 'java',
-                  transactionId: ids.producerExternalOnly.transactionBId,
-                  spanName: 'Span B',
-                  duration: 100000,
-                  spanSubtype: 'http',
-                  spanType: 'external',
-                },
-              },
-              {
-                traceId: ids.producerConsumer.traceId,
-                spanId: ids.producerConsumer.transactionCId,
-                details: {
-                  serviceName: 'producer-consumer',
-                  agentName: 'ruby',
-                  transactionId: ids.producerConsumer.transactionCId,
-                  spanName: 'Transaction C',
-                  duration: 1000000,
-                },
-              },
-            ]);
-          });
-
-          it('returns no children on Span E', () => {
-            expect(spanELinksDetails.childrenLinks.spanLinksDetails.length).to.be(0);
+          const serviceDDetails = spanALinksDetails.childrenLinks.spanLinksDetails.find(
+            (childDetails) => {
+              return (
+                childDetails.traceId === ids.producerMultiple.traceId &&
+                childDetails.spanId === ids.producerMultiple.transactionDId
+              );
+            }
+          );
+          expect(serviceDDetails?.details).to.eql({
+            serviceName: 'consumer-multiple',
+            agentName: 'nodejs',
+            transactionId: ids.producerMultiple.transactionDId,
+            spanName: 'Transaction D',
+            duration: 1000000,
           });
         });
       });
-    }
-  );
+
+      describe('producer-external-only span links details', () => {
+        let transactionBLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        let spanBLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        before(async () => {
+          const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all([
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerExternalOnly.traceId,
+              spanId: ids.producerExternalOnly.transactionBId,
+              processorEvent: ProcessorEvent.transaction,
+            }),
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerExternalOnly.traceId,
+              spanId: ids.producerExternalOnly.spanBId,
+              processorEvent: ProcessorEvent.span,
+            }),
+          ]);
+          transactionBLinksDetails = transactionALinksDetailsResponse;
+          spanBLinksDetails = spanALinksDetailsResponse;
+        });
+
+        it('returns producer-consumer as children of transaction B', () => {
+          expect(transactionBLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
+        });
+
+        it('returns no parent for transaction B', () => {
+          expect(transactionBLinksDetails.parentsLinks.spanLinksDetails).to.eql([]);
+        });
+
+        it('returns external parent on Span B', () => {
+          expect(spanBLinksDetails.parentsLinks.spanLinksDetails.length).to.be(1);
+          expect(spanBLinksDetails.parentsLinks.spanLinksDetails).to.eql([
+            { traceId: 'trace#1', spanId: 'span#1' },
+          ]);
+        });
+
+        it('returns consumer-multiple as child on Span B', () => {
+          expect(spanBLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
+          expect(spanBLinksDetails.childrenLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerMultiple.traceId,
+              spanId: ids.producerMultiple.spanEId,
+              details: {
+                serviceName: 'consumer-multiple',
+                agentName: 'nodejs',
+                transactionId: ids.producerMultiple.transactionDId,
+                spanName: 'Span E',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+          ]);
+        });
+      });
+
+      describe('producer-consumer span links details', () => {
+        let transactionCLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        let spanCLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        before(async () => {
+          const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all([
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerConsumer.traceId,
+              spanId: ids.producerConsumer.transactionCId,
+              processorEvent: ProcessorEvent.transaction,
+            }),
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerConsumer.traceId,
+              spanId: ids.producerConsumer.spanCId,
+              processorEvent: ProcessorEvent.span,
+            }),
+          ]);
+          transactionCLinksDetails = transactionALinksDetailsResponse;
+          spanCLinksDetails = spanALinksDetailsResponse;
+        });
+
+        it('returns producer-internal-only Span A, producer-external-only Transaction B, and External link as parents of Transaction C', () => {
+          expect(transactionCLinksDetails.parentsLinks.spanLinksDetails.length).to.be(3);
+          expect(transactionCLinksDetails.parentsLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerInternalOnly.traceId,
+              spanId: ids.producerInternalOnly.spanAId,
+              details: {
+                serviceName: 'producer-internal-only',
+                agentName: 'go',
+                transactionId: ids.producerInternalOnly.transactionAId,
+                spanName: 'Span A',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+            {
+              traceId: ids.producerExternalOnly.traceId,
+              spanId: ids.producerExternalOnly.transactionBId,
+              details: {
+                serviceName: 'producer-external-only',
+                agentName: 'java',
+                transactionId: ids.producerExternalOnly.transactionBId,
+                duration: 1000000,
+                spanName: 'Transaction B',
+              },
+            },
+            {
+              traceId: ids.producerConsumer.externalTraceId,
+              spanId: ids.producerExternalOnly.spanBId,
+            },
+          ]);
+        });
+
+        it('returns consumer-multiple Span E as child of Transaction C', () => {
+          expect(transactionCLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
+          expect(transactionCLinksDetails.childrenLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerMultiple.traceId,
+              spanId: ids.producerMultiple.spanEId,
+              details: {
+                serviceName: 'consumer-multiple',
+                agentName: 'nodejs',
+                transactionId: ids.producerMultiple.transactionDId,
+                spanName: 'Span E',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+          ]);
+        });
+
+        it('returns no child on Span C', () => {
+          expect(spanCLinksDetails.parentsLinks.spanLinksDetails.length).to.be(0);
+        });
+
+        it('returns consumer-multiple as Child on producer-consumer', () => {
+          expect(spanCLinksDetails.childrenLinks.spanLinksDetails.length).to.be(1);
+          expect(spanCLinksDetails.childrenLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerMultiple.traceId,
+              spanId: ids.producerMultiple.transactionDId,
+              details: {
+                serviceName: 'consumer-multiple',
+                agentName: 'nodejs',
+                transactionId: ids.producerMultiple.transactionDId,
+                spanName: 'Transaction D',
+                duration: 1000000,
+              },
+            },
+          ]);
+        });
+      });
+
+      describe('consumer-multiple span links details', () => {
+        let transactionDLinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        let spanELinksDetails: Awaited<ReturnType<typeof fetchChildrenAndParentsDetails>>;
+        before(async () => {
+          const [transactionALinksDetailsResponse, spanALinksDetailsResponse] = await Promise.all([
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerMultiple.traceId,
+              spanId: ids.producerMultiple.transactionDId,
+              processorEvent: ProcessorEvent.transaction,
+            }),
+            fetchChildrenAndParentsDetails({
+              kuery: '',
+              traceId: ids.producerMultiple.traceId,
+              spanId: ids.producerMultiple.spanEId,
+              processorEvent: ProcessorEvent.span,
+            }),
+          ]);
+          transactionDLinksDetails = transactionALinksDetailsResponse;
+          spanELinksDetails = spanALinksDetailsResponse;
+        });
+
+        it('returns producer-internal-only Span A and producer-consumer Span C as parents of Transaction D', () => {
+          expect(transactionDLinksDetails.parentsLinks.spanLinksDetails.length).to.be(2);
+          expect(transactionDLinksDetails.parentsLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerInternalOnly.traceId,
+              spanId: ids.producerInternalOnly.spanAId,
+              details: {
+                serviceName: 'producer-internal-only',
+                agentName: 'go',
+                transactionId: ids.producerInternalOnly.transactionAId,
+                spanName: 'Span A',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+            {
+              traceId: ids.producerConsumer.traceId,
+              spanId: ids.producerConsumer.spanCId,
+              details: {
+                serviceName: 'producer-consumer',
+                agentName: 'ruby',
+                transactionId: ids.producerConsumer.transactionCId,
+                spanName: 'Span C',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+          ]);
+        });
+
+        it('returns no children on Transaction D', () => {
+          expect(transactionDLinksDetails.childrenLinks.spanLinksDetails.length).to.be(0);
+        });
+
+        it('returns producer-external-only Span B and producer-consumer Transaction C as parents of Span E', () => {
+          expect(spanELinksDetails.parentsLinks.spanLinksDetails.length).to.be(2);
+
+          expect(spanELinksDetails.parentsLinks.spanLinksDetails).to.eql([
+            {
+              traceId: ids.producerExternalOnly.traceId,
+              spanId: ids.producerExternalOnly.spanBId,
+              details: {
+                serviceName: 'producer-external-only',
+                agentName: 'java',
+                transactionId: ids.producerExternalOnly.transactionBId,
+                spanName: 'Span B',
+                duration: 100000,
+                spanSubtype: 'http',
+                spanType: 'external',
+              },
+            },
+            {
+              traceId: ids.producerConsumer.traceId,
+              spanId: ids.producerConsumer.transactionCId,
+              details: {
+                serviceName: 'producer-consumer',
+                agentName: 'ruby',
+                transactionId: ids.producerConsumer.transactionCId,
+                spanName: 'Transaction C',
+                duration: 1000000,
+              },
+            },
+          ]);
+        });
+
+        it('returns no children on Span E', () => {
+          expect(spanELinksDetails.childrenLinks.spanLinksDetails.length).to.be(0);
+        });
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/throughput/service_apis.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/throughput/service_apis.spec.ts
@@ -104,7 +104,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   let throughputMetricValues: Awaited<ReturnType<typeof getThroughputValues>>;
   let throughputTransactionValues: Awaited<ReturnType<typeof getThroughputValues>>;
 
-  registry.when('Services APIs', { config: 'basic', archives: ['apm_mappings_only_8.0.0'] }, () => {
+  registry.when('Services APIs', { config: 'basic', archives: [] }, () => {
     describe('when data is loaded ', () => {
       const GO_PROD_RATE = 80;
       const GO_DEV_RATE = 20;

--- a/x-pack/test/apm_api_integration/tests/throughput/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/throughput/service_maps.spec.ts
@@ -69,74 +69,67 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   let throughputMetricValues: Awaited<ReturnType<typeof getThroughputValues>>;
   let throughputTransactionValues: Awaited<ReturnType<typeof getThroughputValues>>;
 
-  registry.when(
-    'Service maps APIs',
-    { config: 'trial', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('when data is loaded ', () => {
-        const GO_PROD_RATE = 80;
-        const GO_DEV_RATE = 20;
-        before(async () => {
-          const serviceGoProdInstance = apm
-            .service(serviceName, 'production', 'go')
-            .instance('instance-a');
-          const serviceGoDevInstance = apm
-            .service(serviceName, 'development', 'go')
-            .instance('instance-b');
+  registry.when('Service maps APIs', { config: 'trial', archives: [] }, () => {
+    describe('when data is loaded ', () => {
+      const GO_PROD_RATE = 80;
+      const GO_DEV_RATE = 20;
+      before(async () => {
+        const serviceGoProdInstance = apm
+          .service(serviceName, 'production', 'go')
+          .instance('instance-a');
+        const serviceGoDevInstance = apm
+          .service(serviceName, 'development', 'go')
+          .instance('instance-b');
 
-          await synthtraceEsClient.index([
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction('GET /apple 🍎 ', 'Worker')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_DEV_RATE)
-              .generator((timestamp) =>
-                serviceGoDevInstance
-                  .transaction('GET /apple 🍎 ')
-                  .duration(1000)
-                  .timestamp(timestamp)
-              ),
+        await synthtraceEsClient.index([
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction('GET /apple 🍎 ', 'Worker')
+                .duration(1000)
+                .timestamp(timestamp)
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_DEV_RATE)
+            .generator((timestamp) =>
+              serviceGoDevInstance.transaction('GET /apple 🍎 ').duration(1000).timestamp(timestamp)
+            ),
+        ]);
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('compare throughput value between service inventory and service maps', () => {
+        before(async () => {
+          [throughputTransactionValues, throughputMetricValues] = await Promise.all([
+            getThroughputValues('transaction'),
+            getThroughputValues('metric'),
           ]);
         });
 
-        after(() => synthtraceEsClient.clean());
-
-        describe('compare throughput value between service inventory and service maps', () => {
-          before(async () => {
-            [throughputTransactionValues, throughputMetricValues] = await Promise.all([
-              getThroughputValues('transaction'),
-              getThroughputValues('metric'),
-            ]);
-          });
-
-          it('returns same throughput value for Transaction-based and Metric-based data', () => {
-            [
-              ...Object.values(throughputTransactionValues),
-              ...Object.values(throughputMetricValues),
-            ].forEach((value) => expect(roundNumber(value)).to.be.equal(GO_DEV_RATE));
-          });
-        });
-
-        describe('when calling service maps transactions stats api', () => {
-          let serviceMapsNodeThroughput: number | null | undefined;
-          before(async () => {
-            const response = await callApi();
-            serviceMapsNodeThroughput =
-              response.body.currentPeriod.transactionStats?.throughput?.value;
-          });
-
-          it('returns expected throughput value', () => {
-            expect(roundNumber(serviceMapsNodeThroughput)).to.be.equal(GO_DEV_RATE);
-          });
+        it('returns same throughput value for Transaction-based and Metric-based data', () => {
+          [
+            ...Object.values(throughputTransactionValues),
+            ...Object.values(throughputMetricValues),
+          ].forEach((value) => expect(roundNumber(value)).to.be.equal(GO_DEV_RATE));
         });
       });
-    }
-  );
+
+      describe('when calling service maps transactions stats api', () => {
+        let serviceMapsNodeThroughput: number | null | undefined;
+        before(async () => {
+          const response = await callApi();
+          serviceMapsNodeThroughput =
+            response.body.currentPeriod.transactionStats?.throughput?.value;
+        });
+
+        it('returns expected throughput value', () => {
+          expect(roundNumber(serviceMapsNodeThroughput)).to.be.equal(GO_DEV_RATE);
+        });
+      });
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/traces/find_traces.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/find_traces.spec.ts
@@ -80,185 +80,146 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     );
   }
 
-  registry.when(
-    'Find traces when traces do not exist',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      it('handles empty state', async () => {
-        const response = await fetchTraceSamples({
-          query: '',
-          type: TraceSearchType.kql,
-          environment: ENVIRONMENT_ALL.value,
-        });
-
-        expect(response.status).to.be(200);
-        expect(response.body).to.eql({
-          samples: [],
-        });
-      });
-    }
-  );
-
-  registry.when(
-    'Find traces when traces exist',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      before(() => {
-        const java = apm.service('java', 'production', 'java').instance('java');
-
-        const node = apm.service('node', 'development', 'nodejs').instance('node');
-
-        const python = apm.service('python', 'production', 'python').instance('python');
-
-        function generateTrace(
-          timestamp: number,
-          order: Instance[],
-          db?: 'elasticsearch' | 'redis'
-        ) {
-          return order
-            .concat()
-            .reverse()
-            .reduce<Transaction | undefined>((prev, instance, index) => {
-              const invertedIndex = order.length - index - 1;
-
-              const duration = 50;
-              const time = timestamp + invertedIndex * 10;
-
-              const transaction: Transaction = instance
-                .transaction(`GET /${instance.fields['service.name']!}/api`)
-                .timestamp(time)
-                .duration(duration);
-
-              if (prev) {
-                const next = order[invertedIndex + 1].fields['service.name']!;
-                transaction.children(
-                  instance
-                    .span(`GET ${next}/api`, 'external', 'http')
-                    .destination(next)
-                    .duration(duration)
-                    .timestamp(time + 1)
-                    .children(prev)
-                );
-              } else if (db) {
-                transaction.children(
-                  instance
-                    .span(db, 'db', db)
-                    .destination(db)
-                    .duration(duration)
-                    .timestamp(time + 1)
-                );
-              }
-
-              return transaction;
-            }, undefined)!;
-        }
-
-        return synthtraceEsClient.index(
-          timerange(start, end)
-            .interval('15m')
-            .rate(1)
-            .generator((timestamp) => {
-              return [
-                generateTrace(timestamp, [java, node]),
-                generateTrace(timestamp, [node, java], 'redis'),
-                generateTrace(timestamp, [python], 'redis'),
-                generateTrace(timestamp, [python, node, java], 'elasticsearch'),
-                generateTrace(timestamp, [java, python, node]),
-              ];
-            })
-        );
+  registry.when('Find traces when traces do not exist', { config: 'basic', archives: [] }, () => {
+    it('handles empty state', async () => {
+      const response = await fetchTraceSamples({
+        query: '',
+        type: TraceSearchType.kql,
+        environment: ENVIRONMENT_ALL.value,
       });
 
-      describe('when using KQL', () => {
-        describe('and the query is empty', () => {
-          it('returns all trace samples', async () => {
-            const {
-              body: { samples },
-            } = await fetchTraceSamples({
-              query: '',
-              type: TraceSearchType.kql,
-              environment: 'ENVIRONMENT_ALL',
-            });
-
-            expect(samples.length).to.eql(5);
-          });
-        });
-
-        describe('and query is set', () => {
-          it('returns the relevant traces', async () => {
-            const {
-              body: { samples },
-            } = await fetchTraceSamples({
-              query: 'span.destination.service.resource:elasticsearch',
-              type: TraceSearchType.kql,
-              environment: 'ENVIRONMENT_ALL',
-            });
-
-            expect(samples.length).to.eql(1);
-          });
-        });
+      expect(response.status).to.be(200);
+      expect(response.body).to.eql({
+        samples: [],
       });
+    });
+  });
 
-      describe('when using EQL', () => {
-        describe('and the query is invalid', () => {
-          it.skip('returns a 400', async function () {
-            try {
-              await fetchTraceSamples({
-                query: '',
-                type: TraceSearchType.eql,
-                environment: 'ENVIRONMENT_ALL',
-              });
-              this.fail();
-            } catch (error: unknown) {
-              const apiError = error as ApmApiError;
-              expect(apiError.res.status).to.eql(400);
+  registry.when('Find traces when traces exist', { config: 'basic', archives: [] }, () => {
+    before(() => {
+      const java = apm.service('java', 'production', 'java').instance('java');
+
+      const node = apm.service('node', 'development', 'nodejs').instance('node');
+
+      const python = apm.service('python', 'production', 'python').instance('python');
+
+      function generateTrace(timestamp: number, order: Instance[], db?: 'elasticsearch' | 'redis') {
+        return order
+          .concat()
+          .reverse()
+          .reduce<Transaction | undefined>((prev, instance, index) => {
+            const invertedIndex = order.length - index - 1;
+
+            const duration = 50;
+            const time = timestamp + invertedIndex * 10;
+
+            const transaction: Transaction = instance
+              .transaction(`GET /${instance.fields['service.name']!}/api`)
+              .timestamp(time)
+              .duration(duration);
+
+            if (prev) {
+              const next = order[invertedIndex + 1].fields['service.name']!;
+              transaction.children(
+                instance
+                  .span(`GET ${next}/api`, 'external', 'http')
+                  .destination(next)
+                  .duration(duration)
+                  .timestamp(time + 1)
+                  .children(prev)
+              );
+            } else if (db) {
+              transaction.children(
+                instance
+                  .span(db, 'db', db)
+                  .destination(db)
+                  .duration(duration)
+                  .timestamp(time + 1)
+              );
             }
-          });
-        });
 
-        describe('and the query is set', () => {
-          it('returns the correct trace samples for transaction sequences', async () => {
-            const {
-              body: { samples },
-            } = await fetchTraceSamples({
-              query: `sequence by trace.id
-                [ transaction where service.name == "java" ]
-                [ transaction where service.name == "node" ]`,
+            return transaction;
+          }, undefined)!;
+      }
+
+      return synthtraceEsClient.index(
+        timerange(start, end)
+          .interval('15m')
+          .rate(1)
+          .generator((timestamp) => {
+            return [
+              generateTrace(timestamp, [java, node]),
+              generateTrace(timestamp, [node, java], 'redis'),
+              generateTrace(timestamp, [python], 'redis'),
+              generateTrace(timestamp, [python, node, java], 'elasticsearch'),
+              generateTrace(timestamp, [java, python, node]),
+            ];
+          })
+      );
+    });
+
+    describe('when using KQL', () => {
+      describe('and the query is empty', () => {
+        it('returns all trace samples', async () => {
+          const {
+            body: { samples },
+          } = await fetchTraceSamples({
+            query: '',
+            type: TraceSearchType.kql,
+            environment: 'ENVIRONMENT_ALL',
+          });
+
+          expect(samples.length).to.eql(5);
+        });
+      });
+
+      describe('and query is set', () => {
+        it('returns the relevant traces', async () => {
+          const {
+            body: { samples },
+          } = await fetchTraceSamples({
+            query: 'span.destination.service.resource:elasticsearch',
+            type: TraceSearchType.kql,
+            environment: 'ENVIRONMENT_ALL',
+          });
+
+          expect(samples.length).to.eql(1);
+        });
+      });
+    });
+
+    describe('when using EQL', () => {
+      describe('and the query is invalid', () => {
+        it.skip('returns a 400', async function () {
+          try {
+            await fetchTraceSamples({
+              query: '',
               type: TraceSearchType.eql,
               environment: 'ENVIRONMENT_ALL',
             });
-
-            const traces = await fetchTraces(samples);
-
-            expect(traces.length).to.eql(2);
-
-            const mapped = traces.map((traceDocs) => {
-              return sortBy(traceDocs, '@timestamp')
-                .filter((doc) => doc.processor.event === 'transaction')
-                .map((doc) => doc.service.name);
-            });
-
-            expect(mapped).to.eql([
-              ['java', 'node'],
-              ['java', 'python', 'node'],
-            ]);
-          });
+            this.fail();
+          } catch (error: unknown) {
+            const apiError = error as ApmApiError;
+            expect(apiError.res.status).to.eql(400);
+          }
         });
+      });
 
-        it('returns the correct trace samples for join sequences', async () => {
+      describe('and the query is set', () => {
+        it('returns the correct trace samples for transaction sequences', async () => {
           const {
             body: { samples },
           } = await fetchTraceSamples({
             query: `sequence by trace.id
-              [ span where service.name == "java" ] by span.id
-              [ transaction where service.name == "python" ] by parent.id`,
+                [ transaction where service.name == "java" ]
+                [ transaction where service.name == "node" ]`,
             type: TraceSearchType.eql,
             environment: 'ENVIRONMENT_ALL',
           });
 
           const traces = await fetchTraces(samples);
 
-          expect(traces.length).to.eql(1);
+          expect(traces.length).to.eql(2);
 
           const mapped = traces.map((traceDocs) => {
             return sortBy(traceDocs, '@timestamp')
@@ -266,42 +227,69 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               .map((doc) => doc.service.name);
           });
 
-          expect(mapped).to.eql([['java', 'python', 'node']]);
-        });
-
-        it('returns the correct trace samples for exit spans', async () => {
-          const {
-            body: { samples },
-          } = await fetchTraceSamples({
-            query: `sequence by trace.id
-              [ transaction where service.name == "python" ]
-              [ span where span.destination.service.resource == "redis" ]`,
-            type: TraceSearchType.eql,
-            environment: 'ENVIRONMENT_ALL',
-          });
-
-          const traces = await fetchTraces(samples);
-
-          expect(traces.length).to.eql(1);
-
-          const mapped = traces.map((traceDocs) => {
-            return sortBy(traceDocs, '@timestamp')
-              .filter(
-                (doc) => doc.processor.event === 'transaction' || doc.processor.event === 'span'
-              )
-              .map((doc) => {
-                if (doc.span && 'destination' in doc.span) {
-                  return doc.span.destination!.service.resource;
-                }
-                return doc.service.name;
-              });
-          });
-
-          expect(mapped).to.eql([['python', 'redis']]);
+          expect(mapped).to.eql([
+            ['java', 'node'],
+            ['java', 'python', 'node'],
+          ]);
         });
       });
 
-      after(() => synthtraceEsClient.clean());
-    }
-  );
+      it('returns the correct trace samples for join sequences', async () => {
+        const {
+          body: { samples },
+        } = await fetchTraceSamples({
+          query: `sequence by trace.id
+              [ span where service.name == "java" ] by span.id
+              [ transaction where service.name == "python" ] by parent.id`,
+          type: TraceSearchType.eql,
+          environment: 'ENVIRONMENT_ALL',
+        });
+
+        const traces = await fetchTraces(samples);
+
+        expect(traces.length).to.eql(1);
+
+        const mapped = traces.map((traceDocs) => {
+          return sortBy(traceDocs, '@timestamp')
+            .filter((doc) => doc.processor.event === 'transaction')
+            .map((doc) => doc.service.name);
+        });
+
+        expect(mapped).to.eql([['java', 'python', 'node']]);
+      });
+
+      it('returns the correct trace samples for exit spans', async () => {
+        const {
+          body: { samples },
+        } = await fetchTraceSamples({
+          query: `sequence by trace.id
+              [ transaction where service.name == "python" ]
+              [ span where span.destination.service.resource == "redis" ]`,
+          type: TraceSearchType.eql,
+          environment: 'ENVIRONMENT_ALL',
+        });
+
+        const traces = await fetchTraces(samples);
+
+        expect(traces.length).to.eql(1);
+
+        const mapped = traces.map((traceDocs) => {
+          return sortBy(traceDocs, '@timestamp')
+            .filter(
+              (doc) => doc.processor.event === 'transaction' || doc.processor.event === 'span'
+            )
+            .map((doc) => {
+              if (doc.span && 'destination' in doc.span) {
+                return doc.span.destination!.service.resource;
+              }
+              return doc.service.name;
+            });
+        });
+
+        expect(mapped).to.eql([['python', 'redis']]);
+      });
+    });
+
+    after(() => synthtraceEsClient.clean());
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
@@ -52,7 +52,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  registry.when('Trace exists', { config: 'basic', archives: ['apm_mappings_only_8.0.0'] }, () => {
+  registry.when('Trace exists', { config: 'basic', archives: [] }, () => {
     let serviceATraceId: string;
     before(async () => {
       const instanceJava = apm.service('synth-apple', 'production', 'java').instance('instance-b');

--- a/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.spec.ts
@@ -75,178 +75,172 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  registry.when(
-    'data is loaded',
-    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
-    () => {
-      describe('transactions groups detailed stats', () => {
-        const GO_PROD_RATE = 75;
-        const GO_PROD_ERROR_RATE = 25;
+  registry.when('data is loaded', { config: 'basic', archives: [] }, () => {
+    describe('transactions groups detailed stats', () => {
+      const GO_PROD_RATE = 75;
+      const GO_PROD_ERROR_RATE = 25;
+      before(async () => {
+        const serviceGoProdInstance = apm
+          .service(serviceName, 'production', 'go')
+          .instance('instance-a');
+
+        const transactionName = 'GET /api/product/list';
+
+        await synthtraceEsClient.index([
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction(transactionName)
+                .timestamp(timestamp)
+                .duration(1000)
+                .success()
+            ),
+          timerange(start, end)
+            .interval('1m')
+            .rate(GO_PROD_ERROR_RATE)
+            .generator((timestamp) =>
+              serviceGoProdInstance
+                .transaction(transactionName)
+                .duration(1000)
+                .timestamp(timestamp)
+                .failure()
+            ),
+        ]);
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('without comparisons', () => {
+        let transactionsStatistics: TransactionsGroupsDetailedStatistics;
+        let metricsStatistics: TransactionsGroupsDetailedStatistics;
         before(async () => {
-          const serviceGoProdInstance = apm
-            .service(serviceName, 'production', 'go')
-            .instance('instance-a');
-
-          const transactionName = 'GET /api/product/list';
-
-          await synthtraceEsClient.index([
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction(transactionName)
-                  .timestamp(timestamp)
-                  .duration(1000)
-                  .success()
-              ),
-            timerange(start, end)
-              .interval('1m')
-              .rate(GO_PROD_ERROR_RATE)
-              .generator((timestamp) =>
-                serviceGoProdInstance
-                  .transaction(transactionName)
-                  .duration(1000)
-                  .timestamp(timestamp)
-                  .failure()
-              ),
+          [metricsStatistics, transactionsStatistics] = await Promise.all([
+            callApi({ query: { kuery: 'processor.event : "metric"' } }),
+            callApi({ query: { kuery: 'processor.event : "transaction"' } }),
           ]);
         });
 
-        after(() => synthtraceEsClient.clean());
+        it('returns some transactions data', () => {
+          expect(isEmpty(transactionsStatistics.currentPeriod)).to.be.equal(false);
+        });
 
-        describe('without comparisons', () => {
-          let transactionsStatistics: TransactionsGroupsDetailedStatistics;
-          let metricsStatistics: TransactionsGroupsDetailedStatistics;
-          before(async () => {
-            [metricsStatistics, transactionsStatistics] = await Promise.all([
-              callApi({ query: { kuery: 'processor.event : "metric"' } }),
-              callApi({ query: { kuery: 'processor.event : "transaction"' } }),
-            ]);
-          });
+        it('returns some metrics data', () => {
+          expect(isEmpty(metricsStatistics.currentPeriod)).to.be.equal(false);
+        });
 
-          it('returns some transactions data', () => {
-            expect(isEmpty(transactionsStatistics.currentPeriod)).to.be.equal(false);
-          });
+        it('has same latency mean value for metrics and transactions data', () => {
+          const transactionsCurrentPeriod =
+            transactionsStatistics.currentPeriod[transactionNames[0]];
+          const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
+          const transactionsLatencyMean = meanBy(transactionsCurrentPeriod.latency, 'y');
+          const metricsLatencyMean = meanBy(metricsCurrentPeriod.latency, 'y');
+          [transactionsLatencyMean, metricsLatencyMean].forEach((value) =>
+            expect(value).to.be.equal(1000000)
+          );
+        });
 
-          it('returns some metrics data', () => {
-            expect(isEmpty(metricsStatistics.currentPeriod)).to.be.equal(false);
-          });
+        it('has same error rate mean value for metrics and transactions data', () => {
+          const transactionsCurrentPeriod =
+            transactionsStatistics.currentPeriod[transactionNames[0]];
+          const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
 
-          it('has same latency mean value for metrics and transactions data', () => {
-            const transactionsCurrentPeriod =
-              transactionsStatistics.currentPeriod[transactionNames[0]];
-            const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
-            const transactionsLatencyMean = meanBy(transactionsCurrentPeriod.latency, 'y');
-            const metricsLatencyMean = meanBy(metricsCurrentPeriod.latency, 'y');
-            [transactionsLatencyMean, metricsLatencyMean].forEach((value) =>
-              expect(value).to.be.equal(1000000)
-            );
-          });
+          const transactionsErrorRateMean = meanBy(transactionsCurrentPeriod.errorRate, 'y');
+          const metricsErrorRateMean = meanBy(metricsCurrentPeriod.errorRate, 'y');
+          [transactionsErrorRateMean, metricsErrorRateMean].forEach((value) =>
+            expect(asPercent(value, 1)).to.be.equal(`${GO_PROD_ERROR_RATE}%`)
+          );
+        });
 
-          it('has same error rate mean value for metrics and transactions data', () => {
-            const transactionsCurrentPeriod =
-              transactionsStatistics.currentPeriod[transactionNames[0]];
-            const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
+        it('has same throughput mean value for metrics and transactions data', () => {
+          const transactionsCurrentPeriod =
+            transactionsStatistics.currentPeriod[transactionNames[0]];
+          const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
+          const transactionsThroughputMean = roundNumber(
+            meanBy(transactionsCurrentPeriod.throughput, 'y')
+          );
+          const metricsThroughputMean = roundNumber(meanBy(metricsCurrentPeriod.throughput, 'y'));
+          [transactionsThroughputMean, metricsThroughputMean].forEach((value) =>
+            expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_PROD_ERROR_RATE))
+          );
+        });
 
-            const transactionsErrorRateMean = meanBy(transactionsCurrentPeriod.errorRate, 'y');
-            const metricsErrorRateMean = meanBy(metricsCurrentPeriod.errorRate, 'y');
-            [transactionsErrorRateMean, metricsErrorRateMean].forEach((value) =>
-              expect(asPercent(value, 1)).to.be.equal(`${GO_PROD_ERROR_RATE}%`)
-            );
-          });
+        it('has same impact value for metrics and transactions data', () => {
+          const transactionsCurrentPeriod =
+            transactionsStatistics.currentPeriod[transactionNames[0]];
+          const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
 
-          it('has same throughput mean value for metrics and transactions data', () => {
-            const transactionsCurrentPeriod =
-              transactionsStatistics.currentPeriod[transactionNames[0]];
-            const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
-            const transactionsThroughputMean = roundNumber(
-              meanBy(transactionsCurrentPeriod.throughput, 'y')
-            );
-            const metricsThroughputMean = roundNumber(meanBy(metricsCurrentPeriod.throughput, 'y'));
-            [transactionsThroughputMean, metricsThroughputMean].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(GO_PROD_RATE + GO_PROD_ERROR_RATE))
-            );
-          });
+          const transactionsImpact = transactionsCurrentPeriod.impact;
+          const metricsImpact = metricsCurrentPeriod.impact;
+          [transactionsImpact, metricsImpact].forEach((value) => expect(value).to.be.equal(100));
+        });
+      });
 
-          it('has same impact value for metrics and transactions data', () => {
-            const transactionsCurrentPeriod =
-              transactionsStatistics.currentPeriod[transactionNames[0]];
-            const metricsCurrentPeriod = metricsStatistics.currentPeriod[transactionNames[0]];
-
-            const transactionsImpact = transactionsCurrentPeriod.impact;
-            const metricsImpact = metricsCurrentPeriod.impact;
-            [transactionsImpact, metricsImpact].forEach((value) => expect(value).to.be.equal(100));
+      describe('with comparisons', () => {
+        let transactionsStatistics: TransactionsGroupsDetailedStatistics;
+        before(async () => {
+          transactionsStatistics = await callApi({
+            query: {
+              start: moment(end).subtract(7, 'minutes').toISOString(),
+              end: new Date(end).toISOString(),
+              offset: '8m',
+            },
           });
         });
 
-        describe('with comparisons', () => {
-          let transactionsStatistics: TransactionsGroupsDetailedStatistics;
-          before(async () => {
-            transactionsStatistics = await callApi({
-              query: {
-                start: moment(end).subtract(7, 'minutes').toISOString(),
-                end: new Date(end).toISOString(),
-                offset: '8m',
-              },
-            });
+        it('returns some data for both periods', () => {
+          expect(isEmpty(transactionsStatistics.currentPeriod)).to.be.equal(false);
+          expect(isEmpty(transactionsStatistics.previousPeriod)).to.be.equal(false);
+        });
+
+        it('has same start time for both periods', () => {
+          const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
+          const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
+          [
+            [currentPeriod.latency, previousPeriod.latency],
+            [currentPeriod.errorRate, previousPeriod.errorRate],
+            [currentPeriod.throughput, previousPeriod.throughput],
+          ].forEach(([currentTimeseries, previousTimeseries]) => {
+            const firstCurrentPeriodDate = new Date(
+              first(currentTimeseries)?.x ?? NaN
+            ).toISOString();
+            const firstPreviousPeriodDate = new Date(
+              first(previousPeriod.latency)?.x ?? NaN
+            ).toISOString();
+
+            expect(firstCurrentPeriodDate).to.equal(firstPreviousPeriodDate);
           });
+        });
+        it('has same end time for both periods', () => {
+          const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
+          const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
+          [
+            [currentPeriod.latency, previousPeriod.latency],
+            [currentPeriod.errorRate, previousPeriod.errorRate],
+            [currentPeriod.throughput, previousPeriod.throughput],
+          ].forEach(([currentTimeseries, previousTimeseries]) => {
+            const lastCurrentPeriodDate = new Date(last(currentTimeseries)?.x ?? NaN).toISOString();
+            const lastPreviousPeriodDate = new Date(
+              last(previousPeriod.latency)?.x ?? NaN
+            ).toISOString();
 
-          it('returns some data for both periods', () => {
-            expect(isEmpty(transactionsStatistics.currentPeriod)).to.be.equal(false);
-            expect(isEmpty(transactionsStatistics.previousPeriod)).to.be.equal(false);
+            expect(lastCurrentPeriodDate).to.equal(lastPreviousPeriodDate);
           });
+        });
 
-          it('has same start time for both periods', () => {
-            const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
-            const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
-            [
-              [currentPeriod.latency, previousPeriod.latency],
-              [currentPeriod.errorRate, previousPeriod.errorRate],
-              [currentPeriod.throughput, previousPeriod.throughput],
-            ].forEach(([currentTimeseries, previousTimeseries]) => {
-              const firstCurrentPeriodDate = new Date(
-                first(currentTimeseries)?.x ?? NaN
-              ).toISOString();
-              const firstPreviousPeriodDate = new Date(
-                first(previousPeriod.latency)?.x ?? NaN
-              ).toISOString();
-
-              expect(firstCurrentPeriodDate).to.equal(firstPreviousPeriodDate);
-            });
-          });
-          it('has same end time for both periods', () => {
-            const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
-            const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
-            [
-              [currentPeriod.latency, previousPeriod.latency],
-              [currentPeriod.errorRate, previousPeriod.errorRate],
-              [currentPeriod.throughput, previousPeriod.throughput],
-            ].forEach(([currentTimeseries, previousTimeseries]) => {
-              const lastCurrentPeriodDate = new Date(
-                last(currentTimeseries)?.x ?? NaN
-              ).toISOString();
-              const lastPreviousPeriodDate = new Date(
-                last(previousPeriod.latency)?.x ?? NaN
-              ).toISOString();
-
-              expect(lastCurrentPeriodDate).to.equal(lastPreviousPeriodDate);
-            });
-          });
-
-          it('returns same number of buckets for both periods', () => {
-            const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
-            const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
-            [
-              [currentPeriod.latency, previousPeriod.latency],
-              [currentPeriod.errorRate, previousPeriod.errorRate],
-              [currentPeriod.throughput, previousPeriod.throughput],
-            ].forEach(([currentTimeseries, previousTimeseries]) => {
-              expect(currentTimeseries.length).to.equal(previousTimeseries.length);
-            });
+        it('returns same number of buckets for both periods', () => {
+          const currentPeriod = transactionsStatistics.currentPeriod[transactionNames[0]];
+          const previousPeriod = transactionsStatistics.previousPeriod[transactionNames[0]];
+          [
+            [currentPeriod.latency, previousPeriod.latency],
+            [currentPeriod.errorRate, previousPeriod.errorRate],
+            [currentPeriod.throughput, previousPeriod.throughput],
+          ].forEach(([currentTimeseries, previousTimeseries]) => {
+            expect(currentTimeseries.length).to.equal(previousTimeseries.length);
           });
         });
       });
-    }
-  );
+    });
+  });
 }


### PR DESCRIPTION
Separated from: https://github.com/elastic/kibana/pull/137977

- Switches from legacy indices to datastreams for API tests
- Remove usages of `apm_mappings_only_8.0.0` because this is no longer necessary as the APM integration creates the mappings

Tip for reviewing: [Disable whitespace](https://github.com/elastic/kibana/pull/139283/files?diff=unified&w=1) when reviewing