### PR TITLE
[Maps] fix cluster layer disappears when switching from resolution 'high' to resolution 'low'

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.test.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.test.tsx
@@ -23,7 +23,7 @@ import {
   TiledSingleLayerVectorSourceDescriptor,
   VectorLayerDescriptor,
 } from '../../../../../common/descriptor_types';
-import { SOURCE_TYPES } from '../../../../../common/constants';
+import { LAYER_TYPE, SOURCE_TYPES } from '../../../../../common/constants';
 import { MvtVectorLayer } from './mvt_vector_layer';
 
 const defaultConfig = {
@@ -62,6 +62,11 @@ function createLayer(
   const layerDescriptor = MvtVectorLayer.createDescriptor(defaultLayerOptions);
   return new MvtVectorLayer({ layerDescriptor, source: mvtSource, customIcons: [] });
 }
+
+test('should have type MVT_VECTOR_LAYER', () => {
+  const layer: MvtVectorLayer = createLayer({}, {});
+  expect(layer.getType()).toEqual(LAYER_TYPE.MVT_VECTOR);
+});
 
 describe('visiblity', () => {
   it('should get minzoom from source', async () => {

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/vector_layer.tsx
@@ -123,7 +123,8 @@ export class AbstractVectorLayer extends AbstractLayer implements IVectorLayer {
     mapColors?: string[]
   ): VectorLayerDescriptor {
     const layerDescriptor = super.createDescriptor(options) as VectorLayerDescriptor;
-    layerDescriptor.type = LAYER_TYPE.GEOJSON_VECTOR;
+    layerDescriptor.type =
+      layerDescriptor.type !== undefined ? layerDescriptor.type : LAYER_TYPE.GEOJSON_VECTOR;
 
     if (!options.style) {
       const styleProperties = VectorStyle.createDefaultStyleProperties(mapColors ? mapColors : []);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/140332

Steps to view problem
1) Install sample web logs
2) create new map
3) add clusters layer, click add layer
4) change resolution to "high"
5) change resolution to "low". Layer should still be displayed