### PR TITLE
[ML] Notifications indicator 

### DIFF
--- a/x-pack/plugins/ml/common/constants/notifications.ts
+++ b/x-pack/plugins/ml/common/constants/notifications.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ML_NOTIFICATIONS_MESSAGE_LEVEL = {
+  ERROR: 'error',
+  INFO: 'info',
+  WARNING: 'warning',
+} as const;

--- a/x-pack/plugins/ml/common/types/notifications.ts
+++ b/x-pack/plugins/ml/common/types/notifications.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import type { MessageLevel } from '../constants/message_levels';
+import { ML_NOTIFICATIONS_MESSAGE_LEVEL } from '../constants/notifications';
+
+export type MlNotificationMessageLevel =
+  typeof ML_NOTIFICATIONS_MESSAGE_LEVEL[keyof typeof ML_NOTIFICATIONS_MESSAGE_LEVEL];
 
 export interface NotificationsQueryParams {
-  level?: MessageLevel;
+  level?: MlNotificationMessageLevel;
   type?: string;
   size?: number;
   from?: number;
@@ -22,7 +25,7 @@ export interface NotificationsQueryParams {
 export interface NotificationSource {
   message: string;
   job_id: string;
-  level: MessageLevel;
+  level: MlNotificationMessageLevel;
   timestamp: number;
   node_name: string;
   job_type: string;
@@ -44,5 +47,5 @@ export interface NotificationsCountQueryParams {
 }
 
 export type NotificationsCountResponse = {
-  [key in MessageLevel]: number;
+  [key in MlNotificationMessageLevel]: number;
 };

--- a/x-pack/plugins/ml/common/types/storage.ts
+++ b/x-pack/plugins/ml/common/types/storage.ts
@@ -82,6 +82,7 @@ export const ML_STORAGE_KEYS = [
   ML_GETTING_STARTED_CALLOUT_DISMISSED,
   ML_FROZEN_TIER_PREFERENCE,
   ML_ANOMALY_EXPLORER_PANELS,
+  ML_NOTIFICATIONS_LAST_CHECKED_AT,
 ];
 
 export function isMlStorageKey(key: unknown): key is MlStorageKey {

--- a/x-pack/plugins/ml/common/types/storage.ts
+++ b/x-pack/plugins/ml/common/types/storage.ts
@@ -75,3 +75,15 @@ export type TMlStorageMapped<T extends MlStorageKey> = T extends typeof ML_ENTIT
   : T extends typeof ML_NOTIFICATIONS_LAST_CHECKED_AT
   ? number | undefined
   : null;
+
+export const ML_STORAGE_KEYS = [
+  ML_ENTITY_FIELDS_CONFIG,
+  ML_APPLY_TIME_RANGE_CONFIG,
+  ML_GETTING_STARTED_CALLOUT_DISMISSED,
+  ML_FROZEN_TIER_PREFERENCE,
+  ML_ANOMALY_EXPLORER_PANELS,
+];
+
+export function isMlStorageKey(key: unknown): key is MlStorageKey {
+  return typeof key === 'string' && ML_STORAGE_KEYS.includes(key);
+}

--- a/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
@@ -11,13 +11,12 @@ import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHealth,
   EuiNotificationBadge,
   EuiToolTip,
-  useEuiTheme,
 } from '@elastic/eui';
-import { timer, combineLatest, of } from 'rxjs';
-import { switchMap, filter, catchError } from 'rxjs/operators';
-import { css } from '@emotion/react';
+import { combineLatest, of, timer } from 'rxjs';
+import { catchError, filter, switchMap } from 'rxjs/operators';
 import { useAsObservable } from '../../hooks';
 import { NotificationsCountResponse } from '../../../../common/types/notifications';
 import { useMlKibana } from '../../contexts/kibana';
@@ -32,7 +31,6 @@ export const NotificationsIndicator: FC = () => {
       mlServices: { mlApiServices },
     },
   } = useMlKibana();
-  const { euiTheme } = useEuiTheme();
   const [lastCheckedAt] = useStorage(ML_NOTIFICATIONS_LAST_CHECKED_AT);
 
   const lastCheckedAt$ = useAsObservable(lastCheckedAt);
@@ -102,20 +100,13 @@ export const NotificationsIndicator: FC = () => {
               />
             }
           >
-            <svg
-              css={css`
-                display: block;
-              `}
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
+            <EuiHealth
+              css={{ display: 'block' }}
+              color="primary"
               aria-label={i18n.translate('xpack.ml.notificationsIndicator.unreadIcon', {
                 defaultMessage: 'Unread notifications indicator.',
               })}
-              fill={euiTheme.colors.primary}
-            >
-              <circle cx="8" cy="8" r="4" />
-            </svg>
+            />
           </EuiToolTip>
         </EuiFlexItem>
       ) : null}

