### PR TITLE
[artifacts] Soft fail on cloud deployment timeout

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -75,6 +75,7 @@ steps:
     label: 'Cloud Deployment'
     soft_fail:
       - exit_status: 255
+      - exit_status: -1
     agents:
       queue: n2-2
     timeout_in_minutes: 30


### PR DESCRIPTION
ecctl has a 5 minute http timeout configured which unfortunately is not triggered when deployment creation is stuck in a pending state. I wasn't able to find a 'create' level timeout.

This is a legitimate failure that is unrelated to Kibana.  I'd rather not turn off failures but we need to unblock snapshots.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/617