### PR TITLE
[Enterprise Search]Add axe reported to the cypress

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/cypress/commands.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cypress/commands.ts
@@ -44,7 +44,7 @@ export const login = ({
   });
 };
 
-const _handleViolations = (violations: Result[], skipTestFailure?: boolean) => {
+const handleViolations = (violations: Result[], skipTestFailure?: boolean) => {
   // Destructure keys from the violations object to create a readable array
   const violationData = violations.map(({ id, description, impact, nodes }) => ({
     description,
@@ -79,7 +79,7 @@ const _handleViolations = (violations: Result[], skipTestFailure?: boolean) => {
 };
 
 const logViolations = (violations: Result[]) => {
-  _handleViolations(violations);
+  handleViolations(violations);
 };
 
 /*

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cypress/commands.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cypress/commands.ts
@@ -78,8 +78,8 @@ const _handleViolations = (violations: Result[], skipTestFailure?: boolean) => {
   cy.task('table', violationData);
 };
 
-const logViolationsToConsoleOnly = (violations: Result[]) => {
-  _handleViolations(violations, true);
+const logViolations = (violations: Result[]) => {
+  _handleViolations(violations);
 };
 
 /*
@@ -106,5 +106,5 @@ export const checkA11y = () => {
   cy.injectAxe();
   cy.configureAxe(axeConfig);
   const context = '.kbnAppWrapper'; // Scopes a11y checks to only our app
-  cy.checkA11y(context, axeOptions, logViolationsToConsoleOnly);
+  cy.checkA11y(context, axeOptions, logViolations);
 };


### PR DESCRIPTION
## Summary

Adds a custom a11y reporter to the cypress commands.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
