### PR TITLE
[Enterprise Search] Display user agent in crawl requests table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/_mocks_/crawler.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/_mocks_/crawler.mock.ts
@@ -19,10 +19,12 @@ export const CRAWLER_DATA: CrawlerData = {
   domains: [CRAWLER_DOMAIN],
   events: [CRAWL_EVENT],
   mostRecentCrawlRequest: CRAWL_REQUEST,
+  userAgent: 'Elastic Crawler (0.0.1)',
 };
 
 export const CRAWLER_DATA_FROM_SERVER: CrawlerDataFromServer = {
   domains: [CRAWLER_DOMAIN_FROM_SERVER],
   events: [CRAWL_EVENT_FROM_SERVER],
   most_recent_crawl_request: CRAWL_REQUEST_FROM_SERVER,
+  user_agent: 'Elastic Crawler (0.0.1)',
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/types.ts
@@ -89,6 +89,7 @@ export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
   events: CrawlEventFromServer[];
   most_recent_crawl_request: CrawlRequestFromServer | null;
+  user_agent: string;
 }
 
 export interface CrawlerDomainValidationResultFromServer {
@@ -172,6 +173,7 @@ export interface CrawlerData {
   domains: CrawlerDomain[];
   events: CrawlEvent[];
   mostRecentCrawlRequest: CrawlRequest | null;
+  userAgent: string;
 }
 
 export interface CrawlerDomainValidationStep {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/utils.ts
@@ -177,13 +177,19 @@ export function crawlRequestWithDetailsServerToClient(
 }
 
 export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
-  const { domains, events, most_recent_crawl_request: mostRecentCrawlRequest } = payload;
+  const {
+    domains,
+    events,
+    most_recent_crawl_request: mostRecentCrawlRequest,
+    user_agent: userAgent,
+  } = payload;
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
     events: events.map((event) => crawlEventServerToClient(event)),
     mostRecentCrawlRequest:
       mostRecentCrawlRequest && crawlRequestServerToClient(mostRecentCrawlRequest),
+    userAgent,
   };
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
@@ -7,29 +7,58 @@
 
 import React from 'react';
 
+import { useValues } from 'kea';
+
+import { EuiCode, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { DataPanel } from '../../../../../shared/data_panel/data_panel';
+import { CrawlerLogic } from '../crawler_logic';
 
 import { CrawlRequestsTable } from './crawl_requests_table';
 
-export const CrawlRequestsPanel: React.FC = () => (
-  <DataPanel
-    hasBorder
-    title={
-      <h2>
-        {i18n.translate('xpack.enterpriseSearch.crawler.crawlRequestsPanel.title', {
-          defaultMessage: 'Crawl requests',
-        })}
-      </h2>
-    }
-    titleSize="s"
-    iconType="documents"
-    subtitle={i18n.translate('xpack.enterpriseSearch.crawler.crawlRequestsPanel.description', {
-      defaultMessage:
-        "Recent crawl requests are logged here. You can track progress and examine crawl events in Kibana's Discover or Logs user intefaces",
-    })}
-  >
-    <CrawlRequestsTable />
-  </DataPanel>
-);
+export const CrawlRequestsPanel: React.FC = () => {
+  const { data } = useValues(CrawlerLogic);
+  return (
+    <DataPanel
+      hasBorder
+      title={
+        <h2>
+          {i18n.translate('xpack.enterpriseSearch.crawler.crawlRequestsPanel.title', {
+            defaultMessage: 'Crawl requests',
+          })}
+        </h2>
+      }
+      titleSize="s"
+      iconType="documents"
+      subtitle={i18n.translate('xpack.enterpriseSearch.crawler.crawlRequestsPanel.description', {
+        defaultMessage:
+          "Recent crawl requests are logged here. You can track progress and examine crawl events in Kibana's Discover or Logs user intefaces",
+      })}
+    >
+      <EuiPanel color="subdued">
+        <EuiText size="s">
+          {i18n.translate(
+            'xpack.enterpriseSearch.crawler.crawlRequestsPanel.userAgentDescription',
+            {
+              defaultMessage:
+                'Requests originating from the crawler can be identified by the following User Agent. This is configured in your enterprise-search.yml file.',
+            }
+          )}{' '}
+          <EuiLink target="_blank" href={'' /* needs docLink */}>
+            {i18n.translate(
+              'xpack.enterpriseSearch.crawler.crawlRequestsPanel.userAgentDocumentationLink',
+              {
+                defaultMessage: 'Learn more about Elastic crawler user agents',
+              }
+            )}
+          </EuiLink>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiCode>{data ? data.userAgent : ''}</EuiCode>
+      </EuiPanel>
+      <EuiSpacer />
+      <CrawlRequestsTable />
+    </DataPanel>
+  );
+};


### PR DESCRIPTION
## Summary

This is coming from the Crawler2 internal API 

![image](https://user-images.githubusercontent.com/2479295/190298528-6380ffd1-8962-424a-8c48-e07dbebcf4f0.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
