### PR TITLE
[Graph] Fix positioning of Add fields popover

### DIFF
--- a/x-pack/plugins/graph/public/components/field_manager/field_editor.tsx
+++ b/x-pack/plugins/graph/public/components/field_manager/field_editor.tsx
@@ -125,7 +125,7 @@ export function FieldEditor({
   return (
     <EuiPopover
       id={`graphFieldEditor-${initialField.name}`}
-      anchorPosition="downLeft"
+      anchorPosition="downCenter"
       ownFocus
       panelPaddingSize="none"
       button={

--- a/x-pack/plugins/graph/public/components/field_manager/field_picker.tsx
+++ b/x-pack/plugins/graph/public/components/field_manager/field_picker.tsx
@@ -49,7 +49,7 @@ export function FieldPicker({
   return (
     <EuiPopover
       id="graphFieldPicker"
-      anchorPosition="downLeft"
+      anchorPosition="downCenter"
       ownFocus
       panelPaddingSize="none"
       button={


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/85009

## Summary

This PR fixes the popovers position.

Before:
<img width="300" alt="Screenshot 2022-09-20 at 10 59 17" src="https://user-images.githubusercontent.com/1415710/191216012-a545c0c4-d087-46e5-af2b-73e42a65e5f7.png">

After:
<img width="300" alt="Screenshot 2022-09-20 at 10 58 53" src="https://user-images.githubusercontent.com/1415710/191216080-abb16141-3c9f-47aa-bfe8-be4cfc50fa31.png">



<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->