### PR TITLE
[PoC] Kibana retrieves deployment metadata using ESS APIs

### DIFF
--- a/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
+++ b/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
@@ -6,23 +6,63 @@
  */
 
 import type { AnalyticsClient } from '@kbn/analytics-client';
-import { of } from 'rxjs';
+import { map, type Observable, of } from 'rxjs';
+import type { EssDeploymentMetadata } from '../server/ess_metadata_service';
 
 export function registerCloudDeploymentIdAnalyticsContext(
   analytics: Pick<AnalyticsClient, 'registerContextProvider'>,
-  cloudId?: string
+  cloudId?: string,
+  deploymentMetadata$?: Observable<EssDeploymentMetadata>
 ) {
   if (!cloudId) {
     return;
   }
   analytics.registerContextProvider({
-    name: 'Cloud Deployment ID',
+    name: 'Cloud ID',
     context$: of({ cloudId }),
     schema: {
       cloudId: {
         type: 'keyword',
-        _meta: { description: 'The Cloud Deployment ID' },
+        _meta: { description: 'The Cloud ID' },
       },
     },
   });
+
+  if (deploymentMetadata$) {
+    analytics.registerContextProvider({
+      name: 'Cloud Deployment Metadata',
+      context$: deploymentMetadata$.pipe(
+        map(({ deploymentId, organizationId, isElasticStaffOrganization, inTrial }) => ({
+          cloudDeploymentId: deploymentId,
+          cloudOrganizationId: organizationId,
+          isElasticStaffOrganization,
+          inTrial,
+        }))
+      ),
+      schema: {
+        cloudDeploymentId: {
+          type: 'keyword',
+          _meta: { description: 'The Cloud Deployment ID' },
+        },
+        cloudOrganizationId: {
+          type: 'keyword',
+          _meta: { description: 'The Cloud Organization ID', optional: true },
+        },
+        isElasticStaffOrganization: {
+          type: 'boolean',
+          _meta: {
+            description: '`true` if the deployment was created by an Elastician',
+            optional: true,
+          },
+        },
+        inTrial: {
+          type: 'boolean',
+          _meta: {
+            description: '`true` if the organization is in a trial period on Cloud',
+            optional: true,
+          },
+        },
+      },
+    });
+  }
 }

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
@@ -5,27 +5,55 @@
  * 2.0.
  */
 
