### PR TITLE
Adds title and link to inference pipelines action panel

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState } from 'react';
 
+import { useValues } from 'kea';
+
 import {
   EuiBadge,
   EuiButtonEmpty,
@@ -15,11 +17,14 @@ import {
   EuiHealth,
   EuiPanel,
   EuiPopover,
+  EuiPopoverTitle,
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
+import { HttpLogic } from '../../../../shared/http';
 
 import { InferencePipeline } from './types';
 
@@ -29,6 +34,7 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = ({
   isDeployed,
   modelType,
 }) => {
+  const { http } = useValues(HttpLogic);
   const [isPopOverOpen, setIsPopOverOpen] = useState(false);
 
   const deployedText = i18n.translate('xpack.enterpriseSearch.inferencePipelineCard.isDeployed', {
@@ -69,20 +75,33 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = ({
                 isOpen={isPopOverOpen}
                 closePopover={() => setIsPopOverOpen(false)}
               >
+                <EuiPopoverTitle paddingSize="m">
+                  {i18n.translate('xpack.enterpriseSearch.inferencePipelineCard.action.title', {
+                    defaultMessage: 'Actions',
+                  })}
+                </EuiPopoverTitle>
                 <EuiFlexGroup direction="column" gutterSize="none">
                   <EuiFlexItem>
                     <div>
-                      <EuiButtonEmpty flush="both" iconType="eye" color="text">
+                      <EuiButtonEmpty
+                        size="s"
+                        flush="both"
+                        iconType="eye"
+                        color="text"
+                        href={http.basePath.prepend(
+                          `/app/management/ingest/ingest_pipelines/?pipeline=${pipelineName}`
+                        )}
+                      >
                         {i18n.translate(
                           'xpack.enterpriseSearch.inferencePipelineCard.action.view',
-                          { defaultMessage: 'View pipeline in Stack Management' }
+                          { defaultMessage: 'View in Stack Management' }
                         )}
                       </EuiButtonEmpty>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <div>
-                      <EuiButtonEmpty flush="both" iconType="trash" color="text">
+                      <EuiButtonEmpty size="s" flush="both" iconType="trash" color="text">
                         {i18n.translate(
                           'xpack.enterpriseSearch.inferencePipelineCard.action.delete',
                           { defaultMessage: 'Delete pipeline' }


### PR DESCRIPTION
## Summary

The "View in Stack Management" link in the inference pipeline card action panel now navigates to `management/ingest/ingest_pipelines/?pipeline=${pipelineName}` and opens the flyout for the given pipeline.

#### Closes https://github.com/elastic/enterprise-search-team/issues/2705

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
