### PR TITLE
[DOCS] Removes 8.4.2 release notes tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,8 +38,6 @@ Review important information about the {kib} 8.4.x releases.
 [[release-notes-8.4.2]]
 == {kib} 8.4.2
 
-coming::[8.4.2]
-
 Review the following information about the {kib} 8.4.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 8.4.2 release notes.