### PR TITLE
[Enterprise Search] Fix connector id yml block indentation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -146,8 +146,8 @@ export const ConnectorConfiguration: React.FC = () => {
                         {`${
                           apiKeyData?.encoded
                             ? `elasticsearch:
-              api_key: "${apiKeyData?.encoded}"
-            `
+  api_key: "${apiKeyData?.encoded}"
+`
                             : ''
                         }connector_id: "${indexData.connector.id}"
             `}


### PR DESCRIPTION
This fixes the yml file indentation for the connector_id and api_key in Enterprise Search connectors.
<img width="817" alt="Screenshot 2022-08-25 at 11 23 49" src="https://user-images.githubusercontent.com/94373878/186627926-cbb99e93-7114-49ea-b281-49b4cca330c3.png">



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->