### PR TITLE
[ResponseOps][Cases] Implementing deduping on assignees field

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   createIncident,
+  dedupAssignees,
   getClosedInfoForUpdate,
   getDurationForUpdate,
   getLatestPushInfo,
@@ -91,6 +92,26 @@ const formatIsolateCommentActionsMultipleTargets = {
 const params = { ...basicParams };
 
 describe('utils', () => {
+  describe('dedupAssignees', () => {
+    it('removes duplicate assignees', () => {
+      expect(dedupAssignees([{ uid: '123' }, { uid: '123' }, { uid: '456' }])).toEqual([
+        { uid: '123' },
+        { uid: '456' },
+      ]);
+    });
+
+    it('leaves the array as it is when there are no duplicates', () => {
+      expect(dedupAssignees([{ uid: '123' }, { uid: '456' }])).toEqual([
+        { uid: '123' },
+        { uid: '456' },
+      ]);
+    });
+
+    it('returns undefined when the assignees is undefined', () => {
+      expect(dedupAssignees()).toBeUndefined();
+    });
+  });
+
   describe('prepareFieldsForTransformation', () => {
     test('prepare fields with defaults', () => {
       const res = prepareFieldsForTransformation({

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { flow } from 'lodash';
+import { flow, uniqBy } from 'lodash';
 import { ActionsClient } from '@kbn/actions-plugin/server';
 import { isPushedUserAction } from '../../../common/utils/user_actions';
 import {
@@ -26,6 +26,7 @@ import {
   CaseStatuses,
   User,
   CaseAttributes,
+  CaseAssignees,
 } from '../../../common/api';
 import { CasesClientGetAlertsResponse } from '../alerts/types';
 import {
@@ -54,6 +55,14 @@ interface CreateIncidentArgs {
   alerts: CasesClientGetAlertsResponse;
   casesConnectors: CasesConnectorsMap;
 }
+
+export const dedupAssignees = (assignees?: CaseAssignees): CaseAssignees | undefined => {
+  if (assignees == null) {
+    return;
+  }
+
+  return uniqBy(assignees, 'uid');
+};
 
 export const getLatestPushInfo = (
   connectorId: string,

--- a/x-pack/plugins/cases/server/common/utils.ts
+++ b/x-pack/plugins/cases/server/common/utils.ts
@@ -40,6 +40,7 @@ import {
   parseCommentString,
   getLensVisualizations,
 } from '../../common/utils/markdown_plugins/utils';
+import { dedupAssignees } from '../client/cases/utils';
 
 /**
  * Default sort field for querying saved objects.
@@ -69,7 +70,7 @@ export const transformNewCase = ({
   status: CaseStatuses.open,
   updated_at: null,
   updated_by: null,
-  assignees: newCase.assignees ?? [],
+  assignees: dedupAssignees(newCase.assignees) ?? [],
 });
 
 export const transformCases = ({

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/assignees.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/assignees.ts
@@ -106,6 +106,17 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(retrievedProfiles).to.eql(profiles);
     });
 
+    it('removes duplicate assignees when creating a case', async () => {
+      const postedCase = await createCase(
+        supertest,
+        getPostCaseRequest({
+          assignees: [{ uid: '123' }, { uid: '123' }],
+        })
+      );
+
+      expect(postedCase.assignees).to.eql([{ uid: '123' }]);
+    });
+
     it('assigns a user to a case and retrieves the users profile from a get case call', async () => {
       const profile = await suggestUserProfiles({
         supertest: supertestWithoutAuth,
@@ -248,6 +259,50 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       expect(retrievedProfiles).to.eql(profiles);
+    });
+
+    it('remove duplicate assignees when updating a case', async () => {
+      const postedCase = await createCase(supertest, getPostCaseRequest());
+
+      const patchedCases = await updateCase({
+        supertest,
+        params: {
+          cases: [
+            {
+              id: postedCase.id,
+              version: postedCase.version,
+              assignees: [{ uid: '123' }, { uid: '123' }],
+            },
+          ],
+        },
+      });
+
+      expect(patchedCases[0].assignees).to.eql([{ uid: '123' }]);
+    });
+
+    it('does not set the assignees to an empty array when the field is not updated', async () => {
+      const postedCase = await createCase(
+        supertest,
+        getPostCaseRequest({
+          assignees: [{ uid: '123' }],
+        })
+      );
+
+      await updateCase({
+        supertest,
+        params: {
+          cases: [
+            {
+              id: postedCase.id,
+              version: postedCase.version,
+              title: 'abc',
+            },
+          ],
+        },
+      });
+
+      const updatedCase = await getCase({ supertest, caseId: postedCase.id });
+      expect(updatedCase.assignees).to.eql([{ uid: '123' }]);
     });
   });
 };


### PR DESCRIPTION
This PR implements backend functionality to remove duplicate assignees when a case is created and updated.