### PR TITLE
[DOCS] Removes tag from 8.4.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,8 +37,6 @@ Review important information about the {kib} 8.4.x releases.
 [[release-notes-8.4.1]]
 == {kib} 8.4.1
 
-coming::[8.4.1]
-
 Review the following information about the {kib} 8.4.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes `coming` tag from the 8.4.1 release notes.