### PR TITLE
Documents saved objects bulk delete API

### DIFF
--- a/docs/api/saved-objects.asciidoc
+++ b/docs/api/saved-objects.asciidoc
@@ -30,6 +30,8 @@ The following saved objects APIs are available:
 
 * <<saved-objects-api-delete, Delete object API>> to remove {kib} saved objects
 
+* <<saved-objects-api-bulk-delete, Bulk delete objects API>> to remove multiple {kib} saved objects
+
 * <<saved-objects-api-export, Export objects API>> to retrieve sets of saved objects that you want to import into {kib}
 
 * <<saved-objects-api-import, Import objects API>> to create sets of {kib} saved objects from a file created by the export API
@@ -46,6 +48,7 @@ include::saved-objects/bulk_create.asciidoc[]
 include::saved-objects/update.asciidoc[]
 include::saved-objects/bulk_update.asciidoc[]
 include::saved-objects/delete.asciidoc[]
+include::saved-objects/bulk_delete.asciidoc[]
 include::saved-objects/export.asciidoc[]
 include::saved-objects/import.asciidoc[]
 include::saved-objects/resolve_import_errors.asciidoc[]

--- a/docs/api/saved-objects/bulk_delete.asciidoc
+++ b/docs/api/saved-objects/bulk_delete.asciidoc
@@ -30,7 +30,7 @@ WARNING: Once you delete a saved object, _it cannot be recovered_.
 ==== Query parameters
 
 `force`::
-  (Optional, boolean) When true, force delete objects that exist in multiple namespaces. Note that the option applies the whole request. Use the <<saved-objects-api-delete, delete object>> to specify per-object delete behavior.
+  (Optional, boolean) When true, force delete objects that exist in multiple namespaces. Note that the option applies to the whole request. Use the <<saved-objects-api-delete, delete object>> to specify per-object delete behavior.
 +
 TIP: Use this if you attempted to delete objects and received an HTTP 400 error with the following message: _"Unable to delete saved object that exists in multiple namespaces, use the `force` option to delete it anyway"_
 +

--- a/docs/api/saved-objects/bulk_delete.asciidoc
+++ b/docs/api/saved-objects/bulk_delete.asciidoc
@@ -34,7 +34,7 @@ WARNING: Once you delete a saved object, _it cannot be recovered_.
 +
 TIP: Use this if you attempted to delete objects and received an HTTP 400 error with the following message: _"Unable to delete saved object that exists in multiple namespaces, use the `force` option to delete it anyway"_
 +
-WARNING: When you bulk delete objects that exist in multiple namespaces, the API also deletes <<legacy-url-aliases, legacy url aliases>> that reference the object. These requests are batched to minimise the impact but they can place a heavy load on {kib}. Make sure you limit the number of objects that exist in multiple namespaces in a single bulk delete opertation.
+WARNING: When you bulk delete objects that exist in multiple namespaces, the API also deletes <<legacy-url-aliases, legacy url aliases>> that reference the object. These requests are batched to minimise the impact but they can place a heavy load on {kib}. Make sure you limit the number of objects that exist in multiple namespaces in a single bulk delete operation.
 
 ==== Response code
 `200`::

--- a/docs/api/saved-objects/bulk_delete.asciidoc
+++ b/docs/api/saved-objects/bulk_delete.asciidoc
@@ -1,0 +1,107 @@
+[[saved-objects-api-bulk-delete]]
+=== Bulk delete object API
+++++
+<titleabbrev>Bulk delete objects</titleabbrev>
+++++
+
+experimental[] Remove multiple {kib} saved objects.
+
+WARNING: Once you delete a saved object, _it cannot be recovered_.
+
+==== Request
+
+`POST <kibana host>:<port>/api/saved_objects/_bulk_delete`
+
+`POST <kibana host>:<port>/s/<space_id>/api/saved_objects/_bulk_delete`
+
+==== Path parameters
+
+`space_id`::
+  (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
+
+==== Request body
+
+`type`::
+  (Required, string) Valid options include `visualization`, `dashboard`, `search`, `index-pattern`, `config`.
+
+`id`::
+  (Required, string) The object ID to remove.
+
+==== Query parameters
+
+`force`::
+  (Optional, boolean) When true, force delete objects that exist in multiple namespaces. Note that the option applies the whole request. Use the <<saved-objects-api-delete, delete object>> to specify per-object delete behavior.
++
+TIP: Use this if you attempted to delete objects and received an HTTP 400 error with the following message: _"Unable to delete saved object that exists in multiple namespaces, use the `force` option to delete it anyway"_
++
+WARNING: When you bulk delete objects that exist in multiple namespaces, the API also deletes <<legacy-url-aliases, legacy url aliases>> that reference the object. These requests are batched to minimise the impact but they can place a heavy load on {kib}. Make sure you limit the number of objects that exist in multiple namespaces in a single bulk delete opertation.
+
+==== Response code
+`200`::
+  Indicates a successful call. Note, this HTTP response code indicates that the bulk operation succeeded. Errors pertaining to individual
+  objects will be returned in the response body. Refer to the example below for details.
+
+==== Response body
+
+`statuses`::
+  (array) Top-level property that contains objects that represent the response for each of the requested objects. The order of the objects in the response is identical to the order of the objects in the request.
+
+Saved objects that cannot be removed will include an error object.
+
+==== Example
+
+Delete three saved objects, where one of them does not exist and one exists in multiple namespaces:
+
+[source,sh]
+--------------------------------------------------
+$ curl -X POST api/saved_objects/_bulk_delete
+[
+  {
+    type: 'visualization',
+    id: 'not an id',
+  },
+  {
+    type: 'dashboard',
+    id: 'be3733a0-9efe-11e7-acb3-3dab96693fab',
+  {
+    type: 'index-pattern',
+    id: 'd3d7af60-4c81-11e8-b3d7-01146121b73d',
+  }
+]
+--------------------------------------------------
+// KIBANA
+
+The API returns the following:
+
+[source,sh]
+--------------------------------------------------
+{
+  "statuses": [
+    {
+      "success": false,
+      "id": "not an id",
+      "type": "visualization",
+      "error": {
+        "statusCode": 404,
+        "error": "Not Found",
+        "message": "Saved object [visualization/not an id] not found",
+      },
+    },
+    {
+      "success": true,
+      "id": "be3733a0-9efe-11e7-acb3-3dab96693fab",
+      "type": "dashboard",
+    },
+    {
+      "success": false,
+      "id": "d3d7af60-4c81-11e8-b3d7-01146121b73d",
+      "type": "index-pattern",
+      "error": {
+        "statusCode": 400,
+        "error": "Bad Request",
+        "message": "Unable to delete saved object id: d3d7af60-4c81-11e8-b3d7-01146121b73d, type: index-pattern that exists in multiple namespaces, use the \"force\" option to delete all saved objects: Bad Request",
+      },
+    }
+  ]
+}
+--------------------------------------------------


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/141143

Adds public documentation for the saved objects `bulkDelete` API.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials (this PR)

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->