### PR TITLE
[Security Solution][Endpoint] Un-skip unit test increasing timeout and waiting for an element to disappear

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/artifacts/list/policy_artifacts_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/artifacts/list/policy_artifacts_list.test.tsx
@@ -36,8 +36,9 @@ const getDefaultQueryParameters = (customFilter: string | undefined = '') => ({
   },
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/139183
-describe.skip('Policy details artifacts list', () => {
+jest.setTimeout(10000);
+
+describe('Policy details artifacts list', () => {
   let render: (externalPrivileges?: boolean) => Promise<ReturnType<AppContextTestRender['render']>>;
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let history: AppContextTestRender['history'];
@@ -69,6 +70,9 @@ describe.skip('Policy details artifacts list', () => {
           />
         );
         await waitFor(() => expect(mockedApi.responseProvider.eventFiltersList).toHaveBeenCalled());
+        await waitFor(() =>
+          expect(renderResult.queryByTestId('artifacts-collapsed-list-loader')).toBeFalsy()
+        );
       });
       return renderResult;
     };


### PR DESCRIPTION
## Summary

Increases jest timeout and adds a wait for loader to disappear.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
