### PR TITLE
Minor layout adjustments to the ingest PL modal

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipeline_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipeline_modal.tsx
@@ -65,7 +65,7 @@ export const IngestPipelineModal: React.FC<IngestPipelineModalProps> = ({
   const canCustomize = name === DEFAULT_PIPELINE_NAME;
 
   return showModal ? (
-    <EuiModal onClose={closeModal}>
+    <EuiModal onClose={closeModal} maxWidth={'40rem'}>
       <EuiModalHeader>
         <EuiFlexGroup direction="column" gutterSize="none">
           <EuiFlexItem>
@@ -90,7 +90,7 @@ export const IngestPipelineModal: React.FC<IngestPipelineModalProps> = ({
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText color="subdued" grow={false} size="s">
+                <EuiText color="subdued" size="s">
                   {displayOnly
                     ? i18n.translate(
                         'xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyAPIText',
@@ -124,7 +124,7 @@ export const IngestPipelineModal: React.FC<IngestPipelineModalProps> = ({
           <EuiSpacer size="xl" />
           <EuiFlexItem>
             <EuiForm aria-labelledby="ingestPipelineHeader">
-              <EuiFormRow>
+              <EuiFormRow fullWidth>
                 <EuiText size="m" id="ingestPipelineHeader">
                   <strong>
                     {i18n.translate(
@@ -136,10 +136,11 @@ export const IngestPipelineModal: React.FC<IngestPipelineModalProps> = ({
                   </strong>
                 </EuiText>
               </EuiFormRow>
-              <EuiFormRow>
+              <EuiFormRow fullWidth>
                 <PipelineSettingsForm pipeline={pipeline} setPipeline={setPipeline} />
               </EuiFormRow>
             </EuiForm>
+            <EuiSpacer />
           </EuiFlexItem>
           {displayOnly && (
             <>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipeline_settings_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipeline_settings_form.tsx
@@ -28,7 +28,7 @@ export const PipelineSettingsForm: React.FC<PipelineSettingsFormProps> = ({
     run_ml_inference: runMLInference,
   } = pipeline;
   return (
-    <EuiFlexGroup direction="column" gutterSize="xs">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
         <SettingsCheckableCard
           description={i18n.translate(


### PR DESCRIPTION
## Summary

Some small tweaks to the layout of the ingest pipelines modal in Enterprise Search.

<img width="643" alt="holler- Slack-2022-09-15 at 14 37@2x" src="https://user-images.githubusercontent.com/739960/190513380-f2471c7c-b9f4-4cc2-976b-ff55df194114.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
