### PR TITLE
[8.4] [optimizer/updateLimits] fix check which enables dropping missing bundles (#140285)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,23 +1,55 @@
 pageLoadAssetSize:
-  advancedSettings: 27596
   actions: 20000
+  advancedSettings: 27596
   aiops: 10000
   alerting: 106936
   apm: 64385
+  banners: 17946
+  bfetch: 22837
   canvas: 1066647
+  cases: 144442
   charts: 55000
   cloud: 21076
+  cloudSecurityPosture: 19109
   console: 46091
+  controls: 40000
   core: 435325
   crossClusterReplication: 65408
+  customIntegrations: 28810
   dashboard: 82025
   dashboardEnhanced: 65646
+  data: 454087
+  dataViewEditor: 12000
+  dataViewFieldEditor: 27000
+  dataViewManagement: 5000
+  dataViews: 43532
+  dataVisualizer: 27530
   devTools: 38637
   discover: 99999
   discoverEnhanced: 42730
+  embeddable: 87309
+  embeddableEnhanced: 22107
   enterpriseSearch: 35741
   esUiShared: 326654
+  eventAnnotation: 19334
+  expressionError: 22127
+  expressionGauge: 25000
+  expressionHeatmap: 27505
+  expressionImage: 19288
+  expressionLegacyMetricVis: 23121
+  expressionMetric: 22238
+  expressionMetricVis: 23121
+  expressionPartitionVis: 26338
+  expressionRepeatImage: 22341
+  expressionRevealImage: 25675
+  expressions: 140958
+  expressionShape: 34008
+  expressionTagcloud: 27505
+  expressionXY: 36000
   features: 21723
+  fieldFormats: 65209
+  fileUpload: 25664
+  fleet: 126917
   globalSearch: 29696
   globalSearchBar: 50403
   globalSearchProviders: 25554
@@ -27,11 +59,15 @@ pageLoadAssetSize:
   indexLifecycleManagement: 107090
   indexManagement: 140608
   infra: 184320
-  fleet: 126917
   ingestPipelines: 58003
   inputControlVis: 172675
   inspector: 148711
+  interactiveSetup: 80000
   kibanaOverview: 56279
+  kibanaReact: 74422
+  kibanaUsageCollection: 16463
+  kibanaUtils: 79713
+  kubernetesSecurity: 77234
   lens: 36000
   licenseManagement: 41817
   licensing: 29004
@@ -39,31 +75,55 @@ pageLoadAssetSize:
   logstash: 53548
   management: 46112
   maps: 90000
+  mapsEms: 26072
   ml: 82187
   monitoring: 80000
   navigation: 37269
   newsfeed: 42228
   observability: 95000
+  osquery: 107090
   painlessLab: 179748
+  presentationUtil: 58834
   remoteClusters: 51327
+  reporting: 57003
   rollup: 97204
+  runtimeFields: 41752
   savedObjects: 108518
   savedObjectsManagement: 101836
   savedObjectsTagging: 59482
   savedObjectsTaggingOss: 20590
+  screenshotMode: 17856
+  screenshotting: 22870
   searchprofiler: 67080
   security: 65433
+  securitySolution: 273763
+  sessionView: 77750
+  share: 71239
+  sharedUX: 16225
   snapshotRestore: 79032
   spaces: 57868
+  stackAlerts: 29684
+  synthetics: 40958
   telemetry: 51957
   telemetryManagementSection: 38586
+  threatIntelligence: 29195
+  timelines: 327300
   transform: 41007
   triggersActionsUi: 119000
+  uiActions: 35121
+  uiActionsEnhanced: 38494
+  unifiedSearch: 71059
   upgradeAssistant: 81241
+  urlDrilldown: 30063
   urlForwarding: 32579
   usageCollection: 39762
+  ux: 20784
   visDefaultEditor: 50178
+  visTypeGauge: 24113
+  visTypeHeatmap: 25340
   visTypeMarkdown: 30896
+  visTypeMetric: 23332
+  visTypePie: 35583
   visTypeTable: 94934
   visTypeTagcloud: 37575
   visTypeTimelion: 68883
@@ -73,63 +133,3 @@ pageLoadAssetSize:
   visTypeXy: 113478
   visualizations: 90000
   watcher: 43598
-  runtimeFields: 41752
-  stackAlerts: 29684
-  presentationUtil: 58834
-  osquery: 107090
-  fileUpload: 25664
-  dataVisualizer: 27530
-  banners: 17946
-  mapsEms: 26072
-  timelines: 327300
-  screenshotMode: 17856
-  visTypePie: 35583
-  expressionRevealImage: 25675
-  cases: 144442
-  expressionError: 22127
-  expressionRepeatImage: 22341
-  expressionImage: 19288
-  expressionMetric: 22238
-  expressionShape: 34008
-  interactiveSetup: 80000
-  expressionTagcloud: 27505
-  securitySolution: 273763
-  customIntegrations: 28810
-  expressionMetricVis: 23121
-  expressionLegacyMetricVis: 23121
-  expressionHeatmap: 27505
-  visTypeMetric: 23332
-  bfetch: 22837
-  kibanaUtils: 79713
-  dataViews: 43532
-  expressions: 140958
-  fieldFormats: 65209
-  kibanaReact: 74422
-  share: 71239
-  uiActions: 35121
-  embeddable: 87309
-  embeddableEnhanced: 22107
-  uiActionsEnhanced: 38494
-  urlDrilldown: 30063
-  dataViewEditor: 12000
-  dataViewFieldEditor: 27000
-  dataViewManagement: 5000
-  reporting: 57003
-  visTypeHeatmap: 25340
-  expressionGauge: 25000
-  controls: 40000
-  expressionPartitionVis: 26338
-  sharedUX: 16225
-  ux: 20784
-  sessionView: 77750
-  cloudSecurityPosture: 19109
-  visTypeGauge: 24113
-  unifiedSearch: 71059
-  data: 454087
-  eventAnnotation: 19334
-  screenshotting: 22870
-  synthetics: 40958
-  expressionXY: 36000
-  kibanaUsageCollection: 16463
-  kubernetesSecurity: 77234
-  threatIntelligence: 29195

--- a/packages/kbn-optimizer/src/cli.ts
+++ b/packages/kbn-optimizer/src/cli.ts
@@ -168,7 +168,7 @@ export function runKbnOptimizerCli(options: { defaultLimitsPath: string }) {
         updateBundleLimits({
           log,
           config,
-          dropMissing: !(focus || filter),
+          dropMissing: !(focus.length || filter.length),
           limitsPath,
         });
       }

--- a/packages/kbn-optimizer/src/limits.ts
+++ b/packages/kbn-optimizer/src/limits.ts
@@ -71,6 +71,28 @@ export function validateLimitsForAllBundles(
     );
   }
 
