### PR TITLE
[TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders

### DIFF
--- a/src/plugins/vis_types/table/kibana.json
+++ b/src/plugins/vis_types/table/kibana.json
@@ -6,7 +6,8 @@
   "requiredPlugins": [
     "expressions",
     "visualizations",
-    "fieldFormats"
+    "fieldFormats",
+    "usageCollection"
   ],
   "requiredBundles": [
     "data",

--- a/src/plugins/vis_types/table/public/plugin.ts
+++ b/src/plugins/vis_types/table/public/plugin.ts
@@ -9,10 +9,7 @@
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
 import type { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
-import type {
-  UsageCollectionSetup,
-  UsageCollectionStart,
-} from '@kbn/usage-collection-plugin/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 
 import { setFormatService } from './services';
@@ -22,13 +19,12 @@ import { registerTableVis } from './register_vis';
 export interface TablePluginSetupDependencies {
   expressions: ReturnType<ExpressionsPublicPlugin['setup']>;
   visualizations: VisualizationsSetup;
-  usageCollection?: UsageCollectionSetup;
 }
 
 /** @internal */
 export interface TablePluginStartDependencies {
   fieldFormats: FieldFormatsStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */

--- a/src/plugins/vis_types/table/public/services.ts
+++ b/src/plugins/vis_types/table/public/services.ts
@@ -7,11 +7,7 @@
  */
 
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
-import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 
 export const [getFormatService, setFormatService] =
   createGetterSetter<FieldFormatsStart>('FieldFormats');
-
-export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);

--- a/src/plugins/vis_types/table/public/table_vis_renderer.tsx
+++ b/src/plugins/vis_types/table/public/table_vis_renderer.tsx
@@ -35,7 +35,7 @@ const extractContainerType = (context?: KibanaExecutionContext): string | undefi
 
 export const getTableVisRenderer: (
   core: CoreStart,
-  usageCollection?: UsageCollectionStart
+  usageCollection: UsageCollectionStart
 ) => ExpressionRenderDefinition<TableVisRenderValue> = (core, usageCollection) => ({
   name: 'table_vis',
   reuseDomNode: true,
@@ -51,7 +51,7 @@ export const getTableVisRenderer: (
       const containerType = extractContainerType(handlers.getExecutionContext());
       const visualizationType = 'agg_based';
 
-      if (usageCollection && containerType) {
+      if (containerType) {
         const counterEvents = [
           `render_${visualizationType}_table`,
           !visData.table ? `render_${visualizationType}_table_split` : undefined,

--- a/src/plugins/vis_types/timeseries/kibana.json
+++ b/src/plugins/vis_types/timeseries/kibana.json
@@ -4,7 +4,7 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews", "fieldFormats"],
+  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews", "fieldFormats", "usageCollection"],
   "optionalPlugins": ["home"],
   "requiredBundles": ["unifiedSearch", "kibanaUtils", "kibanaReact", "fieldFormats"],
   "owner": {

--- a/src/plugins/vis_types/timeseries/public/plugin.ts
+++ b/src/plugins/vis_types/timeseries/public/plugin.ts
@@ -43,7 +43,7 @@ export interface MetricsPluginStartDependencies {
   fieldFormats: FieldFormatsStart;
   dataViews: DataViewsPublicPluginStart;
   charts: ChartsPluginStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */
@@ -77,8 +77,6 @@ export class MetricsPlugin implements Plugin<void, void> {
     setDataStart(data);
     setDataViewsStart(dataViews);
     setCoreStart(core);
-    if (usageCollection) {
-      setUsageCollectionStart(usageCollection);
-    }
+    setUsageCollectionStart(usageCollection);
   }
 }

--- a/src/plugins/vis_types/timeseries/public/services.ts
+++ b/src/plugins/vis_types/timeseries/public/services.ts
@@ -31,4 +31,4 @@ export const [getI18n, setI18n] = createGetterSetter<I18nStart>('I18n');
 export const [getCharts, setCharts] = createGetterSetter<ChartsPluginStart>('ChartsPluginStart');
 
 export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);
+  createGetterSetter<UsageCollectionStart>('UsageCollection');

--- a/src/plugins/vis_types/vega/kibana.json
+++ b/src/plugins/vis_types/vega/kibana.json
@@ -3,7 +3,7 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "visualizations", "mapsEms", "expressions", "inspector", "dataViews"],
+  "requiredPlugins": ["data", "visualizations", "mapsEms", "expressions", "inspector", "dataViews", "usageCollection"],
   "optionalPlugins": ["home"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor"],
   "owner": {

--- a/src/plugins/vis_types/vega/public/plugin.ts
+++ b/src/plugins/vis_types/vega/public/plugin.ts
@@ -58,7 +58,7 @@ export interface VegaPluginStartDependencies {
   data: DataPublicPluginStart;
   mapsEms: MapsEmsPluginPublicStart;
   dataViews: DataViewsPublicPluginStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */
@@ -104,9 +104,6 @@ export class VegaPlugin implements Plugin<void, void> {
     setDataViews(dataViews);
     setDocLinks(core.docLinks);
     setMapsEms(mapsEms);
-
-    if (usageCollection) {
-      setUsageCollectionStart(usageCollection);
-    }
+    setUsageCollectionStart(usageCollection);
   }
 }

--- a/src/plugins/vis_types/vega/public/services.ts
+++ b/src/plugins/vis_types/vega/public/services.ts
@@ -34,4 +34,4 @@ export const getEnableExternalUrls = () => getInjectedVars().enableExternalUrls;
 export const [getDocLinks, setDocLinks] = createGetterSetter<DocLinksStart>('docLinks');
 
 export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);
+  createGetterSetter<UsageCollectionStart>('UsageCollection');


### PR DESCRIPTION
Closes: #140277

## Summary

Fixes the regression of https://github.com/elastic/kibana/pull/135634 . It that PR `usageCollection` was removed from `optionalPlugins` as a result telemetry for TSVB stopped working

To protect ourselves in the future, we moved this plugin to `requiredPlugins`

### Screen with telemetry 

TSVB:

<img width="1554" alt="image" src="https://user-images.githubusercontent.com/20072247/189142247-85dc103b-ee13-443b-a352-94a6d7226f29.png">

VEGA: 
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/20072247/189146075-9b2555f3-8d52-4313-9a26-d381e559b1fc.png">


TABLE: 
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/20072247/189148944-fe859ff6-4dc8-42c4-8e44-8bd01e89a01e.png">





<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->