### PR TITLE
[Files] Add `cache-control` headers to file download response

### DIFF
--- a/x-pack/plugins/files/server/routes/common.test.ts
+++ b/x-pack/plugins/files/server/routes/common.test.ts
@@ -9,40 +9,46 @@ import type { File } from '../file';
 import { getDownloadHeadersForFile } from './common';
 
 describe('getDownloadHeadersForFile', () => {
-  function t({ cd, ct }: { cd: string; ct: string }) {
+  function expectHeaders({
+    contentDisposition,
+    contentType,
+  }: {
+    contentDisposition: string;
+    contentType: string;
+  }) {
     return {
-      'content-type': ct,
-      'content-disposition': `attachment; filename="${cd}"`,
+      'content-type': contentType,
+      'content-disposition': `attachment; filename="${contentDisposition}"`,
     };
   }
 
   const file = { data: { name: 'test', mimeType: undefined } } as unknown as File;
   test('no mime type and name from file object', () => {
     expect(getDownloadHeadersForFile(file, undefined)).toEqual(
-      t({ ct: 'application/octet-stream', cd: 'test' })
+      expectHeaders({ contentType: 'application/octet-stream', contentDisposition: 'test' })
     );
   });
 
   test('no mime type and name (without ext)', () => {
     expect(getDownloadHeadersForFile(file, 'myfile')).toEqual(
-      t({ ct: 'application/octet-stream', cd: 'myfile' })
+      expectHeaders({ contentType: 'application/octet-stream', contentDisposition: 'myfile' })
     );
   });
   test('no mime type and name (with ext)', () => {
     expect(getDownloadHeadersForFile(file, 'myfile.png')).toEqual(
-      t({ ct: 'image/png', cd: 'myfile.png' })
+      expectHeaders({ contentType: 'image/png', contentDisposition: 'myfile.png' })
     );
   });
   test('mime type and no name', () => {
     const fileWithMime = { data: { ...file.data, mimeType: 'application/pdf' } } as File;
     expect(getDownloadHeadersForFile(fileWithMime, undefined)).toEqual(
-      t({ ct: 'application/pdf', cd: 'test' })
+      expectHeaders({ contentType: 'application/pdf', contentDisposition: 'test' })
     );
   });
   test('mime type and name', () => {
     const fileWithMime = { data: { ...file.data, mimeType: 'application/pdf' } } as File;
     expect(getDownloadHeadersForFile(fileWithMime, 'a cool file.pdf')).toEqual(
-      t({ ct: 'application/pdf', cd: 'a cool file.pdf' })
+      expectHeaders({ contentType: 'application/pdf', contentDisposition: 'a cool file.pdf' })
     );
   });
 });

--- a/x-pack/plugins/files/server/routes/common.test.ts
+++ b/x-pack/plugins/files/server/routes/common.test.ts
@@ -19,6 +19,7 @@ describe('getDownloadHeadersForFile', () => {
     return {
       'content-type': contentType,
       'content-disposition': `attachment; filename="${contentDisposition}"`,
+      'cache-control': 'max-age=31536000, immutable',
     };
   }
 

--- a/x-pack/plugins/files/server/routes/common.ts
+++ b/x-pack/plugins/files/server/routes/common.ts
@@ -14,6 +14,7 @@ export function getDownloadHeadersForFile(file: File, fileName?: string): Respon
       (fileName && mime.getType(fileName)) ?? file.data.mimeType ?? 'application/octet-stream',
     // Note, this name can be overridden by the client if set via a "download" attribute on the HTML tag.
     'content-disposition': `attachment; filename="${fileName || getDownloadedFileName(file)}"`,
+    'cache-control': 'max-age=31536000, immutable',
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the following headers to a download response for a file:

```
cache-control: max-age=31536000 , immutable
```

This is based on the [cache-busting pattern](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#caching_static_assets_with_cache_busting) recommended by MDN for static content to avoid (re)validation. This suits our use-case quite well because every file's content is intended to be immutable and so will contain an ID in the path that will serve to "cache bust" whenever a linked resource changes on a page. The URL looks something like:

`/api/files/files/<file-kind>/cl761nzgh0000nl4ra2treid8/blob`

## Screenshots

Subsequent requests are served from local disk. This works very well for files that are images being served to the frontend:

<img width="935" alt="Screenshot 2022-08-24 at 14 39 40" src="https://user-images.githubusercontent.com/8155004/186421054-4cb4094c-7d81-41ab-821e-cc49eccc2248.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios