### PR TITLE
[Files] Add `x-content-type-options: nosniff` header to files

### DIFF
--- a/x-pack/plugins/files/server/routes/common.test.ts
+++ b/x-pack/plugins/files/server/routes/common.test.ts
@@ -20,6 +20,7 @@ describe('getDownloadHeadersForFile', () => {
       'content-type': contentType,
       'content-disposition': `attachment; filename="${contentDisposition}"`,
       'cache-control': 'max-age=31536000, immutable',
+      'x-content-type-options': 'nosniff',
     };
   }
 

--- a/x-pack/plugins/files/server/routes/common.ts
+++ b/x-pack/plugins/files/server/routes/common.ts
@@ -15,6 +15,8 @@ export function getDownloadHeadersForFile(file: File, fileName?: string): Respon
     // Note, this name can be overridden by the client if set via a "download" attribute on the HTML tag.
     'content-disposition': `attachment; filename="${fileName || getDownloadedFileName(file)}"`,
     'cache-control': 'max-age=31536000, immutable',
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+    'x-content-type-options': 'nosniff',
   };
 }
 


### PR DESCRIPTION
## Summary

Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options