### PR TITLE
[Security Solution][Detections] Rule Preview: Refreshing does not work on override fields changes

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/use_preview_route.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/use_preview_route.tsx
@@ -59,8 +59,8 @@ export const usePreviewRoute = ({
   }, [setRule]);
 
   useEffect(() => {
-     clearPreview();
-   }, [clearPreview, defineRuleData, aboutRuleData, scheduleRuleData]);
+    clearPreview();
+  }, [clearPreview, defineRuleData, aboutRuleData, scheduleRuleData]);
 
   useEffect(() => {
     if (!defineRuleData || !aboutRuleData || !scheduleRuleData) {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/use_preview_route.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/use_preview_route.tsx
@@ -59,6 +59,10 @@ export const usePreviewRoute = ({
   }, [setRule]);
 
   useEffect(() => {
+     clearPreview();
+   }, [clearPreview, defineRuleData, aboutRuleData, scheduleRuleData]);
+
+  useEffect(() => {
     if (!defineRuleData || !aboutRuleData || !scheduleRuleData) {
       return;
     }


### PR DESCRIPTION
## Summary

Fixes the issue where the rule preview shows old results even though the override fields were updated.

The issue was found while testing [this PR](https://github.com/elastic/kibana/pull/140221#issuecomment-1245846537):
> One thing to add with the unmounting-remounting is that when you switch the rule type the "refresh" in the rule preview might lead a user to think the query has been rerun with the new rule type, but it actually hasn't. It might be worth just completely unmounting the component if the user changes the rule? Even though I start in ML in the video below, I was originally on a threshold rule. When I got to custom query nothing changes in the panel, but it does a little reload. When I hit refresh it still shows the threshold results. The results are only updated when I close and re-open the panel

I incorrectly removed state invalidation in one of the [review feedback commits](62eb95d8fe871b342d21dcbceda810de0c1c363c) from my [original PR](https://github.com/elastic/kibana/pull/140221).

Main ticket [#4680](https://github.com/elastic/security-team/issues/4680)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
