### PR TITLE
[APM] Use `_doc_count` from service metrics

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/transaction_error_rate.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transaction_error_rate.test.ts
@@ -17,7 +17,7 @@ describe('calculateFailedTransactionRateFromServiceMetrics', () => {
     ).toBe(0);
   });
 
-  it('should return 9 when failedTransactions:null', () => {
+  it('should return 0 when failedTransactions:null', () => {
     expect(
       calculateFailedTransactionRateFromServiceMetrics({
         failedTransactions: null,

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
@@ -91,11 +91,6 @@ export async function getServiceAggregatedTransactionStats({
                           field: TRANSACTION_DURATION_SUMMARY,
                         },
                       },
-                      total_doc: {
-                        value_count: {
-                          field: TRANSACTION_DURATION_SUMMARY,
-                        },
-                      },
                       failure_count: {
                         sum: {
                           field: TRANSACTION_FAILURE_COUNT,
@@ -117,17 +112,6 @@ export async function getServiceAggregatedTransactionStats({
                           sort: {
                             '@timestamp': 'desc' as const,
                           },
-                        },
-                      },
-                      bucket_sort: {
-                        bucket_sort: {
-                          sort: [
-                            {
-                              total_doc: {
-                                order: 'desc',
-                              },
-                            },
-                          ],
                         },
                       },
                     },
@@ -166,7 +150,7 @@ export async function getServiceAggregatedTransactionStats({
         throughput: calculateThroughputWithRange({
           start,
           end,
-          value: topTransactionTypeBucket.total_doc.value,
+          value: topTransactionTypeBucket.doc_count,
         }),
       };
     }) ?? []

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
@@ -133,17 +133,6 @@ export async function getServiceAggregatedTransactionDetailedStats({
                         },
                         aggs: metrics,
                       },
-                      bucket_sort: {
-                        bucket_sort: {
-                          sort: [
-                            {
-                              total_doc: {
-                                order: 'desc',
-                              },
-                            },
-                          ],
-                        },
-                      },
                     },
                   },
                 },
@@ -186,7 +175,7 @@ export async function getServiceAggregatedTransactionDetailedStats({
             y: calculateThroughputWithRange({
               start,
               end,
-              value: dateBucket.total_doc.value,
+              value: dateBucket.doc_count,
             }),
           })
         ),

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
@@ -63,11 +63,6 @@ export async function getServiceAggregatedTransactionDetailedStats({
         field: TRANSACTION_DURATION_SUMMARY,
       },
     },
-    total_doc: {
-      value_count: {
-        field: TRANSACTION_DURATION_SUMMARY,
-      },
-    },
     failure_count: {
       sum: {
         field: TRANSACTION_FAILURE_COUNT,


### PR DESCRIPTION
part of: #141185

https://github.com/elastic/apm-server/pull/9143

apm-server added the `_doc_count` to ensure proper bucket counts and avoid the aggregation on value count. 

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->