### PR TITLE
[Enterprise Search] remove pipelines feature flag

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -562,10 +562,6 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
-  'enterpriseSearch:enableIndexTransformsTab': {
-    type: 'boolean',
-    _meta: { description: 'Non-default value of setting.' },
-  },
   'enterpriseSearch:enableBehavioralAnalyticsSection': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -150,6 +150,5 @@ export interface UsageStats {
   'securitySolution:enableGroupedNav': boolean;
   'securitySolution:showRelatedIntegrations': boolean;
   'visualization:visualize:legacyGaugeChartsLibrary': boolean;
-  'enterpriseSearch:enableIndexTransformsTab': boolean;
   'enterpriseSearch:enableBehavioralAnalyticsSection': boolean;
 }

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -8888,12 +8888,6 @@
             "description": "Non-default value of setting."
           }
         },
-        "enterpriseSearch:enableIndexTransformsTab": {
-          "type": "boolean",
-          "_meta": {
-            "description": "Non-default value of setting."
-          }
-        },
         "enterpriseSearch:enableBehavioralAnalyticsSection": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/plugins/enterprise_search/common/ui_settings_keys.ts
+++ b/x-pack/plugins/enterprise_search/common/ui_settings_keys.ts
@@ -6,5 +6,4 @@
  */
 
 export const enterpriseSearchFeatureId = 'enterpriseSearch';
-export const enableIndexPipelinesTab = 'enterpriseSearch:enableIndexTransformsTab';
 export const enableBehavioralAnalyticsSection = 'enterpriseSearch:enableBehavioralAnalyticsSection';

--- a/x-pack/plugins/enterprise_search/server/ui_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/ui_settings.ts
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 
 import {
   enterpriseSearchFeatureId,
-  enableIndexPipelinesTab,
   enableBehavioralAnalyticsSection,
 } from '../common/ui_settings_keys';
 
@@ -28,18 +27,6 @@ export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
       defaultMessage: 'Enable Behavioral Analytics',
     }),
     requiresPageReload: true,
-    schema: schema.boolean(),
-    value: false,
-  },
-  [enableIndexPipelinesTab]: {
-    category: [enterpriseSearchFeatureId],
-    description: i18n.translate('xpack.enterpriseSearch.uiSettings.indexPipelines.description', {
-      defaultMessage: 'Enable the new index pipelines tab in Enterprise Search.',
-    }),
-    name: i18n.translate('xpack.enterpriseSearch.uiSettings.indexPipelines.name', {
-      defaultMessage: 'Enable index pipelines',
-    }),
-    requiresPageReload: false,
     schema: schema.boolean(),
     value: false,
   },


### PR DESCRIPTION
## Summary

We add the `enterpriseSearch:enableIndexTransformsTab` ui setting to be a feature flag in case we had issues shipping the new Pipelines tab in Enterprise Search. We ended up not needing it in 8.5 so this removes the ui setting since its not used.