### PR TITLE
[artifacts/cft] Soft fail on timeout

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -75,6 +75,7 @@ steps:
     label: 'Cloud Deployment'
     soft_fail:
       - exit_status: 255
+      - exit_status: '-1'
     agents:
       queue: n2-2
     timeout_in_minutes: 30


### PR DESCRIPTION
We're seeing timeouts instead of 255 statuses on deployment creation when a stack pack doesn't exist yet.  This lets us publish artifacts for timeout related failures.

<!--ONMERGE {"backportTargets":["8.4"]} ONMERGE-->