### PR TITLE
Fix sample count from down-sampled to fully sampled

### DIFF
--- a/x-pack/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/plugins/profiling/server/routes/flamechart.ts
@@ -40,24 +40,18 @@ export function registerFlameChartElasticSearchRoute({ router, logger }: RouteRe
           kuery,
         });
 
-        const {
-          stackTraces,
-          executables,
-          stackFrames,
-          eventsIndex,
-          downsampledTotalCount,
-          stackTraceEvents,
-        } = await getExecutablesAndStackTraces({
-          logger,
-          client: createProfilingEsClient({ request, esClient }),
-          filter,
-          sampleSize: targetSampleSize,
-        });
+        const { stackTraces, executables, stackFrames, eventsIndex, totalCount, stackTraceEvents } =
+          await getExecutablesAndStackTraces({
+            logger,
+            client: createProfilingEsClient({ request, esClient }),
+            filter,
+            sampleSize: targetSampleSize,
+          });
 
         const flamegraph = await withProfilingSpan('collect_flamegraph', async () => {
           return new FlameGraph(
             eventsIndex.sampleRate,
-            downsampledTotalCount,
+            totalCount,
             stackTraceEvents,
             stackTraces,
             stackFrames,

--- a/x-pack/plugins/profiling/server/routes/get_executables_and_stacktraces.ts
+++ b/x-pack/plugins/profiling/server/routes/get_executables_and_stacktraces.ts
@@ -58,6 +58,12 @@ export async function getExecutablesAndStackTraces({
       logger.info('unique downsampled stacktraces: ' + stackTraceEvents.size);
     }
 
+    // Adjust the sample counts from down-sampled to fully sampled.
+    for (const [id, count] of stackTraceEvents) {
+      stackTraceEvents.set(id, Math.floor(count / eventsIndex.sampleRate));
+    }
+    downsampledTotalCount = Math.floor(downsampledTotalCount / eventsIndex.sampleRate);
+
     const { stackTraces, stackFrameDocIDs, executableDocIDs } = await mgetStackTraces({
       logger,
       client,

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -80,9 +80,9 @@ export async function topNElasticSearchQuery({
 
   const topN = createTopNSamples(aggregations);
 
-  const totalSampledStackTraces = aggregations.total_count.value ?? 0;
-
+  let totalSampledStackTraces = aggregations.total_count.value ?? 0;
   logger.info('total sampled stacktraces: ' + totalSampledStackTraces);
+  totalSampledStackTraces = Math.floor(totalSampledStackTraces / eventsIndex.sampleRate);
 
   if (searchField !== ProfilingESField.StacktraceID) {
     return response.ok({
@@ -96,7 +96,7 @@ export async function topNElasticSearchQuery({
 
   for (let i = 0; i < groupByBuckets.length; i++) {
     const stackTraceID = String(groupByBuckets[i].key);
-    const count = groupByBuckets[i].count.value ?? 0;
+    const count = Math.floor((groupByBuckets[i].count.value ?? 0) / eventsIndex.sampleRate);
     totalAggregatedStackTraces += count;
     stackTraceEvents.set(stackTraceID, count);
   }

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -78,7 +78,7 @@ export async function topNElasticSearchQuery({
     });
   }
 
-  let topN = createTopNSamples(aggregations);
+  const topN = createTopNSamples(aggregations);
 
   for (let i = 0; i < topN.length; i++) {
     topN[i].Count = (topN[i].Count ?? 0) / eventsIndex.sampleRate;

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -78,7 +78,11 @@ export async function topNElasticSearchQuery({
     });
   }
 
-  const topN = createTopNSamples(aggregations);
+  let topN = createTopNSamples(aggregations);
+
+  for (let i = 0; i < topN.length; i++) {
+    topN[i].Count = (topN[i].Count ?? 0) / eventsIndex.sampleRate;
+  }
 
   let totalSampledStackTraces = aggregations.total_count.value ?? 0;
   logger.info('total sampled stacktraces: ' + totalSampledStackTraces);


### PR DESCRIPTION
We currently display the number of samples from the down-sampled indices.
Instead we want to display the extrapolated full sampled counts.