### PR TITLE
[Files] Refactor how types are shared between server and client

### DIFF
--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -98,7 +98,7 @@ export type UpdateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
 
 export type UploadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { id: string },
-  unknown,
+  { selfDestructOnAbort?: boolean },
   { body: unknown },
   {
     ok: true;

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -69,14 +69,7 @@ export type { Endpoint as DeleteFileKindHttpEndpoint } from '../server/routes/fi
 export type { Endpoint as DownloadFileKindHttpEndpoint } from '../server/routes/file_kind/download';
 export type { Endpoint as GetByIdFileKindHttpEndpoint } from '../server/routes/file_kind/get_by_id';
 export type { Endpoint as ListFileKindHttpEndpoint } from '../server/routes/file_kind/list';
-
-export type UpdateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  { id: string },
-  unknown,
-  { name?: string; alt?: string; meta?: Record<string, unknown> },
-  { file: FileJSON }
->;
-
+export type { Endpoint as UpdateFileKindHttpEndpoint } from '../server/routes/file_kind/update';
 export type { Endpoint as UploadFileKindHttpEndpoint } from '../server/routes/file_kind/upload';
 
 export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -106,21 +106,7 @@ export type FilesMetricsHttpEndpoint = HttpApiInterfaceEntryDefinition<
 >;
 
 export type { Endpoint as FileShareHttpEndpoint } from '../server/routes/file_kind/share/share';
-
-export type FileUnshareHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    /**
-     * Share token id
-     */
-    id: string;
-  },
-  unknown,
-  unknown,
-  {
-    ok: true;
-  }
->;
-
+export type { Endpoint as FileUnshareHttpEndpoint } from '../server/routes/file_kind/share/unshare';
 export type { Endpoint as FileGetShareHttpEndpoint } from '../server/routes/file_kind/share/get';
 export type { Endpoint as FileListSharesHttpEndpoint } from '../server/routes/file_kind/share/list';
 export type { Endpoint as FilePublicDownloadHttpEndpoint } from '../server/routes/public_facing/download';

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -144,14 +144,5 @@ export type FileUnshareHttpEndpoint = HttpApiInterfaceEntryDefinition<
 >;
 
 export type { Endpoint as FileGetShareHttpEndpoint } from '../server/routes/file_kind/share/get';
-
-export type FileListSharesHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
-  Pagination & { forFileId?: string },
-  unknown,
-  {
-    shares: FileShareJSON[];
-  }
->;
-
+export type { Endpoint as FileListSharesHttpEndpoint } from '../server/routes/file_kind/share/list';
 export type { Endpoint as FilePublicDownloadHttpEndpoint } from '../server/routes/public_facing/download';

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -7,7 +7,7 @@
 
 import type { TypeOf, Type } from '@kbn/config-schema';
 import { PLUGIN_ID } from './constants';
-import type { FileJSON, Pagination, FilesMetrics, FileShareJSONWithToken } from './types';
+import type { FileJSON, Pagination, FilesMetrics } from './types';
 
 export const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
@@ -105,23 +105,7 @@ export type FilesMetricsHttpEndpoint = HttpApiInterfaceEntryDefinition<
   FilesMetrics
 >;
 
-export type FileShareHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    fileId: string;
-  },
-  unknown,
-  {
-    /**
-     * Unix timestamp of when the share will expire.
-     */
-    validUntil?: number;
-    /**
-     * Optional name to uniquely identify this share instance.
-     */
-    name?: string;
-  },
-  FileShareJSONWithToken
->;
+export type { Endpoint as FileShareHttpEndpoint } from '../server/routes/file_kind/share/share';
 
 export type FileUnshareHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -28,16 +28,16 @@ export interface EndpointInputs<
   Q extends Type<unknown> = Type<unknown>,
   B extends Type<unknown> = Type<unknown>
 > {
-  params: P;
-  query: Q;
-  body: B;
+  params?: P;
+  query?: Q;
+  body?: B;
 }
 
 export interface CreateRouteDefinition<Inputs extends EndpointInputs, R> {
   inputs: {
-    params: TypeOf<Inputs['params']>;
-    query: TypeOf<Inputs['query']>;
-    body: TypeOf<Inputs['body']>;
+    params: TypeOf<NonNullable<Inputs['params']>>;
+    query: TypeOf<NonNullable<Inputs['query']>>;
+    body: TypeOf<NonNullable<Inputs['body']>>;
   };
   output: R;
 }
@@ -64,17 +64,7 @@ export interface HttpApiInterfaceEntryDefinition<
   output: R;
 }
 
-export type CreateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
-  unknown,
-  {
-    name: string;
-    alt?: string;
-    meta?: Record<string, unknown>;
-    mimeType?: string;
-  },
-  { file: FileJSON }
->;
+export type { Endpoint as CreateFileKindHttpEndpoint } from '../server/routes/file_kind/create';
 
 export type DeleteFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -66,16 +66,7 @@ export interface HttpApiInterfaceEntryDefinition<
 
 export type { Endpoint as CreateFileKindHttpEndpoint } from '../server/routes/file_kind/create';
 export type { Endpoint as DeleteFileKindHttpEndpoint } from '../server/routes/file_kind/delete';
-
-export type DownloadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    id: string;
-    fileName?: string;
-  },
-  unknown,
-  unknown,
-  any
->;
+export type { Endpoint as DownloadFileKindHttpEndpoint } from '../server/routes/file_kind/download';
 
 export type GetByIdFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -7,7 +7,7 @@
 
 import type { TypeOf, Type } from '@kbn/config-schema';
 import { PLUGIN_ID } from './constants';
