### PR TITLE
[TIP] Set schema and isSorting for selected indicator columns

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_column_settings.ts
@@ -34,7 +34,7 @@ type CachedColumnsPreferences = Partial<{
   sortingState: EuiDataGridSorting['columns'];
 }>;
 
-export interface ColumnSettings {
+export interface ColumnSettingsValue {
   columns: EuiDataGridColumn[];
   columnVisibility: {
     visibleColumns: string[];
@@ -45,7 +45,7 @@ export interface ColumnSettings {
   handleResetColumns: () => void;
 }
 
-export const useColumnSettings = (): ColumnSettings => {
+export const useColumnSettings = (): ColumnSettingsValue => {
   const {
     services: { storage },
   } = useKibana();

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.tsx
@@ -19,14 +19,16 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDataGridColumn } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import { CellActions } from './cell_actions';
 import { BrowserFields, SecuritySolutionDataViewBase } from '../../../../types';
-import { Indicator } from '../../../../../common/types/indicator';
+import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { cellRendererFactory } from './cell_renderer';
 import { EmptyState } from '../../../../components/empty_state';
 import { IndicatorsTableContext, IndicatorsTableContextValue } from './context';
 import { IndicatorsFlyout } from '../indicators_flyout/indicators_flyout';
 import { Pagination } from '../../hooks/use_indicators';
 import { useToolbarOptions } from './hooks/use_toolbar_options';
-import { ColumnSettings } from './hooks/use_column_settings';
+import { ColumnSettingsValue } from './hooks/use_column_settings';
+import { useFieldTypes } from '../../../../hooks/use_field_types';
+import { getFieldSchema } from '../../lib/get_field_schema';
 
 export interface IndicatorsTableProps {
   indicators: Indicator[];
@@ -37,7 +39,7 @@ export interface IndicatorsTableProps {
   loading: boolean;
   indexPattern: SecuritySolutionDataViewBase;
   browserFields: BrowserFields;
-  columnSettings: ColumnSettings;
+  columnSettings: ColumnSettingsValue;
 }
 
 export const TABLE_TEST_ID = 'tiIndicatorsTable';
@@ -60,6 +62,8 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
   columnSettings: { columns, columnVisibility, handleResetColumns, handleToggleColumn, sorting },
 }) => {
   const [expanded, setExpanded] = useState<Indicator>();
+
+  const fieldTypes = useFieldTypes();
 
   const renderCellValue = useMemo(
     () => cellRendererFactory(pagination.pageIndex * pagination.pageSize),
@@ -91,22 +95,28 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
     [renderCellValue]
   );
 
-  useMemo(() => {
-    columns.forEach(
-      (col: EuiDataGridColumn) =>
-        (col.cellActions = [
-          ({ rowIndex, columnId, Component }: EuiDataGridColumnCellActionProps) => (
-            <CellActions
-              rowIndex={rowIndex}
-              columnId={columnId}
-              Component={Component}
-              indicators={indicators}
-              pagination={pagination}
-            />
-          ),
-        ])
-    );
-  }, [columns, indicators, pagination]);
+  const mappedColumns = useMemo(
+    () =>
+      columns.map((col: EuiDataGridColumn) => {
+        return {
+          ...col,
+          isSortable: col.id !== RawIndicatorFieldId.Id && browserFields[col.id]?.aggregatable,
+          schema: getFieldSchema(fieldTypes[col.id]),
+          cellActions: [
+            ({ rowIndex, columnId, Component }: EuiDataGridColumnCellActionProps) => (
+              <CellActions
+                rowIndex={rowIndex}
+                columnId={columnId}
+                Component={Component}
+                indicators={indicators}
+                pagination={pagination}
+              />
+            ),
+          ],
+        };
+      }),
+    [browserFields, columns, fieldTypes, indicators, pagination]
+  );
 
   const toolbarOptions = useToolbarOptions({
     browserFields,
@@ -159,12 +169,12 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
         data-test-subj={TABLE_TEST_ID}
         sorting={sorting}
         columnVisibility={columnVisibility}
-        columns={columns}
+        columns={mappedColumns}
       />
     );
   }, [
     columnVisibility,
-    columns,
+    mappedColumns,
     indicatorCount,
     leadingControlColumns,
     loading,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/get_field_schema.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/lib/get_field_schema.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KBN_FIELD_TYPES } from '@kbn/data-plugin/public';
+
+/**
+ * Returns datagrid field schema for field type, the same implementation as in discover
+ */
+export const getFieldSchema = (kbnType: string | undefined) => {
+  // Default DataGrid schemas: boolean, numeric, datetime, json, currency, string
+  switch (kbnType) {
+    case KBN_FIELD_TYPES.IP:
+    case KBN_FIELD_TYPES.GEO_SHAPE:
+    case KBN_FIELD_TYPES.NUMBER:
+      return 'numeric';
+    case KBN_FIELD_TYPES.BOOLEAN:
+      return 'boolean';
+    case KBN_FIELD_TYPES.STRING:
+      return 'string';
+    case KBN_FIELD_TYPES.DATE:
+      return 'datetime';
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
## Summary

This PR addresses the issues from this comment:
https://github.com/elastic/security-team/issues/4545#issuecomment-1247854244

`id` column is disabled manually with generic approach based on `aggregable` column (like here: `x-pack/plugins/timelines/public/components/t_grid/body/helpers.tsx`).

Sorting wording is adjusted based on column `schema` property we now also compute (per field type, if applicable).