### PR TITLE
[TIP] Preserve indicator grid state

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.test.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockedServices, TestProvidersComponent } from '../../../../../common/mocks/test_providers';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useColumnSettings } from './use_column_settings';
+
+const renderUseColumnSettings = () =>
+  renderHook(() => useColumnSettings(), { wrapper: TestProvidersComponent });
+
+describe('useColumnSettings()', () => {
+  afterEach(() => mockedServices.storage.clear());
+
+  describe('initial state', () => {
+    describe('when initial state is not persisted into plugin storage service', () => {
+      it('should return correct value', () => {
+        const { result } = renderUseColumnSettings();
+
+        expect(result.current.columns).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "displayAsText": "@timestamp",
+              "id": "@timestamp",
+            },
+            Object {
+              "displayAsText": "Indicator",
+              "id": "display_name",
+            },
+            Object {
+              "displayAsText": "Indicator type",
+              "id": "threat.indicator.type",
+            },
+            Object {
+              "displayAsText": "Feed",
+              "id": "threat.feed.name",
+            },
+            Object {
+              "displayAsText": "First seen",
+              "id": "threat.indicator.first_seen",
+            },
+            Object {
+              "displayAsText": "Last seen",
+              "id": "threat.indicator.last_seen",
+            },
+          ]
+        `);
+
+        expect(result.current.columnVisibility.visibleColumns).toMatchInlineSnapshot(`
+          Array [
+            "@timestamp",
+            "display_name",
+            "threat.indicator.type",
+            "threat.feed.name",
+            "threat.indicator.first_seen",
+            "threat.indicator.last_seen",
+          ]
+        `);
+      });
+    });
+
+    describe('when initial state is present in the plugin storage service', () => {
+      beforeEach(() => {
+        mockedServices.storage.set('indicatorsTable', {
+          visibleColumns: ['display_name', 'threat.indicator.last_seen', 'tags', 'stream'],
+          columns: [
+            { id: 'display_name', displayAsText: 'Indicator' },
+            { id: 'threat.indicator.type', displayAsText: 'Indicator type' },
+            { id: 'threat.feed.name', displayAsText: 'Feed' },
+            { id: 'threat.indicator.first_seen', displayAsText: 'First seen' },
+            { id: 'threat.indicator.last_seen', displayAsText: 'Last seen' },
+            { id: 'tags', displayAsText: 'tags' },
+            { id: 'stream', displayAsText: 'stream' },
+          ],
+        });
+      });
+
+      it('should restore the column settings from the cache', () => {
+        const { result } = renderUseColumnSettings();
+
+        expect(result.current.columnVisibility.visibleColumns).toMatchInlineSnapshot(`
+          Array [
+            "display_name",
+            "threat.indicator.last_seen",
+            "tags",
+            "stream",
+          ]
+        `);
+
+        expect(result.current.columns).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "displayAsText": "Indicator",
+              "id": "display_name",
+            },
+            Object {
+              "displayAsText": "Indicator type",
+              "id": "threat.indicator.type",
+            },
+            Object {
+              "displayAsText": "Feed",
+              "id": "threat.feed.name",
+            },
+            Object {
+              "displayAsText": "First seen",
+              "id": "threat.indicator.first_seen",
+            },
+            Object {
+              "displayAsText": "Last seen",
+              "id": "threat.indicator.last_seen",
+            },
+            Object {
+              "displayAsText": "tags",
+              "id": "tags",
+            },
+            Object {
+              "displayAsText": "stream",
+              "id": "stream",
+            },
+          ]
+        `);
+      });
+    });
+  });
+
+  describe('column toggle and reset', () => {
+    it('should return correct columns list', async () => {
+      const { result } = renderUseColumnSettings();
+
+      expect(result.current.columnVisibility.visibleColumns).toMatchInlineSnapshot(`
+        Array [
+          "@timestamp",
+          "display_name",
+          "threat.indicator.type",
+          "threat.feed.name",
+          "threat.indicator.first_seen",
+          "threat.indicator.last_seen",
+        ]
+      `);
+      expect(result.current.columns).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "displayAsText": "@timestamp",
+            "id": "@timestamp",
+          },
+          Object {
+            "displayAsText": "Indicator",
+            "id": "display_name",
+          },
+          Object {
+            "displayAsText": "Indicator type",
+            "id": "threat.indicator.type",
+          },
+          Object {
+            "displayAsText": "Feed",
+            "id": "threat.feed.name",
+          },
+          Object {
+            "displayAsText": "First seen",
+            "id": "threat.indicator.first_seen",
+          },
+          Object {
+            "displayAsText": "Last seen",
+            "id": "threat.indicator.last_seen",
+          },
+        ]
+      `);
+
+      await act(async () => {
+        result.current.handleToggleColumn('justATestColumn');
+      });
+
+      expect(result.current.columnVisibility.visibleColumns).toMatchInlineSnapshot(`
+        Array [
+          "@timestamp",
+          "display_name",
+          "threat.indicator.type",
+          "threat.feed.name",
+          "threat.indicator.first_seen",
+          "threat.indicator.last_seen",
+          "justATestColumn",
+        ]
+      `);
+      expect(result.current.columns).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "displayAsText": "@timestamp",
+            "id": "@timestamp",
+          },
+          Object {
+            "displayAsText": "Indicator",
+            "id": "display_name",
+          },
+          Object {
+            "displayAsText": "Indicator type",
+            "id": "threat.indicator.type",
+          },
+          Object {
+            "displayAsText": "Feed",
+            "id": "threat.feed.name",
+          },
+          Object {
+            "displayAsText": "First seen",
+            "id": "threat.indicator.first_seen",
+          },
+          Object {
+            "displayAsText": "Last seen",
+            "id": "threat.indicator.last_seen",
+          },
+          Object {
+            "displayAsText": "justATestColumn",
+            "id": "justATestColumn",
+          },
+        ]
+      `);
+
+      await act(async () => {
+        result.current.handleResetColumns();
+      });
+
+      expect(result.current.columnVisibility.visibleColumns).toMatchInlineSnapshot(`
+        Array [
+          "@timestamp",
+          "display_name",
+          "threat.indicator.type",
+          "threat.feed.name",
+          "threat.indicator.first_seen",
+          "threat.indicator.last_seen",
+        ]
+      `);
+      expect(result.current.columns).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "displayAsText": "@timestamp",
+            "id": "@timestamp",
+          },
+          Object {
+            "displayAsText": "Indicator",
+            "id": "display_name",
+          },
+          Object {
+            "displayAsText": "Indicator type",
+            "id": "threat.indicator.type",
+          },
+          Object {
+            "displayAsText": "Feed",
+            "id": "threat.feed.name",
+          },
+          Object {
+            "displayAsText": "First seen",
+            "id": "threat.indicator.first_seen",
+          },
+          Object {
+            "displayAsText": "Last seen",
+            "id": "threat.indicator.last_seen",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiDataGridColumn } from '@elastic/eui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import negate from 'lodash/negate';
+import { RawIndicatorFieldId } from '../../../../../../common/types/indicator';
+import { useKibana } from '../../../../../hooks/use_kibana';
+import { ComputedIndicatorFieldId } from '../cell_renderer';
+
+const DEFAULT_COLUMNS: EuiDataGridColumn[] = [
+  {
+    id: RawIndicatorFieldId.TimeStamp,
+    displayAsText: i18n.translate('xpack.threatIntelligence.indicator.table.timestampColumnTitle', {
+      defaultMessage: '@timestamp',
+    }),
+  },
+  {
+    id: ComputedIndicatorFieldId.DisplayName,
+    displayAsText: i18n.translate('xpack.threatIntelligence.indicator.table.indicatorColumTitle', {
+      defaultMessage: 'Indicator',
+    }),
+  },
+  {
+    id: RawIndicatorFieldId.Type,
+    displayAsText: i18n.translate(
+      'xpack.threatIntelligence.indicator.table.indicatorTypeColumTitle',
+      {
+        defaultMessage: 'Indicator type',
+      }
+    ),
+  },
+  {
+    id: RawIndicatorFieldId.Feed,
+    displayAsText: i18n.translate('xpack.threatIntelligence.indicator.table.FeedColumTitle', {
+      defaultMessage: 'Feed',
+    }),
+  },
+  {
+    id: RawIndicatorFieldId.FirstSeen,
+    displayAsText: i18n.translate('xpack.threatIntelligence.indicator.table.firstSeenColumTitle', {
+      defaultMessage: 'First seen',
+    }),
+  },
+  {
+    id: RawIndicatorFieldId.LastSeen,
+    displayAsText: i18n.translate('xpack.threatIntelligence.indicator.table.lastSeenColumTitle', {
+      defaultMessage: 'Last seen',
+    }),
+  },
+];
+
+const DEFAULT_VISIBLE_COLUMNS = DEFAULT_COLUMNS.map((column) => column.id);
+
+const INDICATORS_TABLE_STORAGE = 'indicatorsTable' as const;
+
+export const useColumnSettings = () => {
+  const {
+    services: { storage },
+  } = useKibana();
+
+  const [columns, setColumns] = useState<EuiDataGridColumn[]>([]);
+  const [visibleColumns, setVisibleColumns] = useState<Array<EuiDataGridColumn['id']>>([]);
+
+  /** Deserialize preferences on mount */
+  useEffect(() => {
+    const cachedPreferences = storage.get(INDICATORS_TABLE_STORAGE) || {
+      visibleColumns: DEFAULT_VISIBLE_COLUMNS,
+      columns: DEFAULT_COLUMNS,
+    };
+
+    const { visibleColumns: cachedVisibleColumns, columns: cachedColumns } = cachedPreferences;
+
+    setVisibleColumns(cachedVisibleColumns);
+    setColumns(cachedColumns);
+  }, [storage]);
+
+  /** Ensure preferences are serialized into plugin storage on change */
+  useEffect(() => {
+    storage.set(INDICATORS_TABLE_STORAGE, { visibleColumns, columns });
+  }, [columns, storage, visibleColumns]);
+
+  /** Toggle column and adjust its visibility */
+  const handleToggleColumn = useCallback((columnId: string) => {
+    setColumns((currentColumns) => {
+      const columnsMatchingId = ({ id }: EuiDataGridColumn) => id === columnId;
+      const columnsNotMatchingId = negate(columnsMatchingId);
+
+      const enabled = Boolean(currentColumns.find(columnsMatchingId));
+
+      if (enabled) {
+        return currentColumns.filter(columnsNotMatchingId);
+      }
+
+      return [...currentColumns, { id: columnId as any, displayAsText: columnId }];
+    });
+
+    setVisibleColumns((currentlyVisibleColumns) => {
+      const matchById = (id: string) => id === columnId;
+      const notMatchingId = negate(matchById);
+
+      const enabled = Boolean(currentlyVisibleColumns.find(matchById));
+
+      if (enabled) {
+        return currentlyVisibleColumns.filter(notMatchingId);
+      }
+
+      return [...currentlyVisibleColumns, columnId];
+    });
+  }, []);
+
+  const handleResetColumns = useCallback(() => {
+    setColumns(DEFAULT_COLUMNS);
+    setVisibleColumns(DEFAULT_VISIBLE_COLUMNS);
+  }, []);
+
+  const columnVisibility = useMemo(
+    () => ({
+      visibleColumns,
+      setVisibleColumns: setVisibleColumns as (cols: string[]) => void,
+    }),
+    [visibleColumns]
+  );
+
+  return {
+    handleResetColumns,
+    handleToggleColumn,
+    columns,
+    columnVisibility,
+  };
+};


### PR DESCRIPTION
## Summary

This PR saves and restores whatever changes the user might have made into column display into local storage.
This does not include sorting yet, as we have not implemented that part so far.

This should resolve the following: https://github.com/elastic/security-team/issues/4534

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
