### PR TITLE
[Security Solution] updates for FleetServerAgent interface

### DIFF
--- a/x-pack/plugins/fleet/common/constants/agent.ts
+++ b/x-pack/plugins/fleet/common/constants/agent.ts
@@ -25,3 +25,13 @@ export const AGENT_POLICY_ROLLOUT_RATE_LIMIT_REQUEST_PER_INTERVAL = 5;
 export const AGENTS_INDEX = '.fleet-agents';
 export const AGENT_ACTIONS_INDEX = '.fleet-actions';
 export const AGENT_ACTIONS_RESULTS_INDEX = '.fleet-actions-results';
+
+export const FleetServerAgentComponentStatuses = [
+  'starting',
+  'configuring',
+  'healthy',
+  'degraded',
+  'failed',
+  'stopping',
+  'stopped',
+] as const;

--- a/x-pack/plugins/fleet/common/index.ts
+++ b/x-pack/plugins/fleet/common/index.ts
@@ -36,6 +36,7 @@ export {
   AGENTS_PREFIX,
   AGENT_UPDATE_LAST_CHECKIN_INTERVAL_MS,
   agentPolicyStatuses,
+  FleetServerAgentComponentStatuses,
   // Routes
   PACKAGE_POLICY_API_ROOT,
   AGENT_API_ROUTES,
@@ -177,6 +178,7 @@ export type {
   InstallFailed,
   // Fleet server models
   FleetServerAgent,
+  FleetServerAgentComponentStatus,
 } from './types';
 
 export { ElasticsearchAssetType } from './types';

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
@@ -33,6 +33,10 @@ properties:
     $ref: ./agent_status.yaml
   default_api_key:
     type: string
+  components:
+    type: array
+    items:
+      $ref: ./agent_component.yaml
 required:
   - type
   - active

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component.yaml
@@ -1,0 +1,15 @@
+title: Agent component
+type: object
+properties:
+  id:
+    type: string
+  type:
+    type: string
+  status:
+    $ref: ./agent_component_status.yaml
+  message:
+    type: string
+  units:
+    type: array
+    items:
+      $ref: ./agent_component_unit.yaml

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_status.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_status.yaml
@@ -1,0 +1,10 @@
+title: Agent component status
+type: string
+enum:
+  - starting
+  - configuring
+  - healthy
+  - degraded
+  - failed
+  - stopping
+  - stopped

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_unit.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_unit.yaml
@@ -1,0 +1,13 @@
+title: Agent component unit
+type: object
+properties:
+  id:
+    type: string
+  type:
+    $ref: ./agent_component_unit_type.yaml
+  status:
+    $ref: ./agent_component_status.yaml
+  message:
+    type: string
+  payload:
+    type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_unit_type.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_component_unit_type.yaml
@@ -1,0 +1,5 @@
+title: Agent component unit type
+type: string
+enum:
+  - input
+  - output

--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -9,6 +9,7 @@ import type {
   AGENT_TYPE_EPHEMERAL,
   AGENT_TYPE_PERMANENT,
   AGENT_TYPE_TEMPORARY,
+  FleetServerAgentComponentStatuses,
 } from '../../constants';
 
 export type AgentType =
@@ -30,6 +31,9 @@ export type AgentStatus =
 export type SimplifiedAgentStatus = 'healthy' | 'unhealthy' | 'updating' | 'offline' | 'inactive';
 
 export type AgentActionType = 'UNENROLL' | 'UPGRADE' | 'SETTINGS' | 'POLICY_REASSIGN' | 'CANCEL';
+
+type FleetServerAgentComponentStatusTuple = typeof FleetServerAgentComponentStatuses;
+export type FleetServerAgentComponentStatus = FleetServerAgentComponentStatusTuple[number];
 
 export interface NewAgentAction {
   type: AgentActionType;
@@ -99,7 +103,25 @@ export interface CurrentUpgrade {
   startTime?: string;
 }
 
-// Generated from FleetServer schema.json
+interface FleetServerAgentComponentUnit {
+  id: string;
+  type: 'input' | 'output';
+  status: FleetServerAgentComponentStatus;
+  message: string;
+  payload?: {
+    [key: string]: any;
+  };
+}
+
+interface FleetServerAgentComponent {
+  id: string;
+  type: string;
+  status: FleetServerAgentComponentStatus;
+  message: string;
+  units: FleetServerAgentComponentUnit[];
+}
+
+// Initially generated from FleetServer schema.json
 
 /**
  * An Elastic Agent that has enrolled into Fleet
@@ -209,6 +231,10 @@ export interface FleetServerAgent {
     id: string;
     retired_at: string;
   }>;
+  /**
+   * Components array
+   */
+  components?: FleetServerAgentComponent[];
 }
 /**
  * An Elastic Agent metadata


### PR DESCRIPTION
## Summary

* update `FleetServerAgent` interface to include new `components` field
* expose new `components` field in `/api/fleet/agents/{agentId}`
* update endpoint doc generator to include new `components` field

Generated `.metrics-endpoint.metadata_united_default` doc with `components` field:
![Screen Shot 2022-08-30 at 4 03 15 PM](https://user-images.githubusercontent.com/11009772/187543152-43b59541-712b-41a5-a95c-af96ce1f27f0.png)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
