### PR TITLE
[Security Solution][Endpoint][Response Actions] Add status to `ActionDetails`

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
@@ -118,6 +118,7 @@ export class EndpointActionGenerator extends BaseDataGenerator {
       wasSuccessful: true,
       errors: undefined,
       startedAt: '2022-04-27T16:08:47.449Z',
+      status: 'completed',
       comment: 'thisisacomment',
       createdBy: 'auserid',
       parameters: undefined,

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -263,6 +263,8 @@ export interface PendingActionsResponse {
 
 export type PendingActionsRequestQuery = TypeOf<typeof ActionStatusRequestSchema.query>;
 
+export const RESPONSE_ACTION_STATUS = ['completed', 'failed', 'pending'] as const;
+export type ResponseActionStatus = typeof RESPONSE_ACTION_STATUS[number];
 export interface ActionDetails<TOutputContent extends object = object> {
   /** The action id */
   id: string;
@@ -311,6 +313,8 @@ export interface ActionDetails<TOutputContent extends object = object> {
       completedAt: string | undefined;
     }
   >;
+  /**  action status */
+  status: ResponseActionStatus;
   /** user that created the action */
   createdBy: string;
   /** comment submitted with action */

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.test.tsx
@@ -13,7 +13,11 @@ import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import type { AppContextTestRender } from '../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
 import { ResponseActionsLog } from './response_actions_log';
-import type { ActionDetails, ActionListApiResponse } from '../../../../common/endpoint/types';
+import type {
+  ActionDetails,
+  ActionListApiResponse,
+  ResponseActionStatus,
+} from '../../../../common/endpoint/types';
 import { MANAGEMENT_PATH } from '../../../../common/constants';
 import { EndpointActionGenerator } from '../../../../common/endpoint/data_generators/endpoint_action_generator';
 
@@ -328,7 +332,7 @@ describe('Response Actions Log', () => {
       return outputs;
     };
 
-    it('Shows completed status badge for successfully completed actions', async () => {
+    it('shows completed status badge for successfully completed actions', async () => {
       mockUseGetEndpointActionList = {
         ...baseMockedActionList,
         data: await getActionListMock({ actionCount: 2 }),
@@ -348,7 +352,7 @@ describe('Response Actions Log', () => {
     it('shows Failed status badge for failed actions', async () => {
       mockUseGetEndpointActionList = {
         ...baseMockedActionList,
-        data: await getActionListMock({ actionCount: 2, wasSuccessful: false }),
+        data: await getActionListMock({ actionCount: 2, wasSuccessful: false, status: 'failed' }),
       };
       render();
 
@@ -362,7 +366,12 @@ describe('Response Actions Log', () => {
     it('shows Failed status badge for expired actions', async () => {
       mockUseGetEndpointActionList = {
         ...baseMockedActionList,
-        data: await getActionListMock({ actionCount: 2, isCompleted: false, isExpired: true }),
+        data: await getActionListMock({
+          actionCount: 2,
+          isCompleted: false,
+          isExpired: true,
+          status: 'failed',
+        }),
       };
       render();
 
@@ -379,7 +388,7 @@ describe('Response Actions Log', () => {
     it('shows Pending status badge for pending actions', async () => {
       mockUseGetEndpointActionList = {
         ...baseMockedActionList,
-        data: await getActionListMock({ actionCount: 2, isCompleted: false }),
+        data: await getActionListMock({ actionCount: 2, isCompleted: false, status: 'pending' }),
       };
       render();
 
@@ -442,6 +451,7 @@ const getActionListMock = async ({
   isCompleted = true,
   isExpired = false,
   wasSuccessful = true,
+  status = 'completed',
 }: {
   agentIds?: string[];
   commands?: string[];
@@ -454,6 +464,7 @@ const getActionListMock = async ({
   isCompleted?: boolean;
   isExpired?: boolean;
   wasSuccessful?: boolean;
+  status?: ResponseActionStatus;
 }): Promise<ActionListApiResponse> => {
   const endpointActionGenerator = new EndpointActionGenerator('seed');
 
@@ -471,6 +482,7 @@ const getActionListMock = async ({
         isCompleted,
         isExpired,
         wasSuccessful,
+        status,
         completedAt: isExpired ? undefined : new Date().toISOString(),
       });
     });

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -47,6 +47,17 @@ const getCommand = (
 ): Exclude<ActionDetails['command'], 'unisolate'> | 'release' =>
   command === 'unisolate' ? 'release' : command;
 
+const getActionStatus = (status: ActionDetails['status']): string => {
+  if (status === 'failed') {
+    return UX_MESSAGES.badge.failed;
+  } else if (status === 'completed') {
+    return UX_MESSAGES.badge.completed;
+  } else if (status === 'pending') {
+    return UX_MESSAGES.badge.pending;
+  }
+  return '';
+};
+
 // Truncated usernames
 const StyledFacetButton = euiStyled(EuiFacetButton)`
   .euiText {
@@ -372,30 +383,18 @@ export const ResponseActionsLog = memo<
         },
       },
       {
-        field: 'isCompleted',
+        field: 'status',
         name: TABLE_COLUMN_NAMES.status,
         width: !showHostNames ? '15%' : '10%',
-        render: (isCompleted: ActionDetails['isCompleted'], data: ActionDetails) => {
-          const status = data.isExpired
-            ? UX_MESSAGES.badge.failed
-            : isCompleted
-            ? data.wasSuccessful
-              ? UX_MESSAGES.badge.completed
-              : UX_MESSAGES.badge.failed
-            : UX_MESSAGES.badge.pending;
+        render: (_status: ActionDetails['status']) => {
+          const status = getActionStatus(_status);
 
           return (
             <EuiToolTip content={status} anchorClassName="eui-textTruncate">
               <EuiBadge
                 data-test-subj={getTestId('column-status')}
                 color={
-                  data.isExpired
-                    ? 'danger'
-                    : isCompleted
-                    ? data.wasSuccessful
-                      ? 'success'
-                      : 'danger'
-                    : 'warning'
+                  _status === 'failed' ? 'danger' : _status === 'completed' ? 'success' : 'warning'
                 }
               >
                 <FormattedMessage

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.test.ts
@@ -76,6 +76,7 @@ describe('When using `getActionDetailsById()', () => {
       isCompleted: true,
       isExpired: false,
       startedAt: '2022-04-27T16:08:47.449Z',
+      status: 'completed',
       comment: doc?.EndpointActions.data.comment,
       createdBy: doc?.user.id,
       parameters: doc?.EndpointActions.data.parameters,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
@@ -14,6 +14,7 @@ import {
   getActionCompletionInfo,
   mapToNormalizedActionRequest,
   getAgentHostNamesWithIds,
+  getActionStatus,
 } from './utils';
 import type {
   ActionDetails,
@@ -119,6 +120,12 @@ export const getActionDetailsById = async (
   const { isCompleted, completedAt, wasSuccessful, errors, outputs, agentState } =
     getActionCompletionInfo(normalizedActionRequest.agents, actionResponses);
 
+  const { isExpired, status } = getActionStatus({
+    expirationDate: normalizedActionRequest.expiration,
+    isCompleted,
+    wasSuccessful,
+  });
+
   const actionDetails: ActionDetails = {
     id: actionId,
     agents: normalizedActionRequest.agents,
@@ -132,7 +139,8 @@ export const getActionDetailsById = async (
     completedAt,
     wasSuccessful,
     errors,
-    isExpired: !isCompleted && normalizedActionRequest.expiration < new Date().toISOString(),
+    isExpired,
+    status,
     outputs,
     agentState,
     createdBy: normalizedActionRequest.createdBy,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.test.ts
@@ -99,6 +99,7 @@ describe('When using `getActionList()', () => {
           isCompleted: true,
           isExpired: false,
           startedAt: '2022-04-27T16:08:47.449Z',
+          status: 'completed',
           comment: doc?.EndpointActions.data.comment,
           createdBy: doc?.user.id,
           parameters: doc?.EndpointActions.data.parameters,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -19,6 +19,7 @@ import {
   getActionCompletionInfo,
   mapToNormalizedActionRequest,
   getAgentHostNamesWithIds,
+  getActionStatus,
 } from './utils';
 import type { EndpointMetadataService } from '../metadata';
 
@@ -198,6 +199,12 @@ const getActionDetailsList = async ({
       matchedResponses
     );
 
+    const { isExpired, status } = getActionStatus({
+      expirationDate: action.expiration,
+      isCompleted,
+      wasSuccessful,
+    });
+
     // NOTE: `outputs` is not returned in this service because including it on a list of data
     // could result in a very large response unnecessarily. In the future, we might include
     // an option to optionally include it.
@@ -215,7 +222,8 @@ const getActionDetailsList = async ({
       wasSuccessful,
       errors,
       agentState,
-      isExpired: !isCompleted && action.expiration < new Date().toISOString(),
+      isExpired,
+      status,
       createdBy: action.createdBy,
       comment: action.comment,
       parameters: action.parameters,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
@@ -185,6 +185,27 @@ export const getActionCompletionInfo = (
   return completedInfo;
 };
 
+export const getActionStatus = ({
+  expirationDate,
+  isCompleted,
+  wasSuccessful,
+}: {
+  expirationDate: string;
+  isCompleted: boolean;
+  wasSuccessful: boolean;
+}): { status: ActionDetails['status']; isExpired: boolean } => {
+  const isExpired = !isCompleted && expirationDate < new Date().toISOString();
+  const status = isExpired
+    ? 'failed'
+    : isCompleted
+    ? wasSuccessful
+      ? 'completed'
+      : 'failed'
+    : 'pending';
+
+  return { isExpired, status };
+};
+
 interface NormalizedAgentActionResponse {
   isCompleted: boolean;
   completedAt: undefined | string;


### PR DESCRIPTION
## Summary

Adds a top-level status property to action list and action details API that would be used for filtering by action status.

### Checklis

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
