### PR TITLE
[Discover] Refactor columns in state code to omit sidebar rendering

### DIFF
--- a/src/plugins/discover/public/application/context/context_app.tsx
+++ b/src/plugins/discover/public/application/context/context_app.tsx
@@ -57,7 +57,7 @@ export const ContextApp = ({ dataView, anchorId }: ContextAppProps) => {
   /**
    * Context app state
    */
-  const { appState, globalState, setAppState } = useContextAppState({ services });
+  const { appState, globalState, setAppState, stateContainer } = useContextAppState({ services });
   const prevAppState = useRef<AppState>();
   const prevGlobalState = useRef<GlobalState>({ filters: [] });
 
@@ -111,13 +111,9 @@ export const ContextApp = ({ dataView, anchorId }: ContextAppProps) => {
   ]);
 
   const { columns, onAddColumn, onRemoveColumn, onSetColumns } = useColumns({
-    capabilities,
-    config: uiSettings,
     dataView,
-    dataViews,
-    state: appState,
+    stateContainer,
     useNewFieldsApi,
-    setAppState,
   });
   const rows = useMemo(
     () => [

--- a/src/plugins/discover/public/application/context/hooks/use_context_app_state.ts
+++ b/src/plugins/discover/public/application/context/hooks/use_context_app_state.ts
@@ -25,7 +25,7 @@ export function useContextAppState({ services }: { services: DiscoverServices })
     });
   }, [config, history, core.notifications.toasts, services.data]);
 
-  const [appState, setAppState] = useState<AppState>(stateContainer.appState.getState());
+  const [appState, setAppState] = useState<AppState>(stateContainer.appStateContainer.getState());
   const [globalState, setGlobalState] = useState<GlobalState>(
     stateContainer.globalState.getState()
   );
