### PR TITLE
[ML] Fix Data visualizer not updating distribution when changing shard size, forbidden error with recognize modules on basic license

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/number_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/number_content.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC, ReactNode, useEffect, useState } from 'react';
+import React, { FC, ReactNode, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiFlexItem,
@@ -19,11 +19,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { FieldDataRowProps } from '../../types/field_data_row';
 import { kibanaFieldFormat, numberAsOrdinal } from '../../../utils';
-import {
-  MetricDistributionChart,
-  MetricDistributionChartData,
-  buildChartDataFromStats,
-} from '../metric_distribution_chart';
+import { MetricDistributionChart, buildChartDataFromStats } from '../metric_distribution_chart';
 import { TopValues } from '../../../top_values';
 import { ExpandedRowFieldHeader } from '../expanded_row_field_header';
 import { DocumentStatsTable } from './document_stats';
@@ -42,14 +38,10 @@ interface SummaryTableItem {
 export const NumberContent: FC<FieldDataRowProps> = ({ config, onAddFilter }) => {
   const { stats } = config;
 
-  useEffect(() => {
-    const chartData = buildChartDataFromStats(stats, METRIC_DISTRIBUTION_CHART_WIDTH);
-    setDistributionChartData(chartData);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const defaultChartData: MetricDistributionChartData[] = [];
-  const [distributionChartData, setDistributionChartData] = useState(defaultChartData);
+  const distributionChartData = useMemo(
+    () => buildChartDataFromStats(stats?.distribution, METRIC_DISTRIBUTION_CHART_WIDTH),
+    [stats?.distribution]
+  );
 
   if (stats === undefined) return null;
   const { min, median, max, distribution } = stats;

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/number_content_preview.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/number_content_preview.tsx
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import {
-  MetricDistributionChart,
-  MetricDistributionChartData,
-  buildChartDataFromStats,
-} from '../metric_distribution_chart';
+import { MetricDistributionChart, buildChartDataFromStats } from '../metric_distribution_chart';
 import { FieldVisConfig } from '../../types';
 import { kibanaFieldFormat, formatSingleValue } from '../../../utils';
 
@@ -24,25 +20,25 @@ export interface NumberContentPreviewProps {
 
 export const IndexBasedNumberContentPreview: FC<NumberContentPreviewProps> = ({ config }) => {
   const { stats, fieldFormat, fieldName } = config;
-  const defaultChartData: MetricDistributionChartData[] = [];
-  const [distributionChartData, setDistributionChartData] = useState(defaultChartData);
-  const [legendText, setLegendText] = useState<{ min: number; max: number } | undefined>();
   const dataTestSubj = `dataVisualizerDataGridChart-${fieldName}`;
-  useEffect(() => {
-    const chartData = buildChartDataFromStats(stats, METRIC_DISTRIBUTION_CHART_WIDTH);
-    if (
-      Array.isArray(chartData) &&
-      chartData[0].x !== undefined &&
-      chartData[chartData.length - 1].x !== undefined
-    ) {
-      setDistributionChartData(chartData);
-      setLegendText({
-        min: formatSingleValue(chartData[0].x),
-        max: formatSingleValue(chartData[chartData.length - 1].x),
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+  const distributionChartData = useMemo(
+    () => buildChartDataFromStats(stats?.distribution, METRIC_DISTRIBUTION_CHART_WIDTH),
+    [stats?.distribution]
+  );
+
+  const legendText = useMemo(
+    () =>
+      Array.isArray(distributionChartData) &&
+      distributionChartData[0].x !== undefined &&
+      distributionChartData[distributionChartData.length - 1].x !== undefined
+        ? {
+            min: formatSingleValue(distributionChartData[0].x),
+            max: formatSingleValue(distributionChartData[distributionChartData.length - 1].x),
+          }
+        : '',
+    [distributionChartData]
+  );
 
   return (
     <div data-test-subj={dataTestSubj} style={{ width: '100%' }}>

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/metric_distribution_chart/metric_distribution_chart_data_builder.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/metric_distribution_chart/metric_distribution_chart_data_builder.tsx
@@ -27,19 +27,18 @@ interface DistributionChartBar {
 }
 
 export function buildChartDataFromStats(
-  stats: any,
+  distribution: any,
   chartWidth: number
 ): MetricDistributionChartData[] {
   // Process the raw percentiles data so it is in a suitable format for plotting in the metric distribution chart.
   let chartData: MetricDistributionChartData[] = [];
 
-  const distribution = stats.distribution;
   if (distribution === undefined) {
     return chartData;
   }
 
   const percentiles: DistributionPercentile[] = distribution.percentiles;
-  if (percentiles.length === 0) {
+  if (percentiles?.length === 0) {
     return chartData;
   }
 

--- a/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
@@ -69,7 +69,7 @@ export const TopValues: FC<Props> = ({ stats, fieldFormat, barColor, compressed,
 
   const topValuesOtherCount =
     (progressBarMax ?? 0) -
-    (topValues ? topValues.map((value) => value.doc_count).reduce((v, acc) => acc + v) : 0);
+    (topValues ? topValues.map((value) => value.doc_count).reduce((v, acc) => acc + v, 0) : 0);
 
   const countsElement =
     totalDocuments !== undefined ? (

--- a/x-pack/plugins/ml/public/application/datavisualizer/index_based/index_data_visualizer.tsx
+++ b/x-pack/plugins/ml/public/application/datavisualizer/index_based/index_data_visualizer.tsx
@@ -45,6 +45,7 @@ export const IndexDataVisualizerPage: FC = () => {
     },
   } = useMlKibana();
   const mlLocator = useMlLocator()!;
+  const mlFeaturesDisabled = !isFullLicense();
   getMlNodeCount();
 
   const [IndexDataVisualizer, setIndexDataVisualizer] = useState<IndexDataVisualizerSpec | null>(
@@ -137,50 +138,56 @@ export const IndexDataVisualizerPage: FC = () => {
 
   const getAsyncRecognizedModuleCards = async (params: GetAdditionalLinksParams) => {
     const { dataViewId, dataViewTitle } = params;
-    const modules = await http.fetch<RecognizerModule[]>(
-      `/api/ml/modules/recognize/${dataViewTitle}`,
-      {
-        method: 'GET',
-      }
-    );
-    return modules?.map(
-      (m): ResultLink => ({
-        id: m.id,
-        title: m.title,
-        description: m.description,
-        icon: m.logo.icon,
-        type: 'index',
-        getUrl: async () => {
-          return await mlLocator.getUrl({
-            page: ML_PAGES.ANOMALY_DETECTION_CREATE_JOB_RECOGNIZER,
-            pageState: {
-              id: m.id,
-              index: dataViewId,
-            },
-          });
-        },
-        canDisplay: async () => {
-          try {
-            const { timeFieldName } = await getDataView(dataViewId);
-            return (
-              isFullLicense() &&
-              timeFieldName !== undefined &&
-              checkPermission('canCreateJob') &&
-              mlNodesAvailable()
-            );
-          } catch (error) {
-            return false;
-          }
-        },
-        'data-test-subj': m.id,
-      })
-    );
+    try {
+      const modules = await http.fetch<RecognizerModule[]>(
+        `/api/ml/modules/recognize/${dataViewTitle}`,
+        {
+          method: 'GET',
+        }
+      );
+      return modules?.map(
+        (m): ResultLink => ({
+          id: m.id,
+          title: m.title,
+          description: m.description,
+          icon: m.logo.icon,
+          type: 'index',
+          getUrl: async () => {
+            return await mlLocator.getUrl({
+              page: ML_PAGES.ANOMALY_DETECTION_CREATE_JOB_RECOGNIZER,
+              pageState: {
+                id: m.id,
+                index: dataViewId,
+              },
+            });
+          },
+          canDisplay: async () => {
+            try {
+              const { timeFieldName } = await getDataView(dataViewId);
+              return (
+                isFullLicense() &&
+                timeFieldName !== undefined &&
+                checkPermission('canCreateJob') &&
+                mlNodesAvailable()
+              );
+            } catch (error) {
+              return false;
+            }
+          },
+          'data-test-subj': m.id,
+        })
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Platinum, Enterprise or trial license needed');
+      return [];
+    }
   };
 
   const getAdditionalLinks: GetAdditionalLinks = useMemo(
-    () => [getAsyncRecognizedModuleCards, getAsyncMLCards],
+    () => (mlFeaturesDisabled ? [] : [getAsyncRecognizedModuleCards, getAsyncMLCards]),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [mlLocator]
+    [mlLocator, mlFeaturesDisabled]
   );
   return IndexDataVisualizer ? (
     <Fragment>


### PR DESCRIPTION
## Summary

This PR fixes a bug with the Data visualizer/Field stats not updating distribution when changing shard size. 

Before:

![image](https://user-images.githubusercontent.com/43350163/191612037-6601bf47-785c-455d-9547-8b4e6c2215d1.png)

After:

https://user-images.githubusercontent.com/43350163/191612129-c73eddce-eb6d-490e-b3f1-69820e9fe4e0.mov

It also fixes an issue with the top values not counting other values if there's no top values. 

Finally, it fixes developer console showing 403 forbidden error for users https://github.com/elastic/kibana/issues/139124 which is caused due to the `ml/recognize` endpoint being called when on basic license.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.4","8.5"]} ONMERGE-->