### PR TITLE
[Fleet] Fix history block to support hash param

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/index.tsx
@@ -35,7 +35,10 @@ export function useHistoryBlock(isEdited: boolean) {
 
         if (confirmRes) {
           unblock();
-          application.navigateToUrl(state.pathname + state.search, { state: state.state });
+
+          application.navigateToUrl(state.pathname + state.hash + state.search, {
+            state: state.state,
+          });
         }
       }
       confirmAsync();


### PR DESCRIPTION
## Summary

Resolve #141021

In the package policy editor we use an history block to prevent user quitting without saving. 
when the user was clicking on confirm we were not using the url hash part, this was causing issue to open API request in the devtools as the state is passed with a hash.

