### PR TITLE
[Security Solution][Endpoint] Shows empty state page for actions log when there is no data

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_empty_state.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_empty_state.tsx
@@ -40,7 +40,7 @@ export const ActionsLogEmptyState = memo(() => {
           </div>
         }
         actions={[
-          <EuiLink external href={docLinks?.links.securitySolution.responseActions}>
+          <EuiLink external href={docLinks?.links.securitySolution.responseActions} target="_blank">
             {i18n.translate('xpack.securitySolution.actions_log.empty.link', {
               defaultMessage: 'Read more about response actions',
             })}

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_empty_state.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_empty_state.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import styled, { css } from 'styled-components';
+import { EuiLink, EuiEmptyPrompt } from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { ManagementEmptyStateWrapper } from '../../management_empty_state_wrapper';
+
+const EmptyPrompt = styled(EuiEmptyPrompt)`
+  ${() => css`
+    max-width: 100%;
+  `}
+`;
+
+export const ActionsLogEmptyState = memo(() => {
+  const { docLinks } = useKibana().services;
+
+  return (
+    <ManagementEmptyStateWrapper>
+      <EmptyPrompt
+        iconType="editorUnorderedList"
+        title={
+          <h2>
+            {i18n.translate('xpack.securitySolution.actions_log.empty.title', {
+              defaultMessage: 'Actions history is empty',
+            })}
+          </h2>
+        }
+        body={
+          <div>
+            {i18n.translate('xpack.securitySolution.actions_log.empty.content', {
+              defaultMessage: 'No response actions performed',
+            })}
+          </div>
+        }
+        actions={[
+          <EuiLink external href={docLinks?.links.securitySolution.responseActions}>
+            {i18n.translate('xpack.securitySolution.actions_log.empty.link', {
+              defaultMessage: 'Read more about response actions',
+            })}
+          </EuiLink>,
+        ]}
+      />
+    </ManagementEmptyStateWrapper>
+  );
+});
+
+ActionsLogEmptyState.displayName = 'ActionsLogEmptyState';

--- a/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_action_list.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_action_list.ts
@@ -13,13 +13,18 @@ import { useHttp } from '../../../common/lib/kibana';
 import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
 import type { ActionListApiResponse } from '../../../../common/endpoint/types';
 
+interface ErrorType {
+  statusCode: number;
+  message: string;
+}
+
 export const useGetEndpointActionList = (
   query: EndpointActionListRequestQuery,
-  options: UseQueryOptions<ActionListApiResponse, IHttpFetchError> = {}
-): UseQueryResult<ActionListApiResponse, IHttpFetchError> => {
+  options: UseQueryOptions<ActionListApiResponse, IHttpFetchError<ErrorType>> = {}
+): UseQueryResult<ActionListApiResponse, IHttpFetchError<ErrorType>> => {
   const http = useHttp();
 
-  return useQuery<ActionListApiResponse, IHttpFetchError>({
+  return useQuery<ActionListApiResponse, IHttpFetchError<ErrorType>>({
     queryKey: ['get-action-list', query],
     ...options,
     queryFn: async () => {

--- a/x-pack/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.tsx
@@ -5,20 +5,29 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { ACTION_HISTORY } from '../../../../app/translations';
 import { AdministrationListPage } from '../../../components/administration_list_page';
 import { ResponseActionsLog } from '../../../components/endpoint_response_actions_list/response_actions_log';
 import { UX_MESSAGES } from '../../../components/endpoint_response_actions_list/translations';
 
 export const ResponseActionsListPage = () => {
+  const [hideHeader, setHideHeader] = useState(true);
+  const setIsDataCallback = useCallback((isData: boolean) => {
+    setHideHeader(!isData);
+  }, []);
   return (
     <AdministrationListPage
       data-test-subj="responseActionsPage"
       title={ACTION_HISTORY}
       subtitle={UX_MESSAGES.pageSubTitle}
+      hideHeader={hideHeader}
     >
-      <ResponseActionsLog showHostNames={true} isFlyout={false} />
+      <ResponseActionsLog
+        showHostNames={true}
+        isFlyout={false}
+        setIsDataCallback={setIsDataCallback}
+      />
     </AdministrationListPage>
   );
 };

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/list_handler.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/list_handler.ts
@@ -12,6 +12,7 @@
  */
 
 import type { RequestHandler } from '@kbn/core/server';
+import { ENDPOINT_ACTIONS_INDEX } from '../../../../common/endpoint/constants';
 import type { EndpointActionListRequestQuery } from '../../../../common/endpoint/schema/actions';
 import { getActionList, getActionListByStatus } from '../../services';
 import type { SecuritySolutionRequestHandlerContext } from '../../../types';
@@ -21,6 +22,7 @@ import type {
   ResponseActions,
   ResponseActionStatus,
 } from '../../../../common/endpoint/service/response_actions/constants';
+import { doesLogsEndpointActionsIndexExist } from '../../utils';
 
 const formatStringIds = (value: string | string[] | undefined): undefined | string[] =>
   typeof value === 'string' ? [value] : value;
@@ -59,6 +61,16 @@ export const actionListHandler = (
     const esClient = (await context.core).elasticsearch.client.asInternalUser;
 
     try {
+      const indexExists = await doesLogsEndpointActionsIndexExist({
+        context,
+        logger,
+        indexName: ENDPOINT_ACTIONS_INDEX,
+      });
+
+      if (!indexExists) {
+        return res.notFound({ body: 'index_not_found_exception' });
+      }
+
       const requestParams = {
         commands: formatCommandValues(commands),
         esClient,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -205,16 +205,6 @@ const getActionDetailsList = async ({
     throw err;
   }
 
-  if (actionRequests?.statusCode === 404) {
-    const err = new CustomHttpRequestError(
-      'index_not_found_exception',
-      404,
-      new Error('index_not_found_exception')
-    );
-    logger.error(err);
-    throw err;
-  }
-
   if (!actionRequests?.body?.hits?.hits)
     // return empty details array
     return { actionDetails: [], totalRecords: 0 };

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -205,8 +205,19 @@ const getActionDetailsList = async ({
     throw err;
   }
 
-  // return empty details array
-  if (!actionRequests?.body?.hits?.hits) return { actionDetails: [], totalRecords: 0 };
+  if (actionRequests?.statusCode === 404) {
+    const err = new CustomHttpRequestError(
+      'index_not_found_exception',
+      404,
+      new Error('index_not_found_exception')
+    );
+    logger.error(err);
+    throw err;
+  }
+
+  if (!actionRequests?.body?.hits?.hits)
+    // return empty details array
+    return { actionDetails: [], totalRecords: 0 };
 
   // format endpoint actions into { type, item } structure
   const formattedActionRequests = formatEndpointActionResults(actionRequests?.body?.hits?.hits);


### PR DESCRIPTION
## Summary

When there is no data:
![action_logs_empty_state](https://user-images.githubusercontent.com/15727784/191020137-29e6ef43-7ead-4978-93ae-16de0fef2595.gif)


When there is data:
![action_logs_no_empty_state](https://user-images.githubusercontent.com/15727784/191020159-ac295422-cb3b-4e8e-893b-1b93130f06ec.gif)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
