### PR TITLE
[Expressions] Fix the `switch` expressions function not to resolve the next case if not necessary

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
@@ -93,49 +93,34 @@ describe('switch', () => {
       it('should support partial results', () => {
         testScheduler.run(({ cold, expectObservable }) => {
           const context = 'foo';
-          const case1 = cold('--ab-c-', {
-            a: {
-              type: 'case',
-              matches: false,
-              result: 1,
-            },
-            b: {
-              type: 'case',
-              matches: true,
-              result: 2,
-            },
-            c: {
-              type: 'case',
-              matches: false,
-              result: 3,
-            },
-          });
-          const case2 = cold('-a--bc-', {
-            a: {
-              type: 'case',
-              matches: true,
-              result: 4,
-            },
-            b: {
-              type: 'case',
-              matches: true,
-              result: 5,
-            },
-            c: {
-              type: 'case',
-              matches: true,
-              result: 6,
-            },
-          });
-          const expected = ' --abc(de)-';
-          const args = { case: [() => case1, () => case2] };
-          expectObservable(fn(context, args)).toBe(expected, {
-            a: 4,
-            b: 2,
-            c: 2,
-            d: 5,
-            e: 6,
-          });
+          const a = { type: 'case', matches: false, result: 'a' };
+          const b = { type: 'case', matches: true, result: 'b' };
+          const c = { type: 'case', matches: false, result: 'c' };
+          const d = { type: 'case', matches: true, result: 'd' };
+          const e = { type: 'case', matches: false, result: 'e' };
+          const f = { type: 'case', matches: true, result: 'f' };
+
+          const case1 = cold('--a---b-c-', { a, b, c });
+          const case2 = cold('  d-e-f-', { d, e, f });
+          const expected = '  --d-g-b-d-g-f';
+          const args = { case: [() => case1, () => case2], default: () => cold('g') };
+          expectObservable(fn(context, args)).toBe(expected);
+        });
+      });
+
+      it('should not resolve the next case if the current one matches', () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          const context = 'foo';
+          const a = { type: 'case', matches: true, result: 'a' };
+          const b = { type: 'case', matches: true, result: 'b' };
+          const c = { type: 'case', matches: false, result: 'c' };
+
+          const case1 = cold('--a-b', { a, b });
+          const case2 = cold('c', { c });
+          const expected = '  --a-b';
+          const args = { case: [() => case1, jest.fn(() => case2)] };
+          expectObservable(fn(context, args)).toBe(expected);
+          expect(args.case[1]).not.toHaveBeenCalled();
         });
       });
     });

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { Observable, combineLatest, defer, of } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
+import { Observable, defaultIfEmpty, defer, of, switchMap } from 'rxjs';
 import { ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { Case } from '../../../types';
 import { getFunctionHelp } from '../../../i18n';
@@ -42,15 +41,21 @@ export function switchFn(): ExpressionFunctionDefinition<
         help: argHelp.default!,
       },
     },
-    fn(input, args) {
-      return combineLatest(args.case.map((item) => defer(() => item()))).pipe(
-        concatMap((items) => {
-          const item = items.find(({ matches }) => matches);
-          const item$ = item && of(item.result);
+    fn: function fn(input, args): Observable<unknown> {
+      return defer(() => {
+        if (!args.case.length) {
+          return args.default?.() ?? of(input);
+        }
 
-          return item$ ?? args.default?.() ?? of(input);
-        })
-      );
+        const [head$, ...tail$] = args.case;
+
+        return head$().pipe(
+          defaultIfEmpty(undefined),
+          switchMap((value) =>
+            value?.matches ? of(value.result) : fn(input, { ...args, case: tail$ })
+          )
+        );
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

Resolves #131657.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
