### PR TITLE
Track usage of Maps embeddables in solutions

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/anomalies_map.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/anomalies_map.tsx
@@ -25,6 +25,7 @@ import {
   VectorLayerDescriptor,
 } from '@kbn/maps-plugin/common';
 import { EMSTermJoinConfig } from '@kbn/maps-plugin/public';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { useMlKibana } from '../contexts/kibana';
 import { isDefined } from '../../../common/types/guards';
 import { MlEmbeddedMapComponent } from '../components/ml_embedded_map';
@@ -252,7 +253,9 @@ export const AnomaliesMap: FC<Props> = ({ anomalies, jobIds }) => {
             data-test-subj="mlAnomalyExplorerAnomaliesMap"
             style={{ width: '100%', height: 300 }}
           >
-            <MlEmbeddedMapComponent layerList={layerList} />
+            <TrackApplicationView viewId="anomalies-map">
+              <MlEmbeddedMapComponent layerList={layerList} />
+            </TrackApplicationView>
           </div>
         </EuiAccordion>
       </EuiPanel>

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 
 import { isTab } from '@kbn/timelines-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import { SecurityPageName } from '../../app/types';
 import type { UpdateDateRange } from '../../common/components/charts/common';
@@ -178,19 +179,21 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
 
                 {canUseMaps && (
                   <>
-                    <EuiPanel
-                      hasBorder
-                      paddingSize="none"
-                      data-test-subj="conditional-embeddable-map"
-                    >
-                      <EmbeddedMap
-                        query={query}
-                        filters={filters}
-                        startDate={from}
-                        endDate={to}
-                        setQuery={setQuery}
-                      />
-                    </EuiPanel>
+                    <TrackApplicationView viewId="network-map">
+                      <EuiPanel
+                        hasBorder
+                        paddingSize="none"
+                        data-test-subj="conditional-embeddable-map"
+                      >
+                        <EmbeddedMap
+                          query={query}
+                          filters={filters}
+                          startDate={from}
+                          endDate={to}
+                          setQuery={setQuery}
+                        />
+                      </EuiPanel>
+                    </TrackApplicationView>
                     <EuiSpacer />
                   </>
                 )}

--- a/x-pack/plugins/ux/kibana.json
+++ b/x-pack/plugins/ux/kibana.json
@@ -27,7 +27,7 @@
   "server": false,
   "ui": true,
   "configPath": ["xpack", "ux"],
-  "requiredBundles": ["kibanaReact", "observability", "maps"],
+  "requiredBundles": ["kibanaReact", "observability", "maps", "usageCollection"],
   "owner": {
     "name": "Uptime",
     "githubTeam": "uptime"

--- a/x-pack/plugins/ux/public/application/ux_app.tsx
+++ b/x-pack/plugins/ux/public/application/ux_app.tsx
@@ -127,42 +127,47 @@ export function UXAppRoot({
   const plugins = { ...deps, maps };
 
   createCallApmApi(core);
+  const ApplicationUsageTrackingProvider =
+    plugins.usageCollection?.components.ApplicationUsageTrackingProvider ??
+    React.Fragment;
 
   return (
-    <RedirectAppLinks
-      className={APP_WRAPPER_CLASS}
-      application={core.application}
-    >
-      <KibanaContextProvider
-        services={{
-          ...core,
-          ...plugins,
-          inspector,
-          observability,
-          embeddable,
-          data,
-          dataViews,
-          lens,
-        }}
+    <ApplicationUsageTrackingProvider>
+      <RedirectAppLinks
+        className={APP_WRAPPER_CLASS}
+        application={core.application}
       >
-        <i18nCore.Context>
-          <RouterProvider history={history} router={uxRouter}>
-            <DatePickerContextProvider>
-              <InspectorContextProvider>
-                <UrlParamsProvider>
-                  <EuiErrorBoundary>
-                    <CsmSharedContextProvider>
-                      <UxApp />
-                    </CsmSharedContextProvider>
-                  </EuiErrorBoundary>
-                  <UXActionMenu appMountParameters={appMountParameters} />
-                </UrlParamsProvider>
-              </InspectorContextProvider>
-            </DatePickerContextProvider>
-          </RouterProvider>
-        </i18nCore.Context>
-      </KibanaContextProvider>
-    </RedirectAppLinks>
+        <KibanaContextProvider
+          services={{
+            ...core,
+            ...plugins,
+            inspector,
+            observability,
+            embeddable,
+            data,
+            dataViews,
+            lens,
+          }}
+        >
+          <i18nCore.Context>
+            <RouterProvider history={history} router={uxRouter}>
+              <DatePickerContextProvider>
+                <InspectorContextProvider>
+                  <UrlParamsProvider>
+                    <EuiErrorBoundary>
+                      <CsmSharedContextProvider>
+                        <UxApp />
+                      </CsmSharedContextProvider>
+                    </EuiErrorBoundary>
+                    <UXActionMenu appMountParameters={appMountParameters} />
+                  </UrlParamsProvider>
+                </InspectorContextProvider>
+              </DatePickerContextProvider>
+            </RouterProvider>
+          </i18nCore.Context>
+        </KibanaContextProvider>
+      </RedirectAppLinks>
+    </ApplicationUsageTrackingProvider>
   );
 }
 
@@ -190,6 +195,9 @@ export const renderApp = ({
     // eslint-disable-next-line no-console
     console.log('Error creating static data view', e);
   });
+  const ApplicationUsageTrackingProvider =
+    deps.usageCollection?.components.ApplicationUsageTrackingProvider ??
+    React.Fragment;
 
   ReactDOM.render(
     <UXAppRoot

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/panels/visitor_breakdowns.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/panels/visitor_breakdowns.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { VisitorBreakdown } from '../visitor_breakdown';
 import { VisitorBreakdownMap } from '../visitor_breakdown_map';
 
@@ -15,7 +16,9 @@ export function VisitorBreakdownsPanel() {
     <EuiFlexGroup gutterSize="s" wrap>
       <EuiFlexItem style={{ flexBasis: 650 }}>
         <EuiPanel hasBorder={true}>
-          <VisitorBreakdownMap />
+          <TrackApplicationView viewId="visitor-breakdown-map">
+            <VisitorBreakdownMap />
+          </TrackApplicationView>
         </EuiPanel>
       </EuiFlexItem>
       <EuiFlexItem style={{ flexBasis: 650 }}>

--- a/x-pack/plugins/ux/public/plugin.ts
+++ b/x-pack/plugins/ux/public/plugin.ts
@@ -34,6 +34,7 @@ import { MapsStartApi } from '@kbn/maps-plugin/public';
 import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
+import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 
 export type UxPluginSetup = void;
 export type UxPluginStart = void;
@@ -44,6 +45,7 @@ export interface ApmPluginSetupDeps {
   home?: HomePublicPluginSetup;
   licensing: LicensingPluginSetup;
   observability: ObservabilityPublicSetup;
+  usageCollection?: UsageCollectionSetup;
 }
 
 export interface ApmPluginStartDeps {


### PR DESCRIPTION
WIP! Please don't review or merge yet. 😄 

## Summary

Track usage of Map embeddables in Machine Learning, Security, and User Experience solutions.

The Maps team wants to better understand how Maps embeddables are used across solutions. This PR wraps the Maps embeddables with the [`TrackApplicationView` component](https://github.com/elastic/kibana/blob/main/src/plugins/kibana_usage_collection/server/collectors/application_usage/README.md) to send active minutes and number of clicks to our telemetry service. 

The UX plugin is not currently capturing any Application Usage, so I added the `usageCollection` module to the plugin so that I could add tracking to the map embeddable component. 

## Testing this PR

Testing this PR requires an Elasticsearch cluster that has data from APM and Security Integrations. Internal users should use the [oblt-cli tool](https://github.com/elastic/observability-test-environments/blob/main/tools/oblt_cli/README.md) to connect to a test elasticsearch instance.

### User experience
1. Open the User Experience application under Observability in the side bar.
2. Change the time picker to a larger window (ex. 30 days) so that data shows on the Page load duration by region (avg.) map.
3. Interact with the map by clicking on features or expanding the Layers menu component.
4. In Dev tools run  the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
5. Search the results for `application_usage` and locate the `ux` plugin. You should see clicks and minutes on screen for the `main` and `visitor-breakdown-map` views. For example: 
```json
...
"ux": {
    "appId": "ux",
    "viewId": "main",
    "clicks_total": 160,
    "clicks_7_days": 160,
    "clicks_30_days": 160,
    "clicks_90_days": 160,
    "minutes_on_screen_total": 32.36535,
    "minutes_on_screen_7_days": 32.36535,
    "minutes_on_screen_30_days": 32.36535,
    "minutes_on_screen_90_days": 32.36535,
    "views": [
      {
        "appId": "ux",
        "viewId": "visitor-breakdown-map",
        "clicks_total": 46,
        "clicks_7_days": 46,
        "clicks_30_days": 46,
        "clicks_90_days": 46,
        "minutes_on_screen_total": 13.511466666666667,
        "minutes_on_screen_7_days": 13.511466666666667,
        "minutes_on_screen_30_days": 13.511466666666667,
        "minutes_on_screen_90_days": 13.511466666666667
      }
    ]
  }
...
```

### Security solution

1. Open the Explore page under Security in the side bar.
2. Choose the Network page.
3. Change the time picker to a larger window (ex. 30 days) so that data shows on the Network map.
4. Interact with the map by clicking on features or expanding the Layers menu component.
5.  In Dev tools run  the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
6. Search the results for `application_usage` and locate the `securitySolutionUI` plugin. You should see clicks and minutes for the `network-map` view.  For example:

```json
...
"securitySolutionUI": {
    "appId": "securitySolutionUI",
    "viewId": "main",
    "clicks_total": 154,
    "clicks_7_days": 154,
    "clicks_30_days": 154,
    "clicks_90_days": 154,
    "minutes_on_screen_total": 28.4324,
    "minutes_on_screen_7_days": 28.4324,
    "minutes_on_screen_30_days": 28.4324,
    "minutes_on_screen_90_days": 28.4324,
    "views": [
      {
        "appId": "securitySolutionUI",
        "viewId": "network",
        "clicks_total": 37,
        "clicks_7_days": 37,
        "clicks_30_days": 37,
        "clicks_90_days": 37,
        "minutes_on_screen_total": 26.45923333333333,
        "minutes_on_screen_7_days": 26.45923333333333,
        "minutes_on_screen_30_days": 26.45923333333333,
        "minutes_on_screen_90_days": 26.45923333333333
      },
      {
        "appId": "securitySolutionUI",
        "viewId": "network-map",
        "clicks_total": 24,
        "clicks_7_days": 24,
        "clicks_30_days": 24,
        "clicks_90_days": 24,
        "minutes_on_screen_total": 16.68948333333333,
        "minutes_on_screen_7_days": 16.68948333333333,
        "minutes_on_screen_30_days": 16.68948333333333,
        "minutes_on_screen_90_days": 16.68948333333333
      },
...
``` 


### Machine Learning (not working yet)

1. Start Elasticsearch and Kibana using a trial license (`yarn es snapshot --license trial` and `yarn start`). 
2. Install the eCommerce and Web logs sample datasets.
3. Use the example at https://www.elastic.co/guide/en/machine-learning/8.4/geographic-anomalies.html to create a new Anomaly detection job.
4. Open the Anomaly Explorer page under Machine Learning and choose the job(s) to display
5. On the Anomaly timeline click a colored cell to open a map showing the anomalies.
6. Interact with the map by clicking on features or expanding the Layers menu component.
7. In Dev tools run  the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
8. Search the results for `application_usage` and locate the `ml` plugin. You should see clicks and minutes for the `anomalies-map` view.  For example:
** TODO **




-----

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
