### PR TITLE
[console] skip failing test on cloud

### DIFF
--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -144,7 +144,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('multiple requests output', () => {
+    // Skip on cloud until issue is fixed
+    // Issue: https://github.com/elastic/kibana/issues/138762
+    describe('multiple requests output', function() {
+      this.tags(['skipCloudFailedTest']);
       const sendMultipleRequests = async (requests: string[]) => {
         await asyncForEach(requests, async (request) => {
           await PageObjects.console.enterRequest(request);

--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -146,7 +146,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     // Skip on cloud until issue is fixed
     // Issue: https://github.com/elastic/kibana/issues/138762
-    describe('multiple requests output', function() {
+    describe('multiple requests output', function () {
       this.tags(['skipCloudFailedTest']);
       const sendMultipleRequests = async (requests: string[]) => {
         await asyncForEach(requests, async (request) => {


### PR DESCRIPTION
There is a bug on console status badges see: https://github.com/elastic/kibana/issues/138762 -- until that bug is fixed, we can skip running the test on cloud.   Test failure: https://github.com/elastic/kibana/issues/140840

Reference run: https://buildkite.com/elastic/estf-cloud-kibana-functional-tests/builds/665

