### PR TITLE
[Profiling] Aggregate ELF frames by exeFilename, not fileID

### DIFF
--- a/x-pack/plugins/profiling/common/frame_group.test.ts
+++ b/x-pack/plugins/profiling/common/frame_group.test.ts
@@ -33,18 +33,21 @@ const elfSymbolizedFrameGroups = [
   createFrameGroup(
     createStackFrameMetadata({
       FileID: '0x0123456789ABCDEF',
+      ExeFileName: 'libc',
       FunctionName: 'strlen()',
     })
   ),
   createFrameGroup(
     createStackFrameMetadata({
       FileID: '0xFEDCBA9876543210',
+      ExeFileName: 'libc',
       FunctionName: 'strtok()',
     })
   ),
   createFrameGroup(
     createStackFrameMetadata({
       FileID: '0xFEDCBA9876543210',
+      ExeFileName: 'myapp',
       FunctionName: 'main()',
     })
   ),
@@ -166,7 +169,7 @@ describe('Frame group operations', () => {
 
     test('non-symbolized ELF frame', () => {
       expect(createFrameGroupID(elfSymbolizedFrameGroups[0])).toEqual(
-        'elf;0x0123456789ABCDEF;strlen()'
+        'elf;libc;strlen()'
       );
     });
 

--- a/x-pack/plugins/profiling/common/frame_group.test.ts
+++ b/x-pack/plugins/profiling/common/frame_group.test.ts
@@ -168,9 +168,7 @@ describe('Frame group operations', () => {
     });
 
     test('non-symbolized ELF frame', () => {
-      expect(createFrameGroupID(elfSymbolizedFrameGroups[0])).toEqual(
-        'elf;libc;strlen()'
-      );
+      expect(createFrameGroupID(elfSymbolizedFrameGroups[0])).toEqual('elf;libc;strlen()');
     });
 
     test('symbolized frame', () => {

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -28,6 +28,7 @@ interface EmptyFrameGroup extends BaseFrameGroup {
 interface ElfFrameGroup extends BaseFrameGroup {
   readonly name: FrameGroupName.ELF;
   readonly fileID: StackFrameMetadata['FileID'];
+  readonly exeFilename: StackFrameMetadata['ExeFileName'];
   readonly functionName: StackFrameMetadata['FunctionName'];
 }
 
@@ -59,6 +60,7 @@ export function createFrameGroup(frame: StackFrameMetadata): FrameGroup {
     return {
       name: FrameGroupName.ELF,
       fileID: frame.FileID,
+      exeFilename: frame.ExeFileName,
       functionName: frame.FunctionName,
     } as ElfFrameGroup;
   }
@@ -123,12 +125,14 @@ export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
     if (b.name === FrameGroupName.ELF) {
       if (a.functionName < b.functionName) return -1;
       if (a.functionName > b.functionName) return 1;
-      if (a.fileID < b.fileID) return -1;
-      if (a.fileID > b.fileID) return 1;
+      if (a.exeFilename < b.exeFilename) return -1;
+      if (a.exeFilename > b.exeFilename) return 1;
       return 0;
     }
     if (a.functionName < b.functionName) return -1;
     if (a.functionName > b.functionName) return 1;
+    if (a.exeFilename < b.exeFilename) return -1;
+    if (a.exeFilename > b.exeFilename) return 1;
     return -1;
   }
 
@@ -144,6 +148,8 @@ export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
   if (b.name === FrameGroupName.ELF) {
     if (a.functionName < b.functionName) return -1;
     if (a.functionName > b.functionName) return 1;
+    if (a.exeFilename < b.exeFilename) return -1;
+    if (a.exeFilename > b.exeFilename) return 1;
   }
   return 1;
 }
@@ -154,7 +160,7 @@ export function createFrameGroupID(frameGroup: FrameGroup): FrameGroupID {
       return `${frameGroup.name};${frameGroup.fileID};${frameGroup.addressOrLine}`;
       break;
     case FrameGroupName.ELF:
-      return `${frameGroup.name};${frameGroup.fileID};${frameGroup.functionName}`;
+      return `${frameGroup.name};${frameGroup.exeFilename};${frameGroup.functionName}`;
       break;
     case FrameGroupName.FULL:
       return `${frameGroup.name};${frameGroup.exeFilename};${frameGroup.functionName};${frameGroup.sourceFilename}`;

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -44,7 +44,7 @@ export type FrameGroup = EmptyFrameGroup | ElfFrameGroup | FullFrameGroup;
 // createFrameGroup is the "standard" way of grouping frames, by commonly
 // shared group identifiers.
 //
-// For ELF-symbolized frames, group by FunctionName and FileID.
+// For ELF-symbolized frames, group by FunctionName, ExeFileName and FileID.
 // For non-symbolized frames, group by FileID and AddressOrLine.
 // otherwise group by ExeFileName, SourceFilename and FunctionName.
 export function createFrameGroup(frame: StackFrameMetadata): FrameGroup {


### PR DESCRIPTION
Fixes https://github.com/elastic/prodfiler/issues/2634

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->