### PR TITLE
[Lens] Preserve push-out behavior for table cells when possible

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/datatable/components/__snapshots__/table_basic.test.tsx.snap
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/__snapshots__/table_basic.test.tsx.snap
@@ -253,9 +253,7 @@ exports[`DatatableComponent it renders actions column when there are row actions
       rowCount={1}
       rowHeightsOptions={
         Object {
-          "defaultHeight": Object {
-            "lineCount": 1,
-          },
+          "defaultHeight": undefined,
         }
       }
       sorting={
@@ -275,6 +273,273 @@ exports[`DatatableComponent it renders actions column when there are row actions
           },
         ]
       }
+    />
+  </ContextProvider>
+</VisualizationContainer>
+`;
+
+exports[`DatatableComponent it renders custom row height if set to another value than 1 1`] = `
+<VisualizationContainer
+  className="lnsDataTableContainer"
+>
+  <ContextProvider
+    value={
+      Object {
+        "alignments": Object {
+          "a": "left",
+          "b": "left",
+          "c": "right",
+        },
+        "getColorForValue": [MockFunction],
+        "minMaxByColumnId": Object {
+          "c": Object {
+            "max": 3,
+            "min": 3,
+          },
+        },
+        "rowHasRowClickTriggerActions": undefined,
+        "table": Object {
+          "columns": Array [
+            Object {
+              "id": "a",
+              "meta": Object {
+                "field": "a",
+                "source": "esaggs",
+                "sourceParams": Object {
+                  "indexPatternId": "indexPatternId",
+                  "type": "terms",
+                },
+                "type": "string",
+              },
+              "name": "a",
+            },
+            Object {
+              "id": "b",
+              "meta": Object {
+                "field": "b",
+                "source": "esaggs",
+                "sourceParams": Object {
+                  "indexPatternId": "indexPatternId",
+                  "type": "date_histogram",
+                },
+                "type": "date",
+              },
+              "name": "b",
+            },
+            Object {
+              "id": "c",
+              "meta": Object {
+                "field": "c",
+                "source": "esaggs",
+                "sourceParams": Object {
+                  "indexPatternId": "indexPatternId",
+                  "type": "count",
+                },
+                "type": "number",
+              },
+              "name": "c",
+            },
+          ],
+          "rows": Array [
+            Object {
+              "a": "shoes",
+              "b": 1588024800000,
+              "c": 3,
+            },
+          ],
+          "type": "datatable",
+        },
+      }
+    }
+  >
+    <EuiDataGrid
+      aria-label="My fanci metric chart"
+      columnVisibility={
+        Object {
+          "setVisibleColumns": [Function],
+          "visibleColumns": Array [
+            "a",
+            "b",
+            "c",
+          ],
+        }
+      }
+      columns={
+        Array [
+          Object {
+            "actions": Object {
+              "additional": Array [
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableResetWidth",
+                  "iconType": "empty",
+                  "isDisabled": true,
+                  "label": "Reset width",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableHide",
+                  "iconType": "eyeClosed",
+                  "isDisabled": false,
+                  "label": "Hide",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+              ],
+              "showHide": false,
+              "showMoveLeft": false,
+              "showMoveRight": false,
+              "showSortAsc": Object {
+                "label": "Sort ascending",
+              },
+              "showSortDesc": Object {
+                "label": "Sort descending",
+              },
+            },
+            "cellActions": undefined,
+            "display": <div
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "13brihr",
+                  "next": undefined,
+                  "styles": "text-align:left;",
+                  "toString": [Function],
+                }
+              }
+            >
+              a
+            </div>,
+            "displayAsText": "a",
+            "id": "a",
+          },
+          Object {
+            "actions": Object {
+              "additional": Array [
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableResetWidth",
+                  "iconType": "empty",
+                  "isDisabled": true,
+                  "label": "Reset width",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableHide",
+                  "iconType": "eyeClosed",
+                  "isDisabled": false,
+                  "label": "Hide",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+              ],
+              "showHide": false,
+              "showMoveLeft": false,
+              "showMoveRight": false,
+              "showSortAsc": Object {
+                "label": "Sort ascending",
+              },
+              "showSortDesc": Object {
+                "label": "Sort descending",
+              },
+            },
+            "cellActions": undefined,
+            "display": <div
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "13brihr",
+                  "next": undefined,
+                  "styles": "text-align:left;",
+                  "toString": [Function],
+                }
+              }
+            >
+              b
+            </div>,
+            "displayAsText": "b",
+            "id": "b",
+          },
+          Object {
+            "actions": Object {
+              "additional": Array [
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableResetWidth",
+                  "iconType": "empty",
+                  "isDisabled": true,
+                  "label": "Reset width",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+                Object {
+                  "color": "text",
+                  "data-test-subj": "lensDatatableHide",
+                  "iconType": "eyeClosed",
+                  "isDisabled": false,
+                  "label": "Hide",
+                  "onClick": [Function],
+                  "size": "xs",
+                },
+              ],
+              "showHide": false,
+              "showMoveLeft": false,
+              "showMoveRight": false,
+              "showSortAsc": Object {
+                "label": "Sort ascending",
+              },
+              "showSortDesc": Object {
+                "label": "Sort descending",
+              },
+            },
+            "cellActions": undefined,
+            "display": <div
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "s2uf1z",
+                  "next": undefined,
+                  "styles": "text-align:right;",
+                  "toString": [Function],
+                }
+              }
+            >
+              c
+            </div>,
+            "displayAsText": "c",
+            "id": "c",
+          },
+        ]
+      }
+      data-test-subj="lnsDataTable"
+      gridStyle={
+        Object {
+          "border": "horizontal",
+          "header": "underline",
+        }
+      }
+      onColumnResize={[Function]}
+      renderCellValue={[Function]}
+      rowCount={1}
+      rowHeightsOptions={
+        Object {
+          "defaultHeight": Object {
+            "lineCount": 5,
+          },
+        }
+      }
+      sorting={
+        Object {
+          "columns": Array [],
+          "onSort": [Function],
+        }
+      }
+      toolbarVisibility={false}
+      trailingControlColumns={Array []}
     />
   </ContextProvider>
 </VisualizationContainer>
