### PR TITLE
[Lens] Fix fullscreen menu disappearing

### DIFF
--- a/x-pack/plugins/lens/public/state_management/fullscreen_middleware.ts
+++ b/x-pack/plugins/lens/public/state_management/fullscreen_middleware.ts
@@ -12,10 +12,10 @@ import { setToggleFullscreen } from './lens_slice';
 /** cancels updates to the store that don't change the state */
 export const fullscreenMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {
   return (next: Dispatch) => (action: Action) => {
-    next(action);
     if (setToggleFullscreen.match(action)) {
       const isFullscreen = (store.getState as LensGetState)().lens.isFullscreenDatasource;
-      storeDeps.lensServices.chrome.setIsVisible(!isFullscreen);
+      storeDeps.lensServices.chrome.setIsVisible(Boolean(isFullscreen));
     }
+    next(action);
   };
 };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/140769

The problem was that the react component containing the top nav menu needs to re-render after the fullscreen mode is toggled. The existing middleware would trigger the fullscreen update after the state change went through which means the UI would re-render again.

Flipping it around and switching the core fullscreen state before updating the local redux state which re-renders the Lens app fixes the problem.