### PR TITLE
[Synthetics] bulkDelete to delete synthetics monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
@@ -43,11 +43,12 @@ export const deleteMonitorBulk = async ({
       savedObjectsClient,
       spaceId
     );
-    const deletePromises = monitors.map((monitor) =>
-      savedObjectsClient.delete(syntheticsMonitorType, monitor.id)
+
+    const deletePromises = savedObjectsClient.bulkDelete(
+      monitors.map((monitor) => ({ type: syntheticsMonitorType, id: monitor.id }))
     );
 
-    const [errors] = await Promise.all([deleteSyncPromise, ...deletePromises]);
+    const [errors] = await Promise.all([deleteSyncPromise, deletePromises]);
 
     monitors.forEach((monitor) => {
       sendTelemetryEvents(


### PR DESCRIPTION
## Summary

Use newly added saved objects api in PR https://github.com/elastic/kibana/pull/139680 which is `bulkDelete` to delete synthetics monitors. 

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->