### PR TITLE
Fix removing a single field formatter 

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -15,7 +15,7 @@ import type {
 } from '@kbn/field-formats-plugin/common';
 import { castEsToKbnFieldTypeName, ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/field-types';
 import { CharacterNotAllowedInField } from '@kbn/kibana-utils-plugin/common';
-import _, { cloneDeep, each, reject } from 'lodash';
+import { cloneDeep, each, reject } from 'lodash';
 import type { DataViewAttributes, FieldAttrs, FieldAttrSet } from '..';
 import type { DataViewField, IIndexPatternFieldList } from '../fields';
 import { fieldList } from '../fields';

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -407,9 +407,6 @@ export class DataView implements DataViewBase {
    * Returns index pattern as saved object body for saving
    */
   getAsSavedObjectBody(): DataViewAttributes {
-    const fieldFormatMap = _.isEmpty(this.fieldFormatMap)
-      ? undefined
-      : JSON.stringify(this.fieldFormatMap);
     const fieldAttrs = this.getFieldAttrs();
     const runtimeFieldMap = this.runtimeFieldMap;
 
@@ -419,7 +416,7 @@ export class DataView implements DataViewBase {
       timeFieldName: this.timeFieldName,
       sourceFilters: this.sourceFilters ? JSON.stringify(this.sourceFilters) : undefined,
       fields: JSON.stringify(this.fields?.filter((field) => field.scripted) ?? []),
-      fieldFormatMap,
+      fieldFormatMap: this.fieldFormatMap ? JSON.stringify(this.fieldFormatMap) : undefined,
       type: this.type!,
       typeMeta: JSON.stringify(this.typeMeta ?? {}),
       allowNoIndex: this.allowNoIndex ? this.allowNoIndex : undefined,

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -318,26 +318,6 @@ describe('IndexPatterns', () => {
     ).rejects.toMatchSnapshot();
   });
 
-  test('can set and remove field format', async () => {
-    const id = 'id';
-    setDocsourcePayload(id, savedObject);
-    const dataView = await indexPatterns.get(id);
-    dataView.setFieldFormat('field', { id: 'formatId' });
-    await indexPatterns.updateSavedObject(dataView);
-    let lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
-    let [, , attrs] = lastCall;
-    expect(attrs).toHaveProperty('fieldFormatMap');
-    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{\\"field\\":{\\"id\\":\\"formatId\\"}}"`);
-    dataView.deleteFieldFormat('field');
-    await indexPatterns.updateSavedObject(dataView);
-    lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
-    [, , attrs] = lastCall;
-
-    // https://github.com/elastic/kibana/issues/134873: must keep an empty object and not delete it
-    expect(attrs).toHaveProperty('fieldFormatMap');
-    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{}"`);
-  });
-
   test('savedObjectToSpec', () => {
     const spec = indexPatterns.savedObjectToSpec(savedObject);
     expect(spec).toMatchSnapshot();
@@ -368,6 +348,26 @@ describe('IndexPatterns', () => {
 
     // successful subsequent request
     expect(async () => await indexPatterns.get(id)).toBeDefined();
+  });
+
+  test('can set and remove field format', async () => {
+    const id = 'id';
+    setDocsourcePayload(id, savedObject);
+    const dataView = await indexPatterns.get(id);
+    dataView.setFieldFormat('field', { id: 'formatId' });
+    await indexPatterns.updateSavedObject(dataView);
+    let lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
+    let [, , attrs] = lastCall;
+    expect(attrs).toHaveProperty('fieldFormatMap');
+    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{\\"field\\":{\\"id\\":\\"formatId\\"}}"`);
+    dataView.deleteFieldFormat('field');
+    await indexPatterns.updateSavedObject(dataView);
+    lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
+    [, , attrs] = lastCall;
+
+    // https://github.com/elastic/kibana/issues/134873: must keep an empty object and not delete it
+    expect(attrs).toHaveProperty('fieldFormatMap');
+    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{}"`);
   });
 
   describe('getDefaultDataView', () => {

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -318,6 +318,26 @@ describe('IndexPatterns', () => {
     ).rejects.toMatchSnapshot();
   });
 
+  test('can set and remove field format', async () => {
+    const id = 'id';
+    setDocsourcePayload(id, savedObject);
+    const dataView = await indexPatterns.get(id);
+    dataView.setFieldFormat('field', { id: 'formatId' });
+    await indexPatterns.updateSavedObject(dataView);
+    let lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
+    let [, , attrs] = lastCall;
+    expect(attrs).toHaveProperty('fieldFormatMap');
+    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{\\"field\\":{\\"id\\":\\"formatId\\"}}"`);
+    dataView.deleteFieldFormat('field');
+    await indexPatterns.updateSavedObject(dataView);
+    lastCall = (savedObjectsClient.update as jest.Mock).mock.calls.pop() ?? [];
+    [, , attrs] = lastCall;
+
+    // https://github.com/elastic/kibana/issues/134873: must keep an empty object and not delete it
+    expect(attrs).toHaveProperty('fieldFormatMap');
+    expect(attrs.fieldFormatMap).toMatchInlineSnapshot(`"{}"`);
+  });
+
   test('savedObjectToSpec', () => {
     const spec = indexPatterns.savedObjectToSpec(savedObject);
     expect(spec).toMatchSnapshot();


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/134873

When updating a data view saved object, make sure we send an empty field format object instead of an undefined one when there are no field formats. 
I think the fix makes sense, especially considering that this is how we treat `sourceFilters` and `runtimeFieldMap`

I saw this attempt to fix it https://github.com/elastic/kibana/pull/134874, but it looks like it is a more risky change





<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->