### PR TITLE
Cache all nested formatters

### DIFF
--- a/src/plugins/data/common/search/aggs/utils/get_aggs_formats.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_aggs_formats.test.ts
@@ -42,7 +42,7 @@ describe('getAggsFormats', () => {
     );
     expect(format.convert({ to: '2020-06-01' })).toBe('Before 2020-06-01');
     expect(format.convert({ from: '2020-06-01' })).toBe('After 2020-06-01');
-    expect(getFormat).toHaveBeenCalledTimes(3);
+    expect(getFormat).toHaveBeenCalledTimes(1);
   });
 
   test('date_range does not crash on empty value', () => {
@@ -62,7 +62,7 @@ describe('getAggsFormats', () => {
     expect(format.convert({ type: 'range', to: '10.0.0.10' })).toBe('-Infinity to 10.0.0.10');
     expect(format.convert({ type: 'range', from: '10.0.0.10' })).toBe('10.0.0.10 to Infinity');
     format.convert({ type: 'mask', mask: '10.0.0.1/24' });
-    expect(getFormat).toHaveBeenCalledTimes(4);
+    expect(getFormat).toHaveBeenCalledTimes(1);
   });
 
   test('ip_range does not crash on empty value', () => {
@@ -135,7 +135,7 @@ describe('getAggsFormats', () => {
     expect(format.convert('machine.os.keyword')).toBe('machine.os.keyword');
     expect(format.convert('__other__')).toBe(mapping.params.otherBucketLabel);
     expect(format.convert('__missing__')).toBe(mapping.params.missingBucketLabel);
-    expect(getFormat).toHaveBeenCalledTimes(3);
+    expect(getFormat).toHaveBeenCalledTimes(1);
   });
 
   test('uses a default separator for multi terms', () => {

--- a/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_aggs_formats.ts
@@ -16,6 +16,7 @@ import {
   IFieldFormat,
   SerializedFieldFormat,
 } from '@kbn/field-formats-plugin/common';
+import { SerializableRecord } from '@kbn/utility-types';
 import { DateRange } from '../../expressions';
 import { convertDateRangeToString } from '../buckets/lib/date_range';
 import { convertIPRangeToString, IpRangeKey } from '../buckets/lib/ip_range';
@@ -35,8 +36,21 @@ type GetFieldFormat = (mapping: SerializedFieldFormat) => IFieldFormat;
  * @internal
  */
 export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInstanceType[] {
+  class FieldFormatWithCache extends FieldFormat {
+    protected formatCache: Map<SerializedFieldFormat, FieldFormat> = new Map();
+
+    protected getCachedFormat(fieldParams: SerializedFieldFormat<{}, SerializableRecord>) {
+      const isCached = this.formatCache.has(fieldParams);
+      const cachedFormat = this.formatCache.get(fieldParams) || getFieldFormat(fieldParams);
+      if (!isCached) {
+        this.formatCache.set(fieldParams, cachedFormat);
+      }
+      return cachedFormat;
+    }
+  }
+
   return [
-    class AggsRangeFieldFormat extends FieldFormat {
+    class AggsRangeFieldFormat extends FieldFormatWithCache {
       static id = 'range';
       static hidden = true;
 
@@ -51,10 +65,7 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
           return range.label;
         }
         const nestedFormatter = params as SerializedFieldFormat;
-        const format = getFieldFormat({
-          id: nestedFormatter.id,
-          params: nestedFormatter.params,
-        });
+        const format = this.getCachedFormat(nestedFormatter);
 
         const gte = '\u2265';
         const lt = '\u003c';
@@ -88,7 +99,7 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
         });
       };
     },
-    class AggsDateRangeFieldFormat extends FieldFormat {
+    class AggsDateRangeFieldFormat extends FieldFormatWithCache {
       static id = 'date_range';
       static hidden = true;
 
@@ -98,14 +109,11 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
         }
 
         const nestedFormatter = this._params as SerializedFieldFormat;
-        const format = getFieldFormat({
-          id: nestedFormatter.id,
-          params: nestedFormatter.params,
-        });
+        const format = this.getCachedFormat(nestedFormatter);
         return convertDateRangeToString(range, format.convert.bind(format));
       };
     },
-    class AggsIpRangeFieldFormat extends FieldFormat {
+    class AggsIpRangeFieldFormat extends FieldFormatWithCache {
       static id = 'ip_range';
       static hidden = true;
 
@@ -115,20 +123,19 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
         }
 
         const nestedFormatter = this._params as SerializedFieldFormat;
-        const format = getFieldFormat({
-          id: nestedFormatter.id,
-          params: nestedFormatter.params,
-        });
+        const format = this.getCachedFormat(nestedFormatter);
         return convertIPRangeToString(range, format.convert.bind(format));
       };
     },
-    class AggsTermsFieldFormat extends FieldFormat {
+    class AggsTermsFieldFormat extends FieldFormatWithCache {
       static id = 'terms';
       static hidden = true;
 
       convert = (val: string, type: FieldFormatsContentType) => {
         const params = this._params;
-        const format = getFieldFormat({ id: `${params.id}`, params });
+        const format = this.getCachedFormat(
+          params as SerializedFieldFormat<{}, SerializableRecord>
+        );
 
         if (val === '__other__') {
           return `${params.otherBucketLabel}`;
@@ -141,21 +148,14 @@ export function getAggsFormats(getFieldFormat: GetFieldFormat): FieldFormatInsta
       };
       getConverterFor = (type: FieldFormatsContentType) => (val: string) => this.convert(val, type);
     },
-    class AggsMultiTermsFieldFormat extends FieldFormat {
+    class AggsMultiTermsFieldFormat extends FieldFormatWithCache {
       static id = 'multi_terms';
       static hidden = true;
-
-      private formatCache: Map<SerializedFieldFormat, FieldFormat> = new Map();
 
       convert = (val: unknown, type: FieldFormatsContentType) => {
         const params = this._params;
         const formats = (params.paramsPerField as SerializedFieldFormat[]).map((fieldParams) => {
-          const isCached = this.formatCache.has(fieldParams);
-          const cachedFormat = this.formatCache.get(fieldParams) || getFieldFormat(fieldParams);
-          if (!isCached) {
-            this.formatCache.set(fieldParams, cachedFormat);
-          }
-          return cachedFormat;
+          return this.getCachedFormat(fieldParams);
         });
 
         if (String(val) === '__other__') {


### PR DESCRIPTION
If there are nested formatters within the agg formatters (like for range, date range or terms), it initializes a new formatter class for every call of the outer formatter. This is expensive and can quickly add up if there are a lot of data points:
<img width="854" alt="Screenshot 2022-09-12 at 12 40 01" src="https://user-images.githubusercontent.com/1508364/189634499-28977e8d-ad91-4f52-b124-40027d650faf.png">

This PR applies the performance optimization that was already applied to the multi field terms also to the others:
<img width="853" alt="Screenshot 2022-09-12 at 12 41 31" src="https://user-images.githubusercontent.com/1508364/189634628-038df28f-ddb5-4729-ae5a-f827f9f42539.png">

This reduces the runtime to roughly 1/20th of the original time, which matters for a lot of data points (the numbers above were obtained by rendering 47k data points with a terms formatter)