### PR TITLE
[DOCS] Update functional tests custom option section

### DIFF
--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -40,8 +40,8 @@ There are three ways to run the tests depending on your goals:
 +
 ["source","shell"]
 ----------
-export TEST_KIBANA_URL=https://elastic:password@my-kbn-cluster.elastic-cloud.com:9243
-export TEST_ES_URL=https://elastic:password@my-es-cluster.elastic-cloud.com:9243
+export TEST_KIBANA_URL=https://elastic:password@my-kbn-cluster.elastic-cloud.com:443
+export TEST_ES_URL=https://elastic:password@my-es-cluster.elastic-cloud.com:443
 
 export TEST_CLOUD=1
 export ES_SECURITY_ENABLED=1

--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -31,18 +31,23 @@ There are three ways to run the tests depending on your goals:
 
 3. Custom option:
 ** Description: Runs tests against instances of {es} & {kib} started some other way (like Elastic Cloud, or an instance you are managing in some other way).
-** just executes the functional tests
-** url, credentials, etc. for {es} and {kib} are specified via environment variables
-** Here's an example that runs against an Elastic Cloud instance. Note that you must run the same branch of tests as the version of {kib} you're testing.
+** Just executes the functional tests
+** URL, credentials, etc. for {es} and {kib} are specified via environment variables
+** When running against an Elastic Cloud instance, additional environment variables are required `TEST_CLOUD` and `ES_SECURITY_ENABLED`
+** You must run the same branch of tests as the version of {kib} you're testing.  To run against a previous minor version use option `--es-version <instance version>`
+** To run a specific configuration use option `--config <configuration file>`
+** Here's an example that runs against an Elastic Cloud instance
 +
 ["source","shell"]
 ----------
-export TEST_KIBANA_URL=https://kibana:password@my-kibana-instance.internal.net:443
+export TEST_KIBANA_URL=https://elastic:password@my-kbn-cluster.elastic-cloud.com:9243
+export TEST_ES_URL=https://elastic:password@my-es-cluster.elastic-cloud.com:9243
 
-export TEST_ES_URL=https://elastic:password@my-es-cluster.internal.net:9200
-node scripts/functional_test_runner
+export TEST_CLOUD=1
+export ES_SECURITY_ENABLED=1
+
+node scripts/functional_test_runner [--config <config>] [--es-version <instance version>]
 ----------
-
 
 ** Or you can override any or all of these individual parts of the URL and leave the others to the default values.
 +


### PR DESCRIPTION
While helping @dimaanj run cloud tests locally, we observed the documentation is missing some setup instructions.  This PR updates the documentation.