### PR TITLE
[Search/public] allow skipping onResponse for no-op post-flight

### DIFF
--- a/src/plugins/data/common/search/aggs/agg_configs.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_configs.test.ts
@@ -677,7 +677,7 @@ describe('AggConfigs', () => {
         },
       };
       const mergedResponse = ac.postFlightTransform(response as unknown as IEsSearchResponse<any>);
-      expect(mergedResponse.rawResponse).toEqual({
+      expect(mergedResponse?.rawResponse).toEqual({
         aggregations: {
           '1': {
             buckets: [
@@ -772,7 +772,7 @@ describe('AggConfigs', () => {
         },
       };
       const mergedResponse = ac.postFlightTransform(response as unknown as IEsSearchResponse<any>);
-      expect(mergedResponse.rawResponse).toEqual({
+      expect(mergedResponse?.rawResponse).toEqual({
         aggregations: {
           '1': {
             buckets: [
@@ -845,7 +845,7 @@ describe('AggConfigs', () => {
       const ac = new AggConfigs(indexPattern, configStates, { typesRegistry }, jest.fn());
 
       expect(toString(ac.toExpressionAst())).toMatchInlineSnapshot(`
-        "esaggs index={indexPatternLoad id=\\"logstash-*\\"} metricsAtAllLevels=false partialRows=false 
+        "esaggs index={indexPatternLoad id=\\"logstash-*\\"} metricsAtAllLevels=false partialRows=false
           aggs={aggDateHistogram field=\\"@timestamp\\" useNormalizedEsInterval=true extendToTimeRange=false scaleMetricValues=false interval=\\"10s\\" drop_partials=false min_doc_count=1 extended_bounds={extendedBounds} id=\\"1\\" enabled=true schema=\\"segment\\"}
           aggs={aggAvg field=\\"bytes\\" id=\\"2\\" enabled=true schema=\\"metric\\"}
           aggs={aggSum field=\\"bytes\\" emptyAsNull=false id=\\"3\\" enabled=true schema=\\"metric\\"}

--- a/src/plugins/data/common/search/aggs/agg_configs.ts
+++ b/src/plugins/data/common/search/aggs/agg_configs.ts
@@ -442,10 +442,7 @@ export class AggConfigs {
     ];
   }
 
-  postFlightTransform(response: IEsSearchResponse) {
-    if (!this.hasTimeShifts()) {
-      return response;
-    }
+  postFlightTransform(response: IEsSearchResponse): IEsSearchResponse<any> | undefined {
     const transformedRawResponse = cloneDeep(response.rawResponse);
     if (!transformedRawResponse.aggregations) {
       transformedRawResponse.aggregations = {

--- a/src/plugins/data/common/search/aggs/agg_type.ts
+++ b/src/plugins/data/common/search/aggs/agg_type.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { constant, noop, identity } from 'lodash';
+import { constant, noop } from 'lodash';
 import { i18n } from '@kbn/i18n';
 
 import { DatatableColumnType } from '@kbn/expressions-plugin/common';
@@ -30,7 +30,7 @@ type PostFlightRequestFn<TAggConfig> = (
   inspectorRequestAdapter?: RequestAdapter,
   abortSignal?: AbortSignal,
   searchSessionId?: string
-) => Promise<estypes.SearchResponse<any>>;
+) => Promise<estypes.SearchResponse<any> | undefined>;
 
 export interface AggTypeConfig<
   TAggConfig extends AggConfig = AggConfig,
@@ -307,7 +307,7 @@ export class AggType<
     this.getRequestAggs = config.getRequestAggs || noop;
     this.getResponseAggs = config.getResponseAggs || (() => {});
     this.decorateAggConfig = config.decorateAggConfig || (() => ({}));
-    this.postFlightRequest = config.postFlightRequest || identity;
+    this.postFlightRequest = config.postFlightRequest || (() => Promise.resolve(undefined));
     this.hasPrecisionError = config.hasPrecisionError;
 
     this.getSerializedFormat =

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -325,7 +325,7 @@ export function constructMultiTermOtherFilter(
 
 export const createOtherBucketPostFlightRequest = (
   otherFilterBuilder: (requestAgg: Record<string, any>, key: string, otherAgg: IAggConfig) => Filter
-) => {
+): IAggType['postFlightRequest'] | undefined => {
   const postFlightRequest: IAggType['postFlightRequest'] = async (
     resp,
     aggConfigs,
@@ -335,11 +335,11 @@ export const createOtherBucketPostFlightRequest = (
     abortSignal,
     searchSessionId
   ) => {
-    if (!resp.aggregations) return resp;
+    if (!resp.aggregations) return;
     const nestedSearchSource = searchSource.createChild();
     if (aggConfig.params.otherBucket) {
       const filterAgg = buildOtherBucketAgg(aggConfigs, aggConfig, resp);
-      if (!filterAgg) return resp;
+      if (!filterAgg) return;
 
       nestedSearchSource.setField('aggs', filterAgg);
 

--- a/src/plugins/data/common/search/search_source/fetch/types.ts
+++ b/src/plugins/data/common/search/search_source/fetch/types.ts
@@ -29,7 +29,7 @@ export interface FetchHandlers {
     request: SearchRequest,
     response: IKibanaSearchResponse,
     options: SearchSourceSearchOptions
-  ) => IKibanaSearchResponse;
+  ) => void;
 }
 
 export interface SearchError {

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -55,10 +55,8 @@ import {
   SearchSourceService,
   selectFilterFunction,
   eqlRawResponse,
-  SearchSourceSearchOptions,
 } from '../../common/search';
 import { AggsService } from './aggs';
-import { IKibanaSearchResponse, SearchRequest } from '..';
 import { ISearchInterceptor, SearchInterceptor } from './search_interceptor';
 import { createUsageCollector, SearchUsageCollector } from './collectors';
 import { getEsaggs, getEsdsl, getEssql, getEql } from './expressions';
@@ -239,8 +237,11 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       aggs,
       getConfig: uiSettings.get.bind(uiSettings),
       search,
-      onResponse: (...args: [SearchRequest, IKibanaSearchResponse, SearchSourceSearchOptions]) =>
-        handleResponse(...args, theme),
+      onResponse: (request, response, options) => {
+        if (response != null) {
+          handleResponse(request, response, options, theme);
+        }
+      },
     };
 
     const config = this.initializerContext.config.get();
@@ -268,7 +269,9 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     return {
       aggs,
       search,
-      showError: (e: Error) => {
+      showError: (e) => {
+        // eslint-disable-next-line no-console
+        console.error(e);
         this.searchInterceptor.showError(e);
       },
       session: this.sessionService,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/139423


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
