### PR TITLE
Visualize: Pass theme to visualize save modal

### DIFF
--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -14,6 +14,7 @@ import { parse } from 'query-string';
 
 import { Capabilities } from '@kbn/core/public';
 import { TopNavMenuData } from '@kbn/navigation-plugin/public';
+import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import {
   showSaveModal,
   SavedObjectSaveModalOrigin,
@@ -122,6 +123,7 @@ export const getTopNavConfig = (
     presentationUtil,
     getKibanaVersion,
     savedObjects,
+    theme,
   }: VisualizeServices
 ) => {
   const { vis, embeddableHandler } = visInstance;
@@ -588,11 +590,18 @@ export const getTopNavConfig = (
                 );
               }
 
-              showSaveModal(
-                saveModal,
-                I18nContext,
-                !originatingApp ? presentationUtil.ContextProvider : React.Fragment
-              );
+              const WrapperComponent = ({ children }: { children?: React.ReactNode }) => {
+                const ContextProvider = !originatingApp
+                  ? presentationUtil.ContextProvider
+                  : React.Fragment;
+                return (
+                  <KibanaThemeProvider theme$={theme.theme$}>
+                    <ContextProvider>{children}</ContextProvider>
+                  </KibanaThemeProvider>
+                );
+              };
+
+              showSaveModal(saveModal, I18nContext, WrapperComponent);
             },
           },
         ]


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/139063

By injecting the theme provider into the react root for the save modal.

Old:
<img width="1788" alt="Screen Shot 2022-08-17 at 4 47 12 PM" src="https://user-images.githubusercontent.com/11466284/185263029-2b97774e-b6e2-4557-82eb-59e4dc05c3d3.png">

New:
<img width="861" alt="Screenshot 2022-08-30 at 09 51 28" src="https://user-images.githubusercontent.com/1508364/187381159-6f616713-298c-4c6c-8b54-2fc5f7fdf482.png">
