### PR TITLE
Add/fix Source filename and line number in TopN Functions and Flamegraph

### DIFF
--- a/x-pack/plugins/profiling/common/profiling.test.ts
+++ b/x-pack/plugins/profiling/common/profiling.test.ts
@@ -63,7 +63,7 @@ describe('Stack frame metadata operations', () => {
       SourceLine: 1456,
     });
     expect(getCalleeSource(metadata)).toEqual(
-      '/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c#2567'
+      '/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c#1456'
     );
   });
 

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -82,6 +82,8 @@ export interface StackFrameMetadata {
   FunctionOffset: number;
   // should this be StackFrame.SourceID?
   SourceID: FileID;
+  // StackFrame.Filename
+  SourceFilename: string;
   // StackFrame.LineNumber
   SourceLine: number;
 
@@ -92,8 +94,6 @@ export interface StackFrameMetadata {
   CommitHash: string;
   // unused atm due to lack of symbolization metadata
   SourceCodeURL: string;
-  // unused atm due to lack of symbolization metadata
-  SourceFilename: string;
   // unused atm due to lack of symbolization metadata
   SourcePackageHash: string;
   // unused atm due to lack of symbolization metadata
@@ -151,7 +151,7 @@ export function getCalleeSource(frame: StackFrameMetadata): string {
     return frame.SourceFilename;
   }
 
-  return frame.SourceFilename + (frame.FunctionOffset !== 0 ? `#${frame.FunctionOffset}` : '');
+  return frame.SourceFilename + (frame.SourceLine !== 0 ? `#${frame.SourceLine}` : '');
 }
 
 // groupStackFrameMetadataByStackTrace collects all of the per-stack-frame
@@ -181,6 +181,7 @@ export function groupStackFrameMetadataByStackTrace(
         FunctionName: frame.FunctionName,
         FunctionOffset: frame.FunctionOffset,
         SourceLine: frame.LineNumber,
+        SourceFilename: frame.FileName,
         ExeFileName: executable.FileName,
       });
 


### PR DESCRIPTION
## Summary
The file names for scripted languages where missing in the TopN functions as well as in the Flamegraph. The line numbers where incorrect (FunctionOffset instead of SourceLine ws used).

See https://elastic.slack.com/archives/C02L64C4PLJ/p1662053460229009

This PR fixes both issues.

Fixes https://github.com/elastic/prodfiler/issues/2565