### PR TITLE
[Stack Monitoring] Use EuiThemeProvider

### DIFF
--- a/x-pack/plugins/monitoring/public/application/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/index.tsx
@@ -5,60 +5,62 @@
  * 2.0.
  */
 
-import { CoreStart, AppMountParameters, MountPoint, CoreTheme } from '@kbn/core/public';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { Route, Switch, Redirect, Router } from 'react-router-dom';
-import { Observable } from 'rxjs';
+import { AppMountParameters, CoreStart, CoreTheme, MountPoint } from '@kbn/core/public';
+import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
-import { LoadingPage } from './pages/loading_page';
-import { LicensePage } from './pages/license_page';
-import { ClusterOverview } from './pages/cluster/overview_page';
-import { ClusterListing } from './pages/home/cluster_listing';
-import { MonitoringStartPluginDependencies } from '../types';
-import { GlobalStateProvider } from './contexts/global_state_context';
-import { ExternalConfigContext, ExternalConfig } from './contexts/external_config_context';
-import { createPreserveQueryHistory } from './preserve_query_history';
-import { RouteInit } from './route_init';
-import { NoDataPage } from './pages/no_data';
-import { ElasticsearchOverviewPage } from './pages/elasticsearch/overview';
-import { BeatsOverviewPage } from './pages/beats/overview';
+import React, { useMemo } from 'react';
+import ReactDOM from 'react-dom';
+import { Redirect, Route, Router, Switch } from 'react-router-dom';
+import useObservable from 'react-use/lib/useObservable';
+import { Observable } from 'rxjs';
 import {
-  CODE_PATH_ELASTICSEARCH,
+  CODE_PATH_APM,
   CODE_PATH_BEATS,
+  CODE_PATH_ELASTICSEARCH,
+  CODE_PATH_ENTERPRISE_SEARCH,
   CODE_PATH_KIBANA,
   CODE_PATH_LOGSTASH,
-  CODE_PATH_APM,
-  CODE_PATH_ENTERPRISE_SEARCH,
 } from '../../common/constants';
+import { MonitoringStartPluginDependencies } from '../types';
+import { ExternalConfig, ExternalConfigContext } from './contexts/external_config_context';
+import { GlobalStateProvider } from './contexts/global_state_context';
+import { HeaderActionMenuContext } from './contexts/header_action_menu_context';
+import { BreadcrumbContainer } from './hooks/use_breadcrumbs';
+import { MonitoringTimeContainer } from './hooks/use_monitoring_time';
+import { AccessDeniedPage } from './pages/access_denied';
+import { ApmInstancePage, ApmInstancesPage, ApmOverviewPage } from './pages/apm';
 import { BeatsInstancePage } from './pages/beats/instance';
-import { ApmOverviewPage, ApmInstancesPage, ApmInstancePage } from './pages/apm';
-import { KibanaOverviewPage } from './pages/kibana/overview';
-import { KibanaInstancesPage } from './pages/kibana/instances';
-import { KibanaInstancePage } from './pages/kibana/instance';
-import { ElasticsearchNodesPage } from './pages/elasticsearch/nodes_page';
-import { ElasticsearchIndicesPage } from './pages/elasticsearch/indices_page';
-import { ElasticsearchIndexPage } from './pages/elasticsearch/index_page';
-import { ElasticsearchIndexAdvancedPage } from './pages/elasticsearch/index_advanced_page';
-import { ElasticsearchNodePage } from './pages/elasticsearch/node_page';
-import { ElasticsearchMLJobsPage } from './pages/elasticsearch/ml_jobs_page';
-import { ElasticsearchNodeAdvancedPage } from './pages/elasticsearch/node_advanced_page';
+import { BeatsInstancesPage } from './pages/beats/instances';
+import { BeatsOverviewPage } from './pages/beats/overview';
+import { ClusterOverview } from './pages/cluster/overview_page';
 import { ElasticsearchCcrPage } from './pages/elasticsearch/ccr_page';
 import { ElasticsearchCcrShardPage } from './pages/elasticsearch/ccr_shard_page';
+import { ElasticsearchIndexAdvancedPage } from './pages/elasticsearch/index_advanced_page';
+import { ElasticsearchIndexPage } from './pages/elasticsearch/index_page';
+import { ElasticsearchIndicesPage } from './pages/elasticsearch/indices_page';
+import { ElasticsearchMLJobsPage } from './pages/elasticsearch/ml_jobs_page';
+import { ElasticsearchNodesPage } from './pages/elasticsearch/nodes_page';
+import { ElasticsearchNodeAdvancedPage } from './pages/elasticsearch/node_advanced_page';
+import { ElasticsearchNodePage } from './pages/elasticsearch/node_page';
+import { ElasticsearchOverviewPage } from './pages/elasticsearch/overview';
 import { EntSearchOverviewPage } from './pages/enterprise_search/overview';
