### PR TITLE
Fix NODE_ENV in kibana.bat

### DIFF
--- a/src/dev/build/tasks/bin/scripts/kibana.bat
+++ b/src/dev/build/tasks/bin/scripts/kibana.bat
@@ -7,7 +7,7 @@ for %%I in ("%SCRIPT_DIR%..") do set DIR=%%~dpfI
 
 set NODE=%DIR%\node\node.exe
 
-set NODE_ENV="production"
+set NODE_ENV=production
 
 If Not Exist "%NODE%" (
   Echo unable to find usable node.js executable.


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/138503 we removed
*.development files from builds.  On Windows we're hitting a code path
where these end up imported, because NODE_ENV is incorrectly wrapped in
quotes.

cmd interpets NODE_ENV="production" as '"production"'.  We can remove
the quotes or set "NODE_ENV=production".

Thanks @pheyos for finding this.