### PR TITLE
[Lens] Fix stack accessor

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
@@ -481,7 +481,7 @@ export const getSeriesProps: GetSeriesPropsFn = ({
 
   return {
     splitSeriesAccessors: splitColumnIds.length ? splitColumnIds : [],
-    stackAccessors: isStacked && xColumnId ? [xColumnId] : [],
+    stackAccessors: isStacked ? [xColumnId || 'unifiedX'] : [],
     id: generateSeriesId(
       layer,
       splitColumnIds.length ? splitColumnIds : [EMPTY_ACCESSOR],


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/140783

as described in the issue.

Cases to test:
* Stacked bar with multiple metrics without breakdown or x axis
* Stacked bar with multiple metrics with breakdown without x axis
* Stacked bar with multiple metrics without breakdown but with x axis
* Stacked bar with multiple metrics with breakdown and with x axis
* Same as the above for percentage bar chart
* Same as the above for unstacked bar chart