### PR TITLE
[ML] Show "No anomalies found" message instead of empty swim lane 

### DIFF
--- a/x-pack/plugins/ml/public/application/overview/components/anomaly_detection_panel/table.tsx
+++ b/x-pack/plugins/ml/public/application/overview/components/anomaly_detection_panel/table.tsx
@@ -93,19 +93,14 @@ export const AnomalyDetectionTable: FC<Props> = ({ items, statsBarData, chartsSe
 
         if (!swimLaneData) return null;
 
-        const hasResults = swimLaneData.points.length > 0;
-
-        const noDatWarning = hasResults ? (
-          <FormattedMessage
-            id="xpack.ml.overview.anomalyDetection.noAnomaliesFoundMessage"
-            defaultMessage="No anomalies found"
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.ml.overview.anomalyDetection.noResultsFoundMessage"
-            defaultMessage="No results found"
-          />
-        );
+        if (swimLaneData.points.length > 0 && swimLaneData.points.every((v) => v.value === 0)) {
+          return (
+            <FormattedMessage
+              id="xpack.ml.overview.anomalyDetection.noAnomaliesFoundMessage"
+              defaultMessage="No anomalies found"
+            />
+          );
+        }
 
         return (
           <SwimlaneContainer
@@ -118,7 +113,12 @@ export const AnomalyDetectionTable: FC<Props> = ({ items, statsBarData, chartsSe
             showTimeline={false}
             showYAxis={false}
             showLegend={false}
-            noDataWarning={noDatWarning}
+            noDataWarning={
+              <FormattedMessage
+                id="xpack.ml.overview.anomalyDetection.noResultsFoundMessage"
+                defaultMessage="No results found"
+              />
+            }
             chartsService={chartsService}
           />
         );


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/138712

Shows a message "No anomalies found" instead of an empty swim lane when all results have a `0` score.

Before: 
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/5236598/191283804-3c449ed9-7928-414c-b416-5b00e5a8d82c.png">

After: 
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/5236598/191283511-365d1d35-ed9d-4e1c-97bd-4b7b948839be.png">

