### PR TITLE
[DOCS] Removes 7.17.6 release notes tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -80,8 +80,6 @@ Review important information about the {kib} 7.17.x releases.
 [[release-notes-7.17.6]]
 == {kib} 7.17.6
 
-coming::[7.17.6]
-
 Review the following information about the 7.17.6 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from 7.17.6 release notes.