### PR TITLE
[TIP] Compute Indicator Names with ES runtime fields

### DIFF
--- a/x-pack/plugins/threat_intelligence/common/types/indicator.ts
+++ b/x-pack/plugins/threat_intelligence/common/types/indicator.ts
@@ -43,6 +43,8 @@ export enum RawIndicatorFieldId {
   MacAddress = 'threat.indicator.mac',
   TimeStamp = '@timestamp',
   Id = '_id',
+  Name = 'threat.indicator.name',
+  NameOrigin = 'threat.indicator.name_origin',
 }
 
 /**
@@ -73,136 +75,7 @@ export const generateMockIndicator = (): Indicator => {
 
   indicator.fields['threat.indicator.type'] = ['ipv4-addr'];
   indicator.fields['threat.indicator.ip'] = ['12.68.554.87'];
-
-  return indicator;
-};
-
-export const generateMockIpIndicator = generateMockIndicator;
-
-export const generateMockUrlIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['url'];
-  indicator.fields['threat.indicator.url.original'] = ['https://google.com'];
-
-  return indicator;
-};
-
-export const generateMockFileIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['file'];
-  indicator.fields['threat.indicator.file.hash.sha256'] = ['sample_sha256_hash'];
-  indicator.fields['threat.indicator.file.hash.md5'] = ['sample_md5_hash'];
-  indicator.fields['threat.indicator.file.hash.sha1'] = ['sample_sha1_hash'];
-
-  return indicator;
-};
-
-export const generateMockFileMd5Indicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['file'];
-  indicator.fields['threat.indicator.file.hash.md5'] = ['sample_md5_hash'];
-  indicator.fields['threat.indicator.file.hash.sha1'] = ['sample_sha1_hash'];
-
-  return indicator;
-};
-
-export const generateMockEmailAddrIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['email-addr'];
-  indicator.fields['threat.indicator.email.address'] = ['sample@example.com'];
-
-  return indicator;
-};
-
-export const generateMockDomainIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['domain'];
-  indicator.fields['threat.indicator.url.domain'] = ['google.com'];
-
-  return indicator;
-};
-
-export const generateMockDomainNameIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['domain-name'];
-  indicator.fields['threat.indicator.url.domain'] = ['google.com'];
-
-  return indicator;
-};
-
-export const generateMockX509CertificateIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['x509-certificate'];
-  indicator.fields['threat.indicator.x509.serial_number'] = ['sample_serial_number'];
-
-  return indicator;
-};
-
-export const generateMockX509SerialIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['x509 Serial'];
-  indicator.fields['threat.indicator.x509.serial_number'] = ['sample_serial_bla'];
-
-  return indicator;
-};
-
-export const generateMockUnknownIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['unknown'];
-  indicator.fields._id = ['sample_id'];
-
-  return indicator;
-};
-
-export const generateMockEmailIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['email'];
-  indicator.fields['threat.indicator.email.address'] = ['sample@example.com'];
-
-  return indicator;
-};
-
-export const generateMockEmailMessageIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['email-message'];
-
-  return indicator;
-};
-
-export const generateMockWindowsRegistryKeyIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['windows-registry-key'];
-  indicator.fields['threat.indicator.registry.key'] = ['sample_registry_key'];
-
-  return indicator;
-};
-
-export const generateMockAutonomousSystemIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['autonomous-system'];
-  indicator.fields['threat.indicator.as.number'] = ['sample_as_number'];
-
-  return indicator;
-};
-
-export const generateMockMacAddressIndicator = (): Indicator => {
-  const indicator = generateMockBaseIndicator();
-
-  indicator.fields['threat.indicator.type'] = ['mac-addr'];
-  indicator.fields['threat.indicator.mac'] = ['sample_mac_address'];
+  indicator.fields['threat.indicator.name'] = ['12.68.554.87'];
 
   return indicator;
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.test.tsx
@@ -15,7 +15,6 @@ import { mockUiSetting } from '../../../../common/mocks/mock_kibana_ui_settings_
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 import { generateFieldTypeMap } from '../../../../common/mocks/mock_field_type_map';
 import { unwrapValue } from '../../lib/unwrap_value';
-import { getDisplayName } from '../../lib/display_name';
 
 const mockIndicator = generateMockIndicator();
 const mockFieldTypesMap = generateFieldTypeMap();
@@ -33,7 +32,7 @@ describe('<IndicatorsFlyout />', () => {
     );
 
     expect(getByTestId(TITLE_TEST_ID).innerHTML).toContain(
-      `Indicator: ${getDisplayName(mockIndicator).value}`
+      `Indicator: ${unwrapValue(mockIndicator, RawIndicatorFieldId.Name)}`
     );
     expect(getByTestId(SUBTITLE_TEST_ID).innerHTML).toContain(
       `First seen: ${dateFormatter(

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.tsx
@@ -24,7 +24,6 @@ import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indi
 import { IndicatorsFlyoutJson } from '../indicators_flyout_json/indicators_flyout_json';
 import { IndicatorsFlyoutTable } from '../indicators_flyout_table/indicators_flyout_table';
 import { unwrapValue } from '../../lib/unwrap_value';
-import { getDisplayName } from '../../lib/display_name';
 
 export const TITLE_TEST_ID = 'tiIndicatorFlyoutTitle';
 export const SUBTITLE_TEST_ID = 'tiIndicatorFlyoutSubtitle';
@@ -103,8 +102,7 @@ export const IndicatorsFlyout: VFC<IndicatorsFlyoutProps> = ({
   );
 
   const firstSeen: string = unwrapValue(indicator, RawIndicatorFieldId.FirstSeen) as string;
-  const displayName = getDisplayName(indicator);
-  const displayNameValue = displayName.value || EMPTY_VALUE;
+  const displayNameValue = unwrapValue(indicator, RawIndicatorFieldId.Name) || EMPTY_VALUE;
   const flyoutTitleId = useGeneratedHtmlId({
     prefix: 'simpleFlyoutTitle',
   });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout_table/indicators_flyout_table.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout_table/indicators_flyout_table.test.tsx
@@ -20,14 +20,13 @@ import {
   TABLE_TEST_ID,
 } from './indicators_flyout_table';
 import { unwrapValue } from '../../lib/unwrap_value';
-import { getDisplayName } from '../../lib/display_name';
 
 const mockIndicator: Indicator = generateMockIndicator();
 const mockFieldTypesMap = generateFieldTypeMap();
 
 describe('<IndicatorsFlyoutTable />', () => {
   it('should render fields and values in table', () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, getAllByText } = render(
       <TestProvidersComponent>
         <IndicatorsFlyoutTable indicator={mockIndicator} fieldTypesMap={mockFieldTypesMap} />
       </TestProvidersComponent>
@@ -37,7 +36,10 @@ describe('<IndicatorsFlyoutTable />', () => {
 
     expect(getByText(RawIndicatorFieldId.Feed)).toBeInTheDocument();
 
-    expect(getByText(getDisplayName(mockIndicator).value as string)).toBeInTheDocument();
+    // There should be two occureces of 'threat.indicator.name' value on the page
+    expect(
+      getAllByText(unwrapValue(mockIndicator, RawIndicatorFieldId.Name) as string)
+    ).toHaveLength(2);
 
     expect(
       getByText(unwrapValue(mockIndicator, RawIndicatorFieldId.Feed) as string)

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/cell_renderer.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/cell_renderer.tsx
@@ -10,15 +10,13 @@ import { useContext, useEffect } from 'react';
 import { euiLightVars as themeLight, euiDarkVars as themeDark } from '@kbn/ui-theme';
 import React from 'react';
 import { useKibana } from '../../../../hooks/use_kibana';
-import { EMPTY_VALUE } from '../../../../../common/constants';
 import { Indicator } from '../../../../../common/types/indicator';
-import { getDisplayName } from '../../lib/display_name';
 import { IndicatorField } from '../indicator_field/indicator_field';
 import { IndicatorsTableContext } from './context';
 import { ActionsRowCell } from './actions_row_cell';
 
 export enum ComputedIndicatorFieldId {
-  DisplayName = 'display_name',
+  DisplayName = 'threat.indicator.name',
 }
 
 export const cellRendererFactory = (from: number) => {
@@ -57,12 +55,6 @@ export const cellRendererFactory = (from: number) => {
 
     if (columnId === 'Actions') {
       return <ActionsRowCell indicator={indicator} />;
-    }
-
-    if (columnId === ComputedIndicatorFieldId.DisplayName) {
-      const displayName = getDisplayName(indicator);
-      const displayNameValue = displayName.value;
-      return displayNameValue || EMPTY_VALUE;
     }
 
     return <IndicatorField indicator={indicator} field={columnId} fieldTypesMap={fieldTypesMap} />;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
@@ -18,6 +18,7 @@ import { Indicator } from '../../../../common/types/indicator';
 import { useKibana } from '../../../hooks/use_kibana';
 import { THREAT_QUERY_BASE } from '../../../../common/constants';
 import { useSourcererDataView } from './use_sourcerer_data_view';
+import { threatIndicatorNamesOriginScript, threatIndicatorNamesScript } from '../lib/display_name';
 
 const PAGE_SIZES = [10, 25, 50];
 
@@ -125,6 +126,20 @@ export const useIndicators = ({
                 from,
                 fields: [{ field: '*', include_unmapped: true }],
                 query: queryToExecute,
+                runtime_mappings: {
+                  'threat.indicator.name': {
+                    type: 'keyword',
+                    script: {
+                      source: threatIndicatorNamesScript(),
+                    },
+                  },
+                  'threat.indicator.name_origin': {
+                    type: 'keyword',
+                    script: {
+                      source: threatIndicatorNamesOriginScript(),
+                    },
+                  },
+                },
               },
             },
           },

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
@@ -6,21 +6,37 @@
  */
 
 import { useMemo } from 'react';
