### PR TITLE
[kbn/pm] add hidden script for migration purposes

### DIFF
--- a/kbn_pm/src/cli.mjs
+++ b/kbn_pm/src/cli.mjs
@@ -18,7 +18,7 @@
 import { Args } from './lib/args.mjs';
 import { getHelp } from './lib/help.mjs';
 import { createFlagError, isCliError } from './lib/cli_error.mjs';
-import { COMMANDS } from './commands/index.mjs';
+import { getCmd } from './commands/index.mjs';
 import { Log } from './lib/log.mjs';
 
 const start = Date.now();
@@ -39,7 +39,7 @@ async function tryToGetCiStatsReporter(log) {
 }
 
 try {
-  const cmd = cmdName ? COMMANDS.find((c) => c.name === cmdName) : undefined;
+  const cmd = getCmd(cmdName);
 
   if (cmdName && !cmd) {
     throw createFlagError(`Invalid command name [${cmdName}]`);

--- a/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -76,7 +76,7 @@ export const command = {
     // That is only intended during the migration process while non Bazel projects are not removed at all.
     if (forceInstall) {
       await time('force install dependencies', async () => {
-        removeYarnIntegrityFileIfExists();
+        await removeYarnIntegrityFileIfExists();
         await Bazel.expungeCache(log, { quiet });
         await Bazel.installYarnDeps(log, { offline, quiet });
       });
@@ -89,19 +89,17 @@ export const command = {
     // generate the synthetic package map which powers several other features, needed
     // as an input to the package build
     await time('regenerate synthetic package map', async () => {
-      regenerateSyntheticPackageMap(plugins);
+      await regenerateSyntheticPackageMap(plugins);
     });
 
-    // build packages
     await time('build packages', async () => {
       await Bazel.buildPackages(log, { offline, quiet });
     });
-
     await time('sort package json', async () => {
       await sortPackageJson();
     });
     await time('regenerate tsconfig.base.json', async () => {
-      regenerateBaseTsconfig(plugins);
+      await regenerateBaseTsconfig(plugins);
     });
 
     if (validate) {

--- a/kbn_pm/src/commands/bootstrap/regenerate_base_tsconfig.mjs
+++ b/kbn_pm/src/commands/bootstrap/regenerate_base_tsconfig.mjs
@@ -7,7 +7,7 @@
  */
 
 import Path from 'path';
-import Fs from 'fs';
+import Fsp from 'fs/promises';
 
 import { REPO_ROOT } from '../../lib/paths.mjs';
 import { convertPluginIdToPackageId } from './plugins.mjs';
@@ -16,9 +16,9 @@ import { normalizePath } from './normalize_path.mjs';
 /**
  * @param {import('@kbn/plugin-discovery').KibanaPlatformPlugin[]} plugins
  */
-export function regenerateBaseTsconfig(plugins) {
+export async function regenerateBaseTsconfig(plugins) {
   const tsconfigPath = Path.resolve(REPO_ROOT, 'tsconfig.base.json');
-  const lines = Fs.readFileSync(tsconfigPath, 'utf-8').split('\n');
+  const lines = (await Fsp.readFile(tsconfigPath, 'utf-8')).split('\n');
 
   const packageMap = plugins
     .slice()
@@ -32,7 +32,7 @@ export function regenerateBaseTsconfig(plugins) {
   const start = lines.findIndex((l) => l.trim() === '// START AUTOMATED PACKAGE LISTING');
   const end = lines.findIndex((l) => l.trim() === '// END AUTOMATED PACKAGE LISTING');
 
-  Fs.writeFileSync(
+  await Fsp.writeFile(
     tsconfigPath,
     [...lines.slice(0, start + 1), ...packageMap, ...lines.slice(end)].join('\n')
   );

--- a/kbn_pm/src/commands/bootstrap/regenerate_synthetic_package_map.mjs
+++ b/kbn_pm/src/commands/bootstrap/regenerate_synthetic_package_map.mjs
@@ -7,7 +7,7 @@
  */
 
 import Path from 'path';
-import Fs from 'fs';
+import Fsp from 'fs/promises';
 
 import { normalizePath } from './normalize_path.mjs';
 import { REPO_ROOT } from '../../lib/paths.mjs';
@@ -16,7 +16,7 @@ import { convertPluginIdToPackageId } from './plugins.mjs';
 /**
  * @param {import('@kbn/plugin-discovery').KibanaPlatformPlugin[]} plugins
  */
-export function regenerateSyntheticPackageMap(plugins) {
+export async function regenerateSyntheticPackageMap(plugins) {
   /** @type {Array<[string, string]>} */
   const entries = [['@kbn/core', 'src/core']];
 
@@ -27,7 +27,7 @@ export function regenerateSyntheticPackageMap(plugins) {
     ]);
   }
 
-  Fs.writeFileSync(
+  await Fsp.writeFile(
     Path.resolve(REPO_ROOT, 'packages/kbn-synthetic-package-map/synthetic-packages.json'),
     JSON.stringify(entries, null, 2)
   );

--- a/kbn_pm/src/commands/bootstrap/yarn.mjs
+++ b/kbn_pm/src/commands/bootstrap/yarn.mjs
@@ -7,20 +7,20 @@
  */
 
 import Path from 'path';
-import Fs from 'fs';
+import Fsp from 'fs/promises';
 
 import { REPO_ROOT } from '../../lib/paths.mjs';
 import { maybeRealpath, isFile, isDirectory } from '../../lib/fs.mjs';
 
 // yarn integrity file checker
-export function removeYarnIntegrityFileIfExists() {
+export async function removeYarnIntegrityFileIfExists() {
   try {
     const nodeModulesRealPath = maybeRealpath(Path.resolve(REPO_ROOT, 'node_modules'));
     const yarnIntegrityFilePath = Path.resolve(nodeModulesRealPath, '.yarn-integrity');
 
     // check if the file exists and delete it in that case
     if (isFile(yarnIntegrityFilePath)) {
-      Fs.unlinkSync(yarnIntegrityFilePath);
+      await Fsp.unlink(yarnIntegrityFilePath);
     }
   } catch {
     // no-op

--- a/kbn_pm/src/commands/index.mjs
+++ b/kbn_pm/src/commands/index.mjs
@@ -12,4 +12,12 @@ export const COMMANDS = [
   (await import('./run_in_packages_command.mjs')).command,
   (await import('./clean_command.mjs')).command,
   (await import('./reset_command.mjs')).command,
+  (await import('./test_command.mjs')).command,
 ];
+
+/**
+ * @param {string | undefined} name
+ */
+export function getCmd(name) {
+  return COMMANDS.find((c) => (c.name.startsWith('_') ? c.name.slice(1) : c.name) === name);
+}

--- a/kbn_pm/src/commands/test_command.mjs
+++ b/kbn_pm/src/commands/test_command.mjs
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** @type {import('../lib/command').Command} */
+export const command = {
+  name: '_test',
+  async run({ log }) {
+    log.success('empty');
+  },
+};

--- a/kbn_pm/src/lib/find_clean_paths.mjs
+++ b/kbn_pm/src/lib/find_clean_paths.mjs
@@ -30,7 +30,7 @@ async function tryToGetSyntheticPackageMap(log) {
 }
 
 /**
- * @param {*} packageDir
+ * @param {string} packageDir
  * @returns {string[]}
  */
 export function readCleanPatterns(packageDir) {

--- a/kbn_pm/src/lib/help.mjs
+++ b/kbn_pm/src/lib/help.mjs
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { COMMANDS } from '../commands/index.mjs';
+import { COMMANDS, getCmd } from '../commands/index.mjs';
 import { dedent, indent } from './indent.mjs';
 import { title } from './colors.mjs';
 
@@ -15,7 +15,7 @@ import { title } from './colors.mjs';
  * @returns {Promise<string>}
  */
 export async function getHelp(cmdName = undefined) {
-  const cmd = cmdName && COMMANDS.find((c) => c.name === cmdName);
+  const cmd = getCmd(cmdName);
 
   /**
    * @param {number} depth
@@ -49,6 +49,6 @@ export async function getHelp(cmdName = undefined) {
     '  yarn kbn <command> [...flags]',
     '',
     'Commands:',
-    ...COMMANDS.map((cmd) => cmdLines(2, cmd)).flat(),
+    ...COMMANDS.flatMap((cmd) => (cmd.name.startsWith('_') ? [] : cmdLines(2, cmd))),
   ].join('\n');
 }


### PR DESCRIPTION
While working on the config file migrations I've needed a script for running some migration stuff. I used a script in the scripts directory, but leaving it in wasn't ideal. This adds an undocumented `yarn kbn test` command. It's not listed in the `yarn kbn --help` docs, but can be run and can have it's own help if desired. The idea here is that this command will change and basically be responsible for whatever automated migration script we need for a specific migration