### PR TITLE
[Enterprise Search] Add replica and shard settings to document indices

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
@@ -85,7 +85,8 @@ describe('addConnector lib function', () => {
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'index_name',
-      settings: textAnalysisSettings('fr'),
+      mappings: {},
+      settings: { ...textAnalysisSettings('fr'), auto_expand_replicas: '0-3', number_of_shards: 2 },
     });
   });
 
@@ -202,7 +203,12 @@ describe('addConnector lib function', () => {
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'index_name',
-      settings: textAnalysisSettings(undefined),
+      mappings: {},
+      settings: {
+        ...textAnalysisSettings(undefined),
+        auto_expand_replicas: '0-3',
+        number_of_shards: 2,
+      },
     });
   });
 
@@ -241,7 +247,8 @@ describe('addConnector lib function', () => {
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'search-index_name',
-      settings: textAnalysisSettings('en'),
+      mappings: {},
+      settings: { ...textAnalysisSettings('en'), auto_expand_replicas: '0-3', number_of_shards: 2 },
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
@@ -13,7 +13,7 @@ import { ErrorCode } from '../../../common/types/error_codes';
 import { setupConnectorsIndices } from '../../index_management/setup_indices';
 
 import { fetchCrawlerByIndexName } from '../crawler/fetch_crawlers';
-import { textAnalysisSettings } from '../indices/text_analysis';
+import { createIndex } from '../indices/create_index';
 
 import { deleteConnectorById } from './delete_connector';
 
@@ -51,10 +51,7 @@ const createConnector = async (
     document,
     index: CONNECTORS_INDEX,
   });
-  await client.asCurrentUser.indices.create({
-    index,
-    settings: textAnalysisSettings(language ?? undefined),
-  });
+  await createIndex(client, document.index_name, language, false);
   await client.asCurrentUser.indices.refresh({ index: CONNECTORS_INDEX });
 
   return { id: result._id, index_name: document.index_name };

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_index.test.ts
@@ -7,17 +7,63 @@
 
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
-import { createApiIndex } from './create_index';
+import { createIndex } from './create_index';
+import { textAnalysisSettings } from './text_analysis';
 
 describe('createApiIndex lib function', () => {
   const mockClient = elasticsearchServiceMock.createScopedClusterClient();
+
+  const defaultMappings = {
+    dynamic: true,
+    dynamic_templates: [
+      {
+        all_text_fields: {
+          mapping: {
+            analyzer: 'iq_text_base',
+            fields: {
+              delimiter: {
+                analyzer: 'iq_text_delimiter',
+                index_options: 'freqs',
+                type: 'text',
+              },
+              enum: {
+                ignore_above: 2048,
+                type: 'keyword',
+              },
+              joined: {
+                analyzer: 'i_text_bigram',
+                index_options: 'freqs',
+                search_analyzer: 'q_text_bigram',
+                type: 'text',
+              },
+              prefix: {
+                analyzer: 'i_prefix',
+                index_options: 'docs',
+                search_analyzer: 'q_prefix',
+                type: 'text',
+              },
+              stem: {
+                analyzer: 'iq_text_stem',
+                type: 'text',
+              },
+            },
+          },
+          match_mapping_type: 'string',
+        },
+      },
+    ],
+  };
+  const defaultSettings = {
+    auto_expand_replicas: '0-3',
+    number_of_shards: 2,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('successfully creates an index', async () => {
-    await expect(createApiIndex(mockClient, 'index_name', 'en')).resolves.toEqual({
+    await expect(createIndex(mockClient, 'index_name', 'en', true)).resolves.toEqual({
       body: {},
       headers: {
         'x-elastic-product': 'Elasticsearch',
@@ -27,162 +73,25 @@ describe('createApiIndex lib function', () => {
       warnings: [],
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
-      body: {
-        mappings: {
-          dynamic: true,
-          dynamic_templates: [
-            {
-              all_text_fields: {
-                mapping: {
-                  analyzer: 'iq_text_base',
-                  fields: {
-                    delimiter: {
-                      analyzer: 'iq_text_delimiter',
-                      index_options: 'freqs',
-                      type: 'text',
-                    },
-                    enum: {
-                      ignore_above: 2048,
-                      type: 'keyword',
-                    },
-                    joined: {
-                      analyzer: 'i_text_bigram',
-                      index_options: 'freqs',
-                      search_analyzer: 'q_text_bigram',
-                      type: 'text',
-                    },
-                    prefix: {
-                      analyzer: 'i_prefix',
-                      index_options: 'docs',
-                      search_analyzer: 'q_prefix',
-                      type: 'text',
-                    },
-                    stem: {
-                      analyzer: 'iq_text_stem',
-                      type: 'text',
-                    },
-                  },
-                },
-                match_mapping_type: 'string',
-              },
-            },
-          ],
-        },
-        settings: {
-          analysis: {
-            analyzer: {
-              i_prefix: {
-                filter: ['cjk_width', 'lowercase', 'asciifolding', 'front_ngram'],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-              i_text_bigram: {
-                filter: [
-                  'cjk_width',
-                  'lowercase',
-                  'asciifolding',
-                  'en-stem-filter',
-                  'bigram_joiner',
-                  'bigram_max_size',
-                ],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-              iq_text_base: {
-                filter: ['cjk_width', 'lowercase', 'asciifolding', 'en-stop-words-filter'],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-              iq_text_delimiter: {
-                filter: [
-                  'delimiter',
-                  'cjk_width',
-                  'lowercase',
-                  'asciifolding',
-                  'en-stop-words-filter',
-                  'en-stem-filter',
-                ],
-                tokenizer: 'whitespace',
-                type: 'custom',
-              },
-              iq_text_stem: {
-                filter: [
-                  'cjk_width',
-                  'lowercase',
-                  'asciifolding',
-                  'en-stop-words-filter',
-                  'en-stem-filter',
-                ],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-              q_prefix: {
-                filter: ['cjk_width', 'lowercase', 'asciifolding'],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-              q_text_bigram: {
-                filter: [
-                  'cjk_width',
-                  'lowercase',
-                  'asciifolding',
-                  'en-stem-filter',
-                  'bigram_joiner_unigrams',
-                  'bigram_max_size',
-                ],
-                tokenizer: 'standard',
-                type: 'custom',
-              },
-            },
-            filter: {
-              bigram_joiner: {
-                max_shingle_size: 2,
-                output_unigrams: false,
-                token_separator: '',
-                type: 'shingle',
-              },
-              bigram_joiner_unigrams: {
-                max_shingle_size: 2,
-                output_unigrams: true,
-                token_separator: '',
-                type: 'shingle',
-              },
-              bigram_max_size: {
-                max: 16,
-                min: 0,
-                type: 'length',
-              },
-              delimiter: {
-                catenate_all: true,
-                catenate_numbers: true,
-                catenate_words: true,
-                generate_number_parts: true,
-                generate_word_parts: true,
-                preserve_original: false,
-                split_on_case_change: true,
-                split_on_numerics: true,
-                stem_english_possessive: true,
-                type: 'word_delimiter_graph',
-              },
-              'en-stem-filter': {
-                name: 'light_english',
-                language: 'light_english',
-                type: 'stemmer',
-              },
-              'en-stop-words-filter': {
-                stopwords: '_english_',
-                type: 'stop',
-              },
-              front_ngram: {
-                max_gram: 12,
-                min_gram: 1,
-                type: 'edge_ngram',
-              },
-            },
-          },
-        },
-      },
       index: 'index_name',
+      mappings: defaultMappings,
+      settings: { ...textAnalysisSettings('en'), ...defaultSettings },
+    });
+  });
+  it('successfully creates an index with no mappings in French', async () => {
+    await expect(createIndex(mockClient, 'index_name', 'fr', false)).resolves.toEqual({
+      body: {},
+      headers: {
+        'x-elastic-product': 'Elasticsearch',
+      },
+      meta: {},
+      statusCode: 200,
+      warnings: [],
+    });
+    expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
+      index: 'index_name',
+      mappings: {},
+      settings: { ...textAnalysisSettings('fr'), ...defaultSettings },
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_index.ts
@@ -61,16 +61,19 @@ const defaultMappings = {
   ],
 };
 
-export const createApiIndex = async (
+export const createIndex = async (
   client: IScopedClusterClient,
   indexName: string,
-  language: string | undefined | null
+  language: string | undefined | null,
+  applyMappings: boolean
 ) => {
   return await client.asCurrentUser.indices.create({
-    body: {
-      mappings: defaultMappings,
-      settings: textAnalysisSettings(language ?? undefined),
-    },
     index: indexName,
+    mappings: applyMappings ? defaultMappings : {},
+    settings: {
+      ...textAnalysisSettings(language ?? undefined),
+      auto_expand_replicas: '0-3',
+      number_of_shards: 2,
+    },
   });
 };

--- a/x-pack/plugins/enterprise_search/server/lib/indices/text_analysis.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/text_analysis.ts
@@ -8,12 +8,12 @@
 import { AnalysisTokenFilter } from '@elastic/elasticsearch/lib/api/types';
 
 interface LanguageDataEntry {
+  custom_filter_definitions?: object;
   name: string;
   stemmer: string;
   stop_words: string;
-  custom_filter_definitions?: object;
-  prepended_filters?: string[];
   postpended_filters?: string[];
+  prepended_filters?: string[];
 }
 
 const languageData: Record<string, LanguageDataEntry> = {
@@ -282,13 +282,13 @@ const filterDefinitions = (language: string) => {
   return {
     ...genericFilters,
     [stemFilterName(language)]: {
-      type: 'stemmer' as const,
-      name: stemmerName,
       language: stemmerName,
+      name: stemmerName,
+      type: 'stemmer' as const,
     },
     [stopWordsFilterName(language)]: {
-      type: 'stop' as const,
       stopwords: stopWordsName,
+      type: 'stop' as const,
     },
     ...customFilterDefinitions,
   };

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -15,7 +15,7 @@ import { deleteConnectorById } from '../../lib/connectors/delete_connector';
 import { fetchConnectorByIndexName, fetchConnectors } from '../../lib/connectors/fetch_connectors';
 import { fetchCrawlerByIndexName, fetchCrawlers } from '../../lib/crawler/fetch_crawlers';
 
-import { createApiIndex } from '../../lib/indices/create_index';
+import { createIndex } from '../../lib/indices/create_index';
 import { fetchIndex } from '../../lib/indices/fetch_index';
 import { fetchIndices } from '../../lib/indices/fetch_indices';
 import { generateApiKey } from '../../lib/indices/generate_api_key';
@@ -319,7 +319,7 @@ export function registerIndexRoutes({ router, log }: RouteDependencies) {
         });
       }
 
-      const createIndexResponse = await createApiIndex(client, indexName, language);
+      const createIndexResponse = await createIndex(client, indexName, language, true);
 
       return response.ok({
         body: createIndexResponse,


### PR DESCRIPTION
## Summary

This updates the default sharding and replica settings for document indices created through the Enterprise Search frontend.
