### PR TITLE
run ml inference by default

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -70,7 +70,7 @@ export const defaultConnectorsPipelineMeta: DefaultConnectorsPipelineMeta = {
   default_extract_binary_content: true,
   default_name: 'ent-search-generic-ingestion',
   default_reduce_whitespace: true,
-  default_run_ml_inference: false,
+  default_run_ml_inference: true,
 };
 
 const indices: IndexDefinition[] = [


### PR DESCRIPTION
## Summary
Part of: https://github.com/elastic/enterprise-search-team/issues/2811
make `default_run_ml_inference` be `true`


## Related Pull Requests

- https://github.com/elastic/ent-search/pull/6852
- https://github.com/elastic/connectors-ruby/pull/326
- https://github.com/elastic/connectors-python/pull/61
