### PR TITLE
Add test for errors distribution

### DIFF
--- a/x-pack/test/apm_api_integration/tests/errors/distribution.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/errors/distribution.spec.ts
@@ -83,6 +83,25 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             (appleTransaction.failureRate + bananaTransaction.failureRate) * numberOfBuckets
           );
         });
+
+        describe('displays correct start in errors distribution chart', () => {
+          let errorsDistributionWithComparison: ErrorsDistribution;
+          before(async () => {
+            const responseWithComparison = await callApi({
+              query: {
+                start: new Date(start).toISOString(),
+                end: new Date(end).toISOString(),
+                offset: '15m',
+              },
+            });
+            errorsDistributionWithComparison = responseWithComparison.body;
+          });
+          it('has same start time when comparison is enabled', () => {
+            expect(first(errorsDistribution.currentPeriod)?.x).to.equal(
+              first(errorsDistributionWithComparison.currentPeriod)?.x
+            );
+          });
+        });
       });
 
       describe('displays occurrences for type "apple transaction" only', () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/134219

### What was done

Add test to cover that x-axis on errors distribution chart is the same for current period if comparison is enabled or not with the same time rage
