### PR TITLE
Remove blob: from our worker-src CSP directive

### DIFF
--- a/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
@@ -34,7 +34,7 @@ describe('CspConfig', () => {
     expect(CspConfig.DEFAULT).toMatchInlineSnapshot(`
       CspConfig {
         "disableEmbedding": false,
-        "header": "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "header": "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
         "strict": true,
         "warnLegacyBrowsers": true,
       }
@@ -65,7 +65,7 @@ describe('CspConfig', () => {
         worker_src: ['foo', 'bar'],
       });
       expect(config.header).toEqual(
-        `script-src 'self'; worker-src blob: 'self' foo bar; style-src 'unsafe-inline' 'self'`
+        `script-src 'self'; worker-src 'self' foo bar; style-src 'unsafe-inline' 'self'`
       );
     });
 
@@ -76,7 +76,7 @@ describe('CspConfig', () => {
       });
 
       expect(config.header).toEqual(
-        `script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self' foo bar`
+        `script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self' foo bar`
       );
     });
 
@@ -87,7 +87,7 @@ describe('CspConfig', () => {
       });
 
       expect(config.header).toEqual(
-        `script-src 'self' foo bar; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
+        `script-src 'self' foo bar; worker-src 'self'; style-src 'unsafe-inline' 'self'`
       );
     });
 
@@ -99,7 +99,7 @@ describe('CspConfig', () => {
         style_src: ['style', 'dolly'],
       });
       expect(config.header).toEqual(
-        `script-src 'self' script foo; worker-src blob: 'self' worker bar; style-src 'unsafe-inline' 'self' style dolly`
+        `script-src 'self' script foo; worker-src 'self' worker bar; style-src 'unsafe-inline' 'self' style dolly`
       );
     });
 
@@ -111,7 +111,7 @@ describe('CspConfig', () => {
         style_src: ['style'],
       });
       expect(config.header).toEqual(
-        `script-src 'self' script; worker-src blob: 'self' worker; style-src 'unsafe-inline' 'self' style`
+        `script-src 'self' script; worker-src 'self' worker; style-src 'unsafe-inline' 'self' style`
       );
     });
 
@@ -124,7 +124,7 @@ describe('CspConfig', () => {
         });
 
         expect(config.header).toEqual(
-          `script-src 'self' foo bar; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
+          `script-src 'self' foo bar; worker-src 'self'; style-src 'unsafe-inline' 'self'`
         );
       });
 
@@ -136,7 +136,7 @@ describe('CspConfig', () => {
         });
 
         expect(config.header).toEqual(
-          `script-src 'self' 'unsafe-eval' foo bar; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
+          `script-src 'self' 'unsafe-eval' foo bar; worker-src 'self'; style-src 'unsafe-inline' 'self'`
         );
       });
 
@@ -150,7 +150,7 @@ describe('CspConfig', () => {
         });
 
         expect(config.header).toEqual(
-          `script-src 'self' 'unsafe-eval' foo bar; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
+          `script-src 'self' 'unsafe-eval' foo bar; worker-src 'self'; style-src 'unsafe-inline' 'self'`
         );
 
         mockConfig.reset();
