### PR TITLE
[Cloud Posture] add functional tests for benchmarks page

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -160,6 +160,7 @@ enabled:
   - x-pack/test/functional/apps/apm/config.ts
   - x-pack/test/functional/apps/canvas/config.ts
   - x-pack/test/functional/apps/cross_cluster_replication/config.ts
+  - x-pack/test/functional/apps/cloud_security_posture/config.ts
   - x-pack/test/functional/apps/dashboard/group1/config.ts
   - x-pack/test/functional/apps/dashboard/group2/config.ts
   - x-pack/test/functional/apps/dashboard/group3/config.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -629,6 +629,8 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 /x-pack/plugins/cloud_security_posture/ @elastic/kibana-cloud-security-posture
 /x-pack/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
 /x-pack/test/api_integration/apis/cloud_security_posture/ @elastic/kibana-cloud-security-posture
+x-pack/test/functional/services/cloud_security_posture/ @elastic/kibana-cloud-security-posture
+x-pack/test/functional/apps/cloud_security_posture/ @elastic/kibana-cloud-security-posture
 
 # Security Solution onboarding tour
 /x-pack/plugins/security_solution/public/common/components/guided_onboarding @elastic/platform-onboarding

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -91,11 +91,13 @@ const TotalIntegrationsCount = ({
 }: Record<'pageCount' | 'totalCount', number>) => (
   <EuiText size="xs" style={{ marginLeft: 8 }}>
     <EuiTextColor color="subdued">
-      <FormattedMessage
-        id="xpack.csp.benchmarks.totalIntegrationsCountMessage"
-        defaultMessage="Showing {pageCount} of {totalCount, plural, one {# integration} other {# integrations}}"
-        values={{ pageCount, totalCount }}
-      />
+      <div data-test-subj="benchmark-integrations-count">
+        <FormattedMessage
+          id="xpack.csp.benchmarks.totalIntegrationsCountMessage"
+          defaultMessage="Showing {pageCount} of {totalCount, plural, one {# integration} other {# integrations}}"
+          values={{ pageCount, totalCount }}
+        />
+      </div>
     </EuiTextColor>
   </EuiText>
 );
@@ -119,6 +121,7 @@ const BenchmarkSearchField = ({
             { defaultMessage: 'e.g. benchmark name' }
           )}
           incremental
