### PR TITLE
[ftr/o11yApp] remove custom timeout for navigation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
 /x-pack/plugins/observability/public/pages/rule_details  @elastic/actionable-observability
+/x-pack/test/observability_functional @elastic/actionable-observability @elastic/unified-observability
 
 # Infra Monitoring
 /x-pack/plugins/infra/ @elastic/infra-monitoring-ui

--- a/x-pack/test/functional/services/cases/navigation.ts
+++ b/x-pack/test/functional/services/cases/navigation.ts
@@ -14,7 +14,7 @@ export function CasesNavigationProvider({ getPageObject, getService }: FtrProvid
   return {
     async navigateToApp(app: string = 'cases', appSelector: string = 'cases-app') {
       await common.navigateToApp(app);
-      await testSubjects.existOrFail(appSelector, { timeout: 2000 });
+      await testSubjects.existOrFail(appSelector);
     },
 
     async navigateToConfigurationPage(app: string = 'cases', appSelector: string = 'cases-app') {

--- a/x-pack/test/observability_functional/apps/observability/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/index.ts
@@ -8,8 +8,7 @@
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  // FAILING: https://github.com/elastic/kibana/issues/140437
-  describe.skip('ObservabilityApp', function () {
+  describe('ObservabilityApp', function () {
     loadTestFile(require.resolve('./pages/alerts'));
     loadTestFile(require.resolve('./pages/cases/case_details'));
     loadTestFile(require.resolve('./pages/alerts/add_to_case'));


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/140437

After skipping the `pages/alerts/index` suite we were now asking the `pages/cases/case_details` suite to load the app from scratch which, based on the details of the [two](https://buildkite.com/organizations/elastic/pipelines/kibana-on-merge/builds/20692/jobs/01832316-0439-4a6c-9f64-4c84139e4315/artifacts/01832340-9f81-403d-a0cb-9a03bfa44ee6) [occurrences](https://buildkite.com/organizations/elastic/pipelines/kibana-on-merge/builds/20692/jobs/01832340-be60-4f6c-a84b-caec23b93597/artifacts/01832345-90dc-4ccd-a445-32e08db7e7f3) I'm pretty confident that the problem was that we just weren't giving the app enough time to load.

First test after skipping the `pages/alerts/index` suite failed the `pages/cases/case_details` suite to consistently fail. With this change we have 50 successes: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1197.