### PR TITLE
[Security Solution] Hide timeline bottom bar on exceptions list page

### DIFF
--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -123,6 +123,7 @@ export const links: LinkItem = {
       }),
       landingIcon: IconExceptionLists,
       path: EXCEPTIONS_PATH,
+      hideTimeline: true,
       globalSearchKeywords: [
         i18n.translate('xpack.securitySolution.appLinks.exceptions', {
           defaultMessage: 'Exception lists',


### PR DESCRIPTION
## Summary

The exceptions list page currently displays timeline controls in 8.4, when it shouldn't. This was fixed in 8.5, so this is 8.4 only.


https://user-images.githubusercontent.com/56408403/191394882-d03c9826-5e25-4429-ae06-6bb6f971e359.mov

