### PR TITLE
[Security Solution] Narrow test skips for Host Isolation Exceptions

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.test.tsx
@@ -85,7 +85,8 @@ describe('When on the host isolation exceptions entry form', () => {
       await render();
     });
 
-    it('should render the form with empty inputs', () => {
+    // FLAKY: https://github.com/elastic/kibana/issues/140140
+    it.skip('should render the form with empty inputs', () => {
       expect(renderResult.getByTestId('hostIsolationExceptions-form-name-input')).toHaveValue('');
       expect(renderResult.getByTestId('hostIsolationExceptions-form-ip-input')).toHaveValue('');
       expect(
@@ -144,14 +145,16 @@ describe('When on the host isolation exceptions entry form', () => {
       ).toBe(true);
     });
 
-    it('should show policy as selected when user clicks on it', async () => {
+    // FLAKY: https://github.com/elastic/kibana/issues/139776
+    it.skip('should show policy as selected when user clicks on it', async () => {
       userEvent.click(renderResult.getByTestId('perPolicy'));
       await clickOnEffectedPolicy(renderResult);
 
       await expect(isEffectedPolicySelected(renderResult)).resolves.toBe(true);
     });
 
-    it('should retain the previous policy selection when switching from per-policy to global', async () => {
+    // FLAKY: https://github.com/elastic/kibana/issues/139899
+    it.skip('should retain the previous policy selection when switching from per-policy to global', async () => {
       // move to per-policy and select the first
       userEvent.click(renderResult.getByTestId('perPolicy'));
       await clickOnEffectedPolicy(renderResult);

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
@@ -22,8 +22,7 @@ import { getFirstCard } from '../../../components/artifact_list_page/mocks';
 jest.mock('../../../../common/components/user_privileges');
 const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
 
-// FLAKY: https://github.com/elastic/kibana/issues/135587
-describe.skip('When on the host isolation exceptions page', () => {
+describe('When on the host isolation exceptions page', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<typeof render>;
   let history: AppContextTestRender['history'];
@@ -78,7 +77,8 @@ describe.skip('When on the host isolation exceptions page', () => {
     );
   });
 
-  it('should hide the Create and Edit actions when host isolation authz is not allowed', async () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/135587
+  it.skip('should hide the Create and Edit actions when host isolation authz is not allowed', async () => {
     // Use case: license downgrade scenario, where user still has entries defined, but no longer
     // able to create or edit them (only Delete them)
     const existingPrivileges = useUserPrivilegesMock();


### PR DESCRIPTION
## Summary

Narrows test skips for a flakey jest test in Host Isolation Exceptions.  We are narrowing the skips to just the flakey tests for now for the most test coverage as we investigate the root cause.

Refers to issues:
https://github.com/elastic/kibana/issues/139899
https://github.com/elastic/kibana/issues/140140
https://github.com/elastic/kibana/issues/135587
https://github.com/elastic/kibana/issues/139776

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios