### PR TITLE
[TIP] Add indicator name to fields browser UI

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
@@ -6,22 +6,33 @@
  */
 
 import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { BrowserField } from '@kbn/triggers-actions-ui-plugin/public/application/sections/field_browser/types';
+import { FieldSpec } from '@kbn/data-views-plugin/common';
+import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 import { SecuritySolutionDataViewBase } from '../../../types';
 import { useSecurityContext } from '../../../hooks/use_security_context';
+
+/**
+ * Inline definition for a runtime field "threat.indicator.name" we are adding for indicators grid
+ */
+const indicatorNameField = {
+  aggregatable: true,
+  name: RawIndicatorFieldId.Name,
+  searchable: true,
+  type: 'string',
+  category: 'threat',
+  description: i18n.translate('xpack.threatIntelligence.indicatorNameFieldDescription', {
+    defaultMessage: 'Indicator display name generated in the runtime ',
+  }),
+  esTypes: ['keyword'],
+} as const;
 
 export const useSourcererDataView = () => {
   const { sourcererDataView } = useSecurityContext();
 
   const updatedPattern = useMemo(() => {
-    const displayNameField = {
-      aggregatable: true,
-      esTypes: ['keyword'],
-      name: 'threat.indicator.name',
-      searchable: true,
-      type: 'string',
-    };
-
-    const fields = [...sourcererDataView.indexPattern.fields, displayNameField];
+    const fields = [...sourcererDataView.indexPattern.fields, indicatorNameField];
 
     return {
       ...sourcererDataView.indexPattern,
@@ -31,12 +42,27 @@ export const useSourcererDataView = () => {
 
   const indexPatterns = useMemo(() => [updatedPattern], [updatedPattern]);
 
+  const browserFields = useMemo(() => {
+    const { threat = { fields: {} } } = sourcererDataView.browserFields;
+
+    return {
+      ...sourcererDataView.browserFields,
+      threat: {
+        fields: {
+          ...threat.fields,
+          [indicatorNameField.name]: indicatorNameField,
+        },
+      },
+    };
+  }, [sourcererDataView.browserFields]);
+
   return useMemo(
     () => ({
       ...sourcererDataView,
       indexPatterns,
       indexPattern: updatedPattern,
+      browserFields,
     }),
-    [indexPatterns, sourcererDataView, updatedPattern]
+    [browserFields, indexPatterns, sourcererDataView, updatedPattern]
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
@@ -7,8 +7,6 @@
 
 import { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import type { BrowserField } from '@kbn/triggers-actions-ui-plugin/public/application/sections/field_browser/types';
-import { FieldSpec } from '@kbn/data-views-plugin/common';
 import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 import { SecuritySolutionDataViewBase } from '../../../types';
 import { useSecurityContext } from '../../../hooks/use_security_context';


### PR DESCRIPTION
## Summary

During the demo, we discovered that the `threat.indicator.name` field is not present in the fields browser. This PR fixes it.

![Screenshot from 2022-09-14 16-20-36](https://user-images.githubusercontent.com/11671118/190182270-0ba940e5-6499-460d-808d-f9f0c7ebabb0.png)

