### PR TITLE
[Reporting] Add browser timezone validation

### DIFF
--- a/x-pack/plugins/reporting/server/routes/generate/integration_tests/generation_from_jobparams.test.ts
+++ b/x-pack/plugins/reporting/server/routes/generate/integration_tests/generation_from_jobparams.test.ts
@@ -155,6 +155,20 @@ describe('POST /api/reporting/generate', () => {
       );
   });
 
+  it('returns 400 on invalid browser timezone', async () => {
+    registerJobGenerationRoutes(mockReportingCore, mockLogger);
+
+    await server.start();
+
+    await supertest(httpSetup.server.listener)
+      .post('/api/reporting/generate/printablePdf')
+      .send({ jobParams: rison.encode({ browserTimezone: 'America/Amsterdam', title: `abc` }) })
+      .expect(400)
+      .then(({ body }) =>
+        expect(body.message).toMatchInlineSnapshot(`"Invalid timezone \\"America/Amsterdam\\"."`)
+      );
+  });
+
   it('returns 500 if job handler throws an error', async () => {
     store.addReport = jest.fn().mockRejectedValue('silly');
 

--- a/x-pack/plugins/reporting/server/routes/lib/request_handler.test.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/request_handler.test.ts
@@ -173,6 +173,26 @@ describe('Handle request to generate', () => {
     `);
   });
 
+  test('disallows invalid browser timezone', async () => {
+    (reportingCore.getLicenseInfo as jest.Mock) = jest.fn(() => ({
+      csv_searchsource: {
+        enableLinks: false,
+        message: `seeing this means the license isn't supported`,
+      },
+    }));
+
+    expect(
+      await requestHandler.handleGenerateRequest('csv_searchsource', {
+        ...mockJobParams,
+        browserTimezone: 'America/Amsterdam',
+      })
+    ).toMatchInlineSnapshot(`
+        Object {
+          "body": "seeing this means the license isn't supported",
+        }
+    `);
+  });
+
   test('generates the download path', async () => {
     const response = (await requestHandler.handleGenerateRequest(
       'csv_searchsource',

--- a/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/request_handler.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import moment from 'moment';
 import Boom from '@hapi/boom';
 import { i18n } from '@kbn/i18n';
 import type { KibanaRequest, KibanaResponseFactory, Logger } from '@kbn/core/server';
@@ -120,6 +121,12 @@ export class RequestHandler {
 
     if (!licenseResults.enableLinks) {
       return this.res.forbidden({ body: licenseResults.message });
+    }
+
+    if (jobParams.browserTimezone && !moment.tz.zone(jobParams.browserTimezone)) {
+      return this.res.badRequest({
+        body: `Invalid timezone "${jobParams.browserTimezone ?? ''}".`,
+      });
     }
 
     try {


### PR DESCRIPTION
## Summary

Resolves #134405.

In the original issue, there was proposed a solution to failing jobs with the invalid parameter. After some analysis there were discovered the following downsides:
- We store job parameters of the completed jobs, and if there is a mechanism to restart those jobs, the change can be considered breaking.
- There is not much difference for the user between a failing job and returning 400 error for the API endpoint. The correct way would be to validate parameters on input which is the HTTP request handler in our case.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
