### PR TITLE
[Profiling] Bump elastic-charts from 47.2.1 to 48.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/charts": "48.0.0",
+    "@elastic/charts": "48.0.1",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.3.0-canary.1",
     "@elastic/ems-client": "8.3.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/charts": "47.2.1",
+    "@elastic/charts": "48.0.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.3.0-canary.1",
     "@elastic/ems-client": "8.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,10 +1478,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@48.0.0":
-  version "48.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-48.0.0.tgz#ccbbe7507102f078b80285e045a421105c0fc780"
-  integrity sha512-sj0L0JKU3KLJw0Ci1RzSj5WkhGc7ptAft/ulunF+w0i5vG7qgDdbnemCvRIPkgGiu2AnAnIj/bkK3IcxpAbmGA==
+"@elastic/charts@48.0.1":
+  version "48.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-48.0.1.tgz#52391ab37bcc3188748e5ac4ffe5275ce8cd93cd"
+  integrity sha512-cmu65UTwbQSj4Gk1gdhlORfbqrCeel9FMpz/fVODOpsRWh/4dwxZhN/x9Ob1e4W5jZDfd6OV47Gc9ZfQVzxKrQ==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,10 +1478,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@47.2.1":
-  version "47.2.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-47.2.1.tgz#a3fcd0d4dbccd7528d62a55dbbe8d11050d2b191"
-  integrity sha512-OeEfr0eO758BzS/IjSxW/O0cu9AvmpQ/dmy15E1Wz5hRTi+0hgHkW/vSOKju5/UHB6ulX36uRmHAJ1x5zuQ3MQ==
+"@elastic/charts@48.0.0":
+  version "48.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-48.0.0.tgz#ccbbe7507102f078b80285e045a421105c0fc780"
+  integrity sha512-sj0L0JKU3KLJw0Ci1RzSj5WkhGc7ptAft/ulunF+w0i5vG7qgDdbnemCvRIPkgGiu2AnAnIj/bkK3IcxpAbmGA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"
@@ -1502,7 +1502,7 @@
     resize-observer-polyfill "^1.5.1"
     ts-debounce "^4.0.0"
     utility-types "^3.10.0"
-    uuid "^3.3.2"
+    uuid "^8.3.2"
 
 "@elastic/datemath@5.0.3":
   version "5.0.3"


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2516

This PR updates the [elastic-charts](https://github.com/elastic/elastic-charts) dependency from 47.2.1 to 48.0.1.

This was prompted by https://github.com/elastic/elastic-charts/pull/1808, which fixes the bug in https://github.com/elastic/prodfiler/issues/2516/