### PR TITLE
beta/beaker badges and feedback links

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -14,6 +14,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { omit } from 'lodash';
 import React from 'react';
+import { EuiBetaBadge } from '@elastic/eui';
 import {
   isMobileAgentName,
   isJavaAgentName,
@@ -35,7 +36,6 @@ import { ApmMainTemplate } from '../apm_main_template';
 import { AnalyzeDataButton } from './analyze_data_button';
 import { getAlertingCapabilities } from '../../../alerting/get_alerting_capabilities';
 import { TechnicalPreviewBadge } from '../../../shared/technical_preview_badge';
-import { EuiBetaBadge } from '@elastic/eui';
 
 type Tab = NonNullable<EuiPageHeaderProps['tabs']>[0] & {
   key:

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -34,8 +34,8 @@ import { ServiceIcons } from '../../../shared/service_icons';
 import { ApmMainTemplate } from '../apm_main_template';
 import { AnalyzeDataButton } from './analyze_data_button';
 import { getAlertingCapabilities } from '../../../alerting/get_alerting_capabilities';
-import { BetaBadge } from '../../../shared/beta_badge';
 import { TechnicalPreviewBadge } from '../../../shared/technical_preview_badge';
+import { EuiBetaBadge } from '@elastic/eui';
 
 type Tab = NonNullable<EuiPageHeaderProps['tabs']>[0] & {
   key:
@@ -276,7 +276,14 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
         path: { serviceName },
         query,
       }),
-      append: <BetaBadge icon="beaker" />,
+      append: (
+        <EuiBetaBadge
+          label="B"
+          title="Beta"
+          color="hollow"
+          tooltipContent="This feature is currently in beta. If you encounter any bugs or have feedback, please open an issue or visit our discussion forum."
+        />
+      ),
       label: i18n.translate('xpack.apm.home.infraTabLabel', {
         defaultMessage: 'Infrastructure',
       }),

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { EuiHeaderLink, EuiHeaderLinks } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHeaderLink,
+  EuiHeaderLinks,
+} from '@elastic/eui';
 import { apmLabsButton } from '@kbn/observability-plugin/common';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -17,6 +22,7 @@ import { AnomalyDetectionSetupLink } from './anomaly_detection_setup_link';
 import { useServiceName } from '../../../hooks/use_service_name';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { Labs } from './labs';
