### PR TITLE
[Fleet] Bump bundled elastic_agent to 1.3.5

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -18,7 +18,7 @@
   },
   {
     "name": "elastic_agent",
-    "version": "1.3.4"
+    "version": "1.3.5"
   },
   {
     "name": "endpoint",


### PR DESCRIPTION
## Summary

Does what it says on the tin.



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->