### PR TITLE
[Enterprise Search] pipelines component

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ui_settings_keys.ts
+++ b/x-pack/plugins/enterprise_search/common/ui_settings_keys.ts
@@ -6,4 +6,4 @@
  */
 
 export const enterpriseSearchFeatureId = 'enterpriseSearch';
-export const enableIndexTransformsTab = 'enterpriseSearch:enableIndexTransformsTab';
+export const enableIndexPipelinesTab = 'enterpriseSearch:enableIndexTransformsTab';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { DataPanel } from '../../../../shared/data_panel/data_panel';
+
+export const SearchIndexPipelines: React.FC = () => {
+  return (
+    <>
+      <EuiSpacer />
+      <EuiFlexGroup direction="row">
+        <EuiFlexItem>
+          <DataPanel
+            hasBorder
+            title={
+              <h2>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.title',
+                  {
+                    defaultMessage: 'Ingest Pipelines',
+                  }
+                )}
+              </h2>
+            }
+            iconType="logstashInput"
+          >
+            <div />
+          </DataPanel>
+          <EuiSpacer />
+          <DataPanel
+            hasBorder
+            title={
+              <h2>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.title',
+                  {
+                    defaultMessage: 'ML Inference pipelines',
+                  }
+                )}
+              </h2>
+            }
+            iconType="compute"
+          >
+            <div />
+          </DataPanel>
+        </EuiFlexItem>
+        <EuiFlexItem />
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -17,7 +17,7 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 import { Status } from '../../../../../common/types/api';
-import { enableIndexTransformsTab } from '../../../../../common/ui_settings_keys';
+import { enableIndexPipelinesTab } from '../../../../../common/ui_settings_keys';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../shared/kibana';
 import { FetchIndexApiLogic } from '../../api/index/fetch_index_api_logic';
@@ -38,16 +38,17 @@ import { SearchIndexDocuments } from './documents';
 import { SearchIndexIndexMappings } from './index_mappings';
 import { IndexNameLogic } from './index_name_logic';
 import { SearchIndexOverview } from './overview';
+import { SearchIndexPipelines } from './pipelines/pipelines';
 
 export enum SearchIndexTabId {
   // all indices
   OVERVIEW = 'overview',
   DOCUMENTS = 'documents',
   INDEX_MAPPINGS = 'index_mappings',
+  PIPELINES = 'pipelines',
   // connector indices
   CONFIGURATION = 'configuration',
   SCHEDULING = 'scheduling',
-  TRANSFORMS = 'transforms',
   // crawler indices
   DOMAIN_MANAGEMENT = 'domain_management',
 }
@@ -64,7 +65,7 @@ export const SearchIndex: React.FC = () => {
 
   const { indexName } = useValues(IndexNameLogic);
 
-  const transformsEnabled = uiSettings?.get<boolean>(enableIndexTransformsTab) ?? false;
+  const pipelinesEnabled = uiSettings?.get<boolean>(enableIndexPipelinesTab) ?? false;
 
   const ALL_INDICES_TABS: EuiTabbedContentTab[] = [
     {
@@ -124,12 +125,12 @@ export const SearchIndex: React.FC = () => {
     },
   ];
 
-  const TRANSFORMS_TAB: EuiTabbedContentTab[] = [
+  const PIPELINES_TAB: EuiTabbedContentTab[] = [
     {
-      content: <div />,
-      id: SearchIndexTabId.TRANSFORMS,
-      name: i18n.translate('xpack.enterpriseSearch.content.searchIndex.transformsTabLabel', {
-        defaultMessage: 'Transforms',
+      content: <SearchIndexPipelines />,
+      id: SearchIndexTabId.PIPELINES,
+      name: i18n.translate('xpack.enterpriseSearch.content.searchIndex.pipelinesTabLabel', {
+        defaultMessage: 'Pipelines',
       }),
     },
   ];
@@ -138,7 +139,7 @@ export const SearchIndex: React.FC = () => {
     ...ALL_INDICES_TABS,
     ...(isConnectorIndex(indexData) ? CONNECTOR_TABS : []),
     ...(isCrawlerIndex(indexData) ? CRAWLER_TABS : []),
-    ...(transformsEnabled && isConnectorIndex(indexData) ? TRANSFORMS_TAB : []),
+    ...(pipelinesEnabled ? PIPELINES_TAB : []),
   ];
 
   const selectedTab = tabs.find((tab) => tab.id === tabId);

--- a/x-pack/plugins/enterprise_search/server/ui_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/ui_settings.ts
@@ -9,19 +9,19 @@ import { schema } from '@kbn/config-schema';
 import { UiSettingsParams } from '@kbn/core/types';
 import { i18n } from '@kbn/i18n';
 
-import { enterpriseSearchFeatureId, enableIndexTransformsTab } from '../common/ui_settings_keys';
+import { enterpriseSearchFeatureId, enableIndexPipelinesTab } from '../common/ui_settings_keys';
 
 /**
  * uiSettings definitions for Enterprise Search
  */
 export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
-  [enableIndexTransformsTab]: {
+  [enableIndexPipelinesTab]: {
     category: [enterpriseSearchFeatureId],
-    description: i18n.translate('xpack.enterpriseSearch.uiSettings.indexTransforms.description', {
-      defaultMessage: 'Enable the new index transforms tab in Enterprise Search.',
+    description: i18n.translate('xpack.enterpriseSearch.uiSettings.indexPipelines.description', {
+      defaultMessage: 'Enable the new index pipelines tab in Enterprise Search.',
     }),
-    name: i18n.translate('xpack.enterpriseSearch.uiSettings.indexTransforms.name', {
-      defaultMessage: 'Enable index transforms',
+    name: i18n.translate('xpack.enterpriseSearch.uiSettings.indexPipelines.name', {
+      defaultMessage: 'Enable index pipelines',
     }),
     requiresPageReload: false,
     schema: schema.boolean(),


### PR DESCRIPTION
## Summary

Add a component for the search index pipelines tab with empty data panels.

Updated the UI settings to reference the tab as pipelines instead of transforms as we are getting closer to settling on that name.

(With feature flag on)
<img width="973" alt="image" src="https://user-images.githubusercontent.com/1972968/189376325-8ad38ada-00e1-4eb1-a9ce-768a08091ed3.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
