### PR TITLE
Fix ML stale element failure on cloud

### DIFF
--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -284,7 +284,7 @@ export function TrainedModelsTableProvider(
     }
 
     public async openStartDeploymentModal(modelId: string) {
-      await testSubjects.clickWhenNotDisabledWithoutRetry(
+      await testSubjects.clickWhenNotDisabled(
         this.rowSelector(modelId, 'mlModelsTableRowStartDeploymentAction'),
         { timeout: 5000 }
       );
@@ -292,7 +292,7 @@ export function TrainedModelsTableProvider(
     }
 
     public async clickStopDeploymentAction(modelId: string) {
-      await testSubjects.clickWhenNotDisabledWithoutRetry(
+      await testSubjects.clickWhenNotDisabled(
         this.rowSelector(modelId, 'mlModelsTableRowStopDeploymentAction'),
         { timeout: 5000 }
       );


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/139964 Spencer added a retry method for clickWhenNotDisabled, we need to use this method in ML tests to swallow up the stale element failures and reduce flakiness.  The rest of the failures are cascading due to this root cause.

ML Failures: https://buildkite.com/elastic/estf-cloud-kibana-functional-tests/builds/629

```
[00:01:51]             └-> stops deployment of the imported model pt_tiny_fill_mask
[00:01:51]               └-> "before each" hook: global before each for "stops deployment of the imported model pt_tiny_fill_mask"
[00:01:51]               │ debg TestSubjects.clickWhenNotDisabled(~mlModelsTable > ~row-pt_tiny_fill_mask > mlModelsTableRowStopDeploymentAction)
[00:01:51]               │ debg Find.clickByCssSelectorWhenNotDisabled('[data-test-subj~="mlModelsTable"] [data-test-subj~="row-pt_tiny_fill_mask"] [data-test-subj="mlModelsTableRowStopDeploymentAction"]') with timeout=5000
[00:01:51]               │ debg Find.findByCssSelector('[data-test-subj~="mlModelsTable"] [data-test-subj~="row-pt_tiny_fill_mask"] [data-test-subj="mlModelsTableRowStopDeploymentAction"]') with timeout=5000
[00:01:52]               │ info Taking screenshot "/opt/local-ssd/buildkite/builds/kb-n2-4-b41791103d8a3409/elastic/estf-cloud-kibana-functional-tests/kibana/x-pack/test/functional/screenshots/failure/machine learning - short tests model management trained models for ML power user-d44af9c4490010e531776d6573a7e6154e31c01c46dc701d1ccf7f09781117f4.png"
[00:01:52]               │ info Current URL is: https://estf-deployment-ci-3762256a-a8ed-466d-8a0e-c8233af.kb.us-west2.gcp.elastic-cloud.com:9243/app/ml/trained_models?_a=(trained_models%3A(pageIndex%3A0%2CpageSize%3A10%2CqueryText%3Apt_tiny_fill_mask%2CsortDirection%3Aasc%2CsortField%3Amodel_id))
[00:01:52]               │ info Saving page source to: /opt/local-ssd/buildkite/builds/kb-n2-4-b41791103d8a3409/elastic/estf-cloud-kibana-functional-tests/kibana/x-pack/test/functional/failure_debug/html/machine learning - short tests model management trained models for ML power user-d44af9c4490010e531776d6573a7e6154e31c01c46dc701d1ccf7f09781117f4.html
[00:01:52]               └- ✖ fail: machine learning - short tests model management trained models for ML power user with imported models stops deployment of the imported model pt_tiny_fill_mask
[00:01:52]               │      StaleElementReferenceError: stale element reference: element is not attached to the page document
[00:01:52]               │   (Session info: headless chrome=105.0.5195.52)
[00:01:52]               │       at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:522:15)
[00:01:52]               │       at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:589:13)
[00:01:52]               │       at Executor.execute (node_modules/selenium-webdriver/lib/http.js:514:28)
[00:01:52]               │       at runMicrotasks (<anonymous>)
[00:01:52]               │       at processTicksAndRejections (node:internal/process/task_queues:96:5)
[00:01:52]               │       at Task.exec (test/functional/services/remote/prevent_parallel_calls.ts:28:20)
[00:01:52]               │ 
```


<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->