### PR TITLE
[TIP] make expand button color primamry when flyout is closed

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/open_indicator_flyout_button/open_indicator_flyout_button.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/open_indicator_flyout_button/open_indicator_flyout_button.stories.tsx
@@ -17,6 +17,12 @@ export default {
   title: 'OpenIndicatorFlyoutButton',
   argTypes: {
     onOpen: { action: 'onOpen' },
+    isOpen: {
+      options: [true, false],
+      control: {
+        type: 'radio',
+      },
+    },
   },
 };
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/open_indicator_flyout_button/open_indicator_flyout_button.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/open_indicator_flyout_button/open_indicator_flyout_button.tsx
@@ -46,7 +46,7 @@ export const OpenIndicatorFlyoutButton: VFC<OpenIndicatorFlyoutButtonProps> = ({
     <EuiToolTip content={buttonLabel} delay="long">
       <EuiButtonIcon
         data-test-subj={BUTTON_TEST_ID}
-        color={isOpen ? 'primary' : 'text'}
+        color={isOpen ? 'text' : 'primary'}
         iconType={isOpen ? 'minimize' : 'expand'}
         isSelected={isOpen}
         iconSize="s"


### PR DESCRIPTION
## Summary

making Expand button blue (`primary` color) when flyout is closed and grey (`text` color) when the flyout is open
<img width="1428" alt="Screenshot 2022-08-25 at 16 58 52" src="https://user-images.githubusercontent.com/478762/186699987-d558cc1e-96ec-4b94-bb11-e1a239f056e0.png">

