### PR TITLE
Do not conditionally gate remove processor

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
@@ -150,29 +150,6 @@ export const createIndexPipelineDefinitions = (
         },
       },
       {
-        remove: {
-          field: [
-            '_attachment',
-            '_attachment_indexed_chars',
-            '_extracted_attachment',
-            '_extract_binary_content',
-          ],
-          if: 'ctx?._extract_binary_content == true',
-          ignore_missing: true,
-          on_failure: [
-            {
-              append: {
-                field: '_ingestion_errors',
-                value: [
-                  "Processor 'remove' with tag 'remove_attachment_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'",
-                ],
-              },
-            },
-          ],
-          tag: 'remove_attachment_fields',
-        },
-      },
-      {
         gsub: {
           field: 'body',
           if: 'ctx?._reduce_whitespace == true',
@@ -211,20 +188,26 @@ export const createIndexPipelineDefinitions = (
       },
       {
         remove: {
-          field: ['_reduce_whitespace'],
-          if: 'ctx?._reduce_whitespace == true',
+          field: [
+            '_attachment',
+            '_attachment_indexed_chars',
+            '_extracted_attachment',
+            '_extract_binary_content',
+            '_reduce_whitespace',
+            '_run_ml_inference',
+          ],
           ignore_missing: true,
           on_failure: [
             {
               append: {
                 field: '_ingestion_errors',
                 value: [
-                  "Processor 'remove' with tag 'remove_whitespace_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'",
+                  "Processor 'remove' with tag 'remove_meta_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'",
                 ],
               },
             },
           ],
-          tag: 'remove_whitespace_fields',
+          tag: 'remove_meta_fields',
         },
       },
     ],


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/enterprise-search-team/issues/2824

- combines the `remove` processors in the pipeline
- adds `_run_ml_inference` to the removed fields
- removes the conditional gating from that processor

