### PR TITLE
[Fleet] Change agent status order offline before updating

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -16,9 +16,7 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
   if (!agent.active) {
     return 'inactive';
   }
-  if (agent.unenrollment_started_at && !agent.unenrolled_at) {
-    return 'unenrolling';
-  }
+
   if (!agent.last_checkin) {
     return 'enrolling';
   }
@@ -26,6 +24,14 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
   const msLastCheckIn = new Date(lastCheckIn || 0).getTime();
   const msSinceLastCheckIn = new Date().getTime() - msLastCheckIn;
   const intervalsSinceLastCheckIn = Math.floor(msSinceLastCheckIn / AGENT_POLLING_THRESHOLD_MS);
+
+  if (intervalsSinceLastCheckIn >= offlineTimeoutIntervalCount) {
+    return 'offline';
+  }
+
+  if (agent.unenrollment_started_at && !agent.unenrolled_at) {
+    return 'unenrolling';
+  }
 
   if (agent.last_checkin_status === 'error') {
     return 'error';
@@ -44,49 +50,74 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
   if (!policyRevision || (agent.upgrade_started_at && agent.upgrade_status !== 'completed')) {
     return 'updating';
   }
-  if (intervalsSinceLastCheckIn >= offlineTimeoutIntervalCount) {
-    return 'offline';
-  }
 
   return 'online';
 }
 
-export function buildKueryForEnrollingAgents(path: string = '') {
+export function buildKueryForEnrollingAgents(path: string = ''): string {
   return `not (${path}last_checkin:*)`;
 }
 
-export function buildKueryForUnenrollingAgents(path: string = '') {
+export function buildKueryForUnenrollingAgents(path: string = ''): string {
   return `${path}unenrollment_started_at:*`;
 }
 
-export function buildKueryForOnlineAgents(path: string = '') {
-  return `not (${buildKueryForOfflineAgents(path)}) AND not (${buildKueryForErrorAgents(
+export function buildKueryForOnlineAgents(path: string = ''): string {
+  return `not (${buildKueryForOfflineAgents(path)}) ${addExclusiveKueryFilter(
+    buildKueryForOnlineAgents,
     path
-  )}) AND not (${buildKueryForUpdatingAgents(path)})`;
+  )}`;
 }
 
-export function buildKueryForErrorAgents(path: string = '') {
-  return `(${path}last_checkin_status:error or ${path}last_checkin_status:degraded) AND not (${buildKueryForUpdatingAgents(
+export function buildKueryForErrorAgents(path: string = ''): string {
+  return `(${path}last_checkin_status:error or ${path}last_checkin_status:degraded) ${addExclusiveKueryFilter(
+    buildKueryForErrorAgents,
     path
-  )})`;
+  )}`;
 }
 
