### PR TITLE
SO management: Use display name for type in overwrite modal

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -618,7 +618,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
   }
 
   render() {
-    const { close } = this.props;
+    const { close, allowedTypes } = this.props;
 
     let confirmOverwriteModal: ReactNode;
     const { conflictingRecord } = this.state;
@@ -626,7 +626,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
       const { conflict } = conflictingRecord;
       const onFinish = (overwrite: boolean, destinationId?: string) =>
         conflictingRecord.done([overwrite, destinationId]);
-      confirmOverwriteModal = <OverwriteModal {...{ conflict, onFinish }} />;
+      confirmOverwriteModal = <OverwriteModal {...{ conflict, onFinish, allowedTypes }} />;
     }
 
     return (

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.test.tsx
@@ -23,6 +23,7 @@ describe('OverwriteModal', () => {
     const props: OverwriteModalProps = {
       conflict: { obj, error: { type: 'conflict', destinationId: 'qux' } },
       onFinish,
+      allowedTypes: [],
     };
 
     it('should render as expected', async () => {
@@ -65,6 +66,7 @@ describe('OverwriteModal', () => {
         },
       },
       onFinish,
+      allowedTypes: [],
     };
 
     it('should render as expected', async () => {
@@ -91,6 +93,26 @@ describe('OverwriteModal', () => {
       findTestSubject(wrapper, 'confirmModalConfirmButton').simulate('click');
       // first destination is selected by default
       expect(onFinish).toHaveBeenCalledWith(true, 'qux');
+    });
+  });
+
+  describe('displaying a type with a displayName', () => {
+    const props: OverwriteModalProps = {
+      conflict: { obj, error: { type: 'conflict', destinationId: 'qux' } },
+      onFinish,
+      allowedTypes: [
+        { name: 'foo', hidden: false, namespaceType: 'multiple', displayName: 'fooDisplayName' },
+      ],
+    };
+
+    it('should use the displayName for the title of the modal', async () => {
+      const wrapper = shallowWithI18nProvider<{ title: string }>(<OverwriteModal {...props} />);
+
+      expect(wrapper.props()).toEqual(
+        expect.objectContaining({
+          title: 'Overwrite fooDisplayName?',
+        })
+      );
     });
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.tsx
@@ -10,15 +10,17 @@ import React, { useState, Fragment, ReactNode } from 'react';
 import { EuiConfirmModal, EUI_MODAL_CONFIRM_BUTTON, EuiText, EuiSuperSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
+import type { SavedObjectManagementTypeInfo } from '../../../../common/types';
 import { FailedImportConflict } from '../../../lib/resolve_import_errors';
 import { getDefaultTitle } from '../../../lib';
 
 export interface OverwriteModalProps {
   conflict: FailedImportConflict;
   onFinish: (overwrite: boolean, destinationId?: string) => void;
+  allowedTypes: SavedObjectManagementTypeInfo[];
 }
 
-export const OverwriteModal = ({ conflict, onFinish }: OverwriteModalProps) => {
+export const OverwriteModal = ({ conflict, onFinish, allowedTypes }: OverwriteModalProps) => {
   const { obj, error } = conflict;
   let initialDestinationId: string | undefined;
   let selectControl: ReactNode = null;
@@ -78,6 +80,8 @@ export const OverwriteModal = ({ conflict, onFinish }: OverwriteModalProps) => {
 
   const { type, meta } = obj;
   const title = meta.title || getDefaultTitle(obj);
+  const typeMeta = allowedTypes.find((t) => t.name === type);
+  const typeDisplayName = typeMeta?.displayName ?? type;
   const bodyText =
     error.type === 'conflict'
       ? i18n.translate('savedObjectsManagement.objectsTable.overwriteModal.body.conflict', {
@@ -91,11 +95,12 @@ export const OverwriteModal = ({ conflict, onFinish }: OverwriteModalProps) => {
             values: { title },
           }
         );
+
   return (
     <EuiConfirmModal
       title={i18n.translate('savedObjectsManagement.objectsTable.overwriteModal.title', {
         defaultMessage: 'Overwrite {type}?',
-        values: { type },
+        values: { type: typeDisplayName },
       })}
       cancelButtonText={i18n.translate(
         'savedObjectsManagement.objectsTable.overwriteModal.cancelButtonText',


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/139479

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->