### PR TITLE
[Cloud Posture] feat: add additional auth with EKS cluster

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/eks_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/eks_form.tsx
@@ -23,14 +23,35 @@ export const eksVars = [
     id: 'secret_access_key',
     label: i18n.translate(
       'xpack.csp.createPackagePolicy.eksIntegrationSettingsSection.secretAccessKeyFieldLabel',
-      { defaultMessage: 'Secret access key' }
+      { defaultMessage: 'Secret Access Key' }
     ),
   },
   {
     id: 'session_token',
     label: i18n.translate(
       'xpack.csp.createPackagePolicy.eksIntegrationSettingsSection.sessionTokenFieldLabel',
-      { defaultMessage: 'Session token' }
+      { defaultMessage: 'Session Token' }
+    ),
+  },
+  {
+    id: 'shared_credential_file',
+    label: i18n.translate(
+      'xpack.csp.createPackagePolicy.eksIntegrationSettingsSection.sharedCredentialsFileFieldLabel',
+      { defaultMessage: 'Shared Credential File' }
+    ),
+  },
+  {
+    id: 'credential_profile_name',
+    label: i18n.translate(
+      'xpack.csp.createPackagePolicy.eksIntegrationSettingsSection.sharedCredentialFileFieldLabel',
+      { defaultMessage: 'Credential Profile Name' }
+    ),
+  },
+  {
+    id: 'role_arn',
+    label: i18n.translate(
+      'xpack.csp.createPackagePolicy.eksIntegrationSettingsSection.roleARNFieldLabel',
+      { defaultMessage: 'ARN Role' }
     ),
   },
 ] as const;
@@ -50,6 +71,9 @@ const getEksVars = (input?: NewPackagePolicyInput): EksFormVars => {
     access_key_id: vars?.access_key_id.value || '',
     secret_access_key: vars?.secret_access_key.value || '',
     session_token: vars?.session_token.value || '',
+    shared_credential_file: vars?.shared_credential_file.value || '',
+    credential_profile_name: vars?.credential_profile_name.value || '',
+    role_arn: vars?.role_arn.value || '',
   };
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/mocks.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/mocks.ts
@@ -51,6 +51,15 @@ export const getCspNewPolicyMock = (type: BenchmarkId = 'cis_k8s'): NewPackagePo
             session_token: {
               type: 'text',
             },
+            shared_credential_file: {
+              type: 'text',
+            },
+            credential_profile_name: {
+              type: 'text',
+            },
+            role_arn: {
+              type: 'text',
+            },
           },
         },
       ],


### PR DESCRIPTION
## Summary

Add additional AWS auth methods to KSPM integration https://github.com/elastic/security-team/issues/4495

![image](https://user-images.githubusercontent.com/23185631/189118202-fbfed773-d6ea-44ef-8676-6467985ece55.png)