@@ -40,7 +40,7 @@ export function useContextAppState({ services }: { services: DiscoverServices })
   }, [stateContainer]);
 
   useEffect(() => {
-    const unsubscribeAppState = stateContainer.appState.subscribe((newState) => {
+    const unsubscribeAppState = stateContainer.appStateContainer.subscribe((newState) => {
       const newStateEnsureFilter = { ...newState, filters: newState.filters ?? [] };
       setAppState((prevState) => ({ ...prevState, ...newStateEnsureFilter }));
     });
@@ -60,5 +60,6 @@ export function useContextAppState({ services }: { services: DiscoverServices })
     appState,
     globalState,
     setAppState: stateContainer.setAppState,
+    stateContainer,
   };
 }

--- a/src/plugins/discover/public/application/context/services/context_state.test.ts
+++ b/src/plugins/discover/public/application/context/services/context_state.test.ts
@@ -41,7 +41,7 @@ describe('Test Discover Context State', () => {
     state.stopSync();
   });
   test('getState function default return', () => {
-    expect(state.appState.getState()).toMatchInlineSnapshot(`
+    expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
       Object {
         "columns": Array [
           "_source",
@@ -69,7 +69,7 @@ describe('Test Discover Context State', () => {
   });
   test('getState -> url to appState syncing', async () => {
     history.push('/#?_a=(columns:!(_source),predecessorCount:1,successorCount:1)');
-    expect(state.appState.getState()).toMatchInlineSnapshot(`
+    expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
       Object {
         "columns": Array [
           "_source",
@@ -81,7 +81,7 @@ describe('Test Discover Context State', () => {
   });
   test('getState -> url to appState syncing with return to a url without state', async () => {
     history.push('/#?_a=(columns:!(_source),predecessorCount:1,successorCount:1)');
-    expect(state.appState.getState()).toMatchInlineSnapshot(`
+    expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
       Object {
         "columns": Array [
           "_source",
@@ -91,7 +91,7 @@ describe('Test Discover Context State', () => {
       }
     `);
     history.push('/');
-    expect(state.appState.getState()).toMatchInlineSnapshot(`
+    expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
       Object {
         "columns": Array [
           "_source",

--- a/src/plugins/discover/public/application/context/services/context_state.ts
+++ b/src/plugins/discover/public/application/context/services/context_state.ts
@@ -93,7 +93,7 @@ export interface GetStateReturn {
   /**
    * App state, the _a part of the URL
    */
-  appState: ReduxLikeStateContainer<AppState>;
+  appStateContainer: ReduxLikeStateContainer<AppState>;
   /**
    * Start sync between state and URL
    */
@@ -106,6 +106,10 @@ export interface GetStateReturn {
    * Set app state to with a partial new app state
    */
   setAppState: (newState: Partial<AppState>) => void;
+  /**
+   * Get app state
+   */
+  getAppState: () => AppState;
   /**
    * Get all filters, global and app state
    */
@@ -189,7 +193,7 @@ export function getState({
 
   return {
     globalState: globalStateContainer,
-    appState: appStateContainer,
+    appStateContainer,
     startSync: () => {
       data.query.filterManager.setFilters(cloneDeep(getAllFilters()));
 
@@ -219,6 +223,9 @@ export function getState({
       if (!isEqualState(oldState, mergedState)) {
         stateStorage.set(APP_STATE_URL_KEY, mergedState, { replace: true });
       }
+    },
+    getAppState: () => {
+      return appStateContainer.getState();
     },
     getFilters: getAllFilters,
     setFilters: (filterManager: FilterManager) => {

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -44,7 +44,18 @@ function mountComponent(fetchStatus: FetchStatus, hits: EsHitRecord[]) {
     searchSource: documents$,
     setExpandedDoc: jest.fn(),
     state: { columns: [] },
-    stateContainer: { setAppState: () => {} } as unknown as GetStateReturn,
+    stateContainer: {
+      setAppState: () => {},
+      getAppState: () => ({
+        interval: 'auto',
+      }),
+      appStateContainer: {
+        getState: () => ({
+          interval: 'auto',
+        }),
+        subscribe: jest.fn(),
+      },
+    } as unknown as GetStateReturn,
     navigateTo: jest.fn(),
     onFieldEdited: jest.fn(),
   };

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -78,7 +78,7 @@ function DiscoverDocumentsComponent({
   stateContainer: GetStateReturn;
   onFieldEdited?: () => void;
 }) {
-  const { capabilities, dataViews, uiSettings } = useDiscoverServices();
+  const { uiSettings } = useDiscoverServices();
   const useNewFieldsApi = useMemo(() => !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE), [uiSettings]);
   const hideAnnouncements = useMemo(() => uiSettings.get(HIDE_ANNOUNCEMENTS), [uiSettings]);
   const isLegacy = useMemo(() => uiSettings.get(DOC_TABLE_LEGACY), [uiSettings]);
@@ -93,12 +93,8 @@ function DiscoverDocumentsComponent({
   const rows = useMemo(() => documentState.result || [], [documentState.result]);
 
   const { columns, onAddColumn, onRemoveColumn, onMoveColumn, onSetColumns } = useColumns({
-    capabilities,
-    config: uiSettings,
     dataView,
-    dataViews,
-    setAppState: stateContainer.setAppState,
-    state,
+    stateContainer,
     useNewFieldsApi,
   });
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
@@ -156,10 +156,14 @@ function mountComponent(
     state: { columns: [], query },
     stateContainer: {
       setAppState: () => {},
+      getAppState: () => ({
+        interval: 'auto',
+      }),
       appStateContainer: {
         getState: () => ({
           interval: 'auto',
         }),
+        subscribe: jest.fn(),
       },
     } as unknown as GetStateReturn,
     setExpandedDoc: jest.fn(),

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -160,12 +160,8 @@ export function DiscoverLayout({
   }, [inspectorSession]);
 
   const { columns, onAddColumn, onRemoveColumn } = useColumns({
-    capabilities,
-    config: uiSettings,
     dataView,
-    dataViews,
-    setAppState: stateContainer.setAppState,
-    state,
+    stateContainer,
     useNewFieldsApi,
   });
 
@@ -272,7 +268,7 @@ export function DiscoverLayout({
               onRemoveField={onRemoveColumn}
               onChangeDataView={onChangeDataView}
               selectedDataView={dataView}
-              state={state}
+              isPlainRecord={isPlainRecord}
               isClosed={isSidebarClosed}
               trackUiMetric={trackUiMetric}
               useNewFieldsApi={useNewFieldsApi}

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.test.tsx
@@ -66,7 +66,6 @@ function getCompProps(): DiscoverSidebarProps {
     onAddField: jest.fn(),
     onRemoveField: jest.fn(),
     selectedDataView: dataView,
-    state: {},
     trackUiMetric: jest.fn(),
     fieldFilter: getDefaultFieldFilter(),
     setFieldFilter: jest.fn(),
@@ -77,6 +76,7 @@ function getCompProps(): DiscoverSidebarProps {
     onDataViewCreated: jest.fn(),
     availableFields$,
     useNewFieldsApi: true,
+    isPlainRecord: false,
   };
 }
 

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -105,7 +105,7 @@ function getCompProps(): DiscoverSidebarResponsiveProps {
     onAddField: jest.fn(),
     onRemoveField: jest.fn(),
     selectedDataView: dataView,
-    state: {},
+    isPlainRecord: false,
     trackUiMetric: jest.fn(),
     onFieldEdited: jest.fn(),
     viewMode: VIEW_MODE.DOCUMENT_LEVEL,
@@ -176,10 +176,7 @@ describe('discover responsive sidebar', function () {
         recordRawType: RecordRawType.PLAIN,
         result: getDataTableRecords(stubLogstashDataView),
       }) as DataDocuments$,
-      state: {
-        ...initialProps.state,
-        query: { sql: 'SELECT * FROM `index`' },
-      },
+      isPlainRecord: true,
     };
     const compInViewerMode = mountWithIntl(
       <KibanaContextProvider services={mockServices}>

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -27,13 +27,11 @@ import { SavedObject } from '@kbn/core/types';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { getDefaultFieldFilter } from './lib/field_filter';
 import { DiscoverSidebar } from './discover_sidebar';
-import { AppState } from '../../services/discover_state';
-import { AvailableFields$, DataDocuments$, RecordRawType } from '../../hooks/use_saved_search';
+import { AvailableFields$, DataDocuments$ } from '../../hooks/use_saved_search';
 import { calcFieldCounts } from '../../utils/calc_field_counts';
 import { VIEW_MODE } from '../../../../components/view_mode_toggle';
 import { FetchStatus } from '../../../types';
 import { DISCOVER_TOUR_STEP_ANCHOR_IDS } from '../../../../components/discover_tour';
-import { getRawRecordType } from '../../utils/get_raw_record_type';
 
 export interface DiscoverSidebarResponsiveProps {
   /**
@@ -78,9 +76,9 @@ export interface DiscoverSidebarResponsiveProps {
    */
   selectedDataView?: DataView;
   /**
-   * Discover App state
+   * determines if documents or text based query language records are displayed
    */
-  state: AppState;
+  isPlainRecord: boolean;
   /**
    * Metric tracking function
    * @param metricType
@@ -116,11 +114,7 @@ export interface DiscoverSidebarResponsiveProps {
  */
 export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps) {
   const services = useDiscoverServices();
-  const isPlainRecord = useMemo(
-    () => getRawRecordType(props.state.query) === RecordRawType.PLAIN,
-    [props.state.query]
-  );
-  const { selectedDataView, onFieldEdited, onDataViewCreated } = props;
+  const { selectedDataView, onFieldEdited, onDataViewCreated, isPlainRecord } = props;
   const [fieldFilter, setFieldFilter] = useState(getDefaultFieldFilter());
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   /**

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -158,6 +158,10 @@ export interface GetStateReturn {
    */
   setAppState: (newState: Partial<AppState>) => void;
   /**
+   * Get app state
+   */
+  getAppState: () => AppState;
+  /**
    * Set state in Url using history.replace
    */
   replaceUrlAppState: (newState: Partial<AppState>) => Promise<void>;
@@ -270,6 +274,7 @@ export function getState({
       return stop;
     },
     setAppState: (newPartial: AppState) => setState(appStateContainerModified, newPartial),
+    getAppState: () => appStateContainer.getState(),
     replaceUrlAppState,
     resetInitialAppState: () => {
       initialAppState = appStateContainer.getState();


### PR DESCRIPTION
## Summary

Generally this PR tries to reduce the number of rerenderings when appState is changed

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
