### PR TITLE
[Fleet] fix for package policy upgrade API with multiple ids

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -106,6 +106,7 @@ async function mockedGetInstallation(params: any) {
   let pkg;
   if (params.pkgName === 'apache') pkg = { version: '1.3.2' };
   if (params.pkgName === 'aws') pkg = { version: '0.3.3' };
+  if (params.pkgName === 'endpoint') pkg = { version: '1.0.0' };
   return Promise.resolve(pkg);
 }
 
@@ -113,7 +114,7 @@ async function mockedGetPackageInfo(params: any) {
   let pkg;
   if (params.pkgName === 'apache') pkg = { version: '1.3.2' };
   if (params.pkgName === 'aws') pkg = { version: '0.3.3' };
-  if (params.pkgName === 'endpoint') pkg = {};
+  if (params.pkgName === 'endpoint') pkg = { version: '1.0.0' };
   if (params.pkgName === 'test') {
     pkg = {
       version: '1.0.2',
@@ -3462,6 +3463,36 @@ describe('getUpgradeDryRunDiff', () => {
     );
 
     expect(res.hasErrors).toBeTruthy();
+  });
+
+  it('should return no errors if upgrading 2 package policies', async () => {
+    savedObjectsClient.get.mockImplementation((type, id) =>
+      Promise.resolve({
+        id,
+        type: 'abcd',
+        references: [],
+        version: '0.9.0',
+        attributes: { ...createPackagePolicyMock(), name: id },
+      })
+    );
+    const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    const res = await packagePolicyService.upgrade(savedObjectsClient, elasticsearchClient, [
+      'package-policy-id',
+      'package-policy-id-2',
+    ]);
+
+    expect(res).toEqual([
+      {
+        id: 'package-policy-id',
+        name: 'package-policy-id',
+        success: true,
+      },
+      {
+        id: 'package-policy-id-2',
+        name: 'package-policy-id-2',
+        success: true,
+      },
+    ]);
   });
 });
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -659,19 +659,22 @@ class PackagePolicyService implements PackagePolicyServiceInterface {
 
     for (const id of ids) {
       try {
-        let packageInfo: PackageInfo;
-        ({ packagePolicy, packageInfo } = await this.getUpgradePackagePolicyInfo(
-          soClient,
-          id,
-          packagePolicy,
-          pkgVersion
-        ));
+        const { packagePolicy: currentPackagePolicy, packageInfo } =
+          await this.getUpgradePackagePolicyInfo(soClient, id, packagePolicy, pkgVersion);
 
-        if (packagePolicy.is_managed && !options?.force) {
+        if (currentPackagePolicy.is_managed && !options?.force) {
           throw new PackagePolicyRestrictionRelatedError(`Cannot upgrade package policy ${id}`);
         }
 
-        await this.doUpgrade(soClient, esClient, id, packagePolicy!, result, packageInfo, options);
+        await this.doUpgrade(
+          soClient,
+          esClient,
+          id,
+          currentPackagePolicy,
+          result,
+          packageInfo,
+          options
+        );
       } catch (error) {
         result.push({
           id,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/140065

Fixed a bug where upgrading multiple ids didn't work correctly, and always returned a duplicate name error starting from the second one.

## To verify:
1. Force install an older version of system package:
```
POST http://elastic:changeme@localhost:5601/julia/api/fleet/epm/packages/system/1.11.0
kbn-xsrf: kibana

{ "force": true }
```

2. Add 2 package policies
3. Upgrade with one API call
```
POST http://elastic:changeme@localhost:5601/julia/api/fleet/package_policies/upgrade
kbn-xsrf: kibana

{"packagePolicyIds":["010ec730-6e2b-4aa3-956a-bef34d448340","df208e90-44da-4ecc-b4ba-0a5f5138e38c"]}
```

4. Expect both to succeed
```
[
  {
    "id": "010ec730-6e2b-4aa3-956a-bef34d448340",
    "name": "system-5",
    "success": true
  },
  {
    "id": "df208e90-44da-4ecc-b4ba-0a5f5138e38c",
    "name": "system-3 (copy)",
    "success": true
  }
]
```

The reason of the bug was that the `upgrade` function reassigned the `packagePolicy` parameter, and this was not working properly with multiple ids (the logic used the first loaded `packagePolicy` when validating duplicates for the next one).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
