### PR TITLE
[8.4] [ResponseOps][Alerting] Rules and Connectors search does not filter exact name (#138999)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/map_filters_to_kuery_node.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/map_filters_to_kuery_node.test.ts
@@ -211,6 +211,48 @@ describe('mapFiltersToKueryNode', () => {
     `);
   });
 
+  test('should handle exact match search Text on rule name and tag', () => {
+    expect(
+      toElasticsearchQuery(
+        mapFiltersToKueryNode({
+          searchText: '"fo"',
+        }) as KueryNode
+      )
+    ).toMatchInlineSnapshot(`
+      Object {
+        "bool": Object {
+          "minimum_should_match": 1,
+          "should": Array [
+            Object {
+              "bool": Object {
+                "minimum_should_match": 1,
+                "should": Array [
+                  Object {
+                    "match_phrase": Object {
+                      "alert.attributes.name": "\\"fo\\"",
+                    },
+                  },
+                ],
+              },
+            },
+            Object {
+              "bool": Object {
+                "minimum_should_match": 1,
+                "should": Array [
+                  Object {
+                    "match_phrase": Object {
+                      "alert.attributes.tags": "\\"fo\\"",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+    `);
+  });
+
   test('should handle typesFilter, actionTypesFilter, ruleExecutionStatusesFilter, and tagsFilter', () => {
     expect(
       toElasticsearchQuery(

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/map_filters_to_kuery_node.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/map_filters_to_kuery_node.ts
@@ -83,10 +83,14 @@ export const mapFiltersToKueryNode = ({
   }
 
   if (searchText && searchText !== '') {
+    // if the searchText includes quotes, treat it as an exact match query
+    const value = searchText.match(/(['"`])(.*?)\1/g)
+      ? nodeTypes.literal.buildNode(searchText, true)
+      : nodeTypes.wildcard.buildNode(searchText);
     filterKueryNode.push(
       nodeBuilder.or([
-        nodeBuilder.is('alert.attributes.name', nodeTypes.wildcard.buildNode(searchText)),
-        nodeBuilder.is('alert.attributes.tags', nodeTypes.wildcard.buildNode(searchText)),
+        nodeBuilder.is('alert.attributes.name', value),
+        nodeBuilder.is('alert.attributes.tags', value),
       ])
     );
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[ResponseOps][Alerting] Rules and Connectors search does not filter exact name (#138999)](https://github.com/elastic/kibana/pull/138999)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"doakalexi","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-08-29T14:57:26Z","message":"[ResponseOps][Alerting] Rules and Connectors search does not filter exact name (#138999)\n\n* Updating search to be literal\r\n\r\n* Fixing tests\r\n\r\n* Updating to honor quotes\r\n\r\n* Reverted test changes\r\n\r\n* Updating regex\r\n\r\n* Using a more simple regex","sha":"65625405c61f64ef6314920520f2558163c60182","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:ResponseOps","v8.5.0","v8.4.2"],"number":138999,"url":"https://github.com/elastic/kibana/pull/138999","mergeCommit":{"message":"[ResponseOps][Alerting] Rules and Connectors search does not filter exact name (#138999)\n\n* Updating search to be literal\r\n\r\n* Fixing tests\r\n\r\n* Updating to honor quotes\r\n\r\n* Reverted test changes\r\n\r\n* Updating regex\r\n\r\n* Using a more simple regex","sha":"65625405c61f64ef6314920520f2558163c60182"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/138999","number":138999,"mergeCommit":{"message":"[ResponseOps][Alerting] Rules and Connectors search does not filter exact name (#138999)\n\n* Updating search to be literal\r\n\r\n* Fixing tests\r\n\r\n* Updating to honor quotes\r\n\r\n* Reverted test changes\r\n\r\n* Updating regex\r\n\r\n* Using a more simple regex","sha":"65625405c61f64ef6314920520f2558163c60182"}},{"branch":"8.4","label":"v8.4.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->