### PR TITLE
[Security Solution][Detections] Add Bulk Scheduling for rules

### DIFF
--- a/packages/kbn-securitysolution-io-ts-types/index.ts
+++ b/packages/kbn-securitysolution-io-ts-types/index.ts
@@ -30,6 +30,6 @@ export * from './src/operator';
 export * from './src/positive_integer_greater_than_zero';
 export * from './src/positive_integer';
 export * from './src/string_to_positive_number';
-export * from './src/time_length';
+export * from './src/time_duration';
 export * from './src/uuid';
 export * from './src/version';

--- a/packages/kbn-securitysolution-io-ts-types/index.ts
+++ b/packages/kbn-securitysolution-io-ts-types/index.ts
@@ -30,5 +30,6 @@ export * from './src/operator';
 export * from './src/positive_integer_greater_than_zero';
 export * from './src/positive_integer';
 export * from './src/string_to_positive_number';
+export * from './src/time_length';
 export * from './src/uuid';
 export * from './src/version';

--- a/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.test.ts
+++ b/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.test.ts
@@ -8,86 +8,97 @@
 
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
-import { TimeLength } from '.';
+import { TimeDuration } from '.';
 import { foldLeftRight, getPaths } from '@kbn/securitysolution-io-ts-utils';
 
 describe('time_unit', () => {
-  test('it should validate a correctly formed TimeLength with time unit of seconds', () => {
+  test('it should validate a correctly formed TimeDuration with time unit of seconds', () => {
     const payload = '1s';
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should validate a correctly formed TimeLength with time unit of minutes', () => {
+  test('it should validate a correctly formed TimeDuration with time unit of minutes', () => {
     const payload = '100m';
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should validate a correctly formed TimeLength with time unit of hours', () => {
+  test('it should validate a correctly formed TimeDuration with time unit of hours', () => {
     const payload = '10000000h';
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should NOT validate a TimeLength with some other time unit', () => {
-    const payload = '10000000w';
-    const decoded = TimeLength.decode(payload);
+  test('it should NOT validate a negative TimeDuration', () => {
+    const payload = '-10s';
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "10000000w" supplied to "TimeLength"',
+      'Invalid value "-10s" supplied to "TimeDuration"',
     ]);
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate a TimeLength with a time interval with incorrect format', () => {
-    const payload = '100ff0000w';
-    const decoded = TimeLength.decode(payload);
+  test('it should NOT validate a TimeDuration with some other time unit', () => {
+    const payload = '10000000w';
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "100ff0000w" supplied to "TimeLength"',
+      'Invalid value "10000000w" supplied to "TimeDuration"',
+    ]);
+    expect(message.schema).toEqual({});
+  });
+
+  test('it should NOT validate a TimeDuration with a time interval with incorrect format', () => {
+    const payload = '100ff0000w';
+    const decoded = TimeDuration.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "100ff0000w" supplied to "TimeDuration"',
     ]);
     expect(message.schema).toEqual({});
   });
 
   test('it should NOT validate an empty string', () => {
     const payload = '';
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))).toEqual(['Invalid value "" supplied to "TimeLength"']);
+    expect(getPaths(left(message.errors))).toEqual(['Invalid value "" supplied to "TimeDuration"']);
     expect(message.schema).toEqual({});
   });
 
   test('it should NOT validate an number', () => {
     const payload = 100;
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "100" supplied to "TimeLength"',
+      'Invalid value "100" supplied to "TimeDuration"',
     ]);
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate an TimeLength with a valid time unit but unsafe integer', () => {
+  test('it should NOT validate an TimeDuration with a valid time unit but unsafe integer', () => {
     const payload = `${Math.pow(2, 53)}h`;
-    const decoded = TimeLength.decode(payload);
+    const decoded = TimeDuration.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([
-      `Invalid value "${Math.pow(2, 53)}h" supplied to "TimeLength"`,
+      `Invalid value "${Math.pow(2, 53)}h" supplied to "TimeDuration"`,
     ]);
     expect(message.schema).toEqual({});
   });

--- a/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.ts
+++ b/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.ts
@@ -11,7 +11,7 @@ import { Either } from 'fp-ts/lib/Either';
 
 /**
  * Types the TimeDuration as:
- *   - A string that is not empty, and composed of a positive integer followed by a unit of time
+ *   - A string that is not empty, and composed of a positive integer greater than 0 followed by a unit of time
  *   - in the format {safe_integer}{timeUnit}, e.g. "30s", "1m", "2h"
  */
 export const TimeDuration = new t.Type<string, string, unknown>(
@@ -24,7 +24,7 @@ export const TimeDuration = new t.Type<string, string, unknown>(
         const time = parseInt(input.trim().substring(0, inputLength - 1), 10);
         const unit = input.trim().at(-1);
         if (
-          time >= 0 &&
+          time >= 1 &&
           Number.isSafeInteger(time) &&
           (unit === 's' || unit === 'm' || unit === 'h')
         ) {

--- a/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.ts
+++ b/packages/kbn-securitysolution-io-ts-types/src/time_duration/index.ts
@@ -10,11 +10,12 @@ import * as t from 'io-ts';
 import { Either } from 'fp-ts/lib/Either';
 
 /**
- * Types the TimeLength as:
- *   - A string that is not empty
+ * Types the TimeDuration as:
+ *   - A string that is not empty, and composed of a positive integer followed by a unit of time
+ *   - in the format {safe_integer}{timeUnit}, e.g. "30s", "1m", "2h"
  */
-export const TimeLength = new t.Type<string, string, unknown>(
-  'TimeLength',
+export const TimeDuration = new t.Type<string, string, unknown>(
+  'TimeDuration',
   t.string.is,
   (input, context): Either<t.Errors, string> => {
     if (typeof input === 'string' && input.trim() !== '') {
@@ -22,7 +23,11 @@ export const TimeLength = new t.Type<string, string, unknown>(
         const inputLength = input.length;
         const time = parseInt(input.trim().substring(0, inputLength - 1), 10);
         const unit = input.trim().at(-1);
-        if (Number.isSafeInteger(time) && (unit === 's' || unit === 'm' || unit === 'h')) {
+        if (
+          time >= 0 &&
+          Number.isSafeInteger(time) &&
+          (unit === 's' || unit === 'm' || unit === 'h')
+        ) {
           return t.success(input);
         } else {
           return t.failure(input, context);
@@ -37,4 +42,4 @@ export const TimeLength = new t.Type<string, string, unknown>(
   t.identity
 );
 
-export type TimeLengthC = typeof TimeLength;
+export type TimeDurationC = typeof TimeDuration;

--- a/packages/kbn-securitysolution-io-ts-types/src/time_length/index.test.ts
+++ b/packages/kbn-securitysolution-io-ts-types/src/time_length/index.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { pipe } from 'fp-ts/lib/pipeable';
+import { left } from 'fp-ts/lib/Either';
+import { TimeLength } from '.';
+import { foldLeftRight, getPaths } from '@kbn/securitysolution-io-ts-utils';
+
+describe('time_unit', () => {
+  test('it should validate a correctly formed TimeLength with time unit of seconds', () => {
+    const payload = '1s';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([]);
+    expect(message.schema).toEqual(payload);
+  });
+
+  test('it should validate a correctly formed TimeLength with time unit of minutes', () => {
+    const payload = '100m';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([]);
+    expect(message.schema).toEqual(payload);
+  });
+
+  test('it should validate a correctly formed TimeLength with time unit of hours', () => {
+    const payload = '10000000h';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([]);
+    expect(message.schema).toEqual(payload);
+  });
+
+  test('it should NOT validate a TimeLength with some other time unit', () => {
+    const payload = '10000000w';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "10000000w" supplied to "TimeLength"',
+    ]);
+    expect(message.schema).toEqual({});
+  });
+
+  test('it should NOT validate a TimeLength with a time interval with incorrect format', () => {
+    const payload = '100ff0000w';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "100ff0000w" supplied to "TimeLength"',
+    ]);
+    expect(message.schema).toEqual({});
+  });
+
+  test('it should NOT validate an empty string', () => {
+    const payload = '';
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual(['Invalid value "" supplied to "TimeLength"']);
+    expect(message.schema).toEqual({});
+  });
+
+  test('it should NOT validate an number', () => {
+    const payload = 100;
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "100" supplied to "TimeLength"',
+    ]);
+    expect(message.schema).toEqual({});
+  });
+
+  test('it should NOT validate an TimeLength with a valid time unit but unsafe integer', () => {
+    const payload = `${Math.pow(2, 53)}h`;
+    const decoded = TimeLength.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual([
+      `Invalid value "${Math.pow(2, 53)}h" supplied to "TimeLength"`,
+    ]);
+    expect(message.schema).toEqual({});
+  });
+});

--- a/packages/kbn-securitysolution-io-ts-types/src/time_length/index.ts
+++ b/packages/kbn-securitysolution-io-ts-types/src/time_length/index.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import * as t from 'io-ts';
+import { Either } from 'fp-ts/lib/Either';
+
+/**
+ * Types the TimeLength as:
+ *   - A string that is not empty
+ */
+export const TimeLength = new t.Type<string, string, unknown>(
+  'TimeLength',
+  t.string.is,
+  (input, context): Either<t.Errors, string> => {
+    if (typeof input === 'string' && input.trim() !== '') {
+      try {
+        const inputLength = input.length;
+        const time = parseInt(input.trim().substring(0, inputLength - 1), 10);
+        const unit = input.trim().at(-1);
+        if (Number.isSafeInteger(time) && (unit === 's' || unit === 'm' || unit === 'h')) {
+          return t.success(input);
+        } else {
+          return t.failure(input, context);
+        }
+      } catch (error) {
+        return t.failure(input, context);
+      }
+    } else {
+      return t.failure(input, context);
+    }
+  },
+  t.identity
+);
+
+export type TimeLengthC = typeof TimeLength;

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
@@ -377,6 +377,102 @@ describe('perform_bulk_action_schema', () => {
       });
     });
 
+    describe('schedules', () => {
+      test('invalid request: wrong schedules payload type', () => {
+        const payload = {
+          query: 'name: test',
+          action: BulkAction.edit,
+          [BulkAction.edit]: [{ type: BulkActionEditType.set_schedule, value: [] }],
+        };
+
+        const message = retrieveValidationMessage(payload);
+
+        expect(getPaths(left(message.errors))).toEqual([
+          'Invalid value "edit" supplied to "action"',
+          'Invalid value "set_schedule" supplied to "edit,type"',
+          'Invalid value "[]" supplied to "edit,value"',
+        ]);
+        expect(message.schema).toEqual({});
+      });
+
+      test('invalid request: missing interval', () => {
+        const payload = {
+          query: 'name: test',
+          action: BulkAction.edit,
+          [BulkAction.edit]: [
+            {
+              type: BulkActionEditType.set_schedule,
+              value: {
+                meta: {
+                  from: '1m',
+                },
+              },
+            },
+          ],
+        };
+
+        const message = retrieveValidationMessage(payload);
+
+        expect(getPaths(left(message.errors))).toEqual(
+          expect.arrayContaining([
+            'Invalid value "edit" supplied to "action"',
+            'Invalid value "{"meta":{"from":"1m"}}" supplied to "edit,value"',
+            'Invalid value "undefined" supplied to "edit,value,interval"',
+          ])
+        );
+        expect(message.schema).toEqual({});
+      });
+
+      test('invalid request: missing lookback', () => {
+        const payload = {
+          query: 'name: test',
+          action: BulkAction.edit,
+          [BulkAction.edit]: [
+            {
+              type: BulkActionEditType.set_schedule,
+              value: {
+                interval: '1m',
+              },
+            },
+          ],
+        };
+
+        const message = retrieveValidationMessage(payload);
+
+        expect(getPaths(left(message.errors))).toEqual(
+          expect.arrayContaining([
+            'Invalid value "edit" supplied to "action"',
+            'Invalid value "{"interval":"1m"}" supplied to "edit,value"',
+            'Invalid value "undefined" supplied to "edit,value,meta"',
+          ])
+        );
+        expect(message.schema).toEqual({});
+      });
+
+      test('valid request: set_schedule edit action', () => {
+        const payload: PerformBulkActionSchema = {
+          query: 'name: test',
+          action: BulkAction.edit,
+          [BulkAction.edit]: [
+            {
+              type: BulkActionEditType.set_schedule,
+              value: {
+                interval: '1m',
+                meta: {
+                  from: '1m',
+                },
+              },
+            },
+          ],
+        };
+
+        const message = retrieveValidationMessage(payload);
+
+        expect(getPaths(left(message.errors))).toEqual([]);
+        expect(message.schema).toEqual(payload);
+      });
+    });
+
     describe('rule actions', () => {
       test('invalid request: invalid rule actions payload', () => {
         const payload = {

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
@@ -403,13 +403,11 @@ describe('perform_bulk_action_schema', () => {
             {
               type: BulkActionEditType.set_schedule,
               value: {
-                meta: {
-                  from: '1m',
-                },
+                lookback: '1m',
               },
             },
           ],
-        };
+        } as PerformBulkActionSchema;
 
         const message = retrieveValidationMessage(payload);
 
@@ -435,7 +433,7 @@ describe('perform_bulk_action_schema', () => {
               },
             },
           ],
-        };
+        } as PerformBulkActionSchema;
 
         const message = retrieveValidationMessage(payload);
 
@@ -462,7 +460,7 @@ describe('perform_bulk_action_schema', () => {
               },
             },
           ],
-        };
+        } as PerformBulkActionSchema;
 
         const message = retrieveValidationMessage(payload);
 

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
@@ -458,9 +458,7 @@ describe('perform_bulk_action_schema', () => {
               type: BulkActionEditType.set_schedule,
               value: {
                 interval: '1m',
-                meta: {
-                  from: '1m',
-                },
+                lookback: '1m',
               },
             },
           ],

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.test.ts
@@ -395,6 +395,33 @@ describe('perform_bulk_action_schema', () => {
         expect(message.schema).toEqual({});
       });
 
+      test('invalid request: wrong type of payload data', () => {
+        const payload = {
+          query: 'name: test',
+          action: BulkAction.edit,
+          [BulkAction.edit]: [
+            {
+              type: BulkActionEditType.set_schedule,
+              value: {
+                interval: '-10m',
+                lookback: '1m',
+              },
+            },
+          ],
+        } as PerformBulkActionSchema;
+
+        const message = retrieveValidationMessage(payload);
+
+        expect(getPaths(left(message.errors))).toEqual(
+          expect.arrayContaining([
+            'Invalid value "edit" supplied to "action"',
+            'Invalid value "{"interval":"-10m","lookback":"1m"}" supplied to "edit,value"',
+            'Invalid value "-10m" supplied to "edit,value,interval"',
+          ])
+        );
+        expect(message.schema).toEqual({});
+      });
+
       test('invalid request: missing interval', () => {
         const payload = {
           query: 'name: test',
@@ -414,7 +441,7 @@ describe('perform_bulk_action_schema', () => {
         expect(getPaths(left(message.errors))).toEqual(
           expect.arrayContaining([
             'Invalid value "edit" supplied to "action"',
-            'Invalid value "{"meta":{"from":"1m"}}" supplied to "edit,value"',
+            'Invalid value "{"lookback":"1m"}" supplied to "edit,value"',
             'Invalid value "undefined" supplied to "edit,value,interval"',
           ])
         );
@@ -441,7 +468,7 @@ describe('perform_bulk_action_schema', () => {
           expect.arrayContaining([
             'Invalid value "edit" supplied to "action"',
             'Invalid value "{"interval":"1m"}" supplied to "edit,value"',
-            'Invalid value "undefined" supplied to "edit,value,meta"',
+            'Invalid value "undefined" supplied to "edit,value,lookback"',
           ])
         );
         expect(message.schema).toEqual({});

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -114,6 +114,9 @@ const bulkActionEditPayloadSchedule = t.type({
   type: t.literal(BulkActionEditType.set_schedule),
   value: t.type({
     interval,
+    meta: t.type({
+      from: t.string,
+    }),
   }),
 });
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;
@@ -141,7 +144,8 @@ export type BulkActionEditForRuleAttributes =
  */
 export type BulkActionEditForRuleParams =
   | BulkActionEditPayloadIndexPatterns
-  | BulkActionEditPayloadTimeline;
+  | BulkActionEditPayloadTimeline
+  | BulkActionEditPayloadSchedule;
 
 export const performBulkActionSchema = t.intersection([
   t.exact(

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -110,21 +110,15 @@ const bulkActionEditPayloadRuleActions = t.type({
 
 export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPayloadRuleActions>;
 
-const bulkActionEditPayloadSchedule = t.intersection([
-  t.type({
-    type: t.literal(BulkActionEditType.set_schedule),
-    value: t.type({
-      interval,
+const bulkActionEditPayloadSchedule = t.type({
+  type: t.literal(BulkActionEditType.set_schedule),
+  value: t.type({
+    interval,
+    meta: t.type({
+      from: t.string,
     }),
   }),
-  t.partial({
-    value: t.type({
-      meta: t.type({
-        from: t.string,
-      }),
-    }),
-  }),
-]);
+});
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;
 
 export const bulkActionEditPayload = t.union([

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -110,15 +110,21 @@ const bulkActionEditPayloadRuleActions = t.type({
 
 export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPayloadRuleActions>;
 
-const bulkActionEditPayloadSchedule = t.type({
-  type: t.literal(BulkActionEditType.set_schedule),
-  value: t.type({
-    interval,
-    meta: t.type({
-      from: t.string,
+const bulkActionEditPayloadSchedule = t.intersection([
+  t.type({
+    type: t.literal(BulkActionEditType.set_schedule),
+    value: t.type({
+      interval,
     }),
   }),
-});
+  t.partial({
+    value: t.type({
+      meta: t.type({
+        from: t.string,
+      }),
+    }),
+  }),
+]);
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;
 
 export const bulkActionEditPayload = t.union([

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -15,7 +15,14 @@ import {
   action_id as actionId,
 } from '@kbn/securitysolution-io-ts-alerting-types';
 
-import { queryOrUndefined, tags, index, timeline_id, timeline_title } from '../common/schemas';
+import {
+  queryOrUndefined,
+  tags,
+  index,
+  timeline_id,
+  timeline_title,
+  interval,
+} from '../common/schemas';
 
 export enum BulkAction {
   'enable' = 'enable',
@@ -38,6 +45,7 @@ export enum BulkActionEditType {
   'set_timeline' = 'set_timeline',
   'add_rule_actions' = 'add_rule_actions',
   'set_rule_actions' = 'set_rule_actions',
+  'set_schedule' = 'set_schedule',
 }
 
 const bulkActionEditPayloadTags = t.type({
@@ -102,11 +110,20 @@ const bulkActionEditPayloadRuleActions = t.type({
 
 export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPayloadRuleActions>;
 
+const bulkActionEditPayloadSchedule = t.type({
+  type: t.literal(BulkActionEditType.set_schedule),
+  value: t.type({
+    interval,
+  }),
+});
+export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;
+
 export const bulkActionEditPayload = t.union([
   bulkActionEditPayloadTags,
   bulkActionEditPayloadIndexPatterns,
   bulkActionEditPayloadTimeline,
   bulkActionEditPayloadRuleActions,
+  bulkActionEditPayloadSchedule,
 ]);
 
 export type BulkActionEditPayload = t.TypeOf<typeof bulkActionEditPayload>;
@@ -116,7 +133,8 @@ export type BulkActionEditPayload = t.TypeOf<typeof bulkActionEditPayload>;
  */
 export type BulkActionEditForRuleAttributes =
   | BulkActionEditPayloadTags
-  | BulkActionEditPayloadRuleActions;
+  | BulkActionEditPayloadRuleActions
+  | BulkActionEditPayloadSchedule;
 
 /**
  * actions that modify rules params

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { NonEmptyArray, enumeration } from '@kbn/securitysolution-io-ts-types';
+import { NonEmptyArray, NonEmptyString, enumeration } from '@kbn/securitysolution-io-ts-types';
 
 import {
   throttle,
@@ -15,14 +15,7 @@ import {
   action_id as actionId,
 } from '@kbn/securitysolution-io-ts-alerting-types';
 
-import {
-  queryOrUndefined,
-  tags,
-  index,
-  timeline_id,
-  timeline_title,
-  interval,
-} from '../common/schemas';
+import { queryOrUndefined, tags, index, timeline_id, timeline_title } from '../common/schemas';
 
 export enum BulkAction {
   'enable' = 'enable',
@@ -113,10 +106,8 @@ export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPay
 const bulkActionEditPayloadSchedule = t.type({
   type: t.literal(BulkActionEditType.set_schedule),
   value: t.type({
-    interval,
-    meta: t.type({
-      from: t.string,
-    }),
+    interval: NonEmptyString,
+    lookback: NonEmptyString,
   }),
 });
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { NonEmptyArray, NonEmptyString, enumeration } from '@kbn/securitysolution-io-ts-types';
+import { NonEmptyArray, TimeDuration, enumeration } from '@kbn/securitysolution-io-ts-types';
 
 import {
   throttle,
@@ -106,8 +106,8 @@ export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPay
 const bulkActionEditPayloadSchedule = t.type({
   type: t.literal(BulkActionEditType.set_schedule),
   value: t.type({
-    interval: NonEmptyString,
-    lookback: NonEmptyString,
+    interval: TimeDuration,
+    lookback: TimeDuration,
   }),
 });
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { NonEmptyArray, NonEmptyString, enumeration } from '@kbn/securitysolution-io-ts-types';
+import { NonEmptyArray, TimeLength, enumeration } from '@kbn/securitysolution-io-ts-types';
 
 import {
   throttle,
@@ -106,8 +106,8 @@ export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPay
 const bulkActionEditPayloadSchedule = t.type({
   type: t.literal(BulkActionEditType.set_schedule),
   value: t.type({
-    interval: NonEmptyString,
-    lookback: NonEmptyString,
+    interval: TimeLength,
+    lookback: TimeLength,
   }),
 });
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;

--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/perform_bulk_action_schema.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { NonEmptyArray, TimeLength, enumeration } from '@kbn/securitysolution-io-ts-types';
+import { NonEmptyArray, NonEmptyString, enumeration } from '@kbn/securitysolution-io-ts-types';
 
 import {
   throttle,
@@ -106,8 +106,8 @@ export type BulkActionEditPayloadRuleActions = t.TypeOf<typeof bulkActionEditPay
 const bulkActionEditPayloadSchedule = t.type({
   type: t.literal(BulkActionEditType.set_schedule),
   value: t.type({
-    interval: TimeLength,
-    lookback: TimeLength,
+    interval: NonEmptyString,
+    lookback: NonEmptyString,
   }),
 });
 export type BulkActionEditPayloadSchedule = t.TypeOf<typeof bulkActionEditPayloadSchedule>;

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -23,7 +23,7 @@ import {
   APPLY_TIMELINE_RULE_BULK_MENU_ITEM,
 } from '../../screens/rules_bulk_edit';
 
-import { TIMELINE_TEMPLATE_DETAILS } from '../../screens/rule_details';
+import { SCHEDULE_DETAILS, TIMELINE_TEMPLATE_DETAILS } from '../../screens/rule_details';
 
 import { EUI_FILTER_SELECT_ITEM } from '../../screens/common/controls';
 
@@ -64,6 +64,12 @@ import {
   openBulkEditDeleteIndexPatternsForm,
   selectTimelineTemplate,
   checkTagsInTagsFilter,
+  clickUpdateScheduleMenuItem,
+  typeScheduleInterval,
+  typeScheduleLookback,
+  setScheduleLookbackTimeUnit,
+  setScheduleIntervalTimeUnit,
+  assertRuleScheduleValues,
 } from '../../tasks/rules_bulk_edit';
 
 import { hasIndexPatterns, getDetails } from '../../tasks/rule_details';
@@ -482,6 +488,51 @@ describe('Detection rules, bulk edit', () => {
       // check if timeline template has been updated to selected one, by opening rule that have had timeline prior to editing
       goToTheRuleDetailsOf(RULE_NAME);
       getDetails(TIMELINE_TEMPLATE_DETAILS).should('have.text', noneTimelineTemplate);
+    });
+  });
+
+  describe('Schedule', () => {
+    it('Updates schedule for custom rules', () => {
+      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      clickUpdateScheduleMenuItem();
+
+      typeScheduleInterval('20');
+      setScheduleIntervalTimeUnit('Hours');
+
+      typeScheduleLookback('10');
+      setScheduleLookbackTimeUnit('Minutes');
+
+      submitBulkEditForm();
+      waitForBulkEditActionToFinish({ rulesCount: expectedNumberOfCustomRulesToBeEdited });
+
+      goToTheRuleDetailsOf(RULE_NAME);
+
+      assertRuleScheduleValues({
+        interval: '20h',
+        lookback: '10m',
+      });
+    });
+
+    it('Validates invalid inputs when scheduling for custom rules', () => {
+      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      clickUpdateScheduleMenuItem();
+
+      // Validate invalid values are corrected to minimumValue - for 0 and negative values
+      typeScheduleInterval('0');
+      setScheduleIntervalTimeUnit('Hours');
+
+      typeScheduleLookback('-5');
+      setScheduleLookbackTimeUnit('Seconds');
+
+      submitBulkEditForm();
+      waitForBulkEditActionToFinish({ rulesCount: expectedNumberOfCustomRulesToBeEdited });
+
+      goToTheRuleDetailsOf(RULE_NAME);
+
+      assertRuleScheduleValues({
+        interval: '1h',
+        lookback: '1s',
+      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -23,7 +23,7 @@ import {
   APPLY_TIMELINE_RULE_BULK_MENU_ITEM,
 } from '../../screens/rules_bulk_edit';
 
-import { SCHEDULE_DETAILS, TIMELINE_TEMPLATE_DETAILS } from '../../screens/rule_details';
+import { TIMELINE_TEMPLATE_DETAILS } from '../../screens/rule_details';
 
 import { EUI_FILTER_SELECT_ITEM } from '../../screens/common/controls';
 
@@ -70,6 +70,7 @@ import {
   setScheduleLookbackTimeUnit,
   setScheduleIntervalTimeUnit,
   assertRuleScheduleValues,
+  assertUpdateScheduleWarningExists,
 } from '../../tasks/rules_bulk_edit';
 
 import { hasIndexPatterns, getDetails } from '../../tasks/rule_details';
@@ -495,6 +496,8 @@ describe('Detection rules, bulk edit', () => {
     it('Updates schedule for custom rules', () => {
       selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
       clickUpdateScheduleMenuItem();
+
+      assertUpdateScheduleWarningExists(expectedNumberOfCustomRulesToBeEdited);
 
       typeScheduleInterval('20');
       setScheduleIntervalTimeUnit('Hours');

--- a/x-pack/plugins/security_solution/cypress/screens/rules_bulk_edit.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/rules_bulk_edit.ts
@@ -48,6 +48,8 @@ export const RULES_BULK_EDIT_TIMELINE_TEMPLATES_SELECTOR =
 export const RULES_BULK_EDIT_TIMELINE_TEMPLATES_WARNING =
   '[data-test-subj="bulkEditRulesTimelineTemplateWarning"]';
 
+export const RULES_BULK_EDIT_SCHEDULES_WARNING = '[data-test-subj="bulkEditRulesSchedulesWarning"]';
+
 export const UPDATE_SCHEDULE_INTERVAL_INPUT =
   '[data-test-subj="bulkEditRulesScheduleIntervalSelector"]';
 

--- a/x-pack/plugins/security_solution/cypress/screens/rules_bulk_edit.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/rules_bulk_edit.ts
@@ -13,6 +13,8 @@ export const ADD_INDEX_PATTERNS_RULE_BULK_MENU_ITEM =
 export const DELETE_INDEX_PATTERNS_RULE_BULK_MENU_ITEM =
   '[data-test-subj="deleteIndexPatternsBulkEditRule"]';
 
+export const UPDATE_SCHEDULE_MENU_ITEM = '[data-test-subj="setScheduleBulk"]';
+
 export const APPLY_TIMELINE_RULE_BULK_MENU_ITEM = '[data-test-subj="applyTimelineTemplateBulk"]';
 
 export const TAGS_RULE_BULK_MENU_ITEM = '[data-test-subj="tagsBulkEditRule"]';
@@ -45,3 +47,11 @@ export const RULES_BULK_EDIT_TIMELINE_TEMPLATES_SELECTOR =
 
 export const RULES_BULK_EDIT_TIMELINE_TEMPLATES_WARNING =
   '[data-test-subj="bulkEditRulesTimelineTemplateWarning"]';
+
+export const UPDATE_SCHEDULE_INTERVAL_INPUT =
+  '[data-test-subj="bulkEditRulesScheduleIntervalSelector"]';
+
+export const UPDATE_SCHEDULE_LOOKBACK_INPUT =
+  '[data-test-subj="bulkEditRulesScheduleLookbackSelector"]';
+
+export const UPDATE_SCHEDULE_TIME_UNIT_SELECT = '[data-test-subj="timeType"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
@@ -35,6 +35,7 @@ import {
   UPDATE_SCHEDULE_INTERVAL_INPUT,
   UPDATE_SCHEDULE_TIME_UNIT_SELECT,
   UPDATE_SCHEDULE_LOOKBACK_INPUT,
+  RULES_BULK_EDIT_SCHEDULES_WARNING,
 } from '../screens/rules_bulk_edit';
 import { SCHEDULE_DETAILS } from '../screens/rule_details';
 
@@ -203,6 +204,13 @@ export const setScheduleLookbackTimeUnit = (timeUnit: TimeUnit) => {
   cy.get(UPDATE_SCHEDULE_LOOKBACK_INPUT).within(() => {
     cy.get(UPDATE_SCHEDULE_TIME_UNIT_SELECT).select(timeUnit);
   });
+};
+
+export const assertUpdateScheduleWarningExists = (expectedNumberOfNotMLRules: number) => {
+  cy.get(RULES_BULK_EDIT_SCHEDULES_WARNING).should(
+    'have.text',
+    `You're about to apply changes to ${expectedNumberOfNotMLRules} selected rules. The changes you made will be overwritten to the existing Rule schedules and additional look-back time (if any).`
+  );
 };
 
 export const assertRuleScheduleValues = ({

--- a/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
@@ -31,7 +31,12 @@ import {
   RULES_BULK_EDIT_OVERWRITE_TAGS_CHECKBOX,
   RULES_BULK_EDIT_OVERWRITE_INDEX_PATTERNS_CHECKBOX,
   RULES_BULK_EDIT_TIMELINE_TEMPLATES_SELECTOR,
+  UPDATE_SCHEDULE_MENU_ITEM,
+  UPDATE_SCHEDULE_INTERVAL_INPUT,
+  UPDATE_SCHEDULE_TIME_UNIT_SELECT,
+  UPDATE_SCHEDULE_LOOKBACK_INPUT,
 } from '../screens/rules_bulk_edit';
+import { SCHEDULE_DETAILS } from '../screens/rule_details';
 
 export const clickApplyTimelineTemplatesMenuItem = () => {
   cy.get(BULK_ACTIONS_BTN).click();
@@ -51,6 +56,11 @@ export const clickTagsMenuItem = () => {
 export const clickAddTagsMenuItem = () => {
   clickTagsMenuItem();
   cy.get(ADD_TAGS_RULE_BULK_MENU_ITEM).click();
+};
+
+export const clickUpdateScheduleMenuItem = () => {
+  cy.get(BULK_ACTIONS_BTN).click();
+  cy.get(UPDATE_SCHEDULE_MENU_ITEM).click().should('not.exist');
 };
 
 export const clickAddIndexPatternsMenuItem = () => {
@@ -165,4 +175,45 @@ export const checkTagsInTagsFilter = (tags: string[]) => {
     .each(($el, index) => {
       cy.wrap($el).should('have.text', tags[index]);
     });
+};
+
+export const typeScheduleInterval = (interval: string) => {
+  cy.get(UPDATE_SCHEDULE_INTERVAL_INPUT)
+    .find('input')
+    .type('{selectAll}')
+    .type(interval.toString())
+    .blur();
+};
+export const typeScheduleLookback = (lookback: string) => {
+  cy.get(UPDATE_SCHEDULE_LOOKBACK_INPUT)
+    .find('input')
+    .type('{selectAll}', { waitForAnimations: true })
+    .type(lookback.toString(), { waitForAnimations: true })
+    .blur();
+};
+
+type TimeUnit = 'Seconds' | 'Minutes' | 'Hours';
+export const setScheduleIntervalTimeUnit = (timeUnit: TimeUnit) => {
+  cy.get(UPDATE_SCHEDULE_INTERVAL_INPUT).within(() => {
+    cy.get(UPDATE_SCHEDULE_TIME_UNIT_SELECT).select(timeUnit);
+  });
+};
+
+export const setScheduleLookbackTimeUnit = (timeUnit: TimeUnit) => {
+  cy.get(UPDATE_SCHEDULE_LOOKBACK_INPUT).within(() => {
+    cy.get(UPDATE_SCHEDULE_TIME_UNIT_SELECT).select(timeUnit);
+  });
+};
+
+export const assertRuleScheduleValues = ({
+  interval,
+  lookback,
+}: {
+  interval: string;
+  lookback: string;
+}) => {
+  cy.get(SCHEDULE_DETAILS).within(() => {
+    cy.get('dd').eq(0).should('contain.text', interval);
+    cy.get('dd').eq(1).should('contain.text', lookback);
+  });
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -30,7 +30,7 @@ interface ScheduleItemProps {
   isDisabled: boolean;
   minimumValue?: number;
   timeTypes?: string[];
-  fullWidth: boolean;
+  fullWidth?: boolean;
 }
 
 const timeTypeOptions = [

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -80,12 +80,12 @@ const MyEuiSelect = styled(EuiSelect)`
   width: auto;
 `;
 
-const getNumberFromUserInput = (input: string, defaultValue = 0): number => {
+const getNumberFromUserInput = (input: string, minimumValue = 0): number => {
   const number = parseInt(input, 10);
   if (Number.isNaN(number)) {
-    return defaultValue;
+    return minimumValue;
   } else {
-    return Math.min(number, Number.MAX_SAFE_INTEGER);
+    return Math.max(minimumValue, Math.min(number, Number.MAX_SAFE_INTEGER));
   }
 };
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiFormRow,
   EuiSelect,
   EuiFormControlLayout,
+  transparentize,
 } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -29,6 +30,7 @@ interface ScheduleItemProps {
   isDisabled: boolean;
   minimumValue?: number;
   timeTypes?: string[];
+  fullWidth: boolean;
 }
 
 const timeTypeOptions = [
@@ -49,12 +51,24 @@ const StyledEuiFormRow = styled(EuiFormRow)`
   max-width: none;
 
   .euiFormControlLayout {
-    max-width: 200px !important;
+    max-width: ${({ fullWidth }) => (fullWidth ? 'auto' : '200px !important')};
+    width: ${({ fullWidth }) => (fullWidth ? 'auto' : 'inherit')};
   }
 
   .euiFormControlLayout__childrenWrapper > *:first-child {
     box-shadow: none;
     height: 38px;
+    width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  }
+
+  .euiFormControlLayout__childrenWrapper > select {
+    background-color: ${({ fullWidth, theme }) =>
+      fullWidth ? transparentize(theme.eui.euiColorPrimary, 0.1) : 'inherit'};
+    color: ${({ fullWidth, theme }) => (fullWidth ? theme.eui.euiColorPrimary : 'inherit')};
+  }
+
+  .euiFormControlLayoutIcons {
+    color: ${({ fullWidth, theme }) => (fullWidth ? theme.eui.euiColorPrimary : 'inherit')};
   }
 
   .euiFormControlLayout:not(:first-child) {
@@ -82,6 +96,7 @@ export const ScheduleItem = ({
   isDisabled,
   minimumValue = 0,
   timeTypes = ['s', 'm', 'h'],
+  fullWidth = false,
 }: ScheduleItemProps) => {
   const [timeType, setTimeType] = useState(timeTypes[0]);
   const [timeVal, setTimeVal] = useState<number>(0);
@@ -150,7 +165,7 @@ export const ScheduleItem = ({
       helpText={field.helpText}
       error={errorMessage}
       isInvalid={isInvalid}
-      fullWidth={false}
+      fullWidth={fullWidth}
       data-test-subj={dataTestSubj}
       describedByIds={idAria ? [idAria] : undefined}
     >

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -51,24 +51,27 @@ const StyledEuiFormRow = styled(EuiFormRow)`
   max-width: none;
 
   .euiFormControlLayout {
-    max-width: ${({ fullWidth }) => (fullWidth ? 'auto' : '200px !important')};
-    width: ${({ fullWidth }) => (fullWidth ? 'auto' : 'inherit')};
+    max-width: auto;
+    width: auto;
   }
 
   .euiFormControlLayout__childrenWrapper > *:first-child {
     box-shadow: none;
     height: 38px;
-    width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+    width: 100%;
   }
 
   .euiFormControlLayout__childrenWrapper > select {
-    background-color: ${({ fullWidth, theme }) =>
-      fullWidth ? transparentize(theme.eui.euiColorPrimary, 0.1) : 'inherit'};
-    color: ${({ fullWidth, theme }) => (fullWidth ? theme.eui.euiColorPrimary : 'inherit')};
+    background-color: ${({ theme }) => transparentize(theme.eui.euiColorPrimary, 0.1)};
+    color: ${({ theme }) => theme.eui.euiColorPrimary};
+  }
+
+  .euiFormControlLayout--group .euiFormControlLayout {
+    min-width: 100px;
   }
 
   .euiFormControlLayoutIcons {
-    color: ${({ fullWidth, theme }) => (fullWidth ? theme.eui.euiColorPrimary : 'inherit')};
+    color: ${({ theme }) => theme.eui.euiColorPrimary};
   }
 
   .euiFormControlLayout:not(:first-child) {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { memo, useCallback, useEffect } from 'react';
-
 import type { RuleStepProps, ScheduleStepRule } from '../../../pages/detection_engine/rules/types';
 import { RuleStep } from '../../../pages/detection_engine/rules/types';
 import { StepRuleDescription } from '../description_step';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { FC } from 'react';
+import styled from 'styled-components';
 import React, { memo, useCallback, useEffect } from 'react';
 import type { RuleStepProps, ScheduleStepRule } from '../../../pages/detection_engine/rules/types';
 import { RuleStep } from '../../../pages/detection_engine/rules/types';
@@ -16,6 +17,9 @@ import { StepContentWrapper } from '../step_content_wrapper';
 import { NextStep } from '../next_step';
 import { schema } from './schema';
 
+const StyledForm = styled(Form)`
+  max-width: 235px !important;
+`;
 interface StepScheduleRuleProps extends RuleStepProps {
   defaultValues: ScheduleStepRule;
   onRuleDataChange?: (data: ScheduleStepRule) => void;
@@ -83,7 +87,7 @@ const StepScheduleRuleComponent: FC<StepScheduleRuleProps> = ({
   ) : (
     <>
       <StepContentWrapper addPadding={!isUpdateView}>
-        <Form form={form} data-test-subj="stepScheduleRule">
+        <StyledForm form={form} data-test-subj="stepScheduleRule">
           <UseField
             path="interval"
             component={ScheduleItem}
@@ -103,7 +107,7 @@ const StepScheduleRuleComponent: FC<StepScheduleRuleProps> = ({
               minimumValue: 1,
             }}
           />
-        </Form>
+        </StyledForm>
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/bulk_edit_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/bulk_edit_flyout.tsx
@@ -14,6 +14,7 @@ import { IndexPatternsForm } from './forms/index_patterns_form';
 import { TagsForm } from './forms/tags_form';
 import { TimelineTemplateForm } from './forms/timeline_template_form';
 import { RuleActionsForm } from './forms/rule_actions_form';
+import { ScheduleForm } from './forms/schedule_form';
 
 interface BulkEditFlyoutProps {
   onClose: () => void;
@@ -41,6 +42,8 @@ const BulkEditFlyoutComponent = ({ editAction, tags, ...props }: BulkEditFlyoutP
     case BulkActionEditType.add_rule_actions:
     case BulkActionEditType.set_rule_actions:
       return <RuleActionsForm {...props} />;
+    case BulkActionEditType.set_schedule:
+      return <ScheduleForm {...props} />;
 
     default:
       return null;

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -7,8 +7,8 @@
 
 import React, { useCallback } from 'react';
 import { EuiCallOut } from '@elastic/eui';
-import { BulkActionEditType } from '../../../../../../../../common/detection_engine/schemas/common';
 import type { BulkActionEditPayload } from '../../../../../../../../common/detection_engine/schemas/request';
+import { BulkActionEditType } from '../../../../../../../../common/detection_engine/schemas/request';
 import { useForm, UseField } from '../../../../../../../shared_imports';
 import type { FormSchema } from '../../../../../../../shared_imports';
 import { BulkEditFormWrapper } from './bulk_edit_form_wrapper';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -86,7 +86,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
         componentProps={{
           idAria: 'bulkEditRulesScheduleIntervalSelector',
           dataTestSubj: 'bulkEditRulesScheduleIntervalSelector',
-          placeholder: 'test',
+          fullWidth: true,
         }}
       />
       <UseField
@@ -95,7 +95,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
         componentProps={{
           idAria: 'bulkEditRulesScheduleLookbackSelector',
           dataTestSubj: 'bulkEditRulesScheduleLookbackSelector',
-          placeholder: 'test',
+          fullWidth: true,
         }}
       />
     </BulkEditFormWrapper>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -33,8 +33,8 @@ export const formSchema: FormSchema<ScheduleFormData> = {
 };
 
 const defaultFormData: ScheduleFormData = {
-  interval: '5s',
-  lookback: '5m',
+  interval: '5m',
+  lookback: '1m',
 };
 
 interface ScheduleFormComponentProps {
@@ -87,6 +87,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
           idAria: 'bulkEditRulesScheduleIntervalSelector',
           dataTestSubj: 'bulkEditRulesScheduleIntervalSelector',
           fullWidth: true,
+          minimumValue: 1,
         }}
       />
       <UseField
@@ -96,6 +97,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
           idAria: 'bulkEditRulesScheduleLookbackSelector',
           dataTestSubj: 'bulkEditRulesScheduleLookbackSelector',
           fullWidth: true,
+          minimumValue: 1,
         }}
       />
     </BulkEditFormWrapper>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -17,24 +17,18 @@ import { ScheduleItem } from '../../../../../../components/rules/schedule_item_f
 import { bulkSetSchedule as i18n } from '../translations';
 
 export interface ScheduleFormData {
-  schedule: {
-    interval: string;
-    from: string;
-  };
+  interval: string;
+  lookback: string;
 }
 
 const formSchema: FormSchema<ScheduleFormData> = {
-  schedule: {
-    interval: 'Interval',
-    from: 'from',
-  },
+  interval: 'INTERVAL',
+  lookback: 'LOOKBACK',
 };
 
 const defaultFormData: ScheduleFormData = {
-  schedule: {
-    interval: 'test',
-    from: 'from',
-  },
+  interval: '5s',
+  lookback: '5m',
 };
 
 interface ScheduleFormComponentProps {
@@ -58,9 +52,9 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
     onConfirm({
       type: BulkActionEditType.set_schedule,
       value: {
-        interval: 'timelineId',
+        interval: data.interval,
         meta: {
-          from: 'string',
+          from: data.lookback,
         },
       },
     });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -86,7 +86,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
         componentProps={{
           idAria: 'bulkEditRulesScheduleIntervalSelector',
           dataTestSubj: 'bulkEditRulesScheduleIntervalSelector',
-          placeholder: "test",
+          placeholder: 'test',
         }}
       />
       <UseField
@@ -95,7 +95,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
         componentProps={{
           idAria: 'bulkEditRulesScheduleLookbackSelector',
           dataTestSubj: 'bulkEditRulesScheduleLookbackSelector',
-          placeholder: "test",
+          placeholder: 'test',
         }}
       />
     </BulkEditFormWrapper>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -21,9 +21,15 @@ export interface ScheduleFormData {
   lookback: string;
 }
 
-const formSchema: FormSchema<ScheduleFormData> = {
-  interval: 'INTERVAL',
-  lookback: 'LOOKBACK',
+export const formSchema: FormSchema<ScheduleFormData> = {
+  interval: {
+    label: i18n.INTERVAL_LABEL,
+    helpText: i18n.INTERVAL_HELP_TEXT,
+  },
+  lookback: {
+    label: i18n.LOOKBACK_LABEL,
+    helpText: i18n.LOOKBACK_HELP_TEXT,
+  },
 };
 
 const defaultFormData: ScheduleFormData = {
@@ -62,7 +68,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
 
   const warningCallout = (
     <EuiCallOut color="warning" data-test-subj="bulkEditRulesTimelineTemplateWarning">
-      warning callout
+      {i18n.warningCalloutMessage(rulesCount)}
     </EuiCallOut>
   );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { BulkActionEditType } from '../../../../../../../../common/detection_engine/schemas/common';
+import type { BulkActionEditPayload } from '../../../../../../../../common/detection_engine/schemas/request';
+import { useForm, UseField } from '../../../../../../../shared_imports';
+import type { FormSchema } from '../../../../../../../shared_imports';
+import { BulkEditFormWrapper } from './bulk_edit_form_wrapper';
+import { ScheduleItem } from '../../../../../../components/rules/schedule_item_form';
+
+import { bulkSetSchedule as i18n } from '../translations';
+
+export interface ScheduleFormData {
+  schedule: {
+    interval: string;
+    from: string;
+  };
+}
+
+const formSchema: FormSchema<ScheduleFormData> = {
+  schedule: {
+    interval: 'Interval',
+    from: 'from',
+  },
+};
+
+const defaultFormData: ScheduleFormData = {
+  schedule: {
+    interval: 'test',
+    from: 'from',
+  },
+};
+
+interface ScheduleFormComponentProps {
+  rulesCount: number;
+  onClose: () => void;
+  onConfirm: (bulkActionEditPayload: BulkActionEditPayload) => void;
+}
+
+export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormComponentProps) => {
+  const { form } = useForm({
+    schema: formSchema,
+    defaultValue: defaultFormData,
+  });
+
+  const handleSubmit = useCallback(async () => {
+    const { data, isValid } = await form.submit();
+    if (!isValid) {
+      return;
+    }
+
+    onConfirm({
+      type: BulkActionEditType.set_schedule,
+      value: {
+        interval: 'timelineId',
+        meta: {
+          from: 'string',
+        },
+      },
+    });
+  }, [form, onConfirm]);
+
+  const warningCallout = (
+    <EuiCallOut color="warning" data-test-subj="bulkEditRulesTimelineTemplateWarning">
+      warning callout
+    </EuiCallOut>
+  );
+
+  return (
+    <BulkEditFormWrapper
+      form={form}
+      title={i18n.FORM_TITLE}
+      banner={warningCallout}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+    >
+      <UseField
+        path="interval"
+        component={ScheduleItem}
+        componentProps={{
+          idAria: 'bulkEditRulesScheduleIntervalSelector',
+          dataTestSubj: 'bulkEditRulesScheduleIntervalSelector',
+          placeholder: "test",
+        }}
+      />
+      <UseField
+        path="lookback"
+        component={ScheduleItem}
+        componentProps={{
+          idAria: 'bulkEditRulesScheduleLookbackSelector',
+          dataTestSubj: 'bulkEditRulesScheduleLookbackSelector',
+          placeholder: "test",
+        }}
+      />
+    </BulkEditFormWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -65,7 +65,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
   }, [form, onConfirm]);
 
   const warningCallout = (
-    <EuiCallOut color="warning" data-test-subj="bulkEditRulesTimelineTemplateWarning">
+    <EuiCallOut color="warning" data-test-subj="bulkEditRulesSchedulesWarning">
       {i18n.warningCalloutMessage(rulesCount)}
     </EuiCallOut>
   );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/forms/schedule_form.tsx
@@ -59,9 +59,7 @@ export const ScheduleForm = ({ rulesCount, onClose, onConfirm }: ScheduleFormCom
       type: BulkActionEditType.set_schedule,
       value: {
         interval: data.interval,
-        meta: {
-          from: data.lookback,
-        },
+        lookback: data.lookback,
       },
     });
   }, [form, onConfirm]);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/translations.tsx
@@ -94,3 +94,12 @@ export const bulkAddRuleActions = {
     }
   ),
 };
+
+export const bulkSetSchedule = {
+  FORM_TITLE: i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.formTitle',
+    {
+      defaultMessage: 'Add rule actions',
+    }
+  ),
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/translations.tsx
@@ -99,7 +99,38 @@ export const bulkSetSchedule = {
   FORM_TITLE: i18n.translate(
     'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.formTitle',
     {
-      defaultMessage: 'Add rule actions',
+      defaultMessage: 'Update rule schedules',
     }
+  ),
+  INTERVAL_LABEL: i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.intervalLabel',
+    {
+      defaultMessage: 'Runs every',
+    }
+  ),
+  INTERVAL_HELP_TEXT: i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.intervalHelpText',
+    {
+      defaultMessage: 'Rules run periodically and detect alerts within the specified time frame.',
+    }
+  ),
+  LOOKBACK_LABEL: i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.lookbackLabel',
+    {
+      defaultMessage: 'Additional look-back time',
+    }
+  ),
+  LOOKBACK_HELP_TEXT: i18n.translate(
+    'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.lookbackHelpText',
+    {
+      defaultMessage: 'Adds time to the look-back period to prevent missed alerts.',
+    }
+  ),
+  warningCalloutMessage: (rulesCount: number): JSX.Element => (
+    <FormattedMessage
+      id="xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.setSchedule.warningCalloutMessage"
+      defaultMessage="You're about to apply changes to {rulesCount, plural, one {# selected rule} other {# selected rules}}. The changes you made will be overwritten to the existing Rule schedules and additional look-back time (if any)."
+      values={{ rulesCount }}
+    />
   ),
 };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/use_bulk_actions.tsx
@@ -371,6 +371,16 @@ export const useBulkActions = ({
               icon: undefined,
             },
             {
+              key: i18n.BULK_ACTION_SET_SCHEDULE,
+              name: i18n.BULK_ACTION_SET_SCHEDULE,
+              'data-test-subj': 'setScheduleBulk',
+              disabled: isEditDisabled,
+              onClick: handleBulkEdit(BulkActionEditType.set_schedule),
+              toolTipContent: missingActionPrivileges ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined,
+              toolTipPosition: 'right',
+              icon: undefined,
+            },
+            {
               key: i18n.BULK_ACTION_APPLY_TIMELINE_TEMPLATE,
               name: i18n.BULK_ACTION_APPLY_TIMELINE_TEMPLATE,
               'data-test-subj': 'applyTimelineTemplateBulk',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/utils/compute_dry_run_payload.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/utils/compute_dry_run_payload.ts
@@ -63,6 +63,13 @@ export const computeDryRunPayload = (
           value: { throttle: '1h', actions: [] },
         },
       ];
+    case BulkActionEditType.set_schedule:
+      return [
+        {
+          type: editAction,
+          value: { interval: '1', meta: { from: '10' } },
+        },
+      ];
 
     default:
       assertUnreachable(editAction);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/utils/compute_dry_run_payload.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/bulk_actions/utils/compute_dry_run_payload.ts
@@ -67,7 +67,7 @@ export const computeDryRunPayload = (
       return [
         {
           type: editAction,
-          value: { interval: '1', meta: { from: '10' } },
+          value: { interval: '5m', lookback: '1m' },
         },
       ];
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/rules_tables.tsx
@@ -274,6 +274,7 @@ export const RulesTables = React.memo<RulesTableProps>(
 
     const shouldShowLinearProgress = isFetched && isRefetching;
     const shouldShowLoadingOverlay = (!isFetched && isRefetching) || isActionInProgress;
+
     return (
       <>
         {shouldShowLinearProgress && (

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -190,7 +190,7 @@ export const BULK_ACTION_ADD_RULE_ACTIONS = i18n.translate(
 export const BULK_ACTION_SET_SCHEDULE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.setScheduleTitle',
   {
-    defaultMessage: 'Set schedule',
+    defaultMessage: 'Update rule schedules',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -187,6 +187,13 @@ export const BULK_ACTION_ADD_RULE_ACTIONS = i18n.translate(
   }
 );
 
+export const BULK_ACTION_SET_SCHEDULE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.setScheduleTitle',
+  {
+    defaultMessage: 'Set schedule',
+  }
+);
+
 export const BULK_ACTION_MENU_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.contextMenuTitle',
   {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.test.ts
@@ -41,4 +41,24 @@ describe('bulkEditActionToRulesClientOperation', () => {
       value: ['test'],
     },
   ]);
+
+  test('should transform schedule bulk edit correctly', () => {
+    expect(
+      bulkEditActionToRulesClientOperation({
+        type: BulkActionEditType.set_schedule,
+        value: {
+          interval: '100m',
+          meta: {
+            from: '10m',
+          },
+        },
+      })
+    ).toEqual([
+      {
+        field: 'schedule',
+        operation: 'set',
+        value: { interval: '100m' },
+      },
+    ]);
+  });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.test.ts
@@ -48,9 +48,7 @@ describe('bulkEditActionToRulesClientOperation', () => {
         type: BulkActionEditType.set_schedule,
         value: {
           interval: '100m',
-          meta: {
-            from: '10m',
-          },
+          lookback: '10m',
         },
       })
     ).toEqual([

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
@@ -92,7 +92,11 @@ export const bulkEditActionToRulesClientOperation = (
         {
           field: 'schedule',
           operation: 'set',
-          value: action.value,
+          // We need to pass a pure Interval object
+          // i.e. get rid of the meta property
+          value: {
+            interval: action.value.interval,
+          },
         },
       ];
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
@@ -87,6 +87,15 @@ export const bulkEditActionToRulesClientOperation = (
         getNotifyWhenOperation(action.value.throttle),
       ];
 
+    case BulkActionEditType.set_schedule:
+      return [
+        {
+          field: 'schedule',
+          operation: 'set',
+          value: action.value,
+        },
+      ];
+
     default:
       return assertUnreachable(action);
   }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/action_to_rules_client_operation.ts
@@ -87,6 +87,7 @@ export const bulkEditActionToRulesClientOperation = (
         getNotifyWhenOperation(action.value.throttle),
       ];
 
+    // schedule actions
     case BulkActionEditType.set_schedule:
       return [
         {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
@@ -351,4 +351,30 @@ describe('ruleParamsModifier', () => {
       expect(editedRuleParams.timelineTitle).toBe('Test timeline');
     });
   });
+
+  describe('schedule', () => {
+    test('should set timeline', () => {
+      const INTERVAL_IN_MINUTES = 5;
+      const LOOKBACK_IN_MINUTES = 1;
+      const FROM_IN_SECONDS = (INTERVAL_IN_MINUTES + LOOKBACK_IN_MINUTES) * 60;
+      const editedRuleParams = ruleParamsModifier(ruleParamsMock, [
+        {
+          type: BulkActionEditType.set_schedule,
+          value: {
+            interval: '5m',
+            meta: {
+              from: '1m',
+            },
+          },
+        },
+      ]);
+
+      // @ts-expect-error
+      expect(editedRuleParams.interval).toBeUndefined();
+      expect(editedRuleParams.meta).toStrictEqual({
+        from: '1m',
+      });
+      expect(editedRuleParams.from).toBe(`now-${FROM_IN_SECONDS}s`);
+    });
+  });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
@@ -361,9 +361,9 @@ describe('ruleParamsModifier', () => {
         {
           type: BulkActionEditType.set_schedule,
           value: {
-            interval: '5m',
+            interval: `${INTERVAL_IN_MINUTES}m`,
             meta: {
-              from: '1m',
+              from: `${LOOKBACK_IN_MINUTES}m`,
             },
           },
         },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.test.ts
@@ -362,9 +362,7 @@ describe('ruleParamsModifier', () => {
           type: BulkActionEditType.set_schedule,
           value: {
             interval: `${INTERVAL_IN_MINUTES}m`,
-            meta: {
-              from: `${LOOKBACK_IN_MINUTES}m`,
-            },
+            lookback: `${LOOKBACK_IN_MINUTES}m`,
           },
         },
       ]);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
@@ -98,7 +98,7 @@ const applyBulkActionEditToRuleParams = (
       const interval = parseInterval(action.value.interval) ?? moment.duration(0);
       const parsedFrom = parseInterval(action.value.meta.from) ?? moment.duration(0);
 
-      const from = parsedFrom.seconds() + interval.seconds();
+      const from = parsedFrom.asSeconds() + interval.asSeconds();
 
       ruleParams = {
         ...ruleParams,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
@@ -90,6 +90,18 @@ const applyBulkActionEditToRuleParams = (
         timelineTitle: action.value.timeline_title || undefined,
       };
       break;
+
+    // update look-back period in from and meta.from fields
+    case BulkActionEditType.set_schedule: {
+      ruleParams = {
+        ...ruleParams,
+        meta: {
+          ...ruleParams.meta,
+          from: action.value.meta.from,
+        },
+        from: action.value.from,
+      };
+    }
   }
 
   return ruleParams;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import type { RuleAlertType } from '../types';
+/* eslint-disable complexity */
 
+import moment from 'moment';
+import { parseInterval } from '@kbn/data-plugin/common/search/aggs/utils/date_interval_utils';
+import type { RuleAlertType } from '../types';
 import type { BulkActionEditForRuleParams } from '../../../../../common/detection_engine/schemas/request/perform_bulk_action_schema';
 import { BulkActionEditType } from '../../../../../common/detection_engine/schemas/request/perform_bulk_action_schema';
-
 import { invariant } from '../../../../../common/utils/invariant';
 
 export const addItemsToArray = <T>(arr: T[], items: T[]): T[] =>
@@ -93,13 +95,18 @@ const applyBulkActionEditToRuleParams = (
 
     // update look-back period in from and meta.from fields
     case BulkActionEditType.set_schedule: {
+      const interval = parseInterval(action.value.interval) ?? moment.duration(0);
+      const parsedFrom = parseInterval(action.value.meta.from) ?? moment.duration(0);
+
+      const from = parsedFrom.seconds() + interval.seconds();
+
       ruleParams = {
         ...ruleParams,
         meta: {
           ...ruleParams.meta,
           from: action.value.meta.from,
         },
-        from: action.value.from,
+        from: `now-${from}s`,
       };
     }
   }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/rule_params_modifier.ts
@@ -96,7 +96,7 @@ const applyBulkActionEditToRuleParams = (
     // update look-back period in from and meta.from fields
     case BulkActionEditType.set_schedule: {
       const interval = parseInterval(action.value.interval) ?? moment.duration(0);
-      const parsedFrom = parseInterval(action.value.meta.from) ?? moment.duration(0);
+      const parsedFrom = parseInterval(action.value.lookback) ?? moment.duration(0);
 
       const from = parsedFrom.asSeconds() + interval.asSeconds();
 
@@ -104,7 +104,7 @@ const applyBulkActionEditToRuleParams = (
         ...ruleParams,
         meta: {
           ...ruleParams.meta,
-          from: action.value.meta.from,
+          from: action.value.lookback,
         },
         from: `now-${from}s`,
       };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/split_bulk_edit_actions.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/split_bulk_edit_actions.ts
@@ -29,12 +29,15 @@ export const splitBulkEditActions = (actions: BulkActionEditPayload[]) => {
 
   return actions.reduce((acc, action) => {
     switch (action.type) {
+      case BulkActionEditType.set_schedule:
+        acc.attributesActions.push(action);
+        acc.paramsActions.push(action);
+        break;
       case BulkActionEditType.add_tags:
       case BulkActionEditType.set_tags:
       case BulkActionEditType.delete_tags:
       case BulkActionEditType.add_rule_actions:
       case BulkActionEditType.set_rule_actions:
-      case BulkActionEditType.set_schedule:
         acc.attributesActions.push(action);
         break;
       default:

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/split_bulk_edit_actions.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_actions/split_bulk_edit_actions.ts
@@ -34,6 +34,7 @@ export const splitBulkEditActions = (actions: BulkActionEditPayload[]) => {
       case BulkActionEditType.delete_tags:
       case BulkActionEditType.add_rule_actions:
       case BulkActionEditType.set_rule_actions:
+      case BulkActionEditType.set_schedule:
         acc.attributesActions.push(action);
         break;
       default:

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_edit_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/bulk_edit_rules.ts
@@ -49,10 +49,10 @@ export const bulkEditRules = async ({
   mlAuthz,
 }: BulkEditRulesArguments) => {
   const { attributesActions, paramsActions } = splitBulkEditActions(actions);
-
+  const operations = attributesActions.map(bulkEditActionToRulesClientOperation).flat();
   const result = await rulesClient.bulkEdit({
     ...(ids ? { ids } : { filter: enrichFilterWithRuleTypeMapping(filter) }),
-    operations: attributesActions.map(bulkEditActionToRulesClientOperation).flat(),
+    operations,
     paramsModifier: async (ruleParams: RuleAlertType['params']) => {
       await validateBulkEditRule({
         mlAuthz,


### PR DESCRIPTION
Addresses [#2127](https://github.com/elastic/security-team/issues/2172) (internal)

## Summary

Adds feature to bulk edit schedule of rules (interval -runs every- and lookback time)


https://user-images.githubusercontent.com/5354282/188846852-8bcb128a-db02-4a81-9fc8-3029a97965c2.mov


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))