@@ -529,9 +794,7 @@ exports[`DatatableComponent it renders the title and value 1`] = `
       rowCount={1}
       rowHeightsOptions={
         Object {
-          "defaultHeight": Object {
-            "lineCount": 1,
-          },
+          "defaultHeight": undefined,
         }
       }
       sorting={
@@ -800,9 +1063,7 @@ exports[`DatatableComponent it should render hide, reset, and sort actions on he
       rowCount={1}
       rowHeightsOptions={
         Object {
-          "defaultHeight": Object {
-            "lineCount": 1,
-          },
+          "defaultHeight": undefined,
         }
       }
       sorting={

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.test.tsx
@@ -143,6 +143,27 @@ describe('DatatableComponent', () => {
     ).toMatchSnapshot();
   });
 
+  test('it renders custom row height if set to another value than 1', () => {
+    const { data, args } = sampleArgs();
+
+    expect(
+      shallow(
+        <DatatableComponent
+          data={data}
+          args={{ ...args, rowHeightLines: 5 }}
+          formatFactory={(x) => x as unknown as IFieldFormat}
+          dispatchEvent={onDispatchEvent}
+          getType={jest.fn()}
+          paletteService={chartPluginMock.createPaletteRegistry()}
+          uiSettings={{ get: jest.fn() } as unknown as IUiSettingsClient}
+          renderMode="edit"
+          interactive
+          renderComplete={renderComplete}
+        />
+      )
+    ).toMatchSnapshot();
+  });
+
   test('it should render hide, reset, and sort actions on header even when it is in read only mode', () => {
     const { data, args } = sampleArgs();
 

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -460,7 +460,7 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
           rowHeightsOptions={{
             defaultHeight: props.args.fitRowToContent
               ? 'auto'
-              : props.args.rowHeightLines
+              : props.args.rowHeightLines && props.args.rowHeightLines !== 1
               ? {
                   lineCount: props.args.rowHeightLines,
                 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/139137 by not setting the line count if it's one to preserve the existing behavior of cell actions pushing out the cell content for default configuration.