### PR TITLE
[Unified Observability] Overview: Rename Guided Setup and update related components (WIP)

### DIFF
--- a/x-pack/plugins/observability/public/components/app/observability_status/observability_status_progress.tsx
+++ b/x-pack/plugins/observability/public/components/app/observability_status/observability_status_progress.tsx
@@ -67,16 +67,14 @@ export function ObservabilityStatusProgress({
 
   return !isGuidedSetupProgressDismissed ? (
     <>
-      <EuiPanel color="primary" data-test-subj="status-progress">
-        <EuiProgress color="primary" value={progress} max={100} size="m" />
-        <EuiSpacer size="s" />
+      <EuiPanel color="warning" data-test-subj="status-progress">
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiTitle size="xxs">
               <h2>
                 <FormattedMessage
                   id="xpack.observability.status.progressBarTitle"
-                  defaultMessage="Guided setup for Observability"
+                  defaultMessage="Integration status"
                 />
               </h2>
             </EuiTitle>
@@ -92,7 +90,7 @@ export function ObservabilityStatusProgress({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup responsive={false} direction="row" alignItems="center">
               <EuiFlexItem>
-                <EuiButtonEmpty size="s" onClick={dismissGuidedSetup}>
+                <EuiButtonEmpty color="warning" size="s" onClick={dismissGuidedSetup}>
                   <FormattedMessage
                     id="xpack.observability.status.progressBarDismiss"
                     defaultMessage="Dismiss"
@@ -100,10 +98,10 @@ export function ObservabilityStatusProgress({
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton size="s" onClick={showDetails}>
+                <EuiButton color="warning" size="s" onClick={showDetails}>
                   <FormattedMessage
                     id="xpack.observability.status.progressBarViewDetails"
-                    defaultMessage="View details"
+                    defaultMessage="Learn more"
                   />
                 </EuiButton>
               </EuiFlexItem>

--- a/x-pack/plugins/observability/public/pages/overview/containers/overview_page/overview_page.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/containers/overview_page/overview_page.tsx
@@ -220,7 +220,7 @@ export function OverviewPage() {
               <h2 id="statusVisualizationFlyoutTitle">
                 <FormattedMessage
                   id="xpack.observability.overview.statusVisualizationFlyoutTitle"
-                  defaultMessage="Guided setup"
+                  defaultMessage="Integration status"
                 />
               </h2>
             </EuiTitle>
@@ -289,7 +289,7 @@ function PageHeader({
         >
           <FormattedMessage
             id="xpack.observability.overview.guidedSetupButton"
-            defaultMessage="Guided setup"
+            defaultMessage="Integration status"
           />
         </EuiButton>
         {showTour ? (


### PR DESCRIPTION
_WORK IN PROGRESS_

## Summary

- [x] Updated "Guided setup" naming to "Integration status" - actual name is still pending https://github.com/elastic/observability-docs/issues/2166
- [x] Removed progress bar and changed callout styling for the main page highlight banner 

<img width="1164" alt="CleanShot 2022-09-12 at 08 31 34@2x" src="https://user-images.githubusercontent.com/4104278/189587789-3758f7a0-a5c7-46fc-a025-6b339e013221.png">

<img width="1419" alt="CleanShot 2022-09-12 at 08 31 38@2x" src="https://user-images.githubusercontent.com/4104278/189587797-8840defa-821a-4937-b8f0-62dcac16b327.png">

