### PR TITLE
Fix the View hosts button to direct to the host page, instead of the host details page.

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_host/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_host/index.tsx
@@ -11,18 +11,17 @@ import numeral from '@elastic/numeral';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo, useCallback, useState, useEffect } from 'react';
 
-import { DEFAULT_NUMBER_FORMAT, APP_UI_ID } from '../../../../common/constants';
+import { DEFAULT_NUMBER_FORMAT } from '../../../../common/constants';
 import type { ESQuery } from '../../../../common/typed_json';
 import { ID as OverviewHostQueryId, useHostOverview } from '../../containers/overview_host';
 import { HeaderSection } from '../../../common/components/header_section';
-import { useUiSetting$, useKibana } from '../../../common/lib/kibana';
-import { getHostDetailsUrl, useFormatUrl } from '../../../common/components/link_to';
+import { useUiSetting$ } from '../../../common/lib/kibana';
 import { getOverviewHostStats, OverviewHostStats } from '../overview_host_stats';
 import { manageQuery } from '../../../common/components/page/manage_query';
 import { InspectButtonContainer } from '../../../common/components/inspect';
+import { SecuritySolutionLinkButton } from '../../../common/components/links';
 import type { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 import { SecurityPageName } from '../../../app/types';
-import { LinkButton } from '../../../common/components/links';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
 
 export interface OwnProps {
@@ -43,8 +42,6 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
   startDate,
   setQuery,
 }) => {
-  const { formatUrl, search: urlSearch } = useFormatUrl(SecurityPageName.hosts);
-  const { navigateToApp } = useKibana().services.application;
   const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
 
   const { toggleStatus, setToggleStatus } = useQueryToggle(OverviewHostQueryId);
@@ -69,17 +66,6 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
     skip: querySkip,
   });
 
-  const goToHost = useCallback(
-    (ev) => {
-      ev.preventDefault();
-      navigateToApp(APP_UI_ID, {
-        deepLinkId: SecurityPageName.hosts,
-        path: getHostDetailsUrl('allHosts', urlSearch),
-      });
-    },
-    [navigateToApp, urlSearch]
-  );
-
   const hostEventsCount = useMemo(
     () => getOverviewHostStats(overviewHost).reduce((total, stat) => total + stat.count, 0),
     [overviewHost]
@@ -88,18 +74,6 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
   const formattedHostEventsCount = useMemo(
     () => numeral(hostEventsCount).format(defaultNumberFormat),
     [defaultNumberFormat, hostEventsCount]
-  );
-
-  const hostPageButton = useMemo(
-    () => (
-      <LinkButton onClick={goToHost} href={formatUrl('/allHosts')}>
-        <FormattedMessage
-          id="xpack.securitySolution.overview.hostsAction"
-          defaultMessage="View hosts"
-        />
-      </LinkButton>
-    ),
-    [goToHost, formatUrl]
   );
 
   const title = useMemo(
@@ -140,7 +114,12 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
           title={title}
           isInspectDisabled={filterQuery === undefined}
         >
-          <>{hostPageButton}</>
+          <SecuritySolutionLinkButton deepLinkId={SecurityPageName.hosts}>
+            <FormattedMessage
+              id="xpack.securitySolution.overview.hostsAction"
+              defaultMessage="View hosts"
+            />
+          </SecuritySolutionLinkButton>
         </HeaderSection>
         {toggleStatus && (
           <OverviewHostStatsManage


### PR DESCRIPTION
## Summary

A fix for #139998 which linked to the wrong page.

The component has been updated to use our new SecuritySolutionLinkButton to handle routing to the Host page

![Recording 2022-09-08 at 17 57 29](https://user-images.githubusercontent.com/28942857/189240237-53cc63c1-dbb0-4853-bb32-f1f9e07e76ea.gif)

To test, visit the overview page and click the `View hosts` button.