-import type { FileJSON, Pagination, FilesMetrics } from './types';
+import type { FilesMetrics } from './types';
 
 export const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
@@ -65,38 +65,7 @@ export type { Endpoint as GetByIdFileKindHttpEndpoint } from '../server/routes/f
 export type { Endpoint as ListFileKindHttpEndpoint } from '../server/routes/file_kind/list';
 export type { Endpoint as UpdateFileKindHttpEndpoint } from '../server/routes/file_kind/update';
 export type { Endpoint as UploadFileKindHttpEndpoint } from '../server/routes/file_kind/upload';
-
-export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
-  Pagination,
-  {
-    /**
-     * Filter for set of file-kinds
-     */
-    kind?: string[];
-
-    /**
-     * Filter for match on names
-     */
-    name?: string[];
-
-    /**
-     * Filter for set of meta attributes matching this object
-     */
-    meta?: {};
-
-    /**
-     * Filter for match on extensions
-     */
-    extension?: string[];
-
-    /**
-     * Filter for match on extensions
-     */
-    status?: string[];
-  },
-  { files: FileJSON[] }
->;
+export type { Endpoint as FindFilesHttpEndpoint } from '../server/routes/find';
 
 export type FilesMetricsHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -65,15 +65,7 @@ export interface HttpApiInterfaceEntryDefinition<
 }
 
 export type { Endpoint as CreateFileKindHttpEndpoint } from '../server/routes/file_kind/create';
-
-export type DeleteFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    id: string;
-  },
-  unknown,
-  unknown,
-  { ok: true }
->;
+export type { Endpoint as DeleteFileKindHttpEndpoint } from '../server/routes/file_kind/delete';
 
 export type DownloadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   {

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -7,13 +7,7 @@
 
 import type { TypeOf, Type } from '@kbn/config-schema';
 import { PLUGIN_ID } from './constants';
-import type {
-  FileJSON,
-  Pagination,
-  FilesMetrics,
-  FileShareJSON,
-  FileShareJSONWithToken,
-} from './types';
+import type { FileJSON, Pagination, FilesMetrics, FileShareJSONWithToken } from './types';
 
 export const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -143,19 +143,7 @@ export type FileUnshareHttpEndpoint = HttpApiInterfaceEntryDefinition<
   }
 >;
 
-export type FileGetShareHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    /**
-     * ID of the share object
-     */
-    id: string;
-  },
-  unknown,
-  unknown,
-  {
-    share: FileShareJSON;
-  }
->;
+export type { Endpoint as FileGetShareHttpEndpoint } from '../server/routes/file_kind/share/get';
 
 export type FileListSharesHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -166,10 +166,4 @@ export type FileListSharesHttpEndpoint = HttpApiInterfaceEntryDefinition<
   }
 >;
 
-export type FilePublicDownloadHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  { fileName?: string },
-  { token: string },
-  unknown,
-  // Should be a readable stream
-  any
->;
+export type { Endpoint as FilePublicDownloadHttpEndpoint } from '../server/routes/public_facing/download';

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -67,15 +67,7 @@ export interface HttpApiInterfaceEntryDefinition<
 export type { Endpoint as CreateFileKindHttpEndpoint } from '../server/routes/file_kind/create';
 export type { Endpoint as DeleteFileKindHttpEndpoint } from '../server/routes/file_kind/delete';
 export type { Endpoint as DownloadFileKindHttpEndpoint } from '../server/routes/file_kind/download';
