### PR TITLE
[DOCS] update rule name to match query my*

### DIFF
--- a/docs/api/alerting/find_rules.asciidoc
+++ b/docs/api/alerting/find_rules.asciidoc
@@ -121,7 +121,7 @@ The API returns the following:
       },
       "actions": [],
       "tags": [],
-      "name": "test rule",
+      "name": "my test rule",
       "enabled": true,
       "throttle": null,
       "api_key_owner": "elastic",


### PR DESCRIPTION
## Summary

The example rule query is `GET api/alerting/rules/_find?search_fields=name&search=my*` but the name of the rule in the example response doesn't match `my*`.  I added that.