### PR TITLE
[APM] Fix search bar suggestions

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/rules/error_count.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/rules/error_count.cy.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import { synthtrace } from '../../../../synthtrace';
+import { generateData } from './generate_data';
+
 function deleteAllRules() {
   cy.log('Delete all rules');
   cy.request({
@@ -36,6 +39,21 @@ describe('Rules', () => {
 
   after(() => {
     deleteAllRules();
+  });
+
+  before(() => {
+    const start = '2021-10-10T00:00:00.000Z';
+    const end = '2021-10-10T00:01:00.000Z';
+    synthtrace.index(
+      generateData({
+        from: new Date(start).getTime(),
+        to: new Date(end).getTime(),
+      })
+    );
+  });
+
+  after(() => {
+    synthtrace.clean();
   });
 
   describe('Error count', () => {

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/rules/generate_data.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/rules/generate_data.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apm, timerange } from '@kbn/apm-synthtrace';
+
+export function generateData({ from, to }: { from: number; to: number }) {
+  const range = timerange(from, to);
+
+  const opbeansJava = apm
+    .service({
+      name: 'opbeans-java',
+      environment: 'production',
+      agentName: 'java',
+    })
+    .instance('opbeans-java-prod-1')
+    .podId('opbeans-java-prod-1-pod');
+
+  const opbeansNode = apm
+    .service({
+      name: 'opbeans-node',
+      environment: 'production',
+      agentName: 'nodejs',
+    })
+    .instance('opbeans-node-prod-1');
+
+  return range
+    .interval('2m')
+    .rate(1)
+    .generator((timestamp, index) => [
+      opbeansJava
+        .transaction({ transactionName: 'GET /apple 🍎 ' })
+        .timestamp(timestamp)
+        .duration(1000)
+        .success()
+        .errors(
+          opbeansJava
+            .error({ message: `Error ${index}`, type: `exception ${index}` })
+            .timestamp(timestamp)
+        ),
+      opbeansNode
+        .transaction({ transactionName: 'GET /banana 🍌' })
+        .timestamp(timestamp)
+        .duration(500)
+        .success(),
+    ]);
+}

--- a/x-pack/plugins/apm/ftr_e2e/cypress_test_runner.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress_test_runner.ts
@@ -73,7 +73,7 @@ export async function cypressTestRunner({ getService }: FtrProviderContext) {
   return res;
 }
 
-function getCypressCliArgs() {
+function getCypressCliArgs(): Record<string, unknown> {
   if (!process.env.CYPRESS_CLI_ARGS) {
     return {};
   }
@@ -82,5 +82,11 @@ function getCypressCliArgs() {
     process.env.CYPRESS_CLI_ARGS
   ) as Record<string, unknown>;
 
-  return cypressCliArgs;
+  const spec =
+    typeof cypressCliArgs.spec === 'string' &&
+    !cypressCliArgs.spec.includes('**')
+      ? `**/${cypressCliArgs.spec}*`
+      : cypressCliArgs.spec;
+
+  return { ...cypressCliArgs, spec };
 }

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory.stories.tsx
@@ -40,7 +40,7 @@ const stories: Meta<{}> = {
         },
         notifications: { toasts: { add: () => {}, addWarning: () => {} } },
         uiSettings: { get: () => [] },
-        dataViews: { get: async () => {} },
+        dataViews: { create: async () => {} },
       } as unknown as CoreStart;
 
       const KibanaReactContext = createKibanaReactContext(coreMock);

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -58,14 +58,17 @@ export function ApmMainTemplate({
   }, []);
 
   // create static data view on inital load
-  useFetcher((callApmApi) => {
-    const canCreateDataView =
-      application?.capabilities.savedObjectsManagement.edit;
+  useFetcher(
+    (callApmApi) => {
+      const canCreateDataView =
+        application?.capabilities.savedObjectsManagement.edit;
 
-    if (canCreateDataView) {
-      return callApmApi('POST /internal/apm/data_view/static');
-    }
-  }, []);
+      if (canCreateDataView) {
+        return callApmApi('POST /internal/apm/data_view/static');
+      }
+    },
+    [application?.capabilities.savedObjectsManagement.edit]
+  );
 
   const shouldBypassNoDataScreen = bypassNoDataScreenPaths.some((path) =>
     location.pathname.includes(path)

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -48,13 +48,23 @@ export function ApmMainTemplate({
   const location = useLocation();
 
   const { services } = useKibana<ApmPluginStartDeps>();
-  const { http, docLinks, observability } = services;
+  const { http, docLinks, observability, application } = services;
   const basePath = http?.basePath.get();
 
   const ObservabilityPageTemplate = observability.navigation.PageTemplate;
 
   const { data, status } = useFetcher((callApmApi) => {
     return callApmApi('GET /internal/apm/has_data');
+  }, []);
+
+  // create static data view on inital load
+  useFetcher((callApmApi) => {
+    const canCreateDataView =
+      application?.capabilities.savedObjectsManagement.edit;
+
+    if (canCreateDataView) {
+      return callApmApi('POST /internal/apm/data_view/static');
+    }
   }, []);
 
   const shouldBypassNoDataScreen = bypassNoDataScreenPaths.some((path) =>

--- a/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
@@ -15,6 +15,7 @@ import { ApmServiceContextProvider } from '../../context/apm_service/apm_service
 import { UrlParamsProvider } from '../../context/url_params_context/url_params_context';
 import type { ApmUrlParams } from '../../context/url_params_context/types';
 import * as useFetcherHook from '../../hooks/use_fetcher';
+import * as useApmDataViewHook from '../../hooks/use_apm_data_view';
 import * as useServiceTransactionTypesHook from '../../context/apm_service/use_service_transaction_types_fetcher';
 import { renderWithTheme } from '../../utils/test_helpers';
 import { fromQuery } from './links/url_helpers';
@@ -44,6 +45,11 @@ function setup({
   jest
     .spyOn(useServiceTransactionTypesHook, 'useServiceTransactionTypesFetcher')
     .mockReturnValue(serviceTransactionTypes);
+
+  // mock transaction types
+  jest
+    .spyOn(useApmDataViewHook, 'useApmDataView')
+    .mockReturnValue({ dataView: undefined });
 
   jest.spyOn(useFetcherHook, 'useFetcher').mockReturnValue({} as any);
 

--- a/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
@@ -7,19 +7,9 @@
 
 import { DataView } from '@kbn/data-views-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
 import { useEffect, useState } from 'react';
-import { APM_STATIC_DATA_VIEW_ID } from '../../common/data_view_constants';
-import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
 import { ApmPluginStartDeps } from '../plugin';
 import { callApmApi } from '../services/rest/create_call_apm_api';
-
-async function createStaticApmDataView() {
-  const res = await callApmApi('POST /internal/apm/data_view/static', {
-    signal: null,
-  });
-  return res.dataView;
-}
 
 async function getApmDataViewTitle() {
   const res = await callApmApi('GET /internal/apm/data_view/title', {
@@ -30,37 +20,16 @@ async function getApmDataViewTitle() {
 
 export function useApmDataView() {
   const { services } = useKibana<ApmPluginStartDeps>();
-  const { core } = useApmPluginContext();
   const [dataView, setDataView] = useState<DataView | undefined>();
-
-  const canCreateDataView =
-    core.application.capabilities.savedObjectsManagement.edit;
 
   useEffect(() => {
     async function fetchDataView() {
-      try {
-        // load static data view
-        return await services.dataViews.get(APM_STATIC_DATA_VIEW_ID);
-      } catch (e) {
-        // re-throw if an unhandled error occurred
-        const notFound = e instanceof SavedObjectNotFound;
-        if (!notFound) {
-          throw e;
-        }
-
-        // create static data view if user has permissions
-        if (canCreateDataView) {
-          return createStaticApmDataView();
-        } else {
-          // or create dynamic data view if user does not have permissions to create a static
-          const title = await getApmDataViewTitle();
-          return services.dataViews.create({ title });
-        }
-      }
+      const title = await getApmDataViewTitle();
+      return services.dataViews.create({ title });
     }
 
-    fetchDataView().then((dv) => setDataView(dv));
-  }, [canCreateDataView, services.dataViews]);
+    fetchDataView().then(setDataView);
+  }, [services.dataViews]);
 
   return { dataView };
 }

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -39,7 +39,7 @@ export async function setupRequest({
   plugins,
   request,
   config,
-}: APMRouteHandlerResources) {
+}: APMRouteHandlerResources): Promise<Setup> {
   return withApmSpan('setup_request', async () => {
     const { query } = params;
     const coreContext = await context.core;

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
@@ -9,7 +9,7 @@ import { createStaticDataView } from './create_static_data_view';
 import { Setup } from '../../lib/helpers/setup_request';
 import * as HistoricalAgentData from '../historical_data/has_historical_agent_data';
 import { DataViewsService } from '@kbn/data-views-plugin/common';
-import { APMRouteHandlerResources } from '../typings';
+import { APMRouteHandlerResources, APMCore } from '../typings';
 import { APMConfig } from '../..';
 
 function getMockedDataViewService(existingDataViewTitle: string) {
@@ -21,7 +21,7 @@ function getMockedDataViewService(existingDataViewTitle: string) {
   } as unknown as DataViewsService;
 }
 
-const setup = {
+const setupMock = {
   indices: {
     transaction: 'apm-*-transaction-*',
     span: 'apm-*-span-*',
@@ -30,11 +30,25 @@ const setup = {
   } as APMConfig['indices'],
 } as unknown as Setup;
 
+const coreMock = {
+  start: () => {
+    return {
+      savedObjects: {
+        getScopedClient: () => {
+          return {
+            updateObjectsSpaces: () => {},
+          };
+        },
+      },
+    };
+  },
+} as unknown as APMCore;
+
 describe('createStaticDataView', () => {
   it(`should not create data view if 'xpack.apm.autocreateApmIndexPattern=false'`, async () => {
     const dataViewService = getMockedDataViewService('apm-*');
     await createStaticDataView({
-      setup,
+      setup: setupMock,
       resources: {
         config: { autoCreateApmDataView: false },
       } as APMRouteHandlerResources,
@@ -52,7 +66,7 @@ describe('createStaticDataView', () => {
     const dataViewService = getMockedDataViewService('apm-*');
 
     await createStaticDataView({
-      setup,
+      setup: setupMock,
       resources: {
         config: { autoCreateApmDataView: false },
       } as APMRouteHandlerResources,
@@ -70,8 +84,9 @@ describe('createStaticDataView', () => {
     const dataViewService = getMockedDataViewService('apm-*');
 
     await createStaticDataView({
-      setup,
+      setup: setupMock,
       resources: {
+        core: coreMock,
         config: { autoCreateApmDataView: true },
       } as APMRouteHandlerResources,
       dataViewService,
@@ -91,8 +106,9 @@ describe('createStaticDataView', () => {
       'apm-*-transaction-*,apm-*-span-*,apm-*-error-*,apm-*-metrics-*';
 
     await createStaticDataView({
-      setup,
+      setup: setupMock,
       resources: {
+        core: coreMock,
         config: { autoCreateApmDataView: true },
       } as APMRouteHandlerResources,
       dataViewService,
@@ -119,8 +135,9 @@ describe('createStaticDataView', () => {
     );
 
     await createStaticDataView({
-      setup,
+      setup: setupMock,
       resources: {
+        core: coreMock,
         config: { autoCreateApmDataView: true },
       } as APMRouteHandlerResources,
       dataViewService,

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
@@ -8,8 +8,9 @@
 import { createStaticDataView } from './create_static_data_view';
 import { Setup } from '../../lib/helpers/setup_request';
 import * as HistoricalAgentData from '../historical_data/has_historical_agent_data';
-import { APMConfig } from '../..';
 import { DataViewsService } from '@kbn/data-views-plugin/common';
+import { APMRouteHandlerResources } from '../typings';
+import { APMConfig } from '../..';
 
 function getMockedDataViewService(existingDataViewTitle: string) {
   return {
@@ -34,7 +35,9 @@ describe('createStaticDataView', () => {
     const dataViewService = getMockedDataViewService('apm-*');
     await createStaticDataView({
       setup,
-      config: { autoCreateApmDataView: false } as APMConfig,
+      resources: {
+        config: { autoCreateApmDataView: false },
+      } as APMRouteHandlerResources,
       dataViewService,
     });
     expect(dataViewService.createAndSave).not.toHaveBeenCalled();
@@ -50,7 +53,9 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup,
-      config: { autoCreateApmDataView: true } as APMConfig,
+      resources: {
+        config: { autoCreateApmDataView: false },
+      } as APMRouteHandlerResources,
       dataViewService,
     });
     expect(dataViewService.createAndSave).not.toHaveBeenCalled();
@@ -66,7 +71,9 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup,
-      config: { autoCreateApmDataView: true } as APMConfig,
+      resources: {
+        config: { autoCreateApmDataView: true },
+      } as APMRouteHandlerResources,
       dataViewService,
     });
 
@@ -85,7 +92,9 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup,
-      config: { autoCreateApmDataView: true } as APMConfig,
+      resources: {
+        config: { autoCreateApmDataView: true },
+      } as APMRouteHandlerResources,
       dataViewService,
     });
 
@@ -111,7 +120,9 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup,
-      config: { autoCreateApmDataView: true } as APMConfig,
+      resources: {
+        config: { autoCreateApmDataView: true },
+      } as APMRouteHandlerResources,
       dataViewService,
     });
 

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
@@ -119,7 +119,7 @@ async function addDataViewToAllSpaces(resources: APMRouteHandlerResources) {
   const scopedClient = startServices.savedObjects.getScopedClient(request);
 
   // make data view available across all spaces
-  await scopedClient.updateObjectsSpaces(
+  return scopedClient.updateObjectsSpaces(
     [{ id: APM_STATIC_DATA_VIEW_ID, type: 'index-pattern' }],
     ['*'],
     []

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
@@ -7,6 +7,7 @@
 
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { DataView, DataViewsService } from '@kbn/data-views-plugin/common';
+import { i18n } from '@kbn/i18n';
 import {
   TRACE_ID,
   TRANSACTION_ID,
@@ -40,8 +41,10 @@ export async function createStaticDataView({
     if (!config.autoCreateApmDataView) {
       return {
         created: false,
-        reason:
-          'Auto-creation of data views has been disabled via "autoCreateApmDataView" config option',
+        reason: i18n.translate('xpack.apm.dataView.autoCreateDisabled', {
+          defaultMessage:
+            'Auto-creation of data views has been disabled via "autoCreateApmDataView" config option',
+        }),
       };
     }
 
@@ -50,7 +53,12 @@ export async function createStaticDataView({
     const hasData = await hasHistoricalAgentData(setup);
 
     if (!hasData) {
-      return { created: false, reason: 'No APM data' };
+      return {
+        created: false,
+        reason: i18n.translate('xpack.apm.dataView.noApmData', {
+          defaultMessage: 'No APM data',
+        }),
+      };
     }
 
     const apmDataViewTitle = getApmDataViewTitle(setup.indices);
@@ -60,10 +68,12 @@ export async function createStaticDataView({
     });
 
     if (!shouldCreateOrUpdate) {
-      await addDataViewToAllSpaces(resources);
       return {
         created: false,
-        reason: 'Dataview already exists in current space',
+        reason: i18n.translate(
+          'xpack.apm.dataView.alreadyExistsInActiveSpace',
+          { defaultMessage: 'Dataview already exists in the active space' }
+        ),
       };
     }
 
@@ -82,8 +92,13 @@ export async function createStaticDataView({
         if (SavedObjectsErrorHelpers.isConflictError(e)) {
           return {
             created: false,
-            reason:
-              'Dataview already exists in another space but is not made available in this space',
+            reason: i18n.translate(
+              'xpack.apm.dataView.alreadyExistsInAnotherSpace',
+              {
+                defaultMessage:
+                  'Dataview already exists in another space but is not made available in this space',
+              }
+            ),
           };
         }
         throw e;

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
@@ -6,7 +6,7 @@
  */
 
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
-import { DataViewsService } from '@kbn/data-views-plugin/common';
+import { DataView, DataViewsService } from '@kbn/data-views-plugin/common';
 import {
   TRACE_ID,
   TRANSACTION_ID,

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
@@ -15,8 +15,9 @@ import { APM_STATIC_DATA_VIEW_ID } from '../../../common/data_view_constants';
 import { hasHistoricalAgentData } from '../historical_data/has_historical_agent_data';
 import { withApmSpan } from '../../utils/with_apm_span';
 import { getApmDataViewTitle } from './get_apm_data_view_title';
-import { setupRequest } from '../../lib/helpers/setup_request';
+
 import { APMRouteHandlerResources } from '../typings';
+import { Setup } from '../../lib/helpers/setup_request';
 
 export type CreateDataViewResponse = Promise<
   | { created: boolean; dataView: DataView }
@@ -26,11 +27,12 @@ export type CreateDataViewResponse = Promise<
 export async function createStaticDataView({
   dataViewService,
   resources,
+  setup,
 }: {
   dataViewService: DataViewsService;
   resources: APMRouteHandlerResources;
+  setup: Setup;
 }): CreateDataViewResponse {
-  const setup = await setupRequest(resources);
   const { config } = resources;
 
   return withApmSpan('create_static_data_view', async () => {

--- a/x-pack/plugins/apm/server/routes/data_view/route.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/route.ts
@@ -12,12 +12,14 @@ import {
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getApmDataViewTitle } from './get_apm_data_view_title';
 import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
+import { setupRequest } from '../../lib/helpers/setup_request';
 
 const staticDataViewRoute = createApmServerRoute({
   endpoint: 'POST /internal/apm/data_view/static',
   options: { tags: ['access:apm'] },
   handler: async (resources): CreateDataViewResponse => {
     const { context, plugins, request } = resources;
+    const setup = await setupRequest(resources);
     const coreContext = await context.core;
 
     const dataViewStart = await plugins.dataViews.start();
@@ -31,6 +33,7 @@ const staticDataViewRoute = createApmServerRoute({
     const res = await createStaticDataView({
       dataViewService,
       resources,
+      setup,
     });
 
     return res;

--- a/x-pack/plugins/apm/server/routes/data_view/route.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/route.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { DataView } from '@kbn/data-views-plugin/common';
-import { createStaticDataView } from './create_static_data_view';
+import {
+  CreateDataViewResponse,
+  createStaticDataView,
+} from './create_static_data_view';
 import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getApmDataViewTitle } from './get_apm_data_view_title';
@@ -15,7 +17,7 @@ import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
 const staticDataViewRoute = createApmServerRoute({
   endpoint: 'POST /internal/apm/data_view/static',
   options: { tags: ['access:apm'] },
-  handler: async (resources): Promise<{ dataView: DataView | undefined }> => {
+  handler: async (resources): CreateDataViewResponse => {
     const setup = await setupRequest(resources);
     const { context, plugins, request, config } = resources;
 
@@ -28,13 +30,13 @@ const staticDataViewRoute = createApmServerRoute({
       true
     );
 
-    const dataView = await createStaticDataView({
+    const res = await createStaticDataView({
       dataViewService,
       config,
       setup,
     });
 
-    return { dataView };
+    return res;
   },
 });
 

--- a/x-pack/plugins/apm/server/routes/data_view/route.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/route.ts
@@ -9,7 +9,6 @@ import {
   CreateDataViewResponse,
   createStaticDataView,
 } from './create_static_data_view';
-import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getApmDataViewTitle } from './get_apm_data_view_title';
 import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
@@ -18,10 +17,9 @@ const staticDataViewRoute = createApmServerRoute({
   endpoint: 'POST /internal/apm/data_view/static',
   options: { tags: ['access:apm'] },
   handler: async (resources): CreateDataViewResponse => {
-    const setup = await setupRequest(resources);
-    const { context, plugins, request, config } = resources;
-
+    const { context, plugins, request } = resources;
     const coreContext = await context.core;
+
     const dataViewStart = await plugins.dataViews.start();
     const dataViewService = await dataViewStart.dataViewsServiceFactory(
       coreContext.savedObjects.client,
@@ -32,8 +30,7 @@ const staticDataViewRoute = createApmServerRoute({
 
     const res = await createStaticDataView({
       dataViewService,
-      config,
-      setup,
+      resources,
     });
 
     return res;

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -47,10 +47,10 @@ export type TelemetryUsageCounter = ReturnType<
   UsageCollectionSetup['createUsageCounter']
 >;
 
-export type APMCore = {
+export interface APMCore {
   setup: CoreSetup;
   start: () => Promise<CoreStart>;
-};
+}
 
 export interface APMRouteHandlerResources {
   request: KibanaRequest;

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -47,6 +47,11 @@ export type TelemetryUsageCounter = ReturnType<
   UsageCollectionSetup['createUsageCounter']
 >;
 
+export type APMCore = {
+  setup: CoreSetup;
+  start: () => Promise<CoreStart>;
+};
+
 export interface APMRouteHandlerResources {
   request: KibanaRequest;
   context: ApmPluginRequestHandlerContext;
@@ -59,10 +64,7 @@ export interface APMRouteHandlerResources {
   };
   config: APMConfig;
   logger: Logger;
-  core: {
-    setup: CoreSetup;
-    start: () => Promise<CoreStart>;
-  };
+  core: APMCore;
   plugins: {
     [key in keyof APMPluginSetupDependencies]: {
       setup: Required<APMPluginSetupDependencies>[key];

--- a/x-pack/test/apm_api_integration/common/apm_api_supertest.ts
+++ b/x-pack/test/apm_api_integration/common/apm_api_supertest.ts
@@ -41,10 +41,19 @@ export function createApmApiClient(st: supertest.SuperTest<supertest.Test>) {
   };
 }
 
+type ApiErrorResponse = Omit<request.Response, 'body'> & {
+  body: {
+    statusCode: number;
+    error: string;
+    message: string;
+    attributes: object;
+  };
+};
+
 export type ApmApiSupertest = ReturnType<typeof createApmApiClient>;
 
 export class ApmApiError extends Error {
-  res: request.Response;
+  res: ApiErrorResponse;
 
   constructor(res: request.Response, endpoint: string) {
     super(

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -10,6 +10,7 @@ import expect from '@kbn/expect';
 import { APM_STATIC_DATA_VIEW_ID } from '@kbn/apm-plugin/common/data_view_constants';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { SupertestReturnType, ApmApiError } from '../../common/apm_api_supertest';
+import { DataView } from '@kbn/data-views-plugin/common';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -84,11 +85,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('successfully creates the apm data view', async () => {
         expect(response.status).to.be(200);
 
-        expect(response.body.dataView!.id).to.be('apm_static_index_pattern_id');
-        expect(response.body.dataView!.name).to.be('APM');
-        expect(response.body.dataView!.title).to.be(
-          'traces-apm*,apm-*,logs-apm*,apm-*,metrics-apm*,apm-*'
-        );
+        // @ts-expect-error
+        const dataView = response.body.dataView as DataView;
+
+        expect(dataView.id).to.be('apm_static_index_pattern_id');
+        expect(dataView.name).to.be('APM');
+        expect(dataView.title).to.be('traces-apm*,apm-*,logs-apm*,apm-*,metrics-apm*,apm-*');
       });
 
       describe('when fetching the data view', async () => {

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -18,7 +18,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
   const supertest = getService('supertest');
   const synthtrace = getService('synthtraceEsClient');
-
   const dataViewPattern = 'traces-apm*,apm-*,logs-apm*,apm-*,metrics-apm*,apm-*';
 
   function createDataViewWithWriteUser() {

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -9,9 +9,9 @@ import { apm, ApmSynthtraceEsClient, timerange } from '@kbn/apm-synthtrace';
 import expect from '@kbn/expect';
 import { APM_STATIC_DATA_VIEW_ID } from '@kbn/apm-plugin/common/data_view_constants';
 import { DataView } from '@kbn/data-views-plugin/common';
+import request from 'superagent';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { SupertestReturnType, ApmApiError } from '../../common/apm_api_supertest';
-import request from 'superagent';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -37,7 +37,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   function getDataView({ space }: { space: string }) {
     const spacePrefix = space !== 'default' ? `/s/${space}` : '';
-    console.log({ spacePrefix });
     return supertest.get(
       `${spacePrefix}/api/saved_objects/index-pattern/${APM_STATIC_DATA_VIEW_ID}`
     );

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -78,6 +78,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
     after(async () => {
       await synthtrace.clean();
+    });
+
+    afterEach(async () => {
       await deleteDataView();
     });
 
@@ -177,17 +180,15 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     describe('when creating data view in "default" space', async () => {
-      before(async () => {
-        await createDataViewWithWriteUser();
-      });
-
       it('can be retrieved from the "default space"', async () => {
+        await createDataViewWithWriteUser();
         const res = await getDataView({ space: 'default' });
         expect(res.body.id).to.eql('apm_static_index_pattern_id');
         expect(res.body.namespaces).to.eql(['*', 'default']);
       });
 
       it('can be retrieved from the "foo" space', async () => {
+        await createDataViewWithWriteUser();
         const res = await getDataView({ space: 'foo' });
         expect(res.body.id).to.eql('apm_static_index_pattern_id');
         expect(res.body.namespaces).to.eql(['*', 'default']);

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -174,7 +174,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(res.status).to.be(200);
         expect(res.body).to.eql({
           created: false,
-          reason: 'Dataview already exists in current space',
+          reason: 'Dataview already exists in the active space',
         });
       });
     });

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -11,6 +11,7 @@ import { APM_STATIC_DATA_VIEW_ID } from '@kbn/apm-plugin/common/data_view_consta
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { SupertestReturnType, ApmApiError } from '../../common/apm_api_supertest';
 import { DataView } from '@kbn/data-views-plugin/common';
+import request from 'superagent';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -30,13 +31,16 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   function deleteDataView() {
     return supertest
-      .delete(`/api/saved_objects/index-pattern/${APM_STATIC_DATA_VIEW_ID}`)
-      .set('kbn-xsrf', 'foo')
-      .expect(200);
+      .delete(`/api/saved_objects/index-pattern/${APM_STATIC_DATA_VIEW_ID}?force=true`)
+      .set('kbn-xsrf', 'foo');
   }
 
-  function getDataView() {
-    return supertest.get(`/api/saved_objects/index-pattern/${APM_STATIC_DATA_VIEW_ID}`);
+  function getDataView({ space }: { space: string }) {
+    const spacePrefix = space !== 'default' ? `/s/${space}` : '';
+    console.log({ spacePrefix });
+    return supertest.get(
+      `${spacePrefix}/api/saved_objects/index-pattern/${APM_STATIC_DATA_VIEW_ID}`
+    );
   }
 
   function getDataViewSuggestions(field: string) {
@@ -48,37 +52,41 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when('no mappings exist', { config: 'basic', archives: [] }, () => {
     let response: SupertestReturnType<'POST /internal/apm/data_view/static'>;
-    describe('when no data is generated', () => {
-      before(async () => {
-        response = await createDataViewWithWriteUser();
-      });
+    before(async () => {
+      response = await createDataViewWithWriteUser();
+    });
 
-      it('does not create data view', async () => {
-        expect(response.status).to.be(200);
-        expect(response.body.dataView).to.be(undefined);
+    it('does not create data view', async () => {
+      expect(response.status).to.be(200);
+      expect(response.body).to.eql({
+        created: false,
+        reason: 'No APM data',
       });
+    });
 
-      it('cannot fetch data view', async () => {
-        await getDataView().expect(404);
-      });
+    it('cannot fetch data view', async () => {
+      const res = await getDataView({ space: 'default' });
+      expect(res.status).to.be(404);
+      expect(res.body.message).to.eql(
+        'Saved object [index-pattern/apm_static_index_pattern_id] not found'
+      );
     });
   });
 
-  registry.when('mappings exists', { config: 'basic', archives: [] }, () => {
-    after(async () => {
-      await synthtrace.clean();
-      try {
-        await deleteDataView();
-      } catch (e) {
-        // swallow error
-      }
+  registry.when('mappings and APM data exists', { config: 'basic', archives: [] }, () => {
+    before(async () => {
+      await generateApmData(synthtrace);
     });
 
-    describe('when data is generated', () => {
+    after(async () => {
+      await synthtrace.clean();
+      await deleteDataView();
+    });
+
+    describe('when creating data view with write user', () => {
       let response: SupertestReturnType<'POST /internal/apm/data_view/static'>;
 
       before(async () => {
-        await generateApmData(synthtrace);
         response = await createDataViewWithWriteUser();
       });
 
@@ -92,57 +100,57 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(dataView.name).to.be('APM');
         expect(dataView.title).to.be('traces-apm*,apm-*,logs-apm*,apm-*,metrics-apm*,apm-*');
       });
+    });
 
-      describe('when fetching the data view', async () => {
-        let resBody: any;
+    describe('when fetching the data view', async () => {
+      let dataViewResponse: request.Response;
 
-        before(async () => {
-          const res = await getDataView().expect(200);
-          resBody = res.body;
-        });
+      before(async () => {
+        await createDataViewWithWriteUser();
+        dataViewResponse = await getDataView({ space: 'default' });
+      });
 
-        it('has correct id', () => {
-          expect(resBody.id).to.be('apm_static_index_pattern_id');
-        });
+      it('return 200', () => {
+        expect(dataViewResponse.status).to.be(200);
+      });
 
-        it('has correct title', () => {
-          expect(resBody.attributes.title).to.be(dataViewPattern);
-        });
+      it('has correct id', () => {
+        expect(dataViewResponse.body.id).to.be('apm_static_index_pattern_id');
+      });
 
-        it('has correct attributes', () => {
-          expect(resBody.attributes.fieldFormatMap).to.be(
-            JSON.stringify({
-              'trace.id': {
-                id: 'url',
-                params: {
-                  urlTemplate: 'apm/link-to/trace/{{value}}',
-                  labelTemplate: '{{value}}',
-                },
+      it('has correct title', () => {
+        expect(dataViewResponse.body.attributes.title).to.be(dataViewPattern);
+      });
+
+      it('has correct attributes', () => {
+        expect(dataViewResponse.body.attributes.fieldFormatMap).to.be(
+          JSON.stringify({
+            'trace.id': {
+              id: 'url',
+              params: {
+                urlTemplate: 'apm/link-to/trace/{{value}}',
+                labelTemplate: '{{value}}',
               },
-              'transaction.id': {
-                id: 'url',
-                params: {
-                  urlTemplate: 'apm/link-to/transaction/{{value}}',
-                  labelTemplate: '{{value}}',
-                },
+            },
+            'transaction.id': {
+              id: 'url',
+              params: {
+                urlTemplate: 'apm/link-to/transaction/{{value}}',
+                labelTemplate: '{{value}}',
               },
-            })
-          );
-        });
+            },
+          })
+        );
+      });
 
-        // this test ensures that the default APM Data View doesn't interfere with suggestions returned in the kuery bar (this has been a problem in the past)
-        it('can get suggestions for `trace.id`', async () => {
-          const suggestions = await getDataViewSuggestions('trace.id');
-          expect(suggestions.body.length).to.be(10);
-        });
+      // this test ensures that the default APM Data View doesn't interfere with suggestions returned in the kuery bar (this has been a problem in the past)
+      it('can get suggestions for `trace.id`', async () => {
+        const suggestions = await getDataViewSuggestions('trace.id');
+        expect(suggestions.body.length).to.be(10);
       });
     });
 
-    describe.only('when creating data view via read user', () => {
-      before(async () => {
-        await generateApmData(synthtrace);
-      });
-
+    describe('when creating data view via read user', () => {
       it('throws an error', async () => {
         try {
           await createDataViewWithReadUser();
@@ -158,16 +166,33 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     describe('when creating data view twice', () => {
-      before(async () => {
-        await generateApmData(synthtrace);
-      });
-
-      it('returns empty response if data view already exists', async () => {
+      it('returns 200 response with reason, if data view already exists', async () => {
         await createDataViewWithWriteUser();
         const res = await createDataViewWithWriteUser();
 
         expect(res.status).to.be(200);
-        expect(res.body).to.eql({});
+        expect(res.body).to.eql({
+          created: false,
+          reason: 'Dataview already exists in current space',
+        });
+      });
+    });
+
+    describe('when creating data view in "default" space', async () => {
+      before(async () => {
+        await createDataViewWithWriteUser();
+      });
+
+      it('can be retrieved from the "default space"', async () => {
+        const res = await getDataView({ space: 'default' });
+        expect(res.body.id).to.eql('apm_static_index_pattern_id');
+        expect(res.body.namespaces).to.eql(['*', 'default']);
+      });
+
+      it('can be retrieved from the "foo" space', async () => {
+        const res = await getDataView({ space: 'foo' });
+        expect(res.body.id).to.eql('apm_static_index_pattern_id');
+        expect(res.body.namespaces).to.eql(['*', 'default']);
       });
     });
   });

--- a/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/data_view/static.spec.ts
@@ -8,9 +8,9 @@
 import { apm, ApmSynthtraceEsClient, timerange } from '@kbn/apm-synthtrace';
 import expect from '@kbn/expect';
 import { APM_STATIC_DATA_VIEW_ID } from '@kbn/apm-plugin/common/data_view_constants';
+import { DataView } from '@kbn/data-views-plugin/common';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { SupertestReturnType, ApmApiError } from '../../common/apm_api_supertest';
-import { DataView } from '@kbn/data-views-plugin/common';
 import request from 'superagent';
 
 export default function ApiTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -16,7 +16,7 @@ function getGlobPattern() {
     return '**/*.spec.ts';
   }
 
-  return envGrepFiles.includes('.spec.ts') ? envGrepFiles : `**/*${envGrepFiles}*.spec.ts`;
+  return envGrepFiles.includes('**') ? envGrepFiles : `**/*${envGrepFiles}*`;
 }
 
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/140964
Related: https://github.com/elastic/kibana/pull/136694

In 8.4 [this PR](https://github.com/elastic/kibana/pull/136694) changed the search bar in APM to prefer static data view over dynamic data view when producing field suggestions. This surfaced a bug that has affected APM for a lot longer, which means that the static APM data view is only available in the space in which it was initially created (normally the "default" space).
Without a static data view the search bar stops working. 

This PR reverts some of the changes introduced in https://github.com/elastic/kibana/pull/136694 specifically the reliance on static data view for search bar. It will now only use the dynamic data view which fixes the problem.

This PR also fixes the underlying problem, making the APM data view available across all spaces.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->