### PR TITLE
Removed Skip Test Comment in Home Security XPack Test

### DIFF
--- a/x-pack/test/functional/apps/home/feature_controls/home_security.ts
+++ b/x-pack/test/functional/apps/home/feature_controls/home_security.ts
@@ -35,7 +35,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
     });
 
-    // https://github.com/elastic/kibana/issues/132628
     describe('global all privileges', () => {
       before(async () => {
         await security.role.create('global_all_role', {


### PR DESCRIPTION
The home tests were already unskipped as part of another [PR](https://github.com/elastic/kibana/pull/139388).