### PR TITLE
[Fleet] Add experimental data stream features support to simplified package policy API

### DIFF
--- a/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -115,5 +115,36 @@ describe('toPackagePolicy', () => {
         'nginx-nginx/metrics': ['nginx.stubstatus'],
       });
     });
+
+    it('should to pass experimental_data_stream_features', () => {
+      const res = simplifiedPackagePolicytoNewPackagePolicy(
+        {
+          name: 'nginx-1',
+          namespace: 'default',
+          policy_id: 'policy123',
+          description: 'Test description',
+        },
+        nginxPackageInfo as unknown as PackageInfo,
+        {
+          experimental_data_stream_features: [
+            {
+              data_stream: 'logs-nginx.access',
+              features: {
+                synthetic_source: true,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(res.package?.experimental_data_stream_features).toEqual([
+        {
+          data_stream: 'logs-nginx.access',
+          features: {
+            synthetic_source: true,
+          },
+        },
+      ]);
+    });
   });
 });

--- a/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.ts
@@ -11,6 +11,7 @@ import type {
   PackagePolicyConfigRecord,
   NewPackagePolicy,
   PackageInfo,
+  ExperimentalDataStreamFeature,
 } from '../types';
 import { PackagePolicyValidationError } from '../errors';
 
@@ -66,7 +67,10 @@ type InputMap = Map<string, { input: NewPackagePolicyInput; streams: StreamsMap 
 
 export function simplifiedPackagePolicytoNewPackagePolicy(
   data: SimplifiedPackagePolicy,
-  packageInfo: PackageInfo
+  packageInfo: PackageInfo,
+  options?: {
+    experimental_data_stream_features: ExperimentalDataStreamFeature[];
+  }
 ): NewPackagePolicy {
   const {
     policy_id: policyId,
@@ -77,6 +81,10 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
     vars: packageLevelVars,
   } = data;
   const packagePolicy = packageToPackagePolicy(packageInfo, policyId, namespace, name, description);
+  if (packagePolicy.package && options?.experimental_data_stream_features) {
+    packagePolicy.package.experimental_data_stream_features =
+      options.experimental_data_stream_features;
+  }
 
   // Build a input and streams Map to easily find package policy stream
   const inputMap: InputMap = new Map();

--- a/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.ts
+++ b/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.ts
@@ -69,7 +69,7 @@ export function simplifiedPackagePolicytoNewPackagePolicy(
   data: SimplifiedPackagePolicy,
   packageInfo: PackageInfo,
   options?: {
-    experimental_data_stream_features: ExperimentalDataStreamFeature[];
+    experimental_data_stream_features?: ExperimentalDataStreamFeature[];
   }
 ): NewPackagePolicy {
   const {

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -205,7 +205,9 @@ export const createPackagePolicyHandler: FleetRequestHandler<
         pkgVersion: pkg.version,
         ignoreUnverified: force,
       });
-      newPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(newPolicy, pkgInfo);
+      newPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(newPolicy, pkgInfo, {
+        experimental_data_stream_features: pkg.experimental_data_stream_features,
+      });
     } else {
       newPackagePolicy = await packagePolicyService.enrichPolicyWithDefaultsFromPackage(soClient, {
         ...newPolicy,
@@ -293,7 +295,8 @@ export const updatePackagePolicyHandler: RequestHandler<
       });
       newData = simplifiedPackagePolicytoNewPackagePolicy(
         body as unknown as SimplifiedPackagePolicy,
-        pkgInfo
+        pkgInfo,
+        { experimental_data_stream_features: pkg.experimental_data_stream_features }
       );
     } else {
       // removed fields not recognized by schema

--- a/x-pack/plugins/fleet/server/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/package_policy.ts
@@ -79,6 +79,15 @@ const PackagePolicyInputsSchema = {
   streams: schema.arrayOf(schema.object(PackagePolicyStreamsSchema)),
 };
 
+const ExperimentalDataStreamFeatures = schema.arrayOf(
+  schema.object({
+    data_stream: schema.string(),
+    features: schema.object({
+      synthetic_source: schema.boolean(),
+    }),
+  })
+);
+
 const PackagePolicyBaseSchema = {
   name: schema.string(),
   description: schema.maybe(schema.string()),
@@ -90,16 +99,7 @@ const PackagePolicyBaseSchema = {
       name: schema.string(),
       title: schema.string(),
       version: schema.string(),
-      experimental_data_stream_features: schema.maybe(
-        schema.arrayOf(
-          schema.object({
-            data_stream: schema.string(),
-            features: schema.object({
-              synthetic_source: schema.boolean(),
-            }),
-          })
-        )
-      ),
+      experimental_data_stream_features: schema.maybe(ExperimentalDataStreamFeatures),
     })
   ),
   // Deprecated TODO create remove issue
@@ -172,6 +172,7 @@ export const SimplifiedCreatePackagePolicyRequestBodySchema = schema.object({
   package: schema.object({
     name: schema.string(),
     version: schema.string(),
+    experimental_data_stream_features: schema.maybe(ExperimentalDataStreamFeatures),
   }),
   force: schema.maybe(schema.boolean()),
   vars: schema.maybe(SimplifiedVarsSchema),


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/141183

It's now possible to define experimental data stream feature in the package policy editor UI this results in preview API request like the one below that where not correctly handled by the fleet package policy API.

That PR fix that by adding support for the `experimental_data_stream_features` property to the simplified package policy API.

<img width="899" alt="Screen Shot 2022-09-21 at 3 20 14 PM" src="https://user-images.githubusercontent.com/1336873/191592526-47f5d643-0e36-474f-824a-6ca93e06d3fa.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->