### PR TITLE
[pkgs/manifest] allow owner to be an array of users/teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,7 +136,6 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/test/functional/apps/apm/  @elastic/apm-ui
 /x-pack/test/apm_api_integration/ @elastic/apm-ui
 /src/apm.js @elastic/kibana-core @vigneshshanmugam
-/packages/kbn-apm-config-loader/ @vigneshshanmugam
 /src/core/types/elasticsearch @elastic/apm-ui
 /packages/kbn-utility-types/src/dot.ts @dgieselaar
 /packages/kbn-utility-types/src/dot_test.ts @dgieselaar
@@ -800,7 +799,7 @@ packages/kbn-alerts @elastic/security-solution
 packages/kbn-ambient-storybook-types @elastic/kibana-operations
 packages/kbn-ambient-ui-types @elastic/kibana-operations
 packages/kbn-analytics @elastic/kibana-core
-packages/kbn-apm-config-loader @elastic/kibana-core
+packages/kbn-apm-config-loader @elastic/kibana-core @vigneshshanmugam
 packages/kbn-apm-synthtrace @elastic/apm-ui
 packages/kbn-apm-utils @elastic/apm-ui
 packages/kbn-axe-config @elastic/kibana-qa

--- a/packages/kbn-apm-config-loader/kibana.jsonc
+++ b/packages/kbn-apm-config-loader/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/apm-config-loader",
-  "owner": "@elastic/kibana-core",
+  "owner": ["@elastic/kibana-core", "@vigneshshanmugam"],
   "runtimeDeps": [],
   "typeDeps": []
 }

--- a/packages/kbn-bazel-packages/src/bazel_package.test.ts
+++ b/packages/kbn-bazel-packages/src/bazel_package.test.ts
@@ -20,7 +20,7 @@ const pkgJson: ParsedPackageJson = {
 const manifest: KibanaPackageManifest = {
   type: 'shared-common',
   id: '@kbn/foo',
-  owner: '@elastic/kibana-operations',
+  owner: ['@elastic/kibana-operations'],
   runtimeDeps: [],
   typeDeps: [],
 };

--- a/packages/kbn-bazel-packages/src/parse_package_manifest.js
+++ b/packages/kbn-bazel-packages/src/parse_package_manifest.js
@@ -31,6 +31,12 @@ const err = (key, value, msg) => {
 };
 
 /**
+ * @param {unknown} v
+ * @returns {v is string}
+ */
+const isValidOwner = (v) => typeof v === 'string' && v.startsWith('@');
+
+/**
  * @param {unknown} plugin
  * @returns {import('./types').PluginPackageManifest['plugin']}
  */
@@ -132,8 +138,15 @@ function validatePackageManifest(parsed) {
     throw err(`id`, id, `must be a string that starts with @kbn/`);
   }
 
-  if (typeof owner !== 'string' || !owner.startsWith('@')) {
-    throw err(`owner`, owner, `must be a valid Github team handle starting with @`);
+  if (
+    !(Array.isArray(owner) && owner.every(isValidOwner)) &&
+    !(typeof owner === 'string' && isValidOwner(owner))
+  ) {
+    throw err(
+      `owner`,
+      owner,
+      `must be a valid Github team handle starting with @, or an array of such handles`
+    );
   }
 
   if (!isArrOfStrings(typeDeps)) {
@@ -150,7 +163,7 @@ function validatePackageManifest(parsed) {
 
   const base = {
     id,
-    owner,
+    owner: Array.isArray(owner) ? owner : [owner],
     typeDeps,
     runtimeDeps,
     devOnly,

--- a/packages/kbn-bazel-packages/src/types.ts
+++ b/packages/kbn-bazel-packages/src/types.ts
@@ -54,12 +54,10 @@ interface PackageManifestBaseFields {
    */
   id: string;
   /**
-   * Github handle for the person or team who is responsible for this package.
-   * This owner will be used in the codeowners files for this package.
-   *
-   * For additional codeowners, you add manually add entries to the codeowners file.
+   * Github handles for the people or teams responsible for this package.
+   * These values will be used in the codeowners files for this package.
    */
-  owner: string;
+  owner: string[];
   /**
    * Packages which are required for the source code in the package to be type-
    * checked. This list is updated automatically by the package linter

--- a/packages/kbn-generate/src/commands/codeowners_command.ts
+++ b/packages/kbn-generate/src/commands/codeowners_command.ts
@@ -42,7 +42,7 @@ export const CodeownersCommand: GenerateCommand = {
     }
 
     const newCodeowners = `${codeowners.slice(0, genStart)}${GENERATED_START}${pkgs
-      .map((pkg) => `${pkg.normalizedRepoRelativeDir} ${pkg.manifest.owner}`)
+      .map((pkg) => `${pkg.normalizedRepoRelativeDir} ${pkg.manifest.owner.join(' ')}`)
       .join('\n')}\n`;
 
     if (codeowners === newCodeowners) {

--- a/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
+++ b/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
@@ -27,14 +27,25 @@ export const MANIFEST_V2: JSONSchema = {
       `,
     },
     owner: {
-      type: 'string',
+      oneOf: [
+        {
+          type: 'string',
+          pattern: '^@',
+        },
+        {
+          type: 'array',
+          items: {
+            type: 'string',
+            pattern: '^@',
+          },
+        },
+      ],
       description: desc`
         Github handle for the person or team who is responsible for this package.
         This owner will be used in the codeowners files for this package.
 
-        For additional codeowners, you add manually add entries to the codeowners file.
+        For additional codeowners, the value can be an array of user/team names.
       `,
-      pattern: '^@',
     },
     typeDeps: {
       type: 'array',


### PR DESCRIPTION
As pointed out by @pgayvallet in https://github.com/elastic/kibana/pull/140522#discussion_r970382038, codeowners entries are not additive, the last value wins, which means we need to support package owners as an array of values.