### PR TITLE
[8.4] [ML] Transform: Fix `percentiles` and `terms` sub-aggs (#138821)

### DIFF
--- a/x-pack/plugins/transform/common/types/pivot_aggs.ts
+++ b/x-pack/plugins/transform/common/types/pivot_aggs.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AggName } from './aggregations';
-import { EsFieldName } from './fields';
 
 export const PIVOT_SUPPORTED_AGGS = {
   AVG: 'avg',
@@ -23,11 +23,7 @@ export const PIVOT_SUPPORTED_AGGS = {
 
 export type PivotSupportedAggs = typeof PIVOT_SUPPORTED_AGGS[keyof typeof PIVOT_SUPPORTED_AGGS];
 
-export type PivotAgg = {
-  [key in PivotSupportedAggs]?: {
-    field: EsFieldName;
-  };
-};
+export type PivotAgg = estypes.AggregationsAggregationContainer;
 
 export type PivotAggDict = {
   [key in AggName]: PivotAgg;

--- a/x-pack/plugins/transform/public/app/common/index.ts
+++ b/x-pack/plugins/transform/public/app/common/index.ts
@@ -37,7 +37,7 @@ export type {
 } from './pivot_aggs';
 export {
   getEsAggFromAggConfig,
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   isPivotAggsConfigPercentiles,
   isPivotAggsConfigTerms,
   PERCENTILES_AGG_DEFAULT_PERCENTS,

--- a/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
+++ b/x-pack/plugins/transform/public/app/common/pivot_aggs.test.ts
@@ -68,7 +68,7 @@ describe('getAggConfigFromEsAgg', () => {
     });
   });
 
-  test('should resolve percentiles agg in sub-aggregations', () => {
+  test('should resolve percentiles and terms agg in sub-aggregations', () => {
     const esConfig = {
       filter: {
         exists: {
@@ -82,6 +82,12 @@ describe('getAggConfigFromEsAgg', () => {
             percents: [1, 5, 25, 50, 75, 95, 99],
           },
         },
+        check_terms: {
+          terms: {
+            field: 'products.base_price',
+            size: 3,
+          },
+        },
       },
     };
 
@@ -93,6 +99,20 @@ describe('getAggConfigFromEsAgg', () => {
       dropDownName: 'products.base_price.percentiles',
       field: 'products.base_price',
       parentAgg: result,
+      aggConfig: {
+        percents: '1,5,25,50,75,95,99',
+      },
+    });
+
+    expect(result.subAggs!.check_terms).toMatchObject({
+      agg: 'terms',
+      aggName: 'check_terms',
+      dropDownName: 'check_terms',
+      field: 'products.base_price',
+      parentAgg: result,
+      aggConfig: {
+        size: 3,
+      },
     });
   });
 

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
@@ -14,7 +14,7 @@ import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiTextColor } fr
 import { AggName } from '../../../../../../common/types/aggregations';
 
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PivotAggsConfig,
   PivotAggsConfigWithUiSupportDict,
 } from '../../../../common';
@@ -50,7 +50,7 @@ export const AggLabelForm: React.FC<Props> = ({
   const helperText = isPivotAggsWithExtendedForm(item) && item.helperText && item.helperText();
 
   const isSubAggSupported =
-    isPivotAggsConfigWithUiSupport(item) &&
+    isPivotAggsConfigWithUiBase(item) &&
     item.isSubAggsSupported &&
     (isPivotAggsWithExtendedForm(item) ? item.isValid() : true);
 

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -13,7 +13,6 @@ import {
   EuiButton,
   EuiCodeBlock,
   EuiComboBox,
-  EuiFieldNumber,
   EuiFieldText,
   EuiForm,
   EuiFormRow,
@@ -25,19 +24,12 @@ import { cloneDeep } from 'lodash';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 import { AggName } from '../../../../../../common/types/aggregations';
 import { dictionaryToArray } from '../../../../../../common/types/common';
-import {
-  PivotSupportedAggs,
-  PIVOT_SUPPORTED_AGGS,
-} from '../../../../../../common/types/pivot_aggs';
+import { PivotSupportedAggs } from '../../../../../../common/types/pivot_aggs';
 
 import {
   isAggName,
-  isPivotAggsConfigPercentiles,
-  isPivotAggsConfigTerms,
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   getEsAggFromAggConfig,
-  PERCENTILES_AGG_DEFAULT_PERCENTS,
-  TERMS_AGG_DEFAULT_SIZE,
   PivotAggsConfig,
   PivotAggsConfigWithUiSupportDict,
 } from '../../../../common';
@@ -51,77 +43,23 @@ interface Props {
   onChange(d: PivotAggsConfig): void;
 }
 
-function getDefaultPercents(defaultData: PivotAggsConfig): number[] | undefined {
-  if (isPivotAggsConfigPercentiles(defaultData)) {
-    return defaultData.percents;
-  }
-}
-
-function parsePercentsInput(inputValue: string | undefined) {
-  if (inputValue !== undefined) {
-    const strVals: string[] = inputValue.split(',');
-    const percents: number[] = [];
-    for (const str of strVals) {
-      if (str.trim().length > 0 && isNaN(str as any) === false) {
-        const val = Number(str);
-        if (val >= 0 && val <= 100) {
-          percents.push(val);
-        } else {
-          return [];
-        }
-      }
-    }
-
-    return percents;
-  }
-
-  return [];
-}
-
-// Input string should only include comma separated numbers
-function isValidPercentsInput(inputValue: string) {
-  return /^[0-9]+(,[0-9]+)*$/.test(inputValue);
-}
-
-function getDefaultSize(defaultData: PivotAggsConfig): number | undefined {
-  if (isPivotAggsConfigTerms(defaultData)) {
-    return defaultData.size;
-  }
-}
-
-function parseSizeInput(inputValue: string | undefined) {
-  if (inputValue !== undefined && isValidSizeInput(inputValue)) {
-    return parseInt(inputValue, 10);
-  }
-
-  return TERMS_AGG_DEFAULT_SIZE;
-}
-
-// Input string should only include numbers
-function isValidSizeInput(inputValue: string) {
-  return /^\d+$/.test(inputValue);
-}
-
 export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onChange, options }) => {
   const [aggConfigDef, setAggConfigDef] = useState(cloneDeep(defaultData));
 
   const [aggName, setAggName] = useState(defaultData.aggName);
   const [agg, setAgg] = useState(defaultData.agg);
   const [field, setField] = useState<string | string[] | null>(
-    isPivotAggsConfigWithUiSupport(defaultData) ? defaultData.field : ''
+    isPivotAggsConfigWithUiBase(defaultData) ? defaultData.field : ''
   );
 
-  const [percents, setPercents] = useState(getDefaultPercents(defaultData));
-  const [validPercents, setValidPercents] = useState(agg === PIVOT_SUPPORTED_AGGS.PERCENTILES);
-  const [size, setSize] = useState(getDefaultSize(defaultData));
-  const [validSize, setValidSize] = useState(agg === PIVOT_SUPPORTED_AGGS.TERMS);
-
-  const isUnsupportedAgg = !isPivotAggsConfigWithUiSupport(defaultData);
+  const isUnsupportedAgg = !isPivotAggsConfigWithUiBase(defaultData);
 
   // Update configuration based on the aggregation type
   useEffect(() => {
     if (agg === aggConfigDef.agg) return;
     const config = getAggFormConfig(agg, {
+      parentAgg: aggConfigDef.parentAgg,
+      subAggs: aggConfigDef.subAggs,
       agg,
       aggName,
       dropDownName: aggName,
@@ -129,7 +67,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
     });
     setAggConfigDef(config);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agg]);
+  }, [agg, aggConfigDef]);
 
   useUpdateEffect(() => {
     if (isPivotAggsWithExtendedForm(aggConfigDef)) {
@@ -145,30 +83,12 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
 
   function updateAgg(aggVal: PivotSupportedAggs) {
     setAgg(aggVal);
-    if (aggVal === PIVOT_SUPPORTED_AGGS.PERCENTILES && percents === undefined) {
-      setPercents(PERCENTILES_AGG_DEFAULT_PERCENTS);
-    }
-    if (aggVal === PIVOT_SUPPORTED_AGGS.TERMS && size === undefined) {
-      setSize(TERMS_AGG_DEFAULT_SIZE);
-    }
-  }
-
-  function updatePercents(inputValue: string) {
-    setPercents(parsePercentsInput(inputValue));
-    setValidPercents(isValidPercentsInput(inputValue));
-  }
-
-  function updateSize(inputValue: string) {
-    setSize(parseSizeInput(inputValue));
-    setValidSize(isValidSizeInput(inputValue));
   }
 
   function getUpdatedItem(): PivotAggsConfig {
-    let updatedItem: PivotAggsConfig;
-
     let resultField = field;
     if (
-      isPivotAggsConfigWithUiSupport(aggConfigDef) &&
+      isPivotAggsConfigWithUiBase(aggConfigDef) &&
       !aggConfigDef.isMultiField &&
       Array.isArray(field)
     ) {
@@ -176,33 +96,13 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
       resultField = field[0];
     }
 
-    if (agg === PIVOT_SUPPORTED_AGGS.PERCENTILES) {
-      updatedItem = {
-        ...aggConfigDef,
-        agg,
-        aggName,
-        field: resultField,
-        dropDownName: defaultData.dropDownName,
-        percents,
-      };
-    } else if (agg === PIVOT_SUPPORTED_AGGS.TERMS) {
-      updatedItem = {
-        ...aggConfigDef,
-        agg,
-        aggName,
-        field: resultField,
-        dropDownName: defaultData.dropDownName,
-        size,
-      };
-    } else {
-      updatedItem = {
-        ...aggConfigDef,
-        agg,
-        aggName,
-        field: resultField,
-        dropDownName: defaultData.dropDownName,
-      };
-    }
+    const updatedItem = {
+      ...aggConfigDef,
+      agg,
+      aggName,
+      field: resultField,
+      dropDownName: defaultData.dropDownName,
+    };
 
     return updatedItem;
   }
@@ -219,7 +119,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
     optionsArr
       .filter(
         (o) =>
-          isPivotAggsConfigWithUiSupport(defaultData) &&
+          isPivotAggsConfigWithUiBase(defaultData) &&
           (Array.isArray(defaultData.field)
             ? defaultData.field.includes(o.field as string)
             : o.field === defaultData.field)
@@ -246,23 +146,8 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
     });
   }
 
-  let percentsText;
-  if (percents !== undefined) {
-    percentsText = percents.toString();
-  }
-
-  let sizeText;
-  if (size !== undefined) {
-    sizeText = size.toString();
-  }
-
   let formValid = validAggName;
-  if (formValid && agg === PIVOT_SUPPORTED_AGGS.PERCENTILES) {
-    formValid = validPercents;
-  }
-  if (formValid && agg === PIVOT_SUPPORTED_AGGS.TERMS) {
-    formValid = validSize;
-  }
+
   if (isPivotAggsWithExtendedForm(aggConfigDef)) {
     formValid = validAggName && aggConfigDef.isValid();
   }
@@ -351,7 +236,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
           />
         </EuiFormRow>
       )}
-      {isPivotAggsWithExtendedForm(aggConfigDef) && (
+      {isPivotAggsWithExtendedForm(aggConfigDef) ? (
         <aggConfigDef.AggFormComponent
           aggConfig={aggConfigDef.aggConfig}
           selectedField={field as string}
@@ -361,45 +246,9 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
               aggConfig: update,
             });
           }}
+          isValid={aggConfigDef.isValid()}
         />
-      )}
-      {agg === PIVOT_SUPPORTED_AGGS.PERCENTILES && (
-        <EuiFormRow
-          label={i18n.translate('xpack.transform.agg.popoverForm.percentsLabel', {
-            defaultMessage: 'Percents',
-          })}
-          error={
-            !validPercents && [
-              i18n.translate('xpack.transform.groupBy.popoverForm.intervalPercents', {
-                defaultMessage: 'Enter a comma-separated list of percentiles',
-              }),
-            ]
-          }
-          isInvalid={!validPercents}
-        >
-          <EuiFieldText
-            defaultValue={percentsText}
-            onChange={(e) => updatePercents(e.target.value)}
-          />
-        </EuiFormRow>
-      )}
-      {agg === PIVOT_SUPPORTED_AGGS.TERMS && (
-        <EuiFormRow
-          label={i18n.translate('xpack.transform.agg.popoverForm.sizeLabel', {
-            defaultMessage: 'Size',
-          })}
-          error={
-            !validSize && [
-              i18n.translate('xpack.transform.groupBy.popoverForm.invalidSizeErrorMessage', {
-                defaultMessage: 'Enter a valid positive number',
-              }),
-            ]
-          }
-          isInvalid={!validSize}
-        >
-          <EuiFieldNumber defaultValue={sizeText} onChange={(e) => updateSize(e.target.value)} />
-        </EuiFormRow>
-      )}
+      ) : null}
       {isUnsupportedAgg && (
         <EuiCodeBlock
           aria-label={i18n.translate('xpack.transform.agg.popoverForm.codeBlock', {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
@@ -9,6 +9,7 @@ import { getPivotDropdownOptions } from '.';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { FilterAggForm } from './filter_agg/components';
 import type { RuntimeField } from '@kbn/data-views-plugin/common';
+import { PercentilesAggForm } from './percentiles_agg/percentiles_form_component';
 
 describe('Transform: Define Pivot Common', () => {
   test('getPivotDropdownOptions()', () => {
@@ -78,7 +79,8 @@ describe('Transform: Define Pivot Common', () => {
           field: ' the-f[i]e>ld ',
           aggName: 'the-field.percentiles',
           dropDownName: 'percentiles( the-f[i]e>ld )',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'filter( the-f[i]e>ld )': {
           agg: 'filter',
@@ -182,7 +184,8 @@ describe('Transform: Define Pivot Common', () => {
           aggName: 'the-field.percentiles',
           dropDownName: 'percentiles( the-f[i]e>ld )',
           field: ' the-f[i]e>ld ',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'sum( the-f[i]e>ld )': {
           agg: 'sum',
@@ -233,7 +236,8 @@ describe('Transform: Define Pivot Common', () => {
           aggName: 'rt_bytes_bigger.percentiles',
           dropDownName: 'percentiles(rt_bytes_bigger)',
           field: 'rt_bytes_bigger',
-          percents: [1, 5, 25, 50, 75, 95, 99],
+          AggFormComponent: PercentilesAggForm,
+          aggConfig: { percents: '1,5,25,50,75,95,99' },
         },
         'sum(rt_bytes_bigger)': {
           agg: 'sum',

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/config.ts
@@ -7,7 +7,7 @@
 
 import { jsonStringValidator } from '../../../../../../common/validators';
 import {
-  isPivotAggsConfigWithUiSupport,
+  isPivotAggsConfigWithUiBase,
   PivotAggsConfigBase,
   PivotAggsConfigWithUiBase,
 } from '../../../../../../common/pivot_aggs';
@@ -29,7 +29,7 @@ import {
 export function getFilterAggConfig(
   commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
 ): PivotAggsConfigFilter {
-  const field = isPivotAggsConfigWithUiSupport(commonConfig) ? commonConfig.field : null;
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
 
   return {
     ...commonConfig,
@@ -50,6 +50,7 @@ export function getFilterAggConfig(
     },
     setUiConfigFromEs(esAggDefinition) {
       const filterAgg = Object.keys(esAggDefinition)[0] as FilterAggType;
+      // @ts-ignore conflicts with a union type
       const filterAggConfig = esAggDefinition[filterAgg];
 
       const aggTypeConfig = getFilterAggTypeConfig(filterAgg, field as string, filterAggConfig);

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/types.ts
@@ -40,11 +40,11 @@ interface FilterAggTypeConfig<U, R> {
 }
 
 /** Filter agg type definition */
-interface FilterAggProps<K extends FilterAggType, U, R = { [key: string]: any }> {
+interface FilterAggProps<K extends FilterAggType, U, ESConfig extends { [key: string]: any }> {
   /** Filter aggregation type */
   filterAgg: K;
   /** Definition of the filter agg config */
-  aggTypeConfig: FilterAggTypeConfig<U, R>;
+  aggTypeConfig: FilterAggTypeConfig<U, ESConfig>;
 }
 
 /** Filter term agg */
@@ -62,10 +62,14 @@ export type FilterAggConfigRange = FilterAggProps<
 /** Filter exists agg */
 export type FilterAggConfigExists = FilterAggProps<'exists', undefined, { field: string }>;
 /** Filter bool agg */
-export type FilterAggConfigBool = FilterAggProps<'bool', string>;
+export type FilterAggConfigBool = FilterAggProps<
+  'bool',
+  string,
+  { must?: object[]; must_not?: object[]; should?: object[] }
+>;
 
 /** General type for filter agg */
-export type FilterAggConfigEditor = FilterAggProps<FilterAggType, string>;
+export type FilterAggConfigEditor = FilterAggProps<FilterAggType, string, Record<string, unknown>>;
 
 export type FilterAggConfigUnion =
   | FilterAggConfigTerm
@@ -78,7 +82,7 @@ export type FilterAggConfigUnion =
  * TODO find out if it's possible to use {@link FilterAggConfigUnion} instead of {@link FilterAggConfigBase}.
  * ATM TS is not able to infer a type.
  */
-export type PivotAggsConfigFilter = PivotAggsConfigWithExtra<FilterAggConfigBase>;
+export type PivotAggsConfigFilter = PivotAggsConfigWithExtra<FilterAggConfigBase, {}>;
 
 export interface FilterAggConfigBase {
   filterAgg?: FilterAggType;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_agg_form_config.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { getTermsAggConfig } from './terms_agg';
+import { getPercentilesAggConfig } from './percentiles_agg';
 import {
   PivotSupportedAggs,
   PIVOT_SUPPORTED_AGGS,
@@ -12,7 +14,7 @@ import {
 
 import { PivotAggsConfigBase, PivotAggsConfigWithUiBase } from '../../../../../common/pivot_aggs';
 import { getFilterAggConfig } from './filter_agg/config';
-import { getTopMetricsAggConfig } from './top_metrics_agg/config';
+import { getTopMetricsAggConfig } from './top_metrics_agg';
 
 /**
  * Gets form configuration for provided aggregation type.
@@ -26,6 +28,10 @@ export function getAggFormConfig(
       return getFilterAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.TOP_METRICS:
       return getTopMetricsAggConfig(commonConfig);
+    case PIVOT_SUPPORTED_AGGS.PERCENTILES:
+      return getPercentilesAggConfig(commonConfig);
+    case PIVOT_SUPPORTED_AGGS.TERMS:
+      return getTermsAggConfig(commonConfig);
     default:
       return commonConfig;
   }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/get_default_aggregation_config.ts
@@ -5,17 +5,16 @@
  * 2.0.
  */
 
+import { getTermsAggConfig } from './terms_agg';
 import { EsFieldName } from '../../../../../../../common/types/fields';
 import {
   PivotSupportedAggs,
   PIVOT_SUPPORTED_AGGS,
 } from '../../../../../../../common/types/pivot_aggs';
-import {
-  PERCENTILES_AGG_DEFAULT_PERCENTS,
-  PivotAggsConfigWithUiSupport,
-} from '../../../../../common';
+import { PivotAggsConfigWithUiSupport } from '../../../../../common';
 import { getFilterAggConfig } from './filter_agg/config';
-import { getTopMetricsAggConfig } from './top_metrics_agg/config';
+import { getPercentilesAggConfig } from './percentiles_agg';
+import { getTopMetricsAggConfig } from './top_metrics_agg';
 
 /**
  * Provides a configuration based on the aggregation type.
@@ -35,11 +34,7 @@ export function getDefaultAggregationConfig(
 
   switch (agg) {
     case PIVOT_SUPPORTED_AGGS.PERCENTILES:
-      return {
-        ...commonConfig,
-        agg,
-        percents: PERCENTILES_AGG_DEFAULT_PERCENTS,
-      };
+      return getPercentilesAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.FILTER:
       return getFilterAggConfig(commonConfig);
     case PIVOT_SUPPORTED_AGGS.TOP_METRICS:
@@ -48,6 +43,8 @@ export function getDefaultAggregationConfig(
         // top_metrics agg has different naming convention by default
         aggName: PIVOT_SUPPORTED_AGGS.TOP_METRICS,
       });
+    case PIVOT_SUPPORTED_AGGS.TERMS:
+      return getTermsAggConfig(commonConfig);
     default:
       return commonConfig;
   }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/config.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PercentilesAggForm } from './percentiles_form_component';
+import { IPivotAggsConfigPercentiles } from './types';
+import {
+  isPivotAggsConfigWithUiBase,
+  PERCENTILES_AGG_DEFAULT_PERCENTS,
+  PivotAggsConfigBase,
+} from '../../../../../../common';
+import { PivotAggsConfigWithUiBase } from '../../../../../../common/pivot_aggs';
+
+/**
+ * TODO this callback has been moved.
+ * The logic of parsing the string should be improved.
+ */
+function parsePercentsInput(inputValue: string | undefined) {
+  if (inputValue !== undefined) {
+    const strVals: string[] = inputValue.split(',');
+    const percents: number[] = [];
+    for (const str of strVals) {
+      if (str.trim().length > 0 && isNaN(str as any) === false) {
+        const val = Number(str);
+        if (val >= 0 && val <= 100) {
+          percents.push(val);
+        } else {
+          return [];
+        }
+      }
+    }
+
+    return percents;
+  }
+
+  return [];
+}
+
+// Input string should only include comma separated numbers
+function isValidPercentsInput(inputValue: string) {
+  return /^[0-9]+(,[0-9]+)*$/.test(inputValue);
+}
+
+export function getPercentilesAggConfig(
+  commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
+): IPivotAggsConfigPercentiles {
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
+
+  return {
+    ...commonConfig,
+    isSubAggsSupported: false,
+    isMultiField: false,
+    AggFormComponent: PercentilesAggForm,
+    field,
+    aggConfig: {
+      percents: PERCENTILES_AGG_DEFAULT_PERCENTS.toString(),
+    },
+    setUiConfigFromEs(esAggDefinition) {
+      const { field: esField, percents } = esAggDefinition;
+
+      this.field = esField;
+      this.aggConfig.percents = percents.join(',');
+    },
+    getEsAggConfig() {
+      if (!this.isValid()) {
+        return null;
+      }
+
+      return {
+        field: this.field as string,
+        percents: parsePercentsInput(this.aggConfig.percents),
+      };
+    },
+    isValid() {
+      return (
+        typeof this.aggConfig.percents === 'string' && isValidPercentsInput(this.aggConfig.percents)
+      );
+    },
+  };
+}

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getPercentilesAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/percentiles_form_component.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/percentiles_form_component.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { IPivotAggsConfigPercentiles } from './types';
+
+export const PercentilesAggForm: IPivotAggsConfigPercentiles['AggFormComponent'] = ({
+  aggConfig,
+  onChange,
+  isValid,
+}) => {
+  return (
+    <>
+      <EuiFormRow
+        label={i18n.translate('xpack.transform.agg.popoverForm.percentsLabel', {
+          defaultMessage: 'Percents',
+        })}
+        error={
+          !isValid && [
+            i18n.translate('xpack.transform.groupBy.popoverForm.intervalPercents', {
+              defaultMessage: 'Enter a comma-separated list of percentiles',
+            }),
+          ]
+        }
+        isInvalid={!isValid}
+      >
+        <EuiFieldText
+          value={aggConfig.percents}
+          onChange={(e) => {
+            onChange({
+              percents: e.target.value,
+            });
+          }}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/percentiles_agg/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PivotAggsConfigWithExtra } from '../../../../../../common/pivot_aggs';
+
+export interface PercentilesAggConfig {
+  /** Comma separated list */
+  percents: string;
+}
+export type IPivotAggsConfigPercentiles = PivotAggsConfigWithExtra<
+  PercentilesAggConfig,
+  { field: string; percents: number[] }
+>;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/config.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TermsAggForm } from './terms_form_component';
+import {
+  isPivotAggsConfigWithUiBase,
+  PivotAggsConfigBase,
+  PivotAggsConfigWithUiBase,
+  TERMS_AGG_DEFAULT_SIZE,
+} from '../../../../../../common/pivot_aggs';
+import { IPivotAggsConfigTerms } from './types';
+
+export function getTermsAggConfig(
+  commonConfig: PivotAggsConfigWithUiBase | PivotAggsConfigBase
+): IPivotAggsConfigTerms {
+  const field = isPivotAggsConfigWithUiBase(commonConfig) ? commonConfig.field : null;
+
+  return {
+    ...commonConfig,
+    isSubAggsSupported: false,
+    isMultiField: false,
+    AggFormComponent: TermsAggForm,
+    field,
+    aggConfig: {
+      size: TERMS_AGG_DEFAULT_SIZE,
+    },
+    setUiConfigFromEs(esAggDefinition) {
+      const { field: esField, size } = esAggDefinition;
+
+      this.field = esField;
+      this.aggConfig.size = size;
+    },
+    getEsAggConfig() {
+      if (!this.isValid()) {
+        return null;
+      }
+
+      return {
+        field: this.field as string,
+        size: this.aggConfig.size as number,
+      };
+    },
+    isValid() {
+      return typeof this.aggConfig.size === 'number' && this.aggConfig.size > 0;
+    },
+  };
+}

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getTermsAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/terms_form_component.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/terms_form_component.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFieldNumber, EuiFormRow } from '@elastic/eui';
+import { IPivotAggsConfigTerms } from './types';
+
+export const TermsAggForm: IPivotAggsConfigTerms['AggFormComponent'] = ({
+  aggConfig,
+  onChange,
+  isValid,
+}) => {
+  return (
+    <>
+      <EuiFormRow
+        label={i18n.translate('xpack.transform.agg.popoverForm.sizeLabel', {
+          defaultMessage: 'Size',
+        })}
+        error={
+          !isValid && [
+            i18n.translate('xpack.transform.groupBy.popoverForm.invalidSizeErrorMessage', {
+              defaultMessage: 'Enter a valid positive number',
+            }),
+          ]
+        }
+        isInvalid={!isValid}
+      >
+        <EuiFieldNumber
+          value={aggConfig.size}
+          onChange={(e) => {
+            onChange({ size: Number(e.target.value) });
+          }}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/terms_agg/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PivotAggsConfigWithExtra } from '../../../../../../common/pivot_aggs';
+
+export interface TermsAggConfig {
+  size: number;
+}
+export type IPivotAggsConfigTerms = PivotAggsConfigWithExtra<
+  TermsAggConfig,
+  { field: string; size: number }
+>;

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/index.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getTopMetricsAggConfig } from './config';

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/types.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/top_metrics_agg/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   PivotAggsConfigWithExtra,
   SortDirection,
@@ -18,7 +19,15 @@ export interface TopMetricsAggConfig {
     order?: SortDirection;
     mode?: SortMode;
     numericType?: SortNumericFieldType;
+    [unsupported: string]: unknown;
   };
 }
 
-export type PivotAggsConfigTopMetrics = PivotAggsConfigWithExtra<TopMetricsAggConfig>;
+export type PivotAggsConfigTopMetrics = PivotAggsConfigWithExtra<
+  TopMetricsAggConfig,
+  {
+    metrics?: estypes.AggregationsTopMetricsValue | estypes.AggregationsTopMetricsValue[];
+    size?: estypes.integer;
+    sort?: estypes.SortCombinations;
+  }
+>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[ML] Transform: Fix `percentiles` and `terms` sub-aggs (#138821)](https://github.com/elastic/kibana/pull/138821)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dima Arnautov","email":"dmitrii.arnautov@elastic.co"},"sourceCommit":{"committedDate":"2022-08-16T13:10:56Z","message":"[ML] Transform: Fix `percentiles` and `terms` sub-aggs (#138821)\n\n* update percentiles agg\r\n\r\n* types\r\n\r\n* optional isValid\r\n\r\n* terms agg\r\n\r\n* update getPivotDropdownOptions tests\r\n\r\n* update getAggConfigFromEsAgg percentiles tests\r\n\r\n* add terms tests\r\n\r\n* rename isPivotAggsConfigWithUiBase type guard\r\n\r\n* remove non-null assertion","sha":"ae26ba7454525a82e517e6f5f1784d7f2c5bb7f0","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:Transforms","Team:ML","v8.5.0","v8.4.2"],"number":138821,"url":"https://github.com/elastic/kibana/pull/138821","mergeCommit":{"message":"[ML] Transform: Fix `percentiles` and `terms` sub-aggs (#138821)\n\n* update percentiles agg\r\n\r\n* types\r\n\r\n* optional isValid\r\n\r\n* terms agg\r\n\r\n* update getPivotDropdownOptions tests\r\n\r\n* update getAggConfigFromEsAgg percentiles tests\r\n\r\n* add terms tests\r\n\r\n* rename isPivotAggsConfigWithUiBase type guard\r\n\r\n* remove non-null assertion","sha":"ae26ba7454525a82e517e6f5f1784d7f2c5bb7f0"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/138821","number":138821,"mergeCommit":{"message":"[ML] Transform: Fix `percentiles` and `terms` sub-aggs (#138821)\n\n* update percentiles agg\r\n\r\n* types\r\n\r\n* optional isValid\r\n\r\n* terms agg\r\n\r\n* update getPivotDropdownOptions tests\r\n\r\n* update getAggConfigFromEsAgg percentiles tests\r\n\r\n* add terms tests\r\n\r\n* rename isPivotAggsConfigWithUiBase type guard\r\n\r\n* remove non-null assertion","sha":"ae26ba7454525a82e517e6f5f1784d7f2c5bb7f0"}},{"branch":"8.4","label":"v8.4.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->