### PR TITLE
[7.17] [Rule Registry] ignore some errors while updating index mappings (#140778)

### DIFF
--- a/x-pack/plugins/rule_registry/common/assets/lifecycle_policies/default_lifecycle_policy.ts
+++ b/x-pack/plugins/rule_registry/common/assets/lifecycle_policies/default_lifecycle_policy.ts
@@ -7,6 +7,9 @@
 
 export const defaultLifecyclePolicy = {
   policy: {
+    _meta: {
+      managed: true,
+    },
     phases: {
       hot: {
         actions: {

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/resource_installer.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/resource_installer.ts
@@ -159,10 +159,25 @@ export class ResourceInstaller {
   private async updateAliasWriteIndexMapping({ index, alias }: ConcreteIndexInfo) {
     const { logger, getClusterClient } = this.options;
     const clusterClient = await getClusterClient();
-    const simulatedIndexMapping = await clusterClient.indices.simulateIndexTemplate({
-      name: index,
-    });
+
+    let simulatedIndexMapping: estypes.IndicesSimulateIndexTemplateResponse;
+    try {
+      simulatedIndexMapping = await clusterClient.indices.simulateIndexTemplate({
+        name: index,
+      });
+    } catch (err) {
+      logger.error(
+        `Ignored PUT mappings for alias ${alias}; error generating simulated mappings: ${err.message}`
+      );
+      return;
+    }
+
     const simulatedMapping = get(simulatedIndexMapping, ['body', 'template', 'mappings']);
+
+    if (simulatedMapping == null) {
+      logger.error(`Ignored PUT mappings for alias ${alias}; simulated mappings were empty`);
+      return;
+    }
 
     try {
       await clusterClient.indices.putMapping({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Rule Registry] ignore some errors while updating index mappings (#140778)](https://github.com/elastic/kibana/pull/140778)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2022-09-20T11:30:36Z","message":"[Rule Registry] ignore some errors while updating index mappings (#140778)\n\nresolves https://github.com/elastic/kibana/issues/139969\r\n\r\nChanges the ResourceInstaller to ignore cases when the elasticsearch \r\nsimulateIndexTemplate() API returns an error or empty mappings, logging an \r\nerror instead. This will hopefully allow initialization to continue to set \r\nup the alerts-as-data indices and backing resources for future indexing.\r\n\r\nAlso adds _meta: { managed: true } to the ILM policy, which should show a \r\nwarning in Kibana UX when attempting to make changes to the policy. Which \r\nwas the cause of why simulateIndexTemplate() could return empty mappings.","sha":"01daf31d04951047bcb3fbf8d151543c8d37cc74","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Alerting/Alerts-as-Data","backport:prev-MAJOR","v8.5.0","ci:cloud-deploy","v8.4.2"],"number":140778,"url":"https://github.com/elastic/kibana/pull/140778","mergeCommit":{"message":"[Rule Registry] ignore some errors while updating index mappings (#140778)\n\nresolves https://github.com/elastic/kibana/issues/139969\r\n\r\nChanges the ResourceInstaller to ignore cases when the elasticsearch \r\nsimulateIndexTemplate() API returns an error or empty mappings, logging an \r\nerror instead. This will hopefully allow initialization to continue to set \r\nup the alerts-as-data indices and backing resources for future indexing.\r\n\r\nAlso adds _meta: { managed: true } to the ILM policy, which should show a \r\nwarning in Kibana UX when attempting to make changes to the policy. Which \r\nwas the cause of why simulateIndexTemplate() could return empty mappings.","sha":"01daf31d04951047bcb3fbf8d151543c8d37cc74"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/140778","number":140778,"mergeCommit":{"message":"[Rule Registry] ignore some errors while updating index mappings (#140778)\n\nresolves https://github.com/elastic/kibana/issues/139969\r\n\r\nChanges the ResourceInstaller to ignore cases when the elasticsearch \r\nsimulateIndexTemplate() API returns an error or empty mappings, logging an \r\nerror instead. This will hopefully allow initialization to continue to set \r\nup the alerts-as-data indices and backing resources for future indexing.\r\n\r\nAlso adds _meta: { managed: true } to the ILM policy, which should show a \r\nwarning in Kibana UX when attempting to make changes to the policy. Which \r\nwas the cause of why simulateIndexTemplate() could return empty mappings.","sha":"01daf31d04951047bcb3fbf8d151543c8d37cc74"}},{"branch":"8.4","label":"v8.4.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/141058","number":141058,"state":"MERGED","mergeCommit":{"sha":"b8f58ced8a97a8e3103adfd6d8bda6c42d3db2d7","message":"[Rule Registry] ignore some errors while updating index mappings (#140778) (#141058)\n\nresolves https://github.com/elastic/kibana/issues/139969\n\nChanges the ResourceInstaller to ignore cases when the elasticsearch\nsimulateIndexTemplate() API returns an error or empty mappings, logging an\nerror instead. This will hopefully allow initialization to continue to set\nup the alerts-as-data indices and backing resources for future indexing.\n\nAlso adds _meta: { managed: true } to the ILM policy, which should show a\nwarning in Kibana UX when attempting to make changes to the policy. Which\nwas the cause of why simulateIndexTemplate() could return empty mappings.\n\n(cherry picked from commit 01daf31d04951047bcb3fbf8d151543c8d37cc74)\n\nCo-authored-by: Patrick Mueller <patrick.mueller@elastic.co>"}}]}] BACKPORT-->