### PR TITLE
[Search] Fix search query builder to generate wildcard query for keyword fields

### DIFF
--- a/packages/kbn-es-query/src/es_query/types.ts
+++ b/packages/kbn-es-query/src/es_query/types.ts
@@ -54,6 +54,10 @@ export type DataViewFieldBase = {
    */
   lang?: estypes.ScriptLanguage;
   scripted?: boolean;
+  /**
+   * ES field types as strings array.
+   */
+  esTypes?: string[];
 };
 
 /**

--- a/packages/kbn-es-query/src/filters/stubs/fields.mocks.ts
+++ b/packages/kbn-es-query/src/filters/stubs/fields.mocks.ts
@@ -43,6 +43,12 @@ export const fields: DataViewFieldBase[] = [
     scripted: false,
   },
   {
+    name: 'machine.os.keyword',
+    type: 'string',
+    esTypes: ['keyword'],
+    scripted: false,
+  },
+  {
     name: 'script number',
     type: 'number',
     scripted: true,

--- a/packages/kbn-es-query/src/kuery/functions/is.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.test.ts
@@ -206,6 +206,25 @@ describe('kuery functions', () => {
         expect(result).toEqual(expected);
       });
 
+      test('should create a wildcard query for keyword fields', () => {
+        const expected = {
+          bool: {
+            should: [
+              {
+                wildcard: {
+                  'machine.os.keyword': 'win*',
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        };
+        const node = nodeTypes.function.buildNode('is', 'machine.os.keyword', 'win*');
+        const result = is.toElasticsearchQuery(node, indexPattern);
+
+        expect(result).toEqual(expected);
+      });
+
       test('should support scripted fields', () => {
         const node = nodeTypes.function.buildNode('is', 'script string', 'foo');
         const result = is.toElasticsearchQuery(node, indexPattern);

--- a/packages/kbn-es-query/src/kuery/functions/is.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.ts
@@ -142,15 +142,20 @@ export function toElasticsearchQuery(
         }),
       ];
     } else if (wildcard.isNode(valueArg)) {
-      return [
-        ...accumulator,
-        wrapWithNestedQuery({
-          query_string: {
-            fields: [field.name],
-            query: wildcard.toQueryStringQuery(valueArg),
-          },
-        }),
-      ];
+      const query = field.esTypes?.includes('keyword')
+        ? {
+            wildcard: {
+              [field.name]: value,
+            },
+          }
+        : {
+            query_string: {
+              fields: [field.name],
+              query: wildcard.toQueryStringQuery(valueArg),
+            },
+          };
+
+      return [...accumulator, wrapWithNestedQuery(query)];
     } else if (field.type === 'date') {
       /*
       If we detect that it's a date field and the user wants an exact date, we need to convert the query to both >= and <= the value provided to force a range query. This is because match and match_phrase queries do not accept a timezone parameter.

--- a/packages/kbn-es-query/src/kuery/functions/utils/get_fields.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/utils/get_fields.test.ts
@@ -74,10 +74,13 @@ describe('getFields', () => {
       const fieldNameNode = nodeTypes.wildcard.buildNode('machine*');
       const results = getFields(fieldNameNode, indexPattern);
 
-      expect(Array.isArray(results)).toBeTruthy();
-      expect(results).toHaveLength(2);
-      expect(results!.find((field) => field.name === 'machine.os')).toBeDefined();
-      expect(results!.find((field) => field.name === 'machine.os.raw')).toBeDefined();
+      expect(results).toEqual(expect.any(Array));
+      expect(results).toHaveLength(3);
+      expect(results).toEqual([
+        expect.objectContaining({ name: 'machine.os' }),
+        expect.objectContaining({ name: 'machine.os.raw' }),
+        expect.objectContaining({ name: 'machine.os.keyword' }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #23001.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
