### PR TITLE
[Profiling] Open trace flyout

### DIFF
--- a/x-pack/plugins/profiling/public/components/subchart.tsx
+++ b/x-pack/plugins/profiling/public/components/subchart.tsx
@@ -17,6 +17,7 @@ import {
 import {
   EuiBadge,
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -160,7 +161,7 @@ export const SubChart: React.FC<SubChartProps> = ({
         <EuiFlexGroup
           direction="row"
           gutterSize="m"
-          alignItems="flexStart"
+          alignItems="center"
           style={{ overflowWrap: 'anywhere' }}
         >
           <EuiFlexItem grow={false}>
@@ -170,10 +171,16 @@ export const SubChart: React.FC<SubChartProps> = ({
               </EuiText>
             </EuiBadge>
           </EuiFlexItem>
-          <EuiFlexItem grow>
-            <EuiLink href={href}>
-              <EuiText size="s">{category}</EuiText>
-            </EuiLink>
+          <EuiFlexItem grow style={{ alignItems: 'flex-start' }}>
+            {showFrames ? (
+              <EuiLink onClick={() => onShowMoreClick?.()}>
+                <EuiText size="s">{category}</EuiText>
+              </EuiLink>
+            ) : (
+              <EuiLink href={href}>
+                <EuiText size="s">{category}</EuiText>
+              </EuiLink>
+            )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{asPercentage(percentage / 100, 2)}</EuiText>

--- a/x-pack/plugins/profiling/public/components/subchart.tsx
+++ b/x-pack/plugins/profiling/public/components/subchart.tsx
@@ -17,7 +17,6 @@ import {
 import {
   EuiBadge,
   EuiButton,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,


### PR DESCRIPTION
Open flyout when clicking on a trace id in the stack traces view, instead of adding a filter.