### PR TITLE
[Security Solution] Optimize CODEOWNERS for the Rules Area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -451,6 +451,9 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-threat-hunting-explore
 
 ## Security Solution sub teams - Detections and Response Alerts
+/x-pack/plugins/security_solution/common/detection_engine/schemas/alerts @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/common/field_maps @elastic/security-detections-response-alerts
+
 /x-pack/plugins/security_solution/public/detections/pages/alerts @elastic/security-detections-response-alerts
 
 /x-pack/plugins/security_solution/server/lib/detection_engine/migrations @elastic/security-detections-response-alerts
@@ -461,29 +464,33 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detections-response-alerts
 /x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detections-response-alerts
 
-
 ## Security Solution sub teams - Detections and Response Rules
-/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/schemas/common @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/schemas/request @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/schemas/response @elastic/security-detections-response-rules
 
-/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/severity @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/status @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/popover_items @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
 
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/fleet @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/tags @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/server/lib/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/factories @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
 /x-pack/plugins/security_solution/server/lib/detection_engine/tags @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
 
 ## Security Solution sub teams - Security Platform
 /x-pack/plugins/lists @elastic/security-solution-platform
@@ -503,22 +510,23 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/plugins/security_solution/public/common/components/threat_match @elastic/security-solution-platform
 
 ## Security Solution cross teams ownership
-/x-pack/plugins/security_solution/cypress/downloads @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
 /x-pack/plugins/security_solution/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/support @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-solution-platform
 
-/x-pack/plugins/security_solution/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
-
-/x-pack/plugins/security_solution/common/ecs @elastic/security-detections-response-rules @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
 
+/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
 /x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
 
-/x-pack/plugins/security_solution/server/routes @elastic/security-detections-response-alerts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/routes @elastic/security-detections-response @elastic/security-threat-hunting
 
 
 ## Security Solution sub teams - security-onboarding-and-lifecycle-mgt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -522,7 +522,7 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
 
-/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response
 /x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
 
 /x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detections-response-rules


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/138795

## Summary

This is an attempt to unassign the @elastic/security-detections-response-rules area from irrelevant folders.

It turns out though, that I ended up assigning @elastic/security-detections-response-rules, @elastic/security-detections-response-alerts and @elastic/security-solution-platform to a bunch of new folders as well 😭 

I will comment on each change below.