-import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import { firstValueFrom, type Observable } from 'rxjs';
+import { type UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import { type EssDeploymentMetadata } from '../ess_metadata_service';
 
 interface Config {
   isCloudEnabled: boolean;
+  deploymentMetadata$?: Observable<EssDeploymentMetadata>;
 }
 
-interface CloudUsage {
+interface CloudUsage extends Partial<EssDeploymentMetadata> {
   isCloudEnabled: boolean;
+  deploymentId?: string;
 }
 
 export function createCloudUsageCollector(usageCollection: UsageCollectionSetup, config: Config) {
-  const { isCloudEnabled } = config;
+  const { isCloudEnabled, deploymentMetadata$ } = config;
   return usageCollection.makeUsageCollector<CloudUsage>({
     type: 'cloud',
     isReady: () => true,
     schema: {
       isCloudEnabled: { type: 'boolean' },
+      deploymentId: {
+        type: 'keyword',
+        _meta: { description: 'The Cloud Deployment ID' },
+      },
+      organizationId: {
+        type: 'keyword',
+        _meta: { description: 'The Cloud Organization ID' },
+      },
+      isElasticStaffOrganization: {
+        type: 'boolean',
+        _meta: {
+          description: '`true` if the deployment was created by an Elastician',
+        },
+      },
+      inTrial: {
+        type: 'boolean',
+        _meta: {
+          description: '`true` if the organization is in a trial period on Cloud',
+        },
+      },
     },
-    fetch: () => {
+    fetch: async () => {
+      const deploymentMetadata = deploymentMetadata$
+        ? await firstValueFrom(deploymentMetadata$)
+        : {};
       return {
         isCloudEnabled,
+        ...deploymentMetadata,
       };
     },
   });

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -47,6 +47,22 @@ const configSchema = schema.object({
   id: schema.maybe(schema.string()),
   organization_url: schema.maybe(schema.string()),
   profile_url: schema.maybe(schema.string()),
+  /**
+   * How often do we cache the ESS information to avoid performing extra requests.
+   */
+  cache_ttl: schema.duration({ defaultValue: '1h' }),
+  /**
+   * Optional settings from Cloud to let Kibana fetch information from their Public APIs.
+   * Documentation on the API is https://www.elastic.co/guide/en/cloud/current/ec-restful-api.html
+   */
+  ess_api: schema.maybe(
+    schema.object({
+      host: schema.string({ defaultValue: 'https://api.elastic-cloud.com' }),
+      auth: schema.object({
+        api_key: schema.string(),
+      }),
+    })
+  ),
 });
 
 export type CloudConfigType = TypeOf<typeof configSchema>;

--- a/x-pack/plugins/cloud/server/ess_metadata_service/ess_api.ts
+++ b/x-pack/plugins/cloud/server/ess_metadata_service/ess_api.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { URL } from 'url';
+import fetch, { type RequestInit } from 'node-fetch';
+
+/**
+ * Configuration to set up the ESS API client
+ */
+export interface EssApiConfiguration {
+  /**
+   * The base host to use when performing the HTTP requests.
+   */
+  host: string;
+  /**
+   * Auth details
+   */
+  auth: {
+    /**
+     * The API Key obtained from ESS.
+     */
+    api_key: string;
+  };
+}
+
+/**
+ * The response to the Get Deployment by ID request.
+ * @remark Extracted from the OpenAPI specification (https://cloud.elastic.co/api/v1/api-docs/spec.json)
+ */
+export interface EssGetDeployment {
+  /**
+   * A randomly-generated id of this Deployment
+   */
+  id: string;
+  /**
+   * The name of this deployment
+   */
+  name: string;
+  /**
+   * A user-defined deployment alias for user-friendly resource URLs
+   */
+  alias?: string;
+  /**
+   * Whether the deployment is overall healthy or not (one or more of the resource info subsections will have healthy: false)
+   */
+  healthy: boolean;
+  /**
+   * The Resources that belong to this Deployment
+   */
+  resources: {}; // we'll define it when needed
+  /**
+   * Additional configuration for this Deployment
+   */
+  settings?: {}; // we'll define it when needed
+  /**
+   * The observability information for this deployment
+   */
+  observability?: {}; // we'll define it when needed
+  /**
+   * Additional information about this deployment
+   */
+  metadata?: {
+    /**
+     * @deprecated Deployments should be owned by organizations, not users. Use organization_id instead.
+     */
+    owner_id?: string;
+    /**
+     * The ESS Organization owning this deployment.
+     */
+    organization_id?: string;
+    system_owned?: boolean;
+    hidden?: boolean;
+    last_modified?: string;
+    last_resource_plan_modified?: string;
+    /**
+     * Arbitrary user-defined metadata associated with this deployment
+     */
+    tags?: Array<{
+      /**
+       * The metadata field name
+       */
+      key: string;
+      /**
+       * The metadata value
+       */
+      value: string;
+    }>;
+  };
+}
+
+/**
+ * The response to the Get Organization by ID request.
+ * @remark Extracted from the OpenAPI specification (https://cloud.elastic.co/api/v1/api-docs/spec.json)
+ */
+export interface EssGetOrganization {
+  /**
+   * The organization's identifier.
+   */
+  id: string;
+  /**
+   * The organization's friendly name.
+   */
+  name: string;
+  /**
+   * `true` if the organization is in trial on Cloud.
+   * `false` when it's a paying customer.
+   */
+  in_trial?: boolean;
+  /**
+   * `true` if the organization is owned by an Elastician.
+   */
+  is_elastic_staff_organization?: boolean;
+}
+
+export class EssApi {
+  constructor(private readonly config: EssApiConfiguration) {}
+
+  /**
+   * Retrieves information about a Deployment.
+   * @param deploymentId Identifier for the Deployment
+   */
+  public async getDeploymentById(deploymentId: string): Promise<EssGetDeployment> {
+    return await this.makeRequest<EssGetDeployment>(`/api/v1/deployments/${deploymentId}`);
+  }
+
+  /**
+   * Retrieves information about a Deployment.
+   * @param organizationId Identifier for the Deployment
+   */
+  public async getOrganizationById(organizationId: string): Promise<EssGetOrganization> {
+    return await this.makeRequest<EssGetOrganization>(`/api/v1/organizations/${organizationId}`);
+  }
+
+  private async makeRequest<Data>(endpoint: string, opts: RequestInit = {}): Promise<Data> {
+    const url = new URL(endpoint, this.config.host);
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...opts.headers,
+        authorization: `ApiKey ${this.config.auth.api_key}`,
+      },
+      ...opts,
+    });
+
+    if (!response.ok) {
+      throw new Error(`${response.status} - ${await response.text()}`);
+    }
+
+    return await response.json();
+  }
+}

--- a/x-pack/plugins/cloud/server/ess_metadata_service/ess_metadata_service.ts
+++ b/x-pack/plugins/cloud/server/ess_metadata_service/ess_metadata_service.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  catchError,
+  exhaustMap,
+  type Observable,
+  shareReplay,
+  Subject,
+  takeUntil,
+  timer,
+} from 'rxjs';
+import type { Logger } from '@kbn/logging';
+import { EssDeploymentMetadata } from '../../common/types';
+import { EssApi, type EssApiConfiguration } from './ess_api';
+
+export interface EssMetadataServiceConfig {
+  deploymentId: string;
+  cache_ttl: number;
+  ess_api: EssApiConfiguration;
+}
+
+/**
+ * Service fetching and caching the metadata of a deployment on Cloud
+ */
+export class EssMetadataService {
+  public readonly cachedMetadata$: Observable<EssDeploymentMetadata>;
+  private readonly stop$ = new Subject<void>();
+  private readonly essApiClient: EssApi;
+  private readonly cacheTtl: number;
+  constructor(config: EssMetadataServiceConfig, private readonly logger: Logger) {
+    this.essApiClient = new EssApi(config.ess_api);
+    this.cacheTtl = config.cache_ttl;
+
+    this.cachedMetadata$ = timer(0, this.cacheTtl).pipe(
+      takeUntil(this.stop$),
+      exhaustMap(async () => {
+        return await this.getDeploymentMetadata(config.deploymentId);
+      }),
+      catchError(async (err) => {
+        this.logger.error(err);
+        return { deploymentId: config.deploymentId };
+      }),
+      shareReplay(1)
+    );
+  }
+
+  public async stop() {
+    this.stop$.next();
+  }
+
+  private async getDeploymentMetadata(deploymentId: string): Promise<EssDeploymentMetadata> {
+    const { metadata } = await this.essApiClient.getDeploymentById(deploymentId);
+    const organizationId = metadata?.organization_id;
+    if (!organizationId) {
+      this.logger.error(
+        `"metadata.organization_id" is not present for deployment ID ${deploymentId}`
+      );
+      return { deploymentId };
+    }
+
+    let inTrial: boolean | undefined;
+    let isElasticStaffOrganization: boolean | undefined;
+    try {
+      const organizationInfo = await this.essApiClient.getOrganizationById(organizationId);
+      inTrial = organizationInfo.in_trial;
+      isElasticStaffOrganization = organizationInfo.is_elastic_staff_organization;
+    } catch (err) {
+      this.logger.error(`Error retrieving the organization details`, { error: err });
+    }
+
+    return {
+      deploymentId,
+      organizationId,
+      inTrial,
+      isElasticStaffOrganization,
+    };
+  }
+}

