### PR TITLE
chore(slo): remove optional destination index settings

### DIFF
--- a/x-pack/plugins/observability/server/saved_objects/slo.ts
+++ b/x-pack/plugins/observability/server/saved_objects/slo.ts
@@ -39,11 +39,6 @@ export const slo: SavedObjectsType = {
           target: { type: 'float' },
         },
       },
-      settings: {
-        properties: {
-          destination_index: { type: 'text' },
-        },
-      },
       created_at: { type: 'date' },
       updated_at: { type: 'date' },
     },

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -52,9 +52,6 @@ export class CreateSLO {
     return {
       ...sloParams,
       id: uuid.v1(),
-      settings: {
-        destination_index: sloParams.settings?.destination_index,
-      },
     };
   }
 

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import { getSLOTransformId } from '../../assets/constants';
+import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
 import { DeleteSLO } from './delete_slo';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 import { createSLORepositoryMock, createTransformManagerMock } from './mocks';
@@ -30,7 +30,6 @@ describe('DeleteSLO', () => {
   describe('happy path', () => {
     it('removes the transform, the roll up data and the SLO from the repository', async () => {
       const slo = createSLO(createAPMTransactionErrorRateIndicator());
-      mockRepository.findById.mockResolvedValueOnce(slo);
 
       await deleteSLO.execute(slo.id);
 
@@ -38,6 +37,7 @@ describe('DeleteSLO', () => {
       expect(mockTransformManager.uninstall).toHaveBeenCalledWith(getSLOTransformId(slo.id));
       expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
         expect.objectContaining({
+          index: `${SLO_INDEX_TEMPLATE_NAME}*`,
           query: {
             match: {
               'slo.id': slo.id,

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient } from '@kbn/core/server';
 import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
-import { SLO } from '../../types/models';
+
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
 
@@ -19,23 +19,21 @@ export class DeleteSLO {
   ) {}
 
   public async execute(sloId: string): Promise<void> {
-    const slo = await this.repository.findById(sloId);
-
     const sloTransformId = getSLOTransformId(sloId);
     await this.transformManager.stop(sloTransformId);
     await this.transformManager.uninstall(sloTransformId);
 
-    await this.deleteRollupData(slo);
+    await this.deleteRollupData(sloId);
     await this.repository.deleteById(sloId);
   }
 
-  private async deleteRollupData(slo: SLO): Promise<void> {
+  private async deleteRollupData(sloId: string): Promise<void> {
     await this.esClient.deleteByQuery({
-      index: slo.settings.destination_index ?? `${SLO_INDEX_TEMPLATE_NAME}*`,
+      index: `${SLO_INDEX_TEMPLATE_NAME}*`,
       wait_for_completion: false,
       query: {
         match: {
-          'slo.id': slo.id,
+          'slo.id': sloId,
         },
       },
     });

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -30,9 +30,6 @@ export const createSLOParams = (indicator: SLI): CreateSLOParams => ({
 export const createSLO = (indicator: SLI): SLO => ({
   ...commonSLO,
   id: uuid.v1(),
-  settings: {
-    destination_index: 'some-index',
-  },
   indicator,
 });
 

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.ts
@@ -69,6 +69,5 @@ function toSLOModel(slo: StoredSLO): SLO {
     time_window: slo.time_window,
     budgeting_method: slo.budgeting_method,
     objective: slo.objective,
-    settings: slo.settings,
   };
 }

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -20,7 +20,8 @@ Object {
     "version": 1,
   },
   "dest": Object {
-    "index": "some-index",
+    "index": "slo-observability.sli-v1-my-namespace",
+    "pipeline": "observability-slo-monthly-index",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -20,7 +20,8 @@ Object {
     "version": 1,
   },
   "dest": Object {
-    "index": "some-index",
+    "index": "slo-observability.sli-v1-my-namespace",
+    "pipeline": "observability-slo-monthly-index",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -105,14 +105,10 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
   }
 
   private buildDestination(slo: APMTransactionDurationSLO, spaceId: string) {
-    if (slo.settings.destination_index === undefined) {
-      return {
-        pipeline: SLO_INGEST_PIPELINE_NAME,
-        index: getSLODestinationIndexName(spaceId),
-      };
-    }
-
-    return { index: slo.settings.destination_index };
+    return {
+      pipeline: SLO_INGEST_PIPELINE_NAME,
+      index: getSLODestinationIndexName(spaceId),
+    };
   }
 
   private buildGroupBy() {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -107,14 +107,10 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
   }
 
   private buildDestination(slo: APMTransactionErrorRateSLO, spaceId: string) {
-    if (slo.settings.destination_index === undefined) {
-      return {
-        pipeline: SLO_INGEST_PIPELINE_NAME,
-        index: getSLODestinationIndexName(spaceId),
-      };
-    }
-
-    return { index: slo.settings.destination_index };
+    return {
+      pipeline: SLO_INGEST_PIPELINE_NAME,
+      index: getSLODestinationIndexName(spaceId),
+    };
   }
 
   private buildGroupBy() {

--- a/x-pack/plugins/observability/server/types/models/slo.ts
+++ b/x-pack/plugins/observability/server/types/models/slo.ts
@@ -25,9 +25,6 @@ const baseSLOSchema = t.type({
   objective: t.type({
     target: t.number,
   }),
-  settings: t.partial({
-    destination_index: t.string,
-  }),
 });
 
 export const apmTransactionErrorRateSLOSchema = t.intersection([

--- a/x-pack/plugins/observability/server/types/schema/slo.ts
+++ b/x-pack/plugins/observability/server/types/schema/slo.ts
@@ -55,25 +55,16 @@ export const indicatorSchema = t.union([
   apmTransactionErrorRateIndicatorSchema,
 ]);
 
-const sloOptionalSettingsSchema = t.partial({
-  settings: t.partial({
-    destination_index: t.string,
+const createSLOBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+  indicator: indicatorSchema,
+  time_window: rollingTimeWindowSchema,
+  budgeting_method: t.literal('occurrences'),
+  objective: t.type({
+    target: t.number,
   }),
 });
-
-const createSLOBodySchema = t.intersection([
-  t.type({
-    name: t.string,
-    description: t.string,
-    indicator: indicatorSchema,
-    time_window: rollingTimeWindowSchema,
-    budgeting_method: t.literal('occurrences'),
-    objective: t.type({
-      target: t.number,
-    }),
-  }),
-  sloOptionalSettingsSchema,
-]);
 
 const createSLOResponseSchema = t.type({
   id: t.string,


### PR DESCRIPTION
## 📝  Summary

Resolves https://github.com/elastic/kibana/issues/141156

This PR removes the optional destination index settings and always use the managed index