+import { SecuritySolutionDataViewBase } from '../../../types';
 import { useSecurityContext } from '../../../hooks/use_security_context';
 
 export const useSourcererDataView = () => {
   const { sourcererDataView } = useSecurityContext();
 
-  const indexPatterns = useMemo(
-    () => [sourcererDataView.indexPattern],
-    [sourcererDataView.indexPattern]
-  );
+  const updatedPattern = useMemo(() => {
+    const displayNameField = {
+      aggregatable: true,
+      esTypes: ['keyword'],
+      name: 'threat.indicator.name',
+      searchable: true,
+      type: 'string',
+    };
+
+    const fields = [...sourcererDataView.indexPattern.fields, displayNameField];
+
+    return {
+      ...sourcererDataView.indexPattern,
+      fields,
+    } as SecuritySolutionDataViewBase;
+  }, [sourcererDataView.indexPattern]);
+
+  const indexPatterns = useMemo(() => [updatedPattern], [updatedPattern]);
 
   return useMemo(
     () => ({
       ...sourcererDataView,
       indexPatterns,
+      indexPattern: updatedPattern,
     }),
-    [indexPatterns, sourcererDataView]
+    [indexPatterns, sourcererDataView, updatedPattern]
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/display_name.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/display_name.test.ts
@@ -5,75 +5,106 @@
  * 2.0.
  */
 
-import {
-  generateMockBaseIndicator,
-  generateMockFileIndicator,
-  generateMockIpIndicator,
-  generateMockUrlIndicator,
-  generateMockFileMd5Indicator,
-  generateMockDomainIndicator,
-  generateMockEmailAddrIndicator,
-  generateMockDomainNameIndicator,
-  generateMockX509CertificateIndicator,
-  generateMockX509SerialIndicator,
-  generateMockUnknownIndicator,
-  generateMockWindowsRegistryKeyIndicator,
-  generateMockAutonomousSystemIndicator,
-  generateMockMacAddressIndicator,
-  Indicator,
-  RawIndicatorFieldId,
-} from '../../../../common/types/indicator';
-import { getDisplayName } from './display_name';
+import { threatIndicatorNamesOriginScript, threatIndicatorNamesScript } from './display_name';
 
-type ExpectedIndicatorValue = string | null;
+describe('display name generation', () => {
+  describe('threatIndicatorNamesScript()', () => {
+    it('should generate a valid painless script', () => {
+      expect(threatIndicatorNamesScript()).toMatchInlineSnapshot(`
+        "if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='ipv4-addr') { if (doc['threat.indicator.ip'].value!=null) { return emit(doc['threat.indicator.ip'].value) } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='ipv6-addr') { if (doc['threat.indicator.ip'].value!=null) { return emit(doc['threat.indicator.ip'].value) } }
 
-const cases: Array<[Indicator, ExpectedIndicatorValue]> = [
-  [generateMockIpIndicator(), '12.68.554.87'],
-  [generateMockUrlIndicator(), 'https://google.com'],
-  [generateMockFileIndicator(), 'sample_sha256_hash'],
-  [generateMockFileMd5Indicator(), 'sample_md5_hash'],
-  [generateMockEmailAddrIndicator(), 'sample@example.com'],
-  [generateMockDomainIndicator(), 'google.com'],
-  [generateMockDomainNameIndicator(), 'google.com'],
-  [generateMockX509CertificateIndicator(), 'sample_serial_number'],
-  [generateMockX509SerialIndicator(), 'sample_serial_bla'],
-  [generateMockUnknownIndicator(), 'sample_id'],
-  [generateMockWindowsRegistryKeyIndicator(), 'sample_registry_key'],
-  [generateMockAutonomousSystemIndicator(), 'sample_as_number'],
-  [generateMockMacAddressIndicator(), 'sample_mac_address'],
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='file') { if (doc['threat.indicator.file.hash.sha256'].value!=null) { return emit(doc['threat.indicator.file.hash.sha256'].value) }
+        if (doc['threat.indicator.file.hash.md5'].value!=null) { return emit(doc['threat.indicator.file.hash.md5'].value) }
+        if (doc['threat.indicator.file.hash.sha1'].value!=null) { return emit(doc['threat.indicator.file.hash.sha1'].value) }
+        if (doc['threat.indicator.file.hash.sha224'].value!=null) { return emit(doc['threat.indicator.file.hash.sha224'].value) }
+        if (doc['threat.indicator.file.hash.sha3-224'].value!=null) { return emit(doc['threat.indicator.file.hash.sha3-224'].value) }
+        if (doc['threat.indicator.file.hash.sha3-256'].value!=null) { return emit(doc['threat.indicator.file.hash.sha3-256'].value) }
+        if (doc['threat.indicator.file.hash.sha384'].value!=null) { return emit(doc['threat.indicator.file.hash.sha384'].value) }
+        if (doc['threat.indicator.file.hash.sha3-384'].value!=null) { return emit(doc['threat.indicator.file.hash.sha3-384'].value) }
+        if (doc['threat.indicator.file.hash.sha512'].value!=null) { return emit(doc['threat.indicator.file.hash.sha512'].value) }
+        if (doc['threat.indicator.file.hash.sha3-512'].value!=null) { return emit(doc['threat.indicator.file.hash.sha3-512'].value) }
+        if (doc['threat.indicator.file.hash.sha512/224'].value!=null) { return emit(doc['threat.indicator.file.hash.sha512/224'].value) }
+        if (doc['threat.indicator.file.hash.sha512/256'].value!=null) { return emit(doc['threat.indicator.file.hash.sha512/256'].value) }
+        if (doc['threat.indicator.file.ssdeep'].value!=null) { return emit(doc['threat.indicator.file.ssdeep'].value) }
+        if (doc['threat.indicator.file.tlsh'].value!=null) { return emit(doc['threat.indicator.file.tlsh'].value) }
+        if (doc['threat.indicator.file.impfuzzy'].value!=null) { return emit(doc['threat.indicator.file.impfuzzy'].value) }
+        if (doc['threat.indicator.file.imphash'].value!=null) { return emit(doc['threat.indicator.file.imphash'].value) }
+        if (doc['threat.indicator.file.pehash'].value!=null) { return emit(doc['threat.indicator.file.pehash'].value) }
+        if (doc['threat.indicator.file.vhash'].value!=null) { return emit(doc['threat.indicator.file.vhash'].value) } }
 
-  // Indicator with no fields should yield null as a display value
-  [{ fields: {} }, null],
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='url') { if (doc['threat.indicator.url.original'].value!=null) { return emit(doc['threat.indicator.url.original'].value) } }
 
-  // Same for an empty object
-  [{} as any, null],
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='domain') { if (doc['threat.indicator.url.domain'].value!=null) { return emit(doc['threat.indicator.url.domain'].value) } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='domain-name') { if (doc['threat.indicator.url.domain'].value!=null) { return emit(doc['threat.indicator.url.domain'].value) } }
 
-  // And falsy value
-  [null, null],
-];
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='x509-certificate') { if (doc['threat.indicator.x509.serial_number'].value!=null) { return emit(doc['threat.indicator.x509.serial_number'].value) } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='x509 serial') { if (doc['threat.indicator.x509.serial_number'].value!=null) { return emit(doc['threat.indicator.x509.serial_number'].value) } }
 
-describe('getDisplayName()', () => {
-  describe.each<[Indicator, ExpectedIndicatorValue]>(cases)(
-    '%s',
-    (indicator, expectedDisplayValue) => {
-      it(`should render the indicator as ${expectedDisplayValue}`, () => {
-        expect(getDisplayName(indicator).value).toEqual(expectedDisplayValue);
-      });
-    }
-  );
-});
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email-addr') { if (doc['threat.indicator.email.address'].value!=null) { return emit(doc['threat.indicator.email.address'].value) } }
 
-describe('displayValueField()', () => {
-  it('should return correct RawIndicatorFieldId for valid field', () => {
-    const mockIndicator = generateMockIpIndicator();
-    const result = getDisplayName(mockIndicator);
-    expect(result.field).toEqual(RawIndicatorFieldId.Ip);
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='unknown') { if (doc['_id'].value!=null) { return emit(doc['_id'].value) } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email') { if (doc['_id'].value!=null) { return emit(doc['_id'].value) } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email-message') { if (doc['_id'].value!=null) { return emit(doc['_id'].value) } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='windows-registry-key') { if (doc['threat.indicator.registry.key'].value!=null) { return emit(doc['threat.indicator.registry.key'].value) } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='autonomous-system') { if (doc['threat.indicator.as.number'].value!=null) { return emit(doc['threat.indicator.as.number'].value) } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='mac-addr') { if (doc['threat.indicator.mac'].value!=null) { return emit(doc['threat.indicator.mac'].value) } }
+
+        return emit('')"
+      `);
+    });
   });
 
-  it('should return null for invalid field', () => {
-    const mockIndicator = generateMockBaseIndicator();
-    mockIndicator.fields['threat.indicator.type'] = ['abc'];
-    const result = getDisplayName(mockIndicator);
-    expect(result.field).toEqual(RawIndicatorFieldId.Id);
+  describe('threatIndicatorNamesOriginScript()', () => {
+    it('should generate a valid painless script', () => {
+      expect(threatIndicatorNamesOriginScript()).toMatchInlineSnapshot(`
+        "if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='ipv4-addr') { if (doc['threat.indicator.ip'].value!=null) { return emit('threat.indicator.ip') } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='ipv6-addr') { if (doc['threat.indicator.ip'].value!=null) { return emit('threat.indicator.ip') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='file') { if (doc['threat.indicator.file.hash.sha256'].value!=null) { return emit('threat.indicator.file.hash.sha256') }
+        if (doc['threat.indicator.file.hash.md5'].value!=null) { return emit('threat.indicator.file.hash.md5') }
+        if (doc['threat.indicator.file.hash.sha1'].value!=null) { return emit('threat.indicator.file.hash.sha1') }
+        if (doc['threat.indicator.file.hash.sha224'].value!=null) { return emit('threat.indicator.file.hash.sha224') }
+        if (doc['threat.indicator.file.hash.sha3-224'].value!=null) { return emit('threat.indicator.file.hash.sha3-224') }
+        if (doc['threat.indicator.file.hash.sha3-256'].value!=null) { return emit('threat.indicator.file.hash.sha3-256') }
+        if (doc['threat.indicator.file.hash.sha384'].value!=null) { return emit('threat.indicator.file.hash.sha384') }
+        if (doc['threat.indicator.file.hash.sha3-384'].value!=null) { return emit('threat.indicator.file.hash.sha3-384') }
+        if (doc['threat.indicator.file.hash.sha512'].value!=null) { return emit('threat.indicator.file.hash.sha512') }
+        if (doc['threat.indicator.file.hash.sha3-512'].value!=null) { return emit('threat.indicator.file.hash.sha3-512') }
+        if (doc['threat.indicator.file.hash.sha512/224'].value!=null) { return emit('threat.indicator.file.hash.sha512/224') }
+        if (doc['threat.indicator.file.hash.sha512/256'].value!=null) { return emit('threat.indicator.file.hash.sha512/256') }
+        if (doc['threat.indicator.file.ssdeep'].value!=null) { return emit('threat.indicator.file.ssdeep') }
+        if (doc['threat.indicator.file.tlsh'].value!=null) { return emit('threat.indicator.file.tlsh') }
+        if (doc['threat.indicator.file.impfuzzy'].value!=null) { return emit('threat.indicator.file.impfuzzy') }
+        if (doc['threat.indicator.file.imphash'].value!=null) { return emit('threat.indicator.file.imphash') }
+        if (doc['threat.indicator.file.pehash'].value!=null) { return emit('threat.indicator.file.pehash') }
+        if (doc['threat.indicator.file.vhash'].value!=null) { return emit('threat.indicator.file.vhash') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='url') { if (doc['threat.indicator.url.original'].value!=null) { return emit('threat.indicator.url.original') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='domain') { if (doc['threat.indicator.url.domain'].value!=null) { return emit('threat.indicator.url.domain') } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='domain-name') { if (doc['threat.indicator.url.domain'].value!=null) { return emit('threat.indicator.url.domain') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='x509-certificate') { if (doc['threat.indicator.x509.serial_number'].value!=null) { return emit('threat.indicator.x509.serial_number') } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='x509 serial') { if (doc['threat.indicator.x509.serial_number'].value!=null) { return emit('threat.indicator.x509.serial_number') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email-addr') { if (doc['threat.indicator.email.address'].value!=null) { return emit('threat.indicator.email.address') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='unknown') { if (doc['_id'].value!=null) { return emit('_id') } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email') { if (doc['_id'].value!=null) { return emit('_id') } }
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='email-message') { if (doc['_id'].value!=null) { return emit('_id') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='windows-registry-key') { if (doc['threat.indicator.registry.key'].value!=null) { return emit('threat.indicator.registry.key') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='autonomous-system') { if (doc['threat.indicator.as.number'].value!=null) { return emit('threat.indicator.as.number') } }
+
+        if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='mac-addr') { if (doc['threat.indicator.mac'].value!=null) { return emit('threat.indicator.mac') } }
+
+        return emit('')"
+      `);
+    });
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/display_name.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/display_name.ts
@@ -5,228 +5,107 @@
  * 2.0.
  */
 
-import { Indicator, RawIndicatorFieldId } from '../../../../common/types/indicator';
-import { unwrapValue } from './unwrap_value';
-
-type IndicatorDisplayName = [RawIndicatorFieldId, string | null];
-interface IndicatorDisplayNameAsObject {
-  field: RawIndicatorFieldId;
-  value: string | null;
-}
-type IndicatorDisplayNameExtractor = (indicator: Indicator) => IndicatorDisplayName;
-type IndicatorTypePredicate = (indicatorType: string | null) => boolean;
-
-type MapperRule = [predicate: IndicatorTypePredicate, extract: IndicatorDisplayNameExtractor];
+import dedent from 'dedent';
+import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 
 /**
- * Predicates to help identify indicator by type
+ * Mapping connects one ore more types to field values that should be used to generate threat.indicator.name field.
  */
-const isIpIndicator: IndicatorTypePredicate = (indicatorType) =>
-  !!indicatorType && ['ipv4-addr', 'ipv6-addr'].includes(indicatorType);
+type Mapping = [types: string[], paths: RawIndicatorFieldId[]];
 
-const isFileIndicator: IndicatorTypePredicate = (indicatorType) => indicatorType === 'file';
-const isUrlIndicator: IndicatorTypePredicate = (indicatorType) => indicatorType === 'url';
-const isEmailAddress: IndicatorTypePredicate = (indicatorType) => indicatorType === 'email-addr';
-const isDomain: IndicatorTypePredicate = (indicatorType) =>
-  !!indicatorType && ['domain', 'domain-name'].includes(indicatorType);
-const isX509Certificate: IndicatorTypePredicate = (indicatorType) =>
-  !!indicatorType && ['x509-certificate', 'x509 serial'].includes(indicatorType);
-const isUnknownIndicator: IndicatorTypePredicate = (indicatorType) =>
-  !!indicatorType && ['unknown', 'email', 'email-message'].includes(indicatorType);
-const isWindowsRegistryKey: IndicatorTypePredicate = (indicatorType) =>
-  indicatorType === 'windows-registry-key';
-const isAutonomousSystem: IndicatorTypePredicate = (indicatorType) =>
-  indicatorType === 'autonomous-system';
-const isMacAddress: IndicatorTypePredicate = (indicatorType) => indicatorType === 'mac-addr';
+type Mappings = Mapping[];
 
-/**
- * Display value extraction logic
- */
-const extractIp: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.Ip,
-  unwrapValue(indicator, RawIndicatorFieldId.Ip),
-];
-
-const extractUrl: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.UrlOriginal,
-  unwrapValue(indicator, RawIndicatorFieldId.UrlOriginal),
-];
-
-const extractId: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.Id,
-  unwrapValue(indicator, RawIndicatorFieldId.Id),
-];
-
-const extractFile: IndicatorDisplayNameExtractor = (indicator: Indicator) => {
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha256)) {
-    return [RawIndicatorFieldId.FileSha256, unwrapValue(indicator, RawIndicatorFieldId.FileSha256)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileMd5)) {
-    return [RawIndicatorFieldId.FileMd5, unwrapValue(indicator, RawIndicatorFieldId.FileMd5)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha1)) {
-    return [RawIndicatorFieldId.FileSha1, unwrapValue(indicator, RawIndicatorFieldId.FileSha1)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha512)) {
-    return [RawIndicatorFieldId.FileSha512, unwrapValue(indicator, RawIndicatorFieldId.FileSha512)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha224)) {
-    return [RawIndicatorFieldId.FileSha224, unwrapValue(indicator, RawIndicatorFieldId.FileSha224)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha384)) {
-    return [RawIndicatorFieldId.FileSha384, unwrapValue(indicator, RawIndicatorFieldId.FileSha384)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha3224)) {
-    return [
+const mappingsArray: Mappings = [
+  [['ipv4-addr', 'ipv6-addr'], [RawIndicatorFieldId.Ip]],
+  // For example, `file` indicator will have `threat.indicator.name` computed out of the first
+  // hash value field defined below, in order of occurrence
+  [
+    ['file'],
+    [
+      RawIndicatorFieldId.FileSha256,
+      RawIndicatorFieldId.FileMd5,
+      RawIndicatorFieldId.FileSha1,
+      RawIndicatorFieldId.FileSha224,
       RawIndicatorFieldId.FileSha3224,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha3224),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha3256)) {
-    return [
       RawIndicatorFieldId.FileSha3256,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha3256),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha3384)) {
-    return [
+      RawIndicatorFieldId.FileSha384,
       RawIndicatorFieldId.FileSha3384,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha3384),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha3512)) {
-    return [
+      RawIndicatorFieldId.FileSha512,
       RawIndicatorFieldId.FileSha3512,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha3512),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha512224)) {
-    return [
       RawIndicatorFieldId.FileSha512224,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha512224),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSha512256)) {
-    return [
       RawIndicatorFieldId.FileSha512256,
-      unwrapValue(indicator, RawIndicatorFieldId.FileSha512256),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileSSDeep)) {
-    return [RawIndicatorFieldId.FileSSDeep, unwrapValue(indicator, RawIndicatorFieldId.FileSSDeep)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileTlsh)) {
-    return [RawIndicatorFieldId.FileTlsh, unwrapValue(indicator, RawIndicatorFieldId.FileTlsh)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileImpfuzzy)) {
-    return [
+      RawIndicatorFieldId.FileSSDeep,
+      RawIndicatorFieldId.FileTlsh,
       RawIndicatorFieldId.FileImpfuzzy,
-      unwrapValue(indicator, RawIndicatorFieldId.FileImpfuzzy),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileImphash)) {
-    return [
       RawIndicatorFieldId.FileImphash,
-      unwrapValue(indicator, RawIndicatorFieldId.FileImphash),
-    ];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FilePehash)) {
-    return [RawIndicatorFieldId.FilePehash, unwrapValue(indicator, RawIndicatorFieldId.FilePehash)];
-  }
-
-  if (unwrapValue(indicator, RawIndicatorFieldId.FileVhash)) {
-    return [RawIndicatorFieldId.FileVhash, unwrapValue(indicator, RawIndicatorFieldId.FileVhash)];
-  }
-
-  return extractId(indicator);
-};
-
-const extractEmailAddress: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.EmailAddress,
-  unwrapValue(indicator, RawIndicatorFieldId.EmailAddress),
-];
-
-const extractDomain: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.UrlDomain,
-  unwrapValue(indicator, RawIndicatorFieldId.UrlDomain),
-];
-
-const extractX509Serial: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.X509Serial,
-  unwrapValue(indicator, RawIndicatorFieldId.X509Serial),
-];
-
-const extractWindowsRegistryKey: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.WindowsRegistryKey,
-  unwrapValue(indicator, RawIndicatorFieldId.WindowsRegistryKey),
-];
-
-const extractAutonomousSystemNumber: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.AutonomousSystemNumber,
-  unwrapValue(indicator, RawIndicatorFieldId.AutonomousSystemNumber),
-];
-
-const extractMacAddress: IndicatorDisplayNameExtractor = (indicator: Indicator) => [
-  RawIndicatorFieldId.MacAddress,
-  unwrapValue(indicator, RawIndicatorFieldId.MacAddress),
+      RawIndicatorFieldId.FilePehash,
+      RawIndicatorFieldId.FileVhash,
+    ],
+  ],
+  [['url'], [RawIndicatorFieldId.UrlOriginal]],
+  [['domain', 'domain-name'], [RawIndicatorFieldId.UrlDomain]],
+  [['x509-certificate', 'x509 serial'], [RawIndicatorFieldId.X509Serial]],
+  [['email-addr'], [RawIndicatorFieldId.EmailAddress]],
+  [['unknown', 'email', 'email-message'], [RawIndicatorFieldId.Id]],
+  [['windows-registry-key'], [RawIndicatorFieldId.WindowsRegistryKey]],
+  [['autonomous-system'], [RawIndicatorFieldId.AutonomousSystemNumber]],
+  [['mac-addr'], [RawIndicatorFieldId.MacAddress]],
 ];
 
 /**
- * Pairs rule condition with display value extraction logic
+ * Generates Painless condition checking if given `type` is matched
  */
