### PR TITLE
[APM] Fix synthtrace cli script

### DIFF
--- a/scripts/synthtrace.js
+++ b/scripts/synthtrace.js
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-require('../src/setup_node_env');
+require('@babel/register')({
+  extensions: ['.ts', '.js'],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+});
 
 // We have to import directly from package since scenarios and worker.js are imported dynamically,
 // If we import the package (require('@kbn/apm-synthtrace')) the program will be executed on the compiled files, and thus we need to


### PR DESCRIPTION
Running `node scripts/synthtrace` broke somehow. This fixes it.