### PR TITLE
[Bug][Security Solution][Timelines] - Fix modal visibility

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/cases/attach_timeline.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/cases/attach_timeline.spec.ts
@@ -81,5 +81,17 @@ describe('attach timeline to case', () => {
         );
       });
     });
+
+    it('modal can be re-opened once closed', function () {
+      visitTimeline(this.timelineId);
+      attachTimelineToExistingCase();
+      cy.get('[data-test-subj="all-cases-modal"] .euiButton')
+        .contains('Cancel')
+        .click({ force: true });
+
+      cy.get('[data-test-subj="all-cases-modal"]').should('not.exist');
+      attachTimelineToExistingCase();
+      cy.get('[data-test-subj="all-cases-modal"]').should('be.visible');
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/add_to_case_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/add_to_case_button/index.tsx
@@ -107,6 +107,10 @@ const AddToCaseButtonComponent: React.FC<Props> = ({ timelineId }) => {
     openCaseModal(true);
   }, [openCaseModal, handlePopoverClose]);
 
+  const onCaseModalClose = useCallback(() => {
+    openCaseModal(false);
+  }, [openCaseModal]);
+
   const closePopover = useCallback(() => {
     setPopover(false);
   }, []);
@@ -163,6 +167,7 @@ const AddToCaseButtonComponent: React.FC<Props> = ({ timelineId }) => {
       {isCaseModalOpen &&
         cases.ui.getAllCasesSelectorModal({
           onRowClick,
+          onClose: onCaseModalClose,
           owner: [APP_ID],
           permissions: userCasesPermissions,
         })}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/translations.ts
@@ -90,6 +90,6 @@ export const ATTACH_TO_NEW_CASE = i18n.translate(
 export const ATTACH_TO_EXISTING_CASE = i18n.translate(
   'xpack.securitySolution.timeline.properties.attachToExistingCaseButtonLabel',
   {
-    defaultMessage: 'Attach to existing case...',
+    defaultMessage: 'Attach to existing case',
   }
 );

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -28993,7 +28993,6 @@
     "xpack.securitySolution.timeline.properties.addTimelineButtonLabel": "Ajouter une nouvelle chronologie ou un nouveau modèle",
     "xpack.securitySolution.timeline.properties.addToFavoriteButtonLabel": "Ajouter aux favoris",
     "xpack.securitySolution.timeline.properties.attachToCaseButtonLabel": "Attacher à un cas",
-    "xpack.securitySolution.timeline.properties.attachToExistingCaseButtonLabel": "Attacher à un cas existant...",
     "xpack.securitySolution.timeline.properties.attachToNewCaseButtonLabel": "Attacher au nouveau cas",
     "xpack.securitySolution.timeline.properties.autosavedLabel": "Enregistré automatiquement",
     "xpack.securitySolution.timeline.properties.descriptionPlaceholder": "Ajouter une description",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -28970,7 +28970,6 @@
     "xpack.securitySolution.timeline.properties.addTimelineButtonLabel": "新しいタイムラインまたはテンプレートの追加",
     "xpack.securitySolution.timeline.properties.addToFavoriteButtonLabel": "お気に入りに追加",
     "xpack.securitySolution.timeline.properties.attachToCaseButtonLabel": "ケースに関連付ける",
-    "xpack.securitySolution.timeline.properties.attachToExistingCaseButtonLabel": "既存のケースに添付...",
     "xpack.securitySolution.timeline.properties.attachToNewCaseButtonLabel": "新しいケースに添付",
     "xpack.securitySolution.timeline.properties.autosavedLabel": "自動保存済み",
     "xpack.securitySolution.timeline.properties.descriptionPlaceholder": "説明を追加",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -29001,7 +29001,6 @@
     "xpack.securitySolution.timeline.properties.addTimelineButtonLabel": "添加新时间线或模板",
     "xpack.securitySolution.timeline.properties.addToFavoriteButtonLabel": "添加到收藏夹",
     "xpack.securitySolution.timeline.properties.attachToCaseButtonLabel": "附加到案例",
-    "xpack.securitySolution.timeline.properties.attachToExistingCaseButtonLabel": "附加到现有案例......",
     "xpack.securitySolution.timeline.properties.attachToNewCaseButtonLabel": "附加到新案例",
     "xpack.securitySolution.timeline.properties.autosavedLabel": "已自动保存",
     "xpack.securitySolution.timeline.properties.descriptionPlaceholder": "添加描述",


### PR DESCRIPTION
## Summary

Addresses: https://github.com/elastic/kibana/issues/139784 & https://github.com/elastic/kibana/issues/139785

There was a bug where after opening the add to existing case modal in timeline was closed without actually adding the timeline to an existing case, the modal could not be re-opened without refreshing the page. This was due to us not properly resetting the open state of the modal locally once it was closed. This PR fixes that by adding a callback for resetting the modal open state. Secondly, we remove the unnecessary ellipse from the attach to existing case button.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->