### PR TITLE
[Lens] Track ad hoc data view renders

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -79,6 +79,7 @@ import {
   selectChangesApplied,
   VisualizationState,
   DatasourceStates,
+  DataViewsState,
 } from '../../../state_management';
 import type { LensInspector } from '../../../lens_inspector_service';
 import { inferTimeField, DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS } from '../../../utils';
@@ -178,7 +179,10 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
     visualization: VisualizationState;
     visualizationMap: VisualizationMap;
     datasourceLayers: DatasourceLayers;
+    dataViews: DataViewsState;
   }>();
+
+  const { dataViews } = framePublicAPI;
 
   renderDeps.current = {
     datasourceMap,
@@ -186,9 +190,9 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
     visualization,
     visualizationMap,
     datasourceLayers,
+    dataViews,
   };
 
-  const { dataViews } = framePublicAPI;
   const onRender$ = useCallback(() => {
     if (renderDeps.current) {
       const datasourceEvents = Object.values(renderDeps.current.datasourceMap).reduce<string[]>(
@@ -207,8 +211,16 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
             renderDeps.current.visualization.activeId
           ].getRenderEventCounters?.(renderDeps.current.visualization.state) ?? [];
       }
+      const events = ['vis_editor', ...datasourceEvents, ...visualizationEvents];
 
-      trackUiCounterEvents(['vis_editor', ...datasourceEvents, ...visualizationEvents]);
+      const adHocDataViews = Object.values(renderDeps.current.dataViews.indexPatterns || {}).filter(
+        (indexPattern) => !indexPattern.isPersisted
+      );
+      adHocDataViews.forEach(() => {
+        events.push('ad_hoc_data_view');
+      });
+
+      trackUiCounterEvents(events);
     }
   }, []);
 

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -563,10 +563,18 @@ export class Embeddable
 
     const executionContext = this.getExecutionContext();
 
-    trackUiCounterEvents(
-      [...datasourceEvents, ...visualizationEvents, ...getExecutionContextEvents(executionContext)],
-      executionContext
-    );
+    const events = [
+      ...datasourceEvents,
+      ...visualizationEvents,
+      ...getExecutionContextEvents(executionContext),
+    ];
+
+    const adHocDataViews = Object.values(this.savedVis?.state.adHocDataViews || {});
+    adHocDataViews.forEach(() => {
+      events.push('ad_hoc_data_view');
+    });
+
+    trackUiCounterEvents(events, executionContext);
 
     this.renderComplete.dispatchComplete();
     this.updateOutput({


### PR DESCRIPTION
This PR adds a ui counter `render_lens_ad_hoc_data_view` to both the editor and the dashboard to track how often a lens vis is rendered with an ad hoc data view. If more than one ad hoc data view is active, it's counted multiple times.