### PR TITLE
[build] Fix --(skip)all-platforms from linux-arm64

### DIFF
--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -146,7 +146,7 @@ describe('#getNodePlatforms()', () => {
     });
     const platforms = config.getNodePlatforms();
     expect(platforms).toBeInstanceOf(Array);
-    if (process.platform !== 'linux') {
+    if (!(process.platform === 'linux' && process.arch === 'x64')) {
       expect(platforms).toHaveLength(2);
       expect(platforms[0]).toBe(config.getPlatformForThisOs());
       expect(platforms[1]).toBe(config.getPlatform('linux', 'x64'));

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -154,7 +154,7 @@ export class Config {
       return ALL_PLATFORMS;
     }
 
-    if (process.platform === 'linux') {
+    if (process.platform === 'linux' && process.arch === 'x64') {
       return [this.getPlatform('linux', 'x64')];
     }
 


### PR DESCRIPTION
This fixes a node architecture check where x64 was assumed and incorrectly downloaded on arm64 bases.  This only effects builds not using the `--all-platforms` flag.

Testing
`node scripts/build` on linux-arm64 should work