### PR TITLE
refactor performance service

### DIFF
--- a/x-pack/test/performance/journeys/promotion_tracking_dashboard/promotion_tracking_dashboard.ts
+++ b/x-pack/test/performance/journeys/promotion_tracking_dashboard/promotion_tracking_dashboard.ts
@@ -9,54 +9,49 @@ import { StepCtx } from '../../services/performance';
 import { waitForVisualizations } from '../../utils';
 
 export default function ({ getService }: FtrProviderContext) {
-  describe('promotion_tracking_dashboard', () => {
-    const performance = getService('performance');
+  const performance = getService('performance');
 
-    it('promotion_tracking_dashboard', async () => {
-      await performance.runUserJourney(
-        'promotion_tracking_dashboard',
-        [
-          {
-            name: 'Go to Dashboards Page',
-            handler: async ({ page, kibanaUrl }: StepCtx) => {
-              await page.goto(`${kibanaUrl}/app/dashboards`);
-              await page.waitForSelector('#dashboardListingHeading');
-            },
-          },
-          {
-            name: 'Go to Promotion Tracking Dashboard',
-            handler: async ({ page }) => {
-              const promotionDashboardButton = page.locator(
-                '[data-test-subj="dashboardListingTitleLink-Promotion-Dashboard"]'
-              );
-              await promotionDashboardButton.click();
-            },
-          },
-          {
-            name: 'Change time range',
-            handler: async ({ page }) => {
-              const beginningTimeRangeButton = page.locator(
-                '[data-test-subj="superDatePickerToggleQuickMenuButton"]'
-              );
-              await beginningTimeRangeButton.click();
+  performance.runUserJourney(
+    [
+      {
+        name: 'Go to Dashboards Page',
+        handler: async ({ page, kibanaUrl }: StepCtx) => {
+          await page.goto(`${kibanaUrl}/app/dashboards`);
+          await page.waitForSelector('#dashboardListingHeading');
+        },
+      },
+      {
+        name: 'Go to Promotion Tracking Dashboard',
+        handler: async ({ page }) => {
+          const promotionDashboardButton = page.locator(
+            '[data-test-subj="dashboardListingTitleLink-Promotion-Dashboard"]'
+          );
+          await promotionDashboardButton.click();
+        },
+      },
+      {
+        name: 'Change time range',
+        handler: async ({ page }) => {
+          const beginningTimeRangeButton = page.locator(
+            '[data-test-subj="superDatePickerToggleQuickMenuButton"]'
+          );
+          await beginningTimeRangeButton.click();
 
-              const lastYearButton = page.locator(
-                '[data-test-subj="superDatePickerCommonlyUsed_Last_30 days"]'
-              );
-              await lastYearButton.click();
-            },
-          },
-          {
-            name: 'Wait for visualization animations to finish',
-            handler: async ({ page }) => {
-              await waitForVisualizations(page, 1);
-            },
-          },
-        ],
-        {
-          requireAuth: false,
-        }
-      );
-    });
-  });
+          const lastYearButton = page.locator(
+            '[data-test-subj="superDatePickerCommonlyUsed_Last_30 days"]'
+          );
+          await lastYearButton.click();
+        },
+      },
+      {
+        name: 'Wait for visualization animations to finish',
+        handler: async ({ page }) => {
+          await waitForVisualizations(page, 1);
+        },
+      },
+    ],
+    {
+      requireAuth: false,
+    }
+  );
 }


### PR DESCRIPTION
This pr aims to refactor the ergonomics of performance journeys by following:
- Not exposing mocha methods
- Not using journey names in multiple places (it is hardcoded to "xd" now but it will be updated and will use `this.config.get("journeyName")`)
- Logging is improved by using `it` blocks more effectively which radically changed the code structure since withTransaction method exist earlier needed to separated.
- Better error handling - (need to update calling scripts with bail option)

Closes: #140676

Todo List: 
- [ ] Update all journeys when performance service is reviewed 👍🏽 
- [ ] Replace journeyName
- [ ] Update scripts running journeys with `--bail`