### PR TITLE
[Maps] Fix UI counters for embedded maps

### DIFF
--- a/x-pack/plugins/maps/common/telemetry/layer_stats_collector.test.ts
+++ b/x-pack/plugins/maps/common/telemetry/layer_stats_collector.test.ts
@@ -8,7 +8,7 @@
 // @ts-ignore
 import mapSavedObjects from './test_resources/sample_map_saved_objects.json';
 import { LayerStatsCollector } from './layer_stats_collector';
-import { MapSavedObjectAttributes } from '../map_saved_object_type';
+import { LayerDescriptor } from '../descriptor_types';
 
 const expecteds = [
   {
@@ -68,15 +68,13 @@ const expecteds = [
   },
 ];
 
-const testsToRun = mapSavedObjects.map(
-  (savedObject: { attributes: MapSavedObjectAttributes }, index: number) => {
-    const { attributes } = savedObject;
-    return [attributes, expecteds[index]] as const;
-  }
-);
+const testsToRun = mapSavedObjects.map(({ attributes }, index: number) => {
+  const layerList: LayerDescriptor[] = JSON.parse(attributes.layerListJSON);
+  return [layerList, expecteds[index]] as const;
+});
 
-describe.each(testsToRun)('LayerStatsCollector %#', (attributes, expected) => {
-  const statsCollector = new LayerStatsCollector(attributes);
+describe.each(testsToRun)('LayerStatsCollector %#', (layerList, expected) => {
+  const statsCollector = new LayerStatsCollector(layerList);
   test('getLayerCount', () => {
     expect(statsCollector.getLayerCount()).toBe(expected.layerCount);
   });

--- a/x-pack/plugins/maps/common/telemetry/layer_stats_collector.ts
+++ b/x-pack/plugins/maps/common/telemetry/layer_stats_collector.ts
@@ -19,7 +19,6 @@ import {
   LayerDescriptor,
   VectorLayerDescriptor,
 } from '../descriptor_types';
-import { MapSavedObjectAttributes } from '../map_saved_object_type';
 import { EMS_BASEMAP_KEYS, JOIN_KEYS, LAYER_KEYS, RESOLUTION_KEYS, SCALING_KEYS } from './types';
 
 export class LayerStatsCollector {
@@ -34,18 +33,7 @@ export class LayerStatsCollector {
   private _layerTypeCounts: { [key: string]: number } = {};
   private _sourceIds: Set<string> = new Set();
 
-  constructor(attributes: MapSavedObjectAttributes) {
-    if (!attributes || !attributes.layerListJSON) {
-      return;
-    }
-
-    let layerList: LayerDescriptor[] = [];
-    try {
-      layerList = JSON.parse(attributes.layerListJSON);
-    } catch (e) {
-      return;
-    }
-
+  constructor(layerList: LayerDescriptor[]) {
     this._layerCount = layerList.length;
     layerList.forEach((layerDescriptor) => {
       this._updateCounts(getBasemapKey(layerDescriptor), this._basemapCounts);

--- a/x-pack/plugins/maps/common/telemetry/map_settings_collector.test.ts
+++ b/x-pack/plugins/maps/common/telemetry/map_settings_collector.test.ts
@@ -8,7 +8,7 @@
 // @ts-ignore
 import mapSavedObjects from './test_resources/sample_map_saved_objects.json';
 import { MapSettingsCollector } from './map_settings_collector';
-import { MapSavedObjectAttributes } from '../map_saved_object_type';
+import { MapSettings } from '../descriptor_types';
 
 const expecteds = [
   {
@@ -25,19 +25,17 @@ const expecteds = [
   },
   {
     customIconsCount: 3,
-    autoFitToDataBounds: true,
   },
 ];
 
-const testsToRun = mapSavedObjects.map(
-  (savedObject: { attributes: MapSavedObjectAttributes }, index: number) => {
-    const { attributes } = savedObject;
-    return [attributes, expecteds[index]] as const;
-  }
-);
+const testsToRun = mapSavedObjects.map(({ attributes }, index: number) => {
+  const mapState = JSON.parse(attributes.mapStateJSON);
+  const mapSettings: Partial<MapSettings> = mapState.settings;
+  return [mapSettings, expecteds[index]] as const;
+});
 
-describe.each(testsToRun)('MapSettingsCollector %#', (attributes, expected) => {
-  const statsCollector = new MapSettingsCollector(attributes);
+describe.each(testsToRun)('MapSettingsCollector %#', (mapSettings, expected) => {
+  const statsCollector = new MapSettingsCollector(mapSettings);
   test('getCustomIconsCount', () => {
     expect(statsCollector.getCustomIconsCount()).toBe(expected.customIconsCount);
   });

--- a/x-pack/plugins/maps/common/telemetry/map_settings_collector.ts
+++ b/x-pack/plugins/maps/common/telemetry/map_settings_collector.ts
@@ -5,26 +5,12 @@
  * 2.0.
  */
 
-import { MapSavedObjectAttributes } from '../map_saved_object_type';
 import { MapSettings } from '../descriptor_types';
 
 export class MapSettingsCollector {
   private _customIconsCount: number = 0;
 
-  constructor(attributes: MapSavedObjectAttributes) {
-    if (!attributes || !attributes.mapStateJSON) {
-      return;
-    }
-
-    let mapSettings: MapSettings;
-
-    try {
-      const mapState = JSON.parse(attributes.mapStateJSON);
-      mapSettings = mapState.settings;
-    } catch (e) {
-      return;
-    }
-
+  constructor(mapSettings: Partial<MapSettings>) {
     if (!mapSettings) {
       return;
     }


### PR DESCRIPTION
## Summary

Adds UI counters for maps embedded in other solutions.

PR #136306 added UI counter generated when opening a map from a saved object. However, Maps in embedded in other solutions do not trigger UI counters. This PR modifies the usage collection to include embedded maps such as in Security -> Explore -> Network Map, Machine Learning -> Explore, Observability -> User Experience -> Dashboards.

__TODO__: Embeddables only report the basemap layer the UI counters. Looking into this.


