### PR TITLE
[Fleet] reloading activity in sync with agents, added loading spinner

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -55,7 +55,7 @@ export const AgentActivityFlyout: React.FunctionComponent<{
     perPage: SO_SEARCH_LIMIT,
   });
 
-  const { currentActions, abortUpgrade, isLoading } = useActionStatus(
+  const { currentActions, abortUpgrade, isFirstLoading } = useActionStatus(
     onAbortSuccess,
     refreshAgentActivity
   );
@@ -108,7 +108,7 @@ export const AgentActivityFlyout: React.FunctionComponent<{
         </EuiFlyoutHeader>
 
         <FullHeightFlyoutBody>
-          {isLoading ? (
+          {isFirstLoading ? (
             <EuiFlexGroup
               direction="row"
               justifyContent={'center'}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -32,6 +32,8 @@ import { useActionStatus } from '../hooks';
 import { useGetAgentPolicies, useStartServices } from '../../../../hooks';
 import { SO_SEARCH_LIMIT } from '../../../../constants';
 
+import { Loading } from '../../components';
+
 import { getTodayActions, getOtherDaysActions } from './agent_activity_helper';
 
 const FullHeightFlyoutBody = styled(EuiFlyoutBody)`
@@ -47,12 +49,16 @@ const FlyoutFooterWPadding = styled(EuiFlyoutFooter)`
 export const AgentActivityFlyout: React.FunctionComponent<{
   onClose: () => void;
   onAbortSuccess: () => void;
-}> = ({ onClose, onAbortSuccess }) => {
+  refreshAgentActivity: boolean;
+}> = ({ onClose, onAbortSuccess, refreshAgentActivity }) => {
   const { data: agentPoliciesData } = useGetAgentPolicies({
     perPage: SO_SEARCH_LIMIT,
   });
 
-  const { currentActions, abortUpgrade } = useActionStatus(onAbortSuccess);
+  const { currentActions, abortUpgrade, isLoading } = useActionStatus(
+    onAbortSuccess,
+    refreshAgentActivity
+  );
 
   const getAgentPolicyName = (policyId: string) => {
     const policy = agentPoliciesData?.items.find((item) => item.id === policyId);
@@ -102,7 +108,18 @@ export const AgentActivityFlyout: React.FunctionComponent<{
         </EuiFlyoutHeader>
 
         <FullHeightFlyoutBody>
-          {currentActionsEnriched.length === 0 ? (
+          {isLoading ? (
+            <EuiFlexGroup
+              direction="row"
+              justifyContent={'center'}
+              alignItems={'center'}
+              className="eui-fullHeight"
+            >
+              <EuiFlexItem>
+                <Loading />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : currentActionsEnriched.length === 0 ? (
             <EuiFlexGroup
               direction="column"
               justifyContent={'center'}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { sendGetActionStatus, sendPostCancelAction, useStartServices } from '../../../../hooks';
+
+import { useActionStatus } from './use_action_status';
+
+jest.mock('../../../../hooks', () => ({
+  sendGetActionStatus: jest.fn(),
+  sendPostCancelAction: jest.fn(),
+  useStartServices: jest.fn().mockReturnValue({
+    notifications: {
+      toasts: {
+        addError: jest.fn(),
+      },
+    },
+    overlays: {
+      openConfirm: jest.fn(),
+    },
+  }),
+}));
+
+describe('useActionStatus', () => {
+  const mockSendGetActionStatus = sendGetActionStatus as jest.Mock;
+  const mockSendPostCancelAction = sendPostCancelAction as jest.Mock;
+  const startServices = useStartServices();
+  const mockOpenConfirm = startServices.overlays.openConfirm as jest.Mock;
+  const mockErrorToast = startServices.notifications.toasts.addError as jest.Mock;
+  const mockOnAbortSuccess = jest.fn();
+  const mockActionStatuses = [
+    {
+      actionId: 'action1',
+      nbAgentsActionCreated: 2,
+      nbAgentsAck: 1,
+      nbAgentsFailed: 0,
+      nbAgentsActioned: 2,
+      creationTime: '2022-09-19T12:07:27.102Z',
+    },
+  ];
+  beforeEach(() => {
+    mockSendGetActionStatus.mockReset();
+    mockSendGetActionStatus.mockResolvedValue({ data: { items: mockActionStatuses } });
+    mockSendPostCancelAction.mockReset();
+    mockOnAbortSuccess.mockReset();
+    mockOpenConfirm.mockReset();
+    mockOpenConfirm.mockResolvedValue({});
+    mockErrorToast.mockReset();
+    mockErrorToast.mockResolvedValue({});
+  });
+  it('should set action statuses on init', async () => {
+    let result: any | undefined;
+    await act(async () => {
+      ({ result } = renderHook(() => useActionStatus(mockOnAbortSuccess, false)));
+    });
+    expect(result?.current.currentActions).toEqual(mockActionStatuses);
+  });
+
+  it('should refresh statuses on refresh flag', async () => {
+    let refresh = false;
+    await act(async () => {
+      const result = renderHook(() => useActionStatus(mockOnAbortSuccess, refresh));
+      refresh = true;
+      result.rerender();
+    });
+    expect(mockSendGetActionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('should post abort and invoke callback on abort upgrade', async () => {
+    mockSendPostCancelAction.mockResolvedValue({});
+    let result: any | undefined;
+    await act(async () => {
+      ({ result } = renderHook(() => useActionStatus(mockOnAbortSuccess, false)));
+    });
+    await act(async () => {
+      await result.current.abortUpgrade(mockActionStatuses[0]);
+    });
+    expect(mockSendPostCancelAction).toHaveBeenCalledWith('action1');
+    expect(mockOnAbortSuccess).toHaveBeenCalled();
+    expect(mockOpenConfirm).toHaveBeenCalledWith('This action will abort upgrade of 1 agents', {
+      title: 'Abort upgrade?',
+    });
+  });
+
+  it('should report error on abort upgrade failure', async () => {
+    const error = new Error('error');
+    mockSendPostCancelAction.mockRejectedValue(error);
+    let result: any | undefined;
+    await act(async () => {
+      ({ result } = renderHook(() => useActionStatus(mockOnAbortSuccess, false)));
+    });
+    await act(async () => {
+      await result.current.abortUpgrade(mockActionStatuses[0]);
+    });
+    expect(mockOnAbortSuccess).not.toHaveBeenCalled();
+    expect(mockErrorToast).toHaveBeenCalledWith(error, {
+      title: 'An error happened while aborting upgrade',
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.tsx
@@ -14,13 +14,13 @@ import type { ActionStatus } from '../../../../types';
 
 export function useActionStatus(onAbortSuccess: () => void, refreshAgentActivity: boolean) {
   const [currentActions, setCurrentActions] = useState<ActionStatus[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isFirstLoading, setIsFirstLoading] = useState(true);
   const { notifications, overlays } = useStartServices();
 
   const refreshActions = useCallback(async () => {
     try {
       const res = await sendGetActionStatus();
-      setIsLoading(false);
+      setIsFirstLoading(false);
       if (res.error) {
         throw res.error;
       }
@@ -39,7 +39,7 @@ export function useActionStatus(onAbortSuccess: () => void, refreshAgentActivity
     }
   }, [notifications.toasts]);
 
-  if (isLoading) {
+  if (isFirstLoading) {
     refreshActions();
   }
 
@@ -86,6 +86,6 @@ export function useActionStatus(onAbortSuccess: () => void, refreshAgentActivity
     currentActions,
     refreshActions,
     abortUpgrade,
-    isLoading,
+    isFirstLoading,
   };
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_action_status.tsx
@@ -5,27 +5,22 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { sendGetActionStatus, sendPostCancelAction, useStartServices } from '../../../../hooks';
 
 import type { ActionStatus } from '../../../../types';
 
-const POLL_INTERVAL = 30 * 1000;
-
-export function useActionStatus(onAbortSuccess: () => void) {
+export function useActionStatus(onAbortSuccess: () => void, refreshAgentActivity: boolean) {
   const [currentActions, setCurrentActions] = useState<ActionStatus[]>([]);
-  const currentTimeoutRef = useRef<NodeJS.Timeout>();
-  const isCancelledRef = useRef<boolean>(false);
+  const [isLoading, setIsLoading] = useState(true);
   const { notifications, overlays } = useStartServices();
 
   const refreshActions = useCallback(async () => {
     try {
       const res = await sendGetActionStatus();
-      if (isCancelledRef.current) {
-        return;
-      }
+      setIsLoading(false);
       if (res.error) {
         throw res.error;
       }
@@ -44,28 +39,15 @@ export function useActionStatus(onAbortSuccess: () => void) {
     }
   }, [notifications.toasts]);
 
-  // Poll for upgrades
+  if (isLoading) {
+    refreshActions();
+  }
+
   useEffect(() => {
-    isCancelledRef.current = false;
-
-    async function pollData() {
-      await refreshActions();
-      if (isCancelledRef.current) {
-        return;
-      }
-      currentTimeoutRef.current = setTimeout(() => pollData(), POLL_INTERVAL);
+    if (refreshAgentActivity) {
+      refreshActions();
     }
-
-    pollData();
-
-    return () => {
-      isCancelledRef.current = true;
-
-      if (currentTimeoutRef.current) {
-        clearTimeout(currentTimeoutRef.current);
-      }
-    };
-  }, [refreshActions]);
+  }, [refreshActions, refreshAgentActivity]);
 
   const abortUpgrade = useCallback(
     async (action: ActionStatus) => {
@@ -104,5 +86,6 @@ export function useActionStatus(onAbortSuccess: () => void) {
     currentActions,
     refreshActions,
     abortUpgrade,
+    isLoading,
   };
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -554,6 +554,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           <AgentActivityFlyout
             onAbortSuccess={fetchData}
             onClose={() => setAgentActivityFlyoutOpen(false)}
+            refreshAgentActivity={isLoading}
           />
         </EuiPortal>
       ) : null}


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/140910
Loading Agent activity at the same time with agents and agent statuses. 
It can still happen that the agent statuses are out of sync with the activity flyout, because the flyout loads the data for the first time when opened, and the agent list is loaded every 30s.

<img width="1763" alt="image" src="https://user-images.githubusercontent.com/90178898/191042722-111e1747-0b35-4378-9afb-94189ec5f2d2.png">

Fix https://github.com/elastic/kibana/issues/140927
Added loading spinner for Agent activity first load.

<img width="509" alt="image" src="https://user-images.githubusercontent.com/90178898/191043152-3bdeb8c2-464b-4a74-8518-fba34c6bb52d.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
