### PR TITLE
[8.4] Filter cases correctly on the recent cases widget. (#141221)

### DIFF
--- a/x-pack/plugins/cases/public/components/recent_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/index.test.tsx
@@ -9,7 +9,12 @@ import React from 'react';
 import { configure } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RecentCases, { RecentCasesProps } from '.';
-import { AppMockRenderer, createAppMockRenderer, TestProviders } from '../../common/mock';
+import {
+  AppMockRenderer,
+  createAppMockRenderer,
+  noCasesCapabilities,
+  TestProviders,
+} from '../../common/mock';
 import { useGetCasesMockState } from '../../containers/mock';
 import { useCurrentUser } from '../../common/lib/kibana/hooks';
 import { useGetCases } from '../../containers/use_get_cases';
@@ -73,7 +78,7 @@ describe('RecentCases', () => {
       </TestProviders>
     );
     expect(useGetCasesMock).toHaveBeenCalledWith({
-      filterOptions: { reporters: [] },
+      filterOptions: { reporters: [], owner: ['securitySolution'] },
       queryParams: { perPage: 2 },
     });
   });
@@ -86,7 +91,7 @@ describe('RecentCases', () => {
     );
 
     expect(useGetCasesMock).toHaveBeenCalledWith({
-      filterOptions: { reporters: [] },
+      filterOptions: { reporters: [], owner: ['securitySolution'] },
       queryParams: { perPage: 10 },
     });
 
@@ -97,6 +102,7 @@ describe('RecentCases', () => {
     expect(useGetCasesMock).toHaveBeenLastCalledWith({
       filterOptions: {
         reporters: [{ email: undefined, full_name: undefined, username: undefined }],
+        owner: ['securitySolution'],
       },
       queryParams: { perPage: 10 },
     });
@@ -108,8 +114,29 @@ describe('RecentCases', () => {
     expect(useGetCasesMock).toHaveBeenLastCalledWith({
       filterOptions: {
         reporters: [],
+        owner: ['securitySolution'],
       },
       queryParams: { perPage: 10 },
+    });
+  });
+
+  it('sets all available solutions correctly', () => {
+    appMockRender = createAppMockRenderer({ owner: [] });
+    /**
+     * We set securitySolutionCases capability to not have
+     * any access to cases. This tests that we get the owners
+     * that have at least read access.
+     */
+    appMockRender.coreStart.application.capabilities = {
+      ...appMockRender.coreStart.application.capabilities,
+      securitySolutionCases: noCasesCapabilities(),
+    };
+
+    appMockRender.render(<RecentCases {...{ ...defaultProps, maxCasesToShow: 2 }} />);
+
+    expect(useGetCasesMock).toHaveBeenCalledWith({
+      filterOptions: { reporters: [], owner: ['cases'] },
+      queryParams: { perPage: 2 },
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
@@ -18,6 +18,8 @@ import { MarkdownRenderer } from '../markdown_editor';
 import { FilterOptions } from '../../containers/types';
 import { TruncatedText } from '../truncated_text';
 import { initialData as initialGetCasesData, useGetCases } from '../../containers/use_get_cases';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 const MarkdownContainer = styled.div`
   max-height: 150px;
@@ -31,9 +33,13 @@ export interface RecentCasesProps {
 }
 
 export const RecentCasesComp = ({ filterOptions, maxCasesToShow }: RecentCasesProps) => {
+  const { owner } = useCasesContext();
+  const availableSolutions = useAvailableCasesOwners(['read']);
+  const hasOwner = !!owner.length;
+
   const { data = initialGetCasesData, isLoading: isLoadingCases } = useGetCases({
     queryParams: { perPage: maxCasesToShow },
-    filterOptions,
+    filterOptions: { ...filterOptions, owner: hasOwner ? owner : availableSolutions },
   });
 
   return isLoadingCases ? (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Fix bug (#141221)](https://github.com/elastic/kibana/pull/141221)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2022-09-21T13:34:04Z","message":"Fix bug (#141221)","sha":"11588b31758fa95e095d8589c5b5bb68b2ad994c","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Feature:Cases","backport:all-open","v8.5.0"],"number":141221,"url":"https://github.com/elastic/kibana/pull/141221","mergeCommit":{"message":"Fix bug (#141221)","sha":"11588b31758fa95e095d8589c5b5bb68b2ad994c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/141221","number":141221,"mergeCommit":{"message":"Fix bug (#141221)","sha":"11588b31758fa95e095d8589c5b5bb68b2ad994c"}}]}] BACKPORT-->