### PR TITLE
[Profiling] reinstate primary refresh button for now

### DIFF
--- a/x-pack/plugins/profiling/public/components/profiling_app_page_template/profiling_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/profiling_app_page_template/profiling_search_bar.tsx
@@ -69,7 +69,8 @@ export function ProfilingSearchBar({
       showDatePicker
       showFilterBar={false}
       showSaveQuery={false}
-      showSubmitButton={showSubmitButton}
+      // showSubmitButton={showSubmitButton}
+      showSubmitButton={true}
       query={searchBarQuery}
       dateRangeFrom={rangeFrom}
       dateRangeTo={rangeTo}


### PR DESCRIPTION
Puts back the primary refresh button for now, I can't quickly find a way to trigger the `onQuerySubmit` handler if there is no refresh button. I'll reach out to the unified search group to see what we can do about it.

<img width="1788" alt="CleanShot 2022-09-19 at 14 53 54@2x" src="https://user-images.githubusercontent.com/352732/191021976-7dec0252-fa23-4c9f-9d0d-233871f6d9ad.png">
