### PR TITLE
[APM] Synthtrace: add `dbExitSpan` and `httpExitSpan` helpers

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/apm_fields.ts
@@ -32,6 +32,7 @@ export interface ApmException {
   message: string;
 }
 export interface Observer {
+  type: string;
   version: string;
   version_major: number;
 }
@@ -42,6 +43,8 @@ export type ApmFields = Fields &
     'agent.name': string;
     'agent.version': string;
     'container.id': string;
+    'destination.address': string;
+    'destination.port': number;
     'ecs.version': string;
     'event.outcome': string;
     'event.ingested': number;
@@ -75,6 +78,8 @@ export type ApmFields = Fields &
     'service.runtime.name': string;
     'service.runtime.version': string;
     'service.framework.name': string;
+    'service.target.name': string;
+    'service.target.type': string;
     'span.id': string;
     'span.name': string;
     'span.type': string;

--- a/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
@@ -7,6 +7,7 @@
  */
 import { service } from './service';
 import { browser } from './browser';
+import { trace } from './trace';
 import { getTransactionMetrics } from './processors/get_transaction_metrics';
 import { getSpanDestinationMetrics } from './processors/get_span_destination_metrics';
 import { getChromeUserAgentDefaults } from './defaults/get_chrome_user_agent_defaults';
