### PR TITLE
[Security Solution][Endpoint][Response Actions] Add hosts filter to actions log

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/schema/actions.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/actions.test.ts
@@ -47,14 +47,14 @@ describe('actions schemas', () => {
       }).not.toThrow();
     });
 
-    it('should limit multiple agent IDs in an array to 50', () => {
+    it('should not limit multiple agent IDs', () => {
       expect(() => {
         EndpointActionListRequestSchema.query.validate({
-          agentIds: Array(51)
+          agentIds: Array(255)
             .fill(1)
             .map(() => uuid.v4()),
         });
-      }).toThrow();
+      }).not.toThrow();
     });
 
     it('should work with all required query params', () => {

--- a/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
@@ -87,7 +87,7 @@ export const EndpointActionListRequestSchema = {
   query: schema.object({
     agentIds: schema.maybe(
       schema.oneOf([
-        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1, maxSize: 50 }),
+        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
         schema.string({ minLength: 1 }),
       ])
     ),

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -12,7 +12,7 @@ import type {
   ResponseActionBodySchema,
   KillOrSuspendProcessRequestSchema,
 } from '../schema/actions';
-import type { ResponseActionStatus, ResponseActions } from '../service/response_actions/constants';
+import type { RESPONSE_ACTION_STATUS } from '../service/response_actions/constants';
 
 export type ISOLATION_ACTIONS = 'isolate' | 'unisolate';
 

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -12,10 +12,7 @@ import type {
   ResponseActionBodySchema,
   KillOrSuspendProcessRequestSchema,
 } from '../schema/actions';
-import type {
-  RESPONSE_ACTION_STATUS,
-  RESPONSE_ACTION_COMMANDS,
-} from '../service/response_actions/constants';
+import type { ResponseActionStatus, ResponseActions } from '../service/response_actions/constants';
 
 export type ISOLATION_ACTIONS = 'isolate' | 'unisolate';
 

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -12,7 +12,10 @@ import type {
   ResponseActionBodySchema,
   KillOrSuspendProcessRequestSchema,
 } from '../schema/actions';
-import type { RESPONSE_ACTION_STATUS } from '../service/response_actions/constants';
+import type {
+  RESPONSE_ACTION_STATUS,
+  RESPONSE_ACTION_COMMANDS,
+} from '../service/response_actions/constants';
 
 export type ISOLATION_ACTIONS = 'isolate' | 'unisolate';
 

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useMemo, useCallback } from 'react';
+import React, { memo, useMemo, useState, useCallback } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSelectable, EuiPopoverTitle } from '@elastic/eui';
 import { ActionsLogFilterPopover } from './actions_log_filter_popover';
 import { type FilterItems, type FilterName, useActionsLogFilter } from './hooks';
@@ -22,8 +22,9 @@ export const ActionsLogFilter = memo(
     onChangeFilterOptions: (selectedOptions: string[]) => void;
   }) => {
     const getTestId = useTestIdGenerator('response-actions-list');
-    const { items, setItems, hasActiveFilters, numActiveFilters, numFilters } =
-      useActionsLogFilter(filterName);
+    const [searchString, setSearchString] = useState('');
+    const { isError, isLoading, items, setItems, hasActiveFilters, numActiveFilters, numFilters } =
+      useActionsLogFilter(filterName, searchString);
 
     const isSearchable = useMemo(() => filterName !== 'statuses', [filterName]);
 
@@ -65,16 +66,25 @@ export const ActionsLogFilter = memo(
       >
         <EuiSelectable
           aria-label={`${filterName}`}
+          isLoading={isLoading}
           onChange={onChange}
           options={items}
           searchable={isSearchable ? true : undefined}
           searchProps={{
             placeholder: UX_MESSAGES.filterSearchPlaceholder(filterName),
             compressed: true,
+            onChange: (searchValue) => setSearchString(searchValue.trim()),
           }}
         >
           {(list, search) => {
-            return (
+            return isError ? (
+              <div
+                style={{ width: 300 }}
+                data-test-subj={getTestId(`${filterName}-filter-popoverList`)}
+              >
+                {'Error fetching hosts'}
+              </div>
+            ) : (
               <div
                 style={{ width: 300 }}
                 data-test-subj={getTestId(`${filterName}-filter-popoverList`)}

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filters.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filters.tsx
@@ -23,26 +23,32 @@ export const ActionsLogFilters = memo(
     dateRangePickerState,
     isDataLoading,
     onClick,
+    onChangeHostsFilter,
     onChangeCommandsFilter,
     onChangeStatusesFilter,
     onRefresh,
     onRefreshChange,
     onTimeChange,
+    showHostsFilter,
   }: {
     dateRangePickerState: DateRangePickerValues;
     isDataLoading: boolean;
+    onChangeHostsFilter: (selectedCommands: string[]) => void;
     onChangeCommandsFilter: (selectedCommands: string[]) => void;
     onChangeStatusesFilter: (selectedStatuses: string[]) => void;
     onRefresh: () => void;
     onRefreshChange: (evt: OnRefreshChangeProps) => void;
     onTimeChange: ({ start, end }: DurationRange) => void;
     onClick: ReturnType<typeof useGetEndpointActionList>['refetch'];
+    showHostsFilter: boolean;
   }) => {
     const getTestId = useTestIdGenerator('response-actions-list');
     const filters = useMemo(() => {
-      // TODO: add more filter names here (users, hosts, statuses)
       return (
         <>
+          {showHostsFilter && (
+            <ActionsLogFilter filterName={'hosts'} onChangeFilterOptions={onChangeHostsFilter} />
+          )}
           <ActionsLogFilter filterName={'actions'} onChangeFilterOptions={onChangeCommandsFilter} />
           <ActionsLogFilter
             filterName={'statuses'}
@@ -50,7 +56,7 @@ export const ActionsLogFilters = memo(
           />
         </>
       );
-    }, [onChangeCommandsFilter, onChangeStatusesFilter]);
+    }, [onChangeHostsFilter, onChangeCommandsFilter, onChangeStatusesFilter, showHostsFilter]);
 
     const onClickRefreshButton = useCallback(() => onClick(), [onClick]);
 

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -49,6 +49,17 @@ const emptyValue = getEmptyValue();
 const getCommand = (command: ResponseActions): Exclude<ResponseActions, 'unisolate'> | 'release' =>
   command === 'unisolate' ? 'release' : command;
 
+const getActionStatus = (status: ActionDetails['status']): string => {
+  if (status === 'failed') {
+    return UX_MESSAGES.badge.failed;
+  } else if (status === 'completed') {
+    return UX_MESSAGES.badge.completed;
+  } else if (status === 'pending') {
+    return UX_MESSAGES.badge.pending;
+  }
+  return '';
+};
+
 // Truncated usernames
 const StyledFacetButton = euiStyled(EuiFacetButton)`
   .euiText {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -49,17 +49,6 @@ const emptyValue = getEmptyValue();
 const getCommand = (command: ResponseActions): Exclude<ResponseActions, 'unisolate'> | 'release' =>
   command === 'unisolate' ? 'release' : command;
 
-const getActionStatus = (status: ResponseActionStatus): string => {
-  if (status === 'failed') {
-    return UX_MESSAGES.badge.failed;
-  } else if (status === 'successful') {
-    return UX_MESSAGES.badge.successful;
-  } else if (status === 'pending') {
-    return UX_MESSAGES.badge.pending;
-  }
-  return '';
-};
-
 // Truncated usernames
 const StyledFacetButton = euiStyled(EuiFacetButton)`
   .euiText {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -52,8 +52,8 @@ const getCommand = (command: ResponseActions): Exclude<ResponseActions, 'unisola
 const getActionStatus = (status: ResponseActionStatus): string => {
   if (status === 'failed') {
     return UX_MESSAGES.badge.failed;
-  } else if (status === 'completed') {
-    return UX_MESSAGES.badge.completed;
+  } else if (status === 'successful') {
+    return UX_MESSAGES.badge.successful;
   } else if (status === 'pending') {
     return UX_MESSAGES.badge.pending;
   }
@@ -182,7 +182,10 @@ export const ResponseActionsLog = memo<
   // handle on change actions filter
   const onChangeStatusesFilter = useCallback(
     (selectedStatuses: string[]) => {
-      setQueryParams((prevState) => ({ ...prevState, statuses: selectedStatuses }));
+      setQueryParams((prevState) => ({
+        ...prevState,
+        statuses: selectedStatuses as ResponseActionStatus[],
+      }));
     },
     [setQueryParams]
   );

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -179,6 +179,13 @@ export const ResponseActionsLog = memo<
     [setQueryParams]
   );
 
+  // handle on change hosts filter
+  const onChangeHostsFilter = useCallback(
+    (selectedAgentIds: string[]) => {
+      setQueryParams((prevState) => ({ ...prevState, agentIds: selectedAgentIds }));
+    },
+    [setQueryParams]
+  );
   // total actions
   const totalItemCount = useMemo(() => actionList?.total ?? 0, [actionList]);
 
@@ -531,11 +538,13 @@ export const ResponseActionsLog = memo<
         dateRangePickerState={dateRangePickerState}
         isDataLoading={isFetching}
         onClick={reFetchEndpointActionList}
+        onChangeHostsFilter={onChangeHostsFilter}
         onChangeCommandsFilter={onChangeCommandsFilter}
         onChangeStatusesFilter={onChangeStatusesFilter}
         onRefresh={onRefresh}
         onRefreshChange={onRefreshChange}
         onTimeChange={onTimeChange}
+        showHostsFilter={showHostNames}
       />
       {isFetched && !totalItemCount ? (
         <ManagementEmptyStateWrapper>

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.tsx
@@ -49,7 +49,7 @@ const emptyValue = getEmptyValue();
 const getCommand = (command: ResponseActions): Exclude<ResponseActions, 'unisolate'> | 'release' =>
   command === 'unisolate' ? 'release' : command;
 
-const getActionStatus = (status: ActionDetails['status']): string => {
+const getActionStatus = (status: ResponseActionStatus): string => {
   if (status === 'failed') {
     return UX_MESSAGES.badge.failed;
   } else if (status === 'completed') {
@@ -175,6 +175,14 @@ export const ResponseActionsLog = memo<
         ...prevState,
         statuses: selectedStatuses as ResponseActionStatus[],
       }));
+    },
+    [setQueryParams]
+  );
+
+  // handle on change actions filter
+  const onChangeStatusesFilter = useCallback(
+    (selectedStatuses: string[]) => {
+      setQueryParams((prevState) => ({ ...prevState, statuses: selectedStatuses }));
     },
     [setQueryParams]
   );

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
@@ -160,6 +160,9 @@ export const FILTER_NAMES = Object.freeze({
   actions: i18n.translate('xpack.securitySolution.responseActionsList.list.filter.actions', {
     defaultMessage: 'Actions',
   }),
+  hosts: i18n.translate('xpack.securitySolution.responseActionsList.list.filter.Hosts', {
+    defaultMessage: 'Hosts',
+  }),
   statuses: i18n.translate('xpack.securitySolution.responseActionsList.list.filter.statuses', {
     defaultMessage: 'Statuses',
   }),

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoints_list.test.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoints_list.test.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoints_list.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoints_list.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { useHttp } from '../../../common/lib/kibana';
+import type { HostInfo, MetadataListResponse } from '../../../../common/endpoint/types';
+import { HOST_METADATA_LIST_ROUTE } from '../../../../common/endpoint/constants';
+
+type GetEndpointsListResponse = Array<{
+  id: HostInfo['metadata']['agent']['id'];
+  name: HostInfo['metadata']['host']['hostname'];
+}>;
+
+/**
+ * Get info for a security solution endpoint host using hostnames via kuery param
+ * page and pageSize are fixed for showing 50 hosts at most on the 1st page
+ * @param query
+ * @param options
+ */
+export const useGetEndpointsList = (
+  searchString: string,
+  options: UseQueryOptions<GetEndpointsListResponse, IHttpFetchError> = {}
+): UseQueryResult<GetEndpointsListResponse, IHttpFetchError> => {
+  const http = useHttp();
+
+  const kuery = `united.endpoint.host.hostname:${searchString.length ? `*${searchString}` : ''}*`;
+
+  return useQuery<GetEndpointsListResponse, IHttpFetchError>({
+    queryKey: ['get-endpoints-list', kuery],
+    ...options,
+    queryFn: async () => {
+      const metadataListResponse = await http.get<MetadataListResponse>(HOST_METADATA_LIST_ROUTE, {
+        query: {
+          page: 0,
+          pageSize: 50,
+          kuery,
+        },
+      });
+
+      return metadataListResponse.data.map((list) => ({
+        id: list.metadata.agent.id,
+        name: list.metadata.host.hostname,
+      }));
+    },
+  });
+};


### PR DESCRIPTION
## Summary

**WIP**

Adds a host filter to the actions log table on the response actions page so a user can filter log data by host names.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
