### PR TITLE
[Lens] Use query input for annotations

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/filtering.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/filtering.tsx
@@ -4,34 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState, useCallback } from 'react';
-import { i18n } from '@kbn/i18n';
+import React, { useCallback } from 'react';
 import { isEqual } from 'lodash';
-import {
-  EuiLink,
-  EuiPanel,
-  EuiPopover,
-  EuiFormRow,
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiPopoverProps,
-  EuiIconTip,
-} from '@elastic/eui';
 import type { Query } from '@kbn/es-query';
 import { GenericIndexPatternColumn, operationDefinitionMap } from '../operations';
 import type { IndexPatternLayer } from '../types';
-import { QueryInput, useDebouncedValue, validateQuery } from '../../shared_components';
+import { validateQuery, FilterQueryInput } from '../../shared_components';
 import type { IndexPattern } from '../../types';
-
-const filterByLabel = i18n.translate('xpack.lens.indexPattern.filterBy.label', {
-  defaultMessage: 'Filter by',
-});
-
-// to do: get the language from uiSettings
-export const defaultFilter: Query = {
-  query: '',
-  language: 'kuery',
-};
 
 export function setFilter(columnId: string, layer: IndexPatternLayer, query: Query | undefined) {
   return {
@@ -71,18 +50,6 @@ export function Filtering({
     },
     [columnId, indexPattern, inputFilter, layer, updateLayer]
   );
-  const { inputValue: queryInput, handleInputChange: setQueryInput } = useDebouncedValue<Query>({
-    value: inputFilter ?? defaultFilter,
-    onChange,
-  });
-  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
-
-  const onClosePopup: EuiPopoverProps['closePopover'] = useCallback(() => {
-    setFilterPopoverOpen(false);
-    if (inputFilter) {
-      setQueryInput(inputFilter);
-    }
-  }, [inputFilter, setQueryInput]);
 
   const selectedOperation = operationDefinitionMap[selectedColumn.operationType];
 
@@ -90,84 +57,12 @@ export function Filtering({
     return null;
   }
 
-  const { isValid: isInputFilterValid } = validateQuery(inputFilter, indexPattern);
-  const { isValid: isQueryInputValid, error: queryInputError } = validateQuery(
-    queryInput,
-    indexPattern
-  );
-
-  const labelNode = helpMessage ? (
-    <>
-      {filterByLabel}{' '}
-      <EuiIconTip
-        color="subdued"
-        content={helpMessage}
-        iconProps={{
-          className: 'eui-alignTop',
-        }}
-        position="top"
-        size="s"
-        type="questionInCircle"
-      />
-    </>
-  ) : (
-    filterByLabel
-  );
-
   return (
-    <EuiFormRow display="rowCompressed" label={labelNode} fullWidth isInvalid={!isInputFilterValid}>
-      <EuiFlexGroup gutterSize="s" alignItems="center">
-        <EuiFlexItem>
-          <EuiPopover
-            isOpen={filterPopoverOpen}
-            closePopover={onClosePopup}
-            anchorClassName="eui-fullWidth"
-            panelClassName="lnsIndexPatternDimensionEditor__filtersEditor"
-            button={
-              <EuiPanel paddingSize="none" hasShadow={false} hasBorder>
-                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                  <EuiFlexItem grow={false}>{/* Empty for spacing */}</EuiFlexItem>
-                  <EuiFlexItem grow={true}>
-                    <EuiLink
-                      className="lnsFiltersOperation__popoverButton"
-                      data-test-subj="indexPattern-filters-existingFilterTrigger"
-                      onClick={() => {
-                        setFilterPopoverOpen(!filterPopoverOpen);
-                      }}
-                      color={isInputFilterValid ? 'text' : 'danger'}
-                      title={i18n.translate('xpack.lens.indexPattern.filterBy.clickToEdit', {
-                        defaultMessage: 'Click to edit',
-                      })}
-                    >
-                      {inputFilter?.query ||
-                        i18n.translate('xpack.lens.indexPattern.filterBy.emptyFilterQuery', {
-                          defaultMessage: '(empty)',
-                        })}
-                    </EuiLink>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiPanel>
-            }
-          >
-            <EuiFormRow
-              label={filterByLabel}
-              isInvalid={!isQueryInputValid}
-              error={queryInputError}
-              fullWidth={true}
-              data-test-subj="indexPattern-filter-by-input"
-            >
-              <QueryInput
-                indexPatternTitle={indexPattern.title}
-                disableAutoFocus={true}
-                value={queryInput}
-                onChange={setQueryInput}
-                isInvalid={!isQueryInputValid}
-                onSubmit={() => {}}
-              />
-            </EuiFormRow>
-          </EuiPopover>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiFormRow>
+    <FilterQueryInput
+      helpMessage={helpMessage}
+      onChange={onChange}
+      indexPattern={indexPattern}
+      inputFilter={inputFilter}
+    />
   );
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/time_shift.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/time_shift.tsx
@@ -9,8 +9,6 @@ import { EuiFormRow, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
-
-import type { Query } from '@kbn/es-query';
 import { DatatableUtilitiesService, parseTimeShift } from '@kbn/data-plugin/common';
 import {
   adjustTimeScaleLabelSuffix,
@@ -25,12 +23,6 @@ import {
   timeShiftOptions,
 } from '../time_shift_utils';
 import type { IndexPattern } from '../../types';
-
-// to do: get the language from uiSettings
-export const defaultFilter: Query = {
-  query: '',
-  language: 'kuery',
-};
 
 export function setTimeShift(
   columnId: string,

--- a/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
+++ b/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
@@ -38,9 +38,9 @@ export function FilterQueryInput({
   label = filterByLabel,
 }: {
   inputFilter: Query | undefined;
-  onChange: (query?: Query) => void;
+  onChange: (query: Query) => void;
   indexPattern: IndexPattern;
-  helpMessage: string | null;
+  helpMessage?: string | null;
   label?: string;
 }) {
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);

--- a/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
+++ b/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiLink,
+  EuiPanel,
+  EuiPopover,
+  EuiFormRow,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiIconTip,
+  EuiPopoverProps,
+} from '@elastic/eui';
+import type { Query } from '@kbn/es-query';
+import { QueryInput, useDebouncedValue, validateQuery } from '.';
+import type { IndexPattern } from '../types';
+
+const filterByLabel = i18n.translate('xpack.lens.indexPattern.filterBy.label', {
+  defaultMessage: 'Filter by',
+});
+
+// to do: get the language from uiSettings
+export const defaultFilter: Query = {
+  query: '',
+  language: 'kuery',
+};
+
+export function FilterQueryInput({
+  inputFilter,
+  onChange,
+  indexPattern,
+  helpMessage,
+  label = filterByLabel,
+}: {
+  inputFilter: Query | undefined;
+  onChange: (query?: Query) => void;
+  indexPattern: IndexPattern;
+  helpMessage: string | null;
+  label?: string;
+}) {
+  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+  const { inputValue: queryInput, handleInputChange: setQueryInput } = useDebouncedValue<Query>({
+    value: inputFilter ?? defaultFilter,
+    onChange,
+  });
+
+  const onClosePopup: EuiPopoverProps['closePopover'] = useCallback(() => {
+    setFilterPopoverOpen(false);
+    if (inputFilter) {
+      setQueryInput(inputFilter);
+    }
+  }, [inputFilter, setQueryInput]);
+
+  const { isValid: isInputFilterValid } = validateQuery(inputFilter, indexPattern);
+  const { isValid: isQueryInputValid, error: queryInputError } = validateQuery(
+    queryInput,
+    indexPattern
+  );
+
+  return (
+    <EuiFormRow
+      display="rowCompressed"
+      label={
+        helpMessage ? (
+          <>
+            {label}{' '}
+            <EuiIconTip
+              color="subdued"
+              content={helpMessage}
+              iconProps={{
+                className: 'eui-alignTop',
+              }}
+              position="top"
+              size="s"
+              type="questionInCircle"
+            />
+          </>
+        ) : (
+          label
+        )
+      }
+      fullWidth
+      isInvalid={!isInputFilterValid}
+    >
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        <EuiFlexItem>
+          <EuiPopover
+            isOpen={filterPopoverOpen}
+            closePopover={onClosePopup}
+            anchorClassName="eui-fullWidth"
+            panelClassName="lnsIndexPatternDimensionEditor__filtersEditor"
+            button={
+              <EuiPanel paddingSize="none" hasShadow={false} hasBorder>
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>{/* Empty for spacing */}</EuiFlexItem>
+                  <EuiFlexItem grow={true}>
+                    <EuiLink
+                      className="lnsFiltersOperation__popoverButton"
+                      data-test-subj="indexPattern-filters-existingFilterTrigger"
+                      onClick={() => {
+                        setFilterPopoverOpen(!filterPopoverOpen);
+                      }}
+                      color={isInputFilterValid ? 'text' : 'danger'}
+                      title={i18n.translate('xpack.lens.indexPattern.filterBy.clickToEdit', {
+                        defaultMessage: 'Click to edit',
+                      })}
+                    >
+                      {inputFilter?.query ||
+                        i18n.translate('xpack.lens.indexPattern.filterBy.emptyFilterQuery', {
+                          defaultMessage: '(empty)',
+                        })}
+                    </EuiLink>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            }
+          >
+            <EuiFormRow
+              label={label}
+              isInvalid={!isQueryInputValid}
+              error={queryInputError}
+              fullWidth={true}
+              data-test-subj="indexPattern-filter-by-input"
+            >
+              <QueryInput
+                indexPatternTitle={indexPattern.title}
+                disableAutoFocus={true}
+                value={queryInput}
+                onChange={setQueryInput}
+                isInvalid={!isQueryInputValid}
+                onSubmit={() => {}}
+              />
+            </EuiFormRow>
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFormRow>
+  );
+}

--- a/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
+++ b/x-pack/plugins/lens/public/shared_components/filter_query_input.tsx
@@ -36,14 +36,16 @@ export function FilterQueryInput({
   indexPattern,
   helpMessage,
   label = filterByLabel,
+  initiallyOpen,
 }: {
   inputFilter: Query | undefined;
   onChange: (query: Query) => void;
   indexPattern: IndexPattern;
   helpMessage?: string | null;
   label?: string;
+  initiallyOpen?: boolean;
 }) {
-  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+  const [filterPopoverOpen, setFilterPopoverOpen] = useState(Boolean(initiallyOpen));
   const { inputValue: queryInput, handleInputChange: setQueryInput } = useDebouncedValue<Query>({
     value: inputFilter ?? defaultFilter,
     onChange,
@@ -51,10 +53,7 @@ export function FilterQueryInput({
 
   const onClosePopup: EuiPopoverProps['closePopover'] = useCallback(() => {
     setFilterPopoverOpen(false);
-    if (inputFilter) {
-      setQueryInput(inputFilter);
-    }
-  }, [inputFilter, setQueryInput]);
+  }, []);
 
   const { isValid: isInputFilterValid } = validateQuery(inputFilter, indexPattern);
   const { isValid: isQueryInputValid, error: queryInputError } = validateQuery(

--- a/x-pack/plugins/lens/public/shared_components/index.ts
+++ b/x-pack/plugins/lens/public/shared_components/index.ts
@@ -36,5 +36,6 @@ export { NameInput } from './name_input';
 export { ValueLabelsSettings } from './value_labels_settings';
 export { AxisTitleSettings } from './axis_title_settings';
 export { DimensionEditorSection } from './dimension_section';
+export { FilterQueryInput } from './filter_query_input';
 export * from './static_header';
 export * from './vis_label';

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/annotations_panel.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/annotations_panel.tsx
@@ -6,7 +6,7 @@
  */
 
 import './index.scss';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiSwitch, EuiSwitchEvent, EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 import type { PaletteRegistry } from '@kbn/coloring';
@@ -68,6 +68,15 @@ export const AnnotationsPanel = (
 
   const isQueryBased = isQueryAnnotationConfig(currentAnnotation);
   const isRange = isRangeAnnotationConfig(currentAnnotation);
+
+  const [queryInputShouldOpen, setQueryInputShouldOpen] = React.useState(false);
+  useEffect(() => {
+    if (isQueryBased) {
+      setQueryInputShouldOpen(false);
+    } else {
+      setQueryInputShouldOpen(true);
+    }
+  }, [isQueryBased]);
 
   const setAnnotations = useCallback(
     (annotation) => {
@@ -151,6 +160,7 @@ export const AnnotationsPanel = (
             frame={frame}
             state={state}
             layer={localLayer}
+            queryInputShouldOpen={queryInputShouldOpen}
           />
         ) : (
           <ConfigPanelManualAnnotation

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/query_annotation_panel.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/query_annotation_panel.tsx
@@ -15,8 +15,7 @@ import {
   FieldOption,
   FieldOptionValue,
   FieldPicker,
-  QueryInput,
-  validateQuery,
+  FilterQueryInput,
 } from '../../../../shared_components';
 import type { FramePublicAPI } from '../../../../types';
 import type { XYState, XYAnnotationLayerConfig } from '../../types';
@@ -39,7 +38,6 @@ export const ConfigPanelQueryAnnotation = ({
   state: XYState;
   layer: XYAnnotationLayerConfig;
 }) => {
-  const inputQuery = annotation?.filter ?? defaultQuery;
   const currentIndexPattern = frame.dataViews.indexPatterns[layer.indexPatternId];
   const currentExistingFields = frame.dataViews.existingFields[currentIndexPattern.title];
   // list only supported field by operation, remove the rest
@@ -58,51 +56,35 @@ export const ConfigPanelQueryAnnotation = ({
         'data-test-subj': `lns-fieldOption-${field.name}`,
       } as FieldOption<FieldOptionValue>;
     });
-  const { isValid: isQueryInputValid, error: queryInputError } = validateQuery(
-    annotation?.filter,
-    currentIndexPattern
-  );
 
   const selectedField =
     annotation?.timeField || currentIndexPattern.timeFieldName || options[0]?.value.field;
   const fieldIsValid = selectedField
     ? Boolean(currentIndexPattern.getFieldByName(selectedField))
     : true;
+
   return (
     <>
       <EuiFormRow
+        hasChildLabel
         display="rowCompressed"
         className="lnsRowCompressedMargin"
         fullWidth
         label={i18n.translate('xpack.lens.xyChart.annotation.queryInput', {
           defaultMessage: 'Annotation query',
         })}
-        isInvalid={!isQueryInputValid}
-        error={queryInputError}
+        data-test-subj="annotation-query-based-query-input"
       >
-        <QueryInput
-          value={inputQuery}
-          onChange={function (input: Query): void {
-            onChange({ filter: { type: 'kibana_query', ...input } });
+        <FilterQueryInput
+          label=""
+          inputFilter={annotation?.filter ?? defaultQuery}
+          onChange={(query: Query) => {
+            onChange({ filter: { type: 'kibana_query', ...query } });
           }}
-          disableAutoFocus
-          indexPatternTitle={frame.dataViews.indexPatterns[layer.indexPatternId].title}
-          isInvalid={!isQueryInputValid || inputQuery.query === ''}
-          onSubmit={() => {}}
-          data-test-subj="annotation-query-based-query-input"
-          placeholder={
-            inputQuery.language === 'kuery'
-              ? i18n.translate('xpack.lens.annotations.query.queryPlaceholderKql', {
-                  defaultMessage: '{example}',
-                  values: { example: 'method : "GET"' },
-                })
-              : i18n.translate('xpack.lens.annotations.query.queryPlaceholderLucene', {
-                  defaultMessage: '{example}',
-                  values: { example: 'method:GET' },
-                })
-          }
+          indexPattern={currentIndexPattern}
         />
       </EuiFormRow>
+
       <EuiFormRow
         display="rowCompressed"
         className="lnsRowCompressedMargin"

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/query_annotation_panel.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/query_annotation_panel.tsx
@@ -31,12 +31,14 @@ export const ConfigPanelQueryAnnotation = ({
   state,
   onChange,
   layer,
+  queryInputShouldOpen,
 }: {
   annotation?: QueryPointEventAnnotationConfig;
   onChange: (annotations: Partial<QueryPointEventAnnotationConfig> | undefined) => void;
   frame: FramePublicAPI;
   state: XYState;
   layer: XYAnnotationLayerConfig;
+  queryInputShouldOpen?: boolean;
 }) => {
   const currentIndexPattern = frame.dataViews.indexPatterns[layer.indexPatternId];
   const currentExistingFields = frame.dataViews.existingFields[currentIndexPattern.title];
@@ -76,6 +78,7 @@ export const ConfigPanelQueryAnnotation = ({
         data-test-subj="annotation-query-based-query-input"
       >
         <FilterQueryInput
+          initiallyOpen={queryInputShouldOpen}
           label=""
           inputFilter={annotation?.filter ?? defaultQuery}
           onChange={(query: Query) => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/140202
<img width="760" alt="Screenshot 2022-09-12 at 12 00 11" src="https://user-images.githubusercontent.com/4283304/189626695-b4eaf189-a4e6-4c9d-be0f-608f06cb0526.png">



Refactors datasource indexpattern - specific `Filtering` component to extract `FilterQueryInput` that is used also for query annotation query input.

- [x] removes debouncing - there's another debouncing implemented on top of it and they don't work well together. 
- [x] when opening a query tab from swtiching from manual annotations opens a popover 
- [x] fixes a small bug - configure default range annotation, switch to query - it'll take not supported alpha color and `Event range` label. This PR fixes it.  