### PR TITLE
[Profiling] Apply weight to comparison side based on selected time range

### DIFF
--- a/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
+++ b/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
@@ -80,6 +80,11 @@ export function getFlamegraphModel({
     const totalSamples = sum(primaryFlamegraph.CountExclusive);
     const comparisonTotalSamples = sum(comparisonFlamegraph.CountExclusive);
 
+    const weightComparisonSide =
+      comparisonMode === FlameGraphComparisonMode.Relative
+        ? 1
+        : primaryFlamegraph.TotalSeconds / comparisonFlamegraph.TotalSeconds;
+
     primaryFlamegraph.ID.forEach((nodeID, index) => {
       const samples = primaryFlamegraph.Value[index];
       const comparisonSamples = comparisonNodesById[nodeID]?.Value as number | undefined;
@@ -94,7 +99,11 @@ export function getFlamegraphModel({
       const denominator =
         comparisonMode === FlameGraphComparisonMode.Absolute ? totalSamples : foreground;
 
-      const interpolationValue = getInterpolationValue(foreground, background, denominator);
+      const interpolationValue = getInterpolationValue(
+        foreground,
+        background === undefined ? undefined : background * weightComparisonSide,
+        denominator
+      );
 
       const nodeColor =
         interpolationValue >= 0


### PR DESCRIPTION
In the differential flamegraph, weigh samples of comparison side according to the selected time range (compared to the primary side).