### PR TITLE
[Enterprise Search] Add crawler configuration delete funcitonality

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
@@ -161,7 +161,6 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
           type: 'icon',
         },
         {
-          available: (index) => !isCrawlerIndex(index),
           color: 'danger',
           description: 'Delete this index',
           icon: 'trash',

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -25,7 +25,11 @@ import { createIndexPipelineDefinitions } from '../../utils/create_pipeline_defi
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import { isIndexNotFoundException } from '../../utils/identify_exceptions';
 
-export function registerIndexRoutes({ router, log }: RouteDependencies) {
+export function registerIndexRoutes({
+  router,
+  enterpriseSearchRequestHandler,
+  log,
+}: RouteDependencies) {
   router.get(
     { path: '/internal/enterprise_search/search_indices', validate: false },
     elasticsearchErrorHandler(log, async (context, _, response) => {
@@ -141,15 +145,21 @@ export function registerIndexRoutes({ router, log }: RouteDependencies) {
       const { client } = (await context.core).elasticsearch;
 
       try {
-        const connector = await fetchConnectorByIndexName(client, indexName);
         const crawler = await fetchCrawlerByIndexName(client, indexName);
+        const connector = await fetchConnectorByIndexName(client, indexName);
+
+        if (crawler) {
+          const crawlerRes = await enterpriseSearchRequestHandler.createRequest({
+            path: `/api/ent/v1/internal/indices/${indexName}`,
+          })(context, request, response);
+
+          if (crawlerRes.status !== 200) {
+            throw new Error(crawlerRes.payload.message);
+          }
+        }
 
         if (connector) {
           await deleteConnectorById(client, connector.id);
-        }
-
-        if (crawler) {
-          // do nothing for now because we don't have a way to delete a crawler yet
         }
 
         await client.asCurrentUser.indices.delete({ index: indexName });


### PR DESCRIPTION
Enable delete button for crawler indices and add request to ent-search index deletion endpoint

issue: https://github.com/elastic/enterprise-search-team/issues/2627
ent-search changes: https://github.com/elastic/ent-search/pull/6820

None of the files edited here have test files, so I've not added any tests.
