### PR TITLE
[ML] Anomaly Detection: Anomalies table in results - only show maps link if maps is enabled

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
@@ -669,47 +669,48 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
         );
       }
     }
-
-    if (anomaly.isGeoRecord === true) {
-      items.push(
-        <EuiContextMenuItem
-          key="view_in_maps"
-          icon="gisApp"
-          onClick={async () => {
-            const mapsLink = await getAnomaliesMapsLink(anomaly);
-            await application.navigateToApp(MAPS_APP_ID, { path: mapsLink?.path });
-          }}
-          data-test-subj="mlAnomaliesListRowActionViewInMapsButton"
-        >
-          <FormattedMessage
-            id="xpack.ml.anomaliesTable.linksMenu.viewInMapsLabel"
-            defaultMessage="View in Maps"
-          />
-        </EuiContextMenuItem>
-      );
-    } else if (
-      props.sourceIndicesWithGeoFields &&
-      props.sourceIndicesWithGeoFields[anomaly.jobId]
-    ) {
-      items.push(
-        <EuiContextMenuItem
-          key="view_in_maps"
-          icon="gisApp"
-          onClick={async () => {
-            const mapsLink = await getAnomalySourceMapsLink(
-              anomaly,
-              props.sourceIndicesWithGeoFields
-            );
-            await application.navigateToApp(MAPS_APP_ID, { path: mapsLink?.path });
-          }}
-          data-test-subj="mlAnomaliesListRowActionViewSourceIndexInMapsButton"
-        >
-          <FormattedMessage
-            id="xpack.ml.anomaliesTable.linksMenu.viewSourceIndexInMapsLabel"
-            defaultMessage="View source index in Maps"
-          />
-        </EuiContextMenuItem>
-      );
+    if (application.capabilities.maps?.show) {
+      if (anomaly.isGeoRecord === true) {
+        items.push(
+          <EuiContextMenuItem
+            key="view_in_maps"
+            icon="gisApp"
+            onClick={async () => {
+              const mapsLink = await getAnomaliesMapsLink(anomaly);
+              await application.navigateToApp(MAPS_APP_ID, { path: mapsLink?.path });
+            }}
+            data-test-subj="mlAnomaliesListRowActionViewInMapsButton"
+          >
+            <FormattedMessage
+              id="xpack.ml.anomaliesTable.linksMenu.viewInMapsLabel"
+              defaultMessage="View in Maps"
+            />
+          </EuiContextMenuItem>
+        );
+      } else if (
+        props.sourceIndicesWithGeoFields &&
+        props.sourceIndicesWithGeoFields[anomaly.jobId]
+      ) {
+        items.push(
+          <EuiContextMenuItem
+            key="view_in_maps"
+            icon="gisApp"
+            onClick={async () => {
+              const mapsLink = await getAnomalySourceMapsLink(
+                anomaly,
+                props.sourceIndicesWithGeoFields
+              );
+              await application.navigateToApp(MAPS_APP_ID, { path: mapsLink?.path });
+            }}
+            data-test-subj="mlAnomaliesListRowActionViewSourceIndexInMapsButton"
+          >
+            <FormattedMessage
+              id="xpack.ml.anomaliesTable.linksMenu.viewSourceIndexInMapsLabel"
+              defaultMessage="View source index in Maps"
+            />
+          </EuiContextMenuItem>
+        );
+      }
     }
 
     if (application.capabilities.discover?.show && isCategorizationAnomalyRecord) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/139750
Check if maps plugin is enabled before showing link to maps in anomalies table.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