-import { MonitoringTimeContainer } from './hooks/use_monitoring_time';
-import { BreadcrumbContainer } from './hooks/use_breadcrumbs';
-import { HeaderActionMenuContext } from './contexts/header_action_menu_context';
-import { LogStashOverviewPage } from './pages/logstash/overview';
-import { LogStashNodesPage } from './pages/logstash/nodes';
-import { LogStashPipelinesPage } from './pages/logstash/pipelines';
-import { LogStashPipelinePage } from './pages/logstash/pipeline';
-import { BeatsInstancesPage } from './pages/beats/instances';
+import { ClusterListing } from './pages/home/cluster_listing';
+import { KibanaInstancePage } from './pages/kibana/instance';
+import { KibanaInstancesPage } from './pages/kibana/instances';
+import { KibanaOverviewPage } from './pages/kibana/overview';
+import { LicensePage } from './pages/license_page';
+import { LoadingPage } from './pages/loading_page';
 import { LogStashNodeAdvancedPage } from './pages/logstash/advanced';
 // import { LogStashNodePipelinesPage } from './pages/logstash/node_pipelines';
 import { LogStashNodePage } from './pages/logstash/node';
+import { LogStashNodesPage } from './pages/logstash/nodes';
 import { LogStashNodePipelinesPage } from './pages/logstash/node_pipelines';
