### PR TITLE
[ML] Maps Integration: Anomalies table - use different colors for each geo field map layer

### DIFF
--- a/x-pack/plugins/ml/public/maps/util.ts
+++ b/x-pack/plugins/ml/public/maps/util.ts
@@ -9,7 +9,10 @@ import { FeatureCollection, Feature, Geometry } from 'geojson';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { htmlIdGenerator } from '@elastic/eui';
 import { FIELD_ORIGIN, STYLE_TYPE, LayerDescriptor } from '@kbn/maps-plugin/common';
-import { ESSearchSourceDescriptor } from '@kbn/maps-plugin/common/descriptor_types';
+import {
+  ESSearchSourceDescriptor,
+  VectorStyleDescriptor,
+} from '@kbn/maps-plugin/common/descriptor_types';
 import type { SerializableRecord } from '@kbn/utility-types';
 import { fromKueryExpression, luceneStringToDsl, toElasticsearchQuery } from '@kbn/es-query';
 import { ESSearchResponse } from '@kbn/core/types/elasticsearch';
@@ -20,6 +23,7 @@ import { formatHumanReadableDateTimeSeconds } from '../../common/util/date_utils
 import type { MlApiServices } from '../application/services/ml_api_service';
 import { MLAnomalyDoc } from '../../common/types/anomalies';
 import { SEARCH_QUERY_LANGUAGE } from '../../common/constants/search';
+import { tabColor } from '../../common/util/group_color_utils';
 import { getIndexPattern } from '../application/explorer/reducers/explorer_reducer/get_index_pattern';
 import { AnomalySource } from './anomaly_source';
 import { SourceIndexGeoFields } from '../application/explorer/explorer_utils';
@@ -119,9 +123,28 @@ export function getInitialSourceIndexFieldLayers(sourceIndexWithGeoFields: Sourc
       const { dataViewId, geoFields } = sourceIndexWithGeoFields[index];
 
       geoFields.forEach((geoField) => {
+        const color = tabColor(geoField);
+
         initialLayers.push({
           id: htmlIdGenerator()(),
-          type: LAYER_TYPE.MVT_VECTOR,
+          type: LAYER_TYPE.GEOJSON_VECTOR,
+          style: {
+            type: 'VECTOR',
+            properties: {
+              fillColor: {
+                type: 'STATIC',
+                options: {
+                  color,
+                },
+              },
+              lineColor: {
+                type: 'STATIC',
+                options: {
+                  color,
+                },
+              },
+            },
+          } as unknown as VectorStyleDescriptor,
           sourceDescriptor: {
             id: htmlIdGenerator()(),
             type: SOURCE_TYPES.ES_SEARCH,


### PR DESCRIPTION
## Summary

This PR creates maps link to use different colors for each geo field map layer - this allows user to more easily differentiate between layers once in Maps plugin.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios