### PR TITLE
[Enterprise Search] Modify licensing callout for 8.5

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/licensing_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/licensing_callout.tsx
@@ -9,59 +9,90 @@ import React from 'react';
 
 import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 
 import { docLinks } from '../../../shared/doc_links/doc_links';
 
-export const LicensingCallout: React.FC = () => (
-  <EuiCallOut
-    title={i18n.translate('xpack.enterpriseSearch.content.licensingCallout.title', {
-      defaultMessage: 'Platinum features',
-    })}
-  >
-    <p>
-      {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentOne', {
+export enum LICENSING_FEATURE {
+  NATIVE_CONNECTOR = 'nativeConnector',
+  CRAWLER = 'crawler',
+  INFERENCE = 'inference',
+}
+
+type ContentBlock = Record<LICENSING_FEATURE, string>;
+
+export const LicensingCallout: React.FC<{ feature: LICENSING_FEATURE }> = ({ feature }) => {
+  const firstContentBlock: ContentBlock = {
+    [LICENSING_FEATURE.NATIVE_CONNECTOR]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.nativeConnector.contentOne',
+      {
         defaultMessage:
-          'This feature requires a Platinum license or higher. From 8.5 this feature will be unavailable to Standard license self-managed deployments.',
-      })}
-    </p>
-    <p>
-      <FormattedMessage
-        id="xpack.enterpriseSearch.content.licensingCallout.contentTwoDetail"
-        defaultMessage="You will continue to be able to use web crawlers created in previous versions in 8.5. However, you won't be able to create {strongNew} web crawlers without a Platinum license or higher."
-        values={{
-          strongNew: (
-            <strong>
-              <FormattedMessage
-                id="xpack.enterpriseSearch.content.licensingCallout.contentTwoStrongNew"
-                defaultMessage="new"
-              />
-            </strong>
-          ),
-        }}
-      />
-    </p>
-    <p>
-      {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentThree', {
+          'Built-in connectors require a Platinum license or higher and are not available to Standard license self-managed deployments. You need to upgrade to use this feature.',
+      }
+    ),
+    [LICENSING_FEATURE.CRAWLER]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.crawler.contentOne',
+      {
         defaultMessage:
-          "Did you know that the web crawler is available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services, and we'll handle the maintenance and upkeep for you.",
+          'The web crawler requires a Platinum license or higher and is not available to Standard license self-managed deployments. You need to upgrade to use this feature.',
+      }
+    ),
+    [LICENSING_FEATURE.INFERENCE]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.inference.contentOne',
+      {
+        defaultMessage:
+          'Inference processors require a Platinum license or higher and are not available to Standard license self-managed deployments. You need to upgrade to use this feature.',
+      }
+    ),
+  };
+
+  const secondContentBlock: ContentBlock = {
+    [LICENSING_FEATURE.NATIVE_CONNECTOR]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.contentTwo',
+      {
+        defaultMessage:
+          "Did you know that built-in connectors are available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services, and we'll handle the maintenance and upkeep for you.",
+      }
+    ),
+    [LICENSING_FEATURE.CRAWLER]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.crawler.contentTwo',
+      {
+        defaultMessage:
+          "Did you know that web crawlers are available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services, and we'll handle the maintenance and upkeep for you.",
+      }
+    ),
+    [LICENSING_FEATURE.INFERENCE]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.inference.contentTwo',
+      {
+        defaultMessage:
+          "Did you know that inference processors are available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services, and we'll handle the maintenance and upkeep for you.",
+      }
+    ),
+  };
+
+  return (
+    <EuiCallOut
+      title={i18n.translate('xpack.enterpriseSearch.content.licensingCallout.title', {
+        defaultMessage: 'Platinum features',
       })}
-    </p>
-    <EuiFlexGroup>
-      <EuiFlexItem>
-        <EuiLink external href={docLinks.licenseManagement}>
-          {i18n.translate('xpack.enterpriseSearch.workplaceSearch.explorePlatinumFeatures.link', {
-            defaultMessage: 'Explore Platinum features',
-          })}
-        </EuiLink>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiLink href="https://www.elastic.co/cloud/elasticsearch-service/signup" external>
-          {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentCloudTrial', {
-            defaultMessage: 'Sign up for a free 14-day Elastic Cloud trial.',
-          })}
-        </EuiLink>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiCallOut>
-);
+    >
+      <p>{firstContentBlock[feature]}</p>
+      <p>{secondContentBlock[feature]}</p>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiLink external href={docLinks.licenseManagement}>
+            {i18n.translate('xpack.enterpriseSearch.workplaceSearch.explorePlatinumFeatures.link', {
+              defaultMessage: 'Explore Platinum features',
+            })}
+          </EuiLink>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiLink href="https://www.elastic.co/cloud/elasticsearch-service/signup" external>
+            {i18n.translate('xpack.enterpriseSearch.content.licensingCallout.contentCloudTrial', {
+              defaultMessage: 'Sign up for a free 14-day Elastic Cloud trial.',
+            })}
+          </EuiLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
@@ -9,7 +9,14 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiConfirmModal, EuiLink, EuiSteps, EuiText } from '@elastic/eui';
+import {
+  EuiConfirmModal,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiSteps,
+  EuiText,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -17,8 +24,11 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { Status } from '../../../../../../common/types/api';
 import { docLinks } from '../../../../shared/doc_links';
+import { KibanaLogic } from '../../../../shared/kibana';
+import { LicensingLogic } from '../../../../shared/licensing';
 import { AddConnectorApiLogic } from '../../../api/connector/add_connector_api_logic';
 
+import { LicensingCallout, LICENSING_FEATURE } from '../licensing_callout';
 import { CREATE_ELASTICSEARCH_INDEX_STEP, BUILD_SEARCH_EXPERIENCE_STEP } from '../method_steps';
 import { NewSearchIndexLogic } from '../new_search_index_logic';
 import { NewSearchIndexTemplate } from '../new_search_index_template';
@@ -33,134 +43,151 @@ export const MethodConnector: React.FC<{ isNative: boolean }> = ({ isNative }) =
   const { isModalVisible } = useValues(AddConnectorLogic);
   const { setIsModalVisible } = useActions(AddConnectorLogic);
   const { fullIndexName, language } = useValues(NewSearchIndexLogic);
+  const { isCloud } = useValues(KibanaLogic);
+  const { hasPlatinumLicense } = useValues(LicensingLogic);
+
+  const isGated = isNative && !isCloud && !hasPlatinumLicense;
 
   return (
-    <NewSearchIndexTemplate
-      docsUrl="https://github.com/elastic/connectors-ruby/blob/main/README.md"
-      error={errorToText(error)}
-      title={i18n.translate('xpack.enterpriseSearch.content.newIndex.steps.buildConnector.title', {
-        defaultMessage: 'Build a connector',
-      })}
-      type="connector"
-      onNameChange={() => {
-        apiReset();
-      }}
-      onSubmit={(name, lang) => makeRequest({ indexName: name, isNative, language: lang })}
-      buttonLoading={status === Status.LOADING}
-    >
-      <EuiSteps
-        steps={[
-          CREATE_ELASTICSEARCH_INDEX_STEP,
-          isNative
-            ? {
-                children: (
-                  <EuiText size="s">
-                    <p>
-                      <FormattedMessage
-                        id="xpack.enterpriseSearch.content.newIndex.steps.nativeConnector.content"
-                        defaultMessage="Using our built-in connectors, you’ll be able to ingest data into your Elasticsearch index easily and swiftly using a number of Elastic-developed connectors."
-                      />
-                    </p>
-                  </EuiText>
-                ),
-                status: 'incomplete',
-                title: i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.nativeConnector.title',
-                  {
-                    defaultMessage: 'Use a pre-built connector to populate your index',
-                  }
-                ),
-                titleSize: 'xs',
-              }
-            : {
-                children: isNative ? (
-                  <EuiText size="s">
-                    <p>
-                      <FormattedMessage
-                        id="xpack.enterpriseSearch.content.newIndex.steps.nativeConnector.content"
-                        defaultMessage="Using our built-in connectors, you’ll be able to ingest data into your Elasticsearch index easily and swiftly using a number of Elastic-developed connectors."
-                      />
-                    </p>
-                  </EuiText>
-                ) : (
-                  <EuiText size="s">
-                    <p>
-                      <FormattedMessage
-                        id="xpack.enterpriseSearch.content.newIndex.steps.buildConnector.content"
-                        defaultMessage="Using our connector framework and connector client examples, you’ll be able to accelerate ingestion to the Elasticsearch {bulkApiDocLink} for any data source. After creating your index, you will be guided through the steps to access the connector framework and connect your first connector client."
-                        values={{
-                          bulkApiDocLink: (
-                            <EuiLink href={docLinks.bulkApi} target="_blank" external>
-                              {i18n.translate(
-                                'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.buildConnector.bulkAPILink',
-                                { defaultMessage: 'Bulk API' }
-                              )}
-                            </EuiLink>
-                          ),
-                        }}
-                      />
-                    </p>
-                  </EuiText>
-                ),
-                status: 'incomplete',
-                title: i18n.translate(
-                  'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.buildConnector.title',
-                  {
-                    defaultMessage: 'Build and configure a connector',
-                  }
-                ),
-                titleSize: 'xs',
-              },
-          BUILD_SEARCH_EXPERIENCE_STEP,
-        ]}
-      />
-      {isModalVisible && (
-        <EuiConfirmModal
-          title={i18n.translate(
-            'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.title',
-            {
-              defaultMessage: 'Replace existing connector',
-            }
-          )}
-          onCancel={(event) => {
-            event?.preventDefault();
-            setIsModalVisible(false);
-          }}
-          onConfirm={(event) => {
-            event.preventDefault();
-            makeRequest({
-              deleteExistingConnector: true,
-              indexName: fullIndexName,
-              isNative,
-              language,
-            });
-          }}
-          cancelButtonText={i18n.translate(
-            'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.cancelButton.label',
-            {
-              defaultMessage: 'Cancel',
-            }
-          )}
-          confirmButtonText={i18n.translate(
-            'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.confirmButton.label',
-            {
-              defaultMessage: 'Replace configuration',
-            }
-          )}
-          defaultFocusedButton="confirm"
-        >
-          {i18n.translate(
-            'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.description',
-            {
-              defaultMessage:
-                'A deleted index named {indexName} was originally tied to an existing connector configuration. Would you like to replace the existing connector configuration with a new one?',
-              values: {
-                indexName: fullIndexName,
-              },
-            }
-          )}
-        </EuiConfirmModal>
+    <EuiFlexGroup direction="column">
+      {isGated && (
+        <EuiFlexItem>
+          <LicensingCallout feature={LICENSING_FEATURE.NATIVE_CONNECTOR} />
+        </EuiFlexItem>
       )}
-    </NewSearchIndexTemplate>
+      <EuiFlexItem>
+        <NewSearchIndexTemplate
+          docsUrl="https://github.com/elastic/connectors-ruby/blob/main/README.md"
+          disabled={isGated}
+          error={errorToText(error)}
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.title',
+            {
+              defaultMessage: 'Build a connector',
+            }
+          )}
+          type="connector"
+          onNameChange={() => {
+            apiReset();
+          }}
+          onSubmit={(name, lang) => makeRequest({ indexName: name, isNative, language: lang })}
+          buttonLoading={status === Status.LOADING}
+        >
+          <EuiSteps
+            steps={[
+              CREATE_ELASTICSEARCH_INDEX_STEP,
+              isNative
+                ? {
+                    children: (
+                      <EuiText size="s">
+                        <p>
+                          <FormattedMessage
+                            id="xpack.enterpriseSearch.content.newIndex.steps.nativeConnector.content"
+                            defaultMessage="Using our built-in connectors, you’ll be able to ingest data into your Elasticsearch index easily and swiftly using a number of Elastic-developed connectors."
+                          />
+                        </p>
+                      </EuiText>
+                    ),
+                    status: 'incomplete',
+                    title: i18n.translate(
+                      'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.nativeConnector.title',
+                      {
+                        defaultMessage: 'Use a pre-built connector to populate your index',
+                      }
+                    ),
+                    titleSize: 'xs',
+                  }
+                : {
+                    children: isNative ? (
+                      <EuiText size="s">
+                        <p>
+                          <FormattedMessage
+                            id="xpack.enterpriseSearch.content.newIndex.steps.nativeConnector.content"
+                            defaultMessage="Using our built-in connectors, you’ll be able to ingest data into your Elasticsearch index easily and swiftly using a number of Elastic-developed connectors."
+                          />
+                        </p>
+                      </EuiText>
+                    ) : (
+                      <EuiText size="s">
+                        <p>
+                          <FormattedMessage
+                            id="xpack.enterpriseSearch.content.newIndex.steps.buildConnector.content"
+                            defaultMessage="Using our connector framework and connector client examples, you’ll be able to accelerate ingestion to the Elasticsearch {bulkApiDocLink} for any data source. After creating your index, you will be guided through the steps to access the connector framework and connect your first connector client."
+                            values={{
+                              bulkApiDocLink: (
+                                <EuiLink href={docLinks.bulkApi} target="_blank" external>
+                                  {i18n.translate(
+                                    'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.buildConnector.bulkAPILink',
+                                    { defaultMessage: 'Bulk API' }
+                                  )}
+                                </EuiLink>
+                              ),
+                            }}
+                          />
+                        </p>
+                      </EuiText>
+                    ),
+                    status: 'incomplete',
+                    title: i18n.translate(
+                      'xpack.enterpriseSearch.content.newIndex.methodConnector.steps.buildConnector.title',
+                      {
+                        defaultMessage: 'Build and configure a connector',
+                      }
+                    ),
+                    titleSize: 'xs',
+                  },
+              BUILD_SEARCH_EXPERIENCE_STEP,
+            ]}
+          />
+          {isModalVisible && (
+            <EuiConfirmModal
+              title={i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.title',
+                {
+                  defaultMessage: 'Replace existing connector',
+                }
+              )}
+              onCancel={(event) => {
+                event?.preventDefault();
+                setIsModalVisible(false);
+              }}
+              onConfirm={(event) => {
+                event.preventDefault();
+                makeRequest({
+                  deleteExistingConnector: true,
+                  indexName: fullIndexName,
+                  isNative,
+                  language,
+                });
+              }}
+              cancelButtonText={i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.cancelButton.label',
+                {
+                  defaultMessage: 'Cancel',
+                }
+              )}
+              confirmButtonText={i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.confirmButton.label',
+                {
+                  defaultMessage: 'Replace configuration',
+                }
+              )}
+              defaultFocusedButton="confirm"
+            >
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.steps.buildConnector.confirmModal.description',
+                {
+                  defaultMessage:
+                    'A deleted index named {indexName} was originally tied to an existing connector configuration. Would you like to replace the existing connector configuration with a new one?',
+                  values: {
+                    indexName: fullIndexName,
+                  },
+                }
+              )}
+            </EuiConfirmModal>
+          )}
+        </NewSearchIndexTemplate>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_crawler/method_crawler.tsx
@@ -18,7 +18,7 @@ import { docLinks } from '../../../../shared/doc_links';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { LicensingLogic } from '../../../../shared/licensing';
 import { CreateCrawlerIndexApiLogic } from '../../../api/crawler/create_crawler_index_api_logic';
