### PR TITLE
[docs] Removes kibCoreSavedObjectsPluginApi from nav

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -239,9 +239,6 @@
           "id": "kibCoreChromePluginApi"
         },
         {
-          "id": "kibCoreSavedObjectsPluginApi"
-        },
-        {
           "id": "kibFieldFormatsPluginApi"
         },
         {


### PR DESCRIPTION
The page was [removed](https://github.com/elastic/kibana/pull/139601) as part of the daily API docs update, but a reference still existed in the [nav config](https://github.com/elastic/kibana/blob/main/nav-kibana-dev.docnav.json).

I am unsure why the docs CI jobs were still successful, including the one tonight, but I have informed the team.