@@ -18,6 +19,7 @@ import { ApmSynthtraceKibanaClient } from './client/apm_synthtrace_kibana_client
 import type { ApmException } from './apm_fields';
 
 export const apm = {
+  trace,
   service,
   browser,
   getTransactionMetrics,

--- a/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/index.ts
@@ -7,7 +7,6 @@
  */
 import { service } from './service';
 import { browser } from './browser';
-import { trace } from './trace';
 import { getTransactionMetrics } from './processors/get_transaction_metrics';
 import { getSpanDestinationMetrics } from './processors/get_span_destination_metrics';
 import { getChromeUserAgentDefaults } from './defaults/get_chrome_user_agent_defaults';
@@ -19,7 +18,6 @@ import { ApmSynthtraceKibanaClient } from './client/apm_synthtrace_kibana_client
 import type { ApmException } from './apm_fields';
 
 export const apm = {
-  trace,
   service,
   browser,
   getTransactionMetrics,

--- a/packages/kbn-apm-synthtrace/src/lib/apm/instance.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/instance.ts
@@ -12,7 +12,6 @@ import { Metricset } from './metricset';
 import { Span } from './span';
 import { Transaction } from './transaction';
 import { ApmApplicationMetricFields, ApmFields } from './apm_fields';
-import url from 'url';
 
 export class Instance extends Entity<ApmFields> {
   transaction(transactionName: string, transactionType = 'request') {
@@ -23,48 +22,10 @@ export class Instance extends Entity<ApmFields> {
     });
   }
 
-  dbExitSpan({ spanName, subType }: { spanName: string; subType?: string }) {
-    const exitSpan = new Span({
-      ...this.fields,
-      'service.target.type': subType,
-      'span.destination.service.name': '', //deprecated
-      'span.destination.service.resource': subType,
-      'span.destination.service.type': '', //deprecated
-      'span.name': spanName,
-      'span.subtype': subType,
-      'span.type': 'db',
-    });
-
-    return exitSpan;
-  }
-
-  messagingExitSpan(mesageQueueName: string) {}
-
-  httpExitSpan({ spanName, destination }: { spanName: string; destination: string }) {
-    // host: 'opbeans-go:3000',
-    // hostname: 'opbeans-go',
-    // port: '3000',
-    const parsed = new url.URL(destination);
-
-    const exitSpan = new Span({
-      ...this.fields,
-      'destination.address': parsed.hostname,
-      'destination.port': parseInt(parsed.port, 10),
-      'service.target.name': parsed.host,
-      'span.destination.service.name': '', //deprecated
-      'span.destination.service.resource': parsed.host,
-      'span.destination.service.type': '', //deprecated
-      'span.name': spanName,
-      'span.subtype': 'http',
-      'span.type': 'external',
-    });
-
-    return exitSpan;
-  }
-
-  span(spanName: string, spanType: string, spanSubtype?: string) {
+  span(spanName: string, spanType: string, spanSubtype?: string, apmFields?: ApmFields) {
     return new Span({
       ...this.fields,
+      ...apmFields,
       'span.name': spanName,
       'span.type': spanType,
       'span.subtype': spanSubtype,

--- a/packages/kbn-apm-synthtrace/src/lib/apm/span.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/span.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import url from 'url';
 import { BaseSpan } from './base_span';
 import { generateShortId } from '../utils/generate_id';
 import { ApmFields } from './apm_fields';
@@ -38,4 +39,57 @@ export class Span extends BaseSpan {
 
     return this;
   }
+}
+
+export function httpExitSpan({
+  spanName,
+  destinationUrl,
+}: {
+  spanName: string;
+  destinationUrl: string;
+}): [string, string, string, ApmFields] {
+  // origin: 'http://opbeans-go:3000',
+  // host: 'opbeans-go:3000',
+  // hostname: 'opbeans-go',
+  // port: '3000',
+  const destination = new url.URL(destinationUrl);
+
+  const spanType = 'external';
+  const spanSubType = 'http';
+
+  return [
+    spanName,
+    spanType,
+    spanSubType,
+    {
+      'destination.address': destination.hostname,
+      'destination.port': parseInt(destination.port, 10),
+      'service.target.name': destination.host,
+      'span.destination.service.name': destination.origin,
+      'span.destination.service.resource': destination.host,
+      'span.destination.service.type': 'external',
+    },
+  ];
+}
+
+export function dbExitSpan({
+  spanName,
+  spanSubType,
+}: {
+  spanName: string;
+  spanSubType?: string;
+}): [string, string, string | undefined, ApmFields] {
+  const spanType = 'db';
+
+  return [
+    spanName,
+    spanType,
+    spanSubType,
+    {
+      'service.target.type': spanSubType,
+      'span.destination.service.name': spanSubType,
+      'span.destination.service.resource': spanSubType,
+      'span.destination.service.type': spanType,
+    },
+  ];
 }

--- a/packages/kbn-apm-synthtrace/src/lib/stream_processor.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/stream_processor.ts
@@ -178,6 +178,7 @@ export class StreamProcessor<TFields extends Fields = ApmFields> {
   private static enrich(document: ApmFields, version: string, versionMajor: number): ApmFields {
     // see https://github.com/elastic/apm-server/issues/7088 can not be provided as flat key/values
     document.observer = {
+      type: 'synthtrace',
       version: version ?? '8.2.0',
       version_major: versionMajor,
     };

--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { apm, timerange } from '..';
+import { ApmFields } from '../lib/apm/apm_fields';
+import { Scenario } from '../cli/scenario';
+
+import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
+  return {
+    generate: ({ from, to }) => {
+      const range = timerange(from, to);
+      const transactionName = '240rpm/75% 1000ms';
+      const successfulTimestamps = range.interval('1s').rate(3);
+
+      const opbeansRum = apm.service('opbeans-rum', ENVIRONMENT, 'rum-js').instance('my-instance');
+      const opbeansNode = apm
+        .service('opbeans-node', ENVIRONMENT, 'nodejs')
+        .instance('my-instance');
+      const opbeansGo = apm.service('opbeans-go', ENVIRONMENT, 'go').instance('my-instance');
+
+      const traces = successfulTimestamps.generator((timestamp) => {
+        // opbeans-rum
+        return opbeansRum
+          .transaction(transactionName)
+          .duration(400)
+          .timestamp(timestamp)
+          .children(
+            // opbeans-rum -> opbeans-node
+            opbeansRum
+              .httpExitSpan({
+                spanName: 'GET /api/products/top',
+                destination: 'http://opbeans-node:3000',
+              })
+              .duration(300)
+              .timestamp(timestamp)
+
+              .children(
+                // opbeans-node
+                opbeansNode
+                  .transaction('Initial transaction in opbeans-node')
+                  .duration(300)
+                  .timestamp(timestamp)
+                  .children(
+                    opbeansNode
+                      // opbeans-node -> opbeans-go
+                      .httpExitSpan({
+                        spanName: 'GET opbeans-go:3000',
+                        destination: 'http://opbeans-go:3000',
+                      })
+                      .timestamp(timestamp)
+                      .duration(400)
+
+                      .children(
+                        // opbeans-go
+                        opbeansGo
+
+                          .transaction('Initial transaction in opbeans-go')
+                          .timestamp(timestamp)
+                          .duration(200)
+                          .children(
+                            opbeansGo
+                              .span('custom_operation', 'custom')
+                              .timestamp(timestamp)
+                              .duration(100)
+                              .success()
+                          )
+                      )
+                  )
+              )
+          );
+      });
+
+      return traces;
+    },
+  };
+};
+
+export default scenario;

--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
@@ -12,6 +12,7 @@ import { Scenario } from '../cli/scenario';
 
 import { RunOptions } from '../cli/utils/parse_run_cli_flags';
 import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+import { httpExitSpan } from '../lib/apm/span';
 
 const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
@@ -37,10 +38,12 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
           .children(
             // opbeans-rum -> opbeans-node
             opbeansRum
-              .httpExitSpan({
-                spanName: 'GET /api/products/top',
-                destination: 'http://opbeans-node:3000',
-              })
+              .span(
+                ...httpExitSpan({
+                  spanName: 'GET /api/products/top',
+                  destinationUrl: 'http://opbeans-node:3000',
+                })
+              )
               .duration(300)
               .timestamp(timestamp)
 
@@ -53,10 +56,12 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
                   .children(
                     opbeansNode
                       // opbeans-node -> opbeans-go
-                      .httpExitSpan({
-                        spanName: 'GET opbeans-go:3000',
-                        destination: 'http://opbeans-go:3000',
-                      })
+                      .span(
+                        ...httpExitSpan({
+                          spanName: 'GET opbeans-go:3000',
+                          destinationUrl: 'http://opbeans-go:3000',
+                        })
+                      )
                       .timestamp(timestamp)
                       .duration(400)
 

--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { apm, timerange } from '..';
+import { apm, timerange } from '../..';
 import { ApmFields } from '../lib/apm/apm_fields';
 import { Scenario } from '../cli/scenario';
 

--- a/packages/kbn-apm-synthtrace/src/test/apm_events_to_elasticsearch_output.test.ts
+++ b/packages/kbn-apm-synthtrace/src/test/apm_events_to_elasticsearch_output.test.ts
@@ -46,6 +46,7 @@ describe('output apm events to elasticsearch', () => {
           "version": "1.4",
         },
         "observer": Object {
+          "type": "synthtrace",
           "version": "8.0.0",
           "version_major": 8,
         },


### PR DESCRIPTION
This adds a new distributed tracing scenario and two new helper methods: `dbExitSpan` and `httpExitSpan`

cc @Mpdreamz 