### PR TITLE
[ML] Explain Log Rate Spikes: Fix frequent_items agg config.

### DIFF
--- a/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
+++ b/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
@@ -7,6 +7,7 @@
 
 import { chunk } from 'lodash';
 
+import type { Query } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { asyncForEach } from '@kbn/std';
 import type { IRouter } from '@kbn/core/server';
@@ -212,6 +213,7 @@ export const defineExplainLogRateSpikesRoute = (
           const { fields, df } = await fetchFrequentItems(
             client,
             request.body.index,
+            JSON.parse(request.body.searchQuery) as Query['query'],
             changePoints,
             request.body.timeFieldName,
             request.body.deviationMin,

--- a/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
+++ b/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
@@ -7,7 +7,8 @@
 
 import { chunk } from 'lodash';
 
-import type { Query } from '@kbn/es-query';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import { i18n } from '@kbn/i18n';
 import { asyncForEach } from '@kbn/std';
 import type { IRouter } from '@kbn/core/server';
@@ -213,7 +214,7 @@ export const defineExplainLogRateSpikesRoute = (
           const { fields, df } = await fetchFrequentItems(
             client,
             request.body.index,
-            JSON.parse(request.body.searchQuery) as Query['query'],
+            JSON.parse(request.body.searchQuery) as estypes.QueryDslQueryContainer,
             changePoints,
             request.body.timeFieldName,
             request.body.deviationMin,

--- a/x-pack/plugins/aiops/server/routes/queries/fetch_frequent_items.ts
+++ b/x-pack/plugins/aiops/server/routes/queries/fetch_frequent_items.ts
@@ -9,7 +9,6 @@ import { uniq, uniqWith, pick, isEqual } from 'lodash';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
-import type { Query } from '@kbn/es-query';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { ChangePoint } from '@kbn/ml-agg-utils';
 
@@ -26,7 +25,7 @@ function dropDuplicates(cp: ChangePoint[], uniqueFields: string[]) {
 export async function fetchFrequentItems(
   client: ElasticsearchClient,
   index: string,
-  searchQuery: Query['query'],
+  searchQuery: estypes.QueryDslQueryContainer,
   changePoints: ChangePoint[],
   timeFieldName: string,
   deviationMin: number,

--- a/x-pack/plugins/aiops/server/routes/queries/get_query_with_params.ts
+++ b/x-pack/plugins/aiops/server/routes/queries/get_query_with_params.ts
@@ -7,7 +7,6 @@
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
-import type { Query } from '@kbn/es-query';
 import type { FieldValuePair } from '@kbn/ml-agg-utils';
 
 import type { AiopsExplainLogRateSpikesSchema } from '../../../common/api/explain_log_rate_spikes';
@@ -23,7 +22,7 @@ interface QueryParams {
   termFilters?: FieldValuePair[];
 }
 export const getQueryWithParams = ({ params, termFilters }: QueryParams) => {
-  const searchQuery = JSON.parse(params.searchQuery) as Query['query'];
+  const searchQuery = JSON.parse(params.searchQuery) as estypes.QueryDslQueryContainer;
   return {
     bool: {
       filter: [


### PR DESCRIPTION
## Summary

Part of #138117.

- Tweaks the `frequent_items` agg config. `should_minimum_match:2` for the terms should clause improves getting back groups of results. `minimum_set_size:2` will avoid single item frequent sets.
- Passes on a possible filter bar query to the `frequent_items` agg.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
