### PR TITLE
[Security Solution][Detections] Fix selected rules count and clear selection label on bulk unselect rules with checkbox

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -263,6 +263,7 @@ export const DETECTION_ENGINE_PREPACKAGED_URL =
 export const DETECTION_ENGINE_PRIVILEGES_URL = `${DETECTION_ENGINE_URL}/privileges` as const;
 export const DETECTION_ENGINE_INDEX_URL = `${DETECTION_ENGINE_URL}/index` as const;
 
+export const DETECTION_ENGINE_RULES_URL_FIND = `${DETECTION_ENGINE_RULES_URL}/_find` as const;
 export const DETECTION_ENGINE_TAGS_URL = `${DETECTION_ENGINE_URL}/tags` as const;
 export const DETECTION_ENGINE_PREPACKAGED_RULES_STATUS_URL =
   `${DETECTION_ENGINE_RULES_URL}/prepackaged/_status` as const;

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../common/constants';
 import { rawRules } from '../../../server/lib/detection_engine/rules/prepackaged_rules';
 import {
   COLLAPSED_ACTION_BTN,
@@ -59,7 +60,7 @@ describe('Prebuilt rules', () => {
 
       changeRowsPerPageTo(rowsPerPage);
 
-      cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+      cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
         // Assert the total number of loaded rules equals the expected number of in-memory rules
         expect(body.total).to.equal(rawRules.length);
         // Assert the table was refreshed with the rules returned by the API request

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/rules_selection.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/rules_selection.spec.ts
@@ -4,16 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../common/constants';
+import { totalNumberOfPrebuiltRules } from '../../objects/rule';
 import {
-  ruleCheckboxByIdSelector,
   SELECTED_RULES_NUMBER_LABEL,
   SELECT_ALL_RULES_BTN,
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
 } from '../../screens/alerts_detection_rules';
 import {
   loadPrebuiltDetectionRules,
+  selectNumberOfRules,
+  unselectNumberOfRules,
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../tasks/alerts_detection_rules';
 import { cleanKibana } from '../../tasks/common';
@@ -21,66 +21,58 @@ import { login, visitWithoutDateRange } from '../../tasks/login';
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
 
 describe('Rules selection', () => {
-  before(() => {
+  beforeEach(() => {
     cleanKibana();
     login();
-
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-    loadPrebuiltDetectionRules();
-    waitForPrebuiltDetectionRulesToBeLoaded();
   });
 
   it('should correctly update the selection label when rules are individually selected and unselected', () => {
-    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
-      const [firstRule, secondRule] = body.data;
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
 
-      cy.get(ruleCheckboxByIdSelector(firstRule.id)).click().should('be.checked');
-      cy.get(ruleCheckboxByIdSelector(secondRule.id)).click().should('be.checked');
+    selectNumberOfRules(2);
 
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
 
-      cy.get(ruleCheckboxByIdSelector(firstRule.id)).click().should('not.be.checked');
-      cy.get(ruleCheckboxByIdSelector(secondRule.id)).click().should('not.be.checked');
+    unselectNumberOfRules(2);
 
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
-    });
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
   });
 
   it('should correctly update the selection label when rules are bulk selected and then bulk un-selected', () => {
-    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
-      const numberOfRules = body.total;
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
 
-      cy.get(SELECT_ALL_RULES_BTN).click();
+    cy.get(SELECT_ALL_RULES_BTN).click();
 
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', numberOfRules);
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', totalNumberOfPrebuiltRules);
 
-      const bulkSelectButton = cy.get(SELECT_ALL_RULES_BTN);
+    const bulkSelectButton = cy.get(SELECT_ALL_RULES_BTN);
 
-      // Un-select all rules via the Bulk Selection button from the Utility bar
-      bulkSelectButton.click();
+    // Un-select all rules via the Bulk Selection button from the Utility bar
+    bulkSelectButton.click();
 
-      // Current selection should be 0 rules
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
-      // Bulk selection button should be back to displaying all rules
-      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', numberOfRules);
-    });
+    // Current selection should be 0 rules
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    // Bulk selection button should be back to displaying all rules
+    cy.get(SELECT_ALL_RULES_BTN).should('contain.text', totalNumberOfPrebuiltRules);
   });
 
   it('should correctly update the selection label when rules are bulk selected and then unselected via the table select all checkbox', () => {
-    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
-      const numberOfRules = body.total;
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
 
-      cy.get(SELECT_ALL_RULES_BTN).click();
+    cy.get(SELECT_ALL_RULES_BTN).click();
 
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', numberOfRules);
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', totalNumberOfPrebuiltRules);
 
-      // Un-select all rules via the Un-select All checkbox from the table
-      cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
+    // Un-select all rules via the Un-select All checkbox from the table
+    cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
 
-      // Current selection should be 0 rules
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
-      // Bulk selection button should be back to displaying all rules
-      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', numberOfRules);
-    });
+    // Current selection should be 0 rules
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    // Bulk selection button should be back to displaying all rules
+    cy.get(SELECT_ALL_RULES_BTN).should('contain.text', totalNumberOfPrebuiltRules);
   });
 });

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/rules_selection.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/rules_selection.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../common/constants';
+import {
+  ruleCheckboxByIdSelector,
+  SELECTED_RULES_NUMBER_LABEL,
+  SELECT_ALL_RULES_BTN,
+  SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
+} from '../../screens/alerts_detection_rules';
+import {
+  loadPrebuiltDetectionRules,
+  waitForPrebuiltDetectionRulesToBeLoaded,
+} from '../../tasks/alerts_detection_rules';
+import { cleanKibana } from '../../tasks/common';
+import { login, visitWithoutDateRange } from '../../tasks/login';
+import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
+
+describe('Rules selection', () => {
+  before(() => {
+    cleanKibana();
+    login();
+
+    visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
+  });
+
+  it('should correctly update the selection label when rules are individually selected and unselected', () => {
+    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
+      const [firstRule, secondRule] = body.data;
+
+      cy.get(ruleCheckboxByIdSelector(firstRule.id)).click().should('be.checked');
+      cy.get(ruleCheckboxByIdSelector(secondRule.id)).click().should('be.checked');
+
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
+
+      cy.get(ruleCheckboxByIdSelector(firstRule.id)).click().should('not.be.checked');
+      cy.get(ruleCheckboxByIdSelector(secondRule.id)).click().should('not.be.checked');
+
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    });
+  });
+
+  it('should correctly update the selection label when rules are bulk selected and then bulk un-selected', () => {
+    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
+      const numberOfRules = body.total;
+
+      cy.get(SELECT_ALL_RULES_BTN).click();
+
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', numberOfRules);
+
+      const bulkSelectButton = cy.get(SELECT_ALL_RULES_BTN);
+
+      // Un-select all rules via the Bulk Selection button from the Utility bar
+      bulkSelectButton.click();
+
+      // Current selection should be 0 rules
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+      // Bulk selection button should be back to displaying all rules
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', numberOfRules);
+    });
+  });
+
+  it('should correctly update the selection label when rules are bulk selected and then unselected via the table select all checkbox', () => {
+    cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
+      const numberOfRules = body.total;
+
+      cy.get(SELECT_ALL_RULES_BTN).click();
+
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', numberOfRules);
+
+      // Un-select all rules via the Un-select All checkbox from the table
+      cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
+
+      // Current selection should be 0 rules
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+      // Bulk selection button should be back to displaying all rules
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', numberOfRules);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
@@ -90,6 +90,9 @@ export const rowsPerPageSelector = (count: number) =>
 export const pageSelector = (pageNumber: number) =>
   `[data-test-subj="pagination-button-${pageNumber - 1}"]`;
 
+export const ruleCheckboxByIdSelector = (id: string) =>
+  `[data-test-subj="checkboxSelectRow-${id}"]`;
+
 export const SELECT_ALL_RULES_BTN = '[data-test-subj="selectAllRules"]';
 
 export const RULES_EMPTY_PROMPT = '[data-test-subj="rulesEmptyPrompt"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -201,6 +201,22 @@ export const selectNumberOfRules = (numberOfRules: number) => {
   }
 };
 
