### PR TITLE
Fix frame aggregation by using AddressOrLine

### DIFF
--- a/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
+++ b/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { createStackFrameID } from '../profiling';
+
 enum stackTraceID {
   A = 'yU2Oct2ct0HkxJ7-pRcPkg==',
   B = 'Xt8aKN70PDXpMDLCOmojzQ==',
@@ -24,29 +26,45 @@ enum fileID {
   G = 'ZCOCZlls7r2cbG1HchkbVg==',
   H = 'Og7kGWGe9qiCunkaXDffHQ==',
   I = 'WAE6T1TeDsjDMOuwX4Ynxg==',
+  J = 'ZNiZco1zgh0nJI6hPllMaQ==',
+  K = 'abl5r8Vvvb2Y7NaDZW1QLQ==',
 }
 
-enum frameID {
-  A = 'ZNiZco1zgh0nJI6hPllMaQAAAAABkPp6',
-  B = 'abl5r8Vvvb2Y7NaDZW1QLQAAAAAAZmzG',
-  C = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGTnjJ',
-  D = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGTnwG',
-  E = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGYRMy',
-  F = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGYV1J',
-  G = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGEz_F',
-  H = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAAABjhI',
-  I = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAAAAcit',
-  J = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAAAAfiT',
-  K = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAAAAf7J',
-  L = 'ZCOCZlls7r2cbG1HchkbVgAAAAABGAwE',
-  M = 'Og7kGWGe9qiCunkaXDffHQAAAAAAAAvT',
-  N = 'WAE6T1TeDsjDMOuwX4YnxgAAAAAAABRR',
-  O = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAAABloA',
-  P = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAABV97Q',
-  Q = 'Gf4xoLc8QuAHU49Ch_CFOAAAAAABV9CG',
-  R = 'gnEsgxvvEODj6iFYMQWYlAAAAAAEBDLw',
-  S = 'gnEsgxvvEODj6iFYMQWYlAAAAAAD05_D',
+enum addressOrLine {
+  A = 26278522,
+  B = 6712518,
+  C = 105806025,
+  D = 105806854,
+  E = 107025202,
+  F = 107044169,
+  G = 18353156,
+  H = 3027,
+  I = 5201,
+  J = 67384048,
+  K = 8888,
 }
+
+const frameID: Record<string, string> = {
+  A: createStackFrameID(fileID.A, addressOrLine.A),
+  B: createStackFrameID(fileID.B, addressOrLine.B),
+  C: createStackFrameID(fileID.C, addressOrLine.C),
+  D: createStackFrameID(fileID.D, addressOrLine.D),
+  E: createStackFrameID(fileID.E, addressOrLine.C),
+  F: createStackFrameID(fileID.E, addressOrLine.D),
+  G: createStackFrameID(fileID.E, addressOrLine.E),
+  H: createStackFrameID(fileID.E, addressOrLine.F),
+  I: createStackFrameID(fileID.E, addressOrLine.G),
+  J: createStackFrameID(fileID.F, addressOrLine.H),
+  K: createStackFrameID(fileID.F, addressOrLine.I),
+  L: createStackFrameID(fileID.F, addressOrLine.J),
+  M: createStackFrameID(fileID.F, addressOrLine.K),
+  N: createStackFrameID(fileID.G, addressOrLine.G),
+  O: createStackFrameID(fileID.H, addressOrLine.H),
+  P: createStackFrameID(fileID.I, addressOrLine.I),
+  Q: createStackFrameID(fileID.F, addressOrLine.A),
+  R: createStackFrameID(fileID.E, addressOrLine.B),
+  S: createStackFrameID(fileID.E, addressOrLine.C),
+};
 
 export const events = new Map([
   [stackTraceID.A, 16],
@@ -62,7 +80,8 @@ export const stackTraces = new Map([
     stackTraceID.A,
     {
       FileIDs: [fileID.A, fileID.B, fileID.C, fileID.D],
-      FrameIDs: [frameID.A, frameID.A, frameID.A, frameID.B],
+      AddressOrLines: [addressOrLine.A, addressOrLine.B, addressOrLine.C, addressOrLine.D],
+      FrameIDs: [frameID.A, frameID.B, frameID.C, frameID.D],
       Types: [3, 3, 3, 3],
     },
   ],
@@ -70,7 +89,14 @@ export const stackTraces = new Map([
     stackTraceID.B,
     {
       FileIDs: [fileID.E, fileID.E, fileID.E, fileID.E, fileID.E],
-      FrameIDs: [frameID.C, frameID.D, frameID.E, frameID.F, frameID.G],
+      AddressOrLines: [
+        addressOrLine.C,
+        addressOrLine.D,
+        addressOrLine.E,
+        addressOrLine.F,
+        addressOrLine.G,
+      ],
+      FrameIDs: [frameID.E, frameID.F, frameID.G, frameID.H, frameID.I],
       Types: [3, 3, 3, 3, 3],
     },
   ],
@@ -78,7 +104,8 @@ export const stackTraces = new Map([
     stackTraceID.C,
     {
       FileIDs: [fileID.F, fileID.F, fileID.F, fileID.F],
-      FrameIDs: [frameID.H, frameID.I, frameID.J, frameID.K],
+      AddressOrLines: [addressOrLine.H, addressOrLine.I, addressOrLine.J, addressOrLine.K],
+      FrameIDs: [frameID.J, frameID.K, frameID.L, frameID.M],
       Types: [3, 3, 3, 3],
     },
   ],
@@ -86,7 +113,8 @@ export const stackTraces = new Map([
     stackTraceID.D,
     {
       FileIDs: [fileID.G, fileID.H, fileID.I],
-      FrameIDs: [frameID.L, frameID.M, frameID.N],
+      AddressOrLines: [addressOrLine.G, addressOrLine.H, addressOrLine.I],
+      FrameIDs: [frameID.N, frameID.O, frameID.P],
       Types: [3, 8, 8],
     },
   ],
@@ -94,7 +122,8 @@ export const stackTraces = new Map([
     stackTraceID.E,
     {
       FileIDs: [fileID.F, fileID.F, fileID.F],
-      FrameIDs: [frameID.O, frameID.P, frameID.Q],
+      AddressOrLines: [addressOrLine.I, addressOrLine.J, addressOrLine.K],
+      FrameIDs: [frameID.K, frameID.L, frameID.M],
       Types: [3, 3, 3],
     },
   ],
@@ -102,7 +131,8 @@ export const stackTraces = new Map([
     stackTraceID.F,
     {
       FileIDs: [fileID.E, fileID.E],
-      FrameIDs: [frameID.R, frameID.S],
+      AddressOrLines: [addressOrLine.E, addressOrLine.F],
+      FrameIDs: [frameID.G, frameID.H],
       Types: [3, 3],
     },
   ],

--- a/x-pack/plugins/profiling/common/functions.test.ts
+++ b/x-pack/plugins/profiling/common/functions.test.ts
@@ -17,6 +17,6 @@ describe('TopN function operations', () => {
     expect(topNFunctions.TopN.length).toEqual(5);
 
     const exclusiveCounts = topNFunctions.TopN.map((value) => value.CountExclusive);
-    expect(exclusiveCounts).toEqual([16, 10, 9, 5, 0]);
+    expect(exclusiveCounts).toEqual([16, 9, 7, 5, 2]);
   });
 });

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -41,8 +41,9 @@ export interface StackTraceEvent {
 }
 
 export interface StackTrace {
-  FileIDs: string[];
   FrameIDs: string[];
+  FileIDs: string[];
+  AddressOrLines: number[];
   Types: number[];
 }
 
@@ -161,14 +162,15 @@ export function groupStackFrameMetadataByStackTrace(
     for (let i = 0; i < trace.FrameIDs.length; i++) {
       const frameID = trace.FrameIDs[i];
       const fileID = trace.FileIDs[i];
+      const addressOrLine = trace.AddressOrLines[i];
       const frame = stackFrames.get(frameID)!;
       const executable = executables.get(fileID)!;
 
       const metadata = createStackFrameMetadata({
         FrameID: frameID,
         FileID: fileID,
+        AddressOrLine: addressOrLine,
         FrameType: trace.Types[i],
-        AddressOrLine: frame.LineNumber,
         FunctionName: frame.FunctionName,
         FunctionOffset: frame.FunctionOffset,
         SourceLine: frame.LineNumber,

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -9,6 +9,13 @@ export type StackTraceID = string;
 export type StackFrameID = string;
 export type FileID = string;
 
+export function createStackFrameID(fileID: FileID, addressOrLine: number): StackFrameID {
+  const buf = Buffer.alloc(24);
+  Buffer.from(fileID, 'base64url').copy(buf);
+  buf.writeBigUInt64BE(BigInt(addressOrLine), 16);
+  return buf.toString('base64url');
+}
+
 export enum FrameType {
   Unsymbolized = 0,
   Python,

--- a/x-pack/plugins/profiling/server/routes/stacktrace.test.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { StackTrace } from '../../common/profiling';
+import { createStackFrameID, StackTrace } from '../../common/profiling';
 import {
   decodeStackTrace,
   EncodedStackTrace,
@@ -22,15 +22,25 @@ enum fileID {
   F = 'gnEsgxvvEODj6iFYMQWYlA',
 }
 
-enum frameID {
-  A = 'aQpJmTLWydNvOapSFZOwKgAAAAAAB924',
-  B = 'hz_u-HGyrN6qeIk6UIJeCAAAAAAAAAZZ',
-  C = 'AJ8qrcXSoJbl_haPhlc4ogAAAAAAAAAH',
-  D = 'lHZiv7a58px6Gumcpo-6yAAAAAAAAAAf',
-  E = 'fkbxUTZgljnk71ZMnqJnyAAAAAAAAABv',
-  F = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGVDgH',
-  G = 'gnEsgxvvEODj6iFYMQWYlAAAAAAGBJv6',
+enum addressOrLine {
+  A = 515512,
+  B = 26278522,
+  C = 6712518,
+  D = 105806025,
+  E = 111,
+  F = 106182663,
+  G = 100965370,
 }
+
+const frameID: Record<string, string> = {
+  A: createStackFrameID(fileID.A, addressOrLine.A),
+  B: createStackFrameID(fileID.B, addressOrLine.B),
+  C: createStackFrameID(fileID.C, addressOrLine.C),
+  D: createStackFrameID(fileID.D, addressOrLine.D),
+  E: createStackFrameID(fileID.E, addressOrLine.E),
+  F: createStackFrameID(fileID.F, addressOrLine.F),
+  G: createStackFrameID(fileID.F, addressOrLine.G),
+};
 
 const frameTypeA = [0, 0, 0];
 const frameTypeB = [8, 8, 8, 8];
@@ -51,8 +61,9 @@ describe('Stack trace operations', () => {
           },
         } as EncodedStackTrace,
         expected: {
-          FileIDs: [fileID.C, fileID.B, fileID.A],
           FrameIDs: [frameID.C, frameID.B, frameID.A],
+          FileIDs: [fileID.C, fileID.B, fileID.A],
+          AddressOrLines: [addressOrLine.C, addressOrLine.B, addressOrLine.A],
           Types: frameTypeA,
         } as StackTrace,
       },
@@ -66,8 +77,9 @@ describe('Stack trace operations', () => {
           },
         } as EncodedStackTrace,
         expected: {
-          FileIDs: [fileID.F, fileID.F, fileID.E, fileID.D],
           FrameIDs: [frameID.G, frameID.F, frameID.E, frameID.D],
+          FileIDs: [fileID.F, fileID.F, fileID.E, fileID.D],
+          AddressOrLines: [addressOrLine.G, addressOrLine.F, addressOrLine.E, addressOrLine.D],
           Types: frameTypeB,
         } as StackTrace,
       },


### PR DESCRIPTION
Currently, the TopN function aggregation is not correct as it uses uninitialized (or wrongly initialized) AddressOrLine values.

Fixes https://github.com/elastic/prodfiler/issues/2468

@jbcrail Could you help me fixing the tests ?
I also think that in the fixtures, FrameIDs and FileIDs are not matching. The FiledIDs (and now also the AddressOrLines) should best be derived from the FrameIDs (like `decodeStackTrace()` does it).

**Before**
![Screenshot_20220830_161128](https://user-images.githubusercontent.com/2087964/187460412-15256bb4-9e1f-45a2-a5ce-09a4fae2c2a5.png)

**After**
![Screenshot_20220830_160950](https://user-images.githubusercontent.com/2087964/187460451-f056853e-d2b8-4e45-b86d-eec13122c21c.png)
