### PR TITLE
[Console] Add missing autocompletes

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
@@ -492,6 +492,7 @@ const rules = {
         gamma: 0.5,
         period: 7,
       },
+      script: '',
     },
     cumulative_sum: {
       __template: {

--- a/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
@@ -301,6 +301,9 @@ const rules = {
       format: 'yyyy-MM-dd',
       time_zone: '00:00',
       missing: '',
+      calendar_interval: {
+        __one_of: ['year', 'quarter', 'week', 'day', 'hour', 'minute', 'second']
+      },
     },
     geo_distance: {
       __template: {
@@ -473,7 +476,7 @@ const rules = {
       percents: [],
     },
     sum_bucket: simple_pipeline,
-    moving_avg: {
+    moving_fn: {
       __template: {
         buckets_path: '',
       },

--- a/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
@@ -302,7 +302,7 @@ const rules = {
       time_zone: '00:00',
       missing: '',
       calendar_interval: {
-        __one_of: ['year', 'quarter', 'week', 'day', 'hour', 'minute', 'second']
+        __one_of: ['year', 'quarter', 'week', 'day', 'hour', 'minute', 'second'],
       },
     },
     geo_distance: {

--- a/src/plugins/console/server/lib/spec_definitions/js/aliases.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aliases.ts
@@ -14,6 +14,8 @@ export const aliases = (specService: SpecDefinitionsService) => {
     routing: '1',
     search_routing: '1,2',
     index_routing: '1',
+    is_write_index: false,
+    is_hidden: false,
   };
   specService.addGlobalAutocompleteRules('aliases', {
     '*': aliasRules,

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/indices.put_index_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/indices.put_index_template.json
@@ -1,0 +1,31 @@
+{
+  "indices.put_index_template": {
+    "data_autocomplete_rules": {
+      "composed_of":  [],
+      "index_patterns":  [],
+      "data_stream":  {
+        "__template": {
+          "allow_custom_routing": false,
+          "hidden": false,
+          "index_mode": ""
+        }
+      },
+      "template": {
+        "settings": {
+          "__scope_link": "put_settings"
+        },
+        "aliases": {
+          "__template": {
+            "NAME": {}
+          }
+        },
+        "mappings": {
+          "__scope_link": "put_mapping"
+        }
+      },
+      "_meta": {},
+      "priority": 0,
+      "version": 0
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/slm.put_lifecycle.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/slm.put_lifecycle.json
@@ -4,7 +4,42 @@
       "schedule": "",
       "name": "",
       "repository": "",
-      "config": {}
+      "config": {
+        "expanded_wildcards": {
+          "__one_of": [
+            "open",
+            "closed",
+            "hidden",
+            "none",
+            "all"
+          ]
+        },
+        "ignore_unavailable": false,
+        "include_global_state": false,
+        "indices": [
+          ""
+        ],
+        "feature_states": [
+          ""
+        ],
+        "partial": false,
+        "metadata": {}
+      },
+      "retention": {
+        "expire_after": {
+          "__one_of": [
+            "d",
+            "h",
+            "m",
+            "s",
+            "ms",
+            "micros",
+            "nanos"
+          ]
+        },
+        "min_count": 0,
+        "max_count": 0
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/137285
Fixes https://github.com/elastic/kibana/issues/137261

## Summary

This PR adds missing autocompletes that @maryam-saeidi  reported with https://github.com/elastic/kibana/issues/137285 and https://github.com/elastic/kibana/issues/137261.

### Things added/updated

- Add the missing `calendar_interval` in aggregations
- Replace `moving_avg` with `moving_fn` in aggregations
- Add autocompletion for `_index_template` API
- Add  the missing `retention` and update `config` keys in `_slm/policy/policy_id`
- Add the missing `is_write_index` and `is_hidden` keys for aliases