+          data-test-subj="benchmark-search-field"
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/test/functional/apps/cloud_security_posture/benchmarks.ts
+++ b/x-pack/test/functional/apps/cloud_security_posture/benchmarks.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../ftr_provider_context';
 import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '@kbn/cloud-security-posture-plugin/common/constants';
 import {
   type PackageInfo,
@@ -16,6 +15,7 @@ import {
   epmRouteService,
 } from '@kbn/fleet-plugin/common';
 import { packageToPackagePolicy } from '@kbn/fleet-plugin/common/services/package_to_package_policy';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');

--- a/x-pack/test/functional/apps/cloud_security_posture/benchmarks.ts
+++ b/x-pack/test/functional/apps/cloud_security_posture/benchmarks.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '@kbn/cloud-security-posture-plugin/common/constants';
+import {
+  type PackageInfo,
+  type AgentPolicy,
+  type PackagePolicy,
+  agentPolicyRouteService,
+  packagePolicyRouteService,
+  epmRouteService,
+} from '@kbn/fleet-plugin/common';
+import { packageToPackagePolicy } from '@kbn/fleet-plugin/common/services/package_to_package_policy';
+
+export default function ({ getService }: FtrProviderContext) {
+  const kibanaServer = getService('kibanaServer');
+  const cloudPosture = getService('cloudPosture');
+  const supertest = getService('supertest');
+
+  /**
+   * generates csp-00, csp01, csp-02, etc.
+   * needed for easier table sorting assertions
+   * */
+  const id = (
+    (n: number) => () =>
+      `csp-${String(n++).padStart(2, '0')}`
+  )(0);
+
+  const getAgentPolicyName = (name: string) => `${name}-agent-policy`;
+
+  let packageInfo: PackageInfo;
+  let basePackagePolicy: PackagePolicy;
+
+  const createAgentPolicy = (name: string) =>
+    supertest
+      .post(agentPolicyRouteService.getCreatePath())
+      .set('kbn-xsrf', 'true')
+      .send({ name, description: '', namespace: 'default' })
+      .expect(200)
+      .then<AgentPolicy>((res) => res.body.item);
+
+  const getPackageInfo = () =>
+    supertest
+      .get(epmRouteService.getInfoPath(CLOUD_SECURITY_POSTURE_PACKAGE_NAME))
+      .set('kbn-xsrf', 'xxxx')
+      .expect(200)
+      .then<PackageInfo>((response) => response.body.item);
+
+  /**
+   * creates agent policy + package policy
+   * cleaned by cleanStandardList
+   */
+  const installKSPM = async (name: string) => {
+    const agentPolicy = await createAgentPolicy(getAgentPolicyName(name));
+
+    return supertest
+      .post(packagePolicyRouteService.getCreatePath())
+      .set('kbn-xsrf', 'xxxx')
+      .send(packageToPackagePolicy(packageInfo, agentPolicy.id, 'default', name))
+      .expect(200)
+      .then<PackagePolicy>((response) => response.body.item);
+  };
+
+  /**
+   * The order of 'describe' matters. state is kept to the next 'describe' block.
+   * we use this to avoid installing an integration for each test
+   */
+  describe('Benchmarks Page', () => {
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+    });
+
+    after(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+    });
+
+    describe('Errors handling', () => {
+      it('displays empty prompt when no integration is installed', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.assertEmptyPromptExists();
+      });
+    });
+
+    describe('Navigation', async () => {
+      before(async () => {
+        /**
+         * This is the first installation of the integration.
+         * other test assume it is installed
+         */
+        packageInfo = await getPackageInfo();
+        basePackagePolicy = await installKSPM(id());
+      });
+
+      it('navigates to CSP Benchmarks page', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.assertBenchmarkPageExists();
+      });
+
+      it('navigates from CSP Benchmarks page to Fleet Add Integration page', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.goToNewIntegrationPage();
+        // TODO: add assertion
+      });
+
+      it('navigates from CSP Benchmarks page to Fleet Agent Policy page', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.goToIntegrationAgentPolicyPage();
+        // TODO: add assertion
+      });
+    });
+
+    describe('Table Data', () => {
+      /** Tests below use integration 'csp-00' (first installed) */
+
+      it('displays integration name column', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.assertTableColumnValueExists(
+          'benchmarks-table-column-integration',
+          'csp-00'
+        );
+      });
+
+      it('displays integration type column', async () => {
+        await cloudPosture.benchmarks.assertTableColumnValueExists(
+          'benchmarks-table-column-integration_type',
+          'Kubernetes Security Posture Management'
+        );
+      });
+
+      it('displays agent policy name column', async () => {
+        await cloudPosture.benchmarks.assertTableColumnValueExists(
+          'benchmarks-table-column-agent-policy',
+          getAgentPolicyName('csp-00')
+        );
+      });
+
+      it('displays agents count column', async () => {
+        await cloudPosture.benchmarks.assertTableColumnValueExists(
+          'benchmarks-table-column-number-of-agents',
+          '0' // No agents should be enrolled
+        );
+      });
+
+      it('displays created by column', async () => {
+        await cloudPosture.benchmarks.assertTableColumnValueExists(
+          'benchmarks-table-column-created-by',
+          basePackagePolicy.created_by // TODO: create user explicity
+        );
+      });
+
+      it.skip('created time column is displayed', async () => {
+        // UI is formatted.
+        // TODO: add 'title' timestamp to the column and assert on it?
+      });
+    });
+
+    describe('Table Pagination', async () => {
+      before(async () => {
+        /**
+         * We need more than 10 rows to test pagination, and we currently have 1
+         * unfortunately, this is what takes most of the time in all of the tests
+         *
+         * TODO: find a way to speed this up.
+         */
+        await Promise.all(Array.from({ length: 10 }, () => installKSPM(id())));
+      });
+
+      it('set page size', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+
+        await cloudPosture.benchmarks.assertIntegrationCountExists(10, 11);
+        await cloudPosture.benchmarks.setPageSize(25);
+        await cloudPosture.benchmarks.assertIntegrationCountExists(11, 11);
+      });
+
+      it('move to next and previous pages', async () => {
+        await cloudPosture.benchmarks.setPageSize(10);
+        await cloudPosture.benchmarks.goToNextPage();
+        await cloudPosture.benchmarks.assertIntegrationCountExists(1, 11);
+        await cloudPosture.benchmarks.goToPreviousPage();
+        await cloudPosture.benchmarks.assertIntegrationCountExists(10, 11);
+      });
+    });
+
+    describe('Table Sort', async () => {
+      it('sort by integration name', async () => {
+        await cloudPosture.benchmarks.goToBenchmarkPage();
+        await cloudPosture.benchmarks.assertIntegrationNameRowNumber(0, 'csp-00');
+        await cloudPosture.benchmarks.assertIntegrationNameRowNumber(9, 'csp-09');
+        await cloudPosture.benchmarks.toggleSortByName();
+        await cloudPosture.benchmarks.assertIntegrationNameRowNumber(0, 'csp-10');
+        await cloudPosture.benchmarks.assertIntegrationNameRowNumber(9, 'csp-01');
+      });
+    });
+
+    describe('Search', () => {
+      it('displays all results', async () => {
+        await cloudPosture.benchmarks.filterBenchmarks('');
+        await cloudPosture.benchmarks.assertIntegrationCountExists(10, 11);
+      });
+
+      it('displays filters results', async () => {
+        await cloudPosture.benchmarks.filterBenchmarks('csp-02');
+        await cloudPosture.benchmarks.assertIntegrationCountExists(1, 1);
+      });
+    });
+  });
+}

