### PR TITLE
[Profiling] Use Record instead of Map for TopN metadata

### DIFF
--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -162,8 +162,8 @@ export function groupStackFrameMetadataByStackTrace(
   stackTraces: Map<StackTraceID, StackTrace>,
   stackFrames: Map<StackFrameID, StackFrame>,
   executables: Map<FileID, Executable>
-): Map<StackTraceID, StackFrameMetadata[]> {
-  const frameMetadataForTraces = new Map<StackTraceID, StackFrameMetadata[]>();
+): Record<StackTraceID, StackFrameMetadata[]> {
+  const frameMetadataForTraces: Record<StackTraceID, StackFrameMetadata[]> = {};
   for (const [stackTraceID, trace] of stackTraces) {
     const frameMetadata = new Array<StackFrameMetadata>();
     for (let i = 0; i < trace.FrameIDs.length; i++) {
@@ -187,7 +187,7 @@ export function groupStackFrameMetadataByStackTrace(
 
       frameMetadata.push(metadata);
     }
-    frameMetadataForTraces.set(stackTraceID, frameMetadata);
+    frameMetadataForTraces[stackTraceID] = frameMetadata;
   }
   return frameMetadataForTraces;
 }

--- a/x-pack/plugins/profiling/server/routes/topn.ts
+++ b/x-pack/plugins/profiling/server/routes/topn.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { IRouter, Logger } from '@kbn/core/server';
 import { RouteRegisterParameters } from '.';
-import { fromMapToRecord, getRoutePaths, INDEX_EVENTS } from '../../common';
+import { getRoutePaths, INDEX_EVENTS } from '../../common';
 import { ProfilingESField } from '../../common/elasticsearch';
 import { groupStackFrameMetadataByStackTrace, StackTraceID } from '../../common/profiling';
 import { getFieldNameForTopNType, TopNType } from '../../common/stack_traces';
@@ -123,9 +123,7 @@ export async function topNElasticSearchQuery({
   );
 
   const metadata = await withProfilingSpan('collect_stackframe_metadata', async () => {
-    return fromMapToRecord(
-      groupStackFrameMetadataByStackTrace(stackTraces, stackFrames, executables)
-    );
+    return groupStackFrameMetadataByStackTrace(stackTraces, stackFrames, executables);
   });
 
   logger.info('returning payload response to client');


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2399

This PR switches the metadata structure from a map to a record.

Since JavaScript maps are not serializable to JSON by default, this removes the need to convert from a map to a serializable map-like type (aka `Record`) before sending the response.