### PR TITLE
[Index Template] Fix previewing data streams in template editor

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
@@ -588,4 +588,33 @@ describe('<TemplateCreate />', () => {
       expect(find('saveTemplateError').text()).toContain(error.message);
     });
   });
+
+  test('preview data stream', async () => {
+    await act(async () => {
+      testBed = await setup(httpSetup);
+    });
+    testBed.component.update();
+
+    const { actions } = testBed;
+    // Logistics
+    await actions.completeStepOne({
+      name: TEMPLATE_NAME,
+      indexPatterns: DEFAULT_INDEX_PATTERNS,
+      dataStream: {},
+    });
+
+    await act(async () => {
+      await actions.previewTemplate();
+    });
+
+    expect(httpSetup.post).toHaveBeenLastCalledWith(
+      `${API_BASE_PATH}/index_templates/simulate`,
+      expect.objectContaining({
+        body: JSON.stringify({
+          index_patterns: DEFAULT_INDEX_PATTERNS,
+          data_stream: {},
+        }),
+      })
+    );
+  });
 });

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_form.helpers.ts
@@ -137,6 +137,7 @@ export const formSetup = async (initTestBed: SetupFunc<TestSubjects>) => {
     order,
     priority,
     version,
+    dataStream,
   }: Partial<TemplateDeserialized> = {}) => {
     const { component, form, find } = testBed;
 
@@ -160,6 +161,10 @@ export const formSetup = async (initTestBed: SetupFunc<TestSubjects>) => {
     await act(async () => {
       if (order) {
         form.setInputValue('orderField.input', JSON.stringify(order));
+      }
+
+      if (dataStream) {
+        form.toggleEuiSwitch('dataStreamField.input');
       }
 
       if (priority) {
@@ -255,6 +260,10 @@ export const formSetup = async (initTestBed: SetupFunc<TestSubjects>) => {
     component.update();
   };
 
+  const previewTemplate = async () => {
+    testBed.find('previewIndexTemplate').simulate('click');
+  };
+
   return {
     ...testBed,
     actions: {
@@ -272,6 +281,7 @@ export const formSetup = async (initTestBed: SetupFunc<TestSubjects>) => {
       componentTemplates,
       mappings,
       review,
+      previewTemplate,
     },
   };
 };
@@ -317,6 +327,7 @@ export type TestSubjects =
   | 'orderField'
   | 'orderField.input'
   | 'priorityField.input'
+  | 'dataStreamField.input'
   | 'pageTitle'
   | 'previewTab'
   | 'removeFieldButton'
@@ -341,4 +352,5 @@ export type TestSubjects =
   | 'settingsEditor'
   | 'versionField.input'
   | 'mappingsEditor.formTab'
-  | 'mappingsEditor.advancedConfiguration.sizeEnabledToggle';
+  | 'mappingsEditor.advancedConfiguration.sizeEnabledToggle'
+  | 'previewIndexTemplate';

--- a/x-pack/plugins/index_management/public/application/components/index_templates/simulate_template/simulate_template.tsx
+++ b/x-pack/plugins/index_management/public/application/components/index_templates/simulate_template/simulate_template.tsx
@@ -35,7 +35,9 @@ export const SimulateTemplate = React.memo(({ template, filters }: Props) => {
       return;
     }
 
-    const indexTemplate = serializeTemplate(stripEmptyFields(template) as TemplateDeserialized);
+    const indexTemplate = serializeTemplate(
+      stripEmptyFields(template, { types: ['string'] }) as TemplateDeserialized
+    );
     const { data, error } = await simulateIndexTemplate(indexTemplate);
     let filteredTemplate = data;
 

--- a/x-pack/plugins/index_management/public/application/components/template_form/template_form.tsx
+++ b/x-pack/plugins/index_management/public/application/components/template_form/template_form.tsx
@@ -277,7 +277,7 @@ export const TemplateForm = ({
     }
 
     return (
-      <EuiButton size="s" onClick={showPreviewFlyout}>
+      <EuiButton size="s" onClick={showPreviewFlyout} data-test-subj="previewIndexTemplate">
         <FormattedMessage
           id="xpack.idxMgmt.templateForm.previewIndexTemplateButtonLabel"
           defaultMessage="Preview index template"


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/139925

Currently, when you create a data stream template and try to use the "preview template" functionality, you'll simulate an index template without a data stream configuration because the data stream is configured using an empty object `{}` and existing code strips empty objects from the template during simulation: 

https://github.com/elastic/kibana/blob/bc2a1819b3fd96b7373cd289c4290d09f06839b7/x-pack/plugins/index_management/public/application/components/index_templates/simulate_template/simulate_template.tsx#L38

You can see this that by starting creating a data stream: 
![Screenshot 2022-09-07 at 15 14 18](https://user-images.githubusercontent.com/7784120/188887507-fd325eca-e577-41f4-a32d-a27ad26b2717.png)
And then use "preview" on the next step. See there is no `data_stream:{}` in the `simulate` request:
![Screenshot 2022-09-07 at 15 14 54](https://user-images.githubusercontent.com/7784120/188887572-ffdd9864-d8de-4095-b277-ba4bec1b1815.png)


This is problematic in cases where a configurion is valid for a data stream template, but invalid for a regular index template. I bumped into this while testing new time series streams in https://github.com/elastic/kibana/pull/138748


The fix makes simulation code to remove only empty strings, but leave empty objects untouched. 
Please check if this is OK. Looks like all other places which pre-process template are already removing only empty strings. For example:

https://github.com/elastic/kibana/blob/bc2a1819b3fd96b7373cd289c4290d09f06839b7/x-pack/plugins/index_management/public/application/components/template_form/template_form.tsx#L228-L230

A safer alternative could be to make handling specific for `data_stream` key





