### PR TITLE
[Cases] Filter cases correctly on the recent cases widget.

### DIFF
--- a/x-pack/plugins/cases/public/components/recent_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/index.test.tsx
@@ -9,7 +9,12 @@ import React from 'react';
 import { configure, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RecentCases, { RecentCasesProps } from '.';
-import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
+import {
+  AppMockRenderer,
+  createAppMockRenderer,
+  noCasesCapabilities,
+  TestProviders,
+} from '../../common/mock';
 import { useGetCasesMockState } from '../../containers/mock';
 import { useCurrentUser } from '../../common/lib/kibana/hooks';
 import { useGetCases } from '../../containers/use_get_cases';
@@ -82,7 +87,7 @@ describe('RecentCases', () => {
       </TestProviders>
     );
     expect(useGetCasesMock).toHaveBeenCalledWith({
-      filterOptions: { reporters: [] },
+      filterOptions: { reporters: [], owner: ['securitySolution'] },
       queryParams: { perPage: 2 },
     });
   });
@@ -95,7 +100,7 @@ describe('RecentCases', () => {
     );
 
     expect(useGetCasesMock).toHaveBeenCalledWith({
-      filterOptions: { reporters: [] },
+      filterOptions: { reporters: [], owner: ['securitySolution'] },
       queryParams: { perPage: 10 },
     });
 
@@ -115,6 +120,7 @@ describe('RecentCases', () => {
             username: 'damaged_raccoon',
           },
         ],
+        owner: ['securitySolution'],
       },
       queryParams: { perPage: 10 },
     });
@@ -126,6 +132,7 @@ describe('RecentCases', () => {
     expect(useGetCasesMock).toHaveBeenLastCalledWith({
       filterOptions: {
         reporters: [],
+        owner: ['securitySolution'],
       },
       queryParams: { perPage: 10 },
     });
@@ -141,7 +148,7 @@ describe('RecentCases', () => {
     );
 
     expect(useGetCasesMock).toHaveBeenCalledWith({
-      filterOptions: { reporters: [] },
+      filterOptions: { reporters: [], owner: ['securitySolution'] },
       queryParams: { perPage: 10 },
     });
 
@@ -160,8 +167,29 @@ describe('RecentCases', () => {
             username: 'elastic',
           },
         ],
+        owner: ['securitySolution'],
       },
       queryParams: { perPage: 10 },
+    });
+  });
+
+  it('sets all available solutions correctly', () => {
+    appMockRender = createAppMockRenderer({ owner: [] });
+    /**
+     * We set securitySolutionCases capability to not have
+     * any access to cases. This tests that we get the owners
+     * that have at least read access.
+     */
+    appMockRender.coreStart.application.capabilities = {
+      ...appMockRender.coreStart.application.capabilities,
+      securitySolutionCases: noCasesCapabilities(),
+    };
+
+    appMockRender.render(<RecentCases {...{ ...defaultProps, maxCasesToShow: 2 }} />);
+
+    expect(useGetCasesMock).toHaveBeenCalledWith({
+      filterOptions: { reporters: [], owner: ['cases'] },
+      queryParams: { perPage: 2 },
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
@@ -18,6 +18,8 @@ import { MarkdownRenderer } from '../markdown_editor';
 import { FilterOptions } from '../../containers/types';
 import { TruncatedText } from '../truncated_text';
 import { initialData as initialGetCasesData, useGetCases } from '../../containers/use_get_cases';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 const MarkdownContainer = styled.div`
   max-height: 150px;
@@ -31,9 +33,13 @@ export interface RecentCasesProps {
 }
 
 export const RecentCasesComp = ({ filterOptions, maxCasesToShow }: RecentCasesProps) => {
+  const { owner } = useCasesContext();
+  const availableSolutions = useAvailableCasesOwners(['read']);
+  const hasOwner = !!owner.length;
+
   const { data = initialGetCasesData, isLoading: isLoadingCases } = useGetCases({
     queryParams: { perPage: maxCasesToShow },
-    filterOptions,
+    filterOptions: { ...filterOptions, owner: hasOwner ? owner : availableSolutions },
   });
 
   return isLoadingCases ? (


### PR DESCRIPTION
## Summary

The recent cases widget is being used by solution (only by Security solution at the moment of writing) to show the most recent cases created by a user. The widget did not set the correct owner. As a result, cases from other solutions will be shown if the user has permission for them. This PR fixes the filtering issue by applying the correct `owner`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release notes
Fix bug where the recent cases widget shows cases from other solutions.


<!--ONMERGE {"backportTargets":["7.17","8.4"]} ONMERGE-->