### PR TITLE
[Profiling] Pre-allocate arrays when constructing flamegraph

### DIFF
--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -154,41 +154,52 @@ export class FlameGraph {
     this.executables = executables;
   }
 
+  private countCallees(root: CallerCalleeNode): number {
+    let numCallees = 1;
+    for (const callee of root.Callees) {
+      numCallees += this.countCallees(callee);
+    }
+    return numCallees;
+  }
+
   // createColumnarCallerCallee flattens the intermediate representation of the diagram
   // into a columnar format that is more compact than JSON. This representation will later
   // need to be normalized into the response ultimately consumed by the flamegraph.
   private createColumnarCallerCallee(root: CallerCalleeNode): ColumnarCallerCallee {
+    const numCallees = this.countCallees(root);
     const columnar: ColumnarCallerCallee = {
-      Label: [],
-      Value: [],
-      X: [],
-      Y: [],
-      Color: [],
-      CountInclusive: [],
-      CountExclusive: [],
-      ID: [],
+      Label: new Array<string>(numCallees),
+      Value: new Array<number>(numCallees),
+      X: new Array<number>(numCallees),
+      Y: new Array<number>(numCallees),
+      Color: new Array<number>(numCallees),
+      CountInclusive: new Array<number>(numCallees),
+      CountExclusive: new Array<number>(numCallees),
+      ID: new Array<string>(numCallees),
     };
-    const queue = [{ x: 0, depth: 1, node: root, parentID: 'root' }];
 
+    const queue = [{ x: 0, depth: 1, node: root, parentID: 'root' }];
+    
+    let idx = 0;
     while (queue.length > 0) {
       const { x, depth, node, parentID } = queue.pop()!;
 
       if (x === 0 && depth === 1) {
-        columnar.Label.push('root: Represents 100% of CPU time.');
+        columnar.Label[idx] = 'root: Represents 100% of CPU time.';
       } else {
-        columnar.Label.push(getLabel(node));
+        columnar.Label[idx] = getLabel(node);
       }
-      columnar.Value.push(node.Samples);
-      columnar.X.push(x);
-      columnar.Y.push(depth);
-      columnar.Color.push(frameTypeToRGB(node.FrameType, x));
+      columnar.Value[idx] = node.Samples;
+      columnar.X[idx] = x;
+      columnar.Y[idx] = depth;
+      columnar.Color[idx] = frameTypeToRGB(node.FrameType, x);
 
-      columnar.CountInclusive.push(node.CountInclusive);
-      columnar.CountExclusive.push(node.CountExclusive);
+      columnar.CountInclusive[idx] = node.CountInclusive;
+      columnar.CountExclusive[idx] = node.CountExclusive;
 
       const id = objectHash([parentID, node.FrameGroupID]);
 
-      columnar.ID.push(id);
+      columnar.ID[idx] = id;
 
       node.Callees.sort((a: CallerCalleeNode, b: CallerCalleeNode) => b.Samples - a.Samples);
 
@@ -201,6 +212,8 @@ export class FlameGraph {
         delta -= node.Callees[i].Samples;
         queue.push({ x: x + delta, depth: depth + 1, node: node.Callees[i], parentID: id });
       }
+
+      idx++;
     }
 
     return columnar;

--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -78,7 +78,7 @@ function frameTypeToRGB(frameType: number, x: number): number {
   return frameTypeToColors[frameType][x % 4];
 }
 
-export function normalizeColorForFlamegraph(rgb: number): number[] {
+export function rgbToRGBA(rgb: number): number[] {
   return [
     Math.floor(rgb / 65536) / 255,
     (Math.floor(rgb / 256) % 256) / 255,
@@ -172,7 +172,7 @@ export class FlameGraph {
       Value: new Array<number>(numCallees),
       X: new Array<number>(numCallees),
       Y: new Array<number>(numCallees),
-      Color: new Array<number>(numCallees),
+      Color: new Array<number>(numCallees * 4),
       CountInclusive: new Array<number>(numCallees),
       CountExclusive: new Array<number>(numCallees),
       ID: new Array<string>(numCallees),
@@ -192,7 +192,13 @@ export class FlameGraph {
       columnar.Value[idx] = node.Samples;
       columnar.X[idx] = x;
       columnar.Y[idx] = depth;
-      columnar.Color[idx] = frameTypeToRGB(node.FrameType, x);
+
+      const [red, green, blue, alpha] = rgbToRGBA(frameTypeToRGB(node.FrameType, x));
+      const j = 4 * idx;
+      columnar.Color[j] = red;
+      columnar.Color[j + 1] = green;
+      columnar.Color[j + 2] = blue;
+      columnar.Color[j + 3] = alpha;
 
       columnar.CountInclusive[idx] = node.CountInclusive;
       columnar.CountExclusive[idx] = node.CountExclusive;
@@ -235,6 +241,7 @@ export class FlameGraph {
 
     graph.Label = columnar.Label;
     graph.Value = columnar.Value;
+    graph.Color = columnar.Color;
     graph.CountInclusive = columnar.CountInclusive;
     graph.CountExclusive = columnar.CountExclusive;
     graph.ID = columnar.ID;
@@ -249,10 +256,6 @@ export class FlameGraph {
     }
 
     graph.Size = graph.Value.map((n) => normalize(n, 0, maxX));
-
-    for (const color of columnar.Color) {
-      graph.Color.push(...normalizeColorForFlamegraph(color));
-    }
 
     return graph;
   }

--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -179,7 +179,7 @@ export class FlameGraph {
     };
 
     const queue = [{ x: 0, depth: 1, node: root, parentID: 'root' }];
-    
+
     let idx = 0;
     while (queue.length > 0) {
       const { x, depth, node, parentID } = queue.pop()!;

--- a/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
+++ b/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
@@ -10,7 +10,7 @@ import { uniqueId } from 'lodash';
 import {
   ElasticFlameGraph,
   FlameGraphComparisonMode,
-  normalizeColorForFlamegraph,
+  rgbToRGBA,
 } from '../../../common/flamegraph';
 import { getInterpolationValue } from './get_interpolation_value';
 
@@ -89,7 +89,7 @@ export function getFlamegraphModel({
           ? positiveChangeInterpolator(interpolationValue)
           : negativeChangeInterpolator(Math.abs(interpolationValue));
 
-      colors!.push(...normalizeColorForFlamegraph(Number(nodeColor.replace('#', '0x'))));
+      colors!.push(...rgbToRGBA(Number(nodeColor.replace('#', '0x'))));
     });
   }
 

--- a/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
+++ b/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
@@ -7,11 +7,7 @@
 import { ColumnarViewModel } from '@elastic/charts';
 import d3 from 'd3';
 import { uniqueId } from 'lodash';
-import {
-  ElasticFlameGraph,
-  FlameGraphComparisonMode,
-  rgbToRGBA,
-} from '../../../common/flamegraph';
+import { ElasticFlameGraph, FlameGraphComparisonMode, rgbToRGBA } from '../../../common/flamegraph';
 import { getInterpolationValue } from './get_interpolation_value';
 
 const nullColumnarViewModel = {


### PR DESCRIPTION
Part of https://github.com/elastic/prodfiler/issues/2595

This PR implements two optimizations to reduce the latency of flamegraph responses:

1. Since we know the number of nodes in the flamegraph, we can pre-allocate arrays in `createColumnarCallerCallee`.
2. The colors for the flamegraph nodes are calculated in two passes (`createColumnarCallerCallee` and `createElasticFlameGraph`). By calculating the colors in one pass, we reduce the overall time and used memory.

#### Benchmarks

These benchmarks were run locally. Each row represents 100 samples. The `Seconds` column represents the time range for the selected flamegraph. All times are in milliseconds.

The first experiment (`base`) is the unmodified main branch. The second experiment (`commit-1`) uses pre-allocated arrays. The third experiment (`commit-2`) uses pre-allocated arrays and the one-pass color calculation.

The results from the third experiment represent the overall improvement from the optimizations.

| Experiment | Seconds | Minimum | Q1     | Median | Q3     | P90    | P95    | P99     | Maximum |
|------------|---------|---------|--------|--------|--------|--------|--------|---------|---------|
| base       |     900 |    2679 |   2822 |   2920 |   3010 |   3092 |   3182 |    3512 |    3632 |
| base       |    1800 |    3217 |   3315 |   3373 |   3445 |   3506 |   3535 |    3616 |    3639 |
| base       |    3600 |    3148 |   3363 |   3422 |   3488 |   3542 |   3589 |    3695 |    3966 |
| base       |   86400 |    3091 |   3243 |   3307 |   3362 |   3420 |   3439 |    3605 |    3615 |
| commit-1   |     900 |  -4.14% | -6.02% | -8.18% | -9.53% | -8.34% | -8.96% | -14.41% |  -2.67% |
| commit-1   |    1800 |  -8.33% | -7.33% | -2.43% |  0.15% |  1.34% |  1.47% |   3.35% |   4.34% |
| commit-1   |    3600 |  -1.56% |  0.18% |  0.35% |  0.69% |  1.33% |  0.72% |   0.32% |  -4.08% |
| commit-1   |   86400 | -10.22% | -9.10% | -2.30% | -1.13% | -0.18% | -0.09% |  -2.41% |   1.52% |
| commit-2   |     900 |  -3.99% | -4.71% | -6.40% | -6.41% | -4.92% | -2.48% |  -3.53% |  -0.72% |
| commit-2   |    1800 |  -6.28% | -6.12% | -5.96% | -5.46% | -4.11% | -1.98% |  -0.53% |   0.69% |
| commit-2   |    3600 |  -4.80% | -1.55% | -1.46% | -1.20% | -1.24% | -1.53% |  -1.60% |  -7.74% |
| commit-2   |   86400 |  -2.98% | -0.62% | -0.70% | -0.03% |  1.70% |  2.18% |  -1.55% |  -1.72% |