### PR TITLE
fix(slo): use spaceId for pipeline names

### DIFF
--- a/x-pack/plugins/observability/server/assets/constants.ts
+++ b/x-pack/plugins/observability/server/assets/constants.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = 'observability-slo-mappings';
-export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = 'observability-slo-settings';
+export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = 'slo-observability.sli-mappings';
+export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = 'slo-observability.sli-settings';
 export const SLO_INDEX_TEMPLATE_NAME = 'slo-observability.sli';
-export const SLO_INGEST_PIPELINE_NAME = 'observability-slo-monthly-index';
 export const SLO_RESOURCES_VERSION = 1;
+
+export const getSLOIngestPipelineName = (spaceId: string) =>
+  `${SLO_INDEX_TEMPLATE_NAME}.monthly-${spaceId}`;
 
 export const getSLODestinationIndexName = (spaceId: string) =>
   `${SLO_INDEX_TEMPLATE_NAME}-v${SLO_RESOURCES_VERSION}-${spaceId}`;

--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -70,6 +70,10 @@ export function registerRoutes({
             spacesService,
           })) as any;
 
+          if (data === undefined) {
+            return response.noContent();
+          }
+
           return response.ok({ body: data });
         } catch (error) {
           if (error instanceof ObservabilityError) {

--- a/x-pack/plugins/observability/server/services/slo/resource_installer.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/resource_installer.test.ts
@@ -9,14 +9,15 @@ import { IngestGetPipelineResponse } from '@elastic/elasticsearch/lib/api/typesW
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { loggerMock } from '@kbn/logging-mocks';
 import {
+  getSLOIngestPipelineName,
   SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME,
   SLO_COMPONENT_TEMPLATE_SETTINGS_NAME,
   SLO_INDEX_TEMPLATE_NAME,
-  SLO_INGEST_PIPELINE_NAME,
   SLO_RESOURCES_VERSION,
 } from '../../assets/constants';
 import { DefaultResourceInstaller } from './resource_installer';
 
+const SPACE_ID = 'space-id';
 describe('resourceInstaller', () => {
   describe("when the common resources don't exist", () => {
     it('installs the common resources', async () => {
@@ -25,7 +26,7 @@ describe('resourceInstaller', () => {
       const installer = new DefaultResourceInstaller(
         mockClusterClient,
         loggerMock.create(),
-        'space-id'
+        SPACE_ID
       );
 
       await installer.ensureCommonResourcesInstalled();
@@ -43,7 +44,7 @@ describe('resourceInstaller', () => {
         expect.objectContaining({ name: SLO_INDEX_TEMPLATE_NAME })
       );
       expect(mockClusterClient.ingest.putPipeline).toHaveBeenCalledWith(
-        expect.objectContaining({ id: SLO_INGEST_PIPELINE_NAME })
+        expect.objectContaining({ id: getSLOIngestPipelineName(SPACE_ID) })
       );
     });
   });
@@ -53,12 +54,13 @@ describe('resourceInstaller', () => {
       const mockClusterClient = elasticsearchServiceMock.createElasticsearchClient();
       mockClusterClient.indices.existsIndexTemplate.mockResponseOnce(true);
       mockClusterClient.ingest.getPipeline.mockResponseOnce({
-        [SLO_INGEST_PIPELINE_NAME]: { _meta: { version: SLO_RESOURCES_VERSION } },
+        // @ts-ignore _meta not typed properly
+        [getSLOIngestPipelineName(SPACE_ID)]: { _meta: { version: SLO_RESOURCES_VERSION } },
       } as IngestGetPipelineResponse);
       const installer = new DefaultResourceInstaller(
         mockClusterClient,
         loggerMock.create(),
-        'space-id'
+        SPACE_ID
       );
 
       await installer.ensureCommonResourcesInstalled();

--- a/x-pack/plugins/observability/server/services/slo/resource_installer.ts
+++ b/x-pack/plugins/observability/server/services/slo/resource_installer.ts
@@ -13,10 +13,10 @@ import type {
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
 import {
+  getSLOIngestPipelineName,
   SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME,
   SLO_COMPONENT_TEMPLATE_SETTINGS_NAME,
   SLO_INDEX_TEMPLATE_NAME,
-  SLO_INGEST_PIPELINE_NAME,
   SLO_RESOURCES_VERSION,
 } from '../../assets/constants';
 import { getSLOMappingsTemplate } from '../../assets/component_templates/slo_mappings_template';
@@ -64,7 +64,7 @@ export class DefaultResourceInstaller implements ResourceInstaller {
 
       await this.createOrUpdateIngestPipelineTemplate(
         getSLOPipelineTemplate(
-          SLO_INGEST_PIPELINE_NAME,
+          getSLOIngestPipelineName(this.spaceId),
           this.getPipelinePrefix(SLO_RESOURCES_VERSION, this.spaceId)
         )
       );
@@ -87,13 +87,12 @@ export class DefaultResourceInstaller implements ResourceInstaller {
 
     let ingestPipelineExists = false;
     try {
-      const pipeline = await this.esClient.ingest.getPipeline({
-        id: SLO_INGEST_PIPELINE_NAME,
-      });
+      const pipelineName = getSLOIngestPipelineName(this.spaceId);
+      const pipeline = await this.esClient.ingest.getPipeline({ id: pipelineName });
 
       ingestPipelineExists =
         // @ts-ignore _meta is not defined on the type
-        pipeline && pipeline[SLO_INGEST_PIPELINE_NAME]._meta.version === SLO_RESOURCES_VERSION;
+        pipeline && pipeline[pipelineName]._meta.version === SLO_RESOURCES_VERSION;
     } catch (err) {
       return false;
     }

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -21,7 +21,7 @@ Object {
   },
   "dest": Object {
     "index": "slo-observability.sli-v1-my-namespace",
-    "pipeline": "observability-slo-monthly-index",
+    "pipeline": "slo-observability.sli.monthly-my-namespace",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -21,7 +21,7 @@ Object {
   },
   "dest": Object {
     "index": "slo-observability.sli-v1-my-namespace",
-    "pipeline": "observability-slo-monthly-index",
+    "pipeline": "slo-observability.sli.monthly-my-namespace",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -12,8 +12,8 @@ import {
 } from '@elastic/elasticsearch/lib/api/types';
 import {
   getSLODestinationIndexName,
+  getSLOIngestPipelineName,
   getSLOTransformId,
-  SLO_INGEST_PIPELINE_NAME,
 } from '../../../assets/constants';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
 import {
@@ -106,7 +106,7 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
 
   private buildDestination(slo: APMTransactionDurationSLO, spaceId: string) {
     return {
-      pipeline: SLO_INGEST_PIPELINE_NAME,
+      pipeline: getSLOIngestPipelineName(spaceId),
       index: getSLODestinationIndexName(spaceId),
     };
   }

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -14,8 +14,8 @@ import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo
 import { TransformGenerator } from '.';
 import {
   getSLODestinationIndexName,
+  getSLOIngestPipelineName,
   getSLOTransformId,
-  SLO_INGEST_PIPELINE_NAME,
 } from '../../../assets/constants';
 import {
   apmTransactionErrorRateSLOSchema,
@@ -108,7 +108,7 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
 
   private buildDestination(slo: APMTransactionErrorRateSLO, spaceId: string) {
     return {
-      pipeline: SLO_INGEST_PIPELINE_NAME,
+      pipeline: getSLOIngestPipelineName(spaceId),
       index: getSLODestinationIndexName(spaceId),
     };
   }


### PR DESCRIPTION
## 📝  Summary

Fixes https://github.com/elastic/kibana/issues/141154

This PR fixes an issue with the ingest pipeline naming to use the spaceId: `slo-observability.sli.monthly-{spaceId}`

I've also fixed the `204 No Content` as suggested by @fkanout [in a previous PR](https://github.com/elastic/kibana/pull/140760#discussion_r975452129)


Screenshot |
-- |
<img width="1491" alt="image" src="https://user-images.githubusercontent.com/1376800/191308970-b363b065-34f7-48aa-90cb-4dc5a135fc9b.png"> |


