### PR TITLE
[Lens] Add more unit tests for annotation panel switch event type

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/index.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/index.test.tsx
@@ -372,6 +372,218 @@ describe('AnnotationsPanel', () => {
       );
     });
 
+    test('should avoid to retain specific manual configurations when switching to query based annotations', () => {
+      const state = testState();
+      const indexPattern = createMockedIndexPattern();
+      state.layers[0] = {
+        annotations: [customLineStaticAnnotation],
+        layerId: 'annotation',
+        layerType: 'annotations',
+        ignoreGlobalFilters: true,
+        indexPatternId: indexPattern.id,
+      };
+      const frameMock = createMockFramePublicAPI({
+        datasourceLayers: {},
+        dataViews: createMockDataViewsState({
+          indexPatterns: { [indexPattern.id]: indexPattern },
+        }),
+      });
+
+      const setState = jest.fn();
+
+      const component = mount(
+        <AnnotationsPanel
+          layerId={state.layers[0].layerId}
+          frame={frameMock}
+          setState={setState}
+          accessor="ann1"
+          groupId="left"
+          state={state}
+          datatableUtilities={datatableUtilities}
+          formatFactory={jest.fn()}
+          paletteService={chartPluginMock.createPaletteRegistry()}
+          panelRef={React.createRef()}
+        />
+      );
+
+      act(() => {
+        component
+          .find(`[data-test-subj="lns-xyAnnotation-placementType"]`)
+          .find(EuiButtonGroup)
+          .prop('onChange')!('lens_xyChart_annotation_query');
+      });
+      component.update();
+
+      expect(setState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          layers: [
+            expect.objectContaining({
+              annotations: [
+                expect.objectContaining({
+                  key: expect.not.objectContaining({ timestamp: expect.any('string') }),
+                }),
+              ],
+            }),
+          ],
+        })
+      );
+    });
+
+    test('should avoid to retain range manual configurations when switching to query based annotations', () => {
+      const state = testState();
+      const indexPattern = createMockedIndexPattern();
+      state.layers[0] = {
+        annotations: [
+          {
+            color: 'red',
+            icon: 'triangle',
+            id: 'ann1',
+            type: 'manual',
+            isHidden: undefined,
+            key: {
+              endTimestamp: '2022-03-21T10:49:00.000Z',
+              timestamp: '2022-03-18T08:25:00.000Z',
+              type: 'range',
+            },
+            label: 'Event range',
+            lineStyle: 'dashed',
+            lineWidth: 3,
+          },
+        ],
+        layerId: 'annotation',
+        layerType: 'annotations',
+        ignoreGlobalFilters: true,
+        indexPatternId: indexPattern.id,
+      };
+      const frameMock = createMockFramePublicAPI({
+        datasourceLayers: {},
+        dataViews: createMockDataViewsState({
+          indexPatterns: { [indexPattern.id]: indexPattern },
+        }),
+      });
+
+      const setState = jest.fn();
+
+      const component = mount(
+        <AnnotationsPanel
+          layerId={state.layers[0].layerId}
+          frame={frameMock}
+          setState={setState}
+          accessor="ann1"
+          groupId="left"
+          state={state}
+          datatableUtilities={datatableUtilities}
+          formatFactory={jest.fn()}
+          paletteService={chartPluginMock.createPaletteRegistry()}
+          panelRef={React.createRef()}
+        />
+      );
+
+      act(() => {
+        component
+          .find(`[data-test-subj="lns-xyAnnotation-placementType"]`)
+          .find(EuiButtonGroup)
+          .prop('onChange')!('lens_xyChart_annotation_query');
+      });
+      component.update();
+
+      expect(setState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          layers: [
+            expect.objectContaining({
+              annotations: [
+                expect.objectContaining({ label: expect.not.stringContaining('Event range') }),
+              ],
+            }),
+          ],
+        })
+      );
+    });
+
+    test('should set a default tiemstamp when switching from query based to manual annotations', () => {
+      const state = testState();
+      const indexPattern = createMockedIndexPattern();
+      state.layers[0] = {
+        annotations: [
+          {
+            color: 'red',
+            icon: 'triangle',
+            id: 'ann1',
+            type: 'query',
+            isHidden: undefined,
+            timeField: 'timestamp',
+            key: {
+              type: 'point_in_time',
+            },
+            label: 'Query based event',
+            lineStyle: 'dashed',
+            lineWidth: 3,
+            filter: { type: 'kibana_query', query: '', language: 'kuery' },
+          },
+        ],
+        layerId: 'annotation',
+        layerType: 'annotations',
+        indexPatternId: indexPattern.id,
+        ignoreGlobalFilters: true,
+      };
+      const frameMock = createMockFramePublicAPI({
+        datasourceLayers: {},
+        dataViews: createMockDataViewsState({
+          indexPatterns: { [indexPattern.id]: indexPattern },
+        }),
+      });
+
+      const setState = jest.fn();
+
+      const component = mount(
+        <AnnotationsPanel
+          layerId={state.layers[0].layerId}
+          frame={frameMock}
+          setState={setState}
+          accessor="ann1"
+          groupId="left"
+          state={state}
+          datatableUtilities={datatableUtilities}
+          formatFactory={jest.fn()}
+          paletteService={chartPluginMock.createPaletteRegistry()}
+          panelRef={React.createRef()}
+        />
+      );
+
+      act(() => {
+        component
+          .find(`[data-test-subj="lns-xyAnnotation-placementType"]`)
+          .find(EuiButtonGroup)
+          .prop('onChange')!('lens_xyChart_annotation_manual');
+      });
+      component.update();
+
+      expect(setState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          layers: [
+            expect.objectContaining({
+              annotations: [
+                expect.objectContaining({
+                  key: { type: 'point_in_time', timestamp: expect.any(String) },
+                }),
+              ],
+            }),
+          ],
+        })
+      );
+
+      // also check query specific props are not carried over
+      expect(setState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          layers: [
+            expect.objectContaining({
+              annotations: [expect.not.objectContaining({ timeField: 'timestamp' })],
+            }),
+          ],
+        })
+      );
+    });
+
     test('should fallback to the first date field available in the dataView if not time-based', () => {
       const state = testState();
       const indexPattern = createMockedIndexPattern({ timeFieldName: '' });


### PR DESCRIPTION
## Summary

As I could not reproduce #141048, I thought to add some more unit tests in the area to better check the event object sanification during switching type.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
