### PR TITLE
[Stack Monitoring] add padding to page template

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
@@ -148,7 +148,11 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
               })}
             </EuiTabs>
           )}
-          <EuiPageContentBody>{renderContent()}</EuiPageContentBody>
+          <EuiPageContentBody>
+            <EuiPage paddingSize="m">
+              <EuiPageBody>{renderContent()}</EuiPageBody>
+            </EuiPage>
+          </EuiPageContentBody>
         </EuiPageContent>
       </EuiPageBody>
     </EuiPage>


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/kibana/issues/140908

Padding was gone from stack monitoring page template, most likely caused by eui upgrade.

### Testing
- load stack monitoring and enable internal monitoring
- navigate to available elasticsearch/kibana views and notice the perfectly padded content in the grey area

<img width="898" alt="Screenshot 2022-09-19 at 18 24 02" src="https://user-images.githubusercontent.com/5239883/191065845-cc6772b8-02c4-473f-98c6-0b252d10c840.png">
