### PR TITLE
[ci] Fix canvas runtime build

### DIFF
--- a/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
+++ b/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      core_app_image_assets: path.resolve(KIBANA_ROOT, 'src/core/public/core_app/images'),
+      core_app_image_assets: path.resolve(KIBANA_ROOT, 'src/core/public/styles/core_app/images'),
     },
     extensions: ['.js', '.json', '.ts', '.tsx', '.scss'],
     symlinks: false,
@@ -153,7 +153,7 @@ module.exports = {
               additionalData(content, loaderContext) {
                 return `@import ${stringifyRequest(
                   loaderContext,
-                  path.resolve(KIBANA_ROOT, 'src/core/public/core_app/styles/_globals_v8light.scss')
+                  path.resolve(KIBANA_ROOT, 'src/core/public/styles/core_app/_globals_v8light.scss')
                 )};\n${content}`;
               },
               implementation: require('node-sass'),


### PR DESCRIPTION
Fixes two paths for static assets in the canvas runtime webpack config.

https://buildkite.com/elastic/kibana-pull-request/builds/72222#01833c4c-cf5c-46f1-b9ca-c10d0e388b94/205-510