### PR TITLE
Update activated rules data yaml

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_rules_configuration.ts
@@ -13,4 +13,13 @@ export const cspRulesConfigSchema = rt.object({
   }),
 });
 
+// cspRulesConfigSchemaV1 has to match the 'RuntimeCfg' struct in https://github.com/elastic/cloudbeat/blob/main/config/config.go#L45-L51
+export const cspRulesConfigSchemaV1 = rt.object({
+  runtime_cfg: rt.object({
+    v1: rt.object({ rules: rt.recordOf(rt.string(), rt.arrayOf(rt.object({}))) }),
+  }),
+});
+
 export type CspRulesConfiguration = TypeOf<typeof cspRulesConfigSchema>;
+export type CspRulesConfigurationV1 = TypeOf<typeof cspRulesConfigSchemaV1>;
+export type SupportedRuleTypes = CspRulesConfiguration | CspRulesConfigurationV1;

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -24,7 +24,7 @@ import { createCspRuleSearchFilterByPackagePolicy } from '../../../common/utils/
 import type {
   CspRule,
   CspRulesConfiguration,
-  CspRulesConfigurationV1,
+  CspRulesConfigurationV1, SupportedRuleTypes,
 } from '../../../common/schemas';
 import {
   CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
@@ -102,13 +102,13 @@ const getEnabledRulesByBenchmarkV1 = (rules: SavedObjectsFindResponse<CspRule>['
 
 export const createRulesConfig = (
   cspRules: SavedObjectsFindResponse<CspRule>
-): CspRulesConfigurationV1 | CspRulesConfiguration => {
+): SupportedRuleTypes => {
   return V1RuleFormatEnabled ? CreateRuleConfigV1(cspRules) : CreateDeprecatedRuleConfig(cspRules);
 };
 
 export const CreateRuleConfigV1 = (
   cspRules: SavedObjectsFindResponse<CspRule>
-): CspRulesConfigurationV1 | CspRulesConfiguration => ({
+): CspRulesConfigurationV1  => ({
   runtime_cfg: {
     v1: { rules: getEnabledRulesByBenchmarkV1(cspRules.saved_objects) },
   },
@@ -123,7 +123,7 @@ export const CreateDeprecatedRuleConfig = (
 });
 
 export const convertRulesConfigToYaml = (
-  config: CspRulesConfiguration | CspRulesConfigurationV1
+  config: SupportedRuleTypes
 ): string => {
   return yaml.safeDump(config);
 };

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -24,7 +24,8 @@ import { createCspRuleSearchFilterByPackagePolicy } from '../../../common/utils/
 import type {
   CspRule,
   CspRulesConfiguration,
-  CspRulesConfigurationV1, SupportedRuleTypes,
+  CspRulesConfigurationV1,
+  SupportedRuleTypes,
 } from '../../../common/schemas';
 import {
   CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
@@ -108,7 +109,7 @@ export const createRulesConfig = (
 
 export const CreateRuleConfigV1 = (
   cspRules: SavedObjectsFindResponse<CspRule>
-): CspRulesConfigurationV1  => ({
+): CspRulesConfigurationV1 => ({
   runtime_cfg: {
     v1: { rules: getEnabledRulesByBenchmarkV1(cspRules.saved_objects) },
   },
@@ -122,9 +123,7 @@ export const CreateDeprecatedRuleConfig = (
   },
 });
 
-export const convertRulesConfigToYaml = (
-  config: SupportedRuleTypes
-): string => {
+export const convertRulesConfigToYaml = (config: SupportedRuleTypes): string => {
   return yaml.safeDump(config);
 };
 


### PR DESCRIPTION
## Summary
This PR will change the schema of the `data.yaml` file send to Cloudbeat.
This file determined what rule will be evaluated by OPA. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |

### Related issue
- Implements https://github.com/elastic/security-team/issues/3357
### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
