### PR TITLE
[Doc] update deprecation message for `visualization:colorMapping` setting

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -528,7 +528,7 @@ of buckets to try to represent.
 
 [horizontal]
 [[visualization-colormapping]]`visualization:colorMapping`::
-**This setting is deprecated and will not be supported as of 8.0.**
+**This setting is deprecated and will not be supported in a future version.**
 Maps values to specific colors in charts using the *Compatibility* palette.
 
 [[visualization-uselegacytimeaxis]]`visualization:useLegacyTimeAxis`::


### PR DESCRIPTION
## Summary

The deprecation message does not match the current version. I updated it to a similar one from the `Stacked Management` -> `Advanced Settings`. 

 
<img width="921" alt="image" src="https://user-images.githubusercontent.com/20072247/187640195-29b97579-9cf1-4f68-a874-329ed7886337.png">


