### PR TITLE
[ML] Fix navigation for the Basic licence

### DIFF
--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -142,7 +142,7 @@ export const renderApp = (
 
   appMountParams.onAppLeave((actions) => actions.default());
 
-  const mlLicense = setLicenseCache(deps.licensing, [
+  const mlLicense = setLicenseCache(deps.licensing, coreStart.application, [
     () =>
       ReactDOM.render(
         <App coreStart={coreStart} deps={deps} appMountParams={appMountParams} />,

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/utils.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/utils.js
@@ -13,7 +13,7 @@ import {
   getToastNotificationService,
   toastNotificationServiceProvider,
 } from '../../../services/toast_notification_service';
-import { getToastNotifications } from '../../../util/dependency_cache';
+import { getApplication, getToastNotifications } from '../../../util/dependency_cache';
 import { ml } from '../../../services/ml_api_service';
 import { stringMatch } from '../../../util/string_utils';
 import { getDataViewNames } from '../../../util/index_utils';
@@ -22,6 +22,7 @@ import { JOB_ACTION } from '../../../../../common/constants/job_actions';
 import { parseInterval } from '../../../../../common/util/parse_interval';
 import { mlCalendarService } from '../../../services/calendar_service';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
+import { ML_PAGES } from '../../../../../common/constants/locator';
 
 export function loadFullJob(jobId) {
   return new Promise((resolve, reject) => {
@@ -287,7 +288,7 @@ export async function cloneJob(jobId) {
       );
     }
 
-    window.location.href = '#/jobs/new_job';
+    getApplication().navigateToApp('ml', { path: ML_PAGES.ANOMALY_DETECTION_CREATE_JOB });
   } catch (error) {
     getToastNotificationService().displayErrorToast(
       error,

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/utils.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/utils.js
@@ -23,6 +23,7 @@ import { parseInterval } from '../../../../../common/util/parse_interval';
 import { mlCalendarService } from '../../../services/calendar_service';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { ML_PAGES } from '../../../../../common/constants/locator';
+import { PLUGIN_ID } from '../../../../../common/constants/app';
 
 export function loadFullJob(jobId) {
   return new Promise((resolve, reject) => {
@@ -288,7 +289,7 @@ export async function cloneJob(jobId) {
       );
     }
 
-    getApplication().navigateToApp('ml', { path: ML_PAGES.ANOMALY_DETECTION_CREATE_JOB });
+    getApplication().navigateToApp(PLUGIN_ID, { path: ML_PAGES.ANOMALY_DETECTION_CREATE_JOB });
   } catch (error) {
     getToastNotificationService().displayErrorToast(
       error,

--- a/x-pack/plugins/ml/public/application/license/check_license.tsx
+++ b/x-pack/plugins/ml/public/application/license/check_license.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
+import type { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
+import type { CoreStart } from '@kbn/core/public';
 import { MlLicense } from '../../../common/license';
 import { MlClientLicense } from './ml_client_license';
 
@@ -16,13 +17,16 @@ let mlLicense: MlClientLicense | null = null;
  *
  * @export
  * @param {LicensingPluginSetup} licensingSetup
+ * @param application
+ * @param postInitFunctions
  * @returns {MlClientLicense}
  */
 export function setLicenseCache(
   licensingSetup: LicensingPluginSetup,
+  application: CoreStart['application'],
   postInitFunctions?: Array<(lic: MlLicense) => void>
 ) {
-  mlLicense = new MlClientLicense();
+  mlLicense = new MlClientLicense(application);
   mlLicense.setup(licensingSetup.license$, postInitFunctions);
   return mlLicense;
 }

--- a/x-pack/plugins/ml/public/application/license/ml_client_license.test.ts
+++ b/x-pack/plugins/ml/public/application/license/ml_client_license.test.ts
@@ -9,10 +9,13 @@ import { Observable, Subject } from 'rxjs';
 import { ILicense } from '@kbn/licensing-plugin/common/types';
 
 import { MlClientLicense } from './ml_client_license';
+import { applicationServiceMock } from '@kbn/core/public/application/application_service.mock';
 
 describe('MlClientLicense', () => {
+  const startApplicationContractMock = applicationServiceMock.createStartContract();
+
   test('should miss the license update when initialized without postInitFunction', () => {
-    const mlLicense = new MlClientLicense();
+    const mlLicense = new MlClientLicense(startApplicationContractMock);
 
     // upon instantiation the full license doesn't get set
     expect(mlLicense.isFullLicense()).toBe(false);
@@ -35,7 +38,7 @@ describe('MlClientLicense', () => {
   });
 
   test('should not miss the license update when initialized with postInitFunction', (done) => {
-    const mlLicense = new MlClientLicense();
+    const mlLicense = new MlClientLicense(startApplicationContractMock);
 
     // upon instantiation the full license doesn't get set
     expect(mlLicense.isFullLicense()).toBe(false);

--- a/x-pack/plugins/ml/public/application/license/ml_client_license.ts
+++ b/x-pack/plugins/ml/public/application/license/ml_client_license.ts
@@ -5,19 +5,33 @@
  * 2.0.
  */
 
+import type { CoreStart } from '@kbn/core/public';
+import { ML_PAGES } from '../../../common/constants/locator';
 import { MlLicense } from '../../../common/license';
 import { showExpiredLicenseWarning } from './expired_warning';
 
 export class MlClientLicense extends MlLicense {
-  fullLicenseResolver() {
+  constructor(private application: CoreStart['application']) {
+    super();
+  }
+
+  private redirectToKibana() {
+    return this.application.navigateToApp('home');
+  }
+
+  private redirectToBasic() {
+    return this.application.navigateToApp('ml', { path: ML_PAGES.DATA_VISUALIZER });
+  }
+
+  fullLicenseResolver(): Promise<void> {
     if (this.isMlEnabled() === false || this.isMinimumLicense() === false) {
       // ML is not enabled or the license isn't at least basic
-      return redirectToKibana();
+      return this.redirectToKibana();
     }
 
     if (this.isFullLicense() === false) {
       // ML is enabled, but only with a basic or gold license
-      return redirectToBasic();
+      return this.redirectToBasic();
     }
 
     // ML is enabled
@@ -30,7 +44,7 @@ export class MlClientLicense extends MlLicense {
   basicLicenseResolver() {
     if (this.isMlEnabled() === false || this.isMinimumLicense() === false) {
       // ML is not enabled or the license isn't at least basic
-      return redirectToKibana();
+      return this.redirectToKibana();
     }
 
     // ML is enabled
@@ -39,14 +53,4 @@ export class MlClientLicense extends MlLicense {
     }
     return Promise.resolve();
   }
-}
-
-function redirectToKibana() {
-  window.location.href = '/';
-  return Promise.reject();
-}
-
-function redirectToBasic() {
-  window.location.href = '#/datavisualizer';
-  return Promise.reject();
 }

--- a/x-pack/plugins/ml/public/application/license/ml_client_license.ts
+++ b/x-pack/plugins/ml/public/application/license/ml_client_license.ts
@@ -9,6 +9,7 @@ import type { CoreStart } from '@kbn/core/public';
 import { ML_PAGES } from '../../../common/constants/locator';
 import { MlLicense } from '../../../common/license';
 import { showExpiredLicenseWarning } from './expired_warning';
+import { PLUGIN_ID } from '../../../common/constants/app';
 
 export class MlClientLicense extends MlLicense {
   constructor(private application: CoreStart['application']) {
@@ -16,11 +17,13 @@ export class MlClientLicense extends MlLicense {
   }
 
   private redirectToKibana() {
-    return this.application.navigateToApp('home');
+    this.application.navigateToApp('home');
+    return Promise.reject();
   }
 
   private redirectToBasic() {
-    return this.application.navigateToApp('ml', { path: ML_PAGES.DATA_VISUALIZER });
+    this.application.navigateToApp(PLUGIN_ID, { path: ML_PAGES.DATA_VISUALIZER });
+    return Promise.reject();
   }
 
   fullLicenseResolver(): Promise<void> {

--- a/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
+import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
-
 import { USER } from '../../../../functional/services/ml/security_common';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
+  const browser = getService('browser');
 
   const testUsers = [
     { user: USER.ML_POWERUSER, discoverAvailable: true },
@@ -56,6 +57,10 @@ export default function ({ getService }: FtrProviderContext) {
         it('should display tabs in the ML app correctly', async () => {
           await ml.testExecution.logTestStep('should load the ML app');
           await ml.navigation.navigateToMl();
+
+          await ml.testExecution.logTestStep('should redirect to the "Data Visualizer" page');
+          const browserURl = await browser.getCurrentUrl();
+          expect(browserURl).to.contain('/ml/datavisualizer');
 
           await ml.testExecution.logTestStep('should display the disabled "Overview" tab');
           await ml.navigation.assertOverviewTabEnabled(false);

--- a/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
+import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
-
 import { USER } from '../../../../functional/services/ml/security_common';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
+  const browser = getService('browser');
 
   const testUsers = [
     { user: USER.ML_VIEWER, discoverAvailable: true },
@@ -56,6 +57,10 @@ export default function ({ getService }: FtrProviderContext) {
         it('should display tabs in the ML app correctly', async () => {
           await ml.testExecution.logTestStep('should load the ML app');
           await ml.navigation.navigateToMl();
+
+          await ml.testExecution.logTestStep('should redirect to the "Data Visualizer" page');
+          const browserURl = await browser.getCurrentUrl();
+          expect(browserURl).to.contain('/ml/datavisualizer');
 
           await ml.testExecution.logTestStep('should display the disabled "Overview" tab');
           await ml.navigation.assertOverviewTabEnabled(false);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/139279

Previously when running with a basic licence, when you landed on the ML app from certain apps, e.g. Discover or Stack Monitoring, it would get stuck in a redirect loop showing the Page Not Found warning message.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->