### PR TITLE
[ML] Improves messaging when an anomaly detection forecast errors

### DIFF
--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecast_progress.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecast_progress.js
@@ -32,13 +32,11 @@ export function ForecastProgress({ forecastProgress, jobOpeningState, jobClosing
         <React.Fragment>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiText size="xs">
-                <h3>
-                  <FormattedMessage
-                    id="xpack.ml.timeSeriesExplorer.forecastingModal.openingJobTitle"
-                    defaultMessage="Opening job…"
-                  />
-                </h3>
+              <EuiText size="m">
+                <FormattedMessage
+                  id="xpack.ml.timeSeriesExplorer.forecastingModal.openingJobTitle"
+                  defaultMessage="Opening job…"
+                />
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -52,13 +50,11 @@ export function ForecastProgress({ forecastProgress, jobOpeningState, jobClosing
         <React.Fragment>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiText size="xs">
-                <h3>
-                  <FormattedMessage
-                    id="xpack.ml.timeSeriesExplorer.forecastingModal.runningForecastTitle"
-                    defaultMessage="Running forecast…"
-                  />
-                </h3>
+              <EuiText size="m">
+                <FormattedMessage
+                  id="xpack.ml.timeSeriesExplorer.forecastingModal.runningForecastTitle"
+                  defaultMessage="Running forecast…"
+                />
               </EuiText>
             </EuiFlexItem>
             {forecastProgress >= 0 && (
@@ -81,13 +77,11 @@ export function ForecastProgress({ forecastProgress, jobOpeningState, jobClosing
         <React.Fragment>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiText size="xs">
-                <h3>
-                  <FormattedMessage
-                    id="xpack.ml.timeSeriesExplorer.forecastingModal.closingJobTitle"
-                    defaultMessage="Closing job…"
-                  />
-                </h3>
+              <EuiText size="m">
+                <FormattedMessage
+                  id="xpack.ml.timeSeriesExplorer.forecastingModal.closingJobTitle"
+                  defaultMessage="Closing job…"
+                />
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecasting_modal.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecasting_modal.js
@@ -180,10 +180,7 @@ export class ForecastingModalUI extends Component {
     this.setState({ forecastProgress: PROGRESS_STATES.ERROR });
     console.log('Time series forecast modal - error running forecast:', resp);
 
-    let errorMessage;
-    if (resp) {
-      errorMessage = extractErrorMessage(resp);
-    }
+    const errorMessage = resp ? extractErrorMessage(resp) : undefined;
 
     if (errorMessage && errorMessage.length > 0) {
       this.addMessage(

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecasting_modal.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecasting_modal.js
@@ -18,6 +18,7 @@ import { EuiButton, EuiToolTip } from '@elastic/eui';
 
 import { FORECAST_REQUEST_STATE, JOB_STATE } from '../../../../../common/constants/states';
 import { MESSAGE_LEVEL } from '../../../../../common/constants/message_levels';
+import { extractErrorMessage } from '../../../../../common/util/errors';
 import { isJobVersionGte } from '../../../../../common/util/job_utils';
 import { parseInterval } from '../../../../../common/util/parse_interval';
 import { Modal } from './modal';
@@ -178,8 +179,21 @@ export class ForecastingModalUI extends Component {
   runForecastErrorHandler = (resp, closeJob) => {
     this.setState({ forecastProgress: PROGRESS_STATES.ERROR });
     console.log('Time series forecast modal - error running forecast:', resp);
-    if (resp && resp.message) {
-      this.addMessage(resp.message, MESSAGE_LEVEL.ERROR, true);
+
+    let errorMessage;
+    if (resp) {
+      errorMessage = extractErrorMessage(resp);
+    }
+
+    if (errorMessage && errorMessage.length > 0) {
+      this.addMessage(
+        i18n.translate('xpack.ml.timeSeriesExplorer.forecastingModal.errorRunningForecastMessage', {
+          defaultMessage: 'An error has occurred running the forecast: {errorMessage}',
+          values: { errorMessage },
+        }),
+        MESSAGE_LEVEL.ERROR,
+        true
+      );
     } else {
       this.addMessage(
         i18n.translate(


### PR DESCRIPTION
## Summary

Improves the error messaging when an anomaly detection forecast, as run from the Single Metric Viewer, errors. Previously the reason for the error was not being displayed.

For example, if a duration less than the bucket span is entered:
Before:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/7405507/186379951-861709b9-09a8-4593-ab19-e4cc1ac3fa3f.png">

After:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/7405507/186379436-43a2a7d6-ae19-47ab-97c5-1621e7d04a8d.png">

Also made a small change to the display of the progress elements, so that the impact of the text is reduced.

Before:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/7405507/186380048-57f90441-b7bc-44ad-ae24-8bdf83ab9e9d.png">


After:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/7405507/186379791-d7e52d21-5d70-46b9-8182-6e404e1f3b07.png">


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixed https://github.com/elastic/kibana/issues/139089