-const rulesArray: MapperRule[] = [
-  [isIpIndicator, extractIp],
-  [isUrlIndicator, extractUrl],
-  [isFileIndicator, extractFile],
-  [isUnknownIndicator, extractId],
-  [isEmailAddress, extractEmailAddress],
-  [isDomain, extractDomain],
-  [isX509Certificate, extractX509Serial],
-  [isWindowsRegistryKey, extractWindowsRegistryKey],
-  [isAutonomousSystem, extractAutonomousSystemNumber],
-  [isMacAddress, extractMacAddress],
-];
+const fieldTypeCheck = (type: string) =>
+  `if (doc['threat.indicator.type'].value != null && doc['threat.indicator.type'].value.toLowerCase()=='${type.toLowerCase()}')`;
 
 /**
- * Finds display value mapping function for given indicatorType
+ * Generates Painless condition checking if given `field` has value
  */
-const findMappingRule = (indicatorType: string | null): IndicatorDisplayNameExtractor => {
-  const [_, extract = extractId] = rulesArray.find(([check]) => check(indicatorType)) || [];
-  return extract;
+const fieldValueCheck = (field: string) => `if (doc['${field}'].value!=null)`;
+
+/**
+ * Converts Mapping to Painless script, computing `threat.indicator.name` value for given indicator types.
+ */
+const mappingToIndicatorNameScript = ([types, paths]: Mapping) => {
+  return dedent`${types
+    .map(
+      (t) =>
+        `${fieldTypeCheck(t)} { ${paths
+          .map((p) => `${fieldValueCheck(p)} { return emit(doc['${p}'].value) }`)
+          .join('\n')} }`
+    )
+    .join('\n')}`;
 };
 
 /**
- * Cached rules for indicator types
+ * Converts Mapping to Painless script, computing `threat.indicator.name_origin` used to determine which document field has
+ * been used to obtain `threat.indicator.name`.
  */
-const rules: Record<string, IndicatorDisplayNameExtractor> = {};
+const mappingToIndicatorNameOriginScript = ([types, paths]: Mapping) => {
+  return dedent`${types
+    .map(
+      (t) =>
+        `${fieldTypeCheck(t)} { ${paths
+          .map((p) => `${fieldValueCheck(p)} { return emit('${p}') }`)
+          .join('\n')} }`
+    )
+    .join('\n')}`;
+};
 
 /**
- * Find and return indicator display name structure {field, value}
+ * Generates the runtime field script computing display name for the given indicator
  */
-export const getDisplayName = (indicator: Indicator): IndicatorDisplayNameAsObject => {
-  const indicatorType = (unwrapValue(indicator, RawIndicatorFieldId.Type) || '').toLowerCase();
+export const threatIndicatorNamesScript = (mappings: Mappings = mappingsArray) => {
+  const combined = mappings.map(mappingToIndicatorNameScript).join('\n\n');
 
-  if (!rules[indicatorType]) {
-    rules[indicatorType] = findMappingRule(indicatorType);
-  }
+  return `${combined}\n\nreturn emit('')`;
+};
 
-  const [field, value] = rules[indicatorType](indicator);
+/**
+ * Generates the runtime field script computing the display name origin path for given indicator
+ */
+export const threatIndicatorNamesOriginScript = (mappings: Mappings = mappingsArray) => {
+  const combined = mappings.map(mappingToIndicatorNameOriginScript).join('\n\n');
 
-  return { field, value };
+  return `${combined}\n\nreturn emit('')`;
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
@@ -10,8 +10,6 @@ import { DataProvider, QueryOperator } from '@kbn/timelines-plugin/common';
 import { AddToTimelineButtonProps } from '@kbn/timelines-plugin/public';
 import { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui/src/components/button';
 import { EMPTY_VALUE } from '../../../../../common/constants';
-import { getDisplayName } from '../../../indicators/lib/display_name';
-import { ComputedIndicatorFieldId } from '../../../indicators/components/indicators_table/cell_renderer';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { unwrapValue } from '../../../indicators/lib/unwrap_value';
 import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indicator';
@@ -53,12 +51,11 @@ export const AddToTimeline: VFC<AddToTimelineProps> = ({ data, field, component,
   let value: string | null;
   if (typeof data === 'string') {
     value = data;
-  } else if (field === ComputedIndicatorFieldId.DisplayName) {
-    const displayName = getDisplayName(data);
-    field = displayName.field;
-    value = displayName.value;
   } else {
     value = unwrapValue(data, field as RawIndicatorFieldId);
+    if (field === RawIndicatorFieldId.Name) {
+      field = unwrapValue(data, RawIndicatorFieldId.NameOrigin) as string;
+    }
   }
 
   if (!value || value === EMPTY_VALUE || !field) {


### PR DESCRIPTION
## Summary

This PR drops client side mapping entirely, in favor of computing `threat.indicator.name` field entirely on the ES server.

This new field is queryable, which means it should be supported by all the elastic features, such as querying, adding it to filters etc.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


