### PR TITLE
[Lens] dont force metric vis re-render

### DIFF
--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -321,12 +321,6 @@ export const MetricVis = ({
     );
   }, [grid.length, scrollDimensions.height]);
 
-  // force chart to re-render to circumvent a charts bug
-  const magicKey = useRef(0);
-  useEffect(() => {
-    magicKey.current++;
-  }, [data]);
-
   return (
     <div
       ref={scrollContainerRef}
@@ -343,7 +337,7 @@ export const MetricVis = ({
           height: ${scrollChildHeight};
         `}
       >
-        <Chart key={magicKey.current}>
+        <Chart>
           <Settings
             theme={[
               {


### PR DESCRIPTION
## Summary

https://github.com/elastic/elastic-charts/issues/1778 is now resolved on the charts side and pulled into Kibana. There is no longer a need to force the metric chart to a full render any time the data or configuration changes.
