### PR TITLE
[Enterprise Search] delete ml inference pipeline

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/ml_models/delete_ml_inference_pipeline.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/ml_models/delete_ml_inference_pipeline.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface DeleteMlInferencePipelineApiLogicArgs {
+  indexName: string;
+  pipelineName: string;
+}
+
+export interface DeleteMlInferencePipelineResponse {
+  deleted?: string;
+  updated?: string;
+}
+
+export const deleteMlInferencePipeline = async (
+  args: DeleteMlInferencePipelineApiLogicArgs
+): Promise<DeleteMlInferencePipelineResponse> => {
+  const route = `/internal/enterprise_search/indices/${args.indexName}/ml_inference/pipeline_processors/${args.pipelineName}`;
+
+  return await HttpLogic.values.http.delete<DeleteMlInferencePipelineResponse>(route);
+};
+
+export const DeleteMlInferencePipelineApiLogic = createApiLogic(
+  ['delete_ml_inference_pipeline_api_logic'],
+  deleteMlInferencePipeline
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -46,6 +46,11 @@ import {
   FetchIndexApiParams,
   FetchIndexApiResponse,
 } from '../../../api/index/fetch_index_api_logic';
+import {
+  DeleteMlInferencePipelineApiLogic,
+  DeleteMlInferencePipelineApiLogicArgs,
+  DeleteMlInferencePipelineResponse,
+} from '../../../api/ml_models/delete_ml_inference_pipeline';
 import { CreateMlInferencePipelineApiLogic } from '../../../api/ml_models/create_ml_inference_pipeline';
 import { FetchMlInferencePipelineProcessorsApiLogic } from '../../../api/pipelines/fetch_ml_inference_pipeline_processors';
 import { isApiIndex, isConnectorIndex, isCrawlerIndex } from '../../../utils/indices';
@@ -67,6 +72,18 @@ type PipelinesActions = Pick<
   createCustomPipelineSuccess: Actions<
     CreateCustomPipelineApiLogicArgs,
     CreateCustomPipelineApiLogicResponse
+  >['apiSuccess'];
+  deleteMlPipeline: Actions<
+    DeleteMlInferencePipelineApiLogicArgs,
+    DeleteMlInferencePipelineResponse
+  >['makeRequest'];
+  deleteMlPipelineError: Actions<
+    DeleteMlInferencePipelineApiLogicArgs,
+    DeleteMlInferencePipelineResponse
+  >['apiError'];
+  deleteMlPipelineSuccess: Actions<
+    DeleteMlInferencePipelineApiLogicArgs,
+    DeleteMlInferencePipelineResponse
   >['apiSuccess'];
   fetchCustomPipeline: Actions<
     FetchCustomPipelineApiLogicArgs,
@@ -129,6 +146,12 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       ],
       CreateMlInferencePipelineApiLogic,
       ['apiSuccess as createMlInferencePipelineSuccess'],
+      DeleteMlInferencePipelineApiLogic,
+      [
+        'apiError as deleteMlPipelineError',
+        'apiSuccess as deleteMlPipelineSuccess',
+        'makeRequest as deleteMlPipeline',
+      ],
     ],
     values: [
       FetchDefaultPipelineApiLogic,
@@ -188,6 +211,23 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       actions.fetchCustomPipeline({ indexName: values.index.name });
     },
     createMlInferencePipelineSuccess: () => {
+      actions.fetchMlInferenceProcessors({ indexName: values.index.name });
+    },
+    deleteMlPipelineError: (error) => flashAPIErrors(error),
+    deleteMlPipelineSuccess: (value) => {
+      if (value.deleted) {
+        flashSuccessToast(
+          i18n.translate(
+            'xpack.enterpriseSearch.content.indices.pipelines.successToastDeleteMlPipeline.title',
+            {
+              defaultMessage: 'Deleted machine learning inference pipeline "{pipelineName}"',
+              values: {
+                pipelineName: value.deleted,
+              },
+            }
+          )
+        );
+      }
       actions.fetchMlInferenceProcessors({ indexName: values.index.name });
     },
     fetchIndexApiSuccess: (index) => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -46,12 +46,12 @@ import {
   FetchIndexApiParams,
   FetchIndexApiResponse,
 } from '../../../api/index/fetch_index_api_logic';
+import { CreateMlInferencePipelineApiLogic } from '../../../api/ml_models/create_ml_inference_pipeline';
 import {
   DeleteMlInferencePipelineApiLogic,
   DeleteMlInferencePipelineApiLogicArgs,
   DeleteMlInferencePipelineResponse,
 } from '../../../api/ml_models/delete_ml_inference_pipeline';
-import { CreateMlInferencePipelineApiLogic } from '../../../api/ml_models/create_ml_inference_pipeline';
 import { FetchMlInferencePipelineProcessorsApiLogic } from '../../../api/pipelines/fetch_ml_inference_pipeline_processors';
 import { isApiIndex, isConnectorIndex, isCrawlerIndex } from '../../../utils/indices';
 


### PR DESCRIPTION
## Summary

added a confirm modal and delete call for the delete pipeline action on the index pipelines page.
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/1972968/191277448-a0c4f87a-e552-49be-8ef0-e0be43e97912.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))