### PR TITLE
[ML] Transforms: Fix flaky wizard functional tests.

### DIFF
--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -21,8 +21,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // Failing: See https://github.com/elastic/kibana/issues/139781
-  describe.skip('creation_index_pattern', function () {
+  describe('creation_index_pattern', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
       await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
   const transform = getService('transform');
 
   // Failing: See https://github.com/elastic/kibana/issues/139781
-  describe('creation_index_pattern', function () {
+  describe.skip('creation_index_pattern', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
       await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
   const transform = getService('transform');
 
   // Failing: See https://github.com/elastic/kibana/issues/139781
-  describe.skip('creation_index_pattern', function () {
+  describe('creation_index_pattern', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
       await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -36,16 +36,16 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await transform.testResources.resetKibanaTimeZone();
     });
 
-    // loadTestFile(require.resolve('./permissions'));
+    loadTestFile(require.resolve('./permissions'));
     loadTestFile(require.resolve('./creation_index_pattern'));
-    // loadTestFile(require.resolve('./creation_saved_search'));
-    // loadTestFile(require.resolve('./creation_runtime_mappings'));
-    // loadTestFile(require.resolve('./cloning'));
-    // loadTestFile(require.resolve('./editing'));
-    // loadTestFile(require.resolve('./feature_controls'));
-    // loadTestFile(require.resolve('./deleting'));
-    // loadTestFile(require.resolve('./resetting'));
-    // loadTestFile(require.resolve('./starting'));
+    loadTestFile(require.resolve('./creation_saved_search'));
+    loadTestFile(require.resolve('./creation_runtime_mappings'));
+    loadTestFile(require.resolve('./cloning'));
+    loadTestFile(require.resolve('./editing'));
+    loadTestFile(require.resolve('./feature_controls'));
+    loadTestFile(require.resolve('./deleting'));
+    loadTestFile(require.resolve('./resetting'));
+    loadTestFile(require.resolve('./starting'));
   });
 }
 export interface ComboboxOption {

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -36,16 +36,16 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await transform.testResources.resetKibanaTimeZone();
     });
 
-    loadTestFile(require.resolve('./permissions'));
+    // loadTestFile(require.resolve('./permissions'));
     loadTestFile(require.resolve('./creation_index_pattern'));
-    loadTestFile(require.resolve('./creation_saved_search'));
-    loadTestFile(require.resolve('./creation_runtime_mappings'));
-    loadTestFile(require.resolve('./cloning'));
-    loadTestFile(require.resolve('./editing'));
-    loadTestFile(require.resolve('./feature_controls'));
-    loadTestFile(require.resolve('./deleting'));
-    loadTestFile(require.resolve('./resetting'));
-    loadTestFile(require.resolve('./starting'));
+    // loadTestFile(require.resolve('./creation_saved_search'));
+    // loadTestFile(require.resolve('./creation_runtime_mappings'));
+    // loadTestFile(require.resolve('./cloning'));
+    // loadTestFile(require.resolve('./editing'));
+    // loadTestFile(require.resolve('./feature_controls'));
+    // loadTestFile(require.resolve('./deleting'));
+    // loadTestFile(require.resolve('./resetting'));
+    // loadTestFile(require.resolve('./starting'));
   });
 }
 export interface ComboboxOption {

--- a/x-pack/test/functional/services/transform/source_selection.ts
+++ b/x-pack/test/functional/services/transform/source_selection.ts
@@ -26,7 +26,7 @@ export function TransformSourceSelectionProvider({ getService }: FtrProviderCont
     async selectSource(sourceName: string) {
       await this.filterSourceSelection(sourceName);
       await retry.tryForTime(30 * 1000, async () => {
-        await testSubjects.clickWhenNotDisabledWithoutRetry(`savedObjectTitle${sourceName}`);
+        await testSubjects.clickWhenNotDisabled(`savedObjectTitle${sourceName}`);
         await testSubjects.existOrFail('transformPageCreateTransform', { timeout: 10 * 1000 });
       });
     },

--- a/x-pack/test/functional/services/transform/test_execution.ts
+++ b/x-pack/test/functional/services/transform/test_execution.ts
@@ -12,7 +12,7 @@ export function TransformTestExecutionProvider({ getService }: FtrProviderContex
 
   return {
     async logTestStep(stepTitle: string) {
-      await log.info(`=== TEST STEP === ${stepTitle}`);
+      await log.debug(`=== TEST STEP === ${stepTitle}`);
     },
   };
 }

--- a/x-pack/test/functional/services/transform/test_execution.ts
+++ b/x-pack/test/functional/services/transform/test_execution.ts
@@ -12,7 +12,7 @@ export function TransformTestExecutionProvider({ getService }: FtrProviderContex
 
   return {
     async logTestStep(stepTitle: string) {
-      await log.debug(`=== TEST STEP === ${stepTitle}`);
+      await log.info(`=== TEST STEP === ${stepTitle}`);
     },
   };
 }

--- a/x-pack/test/functional/services/transform/wizard.ts
+++ b/x-pack/test/functional/services/transform/wizard.ts
@@ -34,7 +34,7 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
   return {
     async clickNextButton() {
       await testSubjects.existOrFail('transformWizardNavButtonNext');
-      await testSubjects.clickWhenNotDisabledWithoutRetry('transformWizardNavButtonNext');
+      await testSubjects.clickWhenNotDisabled('transformWizardNavButtonNext');
     },
 
     async assertDefineStepActive() {
@@ -317,7 +317,7 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
       const subj = 'transformAdvancedRuntimeMappingsEditorSwitch';
       if ((await this.getRuntimeMappingsEditorSwitchCheckedState()) !== toggle) {
         await retry.tryForTime(5 * 1000, async () => {
-          await testSubjects.clickWhenNotDisabledWithoutRetry(subj);
+          await testSubjects.clickWhenNotDisabled(subj);
           await this.assertRuntimeMappingsEditorSwitchCheckState(toggle);
         });
       }
@@ -355,7 +355,7 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
     async applyRuntimeMappings() {
       const subj = 'transformRuntimeMappingsApplyButton';
       await testSubjects.existOrFail(subj);
-      await testSubjects.clickWhenNotDisabledWithoutRetry(subj);
+      await testSubjects.clickWhenNotDisabled(subj);
       const isEnabled = await testSubjects.isEnabled(subj);
       expect(isEnabled).to.eql(
         false,
@@ -560,7 +560,7 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
             break;
         }
       }
-      await testSubjects.clickWhenNotDisabledWithoutRetry('transformApplyAggChanges');
+      await testSubjects.clickWhenNotDisabled('transformApplyAggChanges');
       await testSubjects.missingOrFail(`transformAggPopoverForm_${expectedLabel}`);
     },
 


### PR DESCRIPTION
## Summary

Fixes error seen in #139781:

```
fail: transform creation_index_pattern batch transform with terms+date_histogram groups and avg agg navigates through the wizard and sets all needed fields
--
  | │      StaleElementReferenceError: stale element reference: element is not attached to the page document
  | │   (Session info: headless chrome=104.0.5112.101)
```

This replaces `clickWhenNotDisabledWithoutRetry` with `clickWhenNotDisabled` to stabilize tests.

Related ML issue: https://github.com/elastic/kibana/pull/140326#event-7350155481

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->