### PR TITLE
[ML] Explain Log Rate Spikes: Reduce data view font size.

### DIFF
--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
@@ -181,7 +181,7 @@ export const ExplainLogRateSpikesPage: FC<ExplainLogRateSpikesPageProps> = ({
           <EuiPageContentHeader className="aiopsPageHeader">
             <EuiPageContentHeaderSection>
               <div className="dataViewTitleHeader">
-                <EuiTitle size={'s'}>
+                <EuiTitle size={'xs'}>
                   <h2>{dataView.getName()}</h2>
                 </EuiTitle>
               </div>


### PR DESCRIPTION
## Summary

Part of #138117.

Reduces the data view `h2` font size from `s` to `xs`.

Before:

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/230104/191689325-51113f73-d059-4238-931f-1eb401cae21b.png">

After:

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/230104/191689164-22f9888a-8be0-4185-a0da-99b3eacf7129.png">

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
