### PR TITLE
[Uptime] Display project ID in monitor management and details page

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
@@ -106,6 +106,10 @@ export const MonitorType = t.intersection([
       lt: t.string,
     }),
     fleet_managed: t.boolean,
+    project: t.type({
+      id: t.string,
+      name: t.string,
+    }),
   }),
 ]);
 

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/common/translations.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/common/translations.ts
@@ -15,6 +15,10 @@ export const TAGS_LABEL = i18n.translate('xpack.synthetics.monitorList.table.tag
   defaultMessage: 'Tags',
 });
 
+export const PROJECT_LABEL = i18n.translate('xpack.synthetics.monitorList.table.project.name', {
+  defaultMessage: 'Project',
+});
+
 export const STATUS_UP_LABEL = i18n.translate('xpack.synthetics.monitorList.statusColumn.upLabel', {
   defaultMessage: 'Up',
 });

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/common/translations.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/common/translations.ts
@@ -16,7 +16,7 @@ export const TAGS_LABEL = i18n.translate('xpack.synthetics.monitorList.table.tag
 });
 
 export const PROJECT_LABEL = i18n.translate('xpack.synthetics.monitorList.table.project.name', {
-  defaultMessage: 'Project',
+  defaultMessage: 'Project ID',
 });
 
 export const STATUS_UP_LABEL = i18n.translate('xpack.synthetics.monitorList.statusColumn.upLabel', {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor/status_details/status_bar/status_bar.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor/status_details/status_bar/status_bar.tsx
@@ -21,7 +21,7 @@ import * as labels from '../translations';
 import { StatusByLocations } from './status_by_location';
 import { useStatusBar } from './use_status_bar';
 import { MonitorIDLabel, OverallAvailability } from '../translations';
-import { TAGS_LABEL, URL_LABEL } from '../../../common/translations';
+import { PROJECT_LABEL, TAGS_LABEL, URL_LABEL } from '../../../common/translations';
 import { MonitorLocations } from '../../../../../../common/runtime_types/monitor';
 import { formatAvailabilityValue } from '../availability_reporting/availability_reporting';
 import { MonitorRedirects } from './monitor_redirects';
@@ -118,6 +118,12 @@ export const MonitorStatusBar: React.FC = () => {
         <MonListDescription>
           <MonitorTags ping={monitorStatus} />
         </MonListDescription>
+        {monitorStatus?.monitor?.project?.id && (
+          <>
+            <MonListTitle>{PROJECT_LABEL}</MonListTitle>
+            <MonListDescription>{monitorStatus?.monitor?.project.id}</MonListDescription>
+          </>
+        )}
         <MonitorSSLCertificate tls={monitorStatus?.tls} />
         <MonitorRedirects monitorStatus={monitorStatus} />
       </EuiDescriptionList>

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
@@ -163,7 +163,7 @@ export const MonitorManagementList = ({
       align: 'left' as const,
       field: ConfigKey.PROJECT_ID,
       name: PROJECT_LABEL,
-      render: (value: string) => (value ? <EuiText>{value}</EuiText> : null),
+      render: (value: string) => (value ? <EuiText size="s">{value}</EuiText> : null),
     },
     {
       align: 'left' as const,

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_list.tsx
@@ -11,11 +11,13 @@ import {
   EuiLink,
   EuiPanel,
   EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
 import { EuiTableSortingType } from '@elastic/eui/src/components/basic_table/table_types';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useContext, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { PROJECT_LABEL } from '../../common/translations';
 import {
   CommonFields,
   ConfigKey,
@@ -156,6 +158,12 @@ export const MonitorManagementList = ({
       }),
       render: (locations: ServiceLocations) =>
         locations ? <MonitorLocations locations={locations} /> : null,
+    },
+    {
+      align: 'left' as const,
+      field: ConfigKey.PROJECT_ID,
+      name: PROJECT_LABEL,
+      render: (value: string) => (value ? <EuiText>{value}</EuiText> : null),
     },
     {
       align: 'left' as const,


### PR DESCRIPTION
## Summary
Fixes
https://github.com/elastic/kibana/issues/140517

In the table
<img width="1504" alt="image" src="https://user-images.githubusercontent.com/3505601/189844453-d7581cf6-8fdc-4b44-96af-7d713080c3e0.png">


In the details page
<img width="1544" alt="image" src="https://user-images.githubusercontent.com/3505601/189844584-e2f537aa-7b9f-40cc-86a9-0baa3a422074.png">


