### PR TITLE
Attempt to harden lens dashboard flaky test

### DIFF
--- a/test/functional/services/filter_bar.ts
+++ b/test/functional/services/filter_bar.ts
@@ -15,6 +15,8 @@ export class FilterBarService extends FtrService {
   private readonly common = this.ctx.getPageObject('common');
   private readonly header = this.ctx.getPageObject('header');
   private readonly retry = this.ctx.getService('retry');
+  private readonly config = this.ctx.getService('config');
+  private readonly defaultTryTimeout = this.config.get('timeouts.try');
 
   /**
    * Checks if specified filter exists
@@ -130,7 +132,7 @@ export class FilterBarService extends FtrService {
    * filterBar.addFilter('extension', 'is one of', ['jpg', 'png']);
    */
   public async addFilter(field: string, operator: string, ...values: any): Promise<void> {
-    await this.retry.try(async () => {
+    await this.retry.tryForTime(this.defaultTryTimeout * 2, async () => {
       await this.testSubjects.click('addFilter');
       await this.testSubjects.existOrFail('addFilterPopover');
 


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/139538

Specific failure: `lens/group2/dashboard.ts` > `should not carry over filters if creating a new lens visualization from within dashboard`

Flaky test runner (50 tries): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1123