### PR TITLE
[Discover] Fix text based query language state transformation hook when there's an error involved

### DIFF
--- a/src/plugins/discover/public/application/main/hooks/use_text_based_query_language.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_text_based_query_language.ts
@@ -55,11 +55,14 @@ export function useTextBasedQueryLanguage({
 
   useEffect(() => {
     const subscription = documents$.subscribe(async (next) => {
-      const { query } = next;
+      const { query, recordRawType } = next;
+      if (!query || next.fetchStatus === FetchStatus.ERROR) {
+        return;
+      }
       const { columns: stateColumns, index } = stateContainer.appStateContainer.getState();
       let nextColumns: string[] = [];
       const isTextBasedQueryLang =
-        next.recordRawType === 'plain' && query && isOfAggregateQueryType(query) && 'sql' in query;
+        recordRawType === 'plain' && isOfAggregateQueryType(query) && 'sql' in query;
       const hasResults = next.result?.length && next.fetchStatus === FetchStatus.COMPLETE;
       const initialFetch = !prev.current.columns.length;
 
@@ -72,8 +75,8 @@ export function useTextBasedQueryLanguage({
             !isEqual(firstRowColumns, prev.current.columns) &&
             !isEqual(query, prev.current.query)
           ) {
+            prev.current = { columns: firstRowColumns, query };
             nextColumns = firstRowColumns;
-            prev.current = { columns: nextColumns, query };
           }
           if (firstRowColumns && initialFetch) {
             prev.current = { columns: firstRowColumns, query };


### PR DESCRIPTION
## Summary

This fixes an issue when using the text based query language feature in Discover (introduced in https://github.com/elastic/kibana/pull/140169). So before this PR, when you've entered:

### Before this fix 
1. Select `kibana_sample_data_logs` in the data view selector and switch to SQL 
2. `SELECT * FROM "kibana_sample_data_logs"` - Run query. 
3. `SELECT agent, FROM "kibana_sample_data_logs"` - Run query - there's an error, this is expected
4. `SELECT agent FROM "kibana_sample_data_logs"` - Run query - works but the displayed columns are wrong. the columns of step 2  are displayed. 

![Bildschirmfoto 2022-09-14 um 11 09 53](https://user-images.githubusercontent.com/463851/190112611-47992566-6421-40bf-8d75-cd41c2bc565d.png)

### With this fix
The right columns should be selected using step 4

![Bildschirmfoto 2022-09-14 um 11 13 22](https://user-images.githubusercontent.com/463851/190113447-b7d5d93d-5681-4f51-b712-c5c0a0de749e.png)

🥣 [deployment](https://kertal-pr-140697-discover-fix-text-based-query-hook.kbndev.co/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(),filters:!(),index:'90943e30-9a47-11e8-b64d-95841ca0b247',interval:auto,query:(language:kql,query:''),sort:!(!(timestamp,desc))))


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

