### PR TITLE
Fix default value for keepAliveMsecs, to be iso-functional with elastic-transport-js

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/agent_manager.test.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/agent_manager.test.ts
@@ -51,7 +51,7 @@ describe('AgentManager', () => {
         expect(HttpAgent).toBeCalledTimes(1);
         expect(HttpAgent).toBeCalledWith({
           keepAlive: true,
-          keepAliveMsecs: 50000,
+          keepAliveMsecs: 1000,
           maxFreeSockets: 256,
           maxSockets: 256,
           scheduling: 'lifo',
@@ -68,7 +68,7 @@ describe('AgentManager', () => {
         expect(HttpAgent).toBeCalledTimes(1);
         expect(HttpAgent).toBeCalledWith({
           keepAlive: true,
-          keepAliveMsecs: 50000,
+          keepAliveMsecs: 1000,
           maxFreeSockets: 32,
           maxSockets: 1024,
           scheduling: 'fifo',

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/agent_manager.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/agent_manager.ts
@@ -13,7 +13,7 @@ import { ConnectionOptions, HttpAgentOptions } from '@elastic/elasticsearch';
 const HTTPS = 'https:';
 const DEFAULT_CONFIG: HttpAgentOptions = {
   keepAlive: true,
-  keepAliveMsecs: 50000,
+  keepAliveMsecs: 1000,
   maxSockets: 256,
   maxFreeSockets: 256,
   scheduling: 'lifo',


### PR DESCRIPTION
## Summary

During some local testing, the value of `keepAliveMsecs` was temporarily increased, to observe behavior of idle sockets.
I totally forgot to switch it back to `1000`, to keep the same configuration as [elastic-transport-js](https://github.com/elastic/elastic-transport-js/blob/main/src/connection/HttpConnection.ts#L69).

