### PR TITLE
[Synthetics] fix monitor editing

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/state/api/monitor_management.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/state/api/monitor_management.ts
@@ -35,7 +35,7 @@ export const setMonitor = async ({
   id?: string;
 }): Promise<{ attributes: { errors: ServiceLocationErrors } } | SyntheticsMonitor> => {
   if (id) {
-    return await apiService.put(`${API_URLS.SYNTHETICS_MONITORS}/${id}`);
+    return await apiService.put(`${API_URLS.SYNTHETICS_MONITORS}/${id}`, monitor);
   } else {
     return await apiService.post(API_URLS.SYNTHETICS_MONITORS, monitor, undefined, {
       preserve_namespace: true,


### PR DESCRIPTION
## Summary

Fixes a bug where the monitor was not being passed to the edit monitor api, causing the monitor to not be edited. 

### Testing
1. Navigate to Uptime and create a monitor
2. Edit the monitor, changing it's locations, tags, script, or anything else
3. Confirm the monitor was saved


<!--ONMERGE {"backportTargets":["8.4","8.5"]} ONMERGE-->