### PR TITLE
[Lens] Do not load all data views on broken data view reference

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_service/loader.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_service/loader.test.ts
@@ -212,7 +212,7 @@ describe('loader', () => {
       const cache = await loadIndexPatterns({
         cache: {},
         patterns: ['1', '2'],
-        notUsedPatterns: ['3'],
+        notUsedPatterns: ['11', '3', '4', '5', '6', '7', '8', '9', '10'],
         dataViews: dataViewsService,
       });
 
@@ -225,6 +225,8 @@ describe('loader', () => {
           fields: [documentField],
         }),
       });
+      // trying to load the used patterns 1 and 2, then trying the not used pattern 11 and succeeding with the pattern 3 - 4 loads
+      expect(dataViewsService.get).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/x-pack/plugins/lens/public/indexpattern_service/loader.ts
+++ b/x-pack/plugins/lens/public/indexpattern_service/loader.ts
@@ -167,6 +167,7 @@ export async function loadIndexPatterns({
       });
       if (resp) {
         indexPatterns = [resp];
+        break;
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/139082

By breaking out of the loop if a functioning data view has been found.

See issue for how to test this in the UI