### PR TITLE
[8.5] [Session view] [TTY output] Implement jump to session from TTY output

### DIFF
--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -400,6 +400,7 @@ export const SessionView = ({
           sessionEntityId={sessionEntityId}
           onClose={onToggleTTY}
           isFullscreen={isFullScreen}
+          onJumpToEvent={onJumpToEvent}
         />
       )}
     </div>

--- a/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
@@ -49,6 +49,7 @@ describe('TTYPlayer component', () => {
     props = {
       sessionEntityId: mockSessionEntityId,
       onClose: jest.fn(),
+      onJumpToEvent: jest.fn(),
       isFullscreen: false,
     };
   });

--- a/x-pack/plugins/session_view/public/components/tty_player/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.tsx
@@ -6,6 +6,7 @@
  */
 import React, { useRef, useState, useCallback } from 'react';
 import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonIcon } from '@elastic/eui';
+import { ProcessEvent } from '../../../common/types/process_tree';
 import { TTYSearchBar } from '../tty_search_bar';
 import { TTYTextSizer } from '../tty_text_sizer';
 import { useStyles } from './styles';
@@ -16,11 +17,17 @@ export interface TTYPlayerDeps {
   sessionEntityId: string; // TODO: we should not load by session id, but instead a combo of process.tty.major+minor, session time range, and host.boot_id (see Rabbitholes section of epic).
   onClose(): void;
   isFullscreen: boolean;
+  onJumpToEvent(event: ProcessEvent): void;
 }
 
 const DEFAULT_FONT_SIZE = 11;
 
