### PR TITLE
[cft] Temporarily disable cloud deployments

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-echo "Cloud deployments are not working for the moment.  Status updates will be posted in #kibana-operations."
+echo "Cloud deployments have been temporarily disabled.  We're investigating, status updates will be posted in #kibana-operations."
+cat << EOF | buildkite-agent annotate --style "error" --context cloud
+  ### Cloud Deployment
+
+  Cloud deployments have been temporarily disabled.  We're investigating, status updates will be posted in #kibana-operations.
+EOF
 exit 0
 
 source .buildkite/scripts/common/util.sh

--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+echo "Cloud deployments are not working for the moment.  Status updates will be posted in #kibana-operations."
+exit 0
+
 source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh


### PR DESCRIPTION
It looks like there was an unintentional breaking change in elasticsearch/cloud for 8.5.0 snapshot builds and deployments aren't working.  This temporarily shuts pull request deployments off to prevent CI from breaking on unrelated changes.