### PR TITLE
[Security Solution][Endpoint][Response Actions] Keep Response console Arrow button disabled for whitespace characters

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.test.tsx
@@ -42,6 +42,10 @@ describe('When entering data into the Console input', () => {
     return renderResult.getByTestId('test-footer').textContent;
   };
 
+  const typeKeyboardKey = (key: string) => {
+    enterCommand(key, { inputOnly: true, useKeyboard: true });
+  };
+
   beforeEach(() => {
     const testSetup = getConsoleTestSetup();
 
@@ -124,6 +128,23 @@ describe('When entering data into the Console input', () => {
     expect(arrowButton).toBeDisabled();
   });
 
+  it('should show the arrow button as disabled if input has only whitespace entered and it is left to the cursor', () => {
+    render();
+    enterCommand(' ', { inputOnly: true });
+
+    const arrowButton = renderResult.getByTestId('test-inputTextSubmitButton');
+    expect(arrowButton).toBeDisabled();
+  });
+
+  it('should show the arrow button as disabled if input has only whitespace entered and it is right to the cursor', () => {
+    render();
+    enterCommand(' ', { inputOnly: true });
+    typeKeyboardKey('{ArrowLeft}');
+
+    const arrowButton = renderResult.getByTestId('test-inputTextSubmitButton');
+    expect(arrowButton).toBeDisabled();
+  });
+
   it('should execute correct command if arrow button is clicked', () => {
     render();
     enterCommand('isolate', { inputOnly: true });
@@ -198,10 +219,6 @@ describe('When entering data into the Console input', () => {
   describe('and keyboard special keys are pressed', () => {
     const getRightOfCursorText = () => {
       return renderResult.getByTestId('test-cmdInput-rightOfCursor').textContent;
-    };
-
-    const typeKeyboardKey = (key: string) => {
-      enterCommand(key, { inputOnly: true, useKeyboard: true });
     };
 
     beforeEach(() => {

--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_input/command_input.tsx
@@ -82,7 +82,7 @@ export interface CommandInputProps extends CommonProps {
 export const CommandInput = memo<CommandInputProps>(({ prompt = '', focusRef, ...commonProps }) => {
   useInputHints();
   const dispatch = useConsoleStateDispatch();
-  const { rightOfCursor, textEntered } = useWithInputTextEntered();
+  const { rightOfCursor, textEntered, fullTextEntered } = useWithInputTextEntered();
   const visibleState = useWithInputVisibleState();
   const [isKeyInputBeingCaptured, setIsKeyInputBeingCaptured] = useState(false);
   const getTestId = useTestIdGenerator(useDataTestSubj());
@@ -117,10 +117,7 @@ export const CommandInput = memo<CommandInputProps>(({ prompt = '', focusRef, ..
     });
   }, [isKeyInputBeingCaptured, visibleState]);
 
-  const disableArrowButton = useMemo(
-    () => textEntered.length === 0 && rightOfCursor.text.length === 0,
-    [rightOfCursor.text.length, textEntered.length]
-  );
+  const disableArrowButton = useMemo(() => fullTextEntered.trim().length === 0, [fullTextEntered]);
 
   const handleSubmitButton = useCallback<MouseEventHandler>(
     (ev) => {


### PR DESCRIPTION
Fixes: #138978

## Summary

Fixes the issue where the submit button on the Response Console is enabled when entering only whitespace characters.

![recorded gif](https://user-images.githubusercontent.com/39014407/189400123-9cf7ff08-41ae-40ce-8315-d0b2a3ee8dae.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios