### PR TITLE
[Synthetics] Add synthetics e2e test README file

### DIFF
--- a/x-pack/plugins/synthetics/e2e/README.md
+++ b/x-pack/plugins/synthetics/e2e/README.md
@@ -1,0 +1,15 @@
+## How to run these tests
+
+These tests rely on the Kibana functional test runner. There is a Kibana config in this directory, and a dedicated
+script for standing up the test server.
+
+### Start the server
+
+From `~/x-pack/plugins/synthetics/scripts`, run `node e2e.js --server`. Wait for the server to startup. It will provide you
+with an example run command when it finishes.
+
+### Run the tests
+
+From this directory, `~/x-pack/plugins/synthetics/e2e`, you can now run `node ../../../../scripts/functional_test_runner --config synthetics_run.ts`.
+
+In addition to the usual flags like `--grep`, you can also specify `--no-headless` in order to view your tests as you debug/develop.


### PR DESCRIPTION
## Summary

Adds a simple README file with some barebones instructions on how to run the tests. This information is available elsewhere but it is good to keep it as close to the test files as possible.

