### PR TITLE
[8.4] [ResponseOps][Alerting] Unable to upgrade to 8.4.0 when I have snoozed rules (#139427)

### DIFF
--- a/x-pack/plugins/alerting/server/saved_objects/migrations.test.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations.test.ts
@@ -2397,6 +2397,33 @@ describe('successful migrations', () => {
       });
     });
 
+    describe('8.4.1', () => {
+      test('removes isSnoozedUntil', () => {
+        const migration841 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.4.1'
+        ];
+        const mutedAlert = getMockData(
+          {
+            isSnoozedUntil: '1970-01-02T00:00:00.000Z',
+          },
+          true
+        );
+        expect(mutedAlert.attributes.isSnoozedUntil).toBeTruthy();
+        const migratedAlert841 = migration841(mutedAlert, migrationContext);
+
+        expect(migratedAlert841.attributes.isSnoozedUntil).toBeFalsy();
+      });
+
+      test('works as expected if isSnoozedUntil is not populated', () => {
+        const migration841 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.4.1'
+        ];
+        const mutedAlert = getMockData({}, true);
+        expect(mutedAlert.attributes.isSnoozedUntil).toBeFalsy();
+        expect(() => migration841(mutedAlert, migrationContext)).not.toThrowError();
+      });
+    });
+
     describe('Metrics Inventory Threshold rule', () => {
       test('Migrates incorrect action group spelling', () => {
         const migration800 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[

--- a/x-pack/plugins/alerting/server/saved_objects/migrations.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations.ts
@@ -169,6 +169,12 @@ export function getMigrations(
     pipeMigrations(addSearchType, removeInternalTags, convertSnoozes)
   );
 
+  const migrationRules841 = createEsoMigration(
+    encryptedSavedObjects,
+    (doc: SavedObjectUnsanitizedDoc<RawRule>): doc is SavedObjectUnsanitizedDoc<RawRule> => true,
+    pipeMigrations(removeIsSnoozedUntil)
+  );
+
   return mergeSavedObjectMigrationMaps(
     {
       '7.10.0': executeMigrationWithErrorHandling(migrationWhenRBACWasIntroduced, '7.10.0'),
@@ -182,6 +188,7 @@ export function getMigrations(
       '8.0.1': executeMigrationWithErrorHandling(migrationRules801, '8.0.1'),
       '8.2.0': executeMigrationWithErrorHandling(migrationRules820, '8.2.0'),
       '8.3.0': executeMigrationWithErrorHandling(migrationRules830, '8.3.0'),
+      '8.4.1': executeMigrationWithErrorHandling(migrationRules841, '8.4.1'),
     },
     getSearchSourceMigrations(encryptedSavedObjects, searchSourceMigrations)
   );
@@ -1012,4 +1019,15 @@ function getSearchSourceMigrations(
     }
   }
   return filteredMigrations;
+}
+
+function removeIsSnoozedUntil(
+  doc: SavedObjectUnsanitizedDoc<RawRule>
+): SavedObjectUnsanitizedDoc<RawRule> {
+  return {
+    ...doc,
+    attributes: {
+      ...(omit(doc.attributes, ['isSnoozedUntil']) as RawRule),
+    },
+  };
 }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/migrations.ts
@@ -443,5 +443,25 @@ export default function createGetTests({ getService }: FtrProviderContext) {
       expect(response.statusCode).to.equal(200);
       expect(response.body._source?.alert?.tags).to.eql(['test-tag-1', 'foo-tag']);
     });
+
+    it('8.4.1 removes IsSnoozedUntil', async () => {
+      const searchResult = await es.search<RawRule>(
+        {
+          index: '.kibana',
+          body: {
+            query: {
+              term: {
+                _id: 'alert:4d973df0-23df-11ed-8ae4-e988ad0f6fa7',
+              },
+            },
+          },
+        },
+        { meta: true }
+      );
+
+      expect(searchResult.statusCode).to.equal(200);
+      const hit = searchResult.body.hits.hits[0];
+      expect((hit!._source!.alert! as RawRule).isSnoozedUntil).to.be(undefined);
+    });
   });
 }

--- a/x-pack/test/functional/es_archives/alerts/data.json
+++ b/x-pack/test/functional/es_archives/alerts/data.json
@@ -1041,3 +1041,41 @@
      }
   }
 }
+
+{
+  "type": "doc",
+  "value": {
+    "id": "alert:4d973df0-23df-11ed-8ae4-e988ad0f6fa7",
+    "index": ".kibana_1",
+    "source": {
+      "alert": {
+          "alertTypeId": "example.always-firing",
+          "apiKey": null,
+          "apiKeyOwner": null,
+          "consumer": "alerts",
+          "createdAt": "2022-08-24T19:02:30.889Z",
+          "createdBy": "elastic",
+          "enabled": false,
+          "muteAll": false,
+          "mutedInstanceIds": [],
+          "name": "remove snoozed",
+          "params": {},
+          "schedule": {
+              "interval": "1m"
+          },
+          "scheduledTaskId": null,
+          "tags": [],
+          "throttle": null,
+          "updatedBy": "elastic",
+          "isSnoozedUntil": "2022-08-24T19:05:49.817Z"
+      },
+      "migrationVersion": {
+          "alert": "8.3.0"
+      },
+      "references": [
+      ],
+      "type": "alert",
+      "updated_at": "2022-08-24T19:05:50.159Z"
+    }
+  }
+}

--- a/x-pack/test/functional/es_archives/alerts/mappings.json
+++ b/x-pack/test/functional/es_archives/alerts/mappings.json
@@ -172,6 +172,9 @@
             },
             "updatedBy": {
               "type": "keyword"
+            },
+            "isSnoozedUntil": {
+              "type": "date"
             }
           }
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[ResponseOps][Alerting] Unable to upgrade to 8.4.0 when I have snoozed rules (#139427)](https://github.com/elastic/kibana/pull/139427)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"doakalexi","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-08-25T14:48:14Z","message":"[ResponseOps][Alerting] Unable to upgrade to 8.4.0 when I have snoozed rules (#139427)\n\n* Adding migration\r\n\r\n* Removing timer\r\n\r\n* Adding functional test\r\n\r\n* Adding another test","sha":"8991e046a2710f71db3a067197f1329f6438a8b4","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","auto-backport","v8.4.1"],"number":139427,"url":"https://github.com/elastic/kibana/pull/139427","mergeCommit":{"message":"[ResponseOps][Alerting] Unable to upgrade to 8.4.0 when I have snoozed rules (#139427)\n\n* Adding migration\r\n\r\n* Removing timer\r\n\r\n* Adding functional test\r\n\r\n* Adding another test","sha":"8991e046a2710f71db3a067197f1329f6438a8b4"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->