### PR TITLE
[Lens] Improve "Debug in Playground" functionality

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -402,6 +402,7 @@ export function App({
           datasourceMap={datasourceMap}
           title={persistedDoc?.title}
           lensInspector={lensInspector}
+          currentDoc={currentDoc}
           goBackToOriginatingApp={goBackToOriginatingApp}
           contextOriginatingApp={contextOriginatingApp}
           initialContextIsEmbedded={initialContextIsEmbedded}

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -218,6 +218,7 @@ export const LensTopNavMenu = ({
   initialContext,
   theme$,
   indexPatternService,
+  currentDoc,
 }: LensTopNavMenuProps) => {
   const {
     data,
@@ -377,6 +378,7 @@ export const LensTopNavMenu = ({
         query,
         filters,
         initialContext,
+        currentDoc,
       });
       return menuEntry ? [menuEntry] : [];
     });
@@ -391,6 +393,7 @@ export const LensTopNavMenu = ({
     query,
     filters,
     initialContext,
+    currentDoc,
   ]);
 
   const layerMetaInfo = useMemo(() => {

--- a/x-pack/plugins/lens/public/app_plugin/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/types.ts
@@ -53,6 +53,7 @@ import type { LensAttributeService } from '../lens_attribute_service';
 import type { LensEmbeddableInput } from '../embeddable/embeddable';
 import type { LensInspector } from '../lens_inspector_service';
 import { IndexPatternServiceAPI } from '../indexpattern_service/service';
+import { Document } from '../persistence/saved_object_store';
 
 export interface RedirectToOriginProps {
   input?: LensEmbeddableInput;
@@ -112,6 +113,7 @@ export interface LensTopNavMenuProps {
   initialContextIsEmbedded?: boolean;
   topNavMenuEntryGenerators: LensTopNavMenuEntryGenerator[];
   initialContext?: VisualizeFieldContext | VisualizeEditorContext;
+  currentDoc: Document | undefined;
   theme$: Observable<CoreTheme>;
   indexPatternService: IndexPatternServiceAPI;
 }

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -47,6 +47,7 @@ import type { LensInspector } from './lens_inspector_service';
 import type { FormatSelectorOptions } from './indexpattern_datasource/dimension_panel/format_selector';
 import type { DataViewsState } from './state_management/types';
 import type { IndexPatternServiceAPI } from './indexpattern_service/service';
+import type { Document } from './persistence/saved_object_store';
 
 export interface IndexPatternRef {
   id: string;
@@ -1191,4 +1192,5 @@ export type LensTopNavMenuEntryGenerator = (props: {
   query: Query;
   filters: Filter[];
   initialContext?: VisualizeFieldContext | VisualizeEditorContext;
+  currentDoc: Document | undefined;
 }) => undefined | TopNavMenuData;


### PR DESCRIPTION
The existing implementation of the "Debug in Playground" functionality would try to piece together the shape of the Lens input by multiple parts, but it's not catching all of them 100% correctly (e.g. data view ids are not extracted correctly).

This PR is passing the already existing `currentDoc` to the navigation item as well so it can grab the true state of the vis from there. This also lets ad hoc data views show up.