-import { LicensingCallout } from '../licensing_callout';
+import { LicensingCallout, LICENSING_FEATURE } from '../licensing_callout';
 import { CREATE_ELASTICSEARCH_INDEX_STEP, BUILD_SEARCH_EXPERIENCE_STEP } from '../method_steps';
 import { NewSearchIndexTemplate } from '../new_search_index_template';
 
@@ -30,13 +30,15 @@ export const MethodCrawler: React.FC = () => {
   const { isCloud } = useValues(KibanaLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
 
+  const isGated = !isCloud && !hasPlatinumLicense;
+
   MethodCrawlerLogic.mount();
 
   return (
     <EuiFlexGroup direction="column">
-      {!isCloud && !hasPlatinumLicense && (
+      {isGated && (
         <EuiFlexItem>
-          <LicensingCallout />
+          <LicensingCallout feature={LICENSING_FEATURE.CRAWLER} />
         </EuiFlexItem>
       )}
       <EuiFlexItem>
@@ -49,6 +51,7 @@ export const MethodCrawler: React.FC = () => {
           )}
           type="crawler"
           onSubmit={(indexName, language) => makeRequest({ indexName, language })}
+          disabled={isGated}
           buttonLoading={status === Status.LOADING}
           docsUrl={docLinks.crawlerOverview}
         >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -32,6 +32,7 @@ import { LanguageForOptimization } from './types';
 
 export interface Props {
   buttonLoading?: boolean;
+  disabled?: boolean;
   docsUrl?: string;
   error?: string | React.ReactNode;
   onNameChange?(name: string): void;
@@ -42,6 +43,7 @@ export interface Props {
 
 export const NewSearchIndexTemplate: React.FC<Props> = ({
   children,
+  disabled,
   docsUrl,
   error,
   title,
@@ -101,12 +103,12 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
   return (
     <EuiPanel hasBorder>
       <EuiForm
+        component="form"
+        id="enterprise-search-add-connector"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmit(fullIndexName, language);
         }}
-        component="form"
-        id="enterprise-search-add-connector"
       >
         <EuiFlexGroup direction="column">
           <EuiFlexItem grow={false}>
@@ -118,6 +120,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
             <EuiFlexGroup>
               <EuiFlexItem grow>
                 <EuiFormRow
+                  isDisabled={disabled}
                   label={i18n.translate(
                     'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputLabel',
                     {
@@ -145,6 +148,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                       }
                     )}
                     fullWidth
+                    disabled={disabled}
                     isInvalid={false}
                     value={rawName}
                     onChange={handleNameChange}
@@ -164,6 +168,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiFormRow
+                  isDisabled={disabled}
                   label={i18n.translate(
                     'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputLabel',
                     {
@@ -178,6 +183,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                   )}
                 >
                   <EuiSelect
+                    disabled={disabled}
                     options={SUPPORTED_LANGUAGES}
                     onChange={handleLanguageChange}
                     value={languageSelectValue}
@@ -192,7 +198,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
           <EuiFlexItem grow={false}>
             <EuiButton
               fill
-              isDisabled={!rawName || buttonLoading || formInvalid}
+              isDisabled={!rawName || buttonLoading || formInvalid || disabled}
               isLoading={buttonLoading}
               type="submit"
             >


### PR DESCRIPTION
## Summary

This adds the licensing callout to the `Use a connector` flow, and blocks users from proceeding.
<img width="894" alt="image" src="https://user-images.githubusercontent.com/94373878/189332555-218e80bc-068d-4dfe-a33c-70aeaba9f5fc.png">