-export const TTYPlayer = ({ sessionEntityId, onClose, isFullscreen }: TTYPlayerDeps) => {
+export const TTYPlayer = ({
+  sessionEntityId,
+  onClose,
+  isFullscreen,
+  onJumpToEvent,
+}: TTYPlayerDeps) => {
   const ref = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -41,7 +48,7 @@ export const TTYPlayer = ({ sessionEntityId, onClose, isFullscreen }: TTYPlayerD
   });
 
   const tty = lines?.[currentLine]?.event?.process?.tty;
-  const currentProcessEntityId = lines[currentLine]?.event.process?.entity_id;
+  const currentProcessEvent = lines[currentLine]?.event;
   const styles = useStyles(tty);
 
   const onSeekLine = useCallback(
@@ -82,7 +89,7 @@ export const TTYPlayer = ({ sessionEntityId, onClose, isFullscreen }: TTYPlayerD
       </div>
 
       <TTYPlayerControls
-        currentProcessEntityId={currentProcessEntityId}
+        currentProcessEvent={currentProcessEvent}
         processIdLineMap={processIdLineMap}
         lastProcessEntityId={lines[lines.length - 1]?.event.process?.entity_id}
         isPlaying={isPlaying}
@@ -90,6 +97,8 @@ export const TTYPlayer = ({ sessionEntityId, onClose, isFullscreen }: TTYPlayerD
         linesLength={lines.length}
         onSeekLine={onSeekLine}
         onTogglePlayback={onTogglePlayback}
+        onClose={onClose}
+        onJumpToEvent={onJumpToEvent}
         textSizer={
           <TTYTextSizer
             tty={tty}

--- a/x-pack/plugins/session_view/public/components/tty_player/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player/styles.ts
@@ -66,7 +66,7 @@ export const useStyles = (tty?: Teletype) => {
 
     const scrollPane: CSSObject = {
       width: '100%',
-      height: 'calc(100% - 142px)',
+      height: 'calc(100% - 126px)',
       border: border.thin,
       overflow: 'auto',
     };

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/index.test.tsx
@@ -6,7 +6,27 @@
  */
 import React from 'react';
 import { AppContextTestRender, createAppRootMockRenderer } from '../../test';
+import { sessionViewIOEventsMock } from '../../../common/mocks/responses/session_view_io_events.mock';
+import { ProcessEvent } from '../../../common/types/process_tree';
 import { TTYPlayerControls, TTYPlayerControlsDeps } from '.';
+
+const MOCK_PROCESS_EVENT_START: ProcessEvent = {
+  process: {
+    entity_id: '1',
+  },
+};
+
+const MOCK_PROCESS_EVENT_MIDDLE: ProcessEvent = {
+  process: {
+    entity_id: '2',
+  },
+};
+
+const MOCK_PROCESS_EVENT_END: ProcessEvent = {
+  process: {
+    entity_id: '3',
+  },
+};
 
 describe('TTYPlayerControls component', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
@@ -18,7 +38,7 @@ describe('TTYPlayerControls component', () => {
     mockedContext = createAppRootMockRenderer();
 
     props = {
-      currentProcessEntityId: '1',
+      currentProcessEvent: MOCK_PROCESS_EVENT_START,
       processIdLineMap: {
         '1': {
           value: 0,
@@ -40,6 +60,8 @@ describe('TTYPlayerControls component', () => {
       linesLength: 10,
       onSeekLine: jest.fn(),
       onTogglePlayback: jest.fn(),
+      onClose: jest.fn(),
+      onJumpToEvent: jest.fn(),
       textSizer: <div>tty text sizer placeholder</div>,
     };
   });
@@ -70,7 +92,7 @@ describe('TTYPlayerControls component', () => {
 
   it('clicking on previous button triggers onSeekLine', async () => {
     renderResult = mockedContext.render(
-      <TTYPlayerControls {...props} currentProcessEntityId="2" />
+      <TTYPlayerControls {...props} currentProcessEvent={MOCK_PROCESS_EVENT_MIDDLE} />
     );
     renderResult.queryByTestId('sessionView:TTYPlayerControlsPrevious')?.click();
     expect(props.onSeekLine).toHaveBeenCalledWith(0);
@@ -78,7 +100,7 @@ describe('TTYPlayerControls component', () => {
 
   it('clicking on start button triggers onSeekLine', async () => {
     renderResult = mockedContext.render(
-      <TTYPlayerControls {...props} currentProcessEntityId="3" />
+      <TTYPlayerControls {...props} currentProcessEvent={MOCK_PROCESS_EVENT_END} />
     );
     renderResult.queryByTestId('sessionView:TTYPlayerControlsStart')?.click();
     expect(props.onSeekLine).toHaveBeenCalledWith(0);
@@ -100,7 +122,7 @@ describe('TTYPlayerControls component', () => {
 
   it('end and next buttons are disabled if currentProcessEntityId is end', async () => {
     renderResult = mockedContext.render(
-      <TTYPlayerControls {...props} currentProcessEntityId="3" />
+      <TTYPlayerControls {...props} currentProcessEvent={MOCK_PROCESS_EVENT_END} />
     );
     renderResult.queryByTestId('sessionView:TTYPlayerControlsNext')?.click();
     expect(props.onSeekLine).not.toHaveBeenCalled();

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/index.test.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { AppContextTestRender, createAppRootMockRenderer } from '../../test';
-import { sessionViewIOEventsMock } from '../../../common/mocks/responses/session_view_io_events.mock';
 import { ProcessEvent } from '../../../common/types/process_tree';
 import { TTYPlayerControls, TTYPlayerControlsDeps } from '.';
 

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/styles.ts
@@ -14,11 +14,17 @@ export const useStyles = () => {
   const cached = useMemo(() => {
     const { size } = euiTheme;
 
+    const controlsPanel: CSSObject = {
+      paddingTop: size.s,
+      paddingBottom: size.s,
+    };
+
     const controlButton: CSSObject = {
       width: size.l,
     };
 
     return {
+      controlsPanel,
       controlButton,
     };
   }, [euiTheme]);

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/translations.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/translations.ts
@@ -29,3 +29,7 @@ export const TTY_NEXT = i18n.translate('xpack.sessionView.ttyNext', {
 export const TTY_END = i18n.translate('xpack.sessionView.ttyEnd', {
   defaultMessage: 'End',
 });
+
+export const VIEW_IN_SESSION = i18n.translate('xpack.sessionView.ttyViewInSession', {
+  defaultMessage: 'View in session',
+});


### PR DESCRIPTION
## Summary

Implement `View in session` button in tty player control bar to allow users to jump to the process event in session view based on the current line of output selected.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
