### PR TITLE
[performance pipeline] 60 min timeout for test step

### DIFF
--- a/.buildkite/pipelines/performance/daily.yml
+++ b/.buildkite/pipelines/performance/daily.yml
@@ -19,6 +19,7 @@ steps:
       queue: kb-static-ubuntu
     depends_on: build
     key: tests
+    timeout_in_minutes: 60
 
   - label: ':shipit: Performance Tests dataset extraction for scalability benchmarking'
     command: .buildkite/scripts/steps/functional/scalability_dataset_extraction.sh


### PR DESCRIPTION
## Summary

Recently our single user perf pipeline got stuck with [30+ active builds](https://buildkite.com/elastic/kibana-single-user-performance/builds?branch=main). Adding timeout to the step with static worker (the one that got stuck) should at least fail the build and let us know fast that things are not working.

Since step takes 25-30 min, timeout of 60 min seems reasonable to me.
