### PR TITLE
[Enterprise Search] Add licensing callout for new crawlers

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -19,6 +19,7 @@ export const mockKibanaValues = {
     deployment_url: 'https://cloud.elastic.co/deployments/some-id',
   },
   history: mockHistory,
+  isCloud: false,
   navigateToUrl: jest.fn(),
   productAccess: {
     hasAppSearchAccess: true,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/licensing_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/licensing_callout.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { docLinks } from '../../../shared/doc_links/doc_links';
+
+export const LicensingCallout: React.FC = () => (
+  <EuiCallOut
+    title={i18n.translate('xpack.enterpriseSearch.content.licensingCallout.title', {
+      defaultMessage: 'Platinum features',
+    })}
+  >
+    <p>
+      {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentOne', {
+        defaultMessage:
+          'This feature requires a Platinum license or higher. From 8.5 this feature will be unavailable to Standard license self-managed deployments.',
+      })}
+    </p>
+    <p>
+      <FormattedMessage
+        id="xpack.enterpriseSearch.content.licensingCallout.contentTwoDetail"
+        defaultMessage="You will continue to be able to use web crawlers created in previous versions in 8.5. However, you won't be able to create {strongNew} web crawlers without a Platinum license or higher."
+        values={{
+          strongNew: (
+            <strong>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.licensingCallout.contentTwoStrongNew"
+                defaultMessage="new"
+              />
+            </strong>
+          ),
+        }}
+      />
+    </p>
+    <p>
+      {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentThree', {
+        defaultMessage:
+          "Did you know that the web crawler is available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services, and we'll handle the maintenance and upkeep for you.",
+      })}
+    </p>
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiLink external href={docLinks.licenseManagement}>
+          {i18n.translate('xpack.enterpriseSearch.workplaceSearch.explorePlatinumFeatures.link', {
+            defaultMessage: 'Explore Platinum features',
+          })}
+        </EuiLink>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiLink href="https://www.elastic.co/cloud/elasticsearch-service/signup" external>
+          {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentCloudTrial', {
+            defaultMessage: 'Sign up for a free 14-day Elastic Cloud trial.',
+          })}
+        </EuiLink>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiCallOut>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
@@ -9,13 +9,16 @@ import React from 'react';
 
 import { useValues, useActions } from 'kea';
 
-import { EuiSteps, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSteps, EuiText } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
 import { Status } from '../../../../../../common/types/api';
 import { docLinks } from '../../../../shared/doc_links';
+import { KibanaLogic } from '../../../../shared/kibana';
+import { LicensingLogic } from '../../../../shared/licensing';
 import { CreateCrawlerIndexApiLogic } from '../../../api/crawler/create_crawler_index_api_logic';
+import { LicensingCallout } from '../licensing_callout';
 import { CREATE_ELASTICSEARCH_INDEX_STEP, BUILD_SEARCH_EXPERIENCE_STEP } from '../method_steps';
 import { NewSearchIndexTemplate } from '../new_search_index_template';
 
@@ -24,51 +27,62 @@ import { MethodCrawlerLogic } from './method_crawler_logic';
 export const MethodCrawler: React.FC = () => {
   const { status } = useValues(CreateCrawlerIndexApiLogic);
   const { makeRequest } = useActions(CreateCrawlerIndexApiLogic);
+  const { isCloud } = useValues(KibanaLogic);
+  const { hasPlatinumLicense } = useValues(LicensingLogic);
 
   MethodCrawlerLogic.mount();
 
   return (
-    <NewSearchIndexTemplate
-      title={i18n.translate(
-        'xpack.enterpriseSearch.content.newIndex.steps.createIndex.crawler.title',
-        {
-          defaultMessage: 'Index using the web crawler',
-        }
+    <EuiFlexGroup direction="column">
+      {!isCloud && !hasPlatinumLicense && (
+        <EuiFlexItem>
+          <LicensingCallout />
+        </EuiFlexItem>
       )}
-      type="crawler"
-      onSubmit={(indexName, language) => makeRequest({ indexName, language })}
-      buttonLoading={status === Status.LOADING}
-      docsUrl={docLinks.crawlerOverview}
-    >
-      <EuiSteps
-        steps={[
-          CREATE_ELASTICSEARCH_INDEX_STEP,
-          {
-            children: (
-              <EuiText size="s">
-                <p>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.methodCrawler.steps.configureIngestion.content',
-                    {
-                      defaultMessage:
-                        'Configure the domains you’d like to crawl, and when ready trigger your first crawl. Let Enterprise Search do the rest.',
-                    }
-                  )}
-                </p>
-              </EuiText>
-            ),
-            status: 'incomplete',
-            title: i18n.translate(
-              'xpack.enterpriseSearch.content.newIndex.steps.configureIngestion.title',
+      <EuiFlexItem>
+        <NewSearchIndexTemplate
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.newIndex.steps.createIndex.crawler.title',
+            {
+              defaultMessage: 'Index using the web crawler',
+            }
+          )}
+          type="crawler"
+          onSubmit={(indexName, language) => makeRequest({ indexName, language })}
+          buttonLoading={status === Status.LOADING}
+          docsUrl={docLinks.crawlerOverview}
+        >
+          <EuiSteps
+            steps={[
+              CREATE_ELASTICSEARCH_INDEX_STEP,
               {
-                defaultMessage: 'Configure ingestion settings',
-              }
-            ),
-            titleSize: 'xs',
-          },
-          BUILD_SEARCH_EXPERIENCE_STEP,
-        ]}
-      />
-    </NewSearchIndexTemplate>
+                children: (
+                  <EuiText size="s">
+                    <p>
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.newIndex.methodCrawler.steps.configureIngestion.content',
+                        {
+                          defaultMessage:
+                            'Configure the domains you’d like to crawl, and when ready trigger your first crawl. Let Enterprise Search do the rest.',
+                        }
+                      )}
+                    </p>
+                  </EuiText>
+                ),
+                status: 'incomplete',
+                title: i18n.translate(
+                  'xpack.enterpriseSearch.content.newIndex.steps.configureIngestion.title',
+                  {
+                    defaultMessage: 'Configure ingestion settings',
+                  }
+                ),
+                titleSize: 'xs',
+              },
+              BUILD_SEARCH_EXPERIENCE_STEP,
+            ]}
+          />
+        </NewSearchIndexTemplate>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -39,8 +39,9 @@ interface KibanaLogicProps {
   cloud?: CloudSetup;
 }
 export interface KibanaValues extends Omit<KibanaLogicProps, 'cloud'> {
-  navigateToUrl(path: string, options?: CreateHrefOptions): Promise<void>;
   cloud: Partial<CloudSetup>;
+  isCloud: boolean;
+  navigateToUrl(path: string, options?: CreateHrefOptions): Promise<void>;
 }
 
 export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
@@ -59,11 +60,14 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
       {},
     ],
     productAccess: [props.productAccess, {}],
+    renderHeaderActions: [props.renderHeaderActions, {}],
     security: [props.security, {}],
     setBreadcrumbs: [props.setBreadcrumbs, {}],
     setChromeIsVisible: [props.setChromeIsVisible, {}],
     setDocTitle: [props.setDocTitle, {}],
-    renderHeaderActions: [props.renderHeaderActions, {}],
+  }),
+  selectors: ({ selectors }) => ({
+    isCloud: [() => [selectors.cloud], (cloud?: Partial<CloudSetup>) => !!cloud?.isCloudEnabled],
   }),
 });
 


### PR DESCRIPTION
## Summary

This adds a licensing callout for 8.4.2 to the Enterprise Search crawler. In 8.5.0 we will block the functionality, for now it's just a callout.


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->