### PR TITLE
[docs] Removes another instance of kibCoreSavedObjectsPluginApi

### DIFF
--- a/dev_docs/contributing/best_practices.mdx
+++ b/dev_docs/contributing/best_practices.mdx
@@ -56,7 +56,7 @@ Es-lint overrides on a per-plugin level are discouraged.
 
 ## Using the SavedObjectClient
 
-The <DocLink id="kibCoreSavedObjectsPluginApi" section="def-public.SavedObjectsClient" text="SavedObjectClient" /> should always be used for reading and writing saved objects that you manage. For saved objects managed by other plugins, their plugin APIs should be used instead.
+The SavedObjectClient should always be used for reading and writing saved objects that you manage. For saved objects managed by other plugins, their plugin APIs should be used instead.
 
 Good:
 ```


### PR DESCRIPTION
A follow-up to #139682, there was another linked instance. 