### PR TITLE
[8.4] [TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders (#140284)

### DIFF
--- a/src/plugins/vis_types/table/kibana.json
+++ b/src/plugins/vis_types/table/kibana.json
@@ -6,7 +6,8 @@
   "requiredPlugins": [
     "expressions",
     "visualizations",
-    "data"
+    "data",
+    "usageCollection"
   ],
   "requiredBundles": [
     "kibanaUtils",

--- a/src/plugins/vis_types/table/public/plugin.ts
+++ b/src/plugins/vis_types/table/public/plugin.ts
@@ -9,7 +9,7 @@
 import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { Plugin as ExpressionsPublicPlugin } from '@kbn/expressions-plugin/public';
 import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
-import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { setFormatService } from './services';
@@ -19,13 +19,12 @@ import { registerTableVis } from './register_vis';
 export interface TablePluginSetupDependencies {
   expressions: ReturnType<ExpressionsPublicPlugin['setup']>;
   visualizations: VisualizationsSetup;
-  usageCollection?: UsageCollectionSetup;
 }
 
 /** @internal */
 export interface TablePluginStartDependencies {
   data: DataPublicPluginStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */

--- a/src/plugins/vis_types/table/public/services.ts
+++ b/src/plugins/vis_types/table/public/services.ts
@@ -8,10 +8,6 @@
 
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 export const [getFormatService, setFormatService] =
   createGetterSetter<DataPublicPluginStart['fieldFormats']>('table data.fieldFormats');
-
-export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);

--- a/src/plugins/vis_types/table/public/table_vis_renderer.tsx
+++ b/src/plugins/vis_types/table/public/table_vis_renderer.tsx
@@ -35,7 +35,7 @@ const extractContainerType = (context?: KibanaExecutionContext): string | undefi
 
 export const getTableVisRenderer: (
   core: CoreStart,
-  usageCollection?: UsageCollectionStart
+  usageCollection: UsageCollectionStart
 ) => ExpressionRenderDefinition<TableVisRenderValue> = (core, usageCollection) => ({
   name: 'table_vis',
   reuseDomNode: true,
@@ -51,7 +51,7 @@ export const getTableVisRenderer: (
       const containerType = extractContainerType(handlers.getExecutionContext());
       const visualizationType = 'agg_based';
 
-      if (usageCollection && containerType) {
+      if (containerType) {
         const counterEvents = [
           `render_${visualizationType}_table`,
           !visData.table ? `render_${visualizationType}_table_split` : undefined,

--- a/src/plugins/vis_types/timeseries/kibana.json
+++ b/src/plugins/vis_types/timeseries/kibana.json
@@ -4,7 +4,7 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews"],
+  "requiredPlugins": ["charts", "data", "expressions", "visualizations", "inspector", "dataViews", "usageCollection"],
   "optionalPlugins": ["home"],
   "requiredBundles": ["unifiedSearch", "kibanaUtils", "kibanaReact", "fieldFormats"],
   "owner": {

--- a/src/plugins/vis_types/timeseries/public/plugin.ts
+++ b/src/plugins/vis_types/timeseries/public/plugin.ts
@@ -40,7 +40,7 @@ export interface MetricsPluginStartDependencies {
   data: DataPublicPluginStart;
   dataViews: DataViewsPublicPluginStart;
   charts: ChartsPluginStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */
@@ -74,8 +74,6 @@ export class MetricsPlugin implements Plugin<void, void> {
     setDataStart(data);
     setDataViewsStart(dataViews);
     setCoreStart(core);
-    if (usageCollection) {
-      setUsageCollectionStart(usageCollection);
-    }
+    setUsageCollectionStart(usageCollection);
   }
 }

--- a/src/plugins/vis_types/timeseries/public/services.ts
+++ b/src/plugins/vis_types/timeseries/public/services.ts
@@ -30,4 +30,4 @@ export const [getI18n, setI18n] = createGetterSetter<I18nStart>('I18n');
 export const [getCharts, setCharts] = createGetterSetter<ChartsPluginStart>('ChartsPluginStart');
 
 export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);
+  createGetterSetter<UsageCollectionStart>('UsageCollection');

--- a/src/plugins/vis_types/vega/kibana.json
+++ b/src/plugins/vis_types/vega/kibana.json
@@ -3,7 +3,7 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "visualizations", "mapsEms", "expressions", "inspector", "dataViews"],
+  "requiredPlugins": ["data", "visualizations", "mapsEms", "expressions", "inspector", "dataViews", "usageCollection"],
   "optionalPlugins": ["home"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor"],
   "owner": {

--- a/src/plugins/vis_types/vega/public/plugin.ts
+++ b/src/plugins/vis_types/vega/public/plugin.ts
@@ -58,7 +58,7 @@ export interface VegaPluginStartDependencies {
   data: DataPublicPluginStart;
   mapsEms: MapsEmsPluginPublicStart;
   dataViews: DataViewsPublicPluginStart;
-  usageCollection?: UsageCollectionStart;
+  usageCollection: UsageCollectionStart;
 }
 
 /** @internal */
@@ -104,9 +104,6 @@ export class VegaPlugin implements Plugin<void, void> {
     setDataViews(dataViews);
     setDocLinks(core.docLinks);
     setMapsEms(mapsEms);
-
-    if (usageCollection) {
-      setUsageCollectionStart(usageCollection);
-    }
+    setUsageCollectionStart(usageCollection);
   }
 }

--- a/src/plugins/vis_types/vega/public/services.ts
+++ b/src/plugins/vis_types/vega/public/services.ts
@@ -34,4 +34,4 @@ export const getEnableExternalUrls = () => getInjectedVars().enableExternalUrls;
 export const [getDocLinks, setDocLinks] = createGetterSetter<DocLinksStart>('docLinks');
 
 export const [getUsageCollectionStart, setUsageCollectionStart] =
-  createGetterSetter<UsageCollectionStart>('UsageCollection', false);
+  createGetterSetter<UsageCollectionStart>('UsageCollection');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders (#140284)](https://github.com/elastic/kibana/pull/140284)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2022-09-08T20:16:45Z","message":"[TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders (#140284)\n\n* [TSVB] fix broken TSVB regression\r\n\r\n* fix VEGA\r\n\r\n* fix table","sha":"46a080020394c6667729e7820829f7ad7fe5b4b7","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:TSVB","Feature:Telemetry","Team:VisEditors","release_note:skip","backport:prev-minor","v8.5.0","v8.4.2"],"number":140284,"url":"https://github.com/elastic/kibana/pull/140284","mergeCommit":{"message":"[TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders (#140284)\n\n* [TSVB] fix broken TSVB regression\r\n\r\n* fix VEGA\r\n\r\n* fix table","sha":"46a080020394c6667729e7820829f7ad7fe5b4b7"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/140284","number":140284,"mergeCommit":{"message":"[TSVB / VEGA / TABLE ] fix `UI` render counter doesn't track renders (#140284)\n\n* [TSVB] fix broken TSVB regression\r\n\r\n* fix VEGA\r\n\r\n* fix table","sha":"46a080020394c6667729e7820829f7ad7fe5b4b7"}},{"branch":"8.4","label":"v8.4.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->