### PR TITLE
[Fleet] Fix package icon margin

### DIFF
--- a/x-pack/plugins/fleet/public/components/package_icon.tsx
+++ b/x-pack/plugins/fleet/public/components/package_icon.tsx
@@ -19,7 +19,7 @@ import { usePackageIconType } from '../hooks';
 // override those styles until the bug is fixed or we find a better approach
 const Icon = styled(EuiIcon)`
   width: '16px';
-  margin: unset !important;
+  margin-block-end: unset !important;
 `;
 
 export const PackageIcon: React.FunctionComponent<


### PR DESCRIPTION
## Summary

Resolve #139075


Fix a bug where the package icon is missing a margin in the integration page. 
We introduced a css fix to fix the margin of the package icon when it's used inside an `EuiText` component (in a modal body, like the reassign modal for example) but that fix broke the integration page that PR fix that.



## UI Changes

<img width="1412" alt="Screen Shot 2022-09-06 at 12 05 34 PM" src="https://user-images.githubusercontent.com/1336873/188683684-a0f18755-ddbd-4b2e-aa7e-894e2e1cbf09.png">
<img width="573" alt="Screen Shot 2022-09-06 at 12 05 22 PM" src="https://user-images.githubusercontent.com/1336873/188683693-4b7d3c1c-0083-45e9-aae8-11cfc1c9254b.png">



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->