### PR TITLE
Fix downsample validation when downsample action disappears from the previous phase

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.test.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.test.tsx
@@ -16,8 +16,6 @@ import { emptyField } from '../../helpers/field_validators';
 import { FieldHook, FieldValidateResponse, VALIDATION_TYPES, FieldConfig } from '..';
 
 describe('useField() hook', () => {
-  let fieldHook: FieldHook;
-
   beforeAll(() => {
     jest.useFakeTimers();
   });
@@ -26,22 +24,23 @@ describe('useField() hook', () => {
     jest.useRealTimers();
   });
 
-  const TestField = ({ field }: { field: FieldHook }) => {
-    fieldHook = field;
-    return null;
-  };
-
-  const getTestForm = (config?: FieldConfig) => () => {
-    const { form } = useForm();
-
-    return (
-      <Form form={form}>
-        <UseField path="test-path" component={TestField} config={config} />
-      </Form>
-    );
-  };
-
   describe('field.validate()', () => {
+    let fieldHook: FieldHook;
+    const TestField = ({ field }: { field: FieldHook }) => {
+      fieldHook = field;
+      return null;
+    };
+
+    const getTestForm = (config?: FieldConfig) => () => {
+      const { form } = useForm();
+
+      return (
+        <Form form={form}>
+          <UseField path="test-path" component={TestField} config={config} />
+        </Form>
+      );
+    };
+
     const EMPTY_VALUE = '   ';
 
     test('it should not invalidate a field with arrayItem validation when isBlocking is false', async () => {
@@ -147,6 +146,59 @@ describe('useField() hook', () => {
       });
 
       expect(validatorFn).toBeCalledTimes(0);
+    });
+  });
+
+  describe('fieldsToValidateOnChange', () => {
+    let fieldHook1: FieldHook;
+    let fieldHook2: FieldHook;
+    const TestField1 = ({ field }: { field: FieldHook }) => {
+      fieldHook1 = field;
+      return null;
+    };
+
+    const TestField2 = ({ field }: { field: FieldHook }) => {
+      fieldHook2 = field;
+      return null;
+    };
+
+    const getTestForm =
+      (configField1?: FieldConfig, configField2?: FieldConfig) =>
+      ({ showField1, showField2 }: { showField1: boolean; showField2: boolean }) => {
+        const { form } = useForm();
+
+        return (
+          <Form form={form}>
+            {showField1 && <UseField path="field1" component={TestField1} config={configField1} />}
+            {showField2 && <UseField path="field2" component={TestField2} config={configField2} />}
+          </Form>
+        );
+      };
+
+    test('validates dependent fields on unmount', async () => {
+      const field2ValidatorFn = jest.fn();
+      const TestForm = getTestForm(
+        {
+          fieldsToValidateOnChange: ['field1', 'field2'],
+        },
+        {
+          validations: [
+            {
+              validator: field2ValidatorFn,
+            },
+          ],
+        }
+      );
+
+      const wrapper = registerTestBed(TestForm, {
+        memoryRouter: { wrapComponent: false },
+      })({ showField1: true, showField2: true });
+      expect(field2ValidatorFn).toBeCalledTimes(0);
+
+      await act(async () => {
+        wrapper.setProps({ showField1: false });
+      });
+      expect(field2ValidatorFn).toBeCalledTimes(1);
     });
   });
 });

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.test.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.test.tsx
@@ -150,18 +150,6 @@ describe('useField() hook', () => {
   });
 
   describe('fieldsToValidateOnChange', () => {
-    let fieldHook1: FieldHook;
-    let fieldHook2: FieldHook;
-    const TestField1 = ({ field }: { field: FieldHook }) => {
-      fieldHook1 = field;
-      return null;
-    };
-
-    const TestField2 = ({ field }: { field: FieldHook }) => {
-      fieldHook2 = field;
-      return null;
-    };
-
     const getTestForm =
       (configField1?: FieldConfig, configField2?: FieldConfig) =>
       ({ showField1, showField2 }: { showField1: boolean; showField2: boolean }) => {
@@ -169,8 +157,8 @@ describe('useField() hook', () => {
 
         return (
           <Form form={form}>
-            {showField1 && <UseField path="field1" component={TestField1} config={configField1} />}
-            {showField2 && <UseField path="field2" component={TestField2} config={configField2} />}
+            {showField1 && <UseField path="field1" component={() => null} config={configField1} />}
+            {showField2 && <UseField path="field2" component={() => null} config={configField2} />}
           </Form>
         );
       };

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
@@ -602,8 +602,14 @@ export const useField = <T, FormType = FormData, I = T>(
       // We only remove the field from the form "fieldsRefs" map when its path
       // changes (which in practice never occurs) or whenever the <UseField /> unmounts
       __removeField(path);
+
+      // We also have to trigger validation of dependant fields
+      const dependantFields = fieldsToValidateOnChange?.filter((f) => f !== path);
+      if (dependantFields?.length) {
+        validateFields(dependantFields);
+      }
     };
-  }, [path, __removeField]);
+  }, [path, __removeField, fieldsToValidateOnChange, validateFields]);
 
   // Value change: notify prop listener (<UseField onChange={() => {...}})
   // We have a separate useEffect for this as the "onChange" handler pass through prop

