### PR TITLE
[Enterprise Search] Fix bug preventing Custom Crawl flyout in App Search from opening

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.test.ts
@@ -94,7 +94,7 @@ describe('CrawlCustomSettingsFlyoutLogic', () => {
 
         expect(http.get).toHaveBeenNthCalledWith(
           1,
-          '/internal/enterprise_search/engines/some-engine/crawler/domain_configs',
+          '/internal/app_search/engines/some-engine/crawler/domain_configs',
           {
             query: {
               'page[current]': 1,
@@ -104,7 +104,7 @@ describe('CrawlCustomSettingsFlyoutLogic', () => {
         );
         expect(http.get).toHaveBeenNthCalledWith(
           2,
-          '/internal/enterprise_search/engines/some-engine/crawler/domain_configs',
+          '/internal/app_search/engines/some-engine/crawler/domain_configs',
           {
             query: {
               'page[current]': 2,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_custom_settings_flyout/crawl_custom_settings_flyout_logic.ts
@@ -210,7 +210,7 @@ export const CrawlCustomSettingsFlyoutLogic = kea<
           } = await http.get<{
             meta: Meta;
             results: DomainConfigFromServer[];
-          }>(`/internal/enterprise_search/engines/${engineName}/crawler/domain_configs`, {
+          }>(`/internal/app_search/engines/${engineName}/crawler/domain_configs`, {
             query: { 'page[current]': nextPage, 'page[size]': pageSize },
           });
 


### PR DESCRIPTION
## Summary

This was the victim of a greedy find-replace.  


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->