### PR TITLE
[Security Solution][Endpoint][Trusted Apps] Show warning for invalid hash when editing Trusted App

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.test.tsx
@@ -32,11 +32,19 @@ describe('Condition entry input', () => {
     onVisitedMock = jest.fn();
   });
 
+  interface GetElementProps {
+    os?: OperatingSystem;
+    isRemoveDisabled?: boolean;
+    entry?: TrustedAppConditionEntry;
+  }
+
   const getElement = (
     subject: string,
-    os: OperatingSystem = OperatingSystem.WINDOWS,
-    isRemoveDisabled: boolean = false,
-    entry: TrustedAppConditionEntry = baseEntry
+    {
+      os = OperatingSystem.WINDOWS,
+      isRemoveDisabled = false,
+      entry = baseEntry,
+    }: GetElementProps = {}
   ) => (
     <ConditionEntryInput
       os={os}
@@ -80,7 +88,7 @@ describe('Condition entry input', () => {
   });
 
   it('should not be able to call on remove for field input because disabled', () => {
-    const element = mount(getElement('testOnRemove', OperatingSystem.WINDOWS, true));
+    const element = mount(getElement('testOnRemove', { isRemoveDisabled: true }));
     expect(onRemoveMock).toHaveBeenCalledTimes(0);
     element.find('[data-test-subj="testOnRemove-remove"]').first().simulate('click');
     expect(onRemoveMock).toHaveBeenCalledTimes(0);
@@ -96,9 +104,7 @@ describe('Condition entry input', () => {
 
   it('should not call on visited for field change if value is empty', () => {
     const emptyEntry = { ...baseEntry, value: '' };
-    const element = shallow(
-      getElement('testOnVisited', OperatingSystem.WINDOWS, false, emptyEntry)
-    );
+    const element = shallow(getElement('testOnVisited', { entry: emptyEntry }));
     expect(onVisitedMock).toHaveBeenCalledTimes(0);
     element.find('[data-test-subj="testOnVisited-field"]').first().simulate('change');
     expect(onVisitedMock).toHaveBeenCalledTimes(0);
@@ -138,7 +144,7 @@ describe('Condition entry input', () => {
   });
 
   it('should be able to select two options when LINUX OS', () => {
-    const element = mount(getElement('testCheckSignatureOption', OperatingSystem.LINUX));
+    const element = mount(getElement('testCheckSignatureOption', { os: OperatingSystem.LINUX }));
     const superSelectProps = element
       .find('[data-test-subj="testCheckSignatureOption-field"]')
       .first()
@@ -147,7 +153,7 @@ describe('Condition entry input', () => {
   });
 
   it('should be able to select two options when MAC OS', () => {
-    const element = mount(getElement('testCheckSignatureOption', OperatingSystem.MAC));
+    const element = mount(getElement('testCheckSignatureOption', { os: OperatingSystem.MAC }));
     const superSelectProps = element
       .find('[data-test-subj="testCheckSignatureOption-field"]')
       .first()
@@ -161,11 +167,10 @@ describe('Condition entry input', () => {
     expect(inputField.contains('is'));
   });
 
-  it('should show operator dorpdown with two values when field is PATH', () => {
+  it('should show operator dropdown with two values when field is PATH', () => {
     const element = shallow(
-      getElement('testOperatorOptions', undefined, undefined, {
-        ...baseEntry,
-        field: ConditionEntryField.PATH,
+      getElement('testOperatorOptions', {
+        entry: { ...baseEntry, field: ConditionEntryField.PATH },
       })
     );
     const superSelectProps = element

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.test.tsx
@@ -94,6 +94,23 @@ describe('Condition entry input', () => {
     expect(onVisitedMock).toHaveBeenCalledWith(baseEntry);
   });
 
+  it('should not call on visited for field change if value is empty', () => {
+    const emptyEntry = { ...baseEntry, value: '' };
+    const element = shallow(
+      getElement('testOnVisited', OperatingSystem.WINDOWS, false, emptyEntry)
+    );
+    expect(onVisitedMock).toHaveBeenCalledTimes(0);
+    element.find('[data-test-subj="testOnVisited-field"]').first().simulate('change');
+    expect(onVisitedMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call on visited for field change if value is not empty', () => {
+    const element = shallow(getElement('testOnVisited'));
+    expect(onVisitedMock).toHaveBeenCalledTimes(0);
+    element.find('[data-test-subj="testOnVisited-field"]').first().simulate('change');
+    expect(onVisitedMock).toHaveBeenCalledTimes(1);
+  });
+
   it('should change value for field input', () => {
     const element = shallow(getElement('testOnChange'));
     expect(onChangeMock).toHaveBeenCalledTimes(0);

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.tsx
@@ -93,6 +93,14 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
     const getTestId = useTestIdGenerator(dataTestSubj);
     const [isVisited, setIsVisited] = useState(false);
 
+    const enterVisitedState = useCallback(() => {
+      onVisited?.(entry);
+
+      if (!isVisited) {
+        setIsVisited(true);
+      }
+    }, [entry, isVisited, onVisited]);
+
     const fieldOptions = useMemo<Array<EuiSuperSelectOption<string>>>(() => {
       const getDropdownDisplay = (field: ConditionEntryField) => (
         <>
@@ -132,8 +140,14 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
     );
 
     const handleFieldUpdate = useCallback(
-      (newField) => onChange({ ...entry, field: newField }, entry),
-      [entry, onChange]
+      (newField) => {
+        onChange({ ...entry, field: newField }, entry);
+
+        if (entry.value) {
+          enterVisitedState();
+        }
+      },
+      [enterVisitedState, entry, onChange]
     );
 
     const handleOperatorUpdate = useCallback(
@@ -144,13 +158,8 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
     const handleRemoveClick = useCallback(() => onRemove(entry), [entry, onRemove]);
 
     const handleValueOnBlur = useCallback(() => {
-      if (onVisited) {
-        onVisited(entry);
-      }
-      if (!isVisited) {
-        setIsVisited(true);
-      }
-    }, [entry, onVisited, isVisited]);
+      enterVisitedState();
+    }, [enterVisitedState]);
 
     return (
       <InputGroup data-test-subj={dataTestSubj}>

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/condition_entry_input/index.tsx
@@ -93,7 +93,7 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
     const getTestId = useTestIdGenerator(dataTestSubj);
     const [isVisited, setIsVisited] = useState(false);
 
-    const enterVisitedState = useCallback(() => {
+    const handleVisited = useCallback(() => {
       onVisited?.(entry);
 
       if (!isVisited) {
@@ -144,10 +144,10 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
         onChange({ ...entry, field: newField }, entry);
 
         if (entry.value) {
-          enterVisitedState();
+          handleVisited();
         }
       },
-      [enterVisitedState, entry, onChange]
+      [handleVisited, entry, onChange]
     );
 
     const handleOperatorUpdate = useCallback(
@@ -158,8 +158,8 @@ export const ConditionEntryInput = memo<ConditionEntryInputProps>(
     const handleRemoveClick = useCallback(() => onRemove(entry), [entry, onRemove]);
 
     const handleValueOnBlur = useCallback(() => {
-      enterVisitedState();
-    }, [enterVisitedState]);
+      handleVisited();
+    }, [handleVisited]);
 
     return (
       <InputGroup data-test-subj={dataTestSubj}>


### PR DESCRIPTION
Fixes: #139367

## Summary

When editing an existing Trusted Application, if changing e.g. a `Signature` to `Hash` would cause an invalid hash, the warning was not displayed because the entry has not been 'visited' yet.

I've updated the 'visited' logic: if the user changes the field (Signature/Path/Hash) and the value is not empty, the condition counts as visited, so the warning will be displayed.

![show invalid hash warning on edit](https://user-images.githubusercontent.com/39014407/189978644-80a50176-da1c-487f-b168-7504a8484e66.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
