### PR TITLE
[8.5][Session view][TTY output] UI Improvements

### DIFF
--- a/x-pack/plugins/session_view/public/components/tty_player/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player/styles.ts
@@ -75,7 +75,7 @@ export const useStyles = (tty?: Teletype, show?: boolean) => {
       transform: `translateY(${show ? 0 : '100%'})`,
       transition: 'transform .2s',
       width: '100%',
-      height: 'calc(100% - 120px)',
+      height: 'calc(100% - 112px)',
       overflow: 'auto',
       backgroundColor: colors.ink,
     };

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexItem,
   EuiButtonIcon,
   EuiToolTip,
+  EuiButtonIconProps,
 } from '@elastic/eui';
 import { findIndex } from 'lodash';
 import { ProcessStartMarker, ProcessEvent } from '../../../common/types/process_tree';
@@ -53,6 +54,13 @@ export const TTYPlayerControls = ({
   textSizer,
 }: TTYPlayerControlsDeps) => {
   const styles = useStyles();
+
+  const commonButtonProps: Partial<EuiButtonIconProps> = {
+    display: 'empty',
+    size: 's',
+    color: 'ghost',
+    css: styles.controlButton,
+  };
 
   const onLineChange = useCallback(
     (event: ChangeEvent<HTMLInputElement> | MouseEvent<HTMLButtonElement>) => {
@@ -111,65 +119,55 @@ export const TTYPlayerControls = ({
         <EuiFlexItem grow={false}>
           <EuiToolTip content={TTY_START}>
             <EuiButtonIcon
-              css={styles.controlButton}
               data-test-subj="sessionView:TTYPlayerControlsStart"
               iconType="arrowStart"
-              display="empty"
-              size="m"
               aria-label={TTY_START}
               onClick={seekToStart}
+              {...commonButtonProps}
             />
           </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiToolTip content={TTY_PREVIOUS}>
             <EuiButtonIcon
-              css={styles.controlButton}
               data-test-subj="sessionView:TTYPlayerControlsPrevious"
               iconType="arrowLeft"
-              display="empty"
-              size="m"
               aria-label={TTY_PREVIOUS}
               onClick={seekToPrevProcess}
+              {...commonButtonProps}
             />
           </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiToolTip content={isPlaying ? TTY_PAUSE : TTY_PLAY}>
             <EuiButtonIcon
-              css={styles.controlButton}
               data-test-subj="sessionView:TTYPlayerControlsPlay"
               iconType={isPlaying ? 'pause' : 'playFilled'}
-              display="empty"
-              size="m"
               aria-label={isPlaying ? TTY_PAUSE : TTY_PLAY}
               onClick={onTogglePlayback}
+              {...commonButtonProps}
             />
           </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiToolTip content={TTY_NEXT}>
             <EuiButtonIcon
-              css={styles.controlButton}
               data-test-subj="sessionView:TTYPlayerControlsNext"
               iconType="arrowRight"
-              display="empty"
-              size="m"
               aria-label={TTY_NEXT}
               onClick={seekToNextProcess}
+              {...commonButtonProps}
             />
           </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiToolTip content={TTY_END}>
             <EuiButtonIcon
-              css={styles.controlButton}
               data-test-subj="sessionView:TTYPlayerControlsEnd"
               iconType="arrowEnd"
-              display="empty"
-              size="m"
               aria-label={TTY_END}
               onClick={seekToEnd}
+              {...commonButtonProps}
             />
           </EuiToolTip>
         </EuiFlexItem>
@@ -179,6 +177,7 @@ export const TTYPlayerControls = ({
             linesLength={linesLength}
             currentLine={currentLine}
             onChange={onLineChange}
+            onSeekLine={onSeekLine}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -188,6 +187,7 @@ export const TTYPlayerControls = ({
             onClick={handleViewInSession}
             iconType="arrowRight"
             aria-label={VIEW_IN_SESSION}
+            color="ghost"
           >
             {VIEW_IN_SESSION}
           </EuiButtonEmpty>

--- a/x-pack/plugins/session_view/public/components/tty_player_controls/tty_player_controls_markers/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player_controls/tty_player_controls_markers/styles.ts
@@ -11,7 +11,7 @@ import { useEuiTheme } from '../../../hooks';
 
 type TTYPlayerLineMarkerType = 'output' | 'data_limited';
 
-export const useStyles = () => {
+export const useStyles = (progress: number) => {
   const { euiTheme, euiVars } = useEuiTheme();
   const cached = useMemo(() => {
     const { border } = euiTheme;
@@ -21,6 +21,12 @@ export const useStyles = () => {
       zIndex: 2,
       position: 'absolute',
       width: '100%',
+    };
+
+    const markerWrapper: CSSObject = {
+      position: 'absolute',
+      top: 0,
+      lineHeight: 0,
     };
 
     const getMarkerBackgroundColor = (type: TTYPlayerLineMarkerType, selected: boolean) => {
@@ -36,7 +42,6 @@ export const useStyles = () => {
     const marker = (type: TTYPlayerLineMarkerType, selected: boolean): CSSObject => ({
       fontSize: 0,
       overflow: 'hidden',
-      position: 'absolute',
       padding: 0,
       width: 3,
       height: 12,
@@ -44,10 +49,8 @@ export const useStyles = () => {
       border: `${border.width.thick} solid ${euiVars.terminalOutputBackground}`,
       borderRadius: border.radius.small,
       boxSizing: 'content-box',
-      top: 0,
-      pointerEvents: 'none',
       marginLeft: '-3.5px',
-      transition: 'left .5s ease-in-out .3s',
+      transition: 'left .5s ease-in-out',
     });
 
     const playHeadThumb: CSSObject = {
@@ -82,6 +85,9 @@ export const useStyles = () => {
       "input[type='range']::-moz-range-thumb": customThumb,
       '.euiRangeHighlight__progress': {
         backgroundColor: euiVars.euiColorVis0_behindText,
+        width: progress + '%',
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
       },
       '.euiRangeSlider:focus ~ .euiRangeHighlight .euiRangeHighlight__progress': {
         backgroundColor: euiVars.euiColorVis0_behindText,
@@ -93,9 +99,10 @@ export const useStyles = () => {
       },
     };
 
-    const playHead = (type: TTYPlayerLineMarkerType): CSSObject => ({
+    const playHead = (type?: TTYPlayerLineMarkerType): CSSObject => ({
       ...playHeadThumb,
       position: 'absolute',
+      left: progress + '%',
       top: 16,
       fill:
         type === 'data_limited'
@@ -105,11 +112,21 @@ export const useStyles = () => {
 
     return {
       marker,
+      markerWrapper,
       markersOverlay,
       range,
       playHead,
     };
-  }, [euiTheme, euiVars]);
+  }, [
+    euiTheme,
+    euiVars.euiColorVis0_behindText,
+    euiVars.euiColorVis1,
+    euiVars.terminalOutputBackground,
+    euiVars.terminalOutputMarkerAccent,
+    euiVars.terminalOutputMarkerWarning,
+    euiVars.terminalOutputSliderBackground,
+    progress,
+  ]);
 
   return cached;
 };

--- a/x-pack/plugins/session_view/public/components/tty_text_sizer/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_text_sizer/index.tsx
@@ -5,7 +5,13 @@
  * 2.0.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiButtonIconProps,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiToolTip,
+} from '@elastic/eui';
 import { Teletype } from '../../../common/types/process_tree';
 import { DEFAULT_TTY_FONT_SIZE } from '../../../common/constants';
 import { ZOOM_IN, ZOOM_FIT, ZOOM_OUT } from './translations';
@@ -18,6 +24,12 @@ export interface TTYTextSizerDeps {
   isFullscreen: boolean;
   onFontSizeChanged(newSize: number): void;
 }
+
+const commonButtonProps: Partial<EuiButtonIconProps> = {
+  display: 'empty',
+  size: 's',
+  color: 'ghost',
+};
 
 const LINE_HEIGHT_SCALE_RATIO = 1.3;
 const MINIMUM_FONT_SIZE = 2;
@@ -88,24 +100,12 @@ export const TTYTextSizer = ({
             display={fit ? 'fill' : 'empty'}
             iconType={fit ? 'expand' : 'minimize'}
             onClick={onToggleFit}
+            {...commonButtonProps}
           />
         </EuiToolTip>
       </EuiFlexItem>
       <EuiFlexItem>
         <div css={styles.separator} />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiToolTip content={ZOOM_IN}>
-          <EuiButtonIcon
-            data-test-subj="sessionView:TTYZoomIn"
-            aria-label={ZOOM_IN}
-            iconType="plusInCircle"
-            onClick={onZoomIn}
-          />
-        </EuiToolTip>
-      </EuiFlexItem>
-      <EuiFlexItem component="span" css={styles.ratio}>
-        {`${Math.round((fontSize / DEFAULT_TTY_FONT_SIZE) * 100)}%`}
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiToolTip content={ZOOM_OUT}>
@@ -114,6 +114,21 @@ export const TTYTextSizer = ({
             aria-label={ZOOM_OUT}
             iconType="minusInCircle"
             onClick={onZoomOut}
+            {...commonButtonProps}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem component="span" css={styles.ratio}>
+        {`${Math.round((fontSize / DEFAULT_TTY_FONT_SIZE) * 100)}%`}
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiToolTip content={ZOOM_IN}>
+          <EuiButtonIcon
+            data-test-subj="sessionView:TTYZoomIn"
+            aria-label={ZOOM_IN}
+            iconType="plusInCircle"
+            onClick={onZoomIn}
+            {...commonButtonProps}
           />
         </EuiToolTip>
       </EuiFlexItem>

--- a/x-pack/plugins/session_view/public/components/tty_text_sizer/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_text_sizer/styles.ts
@@ -16,14 +16,13 @@ export const useStyles = () => {
 
     const ratio: CSSObject = {
       fontSize: size.m,
+      color: colors.ghost,
     };
 
     const separator: CSSObject = {
       background: colors.lightShade,
       height: size.xl,
       width: border.width.thin,
-      marginLeft: size.xs,
-      marginRight: size.xs,
     };
 
     return {

--- a/x-pack/plugins/session_view/public/components/tty_text_sizer/translations.ts
+++ b/x-pack/plugins/session_view/public/components/tty_text_sizer/translations.ts
@@ -11,7 +11,7 @@ export const ZOOM_IN = i18n.translate('xpack.sessionView.zoomIn', {
 });
 
 export const ZOOM_FIT = i18n.translate('xpack.sessionView.zoomFit', {
-  defaultMessage: 'Zoom fit',
+  defaultMessage: 'Fit screen',
 });
 
 export const ZOOM_OUT = i18n.translate('xpack.sessionView.zoomOut', {


### PR DESCRIPTION
## Summary

This PR adds the following UI improvements to the Terminal Output:

- Resizes the control bar panel height to match the design spec.
- Adds a tooltip to the markers
- Update the fit screen button tooltip to match the design spec.
- Updates the progress bar to use relative width instead of absolute to handle better dynamic data.

## Screenshots

![image](https://user-images.githubusercontent.com/19270322/191380308-22236d41-a33d-44d5-807e-97f38aea2fd1.png)

![image](https://user-images.githubusercontent.com/19270322/191380356-be79c81f-cd32-4cb3-9378-4c9b382f4bc3.png)
