### PR TITLE
[Profiling] Minor refactors to constant values, variables, and methods

### DIFF
--- a/x-pack/plugins/profiling/common/index.ts
+++ b/x-pack/plugins/profiling/common/index.ts
@@ -24,7 +24,7 @@ export function getRoutePaths() {
     TopNHosts: `${BASE_ROUTE_PATH}/topn/hosts`,
     TopNThreads: `${BASE_ROUTE_PATH}/topn/threads`,
     TopNTraces: `${BASE_ROUTE_PATH}/topn/traces`,
-    FlamechartElastic: `${BASE_ROUTE_PATH}/flamechart/elastic`,
+    Flamechart: `${BASE_ROUTE_PATH}/flamechart`,
   };
 }
 

--- a/x-pack/plugins/profiling/common/index.ts
+++ b/x-pack/plugins/profiling/common/index.ts
@@ -13,7 +13,7 @@ export const INDEX_TRACES = 'profiling-stacktraces';
 export const INDEX_FRAMES = 'profiling-stackframes';
 export const INDEX_EXECUTABLES = 'profiling-executables';
 
-const BASE_ROUTE_PATH = '/api/prodfiler/v2';
+const BASE_ROUTE_PATH = '/api/profiling/v2';
 
 export function getRoutePaths() {
   return {

--- a/x-pack/plugins/profiling/common/index.ts
+++ b/x-pack/plugins/profiling/common/index.ts
@@ -13,7 +13,7 @@ export const INDEX_TRACES = 'profiling-stacktraces';
 export const INDEX_FRAMES = 'profiling-stackframes';
 export const INDEX_EXECUTABLES = 'profiling-executables';
 
-const BASE_ROUTE_PATH = '/api/profiling/v2';
+const BASE_ROUTE_PATH = '/api/profiling/v1';
 
 export function getRoutePaths() {
   return {

--- a/x-pack/plugins/profiling/public/services.ts
+++ b/x-pack/plugins/profiling/public/services.ts
@@ -91,7 +91,7 @@ export function getServices(core: CoreStart): Services {
           timeTo,
           kuery,
         };
-        return await core.http.get(paths.FlamechartElastic, { query });
+        return await core.http.get(paths.Flamechart, { query });
       } catch (e) {
         return e;
       }

--- a/x-pack/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/plugins/profiling/server/routes/flamechart.ts
@@ -15,7 +15,7 @@ import { getClient } from './compat';
 import { getExecutablesAndStackTraces } from './get_executables_and_stacktraces';
 import { createCommonFilter } from './query';
 
-export function registerFlameChartElasticSearchRoute({ router, logger }: RouteRegisterParameters) {
+export function registerFlameChartSearchRoute({ router, logger }: RouteRegisterParameters) {
   const paths = getRoutePaths();
   router.get(
     {

--- a/x-pack/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/plugins/profiling/server/routes/flamechart.ts
@@ -19,7 +19,7 @@ export function registerFlameChartElasticSearchRoute({ router, logger }: RouteRe
   const paths = getRoutePaths();
   router.get(
     {
-      path: paths.FlamechartElastic,
+      path: paths.Flamechart,
       validate: {
         query: schema.object({
           timeFrom: schema.number(),

--- a/x-pack/plugins/profiling/server/routes/index.ts
+++ b/x-pack/plugins/profiling/server/routes/index.ts
@@ -12,7 +12,7 @@ import {
   ProfilingRequestHandlerContext,
 } from '../types';
 
-import { registerFlameChartElasticSearchRoute } from './flamechart';
+import { registerFlameChartSearchRoute } from './flamechart';
 
 import { registerTopNFunctionsSearchRoute } from './functions';
 
@@ -34,7 +34,7 @@ export interface RouteRegisterParameters {
 }
 
 export function registerRoutes(params: RouteRegisterParameters) {
-  registerFlameChartElasticSearchRoute(params);
+  registerFlameChartSearchRoute(params);
   registerTopNFunctionsSearchRoute(params);
   registerTraceEventsTopNContainersSearchRoute(params);
   registerTraceEventsTopNDeploymentsSearchRoute(params);


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2399

This PR has a few minor refactors before moving to beta:

* Reset version for internal API
* Rename base route for internal API
* Rename route path variable for flamechart
* Rename registered route method for flamechart