--- a/x-pack/test/functional/apps/cloud_security_posture/config.ts
+++ b/x-pack/test/functional/apps/cloud_security_posture/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../config.base.js'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/test/functional/apps/cloud_security_posture/index.ts
+++ b/x-pack/test/functional/apps/cloud_security_posture/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('CSP UI', function () {
+    loadTestFile(require.resolve('./benchmarks'));
+  });
+}

--- a/x-pack/test/functional/services/cloud_security_posture/benchmarks.ts
+++ b/x-pack/test/functional/services/cloud_security_posture/benchmarks.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import expect from '@kbn/expect';
+
+export function BenchmarksProvider({ getService, getPageObjects }: FtrProviderContext) {
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const PageObjects = getPageObjects(['common']);
+
+  /** Actions */
+  const filterBenchmarks = (value: string) =>
+    testSubjects.setValue('benchmark-search-field', value);
+
+  const setPageSize = async (size: 10 | 25) => {
+    await testSubjects.click('tablePaginationPopoverButton');
+    await testSubjects.click(`tablePagination-${size}-rows`);
+  };
+
+  const toggleSortByName = async () => {
+    // TODO: use custom test subject
+    await testSubjects.click('tableHeaderCell_package_policy.name_0');
+  };
+
+  /** Navigation */
+  const goToBenchmarkPage = () =>
+    PageObjects.common.navigateToUrl('securitySolution', 'cloud_security_posture/benchmarks', {
+      shouldUseHashForSubUrl: false,
+    });
+
+  const goToNextPage = async () => {
+    await testSubjects.click('pagination-button-next');
+    await testSubjects.isEnabled('pagination-button-0');
+  };
+
+  const goToPreviousPage = async () => {
+    await testSubjects.click('pagination-button-previous');
+    await testSubjects.isEnabled('pagination-button-1');
+  };
+
+  const goToNewIntegrationPage = async () => {
+    await testSubjects.click('csp_add_integration');
+    // TODO: verify we got there in Fleet
+  };
+
+  const goToIntegrationRulesPage = () =>
+    retry.try(async () => {
+      await testSubjects.click('benchmarks-table-column-integration');
+      await testSubjects.existOrFail('csp_rules_container', { timeout: 10000 });
+    });
+
+  const goToIntegrationAgentPolicyPage = async () => {
+    retry.try(async () => {
+      await testSubjects.click('benchmarks-table-column-integration_type');
+      await testSubjects.existOrFail('csp_rules_container', { timeout: 10000 });
+    });
+    // TODO: verify we got there
+  };
+
+  /** Assertions  */
+  const assertIntegrationCountExists = (visible: number, total: number) =>
+    retry.try(async () => {
+      await testSubjects.existOrFail('benchmark-integrations-count');
+      const text = await (await testSubjects.find('benchmark-integrations-count')).getVisibleText();
+      expect(text).to.be(`Showing ${visible} of ${total} integration${total > 1 ? 's' : ''}`);
+    });
+
+  const assertEmptyPromptExists = () =>
+    retry.try(async () => {
+      await testSubjects.existOrFail('cloud_posture_page_package_not_installed', {
+        timeout: 10000,
+      });
+    });
+
+  const assertTableColumnValueExists = (column: string, value: string) =>
+    retry.try(async () => {
+      expect(await testSubjects.getVisibleText(column)).to.be(value);
+    });
+
+  const assertBenchmarkPageExists = () =>
+    retry.try(async () => {
+      await testSubjects.existOrFail('benchmarks-page-header', { timeout: 10000 });
+      await testSubjects.existOrFail('csp_benchmarks_table', { timeout: 10000 });
+    });
+
+  const assertIntegrationNameRowNumber = async (number: number, value: string) =>
+    retry.try(async () => {
+      const rows = await testSubjects.findAll('benchmarks-table-column-integration');
+      expect(await rows[number].getVisibleText()).to.be(value);
+    });
+
+  return {
+    toggleSortByName,
+    filterBenchmarks,
+    setPageSize,
+    goToBenchmarkPage,
+    goToNewIntegrationPage,
+    goToIntegrationRulesPage,
+    goToIntegrationAgentPolicyPage,
+    goToNextPage,
+    goToPreviousPage,
+    assertBenchmarkPageExists,
+    assertIntegrationCountExists,
+    assertEmptyPromptExists,
+    assertTableColumnValueExists,
+    assertIntegrationNameRowNumber,
+  };
+}

