### PR TITLE
[PoC] runtime field promotion

### DIFF
--- a/src/plugins/data_view_field_editor/public/components/field_editor_context.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_context.tsx
@@ -27,6 +27,7 @@ export interface Context {
   };
   services: {
     search: DataPublicPluginStart['search'];
+    http: CoreStart['http'];
     api: ApiService;
     notifications: NotificationsStart;
   };

--- a/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content.tsx
@@ -86,7 +86,7 @@ const FieldEditorFlyoutContentComponent = ({
       path: `/api/index_management/index_templates`,
       method: 'get',
     });
-    const matchingTemplates = allIndexTemplates.templates.map((t: any) => {
+    const matchingTemplates = allIndexTemplates.templates.filter(t => t.indexPatterns.includes(title)).map((t: any) => {
       return {
         text: t.name,
       } as EuiSelectOption;

--- a/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content.tsx
@@ -21,6 +21,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { EuiSelectOption } from '@elastic/eui/src/components/form/select/select';
 import { euiFlyoutClassname } from '../constants';
 import type { Field } from '../types';
 import { ModifiedFieldModal, SaveFieldTypeOrNameChangedModal } from './confirm_modals';
@@ -29,7 +30,6 @@ import { FieldEditor, FieldEditorFormState } from './field_editor/field_editor';
 import { useFieldEditorContext } from './field_editor_context';
 import { FlyoutPanels } from './flyout_panels';
 import { FieldPreview, useFieldPreviewContext } from './preview';
-import {EuiSelectOption} from "@elastic/eui/src/components/form/select/select";
 
 const i18nTexts = {
   cancelButtonLabel: i18n.translate('indexPatternFieldEditor.editor.flyoutCancelButtonLabel', {
@@ -86,11 +86,13 @@ const FieldEditorFlyoutContentComponent = ({
       path: `/api/index_management/index_templates`,
       method: 'get',
     });
-    const matchingTemplates = allIndexTemplates.templates.filter(t => t.indexPatterns.includes(title)).map((t: any) => {
-      return {
-        text: t.name,
-      } as EuiSelectOption;
-    });
+    const matchingTemplates = allIndexTemplates.templates
+      .filter((t) => t.indexPatterns.includes(title))
+      .map((t: any) => {
+        return {
+          text: t.name,
+        } as EuiSelectOption;
+      });
     setMatchingTemplates(matchingTemplates);
   };
 
@@ -172,8 +174,7 @@ const FieldEditorFlyoutContentComponent = ({
       const { data } = await submit();
       setMyData(data);
       setIsPromoteVisible(true);
-    }
-    else {
+    } else {
       // do the promotion
 
       const indexTemplate = await getIndexTemplate(selectedTemplate);
@@ -191,7 +192,15 @@ const FieldEditorFlyoutContentComponent = ({
         console.log(e);
       }
     }
-  }, [setIsPromoteVisible, isPromoteVisible, selectedTemplate, ingest, submit, fieldToEdit, fieldToCreate]);
+  }, [
+    setIsPromoteVisible,
+    isPromoteVisible,
+    selectedTemplate,
+    ingest,
+    submit,
+    fieldToEdit,
+    fieldToCreate,
+  ]);
 
   const onClickSave = useCallback(async () => {
     const { isValid, data: updatedField } = await submit();
@@ -333,58 +342,58 @@ const FieldEditorFlyoutContentComponent = ({
               </EuiText>
             </FlyoutPanels.Header>
 
-            { !isPromoteVisible && <FieldEditor
-              field={fieldToEdit ?? fieldToCreate}
-              onChange={setFormState}
-              onFormModifiedChange={setIsFormModified}
-            /> }
+            {!isPromoteVisible && (
+              <FieldEditor
+                field={fieldToEdit ?? fieldToCreate}
+                onChange={setFormState}
+                onFormModifiedChange={setIsFormModified}
+              />
+            )}
 
-            {isPromoteVisible &&
-                <EuiFlexGroup>
-                  <EuiFlexItem grow={false}>
-                    <div>
-                      {/* Title */}
-                      <EuiTitle size="xs">
-                        <h3>Promote runtime field</h3>
-                      </EuiTitle>
-                      <EuiSpacer size="xs" />
+            {isPromoteVisible && (
+              <EuiFlexGroup>
+                <EuiFlexItem grow={false}>
+                  <div>
+                    {/* Title */}
+                    <EuiTitle size="xs">
+                      <h3>Promote runtime field</h3>
+                    </EuiTitle>
+                    <EuiSpacer size="xs" />
 
-                      {/* Description */}
-                      <EuiText size="s" color="subdued">
-                        Promote runtime field to the index template
-                      </EuiText>
+                    {/* Description */}
+                    <EuiText size="s" color="subdued">
+                      Promote runtime field to the index template
+                    </EuiText>
 
-                      {/* Content */}
-                      <>
-                        <EuiSpacer size="l" />
-                        <EuiFormRow
-                          label="Select target index template"
+                    {/* Content */}
+                    <>
+                      <EuiSpacer size="l" />
+                      <EuiFormRow label="Select target index template" fullWidth>
+                        <EuiSelect
                           fullWidth
-                        >
-                          <EuiSelect
-                            fullWidth
-                            options={matchingTemplates}
-                            value={selectedTemplate}
-                            onChange={(e) => {
-                              setSelectedTemplate(e.target.value);
-                            }}
-                            hasNoInitialSelection={true}
-                          />
-                        </EuiFormRow>
+                          options={matchingTemplates}
+                          value={selectedTemplate}
+                          onChange={(e) => {
+                            setSelectedTemplate(e.target.value);
+                          }}
+                          hasNoInitialSelection={true}
+                        />
+                      </EuiFormRow>
 
-                        <EuiFormRow
-                          label="Select target index template"
-                          fullWidth
-                        >
-                          <EuiCheckbox id="ingestCheckbox" checked={ingest} onChange={(e) => {
+                      <EuiFormRow label="Select target index template" fullWidth>
+                        <EuiCheckbox
+                          id="ingestCheckbox"
+                          checked={ingest}
+                          onChange={(e) => {
                             setIngest(e.target.checked);
-                          }} />
-                        </EuiFormRow>
-                      </>
-                    </div>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-            }
+                          }}
+                        />
+                      </EuiFormRow>
+                    </>
+                  </div>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )}
           </FlyoutPanels.Content>
 
           <FlyoutPanels.Footer>
@@ -415,16 +424,18 @@ const FieldEditorFlyoutContentComponent = ({
                       </EuiButton>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
-                      {!isPromoteVisible && <EuiButton
-                        color="primary"
-                        onClick={onClickSave}
-                        data-test-subj="fieldSaveButton"
-                        fill
-                        disabled={hasErrors}
-                        isLoading={isSavingField || isSubmitting}
-                      >
-                        {i18nTexts.saveButtonLabel}
-                      </EuiButton> }
+                      {!isPromoteVisible && (
+                        <EuiButton
+                          color="primary"
+                          onClick={onClickSave}
+                          data-test-subj="fieldSaveButton"
+                          fill
+                          disabled={hasErrors}
+                          isLoading={isSavingField || isSubmitting}
+                        >
+                          {i18nTexts.saveButtonLabel}
+                        </EuiButton>
+                      )}
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>

--- a/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
@@ -158,7 +158,7 @@ export const FieldEditorFlyoutContentContainer = ({
         } else {
           dataView.removeRuntimeField(fieldToEdit?.name ?? fieldToCreate?.name);
           updatedField.name = fieldToEdit?.name ?? fieldToCreate?.name;
-          await dataViews.refreshFields(dataView);
+           dataViews.refreshFields(dataView);
         }
       } else {
         try {

--- a/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor_flyout_content_container.tsx
@@ -158,7 +158,7 @@ export const FieldEditorFlyoutContentContainer = ({
         } else {
           dataView.removeRuntimeField(fieldToEdit?.name ?? fieldToCreate?.name);
           updatedField.name = fieldToEdit?.name ?? fieldToCreate?.name;
-           dataViews.refreshFields(dataView);
+          dataViews.refreshFields(dataView);
         }
       } else {
         try {

--- a/src/plugins/data_view_field_editor/public/open_editor.tsx
+++ b/src/plugins/data_view_field_editor/public/open_editor.tsx
@@ -196,6 +196,7 @@ export const getFieldEditorOpener =
               fieldFormatEditors={fieldFormatEditors}
               fieldFormats={fieldFormats}
               uiSettings={uiSettings}
+              http={core.http}
             />
           </KibanaReactContextProvider>,
           { theme$: core.theme.theme$ }

--- a/x-pack/plugins/index_management/server/routes/api/mapping/register_update_route.ts
+++ b/x-pack/plugins/index_management/server/routes/api/mapping/register_update_route.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { TemplateDeserialized } from '../../../../common';
+import { RouteDependencies } from '../../../types';
+import { addBasePath } from '..';
+import { templateSchema } from './validate_schemas';
+
+const bodySchema = templateSchema;
+const paramsSchema = schema.object({
+  name: schema.string(),
+});
+
+export function registerUpdateMappingRoute({ router, lib: { handleEsError } }: RouteDependencies) {
+  router.put(
+    {
+      path: addBasePath('/mapping/{name}'),
+      validate: { body: bodySchema, params: paramsSchema },
+    },
+    async (context, request, response) => {
+      const { client } = (await context.core).elasticsearch;
+      const { name } = request.params as typeof paramsSchema.type;
+      const mapping = request.body as TemplateDeserialized;
+      console.log(mapping);
+      try {
+
+        // Verify the template exists (ES will throw 404 if not)
+        // const templateExists = await doesTemplateExist({ name, client, isLegacy });
+
+        // if (!templateExists) {
+        //   return response.notFound();
+        // }
+
+        // Next, update index template
+
+        const indices = (await client.asCurrentUser.cat.indices({
+          index: name,
+        })).split('\n').map(i => i.split(' ')[2]).filter(i => i);
+        console.log(indices);
+        for (let index of indices) {
+          console.log(index);
+          const indexMapping = (await client.asCurrentUser.indices.getMapping({ index }))[index].mappings;
+          console.log(indexMapping);
+          if (mapping.properties) {
+            indexMapping.properties = { ...indexMapping.properties, ...mapping.properties };
+          } else if (mapping.runtime) {
+            indexMapping.runtime = { ...indexMapping.runtime, ...mapping.runtime };
+          }
+          console.log(indexMapping);
+          const r = await client.asCurrentUser.indices.putMapping({
+            index,
+            body: indexMapping
+          });
+          console.log(r);
+        }
+
+        return response.ok();
+      } catch (error) {
+        return handleEsError({ error, response });
+      }
+    }
+  );
+}

--- a/x-pack/plugins/index_management/server/routes/api/mapping/register_update_route.ts
+++ b/x-pack/plugins/index_management/server/routes/api/mapping/register_update_route.ts
@@ -29,7 +29,6 @@ export function registerUpdateMappingRoute({ router, lib: { handleEsError } }: R
       const mapping = request.body as TemplateDeserialized;
       console.log(mapping);
       try {
-
         // Verify the template exists (ES will throw 404 if not)
         // const templateExists = await doesTemplateExist({ name, client, isLegacy });
 
@@ -39,13 +38,19 @@ export function registerUpdateMappingRoute({ router, lib: { handleEsError } }: R
 
         // Next, update index template
 
-        const indices = (await client.asCurrentUser.cat.indices({
-          index: name,
-        })).split('\n').map(i => i.split(' ')[2]).filter(i => i);
+        const indices = (
+          await client.asCurrentUser.cat.indices({
+            index: name,
+          })
+        )
+          .split('\n')
+          .map((i) => i.split(' ')[2])
+          .filter((i) => i);
         console.log(indices);
-        for (let index of indices) {
+        for (const index of indices) {
           console.log(index);
-          const indexMapping = (await client.asCurrentUser.indices.getMapping({ index }))[index].mappings;
+          const indexMapping = (await client.asCurrentUser.indices.getMapping({ index }))[index]
+            .mappings;
           console.log(indexMapping);
           if (mapping.properties) {
             indexMapping.properties = { ...indexMapping.properties, ...mapping.properties };
@@ -55,7 +60,7 @@ export function registerUpdateMappingRoute({ router, lib: { handleEsError } }: R
           console.log(indexMapping);
           const r = await client.asCurrentUser.indices.putMapping({
             index,
-            body: indexMapping
+            body: indexMapping,
           });
           console.log(r);
         }

--- a/x-pack/plugins/index_management/server/routes/api/mapping/validate_schemas.ts
+++ b/x-pack/plugins/index_management/server/routes/api/mapping/validate_schemas.ts
@@ -5,5 +5,6 @@
  * 2.0.
  */
 
-export { registerMappingRoute } from './register_mapping_route';
-export { registerUpdateMappingRoute } from './register_update_route';
+import { schema } from '@kbn/config-schema';
+
+export const templateSchema = schema.object({}, { unknowns: 'allow' });

--- a/x-pack/plugins/index_management/server/routes/index.ts
+++ b/x-pack/plugins/index_management/server/routes/index.ts
@@ -10,7 +10,7 @@ import { RouteDependencies } from '../types';
 import { registerDataStreamRoutes } from './api/data_streams';
 import { registerIndicesRoutes } from './api/indices';
 import { registerTemplateRoutes } from './api/templates';
-import {registerMappingRoute, registerUpdateMappingRoute} from './api/mapping';
+import { registerMappingRoute, registerUpdateMappingRoute } from './api/mapping';
 import { registerSettingsRoutes } from './api/settings';
 import { registerStatsRoute } from './api/stats';
 import { registerComponentTemplateRoutes } from './api/component_templates';

--- a/x-pack/plugins/index_management/server/routes/index.ts
+++ b/x-pack/plugins/index_management/server/routes/index.ts
@@ -10,7 +10,7 @@ import { RouteDependencies } from '../types';
 import { registerDataStreamRoutes } from './api/data_streams';
 import { registerIndicesRoutes } from './api/indices';
 import { registerTemplateRoutes } from './api/templates';
-import { registerMappingRoute } from './api/mapping';
+import {registerMappingRoute, registerUpdateMappingRoute} from './api/mapping';
 import { registerSettingsRoutes } from './api/settings';
 import { registerStatsRoute } from './api/stats';
 import { registerComponentTemplateRoutes } from './api/component_templates';
@@ -24,6 +24,7 @@ export class ApiRoutes {
     registerSettingsRoutes(dependencies);
     registerStatsRoute(dependencies);
     registerMappingRoute(dependencies);
+    registerUpdateMappingRoute(dependencies);
     registerComponentTemplateRoutes(dependencies);
     registerNodesRoute(dependencies);
   }


### PR DESCRIPTION
## Summary

PoC of runtime field promotion

what is implemented:
- its possible to promote a runtime field defined on a dataview to a runtime field defined on an index template.
- user can choose if the field should be calculated at ingest time or at query time
- after promotion user can continue using the field as before

what is NOT implemented:
- user cannot see that a field is a promoted runtime field
- user can not edit promoted runtime field from the field editor dialog
- user can not edit promoted runtime field that's calculated at ingest time from index management page
- index management page is still using different runtime field editor

hacks:
- as there is no es api to update the index template field and propagate the changes to existing dataviews/indices kibana does that behind the scenes

