### PR TITLE
[Security Solution][Bug] Fix runtime fields actions on hosts tabs

### DIFF
--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -58,7 +58,6 @@ import { ID } from '../containers/hosts';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
 import { LandingPageComponent } from '../../common/components/landing_page';
-import { Loader } from '../../common/components/loader';
 import { hostNameExistsFilter } from '../../common/components/visualization_actions/utils';
 
 /**
@@ -125,7 +124,7 @@ const HostsComponent = () => {
     },
     [dispatch]
   );
-  const { indicesExist, indexPattern, selectedPatterns, loading } = useSourcererDataView();
+  const { indicesExist, indexPattern, selectedPatterns } = useSourcererDataView();
   const [filterQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
@@ -174,10 +173,6 @@ const HostsComponent = () => {
     },
     [containerElement, onSkipFocusBeforeEventsTable, onSkipFocusAfterEventsTable]
   );
-
-  if (loading) {
-    return <Loader data-test-subj="loadingPanelExploreHosts" overlay size="xl" />;
-  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
Solves https://github.com/elastic/kibana/issues/140015

There is a bug affecting the timeline tables in the Hosts pages (Events and Session tabs). It is caused by the main `HostsTabs` component being unmounted when the sourcerer data is loading. 
The `indexFieldsSearch` request is triggered after any runtime action is finished. to refresh the browser fields. The `indexFieldsSearch` sets `isLoading: true` when the request starts, which makes the `HostsTab` unmount the same component that is doing the request, to show a loader, at this point the request is aborted in the cleanup function of the hook.

The fix is doing the same thing as in the Users page or in the Alerts section, not unmount the components when the sourcerer is loading.

before:

https://user-images.githubusercontent.com/17747913/189893973-172f2860-5f6f-4cee-93bb-3e4f66a82abb.mov

after:

https://user-images.githubusercontent.com/17747913/189894022-633e5bd4-2284-4f8b-a2aa-e5d5ef33e903.mov

