### PR TITLE
[Fleet] [ON week] Inform users that they have integration updates available

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -435,6 +435,7 @@ export interface IntegrationCardItem {
   categories: string[];
   fromIntegrations?: string;
   isUnverified?: boolean;
+  isUpdateAvailable?: boolean;
   showLabels?: boolean;
 }
 

--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -5,98 +5,90 @@
  * 2.0.
  */
 import React, { memo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiBadge, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiNotificationBadge } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-
-import styled from 'styled-components';
 
 import { useLink } from '../../../hooks';
 import type { Section } from '../sections';
 
 import { WithHeaderLayout } from '.';
 
-const TabBadge = styled(EuiBadge)`
-  padding: 0 1px;
-  margin-left: 4px;
-`;
-
-const TabTitle: React.FC<{ title: JSX.Element; hasWarning: boolean }> = memo(
-  ({ title, hasWarning }) => {
-    return (
-      <>
-        {title}
-        {hasWarning && <TabBadge color="warning" iconType="alert" />}
-      </>
-    );
-  }
-);
 interface Props {
   section?: Section;
   children?: React.ReactNode;
-  sectionsWithWarning?: Section[];
+  notificationsBySection?: Partial<Record<Section, number>>;
 }
 
-export const DefaultLayout: React.FC<Props> = memo(({ section, children, sectionsWithWarning }) => {
-  const { getHref } = useLink();
-  const tabs = [
-    {
-      name: (
-        <FormattedMessage
-          id="xpack.fleet.appNavigation.integrationsAllLinkText"
-          defaultMessage="Browse integrations"
-        />
-      ),
-      section: 'browse' as Section,
-      href: getHref('integrations_all'),
-    },
-    {
-      name: (
-        <FormattedMessage
-          id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
-          defaultMessage="Installed integrations"
-        />
-      ),
-      section: 'manage' as Section,
-      href: getHref('integrations_installed'),
-    },
-  ];
-
-  return (
-    <WithHeaderLayout
-      leftColumn={
-        <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
-          <EuiText>
-            <h1>
-              <FormattedMessage
-                id="xpack.fleet.integrationsHeaderTitle"
-                defaultMessage="Integrations"
-              />
-            </h1>
-          </EuiText>
-
-          <EuiSpacer size="s" />
-
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              <p>
-                <FormattedMessage
-                  id="xpack.fleet.epm.pageSubtitle"
-                  defaultMessage="Choose an integration to start collecting and analyzing your data."
-                />
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      tabs={tabs.map((tab) => ({
+export const DefaultLayout: React.FC<Props> = memo(
+  ({ section, children, notificationsBySection }) => {
+    const { getHref } = useLink();
+    const tabs = [
+      {
         name: (
-          <TabTitle title={tab.name} hasWarning={!!sectionsWithWarning?.includes(tab.section)} />
+          <FormattedMessage
+            id="xpack.fleet.appNavigation.integrationsAllLinkText"
+            defaultMessage="Browse integrations"
+          />
         ),
-        href: tab.href,
-        isSelected: section === tab.section,
-      }))}
-    >
-      {children}
-    </WithHeaderLayout>
-  );
-});
+        section: 'browse' as Section,
+        href: getHref('integrations_all'),
+      },
+      {
+        name: (
+          <FormattedMessage
+            id="xpack.fleet.appNavigation.integrationsInstalledLinkText"
+            defaultMessage="Installed integrations"
+          />
+        ),
+        section: 'manage' as Section,
+        href: getHref('integrations_installed'),
+      },
+    ];
+
+    return (
+      <WithHeaderLayout
+        leftColumn={
+          <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
+            <EuiText>
+              <h1>
+                <FormattedMessage
+                  id="xpack.fleet.integrationsHeaderTitle"
+                  defaultMessage="Integrations"
+                />
+              </h1>
+            </EuiText>
+
+            <EuiSpacer size="s" />
+
+            <EuiFlexItem grow={false}>
+              <EuiText size="s" color="subdued">
+                <p>
+                  <FormattedMessage
+                    id="xpack.fleet.epm.pageSubtitle"
+                    defaultMessage="Choose an integration to start collecting and analyzing your data."
+                  />
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        tabs={tabs.map((tab) => {
+          console.log(notificationsBySection);
+          const notificationCount = notificationsBySection?.[tab.section];
+          return {
+            name: tab.name,
+            append: notificationCount ? (
+              <EuiNotificationBadge className="eui-alignCenter" size="m">
+                {notificationCount}
+              </EuiNotificationBadge>
+            ) : undefined,
+            href: tab.href,
+            isSelected: section === tab.section,
+          };
+        })}
+      >
+        {children}
+      </WithHeaderLayout>
+    );
+  }
+);

--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -73,7 +73,6 @@ export const DefaultLayout: React.FC<Props> = memo(
           </EuiFlexGroup>
         }
         tabs={tabs.map((tab) => {
-          console.log(notificationsBySection);
           const notificationCount = notificationsBySection?.[tab.section];
           return {
             name: tab.name,

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.stories.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.stories.tsx
@@ -30,6 +30,7 @@ const args: Args = {
   integration: '',
   categories: ['foobar'],
   isUnverified: false,
+  isUpdateAvailable: false,
 };
 
 const argTypes = {
@@ -40,6 +41,9 @@ const argTypes = {
     },
   },
   isUnverified: {
+    control: 'boolean',
+  },
+  isUpdateAvailable: {
     control: 'boolean',
   },
 };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -40,6 +40,7 @@ export function PackageCard({
   id,
   fromIntegrations,
   isUnverified,
+  isUpdateAvailable,
   showLabels = true,
 }: PackageCardProps) {
   let releaseBadge: React.ReactNode | null = null;
@@ -66,6 +67,24 @@ export function PackageCard({
             <FormattedMessage
               id="xpack.fleet.packageCard.unverifiedLabel"
               defaultMessage="Unverified"
+            />
+          </EuiBadge>
+        </span>
+      </EuiFlexItem>
+    );
+  }
+
+  let updateAvailableBadge: React.ReactNode | null = null;
+
+  if (isUpdateAvailable && showLabels) {
+    updateAvailableBadge = (
+      <EuiFlexItem grow={false}>
+        <EuiSpacer size="xs" />
+        <span>
+          <EuiBadge color="warning">
+            <FormattedMessage
+              id="xpack.fleet.packageCard.updateAvailableLabel"
+              defaultMessage="Update available"
             />
           </EuiBadge>
         </span>
@@ -118,6 +137,7 @@ export function PackageCard({
         >
           <EuiFlexGroup gutterSize="xs">
             {verifiedBadge}
+            {updateAvailableBadge}
             {releaseBadge}
           </EuiFlexGroup>
         </Card>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -28,8 +28,6 @@ import type {
 
 import { useGetPackages } from '../../../../hooks';
 
-import type { Section } from '../../..';
-
 import type { CategoryFacet, ExtendedIntegrationCategory } from './category_facets';
 
 import { InstalledPackages } from './installed_packages';
@@ -124,23 +122,24 @@ export const EPMHomePage: React.FC = () => {
     [allPackages?.response]
   );
 
-  const atLeastOneUnverifiedPackageInstalled = installedPackages.some(
+  const unverifiedPackageCount = installedPackages.filter(
     (pkg) => 'savedObject' in pkg && pkg.savedObject.attributes.verification_status === 'unverified'
-  );
-  const atLeastOnePackageUpgradeable = installedPackages.some(isPackageUpdatable);
+  ).length;
 
-  const sectionsWithWarning = (
-    atLeastOneUnverifiedPackageInstalled || atLeastOnePackageUpgradeable ? ['manage'] : []
-  ) as Section[];
+  const upgradeablePackageCount = installedPackages.filter(isPackageUpdatable).length;
+
+  const notificationsBySection = {
+    manage: unverifiedPackageCount + upgradeablePackageCount,
+  };
   return (
     <Switch>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_installed}>
-        <DefaultLayout section="manage" sectionsWithWarning={sectionsWithWarning}>
+        <DefaultLayout section="manage" notificationsBySection={notificationsBySection}>
           <InstalledPackages installedPackages={installedPackages} isLoading={isLoading} />
         </DefaultLayout>
       </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_all}>
-        <DefaultLayout section="browse" sectionsWithWarning={sectionsWithWarning}>
+        <DefaultLayout section="browse" notificationsBySection={notificationsBySection}>
           <AvailablePackages />
         </DefaultLayout>
       </Route>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -84,7 +84,7 @@ export const mapToCard = ({
     }
 
     const url = getHref('integration_details_overview', {
-      pkgkey: `${item.name}-${version}`,
+      pkgkey: `${item.name}-${urlVersion}`,
       ...(item.integration ? { integration: item.integration } : {}),
     });
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
@@ -42,7 +42,7 @@ const AnnouncementLink = () => {
   );
 };
 
-const InstalledIntegrationsInfoCallout = () => (
+const InstalledIntegrationsInfoCallout: React.FC = () => (
   <EuiCallOut
     title={i18n.translate('xpack.fleet.epmList.availableCalloutTitle', {
       defaultMessage: 'Only installed Elastic Agent Integrations are displayed.',
@@ -56,6 +56,23 @@ const InstalledIntegrationsInfoCallout = () => (
         values={{
           link: <AnnouncementLink />,
         }}
+      />
+    </p>
+  </EuiCallOut>
+);
+const UpdatesAvailableCallout: React.FC = () => (
+  <EuiCallOut
+    title={i18n.translate('xpack.fleet.epmList.updatesAvailableCalloutTitle', {
+      defaultMessage: 'Some of your installed integrations have updates available.',
+    })}
+    iconType="alert"
+    color="warning"
+  >
+    <p>
+      <FormattedMessage
+        id="xpack.fleet.epmList.updatesAvailableCalloutText"
+        defaultMessage="Install the latest version of integrations to get the latest integration features."
+       
       />
     </p>
   </EuiCallOut>
@@ -185,9 +202,13 @@ export const InstalledPackages: React.FC<{
     })
   );
 
-  const CalloutComponent = cards.some((c) => c.isUnverified)
-    ? VerificationWarningCallout
-    : InstalledIntegrationsInfoCallout;
+  let CalloutComponent = InstalledIntegrationsInfoCallout
+  
+  if(cards.some((c) => c.isUnverified)){
+    CalloutComponent = VerificationWarningCallout;
+  } else if (cards.some((c) => c.isUpdateAvailable)){
+    CalloutComponent = UpdatesAvailableCallout;
+  }
   const callout = selectedCategory === UPDATES_AVAILABLE || isLoading ? null : <CalloutComponent />;
 
   return (

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
@@ -76,7 +76,7 @@ const UpdatesAvailableCallout: React.FC<{ count: number }> = ({ count }) => (
     <p>
       <FormattedMessage
         id="xpack.fleet.epmList.updatesAvailableCalloutText"
-        defaultMessage="Install the latest version of integrations to get the latest integration features."
+        defaultMessage="Update your integrations to get the latest features."
       />
     </p>
   </EuiCallOut>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
@@ -60,10 +60,15 @@ const InstalledIntegrationsInfoCallout: React.FC = () => (
     </p>
   </EuiCallOut>
 );
-const UpdatesAvailableCallout: React.FC = () => (
+
+const UpdatesAvailableCallout: React.FC<{ count: number }> = ({ count }) => (
   <EuiCallOut
     title={i18n.translate('xpack.fleet.epmList.updatesAvailableCalloutTitle', {
-      defaultMessage: 'Some of your installed integrations have updates available.',
+      defaultMessage:
+        '{count, number} of your installed integrations {count, plural, one {has an update} other {have updates}} available.',
+      values: {
+        count,
+      },
     })}
     iconType="alert"
     color="warning"
@@ -72,7 +77,6 @@ const UpdatesAvailableCallout: React.FC = () => (
       <FormattedMessage
         id="xpack.fleet.epmList.updatesAvailableCalloutText"
         defaultMessage="Install the latest version of integrations to get the latest integration features."
-       
       />
     </p>
   </EuiCallOut>
@@ -202,14 +206,16 @@ export const InstalledPackages: React.FC<{
     })
   );
 
-  let CalloutComponent = InstalledIntegrationsInfoCallout
-  
-  if(cards.some((c) => c.isUnverified)){
-    CalloutComponent = VerificationWarningCallout;
-  } else if (cards.some((c) => c.isUpdateAvailable)){
-    CalloutComponent = UpdatesAvailableCallout;
+  let CalloutComponent = <InstalledIntegrationsInfoCallout />;
+
+  const unverifiedCount = cards.filter((c) => c.isUnverified).length;
+  const updateAvailableCount = cards.filter((c) => c.isUpdateAvailable).length;
+  if (unverifiedCount) {
+    CalloutComponent = <VerificationWarningCallout />;
+  } else if (updateAvailableCount) {
+    CalloutComponent = <UpdatesAvailableCallout count={updateAvailableCount} />;
   }
-  const callout = selectedCategory === UPDATES_AVAILABLE || isLoading ? null : <CalloutComponent />;
+  const callout = selectedCategory === UPDATES_AVAILABLE || isLoading ? null : CalloutComponent;
 
   return (
     <PackageListGrid

--- a/x-pack/plugins/fleet/public/services/index.ts
+++ b/x-pack/plugins/fleet/public/services/index.ts
@@ -43,6 +43,7 @@ export {
   downloadSourceRoutesService,
 } from '../../common/services';
 export { isPackageUnverified, isVerificationError } from './package_verification';
+export { isPackageUpdatable } from './is_package_updatable';
 export { pkgKeyFromPackageInfo } from './pkg_key_from_package_info';
 export { createExtensionRegistrationCallback } from './ui_extensions';
 export { incrementPolicyName } from './increment_policy_name';

--- a/x-pack/plugins/fleet/public/services/is_package_updatable.ts
+++ b/x-pack/plugins/fleet/public/services/is_package_updatable.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import semverLt from 'semver/functions/lt';
+
+import type { PackageInfo, PackageListItem } from '../types';
+
+export const isPackageUpdatable = (pkg: PackageInfo | PackageListItem): boolean =>
+  'savedObject' in pkg &&
+  pkg.savedObject &&
+  semverLt(pkg.savedObject.attributes.version, pkg.version);


### PR DESCRIPTION
## Summary

In the integrations browser, put a notification on the installed integrations tab when we have unverified or out of date packages. Add a new callout for packages with upgrade available.

<img width="1266" alt="Screenshot 2022-11-29 at 14 16 41" src="https://user-images.githubusercontent.com/3315046/204554172-71e9b37c-5d0a-4cc7-9eb1-27f6776ee808.png">

