### PR TITLE
[8.4] [Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info (#138902)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -23,7 +23,6 @@ import {
   RULES_TABLE,
   RULE_SWITCH,
   SEVERITY,
-  SHOWING_RULES_TEXT,
 } from '../../screens/alerts_detection_rules';
 import {
   ABOUT_CONTINUE_BTN,
@@ -218,7 +217,10 @@ describe('Custom query rules', () => {
             const initialNumberOfRules = rules.length;
             const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-            cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing ${initialNumberOfRules} rules`);
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(initialNumberOfRules);
+            });
 
             deleteFirstRule();
             waitForRulesTableToBeRefreshed();
@@ -226,10 +228,10 @@ describe('Custom query rules', () => {
             cy.get(RULES_TABLE)
               .find(RULES_ROW)
               .should('have.length', expectedNumberOfRulesAfterDeletion);
-            cy.get(SHOWING_RULES_TEXT).should(
-              'have.text',
-              `Showing ${expectedNumberOfRulesAfterDeletion} rules`
-            );
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+            });
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
               `Custom rules (${expectedNumberOfRulesAfterDeletion})`
@@ -253,10 +255,10 @@ describe('Custom query rules', () => {
             cy.get(RULES_TABLE)
               .find(RULES_ROW)
               .should('have.length', expectedNumberOfRulesAfterDeletion);
-            cy.get(SHOWING_RULES_TEXT).should(
-              'have.text',
-              `Showing ${expectedNumberOfRulesAfterDeletion} rule`
-            );
+            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+              const numberOfRules = body.data.length;
+              expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+            });
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
               `Custom rules (${expectedNumberOfRulesAfterDeletion})`
@@ -281,10 +283,10 @@ describe('Custom query rules', () => {
               cy.get(RULES_TABLE)
                 .find(RULES_ROW)
                 .should('have.length', expectedNumberOfRulesAfterDeletion);
-              cy.get(SHOWING_RULES_TEXT).should(
-                'have.text',
-                `Showing ${expectedNumberOfRulesAfterDeletion} rules`
-              );
+              cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+                const numberOfRules = body.data.length;
+                expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
+              });
               cy.get(CUSTOM_RULES_BTN).should(
                 'have.text',
                 `Custom rules (${expectedNumberOfRulesAfterDeletion})`

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { rawRules } from '../../../server/lib/detection_engine/rules/prepackaged_rules';
 import {
   COLLAPSED_ACTION_BTN,
   ELASTIC_RULES_BTN,
@@ -12,11 +13,10 @@ import {
   RELOAD_PREBUILT_RULES_BTN,
   RULES_EMPTY_PROMPT,
   RULE_SWITCH,
-  SHOWING_RULES_TEXT,
   RULES_MONITORING_TABLE,
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
+  RULE_NAME,
 } from '../../screens/alerts_detection_rules';
-
 import {
   deleteFirstRule,
   deleteSelectedRules,
@@ -59,7 +59,16 @@ describe('Prebuilt rules', () => {
 
       changeRowsPerPageTo(rowsPerPage);
 
-      cy.get(SHOWING_RULES_TEXT).should('have.text', `Showing ${expectedNumberOfRules} rules`);
+      cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+        // Assert the total number of loaded rules equals the expected number of in-memory rules
+        expect(body.total).to.equal(rawRules.length);
+        // Assert the table was refreshed with the rules returned by the API request
+        const ruleNames = rawRules.map((rule) => rule.name);
+        cy.get(RULE_NAME).each(($item) => {
+          expect($item.text()).to.be.oneOf(ruleNames);
+        });
+      });
+
       cy.get(pageSelector(expectedNumberOfPages)).should('exist');
     });
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -26,7 +26,7 @@ import { useFormatUrl } from '../../../../../../common/components/link_to';
 import { Loader } from '../../../../../../common/components/loader';
 
 import * as i18n from './translations';
-import { AllRulesUtilityBar } from '../utility_bar';
+import { ExceptionsTableUtilityBar } from './exceptions_table_utility_bar';
 import type { AllExceptionListsColumns } from './columns';
 import { getAllExceptionListsColumns } from './columns';
 import { useAllExceptionLists } from './use_all_exception_lists';
@@ -378,11 +378,8 @@ export const ExceptionListsTable = React.memo(() => {
           <EuiLoadingContent data-test-subj="initialLoadingPanelAllRulesTable" lines={10} />
         ) : (
           <>
-            <AllRulesUtilityBar
-              hasBulkActions={false}
-              canBulkEdit={hasPermissions}
-              paginationTotal={exceptionListsWithRuleRefs.length ?? 0}
-              numberSelectedItems={0}
+            <ExceptionsTableUtilityBar
+              totalExceptionLists={exceptionListsWithRuleRefs.length}
               onRefresh={handleRefresh}
             />
             <EuiBasicTable<ExceptionsTableItem>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { TestProviders } from '../../../../../../common/mock';
+import { render, screen, within } from '@testing-library/react';
+import { ExceptionsTableUtilityBar } from './exceptions_table_utility_bar';
+
+describe('ExceptionsTableUtilityBar', () => {
+  it('displays correct exception lists label and refresh rules action button', () => {
+    const EXCEPTION_LISTS_NUMBER = 25;
+    render(
+      <TestProviders>
+        <ExceptionsTableUtilityBar
+          onRefresh={jest.fn()}
+          totalExceptionLists={EXCEPTION_LISTS_NUMBER}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('showingExceptionLists')).toBeInTheDocument();
+    expect(screen.getByTestId('refreshRulesAction')).toBeInTheDocument();
+    expect(screen.getByText(`Showing ${EXCEPTION_LISTS_NUMBER} lists`)).toBeInTheDocument();
+  });
+
+  it('invokes refresh on refresh action click', () => {
+    const mockRefresh = jest.fn();
+    render(
+      <TestProviders>
+        <ExceptionsTableUtilityBar onRefresh={mockRefresh} totalExceptionLists={1} />
+      </TestProviders>
+    );
+
+    const buttonWrapper = screen.getByTestId('refreshRulesAction');
+    within(buttonWrapper).getByRole('button').click();
+
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table_utility_bar.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import {
+  UtilityBar,
+  UtilityBarAction,
+  UtilityBarGroup,
+  UtilityBarSection,
+  UtilityBarText,
+} from '../../../../../../common/components/utility_bar';
+import * as i18n from './translations';
+
+interface ExceptionsTableUtilityBarProps {
+  onRefresh?: () => void;
+  totalExceptionLists: number;
+}
+
+export const ExceptionsTableUtilityBar: React.FC<ExceptionsTableUtilityBarProps> = ({
+  onRefresh,
+  totalExceptionLists,
+}) => {
+  return (
+    <UtilityBar border>
+      <UtilityBarSection>
+        <UtilityBarGroup>
+          <UtilityBarText dataTestSubj="showingExceptionLists">
+            {i18n.SHOWING_EXCEPTION_LISTS(totalExceptionLists)}
+          </UtilityBarText>
+        </UtilityBarGroup>
+        <UtilityBarGroup>
+          <UtilityBarAction
+            dataTestSubj="refreshRulesAction"
+            iconSide="left"
+            iconType="refresh"
+            onClick={onRefresh}
+          >
+            {i18n.REFRESH_EXCEPTIONS_TABLE}
+          </UtilityBarAction>
+        </UtilityBarGroup>
+      </UtilityBarSection>
+    </UtilityBar>
+  );
+};
+
+ExceptionsTableUtilityBar.displayName = 'ExceptionsTableUtilityBar';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
@@ -28,6 +28,15 @@ export const EXCEPTION_LIST_ACTIONS = i18n.translate(
   }
 );
 
+export const SHOWING_EXCEPTION_LISTS = (totalLists: number) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.all.exceptions.showingExceptionLists',
+    {
+      values: { totalLists },
+      defaultMessage: 'Showing {totalLists} {totalLists, plural, =1 {list} other {lists}}',
+    }
+  );
+
 export const RULES_ASSIGNED_TO_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.all.exceptions.rulesAssignedTitle',
   {
@@ -149,5 +158,12 @@ export const EXCEPTION_LIST_SEARCH_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.exceptions.searchPlaceholder',
   {
     defaultMessage: 'e.g. Example List Name',
+  }
+);
+
+export const REFRESH_EXCEPTIONS_TABLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.all.exceptions.refresh',
+  {
+    defaultMessage: 'Refresh',
   }
 );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_table_utility_bar.test.tsx
@@ -9,67 +9,80 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { AllRulesUtilityBar } from './utility_bar';
+import { getShowingRulesParams, RulesTableUtilityBar } from './rules_table_utility_bar';
 import { TestProviders } from '../../../../../common/mock';
 
-describe('AllRules', () => {
-  it('renders AllRulesUtilityBar total rules and selected rules', () => {
+jest.mock('./rules_table/rules_table_context');
+
+describe('RulesTableUtilityBar', () => {
+  it('renders RulesTableUtilityBar total rules and selected rules', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
 
-    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual('Showing 4 rules');
+    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(
+      'Showing 1-10 of 21 rules'
+    );
     expect(wrapper.find('[data-test-subj="selectedRules"]').at(0).text()).toEqual(
       'Selected 1 rule'
     );
   });
 
-  it('does not render total selected and bulk actions when "hasBulkActions" is false', () => {
+  it('renders correct pagination label according to pagination data', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions={false}
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
-
-    expect(wrapper.find('[data-test-subj="showingRules"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-subj="tableBulkActions"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-subj="showingExceptionLists"]').at(0).text()).toEqual(
-      'Showing 4 lists'
+    expect(wrapper.find('[data-test-subj="showingRules"]').at(0).text()).toEqual(
+      'Showing 1-10 of 21 rules'
     );
   });
 
   it('renders utility actions if user has permissions', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -80,15 +93,19 @@ describe('AllRules', () => {
   it('renders no utility actions if user has no permissions', () => {
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit={false}
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -100,15 +117,19 @@ describe('AllRules', () => {
     const mockRefresh = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={mockRefresh}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={jest.fn()}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -122,15 +143,19 @@ describe('AllRules', () => {
     const mockSwitch = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={0}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -146,15 +171,19 @@ describe('AllRules', () => {
     const mockSwitch = jest.fn();
     const wrapper = mount(
       <TestProviders>
-        <AllRulesUtilityBar
+        <RulesTableUtilityBar
           canBulkEdit
           onRefresh={jest.fn()}
-          paginationTotal={4}
+          pagination={{
+            page: 1,
+            perPage: 10,
+            total: 21,
+          }}
           numberSelectedItems={1}
           onGetBulkItemsPopoverContent={jest.fn()}
           isAutoRefreshOn={true}
           onRefreshSwitch={mockSwitch}
-          hasBulkActions
+          onToggleSelectAll={jest.fn()}
         />
       </TestProviders>
     );
@@ -163,6 +192,74 @@ describe('AllRules', () => {
       wrapper.find('[data-test-subj="refreshSettings"] button').first().simulate('click');
       wrapper.find('[data-test-subj="refreshSettingsSwitch"] button').first().simulate('click');
       expect(mockSwitch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getShowingRulesParams creates correct label when', () => {
+    it('there are 0 rules to display', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 0,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(0);
+      expect(lastInPage).toEqual(0);
+    });
+
+    it('there is 1 rule to display', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 1,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(1);
+    });
+
+    it('the table displays the first page, and rules per page is less than total rules', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 21,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(10);
+    });
+
+    it('the table displays the first page, and rules per page is greater than total rules', () => {
+      const pagination = {
+        page: 1,
+        perPage: 10,
+        total: 8,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(1);
+      expect(lastInPage).toEqual(8);
+    });
+
+    it('the table displays the second page, and rules per page is less than total rules', () => {
+      const pagination = {
+        page: 2,
+        perPage: 10,
+        total: 31,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(11);
+      expect(lastInPage).toEqual(20);
+    });
+
+    it('the table displays the last page, displaying the remaining rules', () => {
+      const pagination = {
+        page: 2,
+        perPage: 100,
+        total: 101,
+      };
+      const [firstInPage, lastInPage] = getShowingRulesParams(pagination);
+      expect(firstInPage).toEqual(101);
+      expect(lastInPage).toEqual(101);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable complexity */
-
 import {
   EuiBasicTable,
   EuiConfirmModal,
@@ -33,7 +31,7 @@ import { showRulesTable } from './helpers';
 import { useRulesTableContext } from './rules_table/rules_table_context';
 import { useAsyncConfirmation } from './rules_table/use_async_confirmation';
 import { RulesTableFilters } from './rules_table_filters/rules_table_filters';
-import { AllRulesUtilityBar } from './utility_bar';
+import { RulesTableUtilityBar } from './rules_table_utility_bar';
 import { useBulkActionsDryRun } from './bulk_actions/use_bulk_actions_dry_run';
 import { useBulkActionsConfirmation } from './bulk_actions/use_bulk_actions_confirmation';
 import { useBulkEditFormFlyout } from './bulk_actions/use_bulk_edit_form_flyout';
@@ -147,7 +145,6 @@ export const RulesTables = React.memo<RulesTableProps>(
     } = useBulkEditFormFlyout();
 
     const selectedItemsCount = isAllSelected ? pagination.total : selectedRuleIds.length;
-    const hasPagination = pagination.total > pagination.perPage;
 
     const { isBulkActionsDryRunLoading, executeBulkActionsDryRun } = useBulkActionsDryRun();
 
@@ -334,10 +331,9 @@ export const RulesTables = React.memo<RulesTableProps>(
         )}
         {shouldShowRulesTable && (
           <>
-            <AllRulesUtilityBar
+            <RulesTableUtilityBar
               canBulkEdit={hasPermissions}
-              hasPagination={hasPagination}
-              paginationTotal={pagination.total ?? 0}
+              pagination={pagination}
               numberSelectedItems={selectedItemsCount}
               onGetBulkItemsPopoverContent={getBulkItemsPopoverContent}
               onRefresh={handleRefreshRules}
@@ -347,7 +343,6 @@ export const RulesTables = React.memo<RulesTableProps>(
               onToggleSelectAll={toggleSelectAll}
               isBulkActionInProgress={isBulkActionsDryRunLoading || loadingRulesAction != null}
               hasDisabledActions={loadingRulesAction != null}
-              hasBulkActions
             />
             <EuiBasicTable
               itemId="id"

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -437,10 +437,11 @@ export const SEARCH_PLACEHOLDER = i18n.translate(
   }
 );
 
-export const SHOWING_RULES = (totalRules: number) =>
+export const SHOWING_RULES = (firstInPage: number, lastOfPage: number, totalRules: number) =>
   i18n.translate('xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle', {
-    values: { totalRules },
-    defaultMessage: 'Showing {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
+    values: { firstInPage, lastOfPage, totalRules },
+    defaultMessage:
+      'Showing {firstInPage}-{lastOfPage} of {totalRules} {totalRules, plural, =1 {rule} other {rules}}',
   });
 
 export const SELECT_ALL_RULES = (totalRules: number) =>
@@ -838,12 +839,6 @@ export const REFRESH_RULE_POPOVER_LABEL = i18n.translate(
     defaultMessage: 'Refresh settings',
   }
 );
-
-export const SHOWING_EXCEPTION_LISTS = (totalLists: number) =>
-  i18n.translate('xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists', {
-    values: { totalLists },
-    defaultMessage: 'Showing {totalLists} {totalLists, plural, =1 {list} other {lists}}',
-  });
 
 /**
  * Bulk Export

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -25489,8 +25489,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "Durée de l'écart le plus récent dans l'exécution de la règle. Ajustez l'historique des règles ou {seeDocs} pour réduire les écarts.",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "Sélection totale de {totalRules} {totalRules, plural, =1 {règle} other {règles}} effectuée",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "Sélection de {selectedRules} {selectedRules, plural, =1 {règle} other {règles}} effectuée",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "Affichage de {totalLists} {totalLists, plural, =1 {liste} other {listes}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "Affichage de {totalRules} {totalRules, plural, =1 {règle} other {règles}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} a été créé",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "Infobulle pour la colonne : {columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "Installez {missingRules} {missingRules, plural, =1 {règle prédéfinie} other {règles prédéfinies}} d'Elastic et {missingTimelines} {missingTimelines, plural, =1 {chronologie prédéfinie} other {chronologies prédéfinies}} d'Elastic ",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -25467,8 +25467,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "ルール実行の最新のギャップの期間。ルールルックバックを調整するか、ギャップの軽減については{seeDocs}してください。",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "すべての{totalRules} {totalRules, plural, other  {個のルール}}を選択",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "{selectedRules} {selectedRules, plural, other  {ルール}}を選択しました",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "{totalLists} {totalLists, plural, other  {件のリスト}}を表示しています。",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "{totalRules} {totalRules, plural, other  {ルール}}を表示中",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName}が作成されました",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列のツールチップ：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "{missingRules} Elastic事前構築済み{missingRules, plural, other  {ルール}}と{missingTimelines} Elastic事前構築済み{missingTimelines, plural, other  {タイムライン}}をインストール ",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25497,8 +25497,6 @@
     "xpack.securitySolution.detectionEngine.rules.allRules.columns.gapTooltip": "规则执行中最近缺口的持续时间。调整规则回查或{seeDocs}以缩小缺口。",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectAllRulesTitle": "选择所有 {totalRules} 个{totalRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.allRules.selectedRulesTitle": "已选择 {selectedRules} 个{selectedRules, plural, other {规则}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingExceptionLists": "正在显示 {totalLists} 个{totalLists, plural, other {列表}}",
-    "xpack.securitySolution.detectionEngine.rules.allRules.showingRulesTitle": "正在显示 {totalRules} 个{totalRules, plural, other {规则}}",
     "xpack.securitySolution.detectionEngine.rules.create.successfullyCreatedRuleTitle": "{ruleName} 已创建",
     "xpack.securitySolution.detectionEngine.rules.popoverTooltip.ariaLabel": "列的工具提示：{columnName}",
     "xpack.securitySolution.detectionEngine.rules.reloadMissingPrePackagedRulesAndTimelinesButton": "安装 {missingRules} 个 Elastic 预构建{missingRules, plural, other {规则}}以及 {missingTimelines} 个 Elastic 预构建{missingTimelines, plural, other {时间线}} ",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info (#138902)](https://github.com/elastic/kibana/pull/138902)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Juan Pablo Djeredjian","email":"jpdjeredjian@gmail.com"},"sourceCommit":{"committedDate":"2022-08-23T11:35:53Z","message":"[Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info (#138902)\n\n**Fixes:** https://github.com/elastic/kibana/issues/121754\r\n\r\n## Summary\r\n\r\nChanges rules count pagination count to format:\r\n\r\n**\"Showing 1-10 of 596 rules\"** -> when page 1, rules per page is 10 and total rules is 596\r\n**\"Showing 6-6 of 6 rules\"** -> when page 2, rules per page is 5 and total rules is 6\r\nSee other cases in tests.\r\n\r\n**Before changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184883106-118f0041-5567-4cf8-bfd5-8383e8146018.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184884145-22d30482-cc2d-4796-8f84-d809a8ca6d8a.png)\r\n\r\n\r\n**After changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184882149-d6c55dff-39a0-4a72-94a9-217b2e5ca7ac.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184886334-a107a2c5-31dc-4a7b-9e70-54c87c1630e0.png)\r\n\r\n## Codebase changes\r\n\r\n- Refactors `AllRulesUtilityBar` component to separate usage of the utility bar between the all-rules table use-case and the Exceptions table use-case, by creating a new `ExceptionsTableUtilityBar` component. \r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\r\n- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"147e4142c80b8b30d70f30d44230ec09ad0018f2","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rules","ci:no-auto-commit","v8.5.0","ci:cloud-deploy","v8.4.1"],"number":138902,"url":"https://github.com/elastic/kibana/pull/138902","mergeCommit":{"message":"[Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info (#138902)\n\n**Fixes:** https://github.com/elastic/kibana/issues/121754\r\n\r\n## Summary\r\n\r\nChanges rules count pagination count to format:\r\n\r\n**\"Showing 1-10 of 596 rules\"** -> when page 1, rules per page is 10 and total rules is 596\r\n**\"Showing 6-6 of 6 rules\"** -> when page 2, rules per page is 5 and total rules is 6\r\nSee other cases in tests.\r\n\r\n**Before changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184883106-118f0041-5567-4cf8-bfd5-8383e8146018.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184884145-22d30482-cc2d-4796-8f84-d809a8ca6d8a.png)\r\n\r\n\r\n**After changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184882149-d6c55dff-39a0-4a72-94a9-217b2e5ca7ac.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184886334-a107a2c5-31dc-4a7b-9e70-54c87c1630e0.png)\r\n\r\n## Codebase changes\r\n\r\n- Refactors `AllRulesUtilityBar` component to separate usage of the utility bar between the all-rules table use-case and the Exceptions table use-case, by creating a new `ExceptionsTableUtilityBar` component. \r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\r\n- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"147e4142c80b8b30d70f30d44230ec09ad0018f2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/138902","number":138902,"mergeCommit":{"message":"[Security Solution][Detections] Update rules count indicator in the Rules table to show pagination info (#138902)\n\n**Fixes:** https://github.com/elastic/kibana/issues/121754\r\n\r\n## Summary\r\n\r\nChanges rules count pagination count to format:\r\n\r\n**\"Showing 1-10 of 596 rules\"** -> when page 1, rules per page is 10 and total rules is 596\r\n**\"Showing 6-6 of 6 rules\"** -> when page 2, rules per page is 5 and total rules is 6\r\nSee other cases in tests.\r\n\r\n**Before changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184883106-118f0041-5567-4cf8-bfd5-8383e8146018.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184884145-22d30482-cc2d-4796-8f84-d809a8ca6d8a.png)\r\n\r\n\r\n**After changes**\r\n![image](https://user-images.githubusercontent.com/5354282/184882149-d6c55dff-39a0-4a72-94a9-217b2e5ca7ac.png)\r\n![image](https://user-images.githubusercontent.com/5354282/184886334-a107a2c5-31dc-4a7b-9e70-54c87c1630e0.png)\r\n\r\n## Codebase changes\r\n\r\n- Refactors `AllRulesUtilityBar` component to separate usage of the utility bar between the all-rules table use-case and the Exceptions table use-case, by creating a new `ExceptionsTableUtilityBar` component. \r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\r\n- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"147e4142c80b8b30d70f30d44230ec09ad0018f2"}},{"branch":"8.4","label":"v8.4.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/139288","number":139288,"state":"OPEN"}]}] BACKPORT-->