### PR TITLE
Expose APM Server service metrics settings to fleet policy

### DIFF
--- a/x-pack/plugins/apm/common/fleet.ts
+++ b/x-pack/plugins/apm/common/fleet.ts
@@ -49,6 +49,7 @@ export const INPUT_VAR_NAME_TO_SCHEMA_PATH: Record<string, string> = {
   tail_sampling_enabled: 'apm-server.sampling.tail.enabled',
   tail_sampling_interval: 'apm-server.sampling.tail.interval',
   tail_sampling_policies: 'apm-server.sampling.tail.policies',
+  service_metrics_enabled: 'apm-server.aggregation.service.enabled',
 };
 
 export const LEGACY_TO_CURRENT_SCHEMA_PATHS: Record<string, string> = {

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/apm_settings.ts
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/apm_settings.ts
@@ -194,6 +194,22 @@ export function getApmSettings(): SettingsRow[] {
             }
           ),
         },
+        {
+          key: 'service_metrics_enabled',
+          type: 'boolean',
+          labelAppend: OPTIONAL_LABEL,
+          rowTitle: i18n.translate(
+            'xpack.apm.fleet_integration.settings.apm.serviceMetricsEnabled',
+            { defaultMessage: 'Service Metrics' }
+          ),
+          rowDescription: i18n.translate(
+            'xpack.apm.fleet_integration.settings.apm.serviceMetricsEnabledDescription',
+            {
+              defaultMessage:
+                'Experimental: enables the collection of APM service metrics',
+            }
+          ),
+        },
       ],
     },
   ];


### PR DESCRIPTION
Exposes `service_metrics_enabled` in the `apm` package installation so the policy can enable this setting.

Pending: https://github.com/elastic/apm-server/pull/9145