### PR TITLE
[Maps] Track map embeddable usage with ui counters

### DIFF
--- a/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { lastValueFrom } from 'rxjs';
+import { first } from 'rxjs/operators';
 import { i18n } from '@kbn/i18n';
 import { EmbeddableFactoryDefinition, IContainer } from '@kbn/embeddable-plugin/public';
 import { MAP_SAVED_OBJECT_TYPE, APP_ICON } from '../../common/constants';
@@ -53,10 +55,8 @@ export class MapEmbeddableFactory implements EmbeddableFactoryDefinition {
     const { MapEmbeddable } = await lazyLoadMapModules();
     const usageCollection = getUsageCollection();
     if (usageCollection) {
-      const subscription = getApplication().currentAppId$.subscribe((appId) => {
-        usageCollection.reportUiCounter('map', 'loaded', `open_maps_vis_${appId}`);
-      });
-      subscription.unsubscribe();
+      const appId = await lastValueFrom(getApplication().currentAppId$.pipe(first()));
+      usageCollection.reportUiCounter('map', 'loaded', `open_maps_vis_${appId}`);
     }
     return new MapEmbeddable(
       {

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
@@ -12,6 +12,7 @@ import { getMapEmbeddableDisplayName } from '../../common/i18n_getters';
 import { extract, inject } from '../../common/embeddable';
 import { MapByReferenceInput, MapEmbeddableInput } from './types';
 import { lazyLoadMapModules } from '../lazy_load_bundle';
+import { getApplication, getUsageCollection } from '../kibana_services';
 
 export class MapEmbeddableFactory implements EmbeddableFactoryDefinition {
   type = MAP_SAVED_OBJECT_TYPE;
@@ -50,6 +51,13 @@ export class MapEmbeddableFactory implements EmbeddableFactoryDefinition {
 
   create = async (input: MapEmbeddableInput, parent?: IContainer) => {
     const { MapEmbeddable } = await lazyLoadMapModules();
+    const usageCollection = getUsageCollection();
+    if (usageCollection) {
+      const subscription = getApplication().currentAppId$.subscribe((appId) => {
+        usageCollection.reportUiCounter('map', 'loaded', `open_maps_vis_${appId}`);
+      });
+      subscription.unsubscribe();
+    }
     return new MapEmbeddable(
       {
         editable: await this.isEditable(),

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable_factory.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { lastValueFrom } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { i18n } from '@kbn/i18n';
 import { EmbeddableFactoryDefinition, IContainer } from '@kbn/embeddable-plugin/public';
@@ -55,8 +54,12 @@ export class MapEmbeddableFactory implements EmbeddableFactoryDefinition {
     const { MapEmbeddable } = await lazyLoadMapModules();
     const usageCollection = getUsageCollection();
     if (usageCollection) {
-      const appId = await lastValueFrom(getApplication().currentAppId$.pipe(first()));
-      usageCollection.reportUiCounter('map', 'loaded', `open_maps_vis_${appId}`);
+      // currentAppId$ is a BehaviorSubject exposed as an observable so subscription gets last value upon subscribe
+      getApplication()
+        .currentAppId$.pipe(first())
+        .subscribe((appId) => {
+          if (appId) usageCollection.reportUiCounter('map', 'loaded', `open_maps_vis_${appId}`);
+        });
     }
     return new MapEmbeddable(
       {

--- a/x-pack/plugins/maps/public/kibana_services.ts
+++ b/x-pack/plugins/maps/public/kibana_services.ts
@@ -66,6 +66,7 @@ export const getPresentationUtilContext = () => pluginsStart.presentationUtil.Co
 export const getSecurityService = () => pluginsStart.security;
 export const getSpacesApi = () => pluginsStart.spaces;
 export const getTheme = () => coreStart.theme;
+export const getApplication = () => coreStart.application;
 export const getUsageCollection = () => pluginsStart.usageCollection;
 export const isScreenshotMode = () => {
   return pluginsStart.screenshotMode ? pluginsStart.screenshotMode.isScreenshotMode() : false;


### PR DESCRIPTION
## Summary

Track usage of Map embeddables in solutions such as Machine Learning, Security, and User Experience as well as apps like Discover, Dashboard, and Lens.

The Maps team wants to better understand how Maps embeddables are used across solutions. In this PR we subscribe to the `currentAppId$` in the Map embeddable factory and increment a UI counter each time the map embeddable is constructed. Re-renders such as clicking the refresh button in a dashboard, or changing the time picker do not trigger UI counters. However, collapsing and expanding panels such as in the Field Statistics view in Discover will reconstruct the embeddable each time, triggering a UI counter.

## Testing this PR

Testing this PR requires an Elasticsearch cluster that has data from APM and Security Integrations. Internal users should use the [oblt-cli tool](https://github.com/elastic/observability-test-environments/blob/main/tools/oblt_cli/README.md) to connect to a remote elasticsearch instance.

### User experience
1. Open the User Experience application under Observability in the side bar.
2. Change the time picker to a sufficient time window so that data shows on the Page load duration by region (avg.) map.
3. In Dev tools run the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
4. Search the results for `open_maps_vis_ux` to see how many times the map embeddable was constructed in the user experience application.


### Security solution

1. Open the Explore page under Security in the side bar.
2. Choose the Network page.
3. Change the time picker to a sufficient time window so that data shows on the Network map.
4.  In Dev tools run  the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
5. Search the results for `open_maps_vis_securitySolutionUI` to see how many times the map embeddable was constructed in the security solution application.


### Machine Learning

1. Start Elasticsearch and Kibana using a trial license (`yarn es snapshot --license trial` and `yarn start`). 
2. Install the eCommerce and Web logs sample datasets.
3. Use the example at https://www.elastic.co/guide/en/machine-learning/8.4/geographic-anomalies.html to create a new Anomaly detection job.
4. Open the Anomaly Explorer page under Machine Learning and choose the job(s) to display
5. On the Anomaly timeline click a colored cell to open a map showing the anomalies.
6. In Dev tools run  the following command to view the telemetry that is collected.
```
POST kbn:api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```
7. Search the results for `open_maps_vis_ml` to see how many times the map embeddable was constructed in the machine learning solution.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
