### PR TITLE
[PoC] Cloud reads deployment metadata from config

### DIFF
--- a/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
+++ b/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
@@ -6,10 +6,11 @@
  */
 
 import type { AnalyticsClient } from '@kbn/analytics-client';
-import { of } from 'rxjs';
+import { map, type Observable, of } from 'rxjs';
 
 export function registerCloudDeploymentIdAnalyticsContext(
   analytics: Pick<AnalyticsClient, 'registerContextProvider'>,
+  metadata$: Observable<Record<string, unknown>>,
   cloudId?: string
 ) {
   if (!cloudId) {
@@ -22,6 +23,17 @@ export function registerCloudDeploymentIdAnalyticsContext(
       cloudId: {
         type: 'keyword',
         _meta: { description: 'The Cloud Deployment ID' },
+      },
+    },
+  });
+
+  analytics.registerContextProvider({
+    name: 'Cloud Deployment Metadata',
+    context$: metadata$.pipe(map((cloudMetadata) => ({ cloudMetadata }))),
+    schema: {
+      cloudMetadata: {
+        type: 'pass_through',
+        _meta: { description: 'The Cloud metadata' },
       },
     },
   });

--- a/x-pack/plugins/cloud/public/plugin.tsx
+++ b/x-pack/plugins/cloud/public/plugin.tsx
@@ -53,6 +53,8 @@ export interface CloudConfigType {
     /** The URL to the remotely-hosted chat application. */
     chatURL: string;
   };
+  /** The Cloud Metadata provided via config */
+  metadata: Record<string, unknown>;
 }
 
 interface CloudSetupDependencies {
@@ -257,7 +259,7 @@ export class CloudPlugin implements Plugin<CloudSetup> {
     security?: Pick<SecurityPluginSetup, 'authc'>,
     cloudId?: string
   ) {
-    registerCloudDeploymentIdAnalyticsContext(analytics, cloudId);
+    registerCloudDeploymentIdAnalyticsContext(analytics, of(this.config.metadata), cloudId);
 
     if (security) {
       analytics.registerContextProvider({

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -47,6 +47,7 @@ const configSchema = schema.object({
   id: schema.maybe(schema.string()),
   organization_url: schema.maybe(schema.string()),
   profile_url: schema.maybe(schema.string()),
+  metadata: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
 });
 
 export type CloudConfigType = TypeOf<typeof configSchema>;
@@ -61,6 +62,7 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
     id: true,
     organization_url: true,
     profile_url: true,
+    metadata: true,
   },
   schema: configSchema,
 };


### PR DESCRIPTION
## Summary

This is a Proof of concept to test how ESS Metadata could be provided to the `cloud` plugin via _optional_ config parameters. 

The configuration entries would look like below

```yaml
xpack.cloud.id: "{Cloud ID}"

xpack.cloud.metadata.is_elastic_staff_owned: false
xpack.cloud.metadata.in_trial: true
```


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
