### PR TITLE
[Security Solution][Endpoint] Fixes wrong `0` char at the end of integration name when no errors

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integrations.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integrations.tsx
@@ -136,7 +136,7 @@ export const AgentDetailsIntegration: React.FunctionComponent<{
     return packageErrorUnits;
   }, [agent.components, packagePolicy]);
 
-  const showNeedsAttentionBadge = isAttentionBadgeNeededForPolicyResponse || packageErrors.length;
+  const showNeedsAttentionBadge = isAttentionBadgeNeededForPolicyResponse || !!packageErrors.length;
 
   const genericErrorsListExtensionViewWrapper = useMemo(() => {
     return (


### PR DESCRIPTION
## Summary

Converts array.length result into a boolean.


Before:
<img width="709" alt="Screenshot 2022-09-14 at 17 26 41" src="https://user-images.githubusercontent.com/15727784/190197169-9cead56f-1f2c-4087-998b-88c9aa6bd069.png">


After:

<img width="709" alt="Screenshot 2022-09-14 at 17 26 11" src="https://user-images.githubusercontent.com/15727784/190197059-2a388c0d-3f23-4038-9d78-fcd716cd2bdb.png">

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