-export function buildKueryForOfflineAgents(path: string = '') {
+export function buildKueryForOfflineAgents(path: string = ''): string {
   return `${path}last_checkin < now-${
     (offlineTimeoutIntervalCount * AGENT_POLLING_THRESHOLD_MS) / 1000
-  }s AND not (${buildKueryForErrorAgents(path)}) AND not ( ${buildKueryForUpdatingAgents(path)} )`;
+  }s ${addExclusiveKueryFilter(buildKueryForOfflineAgents, path)}`;
 }
 
-export function buildKueryForUpgradingAgents(path: string = '') {
+export function buildKueryForUpgradingAgents(path: string = ''): string {
   return `(${path}upgrade_started_at:*) and not (${path}upgrade_status:completed)`;
 }
 
-export function buildKueryForUpdatingAgents(path: string = '') {
-  return `(${buildKueryForUpgradingAgents(path)}) or (${buildKueryForEnrollingAgents(
+export function buildKueryForUpdatingAgents(path: string = ''): string {
+  return `((${buildKueryForUpgradingAgents(path)}) or (${buildKueryForEnrollingAgents(
     path
-  )}) or (${buildKueryForUnenrollingAgents(path)}) or (not ${path}policy_revision_idx:*)`;
+  )}) or (${buildKueryForUnenrollingAgents(
+    path
+  )}) or (not ${path}policy_revision_idx:*)) ${addExclusiveKueryFilter(
+    buildKueryForUpdatingAgents,
+    path
+  )}`;
 }
 
 export function buildKueryForInactiveAgents(path: string = '') {
   return `${path}active:false`;
+}
+
+const ORDERED_KUERY_BUILDER = [
+  buildKueryForInactiveAgents,
+  buildKueryForOfflineAgents,
+  buildKueryForErrorAgents,
+  buildKueryForUpdatingAgents,
+  buildKueryForOnlineAgents,
+];
+
+function addExclusiveKueryFilter(currentKueryBuilder: (path?: string) => string, path?: string) {
+  if (ORDERED_KUERY_BUILDER.indexOf(currentKueryBuilder) === 0) {
+    return '';
+  }
+
+  const previousKueryBuilderIndex =
+    ORDERED_KUERY_BUILDER.indexOf(currentKueryBuilder) > 0
+      ? ORDERED_KUERY_BUILDER.indexOf(currentKueryBuilder) - 1
+      : ORDERED_KUERY_BUILDER.length - 1;
+
+  return ` AND not (${ORDERED_KUERY_BUILDER[previousKueryBuilderIndex](path)})`;
 }

--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -54,6 +54,32 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
   return 'online';
 }
 
+export function getPreviousAgentStatusForOfflineAgents(
+  agent: Agent | FleetServerAgent
+): AgentStatus | undefined {
+  if (agent.unenrollment_started_at && !agent.unenrolled_at) {
+    return 'unenrolling';
+  }
+
+  if (agent.last_checkin_status === 'error') {
+    return 'error';
+  }
+  if (agent.last_checkin_status === 'degraded') {
+    return 'degraded';
+  }
+
+  const policyRevision =
+    'policy_revision' in agent
+      ? agent.policy_revision
+      : 'policy_revision_idx' in agent
+      ? agent.policy_revision_idx
+      : undefined;
+
+  if (!policyRevision || (agent.upgrade_started_at && agent.upgrade_status !== 'completed')) {
+    return 'updating';
+  }
+}
+
 export function buildKueryForEnrollingAgents(path: string = ''): string {
   return `not (${path}last_checkin:*)`;
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -46,7 +46,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
             title: i18n.translate('xpack.fleet.agentDetails.statusLabel', {
               defaultMessage: 'Status',
             }),
-            description: <AgentHealth agent={agent} />,
+            description: <AgentHealth agent={agent} showOfflinePreviousStatus={true} />,
           },
           {
             title: i18n.translate('xpack.fleet.agentDetails.lastActivityLabel', {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_health.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_health.tsx
@@ -82,7 +82,7 @@ export const AgentHealth: React.FunctionComponent<Props> = ({
     }
 
     return getPreviousAgentStatusForOfflineAgents(agent);
-  }, [showOfflinePreviousStatus]);
+  }, [showOfflinePreviousStatus, agent]);
 
   return (
     <EuiToolTip

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_health.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_health.tsx
@@ -11,8 +11,9 @@ import { EuiBadge, EuiToolTip } from '@elastic/eui';
 
 import { euiLightVars as euiVars } from '@kbn/ui-theme';
 
+import { getPreviousAgentStatusForOfflineAgents } from '../../../../../../common/services/agent_status';
+
 import type { Agent } from '../../../types';
-import { getPreviousAgentStatusForOfflineAgents } from '@kbn/fleet-plugin/common/services/agent_status';
 
 interface Props {
   agent: Agent;

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -266,13 +266,51 @@ describe('test endpoint routes', () => {
               },
               {
                 bool: {
-                  should: [
+                  filter: [
                     {
                       bool: {
-                        filter: [
+                        should: [
                           {
                             bool: {
-                              should: [{ exists: { field: 'united.agent.upgrade_started_at' } }],
+                              filter: [
+                                {
+                                  bool: {
+                                    should: [
+                                      { exists: { field: 'united.agent.upgrade_started_at' } },
+                                    ],
+                                    minimum_should_match: 1,
+                                  },
+                                },
+                                {
+                                  bool: {
+                                    must_not: {
+                                      bool: {
+                                        should: [
+                                          { match: { 'united.agent.upgrade_status': 'completed' } },
+                                        ],
+                                        minimum_should_match: 1,
+                                      },
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            bool: {
+                              must_not: {
+                                bool: {
+                                  should: [{ exists: { field: 'united.agent.last_checkin' } }],
+                                  minimum_should_match: 1,
+                                },
+                              },
+                            },
+                          },
+                          {
+                            bool: {
+                              should: [
+                                { exists: { field: 'united.agent.unenrollment_started_at' } },
+                              ],
                               minimum_should_match: 1,
                             },
                           },
@@ -281,11 +319,7 @@ describe('test endpoint routes', () => {
                               must_not: {
                                 bool: {
                                   should: [
-                                    {
-                                      match: {
-                                        'united.agent.upgrade_status': 'completed',
-                                      },
-                                    },
+                                    { exists: { field: 'united.agent.policy_revision_idx' } },
                                   ],
                                   minimum_should_match: 1,
                                 },
@@ -293,21 +327,6 @@ describe('test endpoint routes', () => {
                             },
                           },
                         ],
-                      },
-                    },
-                    {
-                      bool: {
-                        must_not: {
-                          bool: {
-                            should: [{ exists: { field: 'united.agent.last_checkin' } }],
-                            minimum_should_match: 1,
-                          },
-                        },
-                      },
-                    },
-                    {
-                      bool: {
-                        should: [{ exists: { field: 'united.agent.unenrollment_started_at' } }],
                         minimum_should_match: 1,
                       },
                     },
@@ -315,14 +334,97 @@ describe('test endpoint routes', () => {
                       bool: {
                         must_not: {
                           bool: {
-                            should: [{ exists: { field: 'united.agent.policy_revision_idx' } }],
+                            should: [
+                              {
+                                bool: {
+                                  should: [
+                                    { range: { 'united.agent.last_checkin': { lt: 'now-300s' } } },
+                                  ],
+                                  minimum_should_match: 1,
+                                },
+                              },
+                              {
+                                bool: {
+                                  filter: [
+                                    {
+                                      bool: {
+                                        should: [
+                                          {
+                                            bool: {
+                                              should: [
+                                                {
+                                                  match: {
+                                                    'united.agent.last_checkin_status': 'error',
+                                                  },
+                                                },
+                                              ],
+                                              minimum_should_match: 1,
+                                            },
+                                          },
+                                          {
+                                            bool: {
+                                              should: [
+                                                {
+                                                  match: {
+                                                    'united.agent.last_checkin_status': 'degraded',
+                                                  },
+                                                },
+                                              ],
+                                              minimum_should_match: 1,
+                                            },
+                                          },
+                                        ],
+                                        minimum_should_match: 1,
+                                      },
+                                    },
+                                    {
+                                      bool: {
+                                        must_not: {
+                                          bool: {
+                                            should: [
+                                              {
+                                                bool: {
+                                                  should: [
+                                                    {
+                                                      range: {
+                                                        'united.agent.last_checkin': {
+                                                          lt: 'now-300s',
+                                                        },
+                                                      },
+                                                    },
+                                                  ],
+                                                  minimum_should_match: 1,
+                                                },
+                                              },
+                                              {
+                                                bool: {
+                                                  should: [
+                                                    {
+                                                      exists: {
+                                                        field:
+                                                          'united.agent.unenrollment_started_at',
+                                                      },
+                                                    },
+                                                  ],
+                                                  minimum_should_match: 1,
+                                                },
+                                              },
+                                            ],
+                                            minimum_should_match: 1,
+                                          },
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
                             minimum_should_match: 1,
                           },
                         },
                       },
                     },
                   ],
-                  minimum_should_match: 1,
                 },
               },
               {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
@@ -30,332 +30,8 @@ export const expectedCompleteUnitedIndexQuery = {
           filter: [
             {
               bool: {
-                must_not: {
-                  bool: {
-                    filter: [
-                      {
-                        bool: {
-                          should: [{ range: { 'united.agent.last_checkin': { lt: 'now-300s' } } }],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          must_not: {
-                            bool: {
-                              filter: [
-                                {
-                                  bool: {
-                                    should: [
-                                      {
-                                        bool: {
-                                          should: [
-                                            {
-                                              match: {
-                                                'united.agent.last_checkin_status': 'error',
-                                              },
-                                            },
-                                          ],
-                                          minimum_should_match: 1,
-                                        },
-                                      },
-                                      {
-                                        bool: {
-                                          should: [
-                                            {
-                                              match: {
-                                                'united.agent.last_checkin_status': 'degraded',
-                                              },
-                                            },
-                                          ],
-                                          minimum_should_match: 1,
-                                        },
-                                      },
-                                    ],
-                                    minimum_should_match: 1,
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    must_not: {
-                                      bool: {
-                                        should: [
-                                          {
-                                            bool: {
-                                              filter: [
-                                                {
-                                                  bool: {
-                                                    should: [
-                                                      {
-                                                        exists: {
-                                                          field: 'united.agent.upgrade_started_at',
-                                                        },
-                                                      },
-                                                    ],
-                                                    minimum_should_match: 1,
-                                                  },
-                                                },
-                                                {
-                                                  bool: {
-                                                    must_not: {
-                                                      bool: {
-                                                        should: [
-                                                          {
-                                                            match: {
-                                                              'united.agent.upgrade_status':
-                                                                'completed',
-                                                            },
-                                                          },
-                                                        ],
-                                                        minimum_should_match: 1,
-                                                      },
-                                                    },
-                                                  },
-                                                },
-                                              ],
-                                            },
-                                          },
-                                          {
-                                            bool: {
-                                              must_not: {
-                                                bool: {
-                                                  should: [
-                                                    {
-                                                      exists: {
-                                                        field: 'united.agent.last_checkin',
-                                                      },
-                                                    },
-                                                  ],
-                                                  minimum_should_match: 1,
-                                                },
-                                              },
-                                            },
-                                          },
-                                          {
-                                            bool: {
-                                              should: [
-                                                {
-                                                  exists: {
-                                                    field: 'united.agent.unenrollment_started_at',
-                                                  },
-                                                },
-                                              ],
-                                              minimum_should_match: 1,
-                                            },
-                                          },
-                                          {
-                                            bool: {
-                                              must_not: {
-                                                bool: {
-                                                  should: [
-                                                    {
-                                                      exists: {
-                                                        field: 'united.agent.policy_revision_idx',
-                                                      },
-                                                    },
-                                                  ],
-                                                  minimum_should_match: 1,
-                                                },
-                                              },
-                                            },
-                                          },
-                                        ],
-                                        minimum_should_match: 1,
-                                      },
-                                    },
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        },
-                      },
-                      {
-                        bool: {
-                          must_not: {
-                            bool: {
-                              should: [
-                                {
-                                  bool: {
-                                    filter: [
-                                      {
-                                        bool: {
-                                          should: [
-                                            {
-                                              exists: { field: 'united.agent.upgrade_started_at' },
-                                            },
-                                          ],
-                                          minimum_should_match: 1,
-                                        },
-                                      },
-                                      {
-                                        bool: {
-                                          must_not: {
-                                            bool: {
-                                              should: [
-                                                {
-                                                  match: {
-                                                    'united.agent.upgrade_status': 'completed',
-                                                  },
-                                                },
-                                              ],
-                                              minimum_should_match: 1,
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    must_not: {
-                                      bool: {
-                                        should: [
-                                          { exists: { field: 'united.agent.last_checkin' } },
-                                        ],
-                                        minimum_should_match: 1,
-                                      },
-                                    },
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    should: [
-                                      { exists: { field: 'united.agent.unenrollment_started_at' } },
-                                    ],
-                                    minimum_should_match: 1,
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    must_not: {
-                                      bool: {
-                                        should: [
-                                          { exists: { field: 'united.agent.policy_revision_idx' } },
-                                        ],
-                                        minimum_should_match: 1,
-                                      },
-                                    },
-                                  },
-                                },
-                              ],
-                              minimum_should_match: 1,
-                            },
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-            {
-              bool: {
-                must_not: {
-                  bool: {
-                    filter: [
-                      {
-                        bool: {
-                          should: [
-                            {
-                              bool: {
-                                should: [
-                                  { match: { 'united.agent.last_checkin_status': 'error' } },
-                                ],
-                                minimum_should_match: 1,
-                              },
-                            },
-                            {
-                              bool: {
-                                should: [
-                                  { match: { 'united.agent.last_checkin_status': 'degraded' } },
-                                ],
-                                minimum_should_match: 1,
-                              },
-                            },
-                          ],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          must_not: {
-                            bool: {
-                              should: [
-                                {
-                                  bool: {
-                                    filter: [
-                                      {
-                                        bool: {
-                                          should: [
-                                            {
-                                              exists: { field: 'united.agent.upgrade_started_at' },
-                                            },
-                                          ],
-                                          minimum_should_match: 1,
-                                        },
-                                      },
-                                      {
-                                        bool: {
-                                          must_not: {
-                                            bool: {
-                                              should: [
-                                                {
-                                                  match: {
-                                                    'united.agent.upgrade_status': 'completed',
-                                                  },
-                                                },
-                                              ],
-                                              minimum_should_match: 1,
-                                            },
-                                          },
-                                        },
-                                      },
-                                    ],
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    must_not: {
-                                      bool: {
-                                        should: [
-                                          { exists: { field: 'united.agent.last_checkin' } },
-                                        ],
-                                        minimum_should_match: 1,
-                                      },
-                                    },
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    should: [
-                                      { exists: { field: 'united.agent.unenrollment_started_at' } },
-                                    ],
-                                    minimum_should_match: 1,
-                                  },
-                                },
-                                {
-                                  bool: {
-                                    must_not: {
-                                      bool: {
-                                        should: [
-                                          { exists: { field: 'united.agent.policy_revision_idx' } },
-                                        ],
-                                        minimum_should_match: 1,
-                                      },
-                                    },
-                                  },
-                                },
-                              ],
-                              minimum_should_match: 1,
-                            },
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
+                should: [{ exists: { field: 'united.agent.last_checkin' } }],
+                minimum_should_match: 1,
               },
             },
             {
@@ -365,10 +41,87 @@ export const expectedCompleteUnitedIndexQuery = {
                     should: [
                       {
                         bool: {
+                          should: [{ range: { 'united.agent.last_checkin': { lt: 'now-300s' } } }],
+                          minimum_should_match: 1,
+                        },
+                      },
+                      {
+                        bool: {
                           filter: [
                             {
                               bool: {
-                                should: [{ exists: { field: 'united.agent.upgrade_started_at' } }],
+                                should: [
+                                  {
+                                    bool: {
+                                      filter: [
+                                        {
+                                          bool: {
+                                            should: [
+                                              {
+                                                exists: {
+                                                  field: 'united.agent.upgrade_started_at',
+                                                },
+                                              },
+                                            ],
+                                            minimum_should_match: 1,
+                                          },
+                                        },
+                                        {
+                                          bool: {
+                                            must_not: {
+                                              bool: {
+                                                should: [
+                                                  {
+                                                    match: {
+                                                      'united.agent.upgrade_status': 'completed',
+                                                    },
+                                                  },
+                                                ],
+                                                minimum_should_match: 1,
+                                              },
+                                            },
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      must_not: {
+                                        bool: {
+                                          should: [
+                                            { exists: { field: 'united.agent.last_checkin' } },
+                                          ],
+                                          minimum_should_match: 1,
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      should: [
+                                        {
+                                          exists: { field: 'united.agent.unenrollment_started_at' },
+                                        },
+                                      ],
+                                      minimum_should_match: 1,
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      must_not: {
+                                        bool: {
+                                          should: [
+                                            {
+                                              exists: { field: 'united.agent.policy_revision_idx' },
+                                            },
+                                          ],
+                                          minimum_should_match: 1,
+                                        },
+                                      },
+                                    },
+                                  },
+                                ],
                                 minimum_should_match: 1,
                               },
                             },
@@ -378,8 +131,92 @@ export const expectedCompleteUnitedIndexQuery = {
                                   bool: {
                                     should: [
                                       {
-                                        match: {
-                                          'united.agent.upgrade_status': 'completed',
+                                        bool: {
+                                          should: [
+                                            {
+                                              range: {
+                                                'united.agent.last_checkin': { lt: 'now-300s' },
+                                              },
+                                            },
+                                          ],
+                                          minimum_should_match: 1,
+                                        },
+                                      },
+                                      {
+                                        bool: {
+                                          filter: [
+                                            {
+                                              bool: {
+                                                should: [
+                                                  {
+                                                    bool: {
+                                                      should: [
+                                                        {
+                                                          match: {
+                                                            'united.agent.last_checkin_status':
+                                                              'error',
+                                                          },
+                                                        },
+                                                      ],
+                                                      minimum_should_match: 1,
+                                                    },
+                                                  },
+                                                  {
+                                                    bool: {
+                                                      should: [
+                                                        {
+                                                          match: {
+                                                            'united.agent.last_checkin_status':
+                                                              'degraded',
+                                                          },
+                                                        },
+                                                      ],
+                                                      minimum_should_match: 1,
+                                                    },
+                                                  },
+                                                ],
+                                                minimum_should_match: 1,
+                                              },
+                                            },
+                                            {
+                                              bool: {
+                                                must_not: {
+                                                  bool: {
+                                                    should: [
+                                                      {
+                                                        bool: {
+                                                          should: [
+                                                            {
+                                                              range: {
+                                                                'united.agent.last_checkin': {
+                                                                  lt: 'now-300s',
+                                                                },
+                                                              },
+                                                            },
+                                                          ],
+                                                          minimum_should_match: 1,
+                                                        },
+                                                      },
+                                                      {
+                                                        bool: {
+                                                          should: [
+                                                            {
+                                                              exists: {
+                                                                field:
+                                                                  'united.agent.unenrollment_started_at',
+                                                              },
+                                                            },
+                                                          ],
+                                                          minimum_should_match: 1,
+                                                        },
+                                                      },
+                                                    ],
+                                                    minimum_should_match: 1,
+                                                  },
+                                                },
+                                              },
+                                            },
+                                          ],
                                         },
                                       },
                                     ],
@@ -393,28 +230,68 @@ export const expectedCompleteUnitedIndexQuery = {
                       },
                       {
                         bool: {
-                          must_not: {
-                            bool: {
-                              should: [{ exists: { field: 'united.agent.last_checkin' } }],
-                              minimum_should_match: 1,
+                          filter: [
+                            {
+                              bool: {
+                                should: [
+                                  {
+                                    bool: {
+                                      should: [
+                                        { match: { 'united.agent.last_checkin_status': 'error' } },
+                                      ],
+                                      minimum_should_match: 1,
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      should: [
+                                        {
+                                          match: { 'united.agent.last_checkin_status': 'degraded' },
+                                        },
+                                      ],
+                                      minimum_should_match: 1,
+                                    },
+                                  },
+                                ],
+                                minimum_should_match: 1,
+                              },
                             },
-                          },
-                        },
-                      },
-                      {
-                        bool: {
-                          should: [{ exists: { field: 'united.agent.unenrollment_started_at' } }],
-                          minimum_should_match: 1,
-                        },
-                      },
-                      {
-                        bool: {
-                          must_not: {
-                            bool: {
-                              should: [{ exists: { field: 'united.agent.policy_revision_idx' } }],
-                              minimum_should_match: 1,
+                            {
+                              bool: {
+                                must_not: {
+                                  bool: {
+                                    should: [
+                                      {
+                                        bool: {
+                                          should: [
+                                            {
+                                              range: {
+                                                'united.agent.last_checkin': { lt: 'now-300s' },
+                                              },
+                                            },
+                                          ],
+                                          minimum_should_match: 1,
+                                        },
+                                      },
+                                      {
+                                        bool: {
+                                          should: [
+                                            {
+                                              exists: {
+                                                field: 'united.agent.unenrollment_started_at',
+                                              },
+                                            },
+                                          ],
+                                          minimum_should_match: 1,
+                                        },
+                                      },
+                                    ],
+                                    minimum_should_match: 1,
+                                  },
+                                },
+                              },
                             },
-                          },
+                          ],
                         },
                       },
                     ],

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
@@ -92,33 +92,31 @@ describe('test filtering endpoint hosts by agent status', () => {
     it('correctly builds kuery for healthy status', () => {
       const status = ['healthy'];
       const kuery = buildStatusesKuery(status);
-      const expected =
-        '(not (united.agent.last_checkin < now-300s AND not ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))) AND not ( ((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*) )) AND not ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*)))';
-      expect(kuery).toEqual(expected);
+      expect(kuery).toMatchInlineSnapshot(
+        `"(united.agent.last_checkin:*  AND not ((united.agent.last_checkin < now-300s) or ((((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*))))) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+      );
     });
 
     it('correctly builds kuery for offline status', () => {
       const status = ['offline'];
       const kuery = buildStatusesKuery(status);
-      const expected =
-        '(united.agent.last_checkin < now-300s AND not ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))) AND not ( ((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*) ))';
-      expect(kuery).toEqual(expected);
+      expect(kuery).toMatchInlineSnapshot(`"(united.agent.last_checkin < now-300s)"`);
     });
 
     it('correctly builds kuery for unhealthy status', () => {
       const status = ['unhealthy'];
       const kuery = buildStatusesKuery(status);
-      const expected =
-        '((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*)))';
-      expect(kuery).toEqual(expected);
+      expect(kuery).toMatchInlineSnapshot(
+        `"((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
+      );
     });
 
     it('correctly builds kuery for updating status', () => {
       const status = ['updating'];
       const kuery = buildStatusesKuery(status);
-      const expected =
-        '(((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))';
-      expect(kuery).toEqual(expected);
+      expect(kuery).toMatchInlineSnapshot(
+        `"((((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+      );
     });
 
     it('correctly builds kuery for inactive status', () => {
@@ -131,9 +129,9 @@ describe('test filtering endpoint hosts by agent status', () => {
     it('correctly builds kuery for multiple statuses', () => {
       const statuses = ['offline', 'unhealthy'];
       const kuery = buildStatusesKuery(statuses);
-      const expected =
-        '(united.agent.last_checkin < now-300s AND not ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))) AND not ( ((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*) ) OR (united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded) AND not (((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*)))';
-      expect(kuery).toEqual(expected);
+      expect(kuery).toMatchInlineSnapshot(
+        `"(united.agent.last_checkin < now-300s OR (united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolve #140477 

Change order status to prioritize `offline` over other statuses `unhealthy`, `upgrading` as an offline agent could not communicate with Fleet server and will not be able to resolve an error from Fleet.


## UI Changes

We now show an offline unhealthy agent as offline in the list and show both offline and unhealthy in the details view @joshdover does it make sense to you? 

<img width="1273" alt="Screen Shot 2022-09-14 at 10 04 32 AM" src="https://user-images.githubusercontent.com/1336873/190177072-616d5547-d312-42b8-8a1d-b6bc247bd1f6.png">

<img width="719" alt="Screen Shot 2022-09-14 at 10 06 42 AM" src="https://user-images.githubusercontent.com/1336873/190177078-36d8390d-24dc-4f38-8388-3e7e8db2f3c9.png">


## Todo

- [ ] add unit tests for `AgentHealth` component