--- a/x-pack/test/functional/services/cloud_security_posture/benchmarks.ts
+++ b/x-pack/test/functional/services/cloud_security_posture/benchmarks.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../ftr_provider_context';
 import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export function BenchmarksProvider({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');

--- a/x-pack/test/functional/services/cloud_security_posture/index.ts
+++ b/x-pack/test/functional/services/cloud_security_posture/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { BenchmarksProvider } from './benchmarks';
+
+export function CloudPostureProvider(context: FtrProviderContext) {
+  const benchmarks = BenchmarksProvider(context);
+
+  return {
+    benchmarks,
+  };
+}

--- a/x-pack/test/functional/services/index.ts
+++ b/x-pack/test/functional/services/index.ts
@@ -71,6 +71,7 @@ import { ObservabilityProvider } from './observability';
 // import { CompareImagesProvider } from './compare_images';
 import { CasesServiceProvider } from './cases';
 import { AiopsProvider } from './aiops';
+import { CloudPostureProvider } from './cloud_security_posture';
 
 // define the name and providers for services that should be
 // available to your tests. If you don't specify anything here
@@ -132,4 +133,5 @@ export const services = {
   // compareImages: CompareImagesProvider,
   cases: CasesServiceProvider,
   aiops: AiopsProvider,
+  cloudPosture: CloudPostureProvider,
 };


### PR DESCRIPTION
## Summary

this PR includes our first functional UI test using kibana's FTR. 

test suite implements the [cases](https://github.com/elastic/security-team/issues/4593#issuecomment-1239706090) defined in testrail. it takes about **6mins** to run, not sure if that's good or bad yet 😄 

notable additions: 
- functional tests and services:  ([might change](https://github.com/elastic/security-team/issues/4593#issuecomment-1242911306)?)
  - `x-pack/test/functional/apps/cloud_security_posture` - this is where our FTR UI tests are.
  - `x-pack/test/functional/services/cloud_security_posture` - this is where our FTR UI services (page objects) are. 


