### PR TITLE
[Security Solution] Fix risk score `isModuleEnabled` bug

### DIFF
--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -67,6 +67,7 @@ export const useHostRiskScore = (params?: UseRiskScoreParams) => {
   const spaceId = useSpaceId();
   const defaultIndex = spaceId ? getHostRiskIndex(spaceId, onlyLatest) : undefined;
   const riskyHostsFeatureEnabled = useIsExperimentalFeatureEnabled('riskyHostsEnabled');
+
   return useRiskScore({
     timerange,
     onlyLatest,
@@ -133,10 +134,10 @@ const useRiskScore = <T extends RiskQueries.hostsRiskScore | RiskQueries.usersRi
       inspect,
       refetch,
       totalCount: response.totalCount,
-      isModuleEnabled: response.data != null,
+      isModuleEnabled: skip ? featureEnabled : featureEnabled && response.data != null,
       isInspected: false,
     }),
-    [inspect, refetch, response]
+    [featureEnabled, inspect, refetch, response.data, response.totalCount, skip]
   );
 
   const riskScoreRequest = useMemo(


### PR DESCRIPTION
## Summary

Previously, `isModuleEnabled` returned false if `data == null`. When query is skipped, `data == null` but that does not mean the module is disabled. In fact, the user could not have skipped it if the query was not already enabled. Now we only check `data == null` if the query is not skipped.

I also consolidated the tests for this hook by using `forEach` as user/host were running identical tests