### PR TITLE
[RAM] Hide description column in fields table

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.test.tsx
@@ -105,7 +105,7 @@ describe('field_items', () => {
 
   describe('getFieldColumns', () => {
     const onToggleColumn = jest.fn();
-    const getFieldColumnsParams = { onToggleColumn, onHide: () => {} };
+    const getFieldColumnsParams = { onToggleColumn, onHide: () => {}, shouldShowDescriptionColumn: true };
 
     beforeEach(() => {
       onToggleColumn.mockClear();
@@ -194,6 +194,27 @@ describe('field_items', () => {
       expect(getByTestId(`field-${timestampFieldId}-checkbox`)).toBeInTheDocument();
       expect(getByTestId(`field-${timestampFieldId}-name`)).toBeInTheDocument();
       expect(getByTestId(`field-${timestampFieldId}-description`)).toBeInTheDocument();
+      expect(getByTestId(`field-${timestampFieldId}-category`)).toBeInTheDocument();
+    });
+
+    it('should render default columns without description column', () => {
+      const timestampField = mockBrowserFields.base.fields![timestampFieldId];
+      const fieldItems = getFieldItems({
+        selectedCategoryIds: ['base'],
+        browserFields: { base: { fields: { [timestampFieldId]: timestampField } } },
+        columnIds: [],
+      });
+
+      const columns = getFieldColumns({ ...getFieldColumnsParams, shouldShowDescriptionColumn: false });
+      const { getByTestId, getAllByText } = render(
+        <EuiInMemoryTable items={fieldItems} itemId="name" columns={columns} />
+      );
+
+      expect(getAllByText('Name').at(0)).toBeInTheDocument();
+      expect(getAllByText('Category').at(0)).toBeInTheDocument();
+
+      expect(getByTestId(`field-${timestampFieldId}-checkbox`)).toBeInTheDocument();
+      expect(getByTestId(`field-${timestampFieldId}-name`)).toBeInTheDocument();
       expect(getByTestId(`field-${timestampFieldId}-category`)).toBeInTheDocument();
     });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.test.tsx
@@ -105,7 +105,11 @@ describe('field_items', () => {
 
   describe('getFieldColumns', () => {
     const onToggleColumn = jest.fn();
-    const getFieldColumnsParams = { onToggleColumn, onHide: () => {}, shouldShowDescriptionColumn: true };
+    const getFieldColumnsParams = {
+      onToggleColumn,
+      onHide: () => {},
+      shouldShowDescriptionColumn: true,
+    };
 
     beforeEach(() => {
       onToggleColumn.mockClear();
@@ -205,7 +209,10 @@ describe('field_items', () => {
         columnIds: [],
       });
 
-      const columns = getFieldColumns({ ...getFieldColumnsParams, shouldShowDescriptionColumn: false });
+      const columns = getFieldColumns({
+        ...getFieldColumnsParams,
+        shouldShowDescriptionColumn: false,
+      });
       const { getByTestId, getAllByText } = render(
         <EuiInMemoryTable items={fieldItems} itemId="name" columns={columns} />
       );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
@@ -67,12 +67,17 @@ export const getFieldItems = ({
   );
 };
 
-const getDefaultFieldTableColumns = (highlight: string): FieldTableColumns => [
-  {
+const getDefaultFieldTableColumns = ({
+  highlight, 
+  shouldShowDescriptionColumn
+}: {
+  highlight: string;
+  shouldShowDescriptionColumn: boolean;
+}): FieldTableColumns => {
+  const nameColumn = {
     field: 'name',
     name: i18n.NAME,
-    render: (name: string, { type }) => {
-      return (
+    render: (name: string, { type }: {type?: string}) => (
         <EuiFlexGroup alignItems="center" gutterSize="none">
           <EuiFlexItem grow={false}>
             <EuiToolTip content={type}>
@@ -88,15 +93,14 @@ const getDefaultFieldTableColumns = (highlight: string): FieldTableColumns => [
             <FieldName fieldId={name} highlight={highlight} />
           </EuiFlexItem>
         </EuiFlexGroup>
-      );
-    },
+      ),
     sortable: true,
     width: '225px',
-  },
-  {
+  }
+  const descriptionColumn = {
     field: 'description',
     name: i18n.DESCRIPTION,
-    render: (description: string, { name, example }) => (
+    render: (description: string, { name, example }: { name: string, example?: string }) => (
       <EuiToolTip content={description}>
         <>
           <EuiScreenReaderOnly data-test-subj="descriptionForScreenReaderOnly">
@@ -112,33 +116,40 @@ const getDefaultFieldTableColumns = (highlight: string): FieldTableColumns => [
     ),
     sortable: true,
     width: '400px',
-  },
-  {
+  }
+
+  const categoryColumn = {
     field: 'category',
     name: i18n.CATEGORY,
-    render: (category: string, { name }) => (
+    render: (category: string, { name }: {name: string}) => (
       <EuiBadge data-test-subj={`field-${name}-category`}>{category}</EuiBadge>
     ),
     sortable: true,
     width: '130px',
-  },
-];
+  }
+
+
+  return shouldShowDescriptionColumn ? [nameColumn, descriptionColumn, categoryColumn ]: [nameColumn, categoryColumn ]
+};
 
 /**
  * Returns a table column template provided to the `EuiInMemoryTable`'s
  * `columns` prop
  */
 export const getFieldColumns = ({
-  onToggleColumn,
-  highlight = '',
   getFieldTableColumns,
+  highlight = '',
   onHide,
+  onToggleColumn,
+  shouldShowDescriptionColumn
 }: {
-  onToggleColumn: (id: string) => void;
-  highlight?: string;
   getFieldTableColumns?: GetFieldTableColumns;
+  highlight?: string;
   onHide: () => void;
-}): FieldTableColumns => [
+  onToggleColumn: (id: string) => void;
+  shouldShowDescriptionColumn: boolean
+}): FieldTableColumns => { 
+  return [
   {
     field: 'selected',
     name: '',
@@ -159,8 +170,8 @@ export const getFieldColumns = ({
   },
   ...(getFieldTableColumns
     ? getFieldTableColumns({ highlight, onHide })
-    : getDefaultFieldTableColumns(highlight)),
-];
+    : getDefaultFieldTableColumns({highlight, shouldShowDescriptionColumn})),
+]};
 
 /** Returns whether the table column has actions attached to it */
 export const isActionsColumn = (column: EuiBasicTableColumn<BrowserFieldItem>): boolean => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
@@ -68,8 +68,8 @@ export const getFieldItems = ({
 };
 
 const getDefaultFieldTableColumns = ({
-  highlight, 
-  shouldShowDescriptionColumn
+  highlight,
+  shouldShowDescriptionColumn,
 }: {
   highlight: string;
   shouldShowDescriptionColumn: boolean;
@@ -77,30 +77,30 @@ const getDefaultFieldTableColumns = ({
   const nameColumn = {
     field: 'name',
     name: i18n.NAME,
-    render: (name: string, { type }: {type?: string}) => (
-        <EuiFlexGroup alignItems="center" gutterSize="none">
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content={type}>
-              <EuiIcon
-                data-test-subj={`field-${name}-icon`}
-                css={styles.icon}
-                type={getIconFromType(type ?? null)}
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
+    render: (name: string, { type }: { type?: string }) => (
+      <EuiFlexGroup alignItems="center" gutterSize="none">
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content={type}>
+            <EuiIcon
+              data-test-subj={`field-${name}-icon`}
+              css={styles.icon}
+              type={getIconFromType(type ?? null)}
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <FieldName fieldId={name} highlight={highlight} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ),
+        <EuiFlexItem grow={false}>
+          <FieldName fieldId={name} highlight={highlight} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ),
     sortable: true,
     width: '225px',
-  }
+  };
   const descriptionColumn = {
     field: 'description',
     name: i18n.DESCRIPTION,
-    render: (description: string, { name, example }: { name: string, example?: string }) => (
+    render: (description: string, { name, example }: { name: string; example?: string }) => (
       <EuiToolTip content={description}>
         <>
           <EuiScreenReaderOnly data-test-subj="descriptionForScreenReaderOnly">
@@ -116,22 +116,18 @@ const getDefaultFieldTableColumns = ({
     ),
     sortable: true,
     width: '400px',
-  }
+  };
   const categoryColumn = {
     field: 'category',
     name: i18n.CATEGORY,
-    render: (category: string, { name }: {name: string}) => (
+    render: (category: string, { name }: { name: string }) => (
       <EuiBadge data-test-subj={`field-${name}-category`}>{category}</EuiBadge>
     ),
     sortable: true,
     width: '130px',
-  }
+  };
 
-  return [
-    nameColumn, 
-    ...(shouldShowDescriptionColumn ? [descriptionColumn] : []),
-    categoryColumn 
-  ]
+  return [nameColumn, ...(shouldShowDescriptionColumn ? [descriptionColumn] : []), categoryColumn];
 };
 
 /**
@@ -143,15 +139,14 @@ export const getFieldColumns = ({
   highlight = '',
   onHide,
   onToggleColumn,
-  shouldShowDescriptionColumn
+  shouldShowDescriptionColumn,
 }: {
   getFieldTableColumns?: GetFieldTableColumns;
   highlight?: string;
   onHide: () => void;
   onToggleColumn: (id: string) => void;
-  shouldShowDescriptionColumn: boolean
-}): FieldTableColumns => { 
-  return [
+  shouldShowDescriptionColumn: boolean;
+}): FieldTableColumns => [
   {
     field: 'selected',
     name: '',
@@ -173,7 +168,7 @@ export const getFieldColumns = ({
   ...(getFieldTableColumns
     ? getFieldTableColumns({ highlight, onHide })
     : getDefaultFieldTableColumns({ highlight, shouldShowDescriptionColumn })),
-]};
+];
 
 /** Returns whether the table column has actions attached to it */
 export const isActionsColumn = (column: EuiBasicTableColumn<BrowserFieldItem>): boolean => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_items/field_items.tsx
@@ -117,7 +117,6 @@ const getDefaultFieldTableColumns = ({
     sortable: true,
     width: '400px',
   }
-
   const categoryColumn = {
     field: 'category',
     name: i18n.CATEGORY,
@@ -128,8 +127,11 @@ const getDefaultFieldTableColumns = ({
     width: '130px',
   }
 
-
-  return shouldShowDescriptionColumn ? [nameColumn, descriptionColumn, categoryColumn ]: [nameColumn, categoryColumn ]
+  return [
+    nameColumn, 
+    ...(shouldShowDescriptionColumn ? [descriptionColumn] : []),
+    categoryColumn 
+  ]
 };
 
 /**
@@ -170,7 +172,7 @@ export const getFieldColumns = ({
   },
   ...(getFieldTableColumns
     ? getFieldTableColumns({ highlight, onHide })
-    : getDefaultFieldTableColumns({highlight, shouldShowDescriptionColumn})),
+    : getDefaultFieldTableColumns({ highlight, shouldShowDescriptionColumn })),
 ]};
 
 /** Returns whether the table column has actions attached to it */

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
@@ -7,7 +7,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiInMemoryTable, Pagination, Direction, useEuiTheme } from '@elastic/eui';
 import { getFieldColumns, getFieldItems, isActionsColumn } from '../field_items';
-import { CATEGORY_TABLE_CLASS_NAME, TABLE_HEIGHT, getShouldShowDescriptionColumn } from '../../helpers';
+import {
+  CATEGORY_TABLE_CLASS_NAME,
+  TABLE_HEIGHT,
+  getShouldShowDescriptionColumn,
+} from '../../helpers';
 import type { BrowserFields, FieldBrowserProps, GetFieldTableColumns } from '../../types';
 import { FieldTableHeader } from './field_table_header';
 import { styles } from './field_table.styles';
@@ -118,13 +122,14 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
    * Process columns
    */
   const columns = useMemo(
-    () => getFieldColumns({ 
-      getFieldTableColumns, 
-      highlight: searchInput, 
-      onHide, 
-      onToggleColumn, 
-      shouldShowDescriptionColumn: getShouldShowDescriptionColumn(fieldItems)
-    }),
+    () =>
+      getFieldColumns({
+        getFieldTableColumns,
+        highlight: searchInput,
+        onHide,
+        onToggleColumn,
+        shouldShowDescriptionColumn: getShouldShowDescriptionColumn(fieldItems),
+      }),
     [fieldItems, getFieldTableColumns, onHide, onToggleColumn, searchInput]
   );
   const hasActions = useMemo(() => columns.some((column) => isActionsColumn(column)), [columns]);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiInMemoryTable, Pagination, Direction, useEuiTheme } from '@elastic/eui';
 import { getFieldColumns, getFieldItems, isActionsColumn } from '../field_items';
-import { CATEGORY_TABLE_CLASS_NAME, TABLE_HEIGHT } from '../../helpers';
+import { CATEGORY_TABLE_CLASS_NAME, TABLE_HEIGHT, getShouldShowDescriptionColumn } from '../../helpers';
 import type { BrowserFields, FieldBrowserProps, GetFieldTableColumns } from '../../types';
 import { FieldTableHeader } from './field_table_header';
 import { styles } from './field_table.styles';
@@ -123,7 +123,7 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
       highlight: searchInput, 
       onHide, 
       onToggleColumn, 
-      shouldShowDescriptionColumn: !!fieldItems.find(fieldItem => !!fieldItem.description?.trim())
+      shouldShowDescriptionColumn: getShouldShowDescriptionColumn(fieldItems)
     }),
     [getFieldTableColumns, onHide, onToggleColumn, searchInput]
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
@@ -118,8 +118,14 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
    * Process columns
    */
   const columns = useMemo(
-    () => getFieldColumns({ highlight: searchInput, onToggleColumn, getFieldTableColumns, onHide }),
-    [onToggleColumn, searchInput, getFieldTableColumns, onHide]
+    () => getFieldColumns({ 
+      getFieldTableColumns, 
+      highlight: searchInput, 
+      onHide, 
+      onToggleColumn, 
+      shouldShowDescriptionColumn: !!fieldItems.find(fieldItem => !!fieldItem.description?.trim())
+    }),
+    [getFieldTableColumns, onHide, onToggleColumn, searchInput]
   );
   const hasActions = useMemo(() => columns.some((column) => isActionsColumn(column)), [columns]);
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/components/field_table/field_table.tsx
@@ -125,7 +125,7 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
       onToggleColumn, 
       shouldShowDescriptionColumn: getShouldShowDescriptionColumn(fieldItems)
     }),
-    [getFieldTableColumns, onHide, onToggleColumn, searchInput]
+    [fieldItems, getFieldTableColumns, onHide, onToggleColumn, searchInput]
   );
   const hasActions = useMemo(() => columns.some((column) => isActionsColumn(column)), [columns]);
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.test.ts
@@ -10,6 +10,7 @@ import { mockBrowserFields } from './mock';
 import {
   categoryHasFields,
   getFieldCount,
+  getShouldShowDescriptionColumn,
   filterBrowserFieldsByFieldName,
   filterSelectedBrowserFields,
 } from './helpers';
@@ -330,4 +331,52 @@ describe('helpers', () => {
       ).toEqual(filtered);
     });
   });
+
+  describe('getShouldShowDescriptionColumn', () => {
+    test('hide description column if there is not description', () => {
+      expect(getShouldShowDescriptionColumn([
+        {
+          category: "base",
+          description: "",
+          example: undefined,
+          isRuntime: false,
+          name: "@timestamp",
+          selected: true,
+          type: "date",
+        },
+        {
+          category: "base",
+          description: "",
+          example: undefined,
+          isRuntime: false,
+          name: "_id",
+          selected: false,
+          type: "string",
+        },
+      ])).toBe(false)
+    })
+
+    test('show description column if there is description', () => {
+      expect(getShouldShowDescriptionColumn([
+        {
+          category: "base",
+          description: "",
+          example: undefined,
+          isRuntime: false,
+          name: "@timestamp",
+          selected: true,
+          type: "date",
+        },
+        {
+          category: "base",
+          description: "id_description",
+          example: undefined,
+          isRuntime: false,
+          name: "_id",
+          selected: false,
+          type: "string",
+        },
+      ])).toBe(true)
+    })
+  })
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.test.ts
@@ -334,49 +334,53 @@ describe('helpers', () => {
 
   describe('getShouldShowDescriptionColumn', () => {
     test('hide description column if there is not description', () => {
-      expect(getShouldShowDescriptionColumn([
-        {
-          category: "base",
-          description: "",
-          example: undefined,
-          isRuntime: false,
-          name: "@timestamp",
-          selected: true,
-          type: "date",
-        },
-        {
-          category: "base",
-          description: "",
-          example: undefined,
-          isRuntime: false,
-          name: "_id",
-          selected: false,
-          type: "string",
-        },
-      ])).toBe(false)
-    })
+      expect(
+        getShouldShowDescriptionColumn([
+          {
+            category: 'base',
+            description: '',
+            example: undefined,
+            isRuntime: false,
+            name: '@timestamp',
+            selected: true,
+            type: 'date',
+          },
+          {
+            category: 'base',
+            description: '',
+            example: undefined,
+            isRuntime: false,
+            name: '_id',
+            selected: false,
+            type: 'string',
+          },
+        ])
+      ).toBe(false);
+    });
 
     test('show description column if there is description', () => {
-      expect(getShouldShowDescriptionColumn([
-        {
-          category: "base",
-          description: "",
-          example: undefined,
-          isRuntime: false,
-          name: "@timestamp",
-          selected: true,
-          type: "date",
-        },
-        {
-          category: "base",
-          description: "id_description",
-          example: undefined,
-          isRuntime: false,
-          name: "_id",
-          selected: false,
-          type: "string",
-        },
-      ])).toBe(true)
-    })
-  })
+      expect(
+        getShouldShowDescriptionColumn([
+          {
+            category: 'base',
+            description: '',
+            example: undefined,
+            isRuntime: false,
+            name: '@timestamp',
+            selected: true,
+            type: 'date',
+          },
+          {
+            category: 'base',
+            description: 'id_description',
+            example: undefined,
+            isRuntime: false,
+            name: '_id',
+            selected: false,
+            type: 'string',
+          },
+        ])
+      ).toBe(true);
+    });
+  });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.ts
@@ -163,7 +163,8 @@ export const getExampleText = (example: string | number | null | undefined): str
 /** Returns `true` if the escape key was pressed */
 export const isEscape = (event: React.KeyboardEvent): boolean => event.key === 'Escape';
 
-export const getShouldShowDescriptionColumn = (fieldItems: BrowserFieldItem[]) => !!fieldItems.find((fieldItem) => !!fieldItem.description?.trim())
+export const getShouldShowDescriptionColumn = (fieldItems: BrowserFieldItem[]) =>
+  !!fieldItems.find((fieldItem) => !!fieldItem.description?.trim());
 
 export const CATEGORY_TABLE_CLASS_NAME = 'category-table';
 export const CLOSE_BUTTON_CLASS_NAME = 'close-button';

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import { BrowserField, BrowserFields } from './types';
+import { BrowserField, BrowserFields, BrowserFieldItem } from './types';
 
 export const FIELD_BROWSER_WIDTH = 925;
 export const TABLE_HEIGHT = 260;
@@ -162,6 +162,8 @@ export const getExampleText = (example: string | number | null | undefined): str
 
 /** Returns `true` if the escape key was pressed */
 export const isEscape = (event: React.KeyboardEvent): boolean => event.key === 'Escape';
+
+export const getShouldShowDescriptionColumn = (fieldItems: BrowserFieldItem[]) => !!fieldItems.find((fieldItem) => !!fieldItem.description?.trim())
 
 export const CATEGORY_TABLE_CLASS_NAME = 'category-table';
 export const CLOSE_BUTTON_CLASS_NAME = 'close-button';


### PR DESCRIPTION
## Summary

issue https://github.com/elastic/kibana/issues/140809

The problem was that we do not have any description in the table on the Fields screen in Observables/Alerts:
![Screenshot 2022-09-15 at 13 02 32](https://user-images.githubusercontent.com/26089545/190985403-ec85dd36-3bc4-47cf-bf25-7d1320f3b538.png)

But in the future, when we'll use this component for another solutions, maybe 'Description' column will be useful. 
So here i've implemented logic, which will hide 'Description' column if there is no content in it for all fields.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