-
-export type GetByIdFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  {
-    id: string;
-  },
-  unknown,
-  unknown,
-  { file: FileJSON }
->;
+export type { Endpoint as GetByIdFileKindHttpEndpoint } from '../server/routes/file_kind/get_by_id';
 
 export type ListFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { TypeOf, Type } from '@kbn/config-schema';
 import { PLUGIN_ID } from './constants';
 import type {
   FileJSON,
@@ -21,6 +22,27 @@ export const FILES_API_BASE_PATH = `${API_BASE_PATH}/files`;
 export const FILES_SHARE_API_BASE_PATH = `${API_BASE_PATH}/shares`;
 
 export const FILES_PUBLIC_API_BASE_PATH = `${API_BASE_PATH}/public`;
+
+export interface EndpointInputs<
+  P extends Type<unknown> = Type<unknown>,
+  Q extends Type<unknown> = Type<unknown>,
+  B extends Type<unknown> = Type<unknown>
+> {
+  params: P;
+  query: Q;
+  body: B;
+}
+
+export interface CreateRouteDefinition<Inputs extends EndpointInputs, R> {
+  inputs: {
+    params: TypeOf<Inputs['params']>;
+    query: TypeOf<Inputs['query']>;
+    body: TypeOf<Inputs['body']>;
+  };
+  output: R;
+}
+
+export type AnyEndpoint = CreateRouteDefinition<EndpointInputs, unknown>;
 
 /**
  * Abstract type definition for API route inputs and outputs.
@@ -96,15 +118,7 @@ export type UpdateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { file: FileJSON }
 >;
 
-export type UploadFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  { id: string },
-  { selfDestructOnAbort?: boolean },
-  { body: unknown },
-  {
-    ok: true;
-    size: number;
-  }
->;
+export type { Endpoint as UploadFileKindHttpEndpoint } from '../server/routes/file_kind/upload';
 
 export type FindFilesHttpEndpoint = HttpApiInterfaceEntryDefinition<
   unknown,

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -7,7 +7,6 @@
 
 import type { TypeOf, Type } from '@kbn/config-schema';
 import { PLUGIN_ID } from './constants';
-import type { FilesMetrics } from './types';
 
 export const API_BASE_PATH = `/api/${PLUGIN_ID}`;
 
@@ -66,14 +65,7 @@ export type { Endpoint as ListFileKindHttpEndpoint } from '../server/routes/file
 export type { Endpoint as UpdateFileKindHttpEndpoint } from '../server/routes/file_kind/update';
 export type { Endpoint as UploadFileKindHttpEndpoint } from '../server/routes/file_kind/upload';
 export type { Endpoint as FindFilesHttpEndpoint } from '../server/routes/find';
-
-export type FilesMetricsHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
-  unknown,
-  unknown,
-  FilesMetrics
->;
-
+export type { Endpoint as FilesMetricsHttpEndpoint } from '../server/routes/metrics';
 export type { Endpoint as FileShareHttpEndpoint } from '../server/routes/file_kind/share/share';
 export type { Endpoint as FileUnshareHttpEndpoint } from '../server/routes/file_kind/share/unshare';
 export type { Endpoint as FileGetShareHttpEndpoint } from '../server/routes/file_kind/share/get';

--- a/x-pack/plugins/files/common/api_routes.ts
+++ b/x-pack/plugins/files/common/api_routes.ts
@@ -68,13 +68,7 @@ export type { Endpoint as CreateFileKindHttpEndpoint } from '../server/routes/fi
 export type { Endpoint as DeleteFileKindHttpEndpoint } from '../server/routes/file_kind/delete';
 export type { Endpoint as DownloadFileKindHttpEndpoint } from '../server/routes/file_kind/download';
 export type { Endpoint as GetByIdFileKindHttpEndpoint } from '../server/routes/file_kind/get_by_id';
-
-export type ListFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
-  unknown,
-  Pagination,
-  unknown,
-  { files: FileJSON[] }
->;
+export type { Endpoint as ListFileKindHttpEndpoint } from '../server/routes/file_kind/list';
 
 export type UpdateFileKindHttpEndpoint = HttpApiInterfaceEntryDefinition<
   { id: string },

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -96,7 +96,16 @@ export interface FilesClient extends GlobalEndpoints {
    *
    * @param args - upload file args
    */
-  upload: ClientMethodFrom<UploadFileKindHttpEndpoint>;
+  upload: (
+    args: UploadFileKindHttpEndpoint['inputs']['params'] &
+      UploadFileKindHttpEndpoint['inputs']['query'] & {
+        /**
+         * Should be blob or ReadableStream of some kind.
+         */
+        body: unknown;
+        kind: string;
+      }
+  ) => Promise<UploadFileKindHttpEndpoint['output']>;
   /**
    * Stream a download of the file object's content.
    *

--- a/x-pack/plugins/files/server/mocks.ts
+++ b/x-pack/plugins/files/server/mocks.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { KibanaRequest } from '@kbn/core/server';
+import { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+import { FileServiceFactory, FileServiceStart } from '.';
+
+export const createFileServiceMock = (): DeeplyMockedKeys<FileServiceStart> => ({
+  create: jest.fn(),
+  delete: jest.fn(),
+  deleteShareObject: jest.fn(),
+  find: jest.fn(),
+  getById: jest.fn(),
+  getByToken: jest.fn(),
+  getShareObject: jest.fn(),
+  getUsageMetrics: jest.fn(),
+  list: jest.fn(),
+  listShareObjects: jest.fn(),
+  update: jest.fn(),
+  updateShareObject: jest.fn(),
+});
+
+export const createFileServiceFactoryMock = (): DeeplyMockedKeys<FileServiceFactory> => ({
+  asInternal: jest.fn(createFileServiceMock),
+  asScoped: jest.fn((_: KibanaRequest) => createFileServiceMock()),
+});

--- a/x-pack/plugins/files/server/routes/file_kind/create.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/create.ts
@@ -5,32 +5,27 @@
  * 2.0.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
-import { Ensure } from '@kbn/utility-types';
-import type { CreateFileKindHttpEndpoint } from '../../../common/api_routes';
-import type { FileKind } from '../../../common/types';
-import { FILES_API_ROUTES } from '../api_routes';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
+import { schema } from '@kbn/config-schema';
+import type { FileJSON, FileKind } from '../../../common/types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
+import type { FileKindRouter } from './types';
 import * as commonSchemas from '../common_schemas';
+import { CreateHandler } from './types';
 
 export const method = 'post' as const;
 
-export const bodySchema = schema.object({
-  name: commonSchemas.fileName,
-  alt: commonSchemas.fileAlt,
-  meta: commonSchemas.fileMeta,
-  mimeType: schema.maybe(schema.string()),
-});
+const rt = {
+  body: schema.object({
+    name: commonSchemas.fileName,
+    alt: commonSchemas.fileAlt,
+    meta: commonSchemas.fileMeta,
+    mimeType: schema.maybe(schema.string()),
+  }),
+};
 
-type Body = Ensure<CreateFileKindHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { file: FileJSON }>;
 
-type Response = CreateFileKindHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
-  { fileKind, files },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ fileKind, files }, req, res) => {
   const { fileService } = await files;
   const {
     body: { name, alt, meta, mimeType },
@@ -38,7 +33,7 @@ export const handler: FileKindsRequestHandler<unknown, unknown, Body> = async (
   const file = await fileService
     .asCurrentUser()
     .create({ fileKind, name, alt, meta, mime: mimeType });
-  const body: Response = {
+  const body: Endpoint['output'] = {
     file: file.toJSON(),
   };
   return res.ok({ body });
@@ -50,7 +45,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
       {
         path: FILES_API_ROUTES.fileKind.getCreateFileRoute(fileKind.id),
         validate: {
-          body: bodySchema,
+          ...rt,
         },
         options: {
           tags: fileKind.http.create.tags,

--- a/x-pack/plugins/files/server/routes/file_kind/delete.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/delete.ts
@@ -5,27 +5,25 @@
  * 2.0.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
-import type { DeleteFileKindHttpEndpoint } from '../../../common/api_routes';
+import { schema } from '@kbn/config-schema';
 import type { FileKind } from '../../../common/types';
 import { fileErrors } from '../../file';
-import { FILES_API_ROUTES } from '../api_routes';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
+import type { CreateHandler, FileKindRouter } from './types';
 
 import { getById } from './helpers';
 
 export const method = 'delete' as const;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-});
+const rt = {
+  params: schema.object({
+    id: schema.string(),
+  }),
+};
 
-type Params = Ensure<DeleteFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { ok: true }>;
 
-type Response = DeleteFileKindHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const {
     params: { id },
   } = req;
@@ -43,7 +41,7 @@ export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind
     }
     throw e;
   }
-  const body: Response = {
+  const body: Endpoint['output'] = {
     ok: true,
   };
   return res.ok({ body });
@@ -54,9 +52,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getDeleteRoute(fileKind.id),
-        validate: {
-          params: paramsSchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.delete.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/download.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/download.ts
@@ -5,35 +5,31 @@
  * 2.0.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
-import { Ensure } from '@kbn/utility-types';
+import { schema } from '@kbn/config-schema';
 import { Readable } from 'stream';
 
-import type { DownloadFileKindHttpEndpoint } from '../../../common/api_routes';
 import type { FileKind } from '../../../common/types';
 import { fileNameWithExt } from '../common_schemas';
 import { fileErrors } from '../../file';
 import { getDownloadHeadersForFile } from '../common';
 import { getById } from './helpers';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
-import { FILES_API_ROUTES } from '../api_routes';
+import type { CreateHandler, FileKindRouter } from './types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
 
 export const method = 'get' as const;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-  fileName: schema.maybe(fileNameWithExt),
-});
+const rt = {
+  params: schema.object({
+    id: schema.string(),
+    fileName: schema.maybe(fileNameWithExt),
+  }),
+};
 
-type Params = Ensure<DownloadFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, any>;
 
 type Response = Readable;
 
-export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
-  { files, fileKind },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;
   const {
     params: { id, fileName },
@@ -59,9 +55,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getDownloadRoute(fileKind.id),
-        validate: {
-          params: paramsSchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.download.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/get_by_id.ts
@@ -5,31 +5,30 @@
  * 2.0.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
-import type { GetByIdFileKindHttpEndpoint } from '../../../common/api_routes';
-import type { FileKind } from '../../../common/types';
-import { FILES_API_ROUTES } from '../api_routes';
+import { schema } from '@kbn/config-schema';
+import type { FileJSON, FileKind } from '../../../common/types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
 import { getById } from './helpers';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
-
-type Response = GetByIdFileKindHttpEndpoint['output'];
+import type { CreateHandler, FileKindRouter } from './types';
 
 export const method = 'get' as const;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-});
-type Params = Ensure<GetByIdFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+const rt = {
+  params: schema.object({
+    id: schema.string(),
+  }),
+};
 
-export const handler: FileKindsRequestHandler<Params> = async ({ files, fileKind }, req, res) => {
+export type Endpoint = CreateRouteDefinition<typeof rt, { file: FileJSON }>;
+
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;
   const {
     params: { id },
   } = req;
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);
   if (error) return error;
-  const body: Response = {
+  const body: Endpoint['output'] = {
     file: file.toJSON(),
   };
   return res.ok({ body });
@@ -40,9 +39,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getByIdRoute(fileKind.id),
-        validate: {
-          params: paramsSchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.getById.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/index.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/index.ts
@@ -9,6 +9,7 @@ import { FileKind } from '../../../common/types';
 import { FilesRouter } from '../types';
 
 import { enhanceRouter } from './enhance_router';
+
 import * as create from './create';
 import * as upload from './upload';
 import * as update from './update';

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -4,35 +4,29 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
-import type { ListFileKindHttpEndpoint } from '../../../common/api_routes';
-import type { FileKind } from '../../../common/types';
-import { FILES_API_ROUTES } from '../api_routes';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
+import { schema } from '@kbn/config-schema';
+import type { FileJSON, FileKind } from '../../../common/types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
+import type { CreateHandler, FileKindRouter } from './types';
 
 export const method = 'get' as const;
 
-export const querySchema = schema.object({
-  page: schema.maybe(schema.number({ defaultValue: 1 })),
-  perPage: schema.maybe(schema.number({ defaultValue: 100 })),
-});
+const rt = {
+  query: schema.object({
+    page: schema.maybe(schema.number({ defaultValue: 1 })),
+    perPage: schema.maybe(schema.number({ defaultValue: 100 })),
+  }),
+};
 
-type Query = Ensure<ListFileKindHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { files: FileJSON[] }>;
 
-type Response = ListFileKindHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<unknown, Query> = async (
-  { files, fileKind },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const {
     query: { page, perPage },
   } = req;
   const { fileService } = await files;
   const response = await fileService.asCurrentUser().list({ fileKind, page, perPage });
-  const body: Response = {
+  const body: Endpoint['output'] = {
     files: response.map((result) => result.toJSON()),
   };
   return res.ok({ body });
@@ -43,9 +37,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getListRoute(fileKind.id),
-        validate: {
-          query: querySchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.list.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/share/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/share/list.ts
@@ -4,30 +4,25 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
+import { schema } from '@kbn/config-schema';
 
-import { FileListSharesHttpEndpoint, FILES_API_ROUTES } from '../../api_routes';
-import type { FileKind } from '../../../../common/types';
-import { FileKindRouter, FileKindsRequestHandler } from '../types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../../api_routes';
+import type { FileKind, FileShareJSON } from '../../../../common/types';
+import { CreateHandler, FileKindRouter } from '../types';
 
 export const method = 'get' as const;
 
-export const querySchema = schema.object({
-  page: schema.maybe(schema.number()),
-  perPage: schema.maybe(schema.number()),
-  forFileId: schema.maybe(schema.string()),
-});
+const rt = {
+  query: schema.object({
+    page: schema.maybe(schema.number()),
+    perPage: schema.maybe(schema.number()),
+    forFileId: schema.maybe(schema.string()),
+  }),
+};
 
-type Query = Ensure<FileListSharesHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { shares: FileShareJSON[] }>;
 
-type Response = FileListSharesHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<unknown, Query, unknown> = async (
-  { files },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files }, req, res) => {
   const { fileService } = await files;
   const {
     query: { forFileId, page, perPage },
@@ -37,7 +32,7 @@ export const handler: FileKindsRequestHandler<unknown, Query, unknown> = async (
     .asCurrentUser()
     .listShareObjects({ fileId: forFileId, page, perPage });
 
-  const body: Response = result;
+  const body: Endpoint['output'] = result;
   return res.ok({
     body,
   });
@@ -48,9 +43,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getListShareRoute(fileKind.id),
-        validate: {
-          query: querySchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.share.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/share/unshare.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/share/unshare.ts
@@ -4,29 +4,24 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
+import { schema } from '@kbn/config-schema';
 
-import { FILES_API_ROUTES, FileUnshareHttpEndpoint } from '../../api_routes';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../../api_routes';
 import type { FileKind } from '../../../../common/types';
-import { FileKindRouter, FileKindsRequestHandler } from '../types';
+import { CreateHandler, FileKindRouter } from '../types';
 import { FileShareNotFoundError } from '../../../file_share_service/errors';
 
 export const method = 'delete' as const;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-});
+const rt = {
+  params: schema.object({
+    id: schema.string(),
+  }),
+};
 
-type Params = Ensure<FileUnshareHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { ok: true }>;
 
-type Response = FileUnshareHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
-  { files },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files }, req, res) => {
   const { fileService } = await files;
   const {
     params: { id },
@@ -41,7 +36,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
     throw e;
   }
 
-  const body: Response = {
+  const body: Endpoint['output'] = {
     ok: true,
   };
   return res.ok({
@@ -54,9 +49,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getUnshareRoute(fileKind.id),
-        validate: {
-          params: paramsSchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.share.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/types.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IRouter, RequestHandler } from '@kbn/core/server';
+import { AnyEndpoint } from '../api_routes';
 import type { FilesRequestHandlerContext } from '../types';
 
 export type FileKindRouter = IRouter<FileKindsRequestHandlerContext>;
@@ -19,4 +20,10 @@ export type FileKindsRequestHandler<P = unknown, Q = unknown, B = unknown> = Req
   Q,
   B,
   FileKindsRequestHandlerContext
+>;
+
+export type CreateHandler<E extends AnyEndpoint> = FileKindsRequestHandler<
+  E['inputs']['params'],
+  E['inputs']['query'],
+  E['inputs']['body']
 >;

--- a/x-pack/plugins/files/server/routes/file_kind/update.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/update.ts
@@ -5,39 +5,30 @@
  * 2.0.
  */
 
-import type { Ensure } from '@kbn/utility-types';
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { FileKind } from '../../../common/types';
-import type { UpdateFileKindHttpEndpoint } from '../../../common/api_routes';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
-import { FILES_API_ROUTES } from '../api_routes';
+import { schema } from '@kbn/config-schema';
+import type { FileJSON, FileKind } from '../../../common/types';
+import type { CreateHandler, FileKindRouter } from './types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
 import { getById } from './helpers';
 
 import * as commonSchemas from '../common_schemas';
 
 export const method = 'patch' as const;
 
-export const bodySchema = schema.object({
-  name: schema.maybe(commonSchemas.fileName),
-  alt: schema.maybe(commonSchemas.fileAlt),
-  meta: schema.maybe(commonSchemas.fileMeta),
-});
+const rt = {
+  body: schema.object({
+    name: schema.maybe(commonSchemas.fileName),
+    alt: schema.maybe(commonSchemas.fileAlt),
+    meta: schema.maybe(commonSchemas.fileMeta),
+  }),
+  params: schema.object({
+    id: schema.string(),
+  }),
+};
 
-type Body = Ensure<UpdateFileKindHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
+export type Endpoint = CreateRouteDefinition<typeof rt, { file: FileJSON }>;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-});
-
-type Params = Ensure<UpdateFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
-
-type Response = UpdateFileKindHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
-  { files, fileKind },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const { fileService } = await files;
   const {
     params: { id },
@@ -46,7 +37,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   const { error, result: file } = await getById(fileService.asCurrentUser(), id, fileKind);
   if (error) return error;
   await file.update(attrs);
-  const body: Response = {
+  const body: Endpoint['output'] = {
     file: file.toJSON(),
   };
   return res.ok({ body });
@@ -57,10 +48,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
     fileKindRouter[method](
       {
         path: FILES_API_ROUTES.fileKind.getUpdateRoute(fileKind.id),
-        validate: {
-          body: bodySchema,
-          params: paramsSchema,
-        },
+        validate: { ...rt },
         options: {
           tags: fileKind.http.update.tags,
         },

--- a/x-pack/plugins/files/server/routes/file_kind/upload.test.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Readable } from 'stream';
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+import { kibanaResponseFactory } from '@kbn/core-http-router-server-internal';
+
+import { FileServiceStart } from '../../file_service';
+
+import { handler } from './upload';
+import { createFileKindsRequestHandlerContextMock } from '../test_utils';
+import { FileKindsRequestHandlerContext } from './types';
+import { File } from '../../file';
+
+const createRequest = httpServerMock.createKibanaRequest;
+
+describe('upload', () => {
+  let ctx: FileKindsRequestHandlerContext;
+  let fileService: DeeplyMockedKeys<FileServiceStart>;
+
+  let uploadContent: jest.Mock<ReturnType<File['uploadContent']>>;
+  let deleteFn: jest.Mock<ReturnType<File['delete']>>;
+
+  const testErrorMessage = 'stop';
+  const stopFn = async () => {
+    throw new Error(testErrorMessage);
+  };
+
+  beforeEach(async () => {
+    ({ ctx, fileService } = createFileKindsRequestHandlerContextMock());
+    uploadContent = jest.fn();
+    deleteFn = jest.fn();
+    fileService.getById.mockResolvedValueOnce({
+      id: 'test',
+      data: { size: 1 },
+      uploadContent,
+      delete: deleteFn,
+    } as unknown as File);
+  });
+
+  it('errors as expected', async () => {
+    fileService.getById.mockReset();
+    fileService.getById.mockImplementation(stopFn);
+    const { status, payload } = await handler(
+      ctx,
+      createRequest({
+        params: { id: 'test' },
+        query: { selfDestructOnFailure: true },
+        body: Readable.from(['test']),
+      }),
+      kibanaResponseFactory
+    );
+    expect(status).toBe(500);
+    expect(payload).toEqual({ message: testErrorMessage });
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+
+  describe('self-destruct', () => {
+    it('deletes a file on failure to upload', async () => {
+      uploadContent.mockImplementationOnce(stopFn);
+
+      await expect(() =>
+        handler(
+          ctx,
+          createRequest({
+            params: { id: 'test' },
+            query: { selfDestructOnFailure: true },
+            body: Readable.from(['test']),
+          }),
+          kibanaResponseFactory
+        )
+      ).rejects.toThrowError(testErrorMessage);
+
+      expect(deleteFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -5,39 +5,38 @@
  * 2.0.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import { ReplaySubject } from 'rxjs';
-import type { Ensure } from '@kbn/utility-types';
 import { Readable } from 'stream';
 import type { FileKind } from '../../../common/types';
-import type { UploadFileKindHttpEndpoint } from '../../../common/api_routes';
+import type { CreateRouteDefinition } from '../../../common/api_routes';
 import { FILES_API_ROUTES } from '../api_routes';
 import { fileErrors } from '../../file';
 import { getById } from './helpers';
-import type { FileKindRouter, FileKindsRequestHandler } from './types';
+import type { FileKindRouter } from './types';
+import { CreateHandler } from './types';
 
 export const method = 'put' as const;
 
-export const bodySchema = schema.stream();
-type Body = TypeOf<typeof bodySchema>;
+const rt = {
+  params: schema.object({
+    id: schema.string(),
+  }),
+  body: schema.stream(),
+  query: schema.object({
+    selfDestructOnAbort: schema.maybe(schema.boolean()),
+  }),
+};
 
-export const querySchema = schema.object({
-  selfDestructOnAbort: schema.maybe(schema.boolean()),
-});
-type Query = Ensure<UploadFileKindHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+export type Endpoint = CreateRouteDefinition<
+  typeof rt,
+  {
+    ok: true;
+    size: number;
+  }
+>;
 
-export const paramsSchema = schema.object({
-  id: schema.string(),
-});
-type Params = Ensure<UploadFileKindHttpEndpoint['inputs']['params'], TypeOf<typeof paramsSchema>>;
-
-type Response = UploadFileKindHttpEndpoint['output'];
-
-export const handler: FileKindsRequestHandler<Params, Query, Body> = async (
-  { files, fileKind },
-  req,
-  res
-) => {
+export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   // Ensure that we are listening to the abort stream as early as possible.
   // In local testing I found that there is a chance for us to miss the abort event
   // if we subscribe too late.
@@ -74,7 +73,7 @@ export const handler: FileKindsRequestHandler<Params, Query, Body> = async (
   } finally {
     sub.unsubscribe();
   }
-  const body: Response = { ok: true, size: file.data.size! };
+  const body: Endpoint['output'] = { ok: true, size: file.data.size! };
   return res.ok({ body });
 };
 
@@ -86,8 +85,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
       {
         path: FILES_API_ROUTES.fileKind.getUploadRoute(fileKind.id),
         validate: {
-          body: bodySchema,
-          params: paramsSchema,
+          ...rt,
         },
         options: {
           tags: fileKind.http.create.tags,

--- a/x-pack/plugins/files/server/routes/file_kind/upload.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/upload.ts
@@ -21,6 +21,11 @@ export const method = 'put' as const;
 export const bodySchema = schema.stream();
 type Body = TypeOf<typeof bodySchema>;
 
+export const querySchema = schema.object({
+  selfDestructOnAbort: schema.maybe(schema.boolean()),
+});
+type Query = Ensure<UploadFileKindHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
+
 export const paramsSchema = schema.object({
   id: schema.string(),
 });
@@ -28,7 +33,7 @@ type Params = Ensure<UploadFileKindHttpEndpoint['inputs']['params'], TypeOf<type
 
 type Response = UploadFileKindHttpEndpoint['output'];
 
-export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
+export const handler: FileKindsRequestHandler<Params, Query, Body> = async (
   { files, fileKind },
   req,
   res
@@ -40,6 +45,7 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
   const sub = req.events.aborted$.subscribe(abort$);
 
   const { fileService } = await files;
+  const { logger } = fileService;
   const {
     body: stream,
     params: { id },
@@ -56,6 +62,12 @@ export const handler: FileKindsRequestHandler<Params, unknown, Body> = async (
       return res.badRequest({ body: { message: e.message } });
     } else if (e instanceof fileErrors.AbortedUploadError) {
       fileService.logger.error(e);
+      if (req.query.selfDestructOnAbort) {
+        logger.info(
+          `File (id: ${file.id}) upload aborted. Deleting file due to self-destruct flag.`
+        );
+        file.delete(); // fire and forget
+      }
       return res.customError({ body: { message: e.message }, statusCode: 499 });
     }
     throw e;

--- a/x-pack/plugins/files/server/routes/find.ts
+++ b/x-pack/plugins/files/server/routes/find.ts
@@ -4,12 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema, TypeOf } from '@kbn/config-schema';
-import type { Ensure } from '@kbn/utility-types';
-import type { FilesRouter } from './types';
-
-import { FindFilesHttpEndpoint, FILES_API_ROUTES } from './api_routes';
-import type { FilesRequestHandler } from './types';
+import { schema } from '@kbn/config-schema';
+import type { CreateHandler, FilesRouter } from './types';
+import { FileJSON } from '../../common';
+import { FILES_API_ROUTES, CreateRouteDefinition } from './api_routes';
 
 const method = 'post' as const;
 
@@ -19,41 +17,39 @@ const string256 = schema.string({ maxLength: 256 });
 const stringOrArrayOfStrings = schema.oneOf([string64, schema.arrayOf(string64)]);
 const nameStringOrArrayOfNameStrings = schema.oneOf([string256, schema.arrayOf(string256)]);
 
-const bodySchema = schema.object({
-  kind: schema.maybe(stringOrArrayOfStrings),
-  status: schema.maybe(stringOrArrayOfStrings),
-  name: schema.maybe(nameStringOrArrayOfNameStrings),
-  meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-});
+const rt = {
+  body: schema.object({
+    kind: schema.maybe(stringOrArrayOfStrings),
+    status: schema.maybe(stringOrArrayOfStrings),
+    extension: schema.maybe(stringOrArrayOfStrings),
+    name: schema.maybe(nameStringOrArrayOfNameStrings),
+    meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+  }),
+  query: schema.object({
+    page: schema.maybe(schema.number()),
+    perPage: schema.maybe(schema.number({ defaultValue: 100 })),
+  }),
+};
 
-const querySchema = schema.object({
-  page: schema.maybe(schema.number()),
-  perPage: schema.maybe(schema.number({ defaultValue: 100 })),
-});
-
-type Body = Ensure<FindFilesHttpEndpoint['inputs']['body'], TypeOf<typeof bodySchema>>;
-
-type Query = Ensure<FindFilesHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
-
-type Response = FindFilesHttpEndpoint['output'];
+export type Endpoint = CreateRouteDefinition<typeof rt, { files: FileJSON[] }>;
 
 function toArray(val: string | string[]) {
   return Array.isArray(val) ? val : [val];
 }
 
-const handler: FilesRequestHandler<unknown, Query, Body> = async ({ files }, req, res) => {
+const handler: CreateHandler<Endpoint> = async ({ files }, req, res) => {
   const { fileService } = await files;
   const {
     body: { meta, extension, kind, name, status },
     query,
   } = req;
 
-  const body: Response = {
+  const body: Endpoint['output'] = {
     files: await fileService.asCurrentUser().find({
-      kind: kind && toArray(kind),
-      name: name && toArray(name),
-      status: status && toArray(status),
-      extension: extension && toArray(extension),
+      kind: kind ? toArray(kind) : undefined,
+      name: name ? toArray(name) : undefined,
+      status: status ? toArray(status) : undefined,
+      extension: extension ? toArray(extension) : undefined,
       meta,
       ...query,
     }),
@@ -72,9 +68,7 @@ export function register(router: FilesRouter) {
   router[method](
     {
       path: FILES_API_ROUTES.find,
-      validate: {
-        body: bodySchema,
-      },
+      validate: { ...rt },
     },
     handler
   );

--- a/x-pack/plugins/files/server/routes/metrics.ts
+++ b/x-pack/plugins/files/server/routes/metrics.ts
@@ -6,16 +6,17 @@
  */
 import type { FilesRouter } from './types';
 
-import { FilesMetricsHttpEndpoint, FILES_API_ROUTES } from './api_routes';
+import { FilesMetrics } from '../../common';
+import { CreateRouteDefinition, FILES_API_ROUTES } from './api_routes';
 import type { FilesRequestHandler } from './types';
 
 const method = 'get' as const;
 
-type Response = FilesMetricsHttpEndpoint['output'];
+export type Endpoint = CreateRouteDefinition<{}, FilesMetrics>;
 
 const handler: FilesRequestHandler = async ({ files }, req, res) => {
   const { fileService } = await files;
-  const body: Response = await fileService.asCurrentUser().getUsageMetrics();
+  const body: Endpoint['output'] = await fileService.asCurrentUser().getUsageMetrics();
   return res.ok({
     body,
   });

--- a/x-pack/plugins/files/server/routes/public_facing/download.ts
+++ b/x-pack/plugins/files/server/routes/public_facing/download.ts
@@ -4,40 +4,34 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { Ensure } from '@kbn/utility-types';
-import { schema, TypeOf } from '@kbn/config-schema';
-
+import { schema } from '@kbn/config-schema';
+import { Readable } from 'stream';
 import { NoDownloadAvailableError } from '../../file/errors';
 import { FileNotFoundError } from '../../file_service/errors';
 import {
   FileShareNotFoundError,
   FileShareTokenInvalidError,
 } from '../../file_share_service/errors';
-import type { FilesRouter, FilesRequestHandler } from '../types';
-import { FilePublicDownloadHttpEndpoint, FILES_API_ROUTES } from '../api_routes';
+import type { FilesRouter } from '../types';
+import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
 import { getDownloadHeadersForFile } from '../common';
 import { fileNameWithExt } from '../common_schemas';
+import { CreateHandler } from '../types';
 
 const method = 'get' as const;
 
-const querySchema = schema.object({
-  token: schema.string(),
-});
+const rt = {
+  query: schema.object({
+    token: schema.string(),
+  }),
+  params: schema.object({
+    fileName: schema.maybe(fileNameWithExt),
+  }),
+};
 
-export const paramsSchema = schema.object({
-  fileName: schema.maybe(fileNameWithExt),
-});
+export type Endpoint = CreateRouteDefinition<typeof rt, any>;
 
-type Query = Ensure<FilePublicDownloadHttpEndpoint['inputs']['query'], TypeOf<typeof querySchema>>;
-
-type Params = Ensure<
-  FilePublicDownloadHttpEndpoint['inputs']['params'],
-  TypeOf<typeof paramsSchema>
->;
-
-type Response = FilePublicDownloadHttpEndpoint['output'];
-
-const handler: FilesRequestHandler<Params, Query> = async ({ files }, req, res) => {
+const handler: CreateHandler<Endpoint> = async ({ files }, req, res) => {
   const { fileService } = await files;
   const {
     query: { token },
@@ -46,7 +40,7 @@ const handler: FilesRequestHandler<Params, Query> = async ({ files }, req, res) 
 
   try {
     const file = await fileService.asInternalUser().getByToken(token);
-    const body: Response = await file.downloadContent();
+    const body: Readable = await file.downloadContent();
     return res.ok({
       body,
       headers: getDownloadHeadersForFile(file, fileName),
@@ -73,10 +67,7 @@ export function register(router: FilesRouter) {
   router[method](
     {
       path: FILES_API_ROUTES.public.download,
-      validate: {
-        query: querySchema,
-        params: paramsSchema,
-      },
+      validate: { ...rt },
       options: {
         authRequired: false,
       },

--- a/x-pack/plugins/files/server/routes/test_utils.ts
+++ b/x-pack/plugins/files/server/routes/test_utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { FileServiceStart } from '../file_service';
+import { createFileServiceMock } from '../mocks';
+import type { FileKindsRequestHandlerContext } from './file_kind/types';
+
+export const createFileKindsRequestHandlerContextMock = (
+  fileKind: string = 'test'
+): {
+  fileService: ReturnType<typeof createFileServiceMock>;
+  ctx: FileKindsRequestHandlerContext;
+} => {
+  const fileService = createFileServiceMock();
+  const ctx = {
+    fileKind,
+    files: Promise.resolve({
+      fileService: {
+        asCurrentUser: () => fileService,
+        asInternalUser: () => fileService,
+        logger: loggingSystemMock.createLogger(),
+      },
+    }),
+  } as unknown as FileKindsRequestHandlerContext;
+
+  return {
+    ctx,
+    fileService,
+  };
+};

--- a/x-pack/plugins/files/server/routes/test_utils.ts
+++ b/x-pack/plugins/files/server/routes/test_utils.ts
@@ -6,7 +6,6 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
-import { FileServiceStart } from '../file_service';
 import { createFileServiceMock } from '../mocks';
 import type { FileKindsRequestHandlerContext } from './file_kind/types';
 

--- a/x-pack/plugins/files/server/routes/types.ts
+++ b/x-pack/plugins/files/server/routes/types.ts
@@ -41,5 +41,5 @@ export type AsyncResponse<T> = Promise<IKibanaResponse<T>>;
 export type CreateHandler<E extends AnyEndpoint> = FilesRequestHandler<
   E['inputs']['params'],
   E['inputs']['query'],
-  E['inputs']['query']
+  E['inputs']['body']
 >;

--- a/x-pack/plugins/files/server/routes/types.ts
+++ b/x-pack/plugins/files/server/routes/types.ts
@@ -15,6 +15,7 @@ import type {
   Logger,
 } from '@kbn/core/server';
 import type { FileServiceStart } from '../file_service';
+import { AnyEndpoint } from './api_routes';
 
 export interface FilesRequestHandlerContext extends RequestHandlerContext {
   files: Promise<{
@@ -36,3 +37,9 @@ export type FilesRequestHandler<
 > = RequestHandler<P, Q, B, FilesRequestHandlerContext, Method, KibanaResponseFactory>;
 
 export type AsyncResponse<T> = Promise<IKibanaResponse<T>>;
+
+export type CreateHandler<E extends AnyEndpoint> = FilesRequestHandler<
+  E['inputs']['params'],
+  E['inputs']['query'],
+  E['inputs']['query']
+>;


### PR DESCRIPTION
## Summary

A repetitive refactor: convert the way we declare the share types to derive their shape from the runtime type checks that live on the server.

The current implementation declares all types under `common` and shares these with client and server. This results in some duplication because much of the declaration can be done once and derived from the `@kbn/config-schema` objects.