### PR TITLE
[TIP] Toggle loading state when result set is completely loaded

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
@@ -153,12 +153,12 @@ export const useIndicators = ({
             setIndicatorCount(response.rawResponse.hits.total || 0);
 
             if (isCompleteResponse(response)) {
+              setLoading(false);
               searchSubscription$.current?.unsubscribe();
             } else if (isErrorResponse(response)) {
+              setLoading(false);
               searchSubscription$.current?.unsubscribe();
             }
-
-            setLoading(false);
           },
           error: (msg) => {
             searchService.showError(msg);


### PR DESCRIPTION
## Summary

I've noticed that we are switching the loading flag off when search results are received entirely. 

This PR fixes the issue by explicitly checking if the result set has been collected entirely.

