### PR TITLE
Add UI counters for Map Embeddables

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
@@ -16,6 +16,7 @@ import {
   EmbeddableExpression,
 } from '../../expression_types';
 import { getFunctionHelp } from '../../../i18n';
+import { CANVAS_APP } from '../../../common/lib/constants';
 
 interface Arguments {
   id: string;
@@ -85,6 +86,7 @@ export function savedMap(): ExpressionFunctionDefinition<
       return {
         type: EmbeddableExpressionType,
         input: {
+          embeddingApp: CANVAS_APP,
           id: args.id,
           attributes: { title: '' },
           savedObjectId: args.id,

--- a/x-pack/plugins/data_visualizer/public/application/common/components/embedded_map/embedded_map.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/embedded_map/embedded_map.tsx
@@ -23,6 +23,7 @@ import {
 } from '@kbn/embeddable-plugin/public';
 import { useDataVisualizerKibana } from '../../../kibana_context';
 import './_embedded_map.scss';
+import { APP_ID } from '../../../../../common/constants';
 
 export function EmbeddedMapComponent({
   layerList,
@@ -71,6 +72,7 @@ export function EmbeddedMapComponent({
         return;
       }
       const input: MapEmbeddableInput = {
+        embeddingApp: APP_ID,
         id: htmlIdGenerator()(),
         attributes: { title: '' },
         filters: data.query.filterManager.getFilters() ?? [],

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { METRIC_TYPE } from '@kbn/analytics';
 import _ from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -77,6 +78,7 @@ import {
   getSpacesApi,
   getSearchService,
   getTheme,
+  getUsageCollection,
 } from '../kibana_services';
 import { LayerDescriptor, MapExtent } from '../../common/descriptor_types';
 import { MapContainer } from '../connected_components/map_container';
@@ -446,6 +448,15 @@ export class MapEmbeddable
     this._domNode = domNode;
     if (!this._isInitialized) {
       return;
+    }
+
+    const { embeddingApp } = this.getInput();
+    if (embeddingApp) {
+      getUsageCollection()?.reportUiCounter(
+        APP_ID,
+        METRIC_TYPE.LOADED,
+        `open_maps_embeddable_${embeddingApp}`
+      );
     }
 
     mapEmbeddablesSingleton.register(this.input.id, {

--- a/x-pack/plugins/maps/public/embeddable/types.ts
+++ b/x-pack/plugins/maps/public/embeddable/types.ts
@@ -41,7 +41,9 @@ export type MapByValueInput = {
 } & EmbeddableInput &
   MapEmbeddableState;
 export type MapByReferenceInput = SavedObjectEmbeddableInput & MapEmbeddableState;
-export type MapEmbeddableInput = MapByValueInput | MapByReferenceInput;
+export type MapEmbeddableInput = (MapByValueInput | MapByReferenceInput) & {
+  embeddingApp?: string;
+};
 
 export type MapEmbeddableOutput = EmbeddableOutput & {
   indexPatterns: DataView[];

--- a/x-pack/plugins/ml/public/application/components/ml_embedded_map/ml_embedded_map.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_embedded_map/ml_embedded_map.tsx
@@ -23,6 +23,7 @@ import {
   ViewMode,
 } from '@kbn/embeddable-plugin/public';
 import { useMlKibana } from '../../contexts/kibana';
+import { PLUGIN_ID } from '../../../../common/constants/app';
 
 export function MlEmbeddedMapComponent({
   layerList,
@@ -71,6 +72,7 @@ export function MlEmbeddedMapComponent({
         return;
       }
       const input: MapEmbeddableInput = {
+        embeddingApp: PLUGIN_ID,
         id: htmlIdGenerator()(),
         attributes: { title: '' },
         filters: [],

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
@@ -29,6 +29,7 @@ import * as i18n from './translations';
 
 import type { IndexPatternSavedObject } from '../../../common/hooks/types';
 import type { GlobalTimeArgs } from '../../../common/containers/use_global_time';
+import { APP_UI_ID } from '../../../../common/constants';
 
 /**
  * Creates MapEmbeddable with provided initial configuration
@@ -65,6 +66,7 @@ export const createEmbeddable = async (
   }
 
   const input: MapEmbeddableInput = {
+    embeddingApp: APP_UI_ID,
     title: i18n.MAP_TITLE,
     attributes: { title: '' },
     id: uuid.v4(),

--- a/x-pack/plugins/ux/public/components/app/rum_dashboard/visitor_breakdown_map/embedded_map.tsx
+++ b/x-pack/plugins/ux/public/components/app/rum_dashboard/visitor_breakdown_map/embedded_map.tsx
@@ -65,6 +65,7 @@ export function EmbeddedMapComponent() {
   const factory = embeddablePlugin.getEmbeddableFactory(MAP_SAVED_OBJECT_TYPE);
 
   const input: MapEmbeddableInput = {
+    embeddingApp: 'ux',
     attributes: { title: '' },
     id: uuid.v4(),
     filters: mapFilters,


### PR DESCRIPTION
WIP. Do not review or merge yet. 😄 

## Summary

Adds Ui counter events that trigger when a MapsEmbeddable is opened in a different app such as the [Security Solution Network page](https://www.elastic.co/guide/en/security/current/network-page-overview.html), [User Experience dashboard](https://www.elastic.co/guide/en/observability/current/user-experience.html), [Machine learning Anomaly Explorer](https://www.elastic.co/guide/en/machine-learning/current/geographic-anomalies.html), Canvas, and Data Visualizer.

This adds an optional `embeddingApp` property to the MapsEmbeddableInput. The property should be set to the plugin name that is embedding the map.