-import { AccessDeniedPage } from './pages/access_denied';
+import { LogStashOverviewPage } from './pages/logstash/overview';
+import { LogStashPipelinePage } from './pages/logstash/pipeline';
+import { LogStashPipelinesPage } from './pages/logstash/pipelines';
+import { NoDataPage } from './pages/no_data';
+import { createPreserveQueryHistory } from './preserve_query_history';
+import { RouteInit } from './route_init';
 
 export const renderApp = (
   core: CoreStart,
@@ -98,251 +100,259 @@ const MonitoringApp: React.FC<{
 }> = ({ core, plugins, externalConfig, setHeaderActionMenu, theme$ }) => {
   const history = createPreserveQueryHistory();
 
+  const darkModeObservable: Observable<boolean> = useMemo(
+    () => core.uiSettings!.get$('theme:darkMode'),
+    [core.uiSettings]
+  );
+  const darkMode = useObservable(darkModeObservable, core.uiSettings!.get('theme:darkMode'));
+
   return (
     <KibanaContextProvider services={{ ...core, ...plugins }}>
-      <KibanaThemeProvider theme$={core.theme.theme$}>
-        <ExternalConfigContext.Provider value={externalConfig}>
-          <GlobalStateProvider
-            query={plugins.data.query}
-            toasts={core.notifications.toasts}
-            uiSettings={core.uiSettings}
-          >
-            <HeaderActionMenuContext.Provider value={{ setHeaderActionMenu, theme$ }}>
-              <MonitoringTimeContainer>
-                <BreadcrumbContainer history={history}>
-                  <Router history={history}>
-                    <Switch>
-                      <Route path="/access-denied" component={AccessDeniedPage} />
-                      <Route path="/no-data" component={NoDataPage} />
-                      <Route path="/loading" component={LoadingPage} />
-                      <RouteInit
-                        path="/license"
-                        component={LicensePage}
-                        codePaths={['all']}
-                        fetchAllClusters={false}
-                      />
-                      <RouteInit
-                        path="/home"
-                        component={ClusterListing}
-                        codePaths={['all']}
-                        fetchAllClusters={true}
-                        unsetGlobalState={true}
-                      />
-                      <RouteInit
-                        path="/overview"
-                        component={ClusterOverview}
-                        codePaths={['all']}
-                        fetchAllClusters={false}
-                      />
+      <EuiThemeProvider darkMode={darkMode}>
+        <KibanaThemeProvider theme$={core.theme.theme$}>
+          <ExternalConfigContext.Provider value={externalConfig}>
+            <GlobalStateProvider
+              query={plugins.data.query}
+              toasts={core.notifications.toasts}
+              uiSettings={core.uiSettings}
+            >
+              <HeaderActionMenuContext.Provider value={{ setHeaderActionMenu, theme$ }}>
+                <MonitoringTimeContainer>
+                  <BreadcrumbContainer history={history}>
+                    <Router history={history}>
+                      <Switch>
+                        <Route path="/access-denied" component={AccessDeniedPage} />
+                        <Route path="/no-data" component={NoDataPage} />
+                        <Route path="/loading" component={LoadingPage} />
+                        <RouteInit
+                          path="/license"
+                          component={LicensePage}
+                          codePaths={['all']}
+                          fetchAllClusters={false}
+                        />
+                        <RouteInit
+                          path="/home"
+                          component={ClusterListing}
+                          codePaths={['all']}
+                          fetchAllClusters={true}
+                          unsetGlobalState={true}
+                        />
+                        <RouteInit
+                          path="/overview"
+                          component={ClusterOverview}
+                          codePaths={['all']}
+                          fetchAllClusters={false}
+                        />
 
-                      {/* ElasticSearch Views */}
-                      <RouteInit
-                        path="/elasticsearch/ml_jobs"
-                        component={ElasticsearchMLJobsPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        {/* ElasticSearch Views */}
+                        <RouteInit
+                          path="/elasticsearch/ml_jobs"
+                          component={ElasticsearchMLJobsPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/ccr/:index/shard/:shardId"
-                        component={ElasticsearchCcrShardPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/ccr/:index/shard/:shardId"
+                          component={ElasticsearchCcrShardPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/ccr"
-                        component={ElasticsearchCcrPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/ccr"
+                          component={ElasticsearchCcrPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/indices/:index/advanced"
-                        component={ElasticsearchIndexAdvancedPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/indices/:index/advanced"
+                          component={ElasticsearchIndexAdvancedPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/indices/:index"
-                        component={ElasticsearchIndexPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/indices/:index"
+                          component={ElasticsearchIndexPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/indices"
-                        component={ElasticsearchIndicesPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/indices"
+                          component={ElasticsearchIndicesPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/nodes/:node/advanced"
-                        component={ElasticsearchNodeAdvancedPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/nodes/:node/advanced"
+                          component={ElasticsearchNodeAdvancedPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/nodes/:node"
-                        component={ElasticsearchNodePage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/nodes/:node"
+                          component={ElasticsearchNodePage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch/nodes"
-                        component={ElasticsearchNodesPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch/nodes"
+                          component={ElasticsearchNodesPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/elasticsearch"
-                        component={ElasticsearchOverviewPage}
-                        codePaths={[CODE_PATH_ELASTICSEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/elasticsearch"
+                          component={ElasticsearchOverviewPage}
+                          codePaths={[CODE_PATH_ELASTICSEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      {/* Kibana Views */}
-                      <RouteInit
-                        path="/kibana/instances/:instance"
-                        component={KibanaInstancePage}
-                        codePaths={[CODE_PATH_KIBANA]}
-                        fetchAllClusters={false}
-                      />
+                        {/* Kibana Views */}
+                        <RouteInit
+                          path="/kibana/instances/:instance"
+                          component={KibanaInstancePage}
+                          codePaths={[CODE_PATH_KIBANA]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/kibana/instances"
-                        component={KibanaInstancesPage}
-                        codePaths={[CODE_PATH_KIBANA]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/kibana/instances"
+                          component={KibanaInstancesPage}
+                          codePaths={[CODE_PATH_KIBANA]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/kibana"
-                        component={KibanaOverviewPage}
-                        codePaths={[CODE_PATH_KIBANA]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/kibana"
+                          component={KibanaOverviewPage}
+                          codePaths={[CODE_PATH_KIBANA]}
+                          fetchAllClusters={false}
+                        />
 
-                      {/* Beats Views */}
-                      <RouteInit
-                        path="/beats/beat/:instance"
-                        component={BeatsInstancePage}
-                        codePaths={[CODE_PATH_BEATS]}
-                        fetchAllClusters={false}
-                      />
+                        {/* Beats Views */}
+                        <RouteInit
+                          path="/beats/beat/:instance"
+                          component={BeatsInstancePage}
+                          codePaths={[CODE_PATH_BEATS]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/beats/beats"
-                        component={BeatsInstancesPage}
-                        codePaths={[CODE_PATH_BEATS]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/beats/beats"
+                          component={BeatsInstancesPage}
+                          codePaths={[CODE_PATH_BEATS]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/beats"
-                        component={BeatsOverviewPage}
-                        codePaths={[CODE_PATH_BEATS]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/beats"
+                          component={BeatsOverviewPage}
+                          codePaths={[CODE_PATH_BEATS]}
+                          fetchAllClusters={false}
+                        />
 
-                      {/* Logstash Routes */}
-                      <RouteInit
-                        path="/logstash/nodes"
-                        component={LogStashNodesPage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        {/* Logstash Routes */}
+                        <RouteInit
+                          path="/logstash/nodes"
+                          component={LogStashNodesPage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash/node/:uuid/advanced"
-                        component={LogStashNodeAdvancedPage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash/node/:uuid/advanced"
+                          component={LogStashNodeAdvancedPage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash/node/:uuid/pipelines"
-                        component={LogStashNodePipelinesPage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash/node/:uuid/pipelines"
+                          component={LogStashNodePipelinesPage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash/node/:uuid"
-                        component={LogStashNodePage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash/node/:uuid"
+                          component={LogStashNodePage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash/pipelines/:id/:hash?"
-                        component={LogStashPipelinePage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash/pipelines/:id/:hash?"
+                          component={LogStashPipelinePage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash/pipelines"
-                        component={LogStashPipelinesPage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash/pipelines"
+                          component={LogStashPipelinesPage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/logstash"
-                        component={LogStashOverviewPage}
-                        codePaths={[CODE_PATH_LOGSTASH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/logstash"
+                          component={LogStashOverviewPage}
+                          codePaths={[CODE_PATH_LOGSTASH]}
+                          fetchAllClusters={false}
+                        />
 
-                      {/* APM Views */}
-                      <RouteInit
-                        path="/apm/instances/:instance"
-                        component={ApmInstancePage}
-                        codePaths={[CODE_PATH_APM]}
-                        fetchAllClusters={false}
-                      />
+                        {/* APM Views */}
+                        <RouteInit
+                          path="/apm/instances/:instance"
+                          component={ApmInstancePage}
+                          codePaths={[CODE_PATH_APM]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/apm/instances"
-                        component={ApmInstancesPage}
-                        codePaths={[CODE_PATH_APM]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/apm/instances"
+                          component={ApmInstancesPage}
+                          codePaths={[CODE_PATH_APM]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/apm"
-                        component={ApmOverviewPage}
-                        codePaths={[CODE_PATH_APM]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/apm"
+                          component={ApmOverviewPage}
+                          codePaths={[CODE_PATH_APM]}
+                          fetchAllClusters={false}
+                        />
 
-                      <RouteInit
-                        path="/enterprise_search"
-                        component={EntSearchOverviewPage}
-                        codePaths={[CODE_PATH_ENTERPRISE_SEARCH]}
-                        fetchAllClusters={false}
-                      />
+                        <RouteInit
+                          path="/enterprise_search"
+                          component={EntSearchOverviewPage}
+                          codePaths={[CODE_PATH_ENTERPRISE_SEARCH]}
+                          fetchAllClusters={false}
+                        />
 
-                      <Redirect
-                        to={{
-                          pathname: '/loading',
-                          search: history.location.search,
-                        }}
-                      />
-                    </Switch>
-                  </Router>
-                </BreadcrumbContainer>
-              </MonitoringTimeContainer>
-            </HeaderActionMenuContext.Provider>
-          </GlobalStateProvider>
-        </ExternalConfigContext.Provider>
-      </KibanaThemeProvider>
+                        <Redirect
+                          to={{
+                            pathname: '/loading',
+                            search: history.location.search,
+                          }}
+                        />
+                      </Switch>
+                    </Router>
+                  </BreadcrumbContainer>
+                </MonitoringTimeContainer>
+              </HeaderActionMenuContext.Provider>
+            </GlobalStateProvider>
+          </ExternalConfigContext.Provider>
+        </KibanaThemeProvider>
+      </EuiThemeProvider>
     </KibanaContextProvider>
   );
 };


### PR DESCRIPTION
Fixes #140623

For some reason the Stack Monitoring UI wasn't wrapping the main app in the `EuiThemeProvider` causing the Edit Alert flyout to not have access to the theme properties.

### How to test
Get the changes: `git fetch git@github.com:miltonhultgren/kibana.git 140623-sm-alerts-eui:140623-sm-alerts-eui && git switch 140623-sm-alerts-eui`

1. Start ES and gather some SM data
2. Start Kibana and create an alert on Disk Usage, set it to warn at a very low limit like 10% 
3. In the overview, click the Alerts badge and follow the dialog to the Edit rule button and click it
4. In the Edit Rule flyout, find the "Filter" field and type anything into it
5. Observe that the UI does not crash

<!--ONMERGE {"backportTargets":["7.17","8.4"]} ONMERGE-->