### PR TITLE
[Cases] Fix delete permissions flaky test 

### DIFF
--- a/x-pack/test/functional/services/cases/single_case_view.ts
+++ b/x-pack/test/functional/services/cases/single_case_view.ts
@@ -20,7 +20,13 @@ export function CasesSingleViewServiceProvider({ getService, getPageObject }: Ft
 
   return {
     async deleteCase() {
-      await common.clickAndValidate('property-actions-ellipses', 'property-actions-trash');
+      const caseActions = await testSubjects.findDescendant(
+        'property-actions-ellipses',
+        await testSubjects.find('case-view-actions')
+      );
+
+      await caseActions.click();
+      await testSubjects.existOrFail('property-actions-trash');
       await common.clickAndValidate('property-actions-trash', 'confirmModalConfirmButton');
       await testSubjects.click('confirmModalConfirmButton');
       await header.waitUntilLoadingHasFinished();

--- a/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
@@ -59,6 +59,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
             it(`User ${user.username} can delete a case while on a specific case page`, async () => {
               await cases.singleCase.deleteCase();
+              await cases.casesTable.waitForTableToFinishLoading();
               await cases.casesTable.validateCasesTableHasNthRows(1);
             });
           });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/view_case.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/view_case.ts
@@ -167,6 +167,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
       it('deletes the case successfully', async () => {
         await cases.singleCase.deleteCase();
+        await cases.casesTable.waitForTableToFinishLoading();
         await cases.casesTable.validateCasesTableHasNthRows(0);
       });
     });


### PR DESCRIPTION
## Summary

The tests, to delete a case, try to find an element with `data-test-subj` equal to `property-actions-ellipses`. On the case view page, there are two elements with this `data-test-subj`: one for the case actions and one for the description. Sometimes the tests select the property actions of the description and fail to delete the case. This PR fixes this issue.

Fixes: https://github.com/elastic/kibana/issues/140547

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1258

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->