@@ -166,7 +166,7 @@ describe('CspConfig', () => {
         });
 
         expect(config.header).toEqual(
-          `script-src 'self' foo bar; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
+          `script-src 'self' foo bar; worker-src 'self'; style-src 'unsafe-inline' 'self'`
         );
 
         mockConfig.reset();
@@ -181,7 +181,7 @@ describe('CspConfig', () => {
         expect(config.disableEmbedding).toEqual(disableEmbedding);
         expect(config.disableEmbedding).not.toEqual(CspConfig.DEFAULT.disableEmbedding);
         expect(config.header).toMatchInlineSnapshot(
-          `"script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'; frame-ancestors 'self'"`
+          `"script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'; frame-ancestors 'self'"`
         );
       });
 
@@ -194,7 +194,7 @@ describe('CspConfig', () => {
         expect(config.disableEmbedding).toEqual(disableEmbedding);
         expect(config.disableEmbedding).not.toEqual(CspConfig.DEFAULT.disableEmbedding);
         expect(config.header).toMatchInlineSnapshot(
-          `"script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'; frame-ancestors 'self'"`
+          `"script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'; frame-ancestors 'self'"`
         );
       });
     });

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.test.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.test.ts
@@ -78,7 +78,7 @@ describe('CspDirectives', () => {
       const config = cspConfig.schema.validate({});
       const directives = CspDirectives.fromConfig(config);
       expect(directives.getCspHeader()).toMatchInlineSnapshot(
-        `"script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'"`
+        `"script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'"`
       );
     });
 
@@ -91,7 +91,7 @@ describe('CspDirectives', () => {
       const directives = CspDirectives.fromConfig(config);
 
       expect(directives.getCspHeader()).toMatchInlineSnapshot(
-        `"script-src 'self' baz; worker-src blob: 'self' foo; style-src 'unsafe-inline' 'self' bar dolly"`
+        `"script-src 'self' baz; worker-src 'self' foo; style-src 'unsafe-inline' 'self' bar dolly"`
       );
     });
 
@@ -108,7 +108,7 @@ describe('CspDirectives', () => {
       });
       const directives = CspDirectives.fromConfig(config);
       expect(directives.getCspHeader()).toMatchInlineSnapshot(
-        `"script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'; connect-src 'self' connect-src; default-src 'self' default-src; font-src 'self' font-src; frame-src 'self' frame-src; img-src 'self' img-src; frame-ancestors 'self' frame-ancestors; report-uri report-uri; report-to report-to"`
+        `"script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'; connect-src 'self' connect-src; default-src 'self' default-src; font-src 'self' font-src; frame-src 'self' frame-src; img-src 'self' img-src; frame-ancestors 'self' frame-ancestors; report-uri report-uri; report-to report-to"`
       );
     });
 
@@ -118,7 +118,7 @@ describe('CspDirectives', () => {
       });
       const directives = CspDirectives.fromConfig(config);
       expect(directives.getCspHeader()).toMatchInlineSnapshot(
-        `"script-src 'self' 'unsafe-hashes'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'"`
+        `"script-src 'self' 'unsafe-hashes'; worker-src 'self'; style-src 'unsafe-inline' 'self'"`
       );
     });
   });

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
@@ -26,7 +26,7 @@ export type CspDirectiveName =
  */
 export const defaultRules: Partial<Record<CspDirectiveName, string[]>> = {
   'script-src': [`'self'`],
-  'worker-src': [`blob:`, `'self'`],
+  'worker-src': [`'self'`],
   'style-src': [`'unsafe-inline'`, `'self'`],
 };
 

--- a/src/core/server/http_resources/http_resources_service.test.ts
+++ b/src/core/server/http_resources/http_resources_service.test.ts
@@ -100,7 +100,7 @@ describe('HttpResources service', () => {
               headers: {
                 'x-kibana': '42',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
@@ -146,7 +146,7 @@ describe('HttpResources service', () => {
               headers: {
                 'x-kibana': '42',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
@@ -166,7 +166,7 @@ describe('HttpResources service', () => {
               headers: {
                 'content-type': 'text/html',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
@@ -195,7 +195,7 @@ describe('HttpResources service', () => {
                 'content-type': 'text/html',
                 'x-kibana': '42',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
@@ -215,7 +215,7 @@ describe('HttpResources service', () => {
               headers: {
                 'content-type': 'text/javascript',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
@@ -244,7 +244,7 @@ describe('HttpResources service', () => {
                 'content-type': 'text/javascript',
                 'x-kibana': '42',
                 'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+                  "script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });

--- a/src/core/server/integration_tests/http_resources/http_resources_service.test.ts
+++ b/src/core/server/integration_tests/http_resources/http_resources_service.test.ts
@@ -20,8 +20,8 @@ function applyTestsWithDisableUnsafeEvalSetTo(disableUnsafeEval: boolean) {
   describe(`with disableUnsafeEval=${disableUnsafeEval}`, () => {
     let root: ReturnType<typeof kbnTestServer.createRoot>;
     const defaultCspRules = disableUnsafeEval
-      ? `script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`
-      : `script-src 'self' 'unsafe-eval'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'`;
+      ? `script-src 'self'; worker-src 'self'; style-src 'unsafe-inline' 'self'`
+      : `script-src 'self' 'unsafe-eval'; worker-src 'self'; style-src 'unsafe-inline' 'self'`;
     beforeEach(async () => {
       root = kbnTestServer.createRoot({
         csp: { disableUnsafeEval },


### PR DESCRIPTION
## Summary

Removes `blob:` from our `worker-src` CSP directive. This was included in our original CSP definition via https://github.com/elastic/kibana/pull/29545, and it appears it was only required for use by our geo features (e.g. Maps).

A lot has changed since then, so I'm opening this PR to see if it is viable to remove this directive from our CSP.


## Findings

`worker-src blob:` cannot be removed from our CSP at this time because it is required by the `ace` editor. We can technically run `ace` without web worker support, but I suspect this would come with a performance penalty. I am not comfortable making this change _at this time_ given the widespread usage within Kibana.

