### PR TITLE
[APM] Agent configuration - EuiMarkdownFormat when rendering setting description

### DIFF
--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/setting_form_row.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/setting_form_row.tsx
@@ -18,6 +18,7 @@ import {
   EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { EuiMarkdownFormat } from '@elastic/eui';
 import { SettingDefinition } from '../../../../../../../common/agent_configuration/setting_definitions/types';
 import { validateSetting } from '../../../../../../../common/agent_configuration/setting_definitions';
 import {
@@ -25,7 +26,6 @@ import {
   amountAndUnitToObject,
 } from '../../../../../../../common/agent_configuration/amount_and_unit';
 import { SelectWithPlaceholder } from '../../../../../shared/select_with_placeholder';
-import { EuiMarkdownFormat } from '@elastic/eui';
 
 function FormRow({
   setting,

--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/setting_form_row.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/setting_form_row.tsx
@@ -25,6 +25,7 @@ import {
   amountAndUnitToObject,
 } from '../../../../../../../common/agent_configuration/amount_and_unit';
 import { SelectWithPlaceholder } from '../../../../../shared/select_with_placeholder';
+import { EuiMarkdownFormat } from '@elastic/eui';
 
 function FormRow({
   setting,
@@ -163,7 +164,7 @@ export function SettingFormRow({
       }
       description={
         <>
-          {setting.description}
+          <EuiMarkdownFormat>{setting.description}</EuiMarkdownFormat>
 
           {setting.defaultValue && (
             <>


### PR DESCRIPTION
closes [61285](https://github.com/elastic/kibana/issues/61285)

- Used `EuiMarkdownFormat` component to render setting description.

**Before this change**
<img width="959" alt="image" src="https://user-images.githubusercontent.com/1313018/191274553-0741abdd-80b2-4d3e-b6a8-2e5684bac99d.png">

**After this change**
<img width="973" alt="image" src="https://user-images.githubusercontent.com/1313018/191283714-56f58665-9ee0-4596-8e51-6feb1b6ced86.png">

