### PR TITLE
[Expressions] Fix the `var_set` expressions function to use input when there is no value

### DIFF
--- a/src/plugins/expressions/common/expression_functions/specs/tests/var_set.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/var_set.test.ts
@@ -47,7 +47,7 @@ describe('expression_functions', () => {
     });
 
     it('stores context if value is not set', () => {
-      const actual = fn(input, { name: ['test'], value: [] }, context);
+      const actual = fn(input, { name: ['test'] }, context);
       expect(variables.test).toEqual(input);
       expect(actual).toEqual(input);
     });

--- a/src/plugins/expressions/common/expression_functions/specs/var_set.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var_set.ts
@@ -12,7 +12,7 @@ import { ExpressionFunctionDefinition } from '../types';
 
 interface Arguments {
   name: string[];
-  value: Serializable[];
+  value?: Serializable[];
 }
 
 export type ExpressionFunctionVarSet = ExpressionFunctionDefinition<
@@ -49,7 +49,7 @@ export const variableSet: ExpressionFunctionVarSet = {
   fn(input, args, context) {
     const { variables } = context;
     args.name.forEach((name, i) => {
-      variables[name] = args.value[i] === undefined ? input : args.value[i];
+      variables[name] = args.value?.[i] === undefined ? input : args.value[i];
     });
 
     return input;


### PR DESCRIPTION
## Summary

Resolves #111262.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
