### PR TITLE
[APM] Synthtrace: Add rate per minute helper

### DIFF
--- a/packages/kbn-apm-synthtrace/README.md
+++ b/packages/kbn-apm-synthtrace/README.md
@@ -13,14 +13,6 @@ This library can currently be used in two ways:
 - Imported as a Node.js module, for instance to be used in Kibana's functional test suite.
 - With a command line interface, to index data based on a specified scenario.
 
-## Testing
-
-Run the Jest tests:
-
-```
-node scripts/jest --config ./packages/kbn-apm-synthtrace/jest.config.js
-```
-
 ### Using the Node.js module
 
 #### Concepts
@@ -163,3 +155,19 @@ Note:
 | `--logLevel`      | [enum]    | `info`  | Log level                                                                                               |
 | `--gcpRepository` | [string]  |         | Allows you to register a GCP repository in <client_name>:<bucket>[:base_path] format                    |
 | `-p`              | [string]  |         | Specify multiple sets of streamaggregators to be included in the StreamProcessor                        |
+
+## Testing
+
+Run the Jest tests:
+
+```
+node scripts/jest --config ./packages/kbn-apm-synthtrace/jest.config.js
+```
+
+## Typescript
+
+Run the type checker:
+
+```
+node scripts/type_check.js --project packages/kbn-apm-synthtrace/tsconfig.json
+```

--- a/packages/kbn-apm-synthtrace/README.md
+++ b/packages/kbn-apm-synthtrace/README.md
@@ -13,6 +13,14 @@ This library can currently be used in two ways:
 - Imported as a Node.js module, for instance to be used in Kibana's functional test suite.
 - With a command line interface, to index data based on a specified scenario.
 
+## Testing
+
+Run the Jest tests:
+
+```
+node scripts/jest --config ./packages/kbn-apm-synthtrace/jest.config.js
+```
+
 ### Using the Node.js module
 
 #### Concepts

--- a/packages/kbn-apm-synthtrace/src/cli/utils/start_historical_data_upload.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/start_historical_data_upload.ts
@@ -54,7 +54,7 @@ export async function startHistoricalDataUpload(
   }
 
   const events = logger.perf('generate_scenario', () => generate({ from, to }));
-  const ratePerMinute = events.ratePerMinute();
+  const ratePerMinute = events.estimatedRatePerMinute();
   logger.info(
     `Scenario is generating ${ratePerMinute.toLocaleString()} events per minute interval`
   );
