### PR TITLE
[APM] trace list columns width is now consistent when switching pages

### DIFF
--- a/x-pack/plugins/apm/public/components/app/dependency_operation_detail_view/dependency_operation_detail_trace_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/dependency_operation_detail_view/dependency_operation_detail_trace_list.tsx
@@ -127,6 +127,7 @@ export function DependencyOperationDetailTraceList() {
         { defaultMessage: 'Trace' }
       ),
       field: 'traceId',
+      truncateText: true,
       render: (
         _,
         {
@@ -158,6 +159,7 @@ export function DependencyOperationDetailTraceList() {
         { defaultMessage: 'Originating service' }
       ),
       field: 'serviceName',
+      truncateText: true,
       render: (_, { serviceName, agentName }) => {
         const serviceLinkQuery = {
           comparisonEnabled,
@@ -187,6 +189,7 @@ export function DependencyOperationDetailTraceList() {
         { defaultMessage: 'Transaction name' }
       ),
       field: 'transactionName',
+      truncateText: true,
       render: (
         _,
         {
@@ -227,6 +230,7 @@ export function DependencyOperationDetailTraceList() {
         { defaultMessage: 'Timestamp' }
       ),
       field: '@timestamp',
+      truncateText: true,
       render: (_, { '@timestamp': timestamp }) => {
         return <TimestampTooltip time={timestamp} />;
       },
@@ -286,7 +290,6 @@ export function DependencyOperationDetailTraceList() {
             status === FETCH_STATUS.LOADING ||
             status === FETCH_STATUS.NOT_INITIATED
           }
-          tableLayout="auto"
         />
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
closes [137937](https://github.com/elastic/kibana/issues/137937)

- tableLayout was changed to `fixed` (default setting). tableLayout with `auto` setting was allowing columns to auto adjust depending on the data of the current page, which varies from page to page.
- `truncateText` was added to columns that potentially contain higher lengths in the data.

https://user-images.githubusercontent.com/1313018/190425734-de3bca5a-d90f-4d53-a66b-d5cb390107c7.mov