### PR TITLE
Fix Entity analytics inconsistencies

### DIFF
--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
@@ -97,3 +97,11 @@ export const enum RiskSeverity {
 
 export const isUserRiskScore = (risk: HostRiskScore | UserRiskScore): risk is UserRiskScore =>
   'user' in risk;
+
+export const EMPTY_SEVERITY_COUNT = {
+  [RiskSeverity.critical]: 0,
+  [RiskSeverity.high]: 0,
+  [RiskSeverity.low]: 0,
+  [RiskSeverity.moderate]: 0,
+  [RiskSeverity.unknown]: 0,
+};

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected.tsx
@@ -5,15 +5,23 @@
  * 2.0.
  */
 
-import { EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiPanel, EuiToolTip } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 
 import { HeaderSection } from '../../header_section';
 import * as i18n from './translations';
 import { RiskScoreHeaderTitle } from './risk_score_header_title';
+import { RiskScoreRestartButton } from './risk_score_restart_button';
+import type { inputsModel } from '../../../store';
 
-const RiskScoresNoDataDetectedComponent = ({ entityType }: { entityType: RiskScoreEntity }) => {
+const RiskScoresNoDataDetectedComponent = ({
+  entityType,
+  refetch,
+}: {
+  entityType: RiskScoreEntity;
+  refetch: inputsModel.Refetch;
+}) => {
   const translations = useMemo(
     () => ({
       title:
@@ -26,7 +34,15 @@ const RiskScoresNoDataDetectedComponent = ({ entityType }: { entityType: RiskSco
   return (
     <EuiPanel data-test-subj={`${entityType}-risk-score-no-data-detected`} hasBorder>
       <HeaderSection title={<RiskScoreHeaderTitle riskScoreEntity={entityType} />} titleSize="s" />
-      <EuiEmptyPrompt title={<h2>{translations.title}</h2>} body={translations.body} />
+      <EuiEmptyPrompt
+        title={<h2>{translations.title}</h2>}
+        body={translations.body}
+        actions={
+          <EuiToolTip content={i18n.RESTART_TOOLTIP}>
+            <RiskScoreRestartButton refetch={refetch} riskScoreEntity={entityType} />
+          </EuiToolTip>
+        }
+      />
     </EuiPanel>
   );
 };

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_restart_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_restart_button.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { RiskScoreEntity } from '../../../../../common/search_strategy';
+import { TestProviders } from '../../../mock/test_providers';
+import { RiskScoreRestartButton } from './risk_score_restart_button';
+
+import { restartRiskScoreTransforms } from './utils';
+
+jest.mock('./utils');
+
+describe('RiskScoreRestartButton', () => {
+  const mockRefetch = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe.each([[RiskScoreEntity.host], [RiskScoreEntity.user]])('%s', (riskScoreEntity) => {
+    it('Renders expected children', () => {
+      render(
+        <TestProviders>
+          <RiskScoreRestartButton refetch={mockRefetch} riskScoreEntity={riskScoreEntity} />
+        </TestProviders>
+      );
+
+      expect(screen.getByTestId(`restart_${riskScoreEntity}_risk_score`)).toHaveTextContent(
+        'Restart'
+      );
+    });
+
+    it('calls restartRiskScoreTransforms', async () => {
+      render(
+        <TestProviders>
+          <RiskScoreRestartButton refetch={mockRefetch} riskScoreEntity={riskScoreEntity} />
+        </TestProviders>
+      );
+
+      await act(async () => {
+        await userEvent.click(screen.getByTestId(`restart_${riskScoreEntity}_risk_score`));
+      });
+
+      expect(restartRiskScoreTransforms).toHaveBeenCalled();
+    });
+
+    it('Update button state while installing', async () => {
+      render(
+        <TestProviders>
+          <RiskScoreRestartButton refetch={mockRefetch} riskScoreEntity={riskScoreEntity} />
+        </TestProviders>
+      );
+
+      userEvent.click(screen.getByTestId(`restart_${riskScoreEntity}_risk_score`));
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`restart_${riskScoreEntity}_risk_score`)).toHaveProperty(
+          'disabled',
+          true
+        );
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_restart_button.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_restart_button.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton } from '@elastic/eui';
+import React, { useCallback } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { RiskScoreEntity } from '../../../../../common/search_strategy';
+import { useSpaceId } from '../../../hooks/use_space_id';
+import { useKibana } from '../../../lib/kibana';
+import type { inputsModel } from '../../../store';
+import { REQUEST_NAMES, useFetch } from '../../../hooks/use_fetch';
+import { useRiskScoreToastContent } from './use_risk_score_toast_content';
+import { restartRiskScoreTransforms } from './utils';
+
+const RiskScoreRestartButtonComponent = ({
+  refetch,
+  riskScoreEntity,
+}: {
+  refetch: inputsModel.Refetch;
+  riskScoreEntity: RiskScoreEntity;
+}) => {
+  const { fetch, isLoading } = useFetch(
+    REQUEST_NAMES.REFRESH_RISK_SCORE,
+    restartRiskScoreTransforms
+  );
+
+  const spaceId = useSpaceId();
+  const { renderDocLink } = useRiskScoreToastContent(riskScoreEntity);
+  const { http, notifications, theme } = useKibana().services;
+
+  const onClick = useCallback(async () => {
+    fetch({
+      http,
+      notifications,
+      refetch,
+      renderDocLink,
+      riskScoreEntity: RiskScoreEntity.host,
+      spaceId,
+      theme,
+    });
+  }, [fetch, http, notifications, refetch, renderDocLink, spaceId, theme]);
+
+  return (
+    <EuiButton
+      color="primary"
+      fill
+      onClick={onClick}
+      isLoading={isLoading}
+      data-test-subj={`restart_${riskScoreEntity}_risk_score`}
+    >
+      <FormattedMessage
+        id="xpack.securitySolution.riskScore.restartButtonTitle"
+        defaultMessage="Restart"
+      />
+    </EuiButton>
+  );
+};
+
+export const RiskScoreRestartButton = React.memo(RiskScoreRestartButtonComponent);
+RiskScoreRestartButton.displayName = 'RiskScoreRestartButton';

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/translations.ts
@@ -40,3 +40,11 @@ export const USER_WARNING_BODY = i18n.translate(
     defaultMessage: `We haven't detected any user risk score data from the users in your environment.`,
   }
 );
+
+export const RESTART_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.riskScore.usersDashboardRestartTooltip',
+  {
+    defaultMessage:
+      'The risk score calculation might take a while to run. However, by pressing restart, you can force it to run immediately.',
+  }
+);

--- a/x-pack/plugins/security_solution/public/common/hooks/use_fetch/request_names.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_fetch/request_names.ts
@@ -12,6 +12,7 @@ export const REQUEST_NAMES = {
   GET_RISK_SCORE_DEPRECATED: `${APP_UI_ID} fetch is risk score deprecated`,
   GET_SAVED_QUERY: `${APP_UI_ID} fetch saved query`,
   ENABLE_RISK_SCORE: `${APP_UI_ID} fetch enable risk score`,
+  REFRESH_RISK_SCORE: `${APP_UI_ID} fetch refresh risk score`,
   UPGRADE_RISK_SCORE: `${APP_UI_ID} fetch upgrade risk score`,
 } as const;
 

--- a/x-pack/plugins/security_solution/public/common/hooks/use_refetch_queries.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_refetch_queries.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { queriesSelector } from '../components/super_date_picker/selectors';
+import type { State, inputsModel } from '../store';
+import { InputsModelId } from '../store/inputs/constants';
+import { useDeepEqualSelector } from './use_selector';
+
+export const useRefetchQueries = () => {
+  const getQueriesSelector = useMemo(() => queriesSelector(), []);
+  const queries = useDeepEqualSelector((state: State) =>
+    getQueriesSelector(state, InputsModelId.global)
+  );
+
+  const refetchPage = useCallback(() => {
+    queries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+  }, [queries]);
+
+  return refetchPage;
+};

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
@@ -13,17 +13,23 @@ import { HostsKpiUniqueIps } from './unique_ips';
 import type { HostsKpiProps } from './types';
 import { CallOutSwitcher } from '../../../common/components/callouts';
 import * as i18n from './translations';
-import { useHostRiskScore } from '../../../risk_score/containers';
 import { RiskScoreDocLink } from '../../../common/components/risk_score/risk_score_onboarding/risk_score_doc_link';
-import { RiskScoreEntity } from '../../../../common/search_strategy';
+import { getHostRiskIndex, RiskQueries, RiskScoreEntity } from '../../../../common/search_strategy';
+import { useRiskScoreFeatureStatus } from '../../../risk_score/containers/feature_status';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 export const HostsKpiComponent = React.memo<HostsKpiProps>(
   ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => {
-    const [loading, { isLicenseValid, isModuleEnabled }] = useHostRiskScore();
+    const spaceId = useSpaceId();
+    const defaultIndex = spaceId ? getHostRiskIndex(spaceId) : undefined;
+    const { isEnabled, isLicenseValid, isLoading } = useRiskScoreFeatureStatus(
+      RiskQueries.hostsRiskScore,
+      defaultIndex
+    );
 
     return (
       <>
-        {isLicenseValid && !isModuleEnabled && !loading && (
+        {isLicenseValid && !isEnabled && !isLoading && (
           <>
             <CallOutSwitcher
               namespace="hosts"

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -21,7 +21,7 @@ import {
   useHostRiskScoreKpi,
 } from '../../../risk_score/containers';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
-import { RiskScoreEntity } from '../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT, RiskScoreEntity } from '../../../../common/search_strategy';
 import { EntityAnalyticsHostRiskScoreDisable } from '../../../common/components/risk_score/risk_score_disabled/host_risk_score_disabled';
 import { RiskScoresNoDataDetected } from '../../../common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected';
 
@@ -109,7 +109,7 @@ export const HostRiskScoreQueryTabBody = ({
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}
-      severityCount={severityCount}
+      severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
       totalCount={totalCount}
       type={type}
     />

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -60,7 +60,6 @@ export const HostRiskScoreQueryTabBody = ({
     setQuerySkip(!toggleStatus);
   }, [toggleStatus]);
   const { from, to } = useGlobalTime();
-
   const timerange = useMemo(() => ({ from, to }), [from, to]);
 
   const [
@@ -83,7 +82,7 @@ export const HostRiskScoreQueryTabBody = ({
     return <EntityAnalyticsHostRiskScoreDisable refetch={refetch} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !loading) {
     return (
       <RiskScoresDeprecated
         refetch={refetch}
@@ -93,7 +92,13 @@ export const HostRiskScoreQueryTabBody = ({
     );
   }
 
-  if (isModuleEnabled && severitySelectionRedux.length === 0 && data && data.length === 0) {
+  if (
+    !loading &&
+    isModuleEnabled &&
+    severitySelectionRedux.length === 0 &&
+    data &&
+    data.length === 0
+  ) {
     return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} />;
   }
 

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -99,7 +99,7 @@ export const HostRiskScoreQueryTabBody = ({
     data &&
     data.length === 0
   ) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} refetch={refetch} />;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_score_tab_body.tsx
@@ -61,6 +61,8 @@ export const HostRiskScoreQueryTabBody = ({
   }, [toggleStatus]);
   const { from, to } = useGlobalTime();
 
+  const timerange = useMemo(() => ({ from, to }), [from, to]);
+
   const [
     loading,
     { data, totalCount, inspect, isInspected, isDeprecated, refetch, isModuleEnabled },
@@ -69,15 +71,13 @@ export const HostRiskScoreQueryTabBody = ({
     skip: querySkip,
     pagination,
     sort,
-    timerange: { from, to },
+    timerange,
   });
 
   const { severityCount, loading: isKpiLoading } = useHostRiskScoreKpi({
     filterQuery,
     skip: querySkip,
   });
-
-  const timerange = useMemo(() => ({ from, to }), [from, to]);
 
   if (!isModuleEnabled && !loading) {
     return <EntityAnalyticsHostRiskScoreDisable refetch={refetch} timerange={timerange} />;

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_tab_body.tsx
@@ -116,7 +116,7 @@ const HostRiskTabBodyComponent: React.FC<
   }
 
   if (isModuleEnabled && severitySelectionRedux.length === 0 && data && data.length === 0) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} refetch={refetch} />;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/host_risk_tab_body.tsx
@@ -69,7 +69,6 @@ const HostRiskTabBodyComponent: React.FC<
     useQueryToggle(`${QUERY_ID} overTime`);
   const { toggleStatus: contributorsToggleStatus, setToggleStatus: setContributorsToggleStatus } =
     useQueryToggle(`${QUERY_ID} contributors`);
-
   const [loading, { data, refetch, inspect, isDeprecated, isModuleEnabled }] = useHostRiskScore({
     filterQuery,
     onlyLatest: false,
@@ -106,7 +105,7 @@ const HostRiskTabBodyComponent: React.FC<
     return <EntityAnalyticsHostRiskScoreDisable refetch={refetch} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !loading) {
     return (
       <RiskScoresDeprecated
         entityType={RiskScoreEntity.host}

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
@@ -7,6 +7,7 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
 import { useDispatch } from 'react-redux';
 import * as i18n from './translations';
@@ -28,6 +29,9 @@ type AnomaliesColumns = Array<EuiBasicTableColumn<AnomaliesCount>>;
 const MediumShadeText = styled.span`
   color: ${({ theme }) => theme.eui.euiColorMediumShade};
 `;
+
+const INSTALL_JOBS_DOC =
+  'https://www.elastic.co/guide/en/machine-learning/current/ml-ad-run-jobs.html';
 
 export const useAnomaliesColumns = (loading: boolean): AnomaliesColumns => {
   const columns: AnomaliesColumns = useMemo(
@@ -73,6 +77,14 @@ export const useAnomaliesColumns = (loading: boolean): AnomaliesColumns => {
               return <EnableJobLink jobId={jobId} />;
             }
 
+            if (status === AnomalyJobStatus.uninstalled) {
+              return (
+                <EuiLink external target={'_blank'} href={INSTALL_JOBS_DOC}>
+                  {i18n.JOB_STATUS_UNINSTALLED}
+                </EuiLink>
+              );
+            }
+
             return <MediumShadeText>{I18N_JOB_STATUS[status]}</MediumShadeText>;
           }
         },
@@ -86,7 +98,6 @@ export const useAnomaliesColumns = (loading: boolean): AnomaliesColumns => {
 const I18N_JOB_STATUS = {
   [AnomalyJobStatus.disabled]: i18n.JOB_STATUS_DISABLED,
   [AnomalyJobStatus.failed]: i18n.JOB_STATUS_FAILED,
-  [AnomalyJobStatus.uninstalled]: i18n.JOB_STATUS_UNINSTALLED,
 };
 
 const EnableJobLink = ({ jobId }: { jobId: string }) => {

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.test.tsx
@@ -19,24 +19,12 @@ const severityCount: SeverityCount = {
   [RiskSeverity.unknown]: 1,
   [RiskSeverity.critical]: 1,
 };
-const href = 'test-href';
 
 describe('RiskScoreDonutChart', () => {
-  it('renders link', () => {
-    const { getByTestId } = render(
-      <TestProviders>
-        <RiskScoreDonutChart severityCount={severityCount} onClick={() => {}} href={href} />
-      </TestProviders>
-    );
-
-    expect(getByTestId('view-total-button')).toBeInTheDocument();
-    expect(getByTestId('view-total-button')).toHaveAttribute('href', href);
-  });
-
   it('renders legends', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <RiskScoreDonutChart severityCount={severityCount} onClick={() => {}} href={href} />
+        <RiskScoreDonutChart severityCount={severityCount} />
       </TestProviders>
     );
 

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.tsx
@@ -10,7 +10,6 @@ import type { MouseEventHandler } from 'react';
 import React from 'react';
 import type { ShapeTreeNode } from '@elastic/charts';
 import styled from 'styled-components';
-import { LinkAnchor } from '../../../../common/components/links';
 import type { SeverityCount } from '../../../../common/components/severity/types';
 import { useRiskDonutChartData } from './use_risk_donut_chart_data';
 import type { FillColor } from '../../../../common/components/charts/donutchart';
@@ -56,11 +55,7 @@ export const RiskScoreDonutChart = ({ severityCount, onClick, href }: RiskScoreD
           data={donutChartData ?? null}
           fillColor={fillColor}
           height={DONUT_HEIGHT}
-          label={
-            <LinkAnchor data-test-subj="view-total-button" onClick={onClick} href={href}>
-              {i18n.TOTAL_LABEL}
-            </LinkAnchor>
-          }
+          label={i18n.TOTAL_LABEL}
           title={<ChartLabel count={total} />}
           totalCount={total}
         />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/risk_score_donut_chart.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import type { MouseEventHandler } from 'react';
 import React from 'react';
 import type { ShapeTreeNode } from '@elastic/charts';
 import styled from 'styled-components';
@@ -38,11 +37,9 @@ const StyledLegendItems = styled(EuiFlexItem)`
 
 interface RiskScoreDonutChartProps {
   severityCount: SeverityCount;
-  onClick: MouseEventHandler<Element>;
-  href: string;
 }
 
-export const RiskScoreDonutChart = ({ severityCount, onClick, href }: RiskScoreDonutChartProps) => {
+export const RiskScoreDonutChart = ({ severityCount }: RiskScoreDonutChartProps) => {
   const [donutChartData, legendItems, total] = useRiskDonutChartData(severityCount);
 
   return (

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
@@ -88,7 +88,7 @@ export const EntityAnalyticsHeader = () => {
     return [onClick, href];
   }, [dispatch, getSecuritySolutionLinkProps]);
 
-  const totalAnomalies = useMemo(() => sum(data.map(({ count }) => count)), [data]);
+  const totalAnomalies = useMemo(() => sum(data.map(({ count }) => count)) || '-', [data]);
 
   const jobsUrl = useMlHref(ml, http.basePath.get(), {
     page: ML_PAGES.ANOMALY_DETECTION_JOBS_MANAGE,
@@ -102,7 +102,9 @@ export const EntityAnalyticsHeader = () => {
             <EuiFlexGroup direction="column" gutterSize="s">
               <EuiFlexItem className="eui-textCenter">
                 <StyledEuiTitle data-test-subj="critical_hosts_quantity" size="l">
-                  <span>{hostsSeverityCount[RiskSeverity.critical]}</span>
+                  <span>
+                    {hostsSeverityCount ? hostsSeverityCount[RiskSeverity.critical] : '-'}
+                  </span>
                 </StyledEuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -122,7 +124,9 @@ export const EntityAnalyticsHeader = () => {
             <EuiFlexGroup direction="column" gutterSize="s">
               <EuiFlexItem className="eui-textCenter">
                 <StyledEuiTitle data-test-subj="critical_users_quantity" size="l">
-                  <span>{usersSeverityCount[RiskSeverity.critical]}</span>
+                  <span>
+                    {usersSeverityCount ? usersSeverityCount[RiskSeverity.critical] : '-'}
+                  </span>
                 </StyledEuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
@@ -8,7 +8,7 @@ import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
-import { sum } from 'lodash/fp';
+import { sumBy } from 'lodash/fp';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
 import { useHostRiskScoreKpi, useUserRiskScoreKpi } from '../../../../risk_score/containers';
 import { LinkAnchor, useGetSecuritySolutionLinkProps } from '../../../../common/components/links';
@@ -134,7 +134,13 @@ export const EntityAnalyticsHeader = () => {
     inspect: inspectHostRiskScore,
   });
 
-  const totalAnomalies = useMemo(() => sum(data.map(({ count }) => count)) || '-', [data]);
+  // Anomalies are enabled if at least one job is installed
+  const areJobsEnabled = useMemo(() => data.some(({ jobId }) => !!jobId), [data]);
+
+  const totalAnomalies = useMemo(
+    () => (areJobsEnabled ? sumBy('count', data) : '-'),
+    [data, areJobsEnabled]
+  );
 
   const jobsUrl = useMlHref(ml, http.basePath.get(), {
     page: ML_PAGES.ANOMALY_DETECTION_JOBS_MANAGE,

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -81,7 +81,6 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
     deleteQuery,
     inspect: inspectKpi,
   });
-
   const [
     isTableLoading,
     { data, inspect, refetch, isDeprecated, isLicenseValid, isModuleEnabled },
@@ -130,11 +129,11 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
     return null;
   }
 
-  if (!isModuleEnabled) {
+  if (!isModuleEnabled && !isTableLoading) {
     return <EntityAnalyticsHostRiskScoreDisable refetch={refreshPage} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !isTableLoading) {
     return (
       <RiskScoresDeprecated
         entityType={RiskScoreEntity.host}

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -19,6 +19,7 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import { useHostRiskScore, useHostRiskScoreKpi } from '../../../../risk_score/containers';
 
 import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT } from '../../../../../common/search_strategy';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 import { SecurityPageName } from '../../../../app/types';
 import * as i18n from './translations';
@@ -156,7 +157,7 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
               <EuiFlexItem grow={false}>
                 <SeverityFilterGroup
                   selectedSeverities={selectedSeverity}
-                  severityCount={severityCount}
+                  severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
                   title={i18n.HOST_RISK}
                   onSelect={setSelectedSeverity}
                 />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -144,7 +144,7 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
   }
 
   if (isModuleEnabled && selectedSeverity.length === 0 && data && data.length === 0) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.host} refetch={refreshPage} />;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -19,8 +19,7 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import { useHostRiskScore, useHostRiskScoreKpi } from '../../../../risk_score/containers';
 
 import type { RiskSeverity } from '../../../../../common/search_strategy';
-import { EMPTY_SEVERITY_COUNT } from '../../../../../common/search_strategy';
-import { RiskScoreEntity } from '../../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT, RiskScoreEntity } from '../../../../../common/search_strategy';
 import { SecurityPageName } from '../../../../app/types';
 import * as i18n from './translations';
 import { generateSeverityFilter } from '../../../../hosts/store/helpers';
@@ -178,7 +177,7 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
           <EuiFlexGroup data-test-subj="entity_analytics_content">
             <EuiFlexItem grow={false}>
               <RiskScoreDonutChart
-                severityCount={severityCount}
+                severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
                 onClick={goToHostRiskTab}
                 href={hostRiskTabUrl}
               />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -194,11 +194,7 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
         {toggleStatus && (
           <EuiFlexGroup data-test-subj="entity_analytics_content">
             <EuiFlexItem grow={false}>
-              <RiskScoreDonutChart
-                severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
-                onClick={goToHostRiskTab}
-                href={hostRiskTabUrl}
-              />
+              <RiskScoreDonutChart severityCount={severityCount ?? EMPTY_SEVERITY_COUNT} />
             </EuiFlexItem>
             <EuiFlexItem>
               <BasicTableWithoutBorderBottom

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -144,7 +144,7 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
   }
 
   if (isModuleEnabled && selectedSeverity.length === 0 && data && data.length === 0) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} refetch={refreshPage} />;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -13,8 +13,7 @@ import { LinkButton, useGetSecuritySolutionLinkProps } from '../../../../common/
 import { LastUpdatedAt } from '../../../../common/components/last_updated_at';
 import { HeaderSection } from '../../../../common/components/header_section';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
-import { EMPTY_SEVERITY_COUNT } from '../../../../../common/search_strategy';
-import { RiskScoreEntity } from '../../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT, RiskScoreEntity } from '../../../../../common/search_strategy';
 import { SecurityPageName } from '../../../../app/types';
 import * as i18n from './translations';
 import { generateSeverityFilter } from '../../../../hosts/store/helpers';
@@ -177,7 +176,7 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
           <EuiFlexGroup data-test-subj="entity_analytics_content">
             <EuiFlexItem grow={false}>
               <RiskScoreDonutChart
-                severityCount={severityCount}
+                severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
                 onClick={goToUserRiskTab}
                 href={userRiskTabUrl}
               />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -129,11 +129,11 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
     return null;
   }
 
-  if (!isModuleEnabled) {
+  if (!isModuleEnabled && !isTableLoading) {
     return <EntityAnalyticsUserRiskScoreDisable refetch={refreshPage} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !isTableLoading) {
     return (
       <RiskScoresDeprecated
         entityType={RiskScoreEntity.user}

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -194,11 +194,7 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
         {toggleStatus && (
           <EuiFlexGroup data-test-subj="entity_analytics_content">
             <EuiFlexItem grow={false}>
-              <RiskScoreDonutChart
-                severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
-                onClick={goToUserRiskTab}
-                href={userRiskTabUrl}
-              />
+              <RiskScoreDonutChart severityCount={severityCount ?? EMPTY_SEVERITY_COUNT} />
             </EuiFlexItem>
             <EuiFlexItem>
               <BasicTableWithoutBorderBottom

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -13,6 +13,7 @@ import { LinkButton, useGetSecuritySolutionLinkProps } from '../../../../common/
 import { LastUpdatedAt } from '../../../../common/components/last_updated_at';
 import { HeaderSection } from '../../../../common/components/header_section';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT } from '../../../../../common/search_strategy';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 import { SecurityPageName } from '../../../../app/types';
 import * as i18n from './translations';
@@ -155,7 +156,7 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
               <EuiFlexItem grow={false}>
                 <SeverityFilterGroup
                   selectedSeverities={selectedSeverity}
-                  severityCount={severityCount}
+                  severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
                   title={i18n.USER_RISK}
                   onSelect={setSelectedSeverity}
                 />

--- a/x-pack/plugins/security_solution/public/overview/components/host_overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/host_overview/index.tsx
@@ -93,7 +93,6 @@ export const HostOverview = React.memo<HostSummaryProps>(
       }),
       [from, to]
     );
-
     const [_, { data: hostRisk, isLicenseValid }] = useHostRiskScore({
       filterQuery,
       skip: hostName == null,

--- a/x-pack/plugins/security_solution/public/overview/components/host_overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/host_overview/index.tsx
@@ -86,10 +86,18 @@ export const HostOverview = React.memo<HostSummaryProps>(
     );
     const { from, to } = useGlobalTime();
 
+    const timerange = useMemo(
+      () => ({
+        from,
+        to,
+      }),
+      [from, to]
+    );
+
     const [_, { data: hostRisk, isLicenseValid }] = useHostRiskScore({
       filterQuery,
       skip: hostName == null,
-      timerange: { to, from },
+      timerange,
     });
 
     const getDefaultRenderer = useCallback(

--- a/x-pack/plugins/security_solution/public/overview/components/user_overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/user_overview/index.tsx
@@ -85,10 +85,18 @@ export const UserOverview = React.memo<UserSummaryProps>(
 
     const { from, to } = useGlobalTime();
 
+    const timerange = useMemo(
+      () => ({
+        from,
+        to,
+      }),
+      [from, to]
+    );
+
     const [_, { data: userRisk, isLicenseValid }] = useUserRiskScore({
       filterQuery,
       skip: userName == null,
-      timerange: { to, from },
+      timerange,
     });
 
     const getDefaultRenderer = useCallback(

--- a/x-pack/plugins/security_solution/public/overview/pages/entity_analytics.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/entity_analytics.tsx
@@ -27,15 +27,15 @@ import { InputsModelId } from '../../common/store/inputs/constants';
 
 const EntityAnalyticsComponent = () => {
   const { indicesExist, loading: isSourcererLoading, indexPattern } = useSourcererDataView();
+  const { isPlatinumOrTrialLicense, capabilitiesFetched } = useMlCapabilities();
 
-  const isPlatinumOrTrialLicense = useMlCapabilities().isPlatinumOrTrialLicense;
   return (
     <>
       {indicesExist ? (
         <>
           <SecuritySolutionPageWrapper data-test-subj="entityAnalyticsPage">
             <HeaderPage title={ENTITY_ANALYTICS}>
-              {isPlatinumOrTrialLicense && (
+              {isPlatinumOrTrialLicense && capabilitiesFetched && (
                 <SiemSearchBar
                   id={InputsModelId.global}
                   indexPattern={indexPattern}
@@ -44,30 +44,28 @@ const EntityAnalyticsComponent = () => {
                 />
               )}
             </HeaderPage>
-            {isPlatinumOrTrialLicense ? (
-              isSourcererLoading ? (
-                <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsLoader" />
-              ) : (
-                <EuiFlexGroup direction="column" data-test-subj="entityAnalyticsSections">
-                  <EuiFlexItem>
-                    <EntityAnalyticsHeader />
-                  </EuiFlexItem>
-
-                  <EuiFlexItem>
-                    <EntityAnalyticsHostRiskScores />
-                  </EuiFlexItem>
-
-                  <EuiFlexItem>
-                    <EntityAnalyticsUserRiskScores />
-                  </EuiFlexItem>
-
-                  <EuiFlexItem>
-                    <EntityAnalyticsAnomalies />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              )
-            ) : (
+            {!isPlatinumOrTrialLicense && capabilitiesFetched ? (
               <Paywall featureDescription={i18n.ENTITY_ANALYTICS_LICENSE_DESC} />
+            ) : isSourcererLoading ? (
+              <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsLoader" />
+            ) : (
+              <EuiFlexGroup direction="column" data-test-subj="entityAnalyticsSections">
+                <EuiFlexItem>
+                  <EntityAnalyticsHeader />
+                </EuiFlexItem>
+
+                <EuiFlexItem>
+                  <EntityAnalyticsHostRiskScores />
+                </EuiFlexItem>
+
+                <EuiFlexItem>
+                  <EntityAnalyticsUserRiskScores />
+                </EuiFlexItem>
+
+                <EuiFlexItem>
+                  <EntityAnalyticsAnomalies />
+                </EuiFlexItem>
+              </EuiFlexGroup>
             )}
           </SecuritySolutionPageWrapper>
         </>

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -226,10 +226,25 @@ const useRiskScore = <T extends RiskQueries.hostsRiskScore | RiskQueries.usersRi
   }, [addError, error]);
 
   useEffect(() => {
-    if (!skip && riskScoreRequest != null && isLicenseValid && isEnabled && !isDeprecated) {
+    if (
+      !skip &&
+      !isDeprecatedLoading &&
+      riskScoreRequest != null &&
+      isLicenseValid &&
+      isEnabled &&
+      !isDeprecated
+    ) {
       search(riskScoreRequest);
     }
-  }, [isEnabled, isDeprecated, isLicenseValid, riskScoreRequest, search, skip]);
+  }, [
+    isEnabled,
+    isDeprecated,
+    isLicenseValid,
+    isDeprecatedLoading,
+    riskScoreRequest,
+    search,
+    skip,
+  ]);
 
   return [loading || isDeprecatedLoading, riskScoreResponse];
 };

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -12,8 +12,8 @@ import { createFilter } from '../../../common/containers/helpers';
 import type { RiskScoreSortField, StrategyResponseType } from '../../../../common/search_strategy';
 import {
   getHostRiskIndex,
-  RiskQueries,
   getUserRiskIndex,
+  RiskQueries,
 } from '../../../../common/search_strategy';
 import type { ESQuery } from '../../../../common/typed_json';
 
@@ -64,7 +64,14 @@ export const initialResult: Omit<
 };
 
 export const useHostRiskScore = (params?: UseRiskScoreParams) => {
-  const { timerange, onlyLatest, filterQuery, sort, skip = false, pagination } = params ?? {};
+  const {
+    timerange,
+    onlyLatest = true,
+    filterQuery,
+    sort,
+    skip = false,
+    pagination,
+  } = params ?? {};
   const spaceId = useSpaceId();
   const defaultIndex = spaceId ? getHostRiskIndex(spaceId, onlyLatest) : undefined;
 
@@ -81,7 +88,14 @@ export const useHostRiskScore = (params?: UseRiskScoreParams) => {
 };
 
 export const useUserRiskScore = (params?: UseRiskScoreParams) => {
-  const { timerange, onlyLatest, filterQuery, sort, skip = false, pagination } = params ?? {};
+  const {
+    timerange,
+    onlyLatest = true,
+    filterQuery,
+    sort,
+    skip = false,
+    pagination,
+  } = params ?? {};
   const spaceId = useSpaceId();
   const defaultIndex = spaceId ? getUserRiskIndex(spaceId, onlyLatest) : undefined;
 
@@ -99,6 +113,7 @@ export const useUserRiskScore = (params?: UseRiskScoreParams) => {
 
 const useRiskScore = <T extends RiskQueries.hostsRiskScore | RiskQueries.usersRiskScore>({
   timerange,
+  onlyLatest,
   filterQuery,
   sort,
   skip = false,
@@ -167,6 +182,11 @@ const useRiskScore = <T extends RiskQueries.hostsRiskScore | RiskQueries.usersRi
     ]
   );
 
+  const requestTimerange = useMemo(
+    () => (timerange ? { to: timerange.to, from: timerange.from, interval: '' } : undefined),
+    [timerange]
+  );
+
   const riskScoreRequest = useMemo(
     () =>
       defaultIndex
@@ -182,9 +202,19 @@ const useRiskScore = <T extends RiskQueries.hostsRiskScore | RiskQueries.usersRi
                   }
                 : undefined,
             sort,
+            timerange: onlyLatest ? undefined : requestTimerange,
           }
         : null,
-    [cursorStart, defaultIndex, factoryQueryType, filterQuery, querySize, sort]
+    [
+      cursorStart,
+      defaultIndex,
+      factoryQueryType,
+      filterQuery,
+      querySize,
+      sort,
+      requestTimerange,
+      onlyLatest,
+    ]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/risk_score/containers/feature_status/index.test.ts
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/feature_status/index.test.ts
@@ -37,7 +37,7 @@ describe(`risk score feature status`, () => {
     isDeprecated: true,
     isLicenseValid: true,
     isEnabled: true,
-    isLoading: false,
+    isLoading: true,
   };
 
   test('does not search if license is not valid, and initial isDeprecated state is false', () => {

--- a/x-pack/plugins/security_solution/public/risk_score/containers/feature_status/index.ts
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/feature_status/index.ts
@@ -27,7 +27,7 @@ export const useRiskScoreFeatureStatus = (
   factoryQueryType: RiskQueries.hostsRiskScore | RiskQueries.usersRiskScore,
   defaultIndex?: string
 ): RiskScoresFeatureStatus => {
-  const isPlatinumOrTrialLicense = useMlCapabilities().isPlatinumOrTrialLicense;
+  const { isPlatinumOrTrialLicense, capabilitiesFetched } = useMlCapabilities();
   const entity = useMemo(
     () =>
       factoryQueryType === RiskQueries.hostsRiskScore ? RiskScoreEntity.host : RiskScoreEntity.user,
@@ -66,7 +66,7 @@ export const useRiskScoreFeatureStatus = (
 
   return {
     error,
-    isLoading,
+    isLoading: isLoading || !capabilitiesFetched || defaultIndex == null,
     refetch: searchIndexStatus,
     isLicenseValid: isPlatinumOrTrialLicense,
     ...response,

--- a/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
@@ -5,77 +5,35 @@
  * 2.0.
  */
 
-import type { Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
 import { useEffect, useMemo } from 'react';
-import { useObservable, withOptionalSignal } from '@kbn/securitysolution-hook-utils';
-import { isCompleteResponse, isErrorResponse } from '@kbn/data-plugin/common';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import { createFilter } from '../../../common/containers/helpers';
 
-import type {
-  KpiRiskScoreRequestOptions,
-  KpiRiskScoreStrategyResponse,
-} from '../../../../common/search_strategy';
 import {
   getHostRiskIndex,
   getUserRiskIndex,
   RiskQueries,
   RiskSeverity,
   RiskScoreEntity,
+  EMPTY_SEVERITY_COUNT,
 } from '../../../../common/search_strategy';
-
-import { useKibana } from '../../../common/lib/kibana';
+import * as i18n from './translations';
 import { isIndexNotFoundError } from '../../../common/utils/exceptions';
 import type { ESTermQuery } from '../../../../common/typed_json';
 import type { SeverityCount } from '../../../common/components/severity/types';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { useMlCapabilities } from '../../../common/components/ml/hooks/use_ml_capabilities';
-
-type GetHostRiskScoreProps = KpiRiskScoreRequestOptions & {
-  data: DataPublicPluginStart;
-  signal: AbortSignal;
-};
-
-const getRiskScoreKpi = ({
-  data,
-  defaultIndex,
-  signal,
-  filterQuery,
-  entity,
-}: GetHostRiskScoreProps): Observable<KpiRiskScoreStrategyResponse> =>
-  data.search.search<KpiRiskScoreRequestOptions, KpiRiskScoreStrategyResponse>(
-    {
-      defaultIndex,
-      factoryQueryType: RiskQueries.kpiRiskScore,
-      filterQuery: createFilter(filterQuery),
-      entity,
-    },
-    {
-      strategy: 'securitySolutionSearchStrategy',
-      abortSignal: signal,
-    }
-  );
-
-const getRiskScoreKpiComplete = (
-  props: GetHostRiskScoreProps
-): Observable<KpiRiskScoreStrategyResponse> => {
-  return getRiskScoreKpi(props).pipe(
-    filter((response) => {
-      return isErrorResponse(response) || isCompleteResponse(response);
-    })
-  );
-};
-
-const getRiskScoreKpiWithOptionalSignal = withOptionalSignal(getRiskScoreKpiComplete);
-
-const useRiskScoreKpiComplete = () => useObservable(getRiskScoreKpiWithOptionalSignal);
+import { useSearchStrategy } from '../../../common/containers/use_search_strategy';
+import type { InspectResponse } from '../../../types';
+import type { inputsModel } from '../../../common/store';
+import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 
 interface RiskScoreKpi {
   error: unknown;
   isModuleDisabled: boolean;
   severityCount?: SeverityCount;
   loading: boolean;
+  refetch: inputsModel.Refetch;
+  inspect: InspectResponse;
+  timerange?: { to: string; from: string };
 }
 
 type UseHostRiskScoreKpiProps = Omit<
@@ -90,6 +48,7 @@ type UseUserRiskScoreKpiProps = Omit<
 export const useUserRiskScoreKpi = ({
   filterQuery,
   skip,
+  timerange,
 }: UseUserRiskScoreKpiProps): RiskScoreKpi => {
   const spaceId = useSpaceId();
   const defaultIndex = spaceId ? getUserRiskIndex(spaceId) : undefined;
@@ -101,12 +60,14 @@ export const useUserRiskScoreKpi = ({
     defaultIndex,
     entity: RiskScoreEntity.user,
     featureEnabled: isPlatinumOrTrialLicense,
+    timerange,
   });
 };
 
 export const useHostRiskScoreKpi = ({
   filterQuery,
   skip,
+  timerange,
 }: UseHostRiskScoreKpiProps): RiskScoreKpi => {
   const spaceId = useSpaceId();
   const defaultIndex = spaceId ? getHostRiskIndex(spaceId) : undefined;
@@ -118,6 +79,7 @@ export const useHostRiskScoreKpi = ({
     defaultIndex,
     entity: RiskScoreEntity.host,
     featureEnabled: isPlatinumOrTrialLicense,
+    timerange,
   });
 };
 
@@ -127,6 +89,7 @@ interface UseRiskScoreKpiProps {
   defaultIndex: string | undefined;
   entity: RiskScoreEntity;
   featureEnabled: boolean;
+  timerange?: { to: string; from: string };
 }
 
 const useRiskScoreKpi = ({
@@ -135,35 +98,59 @@ const useRiskScoreKpi = ({
   defaultIndex,
   entity,
   featureEnabled,
+  timerange,
 }: UseRiskScoreKpiProps): RiskScoreKpi => {
-  const { error, result, start, loading } = useRiskScoreKpiComplete();
-  const { data } = useKibana().services;
+  const { addError } = useAppToasts();
+
+  const { loading, result, search, refetch, inspect, error } =
+    useSearchStrategy<RiskQueries.kpiRiskScore>({
+      factoryQueryType: RiskQueries.kpiRiskScore,
+      initialResult: {
+        kpiRiskScore: EMPTY_SEVERITY_COUNT,
+      },
+      abort: skip,
+      showErrorToast: false,
+    });
+
   const isModuleDisabled = !!error && isIndexNotFoundError(error);
 
   useEffect(() => {
     if (!skip && defaultIndex && featureEnabled) {
-      start({
-        data,
+      search({
         filterQuery,
         defaultIndex: [defaultIndex],
         entity,
       });
     }
-  }, [data, defaultIndex, start, filterQuery, skip, entity, featureEnabled]);
+  }, [defaultIndex, search, filterQuery, skip, entity, featureEnabled]);
+
+  // since query does not take timerange arg, we need to manually refetch when time range updates
+  useEffect(() => {
+    refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timerange?.to, timerange?.from]);
+
+  useEffect(() => {
+    if (error) {
+      if (!isIndexNotFoundError(error)) {
+        addError(error, { title: i18n.FAIL_RISK_SCORE });
+      }
+    }
+  }, [addError, error]);
 
   const severityCount = useMemo(() => {
-    if (result?.kpiRiskScore) {
-      return {
-        [RiskSeverity.unknown]: result?.kpiRiskScore[RiskSeverity.unknown] ?? 0,
-        [RiskSeverity.low]: result?.kpiRiskScore[RiskSeverity.low] ?? 0,
-        [RiskSeverity.moderate]: result?.kpiRiskScore[RiskSeverity.moderate] ?? 0,
-        [RiskSeverity.high]: result?.kpiRiskScore[RiskSeverity.high] ?? 0,
-        [RiskSeverity.critical]: result?.kpiRiskScore[RiskSeverity.critical] ?? 0,
-      };
-    } else {
+    if (loading || error) {
       return undefined;
     }
-  }, [result]);
 
-  return { error, severityCount, loading, isModuleDisabled };
+    return {
+      [RiskSeverity.unknown]: result.kpiRiskScore[RiskSeverity.unknown] ?? 0,
+      [RiskSeverity.low]: result.kpiRiskScore[RiskSeverity.low] ?? 0,
+      [RiskSeverity.moderate]: result.kpiRiskScore[RiskSeverity.moderate] ?? 0,
+      [RiskSeverity.high]: result.kpiRiskScore[RiskSeverity.high] ?? 0,
+      [RiskSeverity.critical]: result.kpiRiskScore[RiskSeverity.critical] ?? 0,
+    };
+  }, [result, loading, error]);
+
+  return { error, severityCount, loading, isModuleDisabled, refetch, inspect };
 };

--- a/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/kpi/index.tsx
@@ -74,7 +74,7 @@ const useRiskScoreKpiComplete = () => useObservable(getRiskScoreKpiWithOptionalS
 interface RiskScoreKpi {
   error: unknown;
   isModuleDisabled: boolean;
-  severityCount: SeverityCount;
+  severityCount?: SeverityCount;
   loading: boolean;
 }
 
@@ -151,17 +151,19 @@ const useRiskScoreKpi = ({
     }
   }, [data, defaultIndex, start, filterQuery, skip, entity, featureEnabled]);
 
-  const severityCount = useMemo(
-    () => ({
-      [RiskSeverity.unknown]: 0,
-      [RiskSeverity.low]: 0,
-      [RiskSeverity.moderate]: 0,
-      [RiskSeverity.high]: 0,
-      [RiskSeverity.critical]: 0,
-      ...(result?.kpiRiskScore ?? {}),
-    }),
-    [result]
-  );
+  const severityCount = useMemo(() => {
+    if (result?.kpiRiskScore) {
+      return {
+        [RiskSeverity.unknown]: result?.kpiRiskScore[RiskSeverity.unknown] ?? 0,
+        [RiskSeverity.low]: result?.kpiRiskScore[RiskSeverity.low] ?? 0,
+        [RiskSeverity.moderate]: result?.kpiRiskScore[RiskSeverity.moderate] ?? 0,
+        [RiskSeverity.high]: result?.kpiRiskScore[RiskSeverity.high] ?? 0,
+        [RiskSeverity.critical]: result?.kpiRiskScore[RiskSeverity.critical] ?? 0,
+      };
+    } else {
+      return undefined;
+    }
+  }, [result]);
 
   return { error, severityCount, loading, isModuleDisabled };
 };

--- a/x-pack/plugins/security_solution/public/risk_score/containers/kpi/translations.ts
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/kpi/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const FAIL_RISK_SCORE = i18n.translate(
+  'xpack.securitySolution.riskScore.kpi.failSearchDescription',
+  {
+    defaultMessage: `Failed to run search on risk score`,
+  }
+);

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
@@ -12,19 +12,25 @@ import type { UsersKpiProps } from './types';
 
 import { UsersKpiAuthentications } from './authentications';
 import { TotalUsersKpi } from './total_users';
-import { useUserRiskScore } from '../../../risk_score/containers';
 import { CallOutSwitcher } from '../../../common/components/callouts';
 import * as i18n from './translations';
 import { RiskScoreDocLink } from '../../../common/components/risk_score/risk_score_onboarding/risk_score_doc_link';
-import { RiskScoreEntity } from '../../../../common/search_strategy';
+import { getUserRiskIndex, RiskQueries, RiskScoreEntity } from '../../../../common/search_strategy';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
+import { useRiskScoreFeatureStatus } from '../../../risk_score/containers/feature_status';
 
 export const UsersKpiComponent = React.memo<UsersKpiProps>(
   ({ filterQuery, from, indexNames, to, setQuery, skip, updateDateRange }) => {
-    const [loading, { isLicenseValid, isModuleEnabled }] = useUserRiskScore();
+    const spaceId = useSpaceId();
+    const defaultIndex = spaceId ? getUserRiskIndex(spaceId) : undefined;
+    const { isEnabled, isLicenseValid, isLoading } = useRiskScoreFeatureStatus(
+      RiskQueries.usersRiskScore,
+      defaultIndex
+    );
 
     return (
       <>
-        {isLicenseValid && !isModuleEnabled && !loading && (
+        {isLicenseValid && !isEnabled && !isLoading && (
           <>
             <CallOutSwitcher
               namespace="users"

--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
@@ -84,7 +84,7 @@ export const UserRiskScoreQueryTabBody = ({
     return <EntityAnalyticsUserRiskScoreDisable refetch={refetch} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !loading) {
     return (
       <RiskScoresDeprecated
         entityType={RiskScoreEntity.user}

--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
@@ -95,7 +95,7 @@ export const UserRiskScoreQueryTabBody = ({
   }
 
   if (isModuleEnabled && userSeveritySelectionRedux.length === 0 && data && data.length === 0) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} refetch={refetch} />;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_score_tab_body.tsx
@@ -23,7 +23,7 @@ import {
   useUserRiskScoreKpi,
 } from '../../../risk_score/containers';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
-import { RiskScoreEntity } from '../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT, RiskScoreEntity } from '../../../../common/search_strategy';
 import { EntityAnalyticsUserRiskScoreDisable } from '../../../common/components/risk_score/risk_score_disabled/user_risk_score.disabled';
 import { RiskScoresNoDataDetected } from '../../../common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected';
 
@@ -110,7 +110,7 @@ export const UserRiskScoreQueryTabBody = ({
       refetch={refetch}
       setQuery={setQuery}
       setQuerySkip={setQuerySkip}
-      severityCount={severityCount}
+      severityCount={severityCount ?? EMPTY_SEVERITY_COUNT}
       totalCount={totalCount}
       type={type}
     />

--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
@@ -105,7 +105,7 @@ const UserRiskTabBodyComponent: React.FC<
   }
 
   if (isModuleEnabled && data && data.length === 0) {
-    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} />;
+    return <RiskScoresNoDataDetected entityType={RiskScoreEntity.user} refetch={refetch} />;
   }
 
   const lastUsertRiskItem: UserRiskScore | null =

--- a/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/users/pages/navigation/user_risk_tab_body.tsx
@@ -94,7 +94,7 @@ const UserRiskTabBodyComponent: React.FC<
     return <EntityAnalyticsUserRiskScoreDisable refetch={refetch} timerange={timerange} />;
   }
 
-  if (isDeprecated) {
+  if (isDeprecated && !loading) {
     return (
       <RiskScoresDeprecated
         entityType={RiskScoreEntity.user}


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/141232

## Summary

- [x] Display a link to documentation when anomalies are uninstalled

<img width="1495" alt="Screenshot 2022-09-23 at 17 22 23" src="https://user-images.githubusercontent.com/1490444/191996154-68613b80-91db-40e4-881e-fe8edf6eec03.png">

- [x] Display a dash instead of 0 when there are zero anomalies
- [x] Display a dash instead of 0 when there is no risk data

<img width="1511" alt="Screenshot 2022-09-23 at 17 26 15" src="https://user-images.githubusercontent.com/1490444/191996958-ddd134f9-e52e-4719-9b7b-fb3c74cbcbe2.png">

- [x] Paywall shows up and disappears while entity analytics page is loading

![Sep-23-2022 17-29-28](https://user-images.githubusercontent.com/1490444/191997901-c4864329-68b7-4e58-a97b-d013248b0c6c.gif)


- [x] Enable callout shows up and disappears while the Host/User risk tab is loading

![Sep-23-2022 17-33-37](https://user-images.githubusercontent.com/1490444/191998537-4cba5ec9-8e27-4e65-b70a-1f1e8af6513e.gif)


- [x] After enabling risk score features, Critical Hosts/Critical Users count at the top of the page does not refresh with page refresh button. A browser refresh is required to see the updated count.
![Sep-26-2022 10-50-28](https://user-images.githubusercontent.com/1490444/192234481-00f4c67c-cf98-4cd8-83b3-34f1e45df821.gif)


- [x] On hovering donut chart Total tooltip background is black but should be white.
       I removed the link and now it looks like the detection and response page.

<img width="278" alt="Screenshot 2022-09-26 at 10 51 42" src="https://user-images.githubusercontent.com/1490444/192234618-575c7463-3d74-4890-b689-f1139452c130.png">

- [x] Put the restart button to the No data available prompt

<img width="1500" alt="Screenshot 2022-09-26 at 10 55 17" src="https://user-images.githubusercontent.com/1490444/192235369-cc4856f0-7f89-4781-b50a-1abcf0a26312.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->