@@ -62,7 +62,7 @@ export async function startHistoricalDataUpload(
   if (runOptions.maxDocs) {
     // estimate a more accurate range end for when --maxDocs is specified
     rangeEnd = moment(from)
-      // ratePerMinute() is not exact if the generator is yielding variable documents
+      // estimatedRatePerMinute() is not exact if the generator is yielding variable documents
       // the rate is calculated by peeking the first yielded event and its children.
       // for real complex cases manually specifying --to is encouraged.
       .subtract((runOptions.maxDocs / ratePerMinute) * runOptions.maxDocsConfidence, 'm')

--- a/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
@@ -36,8 +36,6 @@ export interface Observer {
   version_major: number;
 }
 
-export type ApmLabels = Partial<Record<`labels.${string}`, string>>;
-
 export type ApmFields = Fields &
   Partial<{
     'timestamp.us'?: number;
@@ -106,5 +104,4 @@ export type ApmFields = Fields &
     'faas.trigger.type': string;
     'faas.trigger.request_id': string;
   }> &
-  ApmApplicationMetricFields &
-  ApmLabels;
+  ApmApplicationMetricFields;

--- a/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
@@ -36,6 +36,8 @@ export interface Observer {
   version_major: number;
 }
 
+export type ApmLabels = Partial<Record<`labels.${string}`, string>>;
+
 export type ApmFields = Fields &
   Partial<{
     'timestamp.us'?: number;
@@ -104,4 +106,5 @@ export type ApmFields = Fields &
     'faas.trigger.type': string;
     'faas.trigger.request_id': string;
   }> &
-  ApmApplicationMetricFields;
+  ApmApplicationMetricFields &
+  ApmLabels;

--- a/packages/kbn-apm-synthtrace/src/lib/apm/base_span.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/base_span.ts
@@ -79,6 +79,7 @@ export class BaseSpan extends Serializable<ApmFields> {
 
   labels(labels: Record<string, string>) {
     Object.entries(labels).forEach(([key, value]) => {
+      // @ts-expect-error
       this.fields[`labels.${key}`] = value;
     });
     return this;

--- a/packages/kbn-apm-synthtrace/src/lib/apm/base_span.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/base_span.ts
@@ -76,4 +76,11 @@ export class BaseSpan extends Serializable<ApmFields> {
   isTransaction(): this is Transaction {
     return this.fields['processor.event'] === 'transaction';
   }
+
+  labels(labels: Record<string, string>) {
+    Object.entries(labels).forEach(([key, value]) => {
+      this.fields[`labels.${key}`] = value;
+    });
+    return this;
+  }
 }

--- a/packages/kbn-apm-synthtrace/src/lib/entity_generator.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/entity_generator.ts
@@ -35,7 +35,7 @@ export class EntityGenerator<TField> implements EntityIterable<TField> {
     };
 
     const peekedNumberOfEvents = peek.done ? 0 : peek.value.serialize().length;
-    this._ratePerMinute = interval.ratePerMinute() * peekedNumberOfEvents;
+    this._ratePerMinute = interval.estimatedRatePerMinute() * peekedNumberOfEvents;
   }
 
   private readonly _order: 'desc' | 'asc';
@@ -52,7 +52,7 @@ export class EntityGenerator<TField> implements EntityIterable<TField> {
   }
 
   private readonly _ratePerMinute: number;
-  ratePerMinute() {
+  estimatedRatePerMinute() {
     return this._ratePerMinute;
   }
 

--- a/packages/kbn-apm-synthtrace/src/lib/entity_iterable.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/entity_iterable.ts
@@ -15,7 +15,7 @@ export interface EntityIterable<TFields extends Fields = ApmFields>
     AsyncIterable<TFields> {
   order(): 'desc' | 'asc';
 
-  ratePerMinute(): number;
+  estimatedRatePerMinute(): number;
 
   toArray(): ApmFields[];
 
@@ -40,7 +40,7 @@ export class EntityArrayIterable<TFields extends Fields = ApmFields>
   }
 
   private readonly _ratePerMinute: number;
-  ratePerMinute() {
+  estimatedRatePerMinute() {
     return this._ratePerMinute;
   }
 

--- a/packages/kbn-apm-synthtrace/src/lib/entity_streams.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/entity_streams.ts
@@ -15,7 +15,9 @@ export class EntityStreams<TFields> implements EntityIterable<TFields> {
     if (orders.size > 1) throw Error('Can only combine intervals with the same order()');
     this._order = orders.has('asc') ? 'asc' : 'desc';
 
-    this._ratePerMinute = dataGenerators.map((d) => d.ratePerMinute()).reduce((a, b) => a + b, 0);
+    this._ratePerMinute = dataGenerators
+      .map((d) => d.estimatedRatePerMinute())
+      .reduce((a, b) => a + b, 0);
   }
 
   private readonly _order: 'desc' | 'asc';
@@ -24,7 +26,7 @@ export class EntityStreams<TFields> implements EntityIterable<TFields> {
   }
 
   private readonly _ratePerMinute: number;
-  ratePerMinute() {
+  estimatedRatePerMinute() {
     return this._ratePerMinute;
   }
 

--- a/packages/kbn-apm-synthtrace/src/lib/interval.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/interval.ts
@@ -11,12 +11,18 @@ import { EntityIterable } from './entity_iterable';
 import { EntityGenerator } from './entity_generator';
 import { Serializable } from './serializable';
 
-export function parseInterval(interval: string): [number, unitOfTime.DurationConstructor] {
+export function parseInterval(interval: string): {
+  intervalAmount: number;
+  intervalUnit: unitOfTime.DurationConstructor;
+} {
   const args = interval.match(/(\d+)(s|m|h|d)/);
   if (!args || args.length < 3) {
     throw new Error('Failed to parse interval');
   }
-  return [Number(args[1]), args[2] as any];
+  return {
+    intervalAmount: Number(args[1]),
+    intervalUnit: args[2] as unitOfTime.DurationConstructor,
+  };
 }
 
 export interface IntervalOptions {
@@ -31,9 +37,9 @@ export interface IntervalOptions {
 
 export class Interval implements Iterable<number> {
   constructor(public readonly options: IntervalOptions) {
-    const parsed = parseInterval(options.interval);
-    this.intervalAmount = parsed[0];
-    this.intervalUnit = parsed[1];
+    const { intervalAmount, intervalUnit } = parseInterval(options.interval);
+    this.intervalAmount = intervalAmount;
+    this.intervalUnit = intervalUnit;
     this.from = this.options.from;
     this.to = this.options.to;
   }
@@ -66,7 +72,7 @@ export class Interval implements Iterable<number> {
     return new Interval({ ...this.options, intervalUpper, rateUpper });
   }
 
-  ratePerMinute(): number {
+  estimatedRatePerMinute(): number {
     const rate = this.options.rateUpper
       ? Math.max(1, this.options.rateUpper)
       : this.options.yieldRate ?? 1;

--- a/packages/kbn-apm-synthtrace/src/lib/stream_processor.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/stream_processor.ts
@@ -45,9 +45,11 @@ export class StreamProcessor<TFields extends Fields = ApmFields> {
   private readonly streamAggregators: Array<StreamAggregator<TFields>>;
 
   constructor(private readonly options: StreamProcessorOptions<TFields>) {
-    [this.intervalAmount, this.intervalUnit] = this.options.flushInterval
+    const { intervalAmount, intervalUnit } = this.options.flushInterval
       ? parseInterval(this.options.flushInterval)
       : parseInterval('1m');
+    this.intervalAmount = intervalAmount;
+    this.intervalUnit = intervalUnit;
     this.name = this.options?.name ?? 'StreamProcessor';
     this.version = this.options.version ?? '8.0.0';
     this.versionMajor = Number.parseInt(this.version.split('.')[0], 10);

--- a/packages/kbn-apm-synthtrace/src/lib/timerange.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/timerange.ts
@@ -14,6 +14,22 @@ export class Timerange {
   interval(interval: string) {
     return new Interval({ from: this.from, to: this.to, interval });
   }
+
+  ratePerMinute(rateInTpm: number) {
+    const intervalPerSecond = Math.max(1, 60 / rateInTpm);
+
+    // rate per second
+    let interval = `${intervalPerSecond}s`;
+    let rate = (rateInTpm / 60) * intervalPerSecond;
+
+    // rate per minute
+    if (!Number.isInteger(rate) || !Number.isInteger(intervalPerSecond)) {
+      interval = '1m';
+      rate = rate * 60;
+    }
+
+    return new Interval({ from: this.from, to: this.to, interval, yieldRate: rate });
+  }
 }
 
 export function timerange(from: Date | number, to: Date | number) {

--- a/packages/kbn-apm-synthtrace/src/lib/utils/merge_iterable.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/utils/merge_iterable.ts
@@ -17,7 +17,7 @@ export function merge<TField extends Fields>(
   if (iterables.length === 1) return iterables[0];
 
   const iterators = iterables.map<{ it: Iterator<ApmFields>; weight: number }>((i) => {
-    return { it: i[Symbol.iterator](), weight: Math.max(1, i.ratePerMinute()) };
+    return { it: i[Symbol.iterator](), weight: Math.max(1, i.estimatedRatePerMinute()) };
   });
   let done = false;
   const myIterable: Iterable<TField> = {

--- a/packages/kbn-apm-synthtrace/src/scenarios/aws_lambda.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/aws_lambda.ts
@@ -21,7 +21,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
   return {
     generate: ({ from, to }) => {
       const range = timerange(from, to);
-      const timestamps = range.interval('1s').rate(3);
+      const timestamps = range.ratePerMinute(180);
 
       const instance = apm.service('lambda-python', ENVIRONMENT, 'python').instance('instance');
 

--- a/packages/kbn-apm-synthtrace/src/scenarios/low_throughput.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/low_throughput.ts
@@ -28,7 +28,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
     generate: ({ from, to }) => {
       const range = timerange(from, to);
 
-      const successfulTimestamps = range.interval('1s').rate(1);
+      const successfulTimestamps = range.ratePerMinute(60);
       // `.randomize(3, 180);
 
       const instances = [...Array(numServices).keys()].map((index) =>

--- a/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
@@ -29,7 +29,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
     generate: ({ from, to }) => {
       const range = timerange(from, to);
 
-      const successfulTimestamps = range.interval('1s').rate(3);
+      const successfulTimestamps = range.ratePerMinute(180);
 
       const instances = [...Array(numServices).keys()].map((index) =>
         apm

--- a/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -27,9 +27,8 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
 
       const transactionName = '240rpm/75% 1000ms';
 
-      const successfulTimestamps = range.interval('1s').rate(3);
-
-      const failedTimestamps = range.interval('1s').rate(1);
+      const successfulTimestamps = range.ratePerMinute(180);
+      const failedTimestamps = range.ratePerMinute(180);
 
       const instances = [...Array(numServices).keys()].map((index) =>
         apm.service(`opbeans-go-${index}`, ENVIRONMENT, 'go').instance('instance')

--- a/packages/kbn-apm-synthtrace/src/test/rate_per_minute.test.ts
+++ b/packages/kbn-apm-synthtrace/src/test/rate_per_minute.test.ts
@@ -11,20 +11,12 @@ import { apm } from '../lib/apm';
 import { timerange } from '../lib/timerange';
 import { ApmFields } from '../lib/apm/apm_fields';
 
+const range = timerange(new Date('2021-01-01T00:00:00.000Z'), new Date('2021-01-01T00:15:00.000Z'));
+
 describe('rate per minute calculations', () => {
   let iterable: EntityIterable<ApmFields>;
   let arrayIterable: EntityArrayIterable<ApmFields>;
   let events: Array<Record<string, any>>;
-
-  const range = timerange(
-    new Date('2021-01-01T00:00:00.000Z'),
-    new Date('2021-01-01T00:15:00.000Z')
-  );
-
-  const i1r3 = range.interval('1m').rate(3);
-  const i5r6 = range.interval('5m').rate(6);
-  const i30r6 = range.interval('30m').rate(6);
-  const i1sr3 = range.interval('1s').rate(3);
 
   beforeEach(() => {
     const javaService = apm.service('opbeans-java', 'production', 'java');
@@ -50,6 +42,7 @@ describe('rate per minute calculations', () => {
     events = iterable.toArray();
     arrayIterable = new EntityArrayIterable(events);
   });
+
   it('array iterable returns exact rate per minute', () => {
     expect(arrayIterable.estimatedRatePerMinute()).toEqual(2);
   });
@@ -59,17 +52,34 @@ describe('rate per minute calculations', () => {
   it('iterable returns same rate as materialized iterable', () => {
     expect(iterable.estimatedRatePerMinute()).toEqual(arrayIterable.estimatedRatePerMinute());
   });
+});
 
+describe('estimatedRatePerMinute', () => {
   it('interval of 3 per minute returns 3', () => {
-    expect(i1r3.estimatedRatePerMinute()).toEqual(3);
+    expect(range.interval('1m').rate(3).estimatedRatePerMinute()).toEqual(3);
   });
+
   it('interval of 6 per 5 minutes returns 6/5', () => {
-    expect(i5r6.estimatedRatePerMinute()).toEqual(6 / 5);
+    expect(range.interval('5m').rate(6).estimatedRatePerMinute()).toEqual(6 / 5);
   });
+
   it('interval of 6 per 30 minutes returns 6/30', () => {
-    expect(i30r6.estimatedRatePerMinute()).toEqual(6 / 30);
+    expect(range.interval('30m').rate(6).estimatedRatePerMinute()).toEqual(6 / 30);
   });
+
   it('interval of 3 per second returns 60 * 3', () => {
-    expect(i1sr3.estimatedRatePerMinute()).toEqual(60 * 3);
+    expect(range.interval('1s').rate(3).estimatedRatePerMinute()).toEqual(60 * 3);
+  });
+
+  it('ratePerMinute of 180 returns 180', () => {
+    expect(range.ratePerMinute(180).estimatedRatePerMinute()).toEqual(180);
+  });
+
+  it('ratePerMinute of 1 returns 1', () => {
+    expect(range.ratePerMinute(1).estimatedRatePerMinute()).toEqual(1);
+  });
+
+  it('ratePerMinute of 61 returns 61', () => {
+    expect(range.ratePerMinute(61).estimatedRatePerMinute()).toEqual(61);
   });
 });

--- a/packages/kbn-apm-synthtrace/src/test/rate_per_minute.test.ts
+++ b/packages/kbn-apm-synthtrace/src/test/rate_per_minute.test.ts
@@ -51,25 +51,25 @@ describe('rate per minute calculations', () => {
     arrayIterable = new EntityArrayIterable(events);
   });
   it('array iterable returns exact rate per minute', () => {
-    expect(arrayIterable.ratePerMinute()).toEqual(2);
+    expect(arrayIterable.estimatedRatePerMinute()).toEqual(2);
   });
   it('iterable returns rate per minute approximation', () => {
-    expect(iterable.ratePerMinute()).toEqual(2);
+    expect(iterable.estimatedRatePerMinute()).toEqual(2);
   });
   it('iterable returns same rate as materialized iterable', () => {
-    expect(iterable.ratePerMinute()).toEqual(arrayIterable.ratePerMinute());
+    expect(iterable.estimatedRatePerMinute()).toEqual(arrayIterable.estimatedRatePerMinute());
   });
 
   it('interval of 3 per minute returns 3', () => {
-    expect(i1r3.ratePerMinute()).toEqual(3);
+    expect(i1r3.estimatedRatePerMinute()).toEqual(3);
   });
   it('interval of 6 per 5 minutes returns 6/5', () => {
-    expect(i5r6.ratePerMinute()).toEqual(6 / 5);
+    expect(i5r6.estimatedRatePerMinute()).toEqual(6 / 5);
   });
   it('interval of 6 per 30 minutes returns 6/30', () => {
-    expect(i30r6.ratePerMinute()).toEqual(6 / 30);
+    expect(i30r6.estimatedRatePerMinute()).toEqual(6 / 30);
   });
   it('interval of 3 per second returns 60 * 3', () => {
-    expect(i1sr3.ratePerMinute()).toEqual(60 * 3);
+    expect(i1sr3.estimatedRatePerMinute()).toEqual(60 * 3);
   });
 });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/115374

Introduces a helper `ratePerMinute` helper, that will distribute the throughput evenly over a 1 minute interval to avoid spikes and create more realistic data.

## Before
![image](https://user-images.githubusercontent.com/209966/186896076-54740805-741c-43e0-a6a6-d7503c4d6da4.png)

## After 
![image](https://user-images.githubusercontent.com/209966/186896110-b68905be-288b-46a9-9594-672e94b7045f.png)
