### PR TITLE
[Fleet] Hide API reference for integration with custom UI extension

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -43,6 +43,12 @@ export const autoUpdatePackages = [
   FLEET_SYNTHETICS_PACKAGE,
 ];
 
+export const HIDDEN_API_REFERENCE_PACKAGES = [
+  FLEET_ENDPOINT_PACKAGE,
+  FLEET_APM_PACKAGE,
+  FLEET_SYNTHETICS_PACKAGE,
+];
+
 export const autoUpgradePoliciesPackages = [FLEET_APM_PACKAGE, FLEET_SYNTHETICS_PACKAGE];
 
 export const agentAssetTypes = {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -27,7 +27,11 @@ import { useCancelAddPackagePolicy, useOnSaveNavigate } from '../hooks';
 import type { CreatePackagePolicyRequest } from '../../../../../../../common/types';
 
 import { splitPkgKey } from '../../../../../../../common/services';
-import { dataTypes, FLEET_SYSTEM_PACKAGE } from '../../../../../../../common/constants';
+import {
+  dataTypes,
+  FLEET_SYSTEM_PACKAGE,
+  HIDDEN_API_REFERENCE_PACKAGES,
+} from '../../../../../../../common/constants';
 import { useConfirmForceInstall } from '../../../../../integrations/hooks';
 import type {
   AgentPolicy,
@@ -557,7 +561,13 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     },
   ];
 
-  const { showDevtoolsRequest } = ExperimentalFeaturesService.get();
+  const { showDevtoolsRequest: isShowDevtoolRequestExperimentEnabled } =
+    ExperimentalFeaturesService.get();
+
+  const showDevtoolsRequest =
+    !HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo?.name ?? '') &&
+    isShowDevtoolRequestExperimentEnabled;
+
   const devtoolRequest = useMemo(
     () =>
       generateCreatePackagePolicyDevToolsRequest({

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -63,6 +63,7 @@ import type {
   GetOnePackagePolicyResponse,
   UpgradePackagePolicyDryRunResponse,
 } from '../../../../../../common/types/rest_spec';
+import { HIDDEN_API_REFERENCE_PACKAGES } from '../../../../../../common/constants';
 import type { PackagePolicyEditExtensionComponentProps } from '../../../types';
 import { ExperimentalFeaturesService, pkgKeyFromPackageInfo } from '../../../services';
 import { generateUpdatePackagePolicyDevToolsRequest } from '../services';
@@ -577,7 +578,12 @@ export const EditPackagePolicyForm = memo<{
     ]
   );
 
-  const { showDevtoolsRequest } = ExperimentalFeaturesService.get();
+  const { showDevtoolsRequest: isShowDevtoolRequestExperimentEnabled } =
+    ExperimentalFeaturesService.get();
+
+  const showDevtoolsRequest =
+    !HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo?.name ?? '') &&
+    isShowDevtoolRequestExperimentEnabled;
 
   const devtoolRequest = useMemo(
     () =>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -25,6 +25,8 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import semverLt from 'semver/functions/lt';
 
 import { splitPkgKey } from '../../../../../../../common/services';
+import { HIDDEN_API_REFERENCE_PACKAGES } from '../../../../../../../common/constants';
+
 import {
   useGetPackageInstallStatus,
   useSetPackageInstallStatus,
@@ -490,21 +492,23 @@ export function Detail() {
       });
     }
 
-    tabs.push({
-      id: 'api-reference',
-      name: (
-        <FormattedMessage
-          id="xpack.fleet.epm.packageDetailsNav.documentationLinkText"
-          defaultMessage="API reference"
-        />
-      ),
-      isSelected: panel === 'api-reference',
-      'data-test-subj': `tab-api-reference`,
-      href: getHref('integration_details_api_reference', {
-        pkgkey: packageInfoKey,
-        ...(integration ? { integration } : {}),
-      }),
-    });
+    if (!HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo.name)) {
+      tabs.push({
+        id: 'api-reference',
+        name: (
+          <FormattedMessage
+            id="xpack.fleet.epm.packageDetailsNav.documentationLinkText"
+            defaultMessage="API reference"
+          />
+        ),
+        isSelected: panel === 'api-reference',
+        'data-test-subj': `tab-api-reference`,
+        href: getHref('integration_details_api_reference', {
+          pkgkey: packageInfoKey,
+          ...(integration ? { integration } : {}),
+        }),
+      });
+    }
 
     return tabs;
   }, [


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/141182 

We cannot generate API reference for integration using custom UI extension, that PR fix that by hidding the API reference tab and preview API request for plugins with a custom UI extension 

<img width="1614" alt="Screen Shot 2022-09-21 at 9 52 32 AM" src="https://user-images.githubusercontent.com/1336873/191522633-183e65b5-6eb9-4e71-b9fc-43b89a0ac241.png">
<img width="1209" alt="Screen Shot 2022-09-21 at 9 52 55 AM" src="https://user-images.githubusercontent.com/1336873/191522847-cfa3bdb3-b822-436f-86d1-b2dcf7dcd562.png">