+  const sorted = limitBundleIds
+    .slice()
+    .sort((a, b) => a.localeCompare(b))
+    .every((key, i) => limitBundleIds[i] === key);
+  if (!sorted) {
+    throw createFailError(
+      dedent`
+        The limits defined in packages/kbn-optimizer/limits.yml are not sorted correctly. To make
+        sure the file is automatically updatedable without dozens of extra changes, the keys in this
+        file must be sorted.
+
+        Please sort the keys alphabetically or, to automatically update the limits file locally run:
+
+          node scripts/build_kibana_platform_plugins.js --update-limits
+
+        To validate your changes locally run:
+
+          node scripts/build_kibana_platform_plugins.js --validate-limits
+      ` + '\n'
+    );
+  }
+
   log.success('limits.yml file valid');
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[optimizer/updateLimits] fix check which enables dropping missing bundles (#140285)](https://github.com/elastic/kibana/pull/140285)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Spencer","email":"spencer@elastic.co"},"sourceCommit":{"committedDate":"2022-09-08T18:25:38Z","message":"[optimizer/updateLimits] fix check which enables dropping missing bundles (#140285)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f378b16b0fc3818de58196995ef340fdc2051f55","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v8.5.0"],"number":140285,"url":"https://github.com/elastic/kibana/pull/140285","mergeCommit":{"message":"[optimizer/updateLimits] fix check which enables dropping missing bundles (#140285)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f378b16b0fc3818de58196995ef340fdc2051f55"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/140285","number":140285,"mergeCommit":{"message":"[optimizer/updateLimits] fix check which enables dropping missing bundles (#140285)\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f378b16b0fc3818de58196995ef340fdc2051f55"}}]}] BACKPORT-->