### PR TITLE
[Synthetics] unskip edit_monitor api integration tests

### DIFF
--- a/x-pack/test/api_integration/apis/uptime/rest/edit_monitor.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/edit_monitor.ts
@@ -17,7 +17,7 @@ import { PrivateLocationTestService } from './services/private_location_test_ser
 
 export default function ({ getService }: FtrProviderContext) {
   // Failing: See https://github.com/elastic/kibana/issues/140520
-  describe.skip('[PUT] /internal/uptime/service/monitors', function () {
+  describe('[PUT] /internal/uptime/service/monitors', function () {
     this.tags('skipCloud');
 
     const supertest = getService('supertest');

--- a/x-pack/test/api_integration/apis/uptime/rest/edit_monitor.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/edit_monitor.ts
@@ -16,7 +16,6 @@ import { getFixtureJson } from './helper/get_fixture_json';
 import { PrivateLocationTestService } from './services/private_location_test_service';
 
 export default function ({ getService }: FtrProviderContext) {
-  // Failing: See https://github.com/elastic/kibana/issues/140520
   describe('[PUT] /internal/uptime/service/monitors', function () {
     this.tags('skipCloud');
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/140520

Unskips test

Run against flaky test runner for 200 iterations: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1281#01836146-8f68-4c26-a54a-1f420947dc36

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->