### PR TITLE
[Lens] Fix query input A11y bug: doesn't react to `escape` button

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -378,6 +378,9 @@ export default class QueryStringInputUI extends PureComponent<Props, State> {
           }
           break;
         case KEY_CODES.ESC:
+          if (isSuggestionsVisible) {
+            event.preventDefault();
+          }
           this.setState({ isSuggestionsVisible: false, index: null });
           break;
         case KEY_CODES.TAB:

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -378,7 +378,6 @@ export default class QueryStringInputUI extends PureComponent<Props, State> {
           }
           break;
         case KEY_CODES.ESC:
-          event.preventDefault();
           this.setState({ isSuggestionsVisible: false, index: null });
           break;
         case KEY_CODES.TAB:


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/140380 - didn't notice any behaviour breaking. 