--- a/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/form_validation/downsample_interval.test.ts
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/form_validation/downsample_interval.test.ts
@@ -112,10 +112,13 @@ describe('<EditPolicy /> downsample interval validation', () => {
       'cold'
     );
 
-    // disable warm phase;
+    // disable warm phase, check that we now get an error because of the hot phase;
     await actions.togglePhase('warm');
-    // TODO: there is a bug that disabling a phase doesn't trigger downsample validation in other phases,
-    // users can work around it by changing the value
+    actions.errors.waitForValidation();
+    actions.errors.expectMessages(
+      ['Must be greater than and a multiple of the hot phase value (60m)'],
+      'cold'
+    );
     await actions.cold.downsample.setDownsampleInterval('120', 'm');
     actions.errors.waitForValidation();
     actions.errors.expectMessages([], 'cold');


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/140714

## Problem

The [PR](https://github.com/elastic/kibana/pull/138748) for downsampling action was merged, but there is this validation edge case that bothers me: 

You can enable Downsample action in hot, warm, and cold phases. You can configure downsampling interval. The interval has validation where it depends on the interval in the previous phase: 

![image](https://user-images.githubusercontent.com/7784120/189925497-ca105c70-d107-4af9-8dc6-995976f8cb58.png)

- they must be greater than any previous interval and a multiple of that interval.
  - For example, on the warm phase, the user includes a 3-hour interval; if they choose to add a rollup action on the cold phase, the interval must be a multiple of 3h. It cannot be 5h, for example.
  - Another example: a user can have a rollup on the hot phase of 2d and then no rollup action on the warm phase, and then a rollup action on the cold phase, but it must be a multiple of 2d, for example, it cannot be 1d nor can it be 3d.

![image](https://user-images.githubusercontent.com/7784120/189925538-ed4edc37-2827-4fdf-a13b-342cf66c7711.png)

There is currently the following bug that I struggle to fix: 

- Enable Downsample in hot phase and set the interval to 1 day 
- Enable Downsample in warm phase and set the interval to 1 day (see the error) 
- Disable Downsample in hot phase (through the custom rollover option) 
- See that the error in warm didn't disappear. The user needs to change the field to trigger validation 


See the video: 


https://user-images.githubusercontent.com/7784120/189926410-c65fc94a-78f5-4f2e-8276-a6c45c558478.mov


## Solution 

The proper fix ended up being inside the lib itself. 
When a field was unmounted, the corresponding value was changed, but this didn't trigger the validation of dependant fields from `fieldsToValidateOnChange`. 
The fix is to trigger validation of the fields from `fieldsToValidateOnChange` when a field is being unmounted.