+/**
+ * Unselects a passed number of rules. To use together with selectNumberOfRules
+ * as this utility will expect and check the passed number of rules
+ * to have been previously checked.
+ * @param numberOfRules The number of rules to click/check
+ */
+export const unselectNumberOfRules = (numberOfRules: number) => {
+  for (let i = 0; i < numberOfRules; i++) {
+    cy.get(RULE_CHECKBOX)
+      .eq(i)
+      .should('be.checked')
+      .pipe(($el) => $el.trigger('click'))
+      .should('not.be.checked');
+  }
+};
+
 export const selectAllRules = () => {
   cy.get(SELECT_ALL_RULES_BTN).contains('Select all').click();
   cy.get(SELECT_ALL_RULES_BTN).contains('Clear');

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/api.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/api.ts
@@ -16,6 +16,7 @@ import {
   DETECTION_ENGINE_RULES_BULK_ACTION,
   DETECTION_ENGINE_RULES_PREVIEW,
   DETECTION_ENGINE_INSTALLED_INTEGRATIONS_URL,
+  DETECTION_ENGINE_RULES_URL_FIND,
 } from '../../../../../common/constants';
 import type { BulkAction } from '../../../../../common/detection_engine/schemas/common';
 import type {
@@ -151,14 +152,11 @@ export const fetchRules = async ({
     ...(filterString !== '' ? { filter: filterString } : {}),
   };
 
-  return KibanaServices.get().http.fetch<FetchRulesResponse>(
-    `${DETECTION_ENGINE_RULES_URL}/_find`,
-    {
-      method: 'GET',
-      query,
-      signal,
-    }
-  );
+  return KibanaServices.get().http.fetch<FetchRulesResponse>(DETECTION_ENGINE_RULES_URL_FIND, {
+    method: 'GET',
+    query,
+    signal,
+  });
 };
 
 /**

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -219,6 +219,12 @@ export const RulesTables = React.memo<RulesTableProps>(
            */
           if (isSelectAllCalled.current) {
             isSelectAllCalled.current = false;
+            // Handle special case of unselecting all rules via checkbox
+            // after all rules were selected via Bulk select.
+            if (selected.length === 0) {
+              setIsAllSelected(false);
+              setSelectedRuleIds([]);
+            }
           } else {
             setSelectedRuleIds(selected.map(({ id }) => id));
             setIsAllSelected(false);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
@@ -23,6 +23,7 @@ import {
   DETECTION_ENGINE_RULES_BULK_UPDATE,
   DETECTION_ENGINE_RULES_BULK_DELETE,
   DETECTION_ENGINE_RULES_BULK_CREATE,
+  DETECTION_ENGINE_RULES_URL_FIND,
 } from '../../../../../common/constants';
 import type { RuleAlertType, HapiReadableStream } from '../../rules/types';
 import { requestMock } from './request';
@@ -97,7 +98,7 @@ export const getReadRequestWithId = (id: string) =>
 export const getFindRequest = () =>
   requestMock.create({
     method: 'get',
-    path: `${DETECTION_ENGINE_RULES_URL}/_find`,
+    path: DETECTION_ENGINE_RULES_URL_FIND,
   });
 
 export const getReadBulkRequest = () =>

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
-import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
+import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../../../common/constants';
 import { getQueryRuleParams } from '../../schemas/rule_schemas.mock';
 import { requestContextMock, requestMock, serverMock } from '../__mocks__';
 import {
@@ -63,7 +63,7 @@ describe('find_rules', () => {
     test('allows optional query params', async () => {
       const request = requestMock.create({
         method: 'get',
-        path: `${DETECTION_ENGINE_RULES_URL}/_find`,
+        path: DETECTION_ENGINE_RULES_URL_FIND,
         query: {
           page: 2,
           per_page: 20,
@@ -79,7 +79,7 @@ describe('find_rules', () => {
     test('rejects unknown query params', async () => {
       const request = requestMock.create({
         method: 'get',
-        path: `${DETECTION_ENGINE_RULES_URL}/_find`,
+        path: DETECTION_ENGINE_RULES_URL_FIND,
         query: {
           invalid_value: 'hi mom',
         },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
@@ -11,7 +11,7 @@ import { findRuleValidateTypeDependents } from '../../../../../common/detection_
 import type { FindRulesSchemaDecoded } from '../../../../../common/detection_engine/schemas/request/find_rules_schema';
 import { findRulesSchema } from '../../../../../common/detection_engine/schemas/request/find_rules_schema';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
-import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
+import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../../../common/constants';
 import { findRules } from '../../rules/find_rules';
 import { buildSiemResponse } from '../utils';
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
@@ -23,7 +23,7 @@ import { legacyGetBulkRuleActionsSavedObject } from '../../rule_actions/legacy_g
 export const findRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   router.get(
     {
-      path: `${DETECTION_ENGINE_RULES_URL}/_find`,
+      path: DETECTION_ENGINE_RULES_URL_FIND,
       validate: {
         query: buildRouteValidation<typeof findRulesSchema, FindRulesSchemaDecoded>(
           findRulesSchema


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/136616

## Summary

### Behaviour before fix
Selected rules count doesn't update in the special case of a user having selected all rules via the "Select all XXX rules" bulk action button from the Utility bar, and later trying to unselect rules via the "Select/Unselect All rows" checkbox of the table. 

In this specific case, the selected rules label got stuck at "Selected XXX Rules" and the the "Select All XXX rules" bulk action button got stuck on "Clear selection".

See video below for details:

https://user-images.githubusercontent.com/5354282/186687704-c1a4a36b-6f49-4347-abf3-6cfc648b586e.mp4



### Behaviour after fix
If, after selection all rules with the bulk select all rules button, the user clicks on the "Select/Unselect All rows" checkbox of the table:
- the selected rules label resets to "Selected 0 Rules"
- the "bulk select all rules" button from the Utility bar switches back from its "Clear selection" state back to its "Select all XXX rules"  state.

https://user-images.githubusercontent.com/5354282/186687602-815ef9a0-53be-4476-a8bb-9edcc5df7db4.mov

## Other changes
- Create constant for API route `/api/detection_engine/rules/_find` as `DETECTION_ENGINE_RULES_URL_FIND` and replaces its uses.

### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->