### PR TITLE
Improve flamegraph aggregation

### DIFF
--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import objectHash from 'object-hash';
 import { CallerCalleeNode, createCallerCalleeDiagram } from './callercallee';
 import {
   describeFrameType,
@@ -186,7 +185,7 @@ export class FlameGraph {
       columnar.CountInclusive.push(node.CountInclusive);
       columnar.CountExclusive.push(node.CountExclusive);
 
-      const id = objectHash([parentID, node.FrameGroupID]);
+      const id = x + ',' + depth;
 
       columnar.ID.push(id);
 


### PR DESCRIPTION
Avoiding `objectHash()` in `createColumnarCallerCallee()` shaves off 30-50% CPU from the aggregations (local testing).

If I understood the code correctly, we only need a unique identifier for each `columnar.ID`. We possible can also just use a counter here ?