--- a/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
@@ -5,22 +5,101 @@
  * 2.0.
  */
 
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiFlexGroup, EuiFlexItem, EuiNotificationBadge } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { EuiFlexGroup, EuiFlexItem, EuiNotificationBadge, EuiToolTip, EuiIcon } from '@elastic/eui';
+import { timer, combineLatest, of } from 'rxjs';
+import { switchMap, filter, catchError } from 'rxjs/operators';
+import { useAsObservable } from '../../hooks';
+import { NotificationsCountResponse } from '../../../../common/types/notifications';
+import { useMlKibana } from '../../contexts/kibana';
+import { useStorage } from '../../contexts/storage';
+import { ML_NOTIFICATIONS_LAST_CHECKED_AT } from '../../../../common/types/storage';
 
 export const NotificationsIndicator: FC = () => {
+  const {
+    services: {
+      mlServices: { mlApiServices },
+    },
+  } = useMlKibana();
+  const [lastCheckedAt] = useStorage(ML_NOTIFICATIONS_LAST_CHECKED_AT);
+
+  const lastCheckedAt$ = useAsObservable(lastCheckedAt);
+
+  const [notificationsCounts, setNotificationsCounts] = useState<NotificationsCountResponse>();
+
+  useEffect(function startPollingNotifications() {
+    const sub = combineLatest([
+      lastCheckedAt$.pipe(filter((v): v is number => !!v)),
+      timer(0, 5000),
+    ])
+      .pipe(
+        switchMap(([lastChecked]) =>
+          mlApiServices.notifications.countMessages$({ lastCheckedAt: lastChecked })
+        ),
+        catchError((error) => {
+          // Fail silently for now
+          return of({} as NotificationsCountResponse);
+        })
+      )
+      .subscribe((response) => {
+        setNotificationsCounts(response);
+      });
+
+    return () => {
+      sub.unsubscribe();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const errorsAndWarningCount =
+    (notificationsCounts?.error ?? 0) + (notificationsCounts?.warning ?? 0);
+  const hasUnread = notificationsCounts && Object.values(notificationsCounts).some((v) => v > 0);
+
   return (
-    <EuiFlexGroup alignItems={'center'} gutterSize={'xs'}>
+    <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
       <EuiFlexItem grow={false}>
         <FormattedMessage
           id="xpack.ml.navMenu.notificationsTabLinkText"
           defaultMessage="Notifications"
         />
       </EuiFlexItem>
-      {false ? (
+      {errorsAndWarningCount ? (
         <EuiFlexItem grow={false}>
-          <EuiNotificationBadge>{0}</EuiNotificationBadge>
+          <EuiToolTip
+            position="right"
+            content={
+              <FormattedMessage
+                id="xpack.ml.notificationsIndicator.errorsAndWarningLabel"
+                defaultMessage="There {count, plural, one {is # error} other {are # errors}}"
+                values={{ count: errorsAndWarningCount }}
+              />
+            }
+          >
+            <EuiNotificationBadge>{errorsAndWarningCount}</EuiNotificationBadge>
+          </EuiToolTip>
+        </EuiFlexItem>
+      ) : null}
+      {!errorsAndWarningCount && hasUnread ? (
+        <EuiFlexItem grow={false}>
+          <EuiToolTip
+            position="right"
+            content={
+              <FormattedMessage
+                id="xpack.ml.notificationsIndicator.unreadLabel"
+                defaultMessage="You have unread notifications"
+              />
+            }
+          >
+            <EuiIcon
+              type="bell"
+              size={'s'}
+              aria-label={i18n.translate('xpack.ml.notificationsIndicator.unreadIcon', {
+                defaultMessage: 'Unread notifications indicator.',
+              })}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       ) : null}
     </EuiFlexGroup>

--- a/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
@@ -82,7 +82,7 @@ export const NotificationsIndicator: FC = () => {
             content={
               <FormattedMessage
                 id="xpack.ml.notificationsIndicator.errorsAndWarningLabel"
-                defaultMessage="There {count, plural, one {is # notification} other {are # notification}} with the error or warning level"
+                defaultMessage="There {count, plural, one {is # notification} other {are # notification}} with error or warning level"
                 values={{ count: errorsAndWarningCount }}
               />
             }

--- a/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
@@ -82,7 +82,7 @@ export const NotificationsIndicator: FC = () => {
             content={
               <FormattedMessage
                 id="xpack.ml.notificationsIndicator.errorsAndWarningLabel"
-                defaultMessage="There {count, plural, one {is # error} other {are # errors}}"
+                defaultMessage="There {count, plural, one {is # notification} other {are # notification}} with the error or warning level"
                 values={{ count: errorsAndWarningCount }}
               />
             }

--- a/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/notifications_indicator.tsx
@@ -80,7 +80,7 @@ export const NotificationsIndicator: FC = () => {
             content={
               <FormattedMessage
                 id="xpack.ml.notificationsIndicator.errorsAndWarningLabel"
-                defaultMessage="There {count, plural, one {is # notification} other {are # notification}} with error or warning level"
+                defaultMessage="There {count, plural, one {is # notification} other {are # notifications}} with error or warning level"
                 values={{ count: errorsAndWarningCount }}
               />
             }

--- a/x-pack/plugins/ml/public/application/contexts/storage/index.ts
+++ b/x-pack/plugins/ml/public/application/contexts/storage/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { MlStorageContextProvider, useStorage } from './storage_context';

--- a/x-pack/plugins/ml/public/application/contexts/storage/storage_context.tsx
+++ b/x-pack/plugins/ml/public/application/contexts/storage/storage_context.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, useEffect, useMemo, useCallback, useState, useContext } from 'react';
+import { omit } from 'lodash';
+import { isDefined } from '../../../../common/types/guards';
+import { useMlKibana } from '../kibana';
+import { MlStorage, ML_STORAGE_KEYS, isMlStorageKey } from '../../../../common/types/storage';
+import { MlStorageKey, TMlStorageMapped } from '../../../../common/types/storage';
+
+interface StorageAPI {
+  value: MlStorage;
+  setValue: <K extends MlStorageKey, T extends TMlStorageMapped<K>>(key: K, value: T) => void;
+  removeValue: <K extends MlStorageKey>(key: K) => void;
+}
+
+export const MlStorageContext = React.createContext<StorageAPI>({
+  value: null,
+  setValue() {
+    throw new Error('MlStorageContext set method is not implemented');
+  },
+  removeValue() {
+    throw new Error('MlStorageContext remove method is not implemented');
+  },
+});
+
+export const MlStorageContextProvider: FC = ({ children }) => {
+  const {
+    services: { storage },
+  } = useMlKibana();
+
+  const initialValue = ML_STORAGE_KEYS.reduce((acc, curr) => {
+    acc[curr as MlStorageKey] = storage.get(curr);
+    return acc;
+  }, {} as Exclude<MlStorage, null>);
+
+  const [state, setState] = useState<MlStorage>(initialValue);
+
+  const setStorageValue = useCallback(
+    <K extends MlStorageKey, T extends TMlStorageMapped<K>>(key: K, value: T) => {
+      storage.set(key, value);
+
+      const update = {
+        ...state,
+        [key]: value,
+      };
+      setState(update);
+    },
+    [state, storage]
+  );
+
+  const removeStorageValue = useCallback(
+    (key: MlStorageKey) => {
+      storage.remove(key);
+      setState(omit(state, key));
+    },
+    [state, storage]
+  );
+
+  useEffect(function updateStorageOnExternalChange() {
+    const eventListener = (event: StorageEvent) => {
+      if (!isMlStorageKey(event.key)) return;
+
+      if (isDefined(event.newValue)) {
+        setState((prev) => {
+          return {
+            ...prev,
+            [event.key as MlStorageKey]: event.newValue,
+          };
+        });
+      } else {
+        setState((prev) => {
+          return omit(prev, event.key as MlStorageKey);
+        });
+      }
+    };
+
+    /**
+     * This event listener is only invoked when
+     * the change happens in another browser's tab.
+     */
+    window.addEventListener('storage', eventListener);
+
+    return () => {
+      window.removeEventListener('storage', eventListener);
+    };
+  }, []);
+
+  const value: StorageAPI = useMemo(() => {
+    return {
+      value: state,
+      setValue: setStorageValue,
+      removeValue: removeStorageValue,
+    };
+  }, [state, setStorageValue, removeStorageValue]);
+
+  return <MlStorageContext.Provider value={value}>{children}</MlStorageContext.Provider>;
+};
+
+/**
+ * Hook for consuming a storage value
+ * @param key
+ * @param initValue
+ */
+export function useStorage<K extends MlStorageKey>(
+  key: K,
+  initValue?: TMlStorageMapped<K>
+): [TMlStorageMapped<K> | undefined, (value: TMlStorageMapped<K>) => void] {
+  const { value, setValue } = useContext(MlStorageContext);
+
+  const resultValue = useMemo(() => {
+    return (value?.[key] ?? initValue) as TMlStorageMapped<K>;
+  }, [value, key, initValue]);
+
+  const setVal = useCallback(
+    (v: TMlStorageMapped<K>) => {
+      setValue(key, v);
+    },
+    [setValue, key]
+  );
+
+  return [resultValue, setVal];
+}

--- a/x-pack/plugins/ml/public/application/hooks/index.ts
+++ b/x-pack/plugins/ml/public/application/hooks/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { useAsObservable } from './use_as_observable';

--- a/x-pack/plugins/ml/public/application/hooks/use_as_observable.ts
+++ b/x-pack/plugins/ml/public/application/hooks/use_as_observable.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo, useEffect } from 'react';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * Provides an observable based on the input
+ * preserving the reference.
+ *
+ * @param value
+ */
+export function useAsObservable<T>(value: T): Observable<T> {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const subject = useMemo(() => new BehaviorSubject<T>(value), []);
+
+  useEffect(
+    function updateSubject() {
+      subject.next(value);
+    },
+    [subject, value]
+  );
+
+  return subject.asObservable();
+}

--- a/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
+++ b/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
@@ -22,7 +22,6 @@ import {
 import { EuiBasicTableColumn } from '@elastic/eui/src/components/basic_table/basic_table';
 import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import useDebounce from 'react-use/lib/useDebounce';
-import { isEqual } from 'lodash';
 import { ML_NOTIFICATIONS_MESSAGE_LEVEL } from '../../../../common/constants/notifications';
 import { ML_NOTIFICATIONS_LAST_CHECKED_AT } from '../../../../common/types/storage';
 import { useStorage } from '../../contexts/storage';
@@ -33,7 +32,7 @@ import { useFieldFormatter } from '../../contexts/kibana/use_field_formatter';
 import { useRefresh } from '../../routing/use_refresh';
 import { useTableSettings } from '../../data_frame_analytics/pages/analytics_management/components/analytics_list/use_table_settings';
 import { ListingPageUrlState } from '../../../../common/types/common';
-import { usePageUrlState } from '../../util/url_state';
+import { usePageUrlState, useUrlState } from '../../util/url_state';
 import { ML_PAGES } from '../../../../common/constants/locator';
 import type {
   MlNotificationMessageLevel,
@@ -66,15 +65,15 @@ export const NotificationsList: FC = () => {
   const timeFilter = useTimefilter();
   const timeRange = useTimeRangeUpdates();
 
-  useEffect(function setTimeRangeOnMount() {
-    const defaults = timeFilter.getTimeDefaults();
+  const [globalState] = useUrlState('_g');
 
-    if (lastCheckedAt && isEqual(defaults, timeRange)) {
-      timeFilter.setTime({
-        from: moment(lastCheckedAt).toISOString(),
-        to: 'now',
-      });
-    }
+  useEffect(function setTimeRangeOnMount() {
+    if (globalState?.time || !lastCheckedAt) return;
+
+    timeFilter.setTime({
+      from: moment(lastCheckedAt).toISOString(),
+      to: 'now',
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
+++ b/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
@@ -21,6 +21,7 @@ import {
 import { EuiBasicTableColumn } from '@elastic/eui/src/components/basic_table/basic_table';
 import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import useDebounce from 'react-use/lib/useDebounce';
+import { ML_NOTIFICATIONS_MESSAGE_LEVEL } from '../../../../common/constants/notifications';
 import { ML_NOTIFICATIONS_LAST_CHECKED_AT } from '../../../../common/types/storage';
 import { useStorage } from '../../contexts/storage';
 import { SavedObjectsWarning } from '../../components/saved_objects_warning';
@@ -29,18 +30,19 @@ import { useToastNotificationService } from '../../services/toast_notification_s
 import { useFieldFormatter } from '../../contexts/kibana/use_field_formatter';
 import { useRefresh } from '../../routing/use_refresh';
 import { useTableSettings } from '../../data_frame_analytics/pages/analytics_management/components/analytics_list/use_table_settings';
-import { MESSAGE_LEVEL, MessageLevel } from '../../../../common/constants/message_levels';
 import { ListingPageUrlState } from '../../../../common/types/common';
 import { usePageUrlState } from '../../util/url_state';
 import { ML_PAGES } from '../../../../common/constants/locator';
-import type { NotificationItem } from '../../../../common/types/notifications';
+import type {
+  MlNotificationMessageLevel,
+  NotificationItem,
+} from '../../../../common/types/notifications';
 import { useMlKibana } from '../../contexts/kibana';
 
-const levelBadgeMap: Record<MessageLevel, IconColor> = {
-  error: 'danger',
-  info: 'default',
-  success: 'subdued',
-  warning: 'warning',
+const levelBadgeMap: Record<MlNotificationMessageLevel, IconColor> = {
+  [ML_NOTIFICATIONS_MESSAGE_LEVEL.ERROR]: 'danger',
+  [ML_NOTIFICATIONS_MESSAGE_LEVEL.WARNING]: 'warning',
+  [ML_NOTIFICATIONS_MESSAGE_LEVEL.INFO]: 'default',
 };
 
 export const getDefaultNotificationsListState = (): ListingPageUrlState => ({
@@ -161,7 +163,7 @@ export const NotificationsList: FC = () => {
       sortable: true,
       truncateText: false,
       'data-test-subj': 'mlNotificationLabel',
-      render: (value: MessageLevel) => {
+      render: (value: MlNotificationMessageLevel) => {
         return <EuiBadge color={levelBadgeMap[value]}>{value}</EuiBadge>;
       },
       width: '100px',
@@ -172,7 +174,7 @@ export const NotificationsList: FC = () => {
       sortable: true,
       truncateText: false,
       'data-test-subj': 'mlNotificationType',
-      render: (value: MessageLevel) => {
+      render: (value: string) => {
         return <EuiBadge color={'hollow'}>{value}</EuiBadge>;
       },
       width: '200px',
@@ -205,21 +207,21 @@ export const NotificationsList: FC = () => {
         multiSelect: 'or',
         options: [
           {
-            value: MESSAGE_LEVEL.ERROR,
+            value: ML_NOTIFICATIONS_MESSAGE_LEVEL.ERROR,
             name: i18n.translate('xpack.ml.notifications.filters.level.error', {
               defaultMessage: 'Error',
             }),
             field: 'level',
           },
           {
-            value: MESSAGE_LEVEL.WARNING,
+            value: ML_NOTIFICATIONS_MESSAGE_LEVEL.WARNING,
             name: i18n.translate('xpack.ml.notifications.filters.level.warning', {
               defaultMessage: 'Warning',
             }),
             field: 'level',
           },
           {
-            value: MESSAGE_LEVEL.INFO,
+            value: ML_NOTIFICATIONS_MESSAGE_LEVEL.INFO,
             name: i18n.translate('xpack.ml.notifications.filters.level.info', {
               defaultMessage: 'Info',
             }),

--- a/x-pack/plugins/ml/public/application/routing/router.tsx
+++ b/x-pack/plugins/ml/public/application/routing/router.tsx
@@ -18,6 +18,7 @@ import type {
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 
 import { EuiLoadingContent } from '@elastic/eui';
+import { MlStorageContextProvider } from '../contexts/storage';
 import { MlContext, MlContextValue } from '../contexts/ml';
 import { UrlStateProvider } from '../util/url_state';
 
@@ -104,9 +105,11 @@ export const MlRouter: FC<{
 }> = ({ pageDeps }) => (
   <Router history={pageDeps.history}>
     <LegacyHashUrlRedirect>
-      <UrlStateProvider>
-        <MlPage pageDeps={pageDeps} />
-      </UrlStateProvider>
+      <MlStorageContextProvider>
+        <UrlStateProvider>
+          <MlPage pageDeps={pageDeps} />
+        </UrlStateProvider>
+      </MlStorageContextProvider>
     </LegacyHashUrlRedirect>
   </Router>
 );

--- a/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
+++ b/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
@@ -7,7 +7,6 @@
 
 import { IScopedClusterClient } from '@kbn/core/server';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { MessageLevel } from '../../../common/constants/message_levels';
 import type { MLSavedObjectService } from '../../saved_objects';
 import type { NotificationItem, NotificationSource } from '../../../common/types/notifications';
 import { ML_NOTIFICATION_INDEX_PATTERN } from '../../../common/constants/index_patterns';
@@ -15,7 +14,8 @@ import type {
   MessagesSearchParams,
   NotificationsCountParams,
 } from '../../routes/schemas/notifications_schema';
-import {
+import type {
+  MlNotificationMessageLevel,
   NotificationsCountResponse,
   NotificationsSearchResponse,
 } from '../../../common/types/notifications';
@@ -222,7 +222,7 @@ export class NotificationsService {
 
         return Array.isArray(byLevel.buckets)
           ? byLevel.buckets.reduce((acc, curr) => {
-              acc[curr.key as MessageLevel] = curr.doc_count;
+              acc[curr.key as MlNotificationMessageLevel] = curr.doc_count;
               return acc;
             }, {} as NotificationsCountResponse)
           : ({} as NotificationsCountResponse);
@@ -233,12 +233,13 @@ export class NotificationsService {
       (acc, curr) => {
         for (const levelKey in curr) {
           if (curr.hasOwnProperty(levelKey)) {
-            acc[levelKey as MessageLevel] += curr[levelKey as MessageLevel];
+            acc[levelKey as MlNotificationMessageLevel] +=
+              curr[levelKey as MlNotificationMessageLevel];
           }
         }
         return acc;
       },
-      { error: 0, warning: 0, info: 0, success: 0 } as NotificationsCountResponse
+      { error: 0, warning: 0, info: 0 } as NotificationsCountResponse
     );
   }
 }

--- a/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
+++ b/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
@@ -6,15 +6,19 @@
  */
 
 import { IScopedClusterClient } from '@kbn/core/server';
-import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { MLSavedObjectService } from '../../saved_objects';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { MessageLevel } from '../../../common/constants/message_levels';
+import type { MLSavedObjectService } from '../../saved_objects';
 import type { NotificationItem, NotificationSource } from '../../../common/types/notifications';
 import { ML_NOTIFICATION_INDEX_PATTERN } from '../../../common/constants/index_patterns';
 import type {
   MessagesSearchParams,
   NotificationsCountParams,
 } from '../../routes/schemas/notifications_schema';
-import { NotificationsSearchResponse } from '../../../common/types/notifications';
+import {
+  NotificationsCountResponse,
+  NotificationsSearchResponse,
+} from '../../../common/types/notifications';
 
 const MAX_NOTIFICATIONS_SIZE = 10000;
 
@@ -23,6 +27,25 @@ export class NotificationsService {
     private readonly scopedClusterClient: IScopedClusterClient,
     private readonly mlSavedObjectService: MLSavedObjectService
   ) {}
+
+  /**
+   * Provides entity IDs per type for the current space.
+   * @private
+   */
+  private async _getEntityIdsPerType() {
+    const [adJobIds, dfaJobIds, modelIds] = await Promise.all([
+      this.mlSavedObjectService.getAnomalyDetectionJobIds(),
+      this.mlSavedObjectService.getDataFrameAnalyticsJobIds(),
+      this.mlSavedObjectService.getTrainedModelsIds(),
+    ]);
+
+    return [
+      { type: 'anomaly_detector', ids: adJobIds },
+      { type: 'data_frame_analytics', ids: dfaJobIds },
+      { type: 'inference', ids: modelIds },
+      { type: 'system' },
+    ].filter((v) => v.ids === undefined || v.ids.length > 0);
+  }
 
   /**
    * Searches notifications based on the criteria.
@@ -34,91 +57,80 @@ export class NotificationsService {
    *
    */
   async searchMessages(params: MessagesSearchParams) {
-    const [adJobIds, dfaJobIds, modelIds] = await Promise.all([
-      this.mlSavedObjectService.getAnomalyDetectionJobIds(),
-      this.mlSavedObjectService.getDataFrameAnalyticsJobIds(),
-      this.mlSavedObjectService.getTrainedModelsIds(),
-    ]);
+    const entityIdsPerType = await this._getEntityIdsPerType();
 
     const results = await Promise.all(
-      [
-        { type: 'anomaly_detector', ids: adJobIds },
-        { type: 'data_frame_analytics', ids: dfaJobIds },
-        { type: 'inference', ids: modelIds },
-        { type: 'system' },
-      ]
-        .filter((v) => v.ids === undefined || v.ids.length > 0)
-        .map(async (v) => {
-          const responseBody =
-            await this.scopedClusterClient.asInternalUser.search<NotificationSource>(
-              {
-                index: ML_NOTIFICATION_INDEX_PATTERN,
-                ignore_unavailable: true,
-                from: 0,
-                size: MAX_NOTIFICATIONS_SIZE,
-                body: {
-                  sort: [{ [params.sortField]: { order: params.sortDirection } }],
-                  query: {
-                    bool: {
-                      ...(params.queryString
-                        ? {
-                            must: [
-                              {
-                                query_string: {
-                                  query: params.queryString,
-                                  default_field: 'message',
-                                },
+      entityIdsPerType.map(async (v) => {
+        const responseBody =
+          await this.scopedClusterClient.asInternalUser.search<NotificationSource>(
+            {
+              index: ML_NOTIFICATION_INDEX_PATTERN,
+              ignore_unavailable: true,
+              from: 0,
+              size: MAX_NOTIFICATIONS_SIZE,
+              body: {
+                sort: [{ [params.sortField]: { order: params.sortDirection } }],
+                query: {
+                  bool: {
+                    ...(params.queryString
+                      ? {
+                          must: [
+                            {
+                              query_string: {
+                                query: params.queryString,
+                                default_field: 'message',
                               },
-                            ],
-                          }
-                        : {}),
-                      filter: [
-                        ...(v.ids
-                          ? [
-                              {
-                                terms: {
-                                  job_id: v.ids as string[],
-                                },
-                              },
-                            ]
-                          : []),
-                        {
-                          term: {
-                            job_type: {
-                              value: v.type,
                             },
+                          ],
+                        }
+                      : {}),
+                    filter: [
+                      ...(v.ids
+                        ? [
+                            {
+                              terms: {
+                                job_id: v.ids as string[],
+                              },
+                            },
+                          ]
+                        : []),
+                      {
+                        term: {
+                          job_type: {
+                            value: v.type,
                           },
                         },
-                        ...(params.earliest || params.latest
-                          ? [
-                              {
-                                range: {
-                                  timestamp: {
-                                    ...(params.earliest ? { gt: params.earliest } : {}),
-                                    ...(params.latest ? { lte: params.latest } : {}),
-                                  },
+                      },
+                      ...(params.earliest || params.latest
+                        ? [
+                            {
+                              range: {
+                                timestamp: {
+                                  ...(params.earliest ? { gt: params.earliest } : {}),
+                                  ...(params.latest ? { lte: params.latest } : {}),
                                 },
                               },
-                            ]
-                          : []),
-                      ],
-                    },
+                            },
+                          ]
+                        : []),
+                    ],
                   },
                 },
               },
-              { maxRetries: 0 }
-            );
+            },
+            { maxRetries: 0 }
+          );
 
-          return {
-            total: (responseBody.hits.total as SearchTotalHits).value,
-            results: responseBody.hits.hits.map((result) => {
-              return {
-                ...result._source,
-                id: result._id,
-              };
-            }),
-          } as NotificationsSearchResponse;
-        })
+        return {
+          total: (responseBody.hits.total as estypes.SearchTotalHits).value,
+          results: responseBody.hits.hits.map((result) => {
+            return {
+              ...result._source,
+              id: result._id,
+            };
+          }),
+        } as NotificationsSearchResponse;
+      })
     );
 
     const response = results.reduce(
@@ -159,34 +171,74 @@ export class NotificationsService {
   /**
    * Provides a number of messages by level.
    */
-  async countMessages(params: NotificationsCountParams) {
-    const responseBody = await this.scopedClusterClient.asInternalUser.search({
-      size: 0,
-      index: ML_NOTIFICATION_INDEX_PATTERN,
-      body: {
-        query: {
-          bool: {
-            filter: {
-              range: {
-                timestamp: {
-                  gt: params.lastCheckedAt,
-                },
+  async countMessages(params: NotificationsCountParams): Promise<NotificationsCountResponse> {
+    const entityIdsPerType = await this._getEntityIdsPerType();
+
+    const res = await Promise.all(
+      entityIdsPerType.map(async (v) => {
+        const responseBody = await this.scopedClusterClient.asInternalUser.search({
+          size: 0,
+          index: ML_NOTIFICATION_INDEX_PATTERN,
+          body: {
+            query: {
+              bool: {
+                filter: [
+                  ...(v.ids
+                    ? [
+                        {
+                          terms: {
+                            job_id: v.ids as string[],
+                          },
+                        },
+                      ]
+                    : []),
+                  {
+                    term: {
+                      job_type: {
+                        value: v.type,
+                      },
+                    },
+                  },
+                  {
+                    range: {
+                      timestamp: {
+                        gt: params.lastCheckedAt,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            aggs: {
+              by_level: {
+                terms: { field: 'level' },
               },
             },
           },
-        },
-        aggs: {
-          by_level: {
-            terms: { field: 'level' },
-          },
-        },
-      },
-    });
+        });
 
-    // @ts-ignore
-    return responseBody.aggregations.by_level.buckets.reduce((acc, curr) => {
-      acc[curr.key] = curr.doc_count;
-      return acc;
-    }, {});
+        const byLevel = responseBody.aggregations!
+          .by_level as estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringTermsBucketKeys>;
+
+        return Array.isArray(byLevel.buckets)
+          ? byLevel.buckets.reduce((acc, curr) => {
+              acc[curr.key as MessageLevel] = curr.doc_count;
+              return acc;
+            }, {} as NotificationsCountResponse)
+          : ({} as NotificationsCountResponse);
+      })
+    );
+
+    return res.reduce(
+      (acc, curr) => {
+        for (const levelKey in curr) {
+          if (curr.hasOwnProperty(levelKey)) {
+            acc[levelKey as MessageLevel] += curr[levelKey as MessageLevel];
+          }
+        }
+        return acc;
+      },
+      { error: 0, warning: 0, info: 0, success: 0 } as NotificationsCountResponse
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/135417

Adds a notifications indicator to the side nav menu. 

#### How it works

- When the user visits the Notifications page, the app stashes the timestamp of the latest notification visible on the screen in the local storage 
- The app polling the `.ml-notifications*` index with an interval of 1 minute for new notifications that occurred after the stored timestamp  
- If there are only notifications with an `info` level, displays the generic notification indicator 

<img width="1517" alt="image" src="https://user-images.githubusercontent.com/5236598/191020063-92a0e638-b47a-431c-b491-443167d39c81.png">

- If there are errors or warnings, it shows a counter in the side nav.  
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/5236598/191029711-f0830d21-2d55-4c17-8cfe-026bbb4172b4.png">

- When the user visits the page again, sets the time bounds based on the last checked notification. 

#### How to test

- To trigger an `info` message, you can create any job or deploy model, start/stop datafeed, etc.
- To trigger an `error`, you can delete the source index of the anomaly detection job. Setting `frequency` for this job to something small should make it less time-consuming. 


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
