### PR TITLE
[Lens] Close settings popover on click

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
@@ -45,13 +45,14 @@ export function SettingsMenu({
   const dispatch = useLensDispatch();
 
   const toggleAutoApply = useCallback(() => {
+    onClose();
     writeToStorage(
       new Storage(localStorage),
       AUTO_APPLY_DISABLED_STORAGE_KEY,
       String(autoApplyEnabled)
     );
     dispatch(autoApplyEnabled ? disableAutoApply() : enableAutoApply());
-  }, [dispatch, autoApplyEnabled]);
+  }, [dispatch, autoApplyEnabled, onClose]);
 
   return (
     <EuiWrappingPopover


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/141203 by employing the workaround I mentioned in the issue.

I will create a feature request for the app services team to provide a proper way to do this separately.