+import { EuiBetaBadge } from '@elastic/eui';
 
 export function ApmHeaderActionMenu() {
   const { core, plugins } = useApmPluginContext();
@@ -53,21 +59,23 @@ export function ApmHeaderActionMenu() {
       <EuiHeaderLink
         color="text"
         href={apmHref('/storage-explorer')}
-        iconType="beaker"
         data-test-subj="apmStorageExplorerHeaderLink"
       >
-        {i18n.translate('xpack.apm.storageExplorerLinkLabel', {
-          defaultMessage: 'Storage Explorer',
-        })}
-      </EuiHeaderLink>
-      <EuiHeaderLink
-        color="text"
-        href={apmHref('/settings')}
-        data-test-subj="apmSettingsHeaderLink"
-      >
-        {i18n.translate('xpack.apm.settingsLinkLabel', {
-          defaultMessage: 'Settings',
-        })}
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiBetaBadge
+              size="m"
+              label="B"
+              title="Beta feature"
+              color="accent"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {i18n.translate('xpack.apm.storageExplorerLinkLabel', {
+              defaultMessage: 'Storage Explorer',
+            })}
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiHeaderLink>
       {canAccessML && <AnomalyDetectionSetupLink />}
       {isAlertingAvailable && (
@@ -87,6 +95,16 @@ export function ApmHeaderActionMenu() {
       >
         {i18n.translate('xpack.apm.addDataButtonLabel', {
           defaultMessage: 'Add data',
+        })}
+      </EuiHeaderLink>
+
+      <EuiHeaderLink
+        color="text"
+        href={apmHref('/settings')}
+        data-test-subj="apmSettingsHeaderLink"
+      >
+        {i18n.translate('xpack.apm.settingsLinkLabel', {
+          defaultMessage: 'Settings',
         })}
       </EuiHeaderLink>
       <InspectorHeaderLink />

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
@@ -14,6 +14,7 @@ import {
 import { apmLabsButton } from '@kbn/observability-plugin/common';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { EuiBetaBadge } from '@elastic/eui';
 import { getAlertingCapabilities } from '../../alerting/get_alerting_capabilities';
 import { getLegacyApmHref } from '../links/apm/apm_link';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
@@ -22,7 +23,6 @@ import { AnomalyDetectionSetupLink } from './anomaly_detection_setup_link';
 import { useServiceName } from '../../../hooks/use_service_name';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { Labs } from './labs';
-import { EuiBetaBadge } from '@elastic/eui';
 
 export function ApmHeaderActionMenu() {
   const { core, plugins } = useApmPluginContext();

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/labs_flyout.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/labs_flyout.tsx
@@ -17,6 +17,8 @@ import {
   EuiHorizontalRule,
   EuiIcon,
   EuiLoadingContent,
+  EuiSpacer,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { LazyField } from '@kbn/advanced-settings-plugin/public';
@@ -83,9 +85,9 @@ export function LabsFlyout({ onClose }: Props) {
   return (
     <EuiFlyout onClose={onClose}>
       <EuiFlyoutHeader hasBorder>
-        <EuiFlexGroup gutterSize="m">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="beaker" size="xl" />
+            <EuiIcon type="beaker" size="l" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiTitle>
@@ -97,6 +99,11 @@ export function LabsFlyout({ onClose }: Props) {
             </EuiTitle>
           </EuiFlexItem>
         </EuiFlexGroup>
+        <EuiSpacer size="s" />
+        <EuiText>
+          Try out the APM features that are under technical preview and in
+          progress.
+        </EuiText>
       </EuiFlyoutHeader>
 
       {isLoading ? (

--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -159,8 +159,15 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     value: false,
     description: i18n.translate('xpack.observability.enableServiceGroupsDescription', {
-      defaultMessage: '{technicalPreviewLabel} Enable the Service groups feature on APM UI',
-      values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
+      defaultMessage: 'Enable the Service groups feature on APM UI. {feedbackLink}.',
+      values: {
+        feedbackLink:
+          '<a href="https://ela.st/feedback-service-groups" target="_blank" rel="noopener noreferrer">' +
+          i18n.translate('core.ui_settings.params.dateFormat.optionsLinkText', {
+            defaultMessage: 'Send feedback',
+          }) +
+          '</a>',
+      },
     }),
     schema: schema.boolean(),
     requiresPageReload: true,
@@ -175,8 +182,15 @@ export const uiSettings: Record<string, UiSettings> = {
       'xpack.observability.apmServiceInventoryOptimizedSortingDescription',
       {
         defaultMessage:
-          '{technicalPreviewLabel} Default APM Service Inventory page sort (for Services without Machine Learning applied) to sort by Service Name',
-        values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
+          'Default APM Service Inventory page sort (for Services without Machine Learning applied) to sort by Service Name. {feedbackLink}.',
+        values: {
+          feedbackLink:
+            '<a href="https://ela.st/feedback-apm-page-performance" target="_blank" rel="noopener noreferrer">' +
+            i18n.translate('core.ui_settings.params.dateFormat.optionsLinkText', {
+              defaultMessage: 'Send feedback',
+            }) +
+            '</a>',
+        },
       }
     ),
     schema: schema.boolean(),
@@ -203,8 +217,15 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     description: i18n.translate('xpack.observability.apmTraceExplorerTabDescription', {
       defaultMessage:
-        '{technicalPreviewLabel} Enable the APM Trace Explorer feature, that allows you to search and inspect traces with KQL or EQL',
-      values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
+        'Enable the APM Trace Explorer feature, that allows you to search and inspect traces with KQL or EQL. {feedbackLink}.',
+      values: {
+        feedbackLink:
+          '<a href="https://ela.st/feedback-trace-explorer" target="_blank" rel="noopener noreferrer">' +
+          i18n.translate('core.ui_settings.params.dateFormat.optionsLinkText', {
+            defaultMessage: 'Send feedback',
+          }) +
+          '</a>',
+      },
     }),
     schema: schema.boolean(),
     value: false,
@@ -219,8 +240,15 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     description: i18n.translate('xpack.observability.apmOperationsBreakdownDescription', {
       defaultMessage:
-        '{technicalPreviewLabel} Enable the APM Operations Breakdown feature, that displays aggregates for backend operations',
-      values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
+        'Enable the APM Operations Breakdown feature, that displays aggregates for backend operations. {feedbackLink}.',
+      values: {
+        feedbackLink:
+          '<a href="https://ela.st/feedback-operations-breakdown" target="_blank" rel="noopener noreferrer">' +
+          i18n.translate('core.ui_settings.params.dateFormat.optionsLinkText', {
+            defaultMessage: 'Send feedback',
+          }) +
+          '</a>',
+      },
     }),
     schema: schema.boolean(),
     value: false,


### PR DESCRIPTION
## Summary

In this PR there are few things happening:

1. We now differentiate the beta and tech preview features with a `B` and `beaker` icon for Beta and Tech preview features. To make a clear visual difference. 
2. We're also adding feedback links to all Labs features, with custom elastic links, which will redirect to the discuss forum, for a faster and easier way for people to leave feedback and start a conversation. 
3. Swapped the order of the navigation action links, which we need to rethink better in the future.

![image](https://user-images.githubusercontent.com/13353203/191089610-e416ee3e-ddc3-40a1-ba4d-0ac8fd952922.png)

![image](https://user-images.githubusercontent.com/13353203/191089653-8082b8a7-2476-4827-81a9-abdf1183c4d9.png)


![image](https://user-images.githubusercontent.com/13353203/191094954-254981ee-44be-451c-91da-cd2238d0fe04.png)