--- a/x-pack/plugins/cloud/server/ess_metadata_service/index.ts
+++ b/x-pack/plugins/cloud/server/ess_metadata_service/index.ts
@@ -5,15 +5,4 @@
  * 2.0.
  */
 
-export interface GetChatUserDataResponseBody {
-  token: string;
-  email: string;
-  id: string;
-}
-
-export interface EssDeploymentMetadata {
-  deploymentId: string;
-  organizationId?: string;
-  inTrial?: boolean;
-  isElasticStaffOrganization?: boolean;
-}
+export { EssMetadataService, type EssDeploymentMetadata } from './ess_metadata_service';

--- a/x-pack/plugins/cloud/server/routes/deployment_metadata.ts
+++ b/x-pack/plugins/cloud/server/routes/deployment_metadata.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import { firstValueFrom, type Observable } from 'rxjs';
+import type { EssDeploymentMetadata } from '../../common/types';
+
+export const registerDeploymentMetadataRoute = ({
+  httpRouter,
+  deploymentMetadata$,
+}: {
+  httpRouter: IRouter;
+  deploymentMetadata$: Observable<EssDeploymentMetadata>;
+}) => {
+  httpRouter.get(
+    {
+      path: '/internal/cloud/deployment_metadata',
+      validate: false,
+    },
+    async (context, req, res) => {
+      const deploymentMetadata = await firstValueFrom(deploymentMetadata$);
+      return res.ok({ body: deploymentMetadata });
+    }
+  );
+};


### PR DESCRIPTION
## Summary

This is a Proof of concept to test how an ESS Metadata service would fit in the `cloud` plugin. Using the ESS APIs to fetch the deployment and organization metadata relevant to our Telemetry and A/B testing services.

It requires the following configuration to work:

```yaml
xpack.cloud.id: "{Cloud ID}"
xpack.cloud.deployment_url: "/deployments/{deploymentId}"

xpack.cloud.ess_api.auth.api_key: "{API Key extracted from the Cloud API keys management UI}"
```


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
