### PR TITLE
[TIP] Add sorting capabilities to Indicators Table

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.test.ts
@@ -59,6 +59,8 @@ describe('useColumnSettings()', () => {
             "threat.indicator.last_seen",
           ]
         `);
+
+        expect(result.current.sorting.columns).toMatchInlineSnapshot(`Array []`);
       });
     });
 
@@ -75,6 +77,14 @@ describe('useColumnSettings()', () => {
             { id: 'tags', displayAsText: 'tags' },
             { id: 'stream', displayAsText: 'stream' },
           ],
+          sortingState: {
+            columns: [
+              {
+                id: 'threat.indicator.name',
+                direction: 'asc',
+              },
+            ],
+          },
         });
       });
 
@@ -121,6 +131,17 @@ describe('useColumnSettings()', () => {
               "id": "stream",
             },
           ]
+        `);
+
+        expect(result.current.sorting.columns).toMatchInlineSnapshot(`
+          Object {
+            "columns": Array [
+              Object {
+                "direction": "asc",
+                "id": "threat.indicator.name",
+              },
+            ],
+          }
         `);
       });
     });
@@ -256,6 +277,27 @@ describe('useColumnSettings()', () => {
           Object {
             "displayAsText": "Last seen",
             "id": "threat.indicator.last_seen",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('sorting', () => {
+    it('should update internal state when onSort is called', async () => {
+      const { result } = renderUseColumnSettings();
+
+      expect(result.current.sorting.columns).toMatchInlineSnapshot(`Array []`);
+
+      await act(async () => {
+        result.current.sorting.onSort([{ id: 'threat.indicator.name', direction: 'asc' }]);
+      });
+
+      expect(result.current.sorting.columns).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "direction": "asc",
+            "id": "threat.indicator.name",
           },
         ]
       `);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { EuiDataGridColumn } from '@elastic/eui';
+import { EuiDataGridColumn, EuiDataGridSorting } from '@elastic/eui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import negate from 'lodash/negate';
 import { RawIndicatorFieldId } from '../../../../../../common/types/indicator';
 import { useKibana } from '../../../../../hooks/use_kibana';
 import { translateFieldLabel } from '../../indicator_field_label';
 
-const DEFAULT_COLUMNS: EuiDataGridColumn[] = [
+export const DEFAULT_COLUMNS: EuiDataGridColumn[] = [
   RawIndicatorFieldId.TimeStamp,
   RawIndicatorFieldId.Name,
   RawIndicatorFieldId.Type,
@@ -28,31 +28,58 @@ const DEFAULT_VISIBLE_COLUMNS = DEFAULT_COLUMNS.map((column) => column.id);
 
 const INDICATORS_TABLE_STORAGE = 'indicatorsTable' as const;
 
-export const useColumnSettings = () => {
+type CachedColumnsPreferences = Partial<{
+  visibleColumns: string[];
+  columns: EuiDataGridColumn[];
+  sortingState: EuiDataGridSorting['columns'];
+}>;
+
+export interface ColumnSettings {
+  columns: EuiDataGridColumn[];
+  columnVisibility: {
+    visibleColumns: string[];
+    setVisibleColumns: (columns: string[]) => void;
+  };
+  sorting: EuiDataGridSorting;
+  handleToggleColumn: (columnId: string) => void;
+  handleResetColumns: () => void;
+}
+
+export const useColumnSettings = (): ColumnSettings => {
   const {
     services: { storage },
   } = useKibana();
+
+  const [sortingState, setSortingState] = useState<EuiDataGridSorting['columns']>([]);
+  const sorting: EuiDataGridSorting = useMemo(
+    () => ({ columns: sortingState, onSort: setSortingState }),
+    [sortingState]
+  );
 
   const [columns, setColumns] = useState<EuiDataGridColumn[]>([]);
   const [visibleColumns, setVisibleColumns] = useState<Array<EuiDataGridColumn['id']>>([]);
 
   /** Deserialize preferences on mount */
   useEffect(() => {
-    const cachedPreferences = storage.get(INDICATORS_TABLE_STORAGE) || {
+    const {
+      visibleColumns: cachedVisibleColumns = [],
+      columns: cachedColumns = [],
+      sortingState: cachedSortingState = [],
+    }: CachedColumnsPreferences = storage.get(INDICATORS_TABLE_STORAGE) || {
       visibleColumns: DEFAULT_VISIBLE_COLUMNS,
       columns: DEFAULT_COLUMNS,
+      sortingState: [],
     };
-
-    const { visibleColumns: cachedVisibleColumns, columns: cachedColumns } = cachedPreferences;
 
     setVisibleColumns(cachedVisibleColumns);
     setColumns(cachedColumns);
+    setSortingState(cachedSortingState);
   }, [storage]);
 
   /** Ensure preferences are serialized into plugin storage on change */
   useEffect(() => {
-    storage.set(INDICATORS_TABLE_STORAGE, { visibleColumns, columns });
-  }, [columns, storage, visibleColumns]);
+    storage.set(INDICATORS_TABLE_STORAGE, { visibleColumns, columns, sortingState });
+  }, [columns, sortingState, storage, visibleColumns]);
 
   /** Toggle column and adjust its visibility */
   const handleToggleColumn = useCallback((columnId: string) => {
@@ -101,5 +128,6 @@ export const useColumnSettings = () => {
     handleToggleColumn,
     columns,
     columnVisibility,
+    sorting,
   };
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
@@ -12,6 +12,7 @@ import { StoryProvidersComponent } from '../../../../common/mocks/story_provider
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { IndicatorsTable } from './indicators_table';
 import { IndicatorsFiltersContext } from '../../context';
+import { DEFAULT_COLUMNS } from './hooks/use_column_settings';
 
 export default {
   component: IndicatorsTable,
@@ -22,6 +23,19 @@ const mockIndexPattern: DataView = undefined as unknown as DataView;
 
 const stub = () => void 0;
 
+const columnSettings = {
+  columnVisibility: {
+    visibleColumns: DEFAULT_COLUMNS.map(({ id }) => id),
+    setVisibleColumns: stub,
+  },
+  columns: DEFAULT_COLUMNS,
+  handleResetColumns: stub,
+  handleToggleColumn: stub,
+  sorting: {
+    columns: [],
+    onSort: stub,
+  },
+};
 export function WithIndicators() {
   const indicatorsFixture: Indicator[] = Array(10).fill(generateMockIndicator());
 
@@ -41,6 +55,7 @@ export function WithIndicators() {
           onChangeItemsPerPage={stub}
           indicatorCount={indicatorsFixture.length * 2}
           indexPattern={mockIndexPattern}
+          columnSettings={columnSettings}
         />
       </IndicatorsFiltersContext.Provider>
     </StoryProvidersComponent>
@@ -63,6 +78,7 @@ export function WithNoIndicators() {
         indicatorCount={0}
         loading={false}
         indexPattern={mockIndexPattern}
+        columnSettings={columnSettings}
       />
     </StoryProvidersComponent>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.test.tsx
@@ -25,6 +25,19 @@ const tableProps: IndicatorsTableProps = {
   loading: false,
   browserFields: {},
   indexPattern: { fields: [], title: '' } as SecuritySolutionDataViewBase,
+  columnSettings: {
+    columnVisibility: {
+      visibleColumns: [],
+      setVisibleColumns: () => {},
+    },
+    columns: [],
+    handleResetColumns: () => {},
+    handleToggleColumn: () => {},
+    sorting: {
+      columns: [],
+      onSort: () => {},
+    },
+  },
 };
 
 const indicatorsFixture: Indicator[] = [

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
@@ -26,7 +26,7 @@ import { IndicatorsTableContext, IndicatorsTableContextValue } from './context';
 import { IndicatorsFlyout } from '../indicators_flyout/indicators_flyout';
 import { Pagination } from '../../hooks/use_indicators';
 import { useToolbarOptions } from './hooks/use_toolbar_options';
-import { useColumnSettings } from './hooks/use_column_settings';
+import { ColumnSettings } from './hooks/use_column_settings';
 
 export interface IndicatorsTableProps {
   indicators: Indicator[];
@@ -37,6 +37,7 @@ export interface IndicatorsTableProps {
   loading: boolean;
   indexPattern: SecuritySolutionDataViewBase;
   browserFields: BrowserFields;
+  columnSettings: ColumnSettings;
 }
 
 export const TABLE_TEST_ID = 'tiIndicatorsTable';
@@ -56,6 +57,7 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
   pagination,
   loading,
   browserFields,
+  columnSettings: { columns, columnVisibility, handleResetColumns, handleToggleColumn, sorting },
 }) => {
   const [expanded, setExpanded] = useState<Indicator>();
 
@@ -88,8 +90,6 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
     ],
     [renderCellValue]
   );
-
-  const { columns, columnVisibility, handleResetColumns, handleToggleColumn } = useColumnSettings();
 
   useMemo(() => {
     columns.forEach(
@@ -147,8 +147,6 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
       <EuiDataGrid
         aria-labelledby="indicators-table"
         leadingControlColumns={leadingControlColumns}
-        columns={columns}
-        columnVisibility={columnVisibility}
         rowCount={indicatorCount}
         renderCellValue={renderCellValue}
         toolbarVisibility={toolbarOptions}
@@ -159,6 +157,9 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
         }}
         gridStyle={gridStyle}
         data-test-subj={TABLE_TEST_ID}
+        sorting={sorting}
+        columnVisibility={columnVisibility}
+        columns={columns}
       />
     );
   }, [
@@ -171,6 +172,7 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
     onChangePage,
     pagination,
     renderCellValue,
+    sorting,
     toolbarOptions,
   ]);
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
@@ -21,6 +21,7 @@ const indicatorsResponse = { rawResponse: { hits: { hits: [], total: 0 } } };
 const useIndicatorsParams: UseIndicatorsParams = {
   filters: [],
   filterQuery: { query: '', language: 'kuery' },
+  sorting: [],
 };
 
 describe('useIndicators()', () => {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
@@ -28,6 +28,7 @@ export interface UseIndicatorsParams {
   filterQuery: Query;
   filters: Filter[];
   timeRange?: TimeRange;
+  sorting: any[];
 }
 
 export interface UseIndicatorsValue {
@@ -56,6 +57,7 @@ export interface Pagination {
 export const useIndicators = ({
   filters,
   filterQuery,
+  sorting,
   timeRange,
 }: UseIndicatorsParams): UseIndicatorsValue => {
   const {
@@ -126,6 +128,7 @@ export const useIndicators = ({
                 from,
                 fields: [{ field: '*', include_unmapped: true }],
                 query: queryToExecute,
+                sort: sorting.map(({ id, direction }) => ({ [id]: direction })),
                 runtime_mappings: {
                   'threat.indicator.name': {
                     type: 'keyword',
@@ -168,7 +171,7 @@ export const useIndicators = ({
           },
         });
     },
-    [queryToExecute, searchService, selectedPatterns]
+    [queryToExecute, searchService, selectedPatterns, sorting]
   );
 
   const onChangeItemsPerPage = useCallback(

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
@@ -16,9 +16,12 @@ import { FiltersGlobal } from '../../containers/filters_global';
 import QueryBar from '../query_bar/components/query_bar';
 import { useSourcererDataView } from './hooks/use_sourcerer_data_view';
 import { FieldTypesProvider } from '../../containers/field_types_provider';
+import { useColumnSettings } from './components/indicators_table/hooks/use_column_settings';
 
 export const IndicatorsPage: VFC = () => {
   const { browserFields, indexPattern } = useSourcererDataView();
+
+  const columnSettings = useColumnSettings();
 
   const {
     timeRange,
@@ -35,6 +38,7 @@ export const IndicatorsPage: VFC = () => {
     filters,
     filterQuery,
     timeRange,
+    sorting: columnSettings.sorting.columns,
   });
 
   return (
@@ -60,9 +64,10 @@ export const IndicatorsPage: VFC = () => {
         <IndicatorsFilters filterManager={filterManager}>
           <IndicatorsBarChartWrapper timeRange={timeRange} indexPattern={indexPattern} />
           <IndicatorsTable
-            {...indicators}
             browserFields={browserFields}
             indexPattern={indexPattern}
+            columnSettings={columnSettings}
+            {...indicators}
           />
         </IndicatorsFilters>
       </DefaultPageLayout>


### PR DESCRIPTION
## Summary

With this PR, we are introducing the ability to sort indicators by any column, in a way supported by `EuiGrid`.
Minor changes were made, lifting column preferences up in the component tree as sorting infromation is necessary for indicator query itself.

![image](https://user-images.githubusercontent.com/11671118/189861988-dc59f36d-46de-41ac-ac20-610e13ceca95.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
