### PR TITLE
[Security Solution] [Endpoint] Infinite host isolation exceptions loading state in policy details

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/tabs/policy_tabs.tsx
@@ -336,7 +336,7 @@ export const PolicyTabs = React.memo(() => {
   // show loader for privileges validation
   if (
     isInHostIsolationExceptionsTab &&
-    (privileges.loading || allPolicyHostIsolationExceptionsListRequest.isLoading)
+    (privileges.loading || allPolicyHostIsolationExceptionsListRequest.isFetching)
   ) {
     return <ManagementPageLoader data-test-subj="policyHostIsolationExceptionsTabLoading" />;
   }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/140154

- Due to a react-query library upgrade, `isLoading` will be `true` even if the query is `disabled` so we have to use `isFetching` instead.

![infinite host isolation exceptions loading state](https://user-images.githubusercontent.com/15727784/189100320-2ea6adcc-b9bf-465b-a8dc-422bd6d19ef6.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
