### PR TITLE
[Security Solution] Narrow test skips for Endpoint list management

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/search_bar.test.tsx
@@ -16,8 +16,7 @@ import { fireEvent } from '@testing-library/dom';
 import { uiQueryParams } from '../../store/selectors';
 import type { EndpointIndexUIQueryParams } from '../../types';
 
-// FLAKY: https://github.com/elastic/kibana/issues/132398
-describe.skip('when rendering the endpoint list `AdminSearchBar`', () => {
+describe('when rendering the endpoint list `AdminSearchBar`', () => {
   let render: (
     urlParams?: EndpointIndexUIQueryParams
   ) => Promise<ReturnType<AppContextTestRender['render']>>;
@@ -85,7 +84,8 @@ describe.skip('when rendering the endpoint list `AdminSearchBar`', () => {
     expect(getQueryParamsFromStore().admin_query).toBe("(language:kuery,query:'host.name: foo')");
   });
 
-  it.each([
+  // FLAKY: https://github.com/elastic/kibana/issues/132398
+  it.skip.each([
     ['nothing', ''],
     ['spaces', '  '],
   ])(

--- a/x-pack/plugins/security_solution/public/management/pages/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.test.tsx
@@ -16,8 +16,7 @@ import { endpointPageHttpMock } from './endpoint_hosts/mocks';
 
 jest.mock('../../common/components/user_privileges');
 
-// FLAKY: https://github.com/elastic/kibana/issues/135166
-describe.skip('when in the Administration tab', () => {
+describe('when in the Administration tab', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
 
   beforeEach(() => {
@@ -35,7 +34,8 @@ describe.skip('when in the Administration tab', () => {
     expect(await render().findByTestId('noIngestPermissions')).not.toBeNull();
   });
 
-  it('should display the Management view if user has privileges', async () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/135166
+  it.skip('should display the Management view if user has privileges', async () => {
     (useUserPrivileges as jest.Mock).mockReturnValue({
       endpointPrivileges: { loading: false, canAccessEndpointManagement: true },
     });


### PR DESCRIPTION
## Summary

Narrows test skips for a flakey jest test in Endpoint list management.  We are narrowing the skips to just the flakey tests for now for the most test coverage as we investigate the root cause.

Refers to issues:
https://github.com/elastic/kibana/issues/132398
https://github.com/elastic/kibana/issues/135166

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
