### PR TITLE
remove hardcoded timeouts on integration tests

### DIFF
--- a/src/core/server/integration_tests/execution_context/tracing.test.ts
+++ b/src/core/server/integration_tests/execution_context/tracing.test.ts
@@ -186,7 +186,7 @@ describe('trace', () => {
           },
         });
         await rootExecutionContextDisabled.preboot();
-      }, 30000);
+      });
 
       afterEach(async () => {
         await rootExecutionContextDisabled.shutdown();

--- a/src/core/server/integration_tests/execution_context/tracing.test.ts
+++ b/src/core/server/integration_tests/execution_context/tracing.test.ts
@@ -53,7 +53,7 @@ describe('trace', () => {
       },
     });
     await root.preboot();
-  }, 60000);
+  });
 
   afterEach(async () => {
     await root.shutdown();

--- a/src/core/server/integration_tests/http/core_services.test.ts
+++ b/src/core/server/integration_tests/http/core_services.test.ts
@@ -25,7 +25,7 @@ describe('http service', () => {
   beforeEach(async () => {
     esClient = elasticsearchClientMock.createInternalClient();
     MockElasticsearchClient.mockImplementation(() => esClient);
-  }, 30000);
+  });
 
   afterEach(async () => {
     MockElasticsearchClient.mockClear();
@@ -39,7 +39,7 @@ describe('http service', () => {
         elasticsearch: { skipStartupConnectionCheck: true },
       });
       await root.preboot();
-    }, 30000);
+    });
 
     afterEach(async () => {
       await root.shutdown();
@@ -190,7 +190,7 @@ describe('http service', () => {
         elasticsearch: { skipStartupConnectionCheck: true },
       });
       await root.preboot();
-    }, 30000);
+    });
 
     afterEach(async () => {
       MockElasticsearchClient.mockClear();

--- a/src/core/server/integration_tests/http/http_auth.test.ts
+++ b/src/core/server/integration_tests/http/http_auth.test.ts
@@ -18,7 +18,7 @@ describe('http auth', () => {
       elasticsearch: { skipStartupConnectionCheck: true },
     });
     await root.preboot();
-  }, 30000);
+  });
 
   afterEach(async () => {
     await root.shutdown();

--- a/src/core/server/integration_tests/http/lifecycle_handlers.test.ts
+++ b/src/core/server/integration_tests/http/lifecycle_handlers.test.ts
@@ -92,7 +92,7 @@ describe('core lifecycle handlers', () => {
     const serverSetup = await server.setup(setupDeps);
     router = serverSetup.createRouter('/');
     innerServer = serverSetup.server;
-  }, 30000);
+  });
 
   afterEach(async () => {
     await server.stop();

--- a/src/core/server/integration_tests/http_resources/http_resources_service.test.ts
+++ b/src/core/server/integration_tests/http_resources/http_resources_service.test.ts
@@ -29,7 +29,7 @@ function applyTestsWithDisableUnsafeEvalSetTo(disableUnsafeEval: boolean) {
         elasticsearch: { skipStartupConnectionCheck: true },
       });
       await root.preboot();
-    }, 30000);
+    });
 
     afterEach(async () => {
       await root.shutdown();

--- a/src/core/server/integration_tests/logging/logging.test.ts
+++ b/src/core/server/integration_tests/logging/logging.test.ts
@@ -50,7 +50,7 @@ describe('logging service', () => {
 
       await root.preboot();
       await root.setup();
-    }, 30000);
+    });
 
     beforeEach(() => {
       mockConsoleLog.mockClear();
@@ -154,7 +154,7 @@ describe('logging service', () => {
       await root.preboot();
       setup = await root.setup();
       setup.logging.configure(['plugins', 'myplugin'], loggingConfig$);
-    }, 30000);
+    });
 
     beforeEach(() => {
       mockConsoleLog.mockClear();

--- a/src/core/server/integration_tests/node/logging.test.ts
+++ b/src/core/server/integration_tests/node/logging.test.ts
@@ -44,7 +44,7 @@ describe('node service global context', () => {
 
         await root.preboot();
         await root.setup();
-      }, 30000);
+      });
 
       beforeEach(() => {
         mockConsoleLog.mockClear();

--- a/src/core/server/integration_tests/saved_objects/routes/migrate.test.ts
+++ b/src/core/server/integration_tests/saved_objects/routes/migrate.test.ts
@@ -22,7 +22,7 @@ describe('SavedObjects /_migrate endpoint', () => {
     await root.setup();
     await root.start();
     migratorInstanceMock.runMigrations.mockClear();
-  }, 30000);
+  });
 
   afterEach(async () => {
     await root.shutdown();

--- a/src/core/server/integration_tests/ui_settings/create_or_upgrade.test.ts
+++ b/src/core/server/integration_tests/ui_settings/create_or_upgrade.test.ts
@@ -68,7 +68,7 @@ describe('createOrUpgradeSavedConfig()', () => {
   afterAll(async () => {
     await esServer.stop();
     await kbn.stop();
-  }, 30000);
+  });
 
   it('upgrades the previous version on each increment', async function () {
     // ------------------------------------
@@ -209,5 +209,5 @@ describe('createOrUpgradeSavedConfig()', () => {
       // Should have the transform(s) applied
       isDefaultIndexMigrated: true,
     });
-  }, 30000);
+  });
 });

--- a/src/core/server/integration_tests/ui_settings/routes.test.ts
+++ b/src/core/server/integration_tests/ui_settings/routes.test.ts
@@ -28,7 +28,7 @@ describe('ui settings service', () => {
       });
 
       await root.start();
-    }, 30000);
+    });
     afterAll(async () => await root.shutdown());
 
     describe('set', () => {


### PR DESCRIPTION
## Summary

Jest's integration test configuration has higher values by default. These hardcoded values are causing unwanted timeouts, especially in code coverage mode. 

Fix https://github.com/elastic/kibana/issues/139371
Fix https://github.com/elastic/kibana/issues/139398
Fix https://github.com/elastic/kibana/issues/139463