### PR TITLE
[dashboard controls] skip failing test on cloud

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/options_list.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list.ts
@@ -75,7 +75,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('Options List Control creation and editing experience', async () => {
+    // Skip on cloud until issue is fixed
+    // Issue: https://github.com/elastic/kibana/issues/141280
+    describe('Options List Control creation and editing experience', function () {
+      this.tags(['skipCloudFailedTest']);
       it('can add a new options list control from a blank state', async () => {
         await dashboardControls.createControl({
           controlType: OPTIONS_LIST_CONTROL,


### PR DESCRIPTION
There is a bug on dashboard controls see: https://github.com/elastic/kibana/issues/141280 -- until that bug is fixed, we can skip running this test on cloud. Test failure: https://github.com/elastic/kibana/issues/141285

Reference run: https://buildkite.com/elastic/estf-cloud-kibana-functional-tests/builds/678

<!--ONMERGE {"backportTargets":["8.4","8.5"]} ONMERGE-->