### PR TITLE
[Security Solution] Narrow test skips for Artifact list pages

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.test.tsx
@@ -227,7 +227,8 @@ describe('When using the ArtifactListPage component', () => {
         });
       });
 
-      it('should persist policy filter to the URL params', async () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/129837
+      it.skip('should persist policy filter to the URL params', async () => {
         const policyId = mockedApi.responseProvider.endpointPackagePolicyList().items[0].id;
         const firstPolicyTestId = `policiesSelector-popover-items-${policyId}`;
 

--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.test.tsx
@@ -16,8 +16,7 @@ import { getDeferred } from '../mocks';
 
 jest.mock('../../../common/components/user_privileges');
 
-// FLAKY: https://github.com/elastic/kibana/issues/129837
-describe.skip('When using the ArtifactListPage component', () => {
+describe('When using the ArtifactListPage component', () => {
   let render: (
     props?: Partial<ArtifactListPageProps>
   ) => ReturnType<AppContextTestRender['render']>;
@@ -156,7 +155,8 @@ describe.skip('When using the ArtifactListPage component', () => {
         expect(getByTestId('testPage-flyout')).toBeTruthy();
       });
 
-      it('should display the Delete modal when delete action is clicked', async () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/129837
+      it.skip('should display the Delete modal when delete action is clicked', async () => {
         const { getByTestId } = await renderWithListData();
         await clickCardAction('delete');
 

--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.test.ts
@@ -77,12 +77,14 @@ describe('When displaying the Delete artifact modal in the Artifact List Page', 
     10000
   );
 
-  it('should show Cancel and Delete buttons enabled', async () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/139527
+  it.skip('should show Cancel and Delete buttons enabled', async () => {
     expect(cancelButton).toBeEnabled();
     expect(submitButton).toBeEnabled();
   });
 
-  it('should close modal if Cancel/Close buttons are clicked', async () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/139528
+  it.skip('should close modal if Cancel/Close buttons are clicked', async () => {
     userEvent.click(cancelButton);
 
     expect(renderResult.queryByTestId('testPage-deleteModal')).toBeNull();


### PR DESCRIPTION
## Summary

Narrows test skips for a flakey jest test in Artifact list pages.  We are narrowing the skips to just the flakey tests for now for the most test coverage as we investigate the root cause.

Refers to issues:
https://github.com/elastic/kibana/issues/129837
https://github.com/elastic/kibana/issues/139528
https://github.com/elastic/kibana/issues/139527

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
