### PR TITLE
[Fleet] Bulk update agent tags improvements

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -36,7 +36,8 @@ export type AgentActionType =
   | 'SETTINGS'
   | 'POLICY_REASSIGN'
   | 'CANCEL'
-  | 'FORCE_UNENROLL';
+  | 'FORCE_UNENROLL'
+  | 'UPDATE_TAGS';
 
 type FleetServerAgentComponentStatusTuple = typeof FleetServerAgentComponentStatuses;
 export type FleetServerAgentComponentStatus = FleetServerAgentComponentStatusTuple[number];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -367,7 +367,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
           <p>
             <FormattedMessage
               id="xpack.fleet.agentActivityFlyout.failureDescription"
-              defaultMessage=" A problem occured during this operation."
+              defaultMessage=" A problem occurred during this operation."
             />
             &nbsp;
             {inProgressDescription(action.creationTime)}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -243,6 +243,11 @@ const actionNames: {
     completedText: 'force unenrolled',
     cancelledText: 'force unenrollment',
   },
+  UPDATE_TAGS: {
+    inProgressText: 'Updating tags of',
+    completedText: 'updated tags',
+    cancelledText: 'update tags',
+  },
   CANCEL: { inProgressText: 'Cancelling', completedText: 'cancelled', cancelledText: '' },
   ACTION: { inProgressText: 'Actioning', completedText: 'actioned', cancelledText: 'action' },
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
@@ -25,7 +25,7 @@ import { sanitizeTag } from '../utils';
 interface Props {
   tagName: string;
   isTagHovered: boolean;
-  onTagsUpdated: () => void;
+  onTagsUpdated: (tagsToAdd: string[], tagsToRemove: string[], hasCompleted?: boolean) => void;
 }
 
 export const TagOptions: React.FC<Props> = ({ tagName, isTagHovered, onTagsUpdated }: Props) => {
@@ -65,7 +65,7 @@ export const TagOptions: React.FC<Props> = ({ tagName, isTagHovered, onTagsUpdat
       kuery,
       [newName],
       [tagName],
-      () => onTagsUpdated(),
+      (hasCompleted) => onTagsUpdated([newName], [tagName], hasCompleted),
       i18n.translate('xpack.fleet.renameAgentTags.successNotificationTitle', {
         defaultMessage: 'Tag renamed',
       }),
@@ -81,7 +81,7 @@ export const TagOptions: React.FC<Props> = ({ tagName, isTagHovered, onTagsUpdat
       kuery,
       [],
       [tagName],
-      () => onTagsUpdated(),
+      (hasCompleted) => onTagsUpdated([], [tagName], hasCompleted),
       i18n.translate('xpack.fleet.deleteAgentTags.successNotificationTitle', {
         defaultMessage: 'Tag deleted',
       }),

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.test.tsx
@@ -226,6 +226,30 @@ describe('TagsAddRemove', () => {
     );
   });
 
+  it('should add to selected tags on add if action not completed immediately', async () => {
+    mockBulkUpdateTags.mockImplementation((agents, tagsToAdd, tagsToRemove, onSuccess) => {
+      onSuccess(false);
+    });
+    const result = renderComponent(undefined, '');
+    const getTag = (name: string) => result.getByText(name);
+
+    fireEvent.click(getTag('tag2'));
+
+    expect(result.getByTitle('tag2').getAttribute('aria-checked')).toEqual('true');
+  });
+
+  it('should remove from selected tags on remove if action not completed immediately', async () => {
+    mockBulkUpdateTags.mockImplementation((agents, tagsToAdd, tagsToRemove, onSuccess) => {
+      onSuccess(false);
+    });
+    const result = renderComponent(undefined, '');
+    const getTag = (name: string) => result.getByText(name);
+
+    fireEvent.click(getTag('tag1'));
+
+    expect(result.getByTitle('tag1').getAttribute('aria-checked')).toEqual('false');
+  });
+
   it('should add new tag when not found in search and button clicked - bulk selection', () => {
     const result = renderComponent(undefined, 'query');
     const searchInput = result.getByRole('combobox');
@@ -256,5 +280,40 @@ describe('TagsAddRemove', () => {
     fireEvent.mouseLeave(result.getByText('tag1').closest('.euiFlexGroup')!);
 
     expect(result.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should remove from selected and all tags on delete if action not completed immediately', async () => {
+    mockBulkUpdateTags.mockImplementation((agents, tagsToAdd, tagsToRemove, onSuccess) => {
+      onSuccess(false);
+    });
+    const result = renderComponent('agent1');
+    fireEvent.mouseEnter(result.getByText('tag1').closest('.euiFlexGroup')!);
+
+    fireEvent.click(result.getByRole('button'));
+
+    fireEvent.click(result.getByText('Delete tag').closest('button')!);
+
+    expect(result.queryByTitle('tag1')).toBeNull();
+  });
+
+  it('should update selected and all tags on rename if action not completed immediately', async () => {
+    mockBulkUpdateTags.mockImplementation((agents, tagsToAdd, tagsToRemove, onSuccess) => {
+      onSuccess(false);
+    });
+    const result = renderComponent('agent1');
+    fireEvent.mouseEnter(result.getByText('tag1').closest('.euiFlexGroup')!);
+
+    fireEvent.click(result.getByRole('button'));
+
+    const input = result.getByDisplayValue('tag1');
+    fireEvent.input(input, {
+      target: { value: 'newName' },
+    });
+    fireEvent.keyDown(input, {
+      key: 'Enter',
+    });
+
+    expect(result.queryByTitle('tag1')).toBeNull();
+    expect(result.getByText('newName')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -86,6 +86,23 @@ export const TagsAddRemove: React.FC<Props> = ({
     [labels, searchValue]
   );
 
+  const handleTagsUpdated = (
+    tagsToAdd: string[],
+    tagsToRemove: string[],
+    hasCompleted: boolean = true,
+    isRenameOrDelete = false
+  ) => {
+    if (hasCompleted) {
+      return onTagsUpdated();
+    }
+    const newSelectedTags = difference(selectedTags, tagsToRemove).concat(tagsToAdd);
+    const allTagsWithNew = allTags.includes(tagsToAdd[0]) ? allTags : allTags.concat(tagsToAdd);
+    const allTagsWithRemove = isRenameOrDelete
+      ? difference(allTagsWithNew, tagsToRemove)
+      : allTagsWithNew;
+    setLabels(labelsFromTags(allTagsWithRemove, newSelectedTags));
+  };
+
   const updateTags = async (
     tagsToAdd: string[],
     tagsToRemove: string[],
@@ -106,18 +123,7 @@ export const TagsAddRemove: React.FC<Props> = ({
         agents!,
         tagsToAdd,
         tagsToRemove,
-        (hasCompleted?: boolean) => {
-          if (hasCompleted === false) {
-            setLabels(
-              labelsFromTags(
-                allTags.includes(tagsToAdd[0]) ? allTags : allTags.concat(tagsToAdd),
-                newSelectedTags
-              )
-            );
-          } else {
-            onTagsUpdated();
-          }
-        },
+        (hasCompleted) => handleTagsUpdated(tagsToAdd, tagsToRemove, hasCompleted),
         successMessage,
         errorMessage
       );
@@ -147,7 +153,9 @@ export const TagsAddRemove: React.FC<Props> = ({
           <TagOptions
             tagName={option.label}
             isTagHovered={isTagHovered[option.label]}
-            onTagsUpdated={onTagsUpdated}
+            onTagsUpdated={(tagsToAdd, tagsToRemove, hasCompleted) =>
+              handleTagsUpdated(tagsToAdd, tagsToRemove, hasCompleted, true)
+            }
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tags_add_remove.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, useCallback, useEffect, useState, useMemo } from 'react';
+import React, { Fragment, useEffect, useState, useMemo, useCallback } from 'react';
 import { difference } from 'lodash';
 import styled from 'styled-components';
 import type { EuiSelectableOption } from '@elastic/eui';
@@ -54,16 +54,18 @@ export const TagsAddRemove: React.FC<Props> = ({
   onClosePopover,
 }: Props) => {
   const labelsFromTags = useCallback(
-    (tags: string[]) =>
+    (tags: string[], selected: string[]) =>
       tags.map((tag: string) => ({
         label: tag,
-        checked: selectedTags.includes(tag) ? 'on' : undefined,
+        checked: selected.includes(tag) ? 'on' : undefined,
         onFocusBadge: false,
       })),
-    [selectedTags]
+    []
   );
 
-  const [labels, setLabels] = useState<Array<EuiSelectableOption<any>>>(labelsFromTags(allTags));
+  const [labels, setLabels] = useState<Array<EuiSelectableOption<any>>>(
+    labelsFromTags(allTags, selectedTags)
+  );
   const [searchValue, setSearchValue] = useState<string | undefined>(undefined);
   const [isPopoverOpen, setIsPopoverOpen] = useState(true);
   const [isTagHovered, setIsTagHovered] = useState<{ [tagName: string]: boolean }>({});
@@ -76,8 +78,8 @@ export const TagsAddRemove: React.FC<Props> = ({
 
   // update labels after tags changing
   useEffect(() => {
-    setLabels(labelsFromTags(allTags));
-  }, [allTags, labelsFromTags]);
+    setLabels(labelsFromTags(allTags, selectedTags));
+  }, [allTags, labelsFromTags, selectedTags]);
 
   const isExactMatch = useMemo(
     () => labels.some((label) => label.label === searchValue),
@@ -90,10 +92,11 @@ export const TagsAddRemove: React.FC<Props> = ({
     successMessage?: string,
     errorMessage?: string
   ) => {
+    const newSelectedTags = difference(selectedTags, tagsToRemove).concat(tagsToAdd);
     if (agentId) {
       updateTagsHook.updateTags(
         agentId,
-        difference(selectedTags, tagsToRemove).concat(tagsToAdd),
+        newSelectedTags,
         () => onTagsUpdated(),
         successMessage,
         errorMessage
@@ -103,7 +106,18 @@ export const TagsAddRemove: React.FC<Props> = ({
         agents!,
         tagsToAdd,
         tagsToRemove,
-        () => onTagsUpdated(),
+        (hasCompleted?: boolean) => {
+          if (hasCompleted === false) {
+            setLabels(
+              labelsFromTags(
+                allTags.includes(tagsToAdd[0]) ? allTags : allTags.concat(tagsToAdd),
+                newSelectedTags
+              )
+            );
+          } else {
+            onTagsUpdated();
+          }
+        },
         successMessage,
         errorMessage
       );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.test.tsx
@@ -35,10 +35,11 @@ describe('useUpdateTags', () => {
   const mockOnSuccess = jest.fn();
   beforeEach(() => {
     mockSendPutAgentTagsUpdate.mockReset();
+    mockSendPostBulkAgentTagsUpdate.mockReset();
     mockOnSuccess.mockReset();
   });
   it('should call onSuccess when update tags succeeds', async () => {
-    mockSendPutAgentTagsUpdate.mockResolvedValueOnce({});
+    mockSendPutAgentTagsUpdate.mockResolvedValueOnce({ data: {} });
 
     const { result } = renderHook(() => useUpdateTags());
     await act(() => result.current.updateTags('agent1', ['tag1'], mockOnSuccess));
@@ -61,7 +62,7 @@ describe('useUpdateTags', () => {
   });
 
   it('should call onSuccess when bulk update tags succeeds', async () => {
-    mockSendPostBulkAgentTagsUpdate.mockResolvedValueOnce({});
+    mockSendPostBulkAgentTagsUpdate.mockResolvedValueOnce({ data: { actionId: 'action' } });
 
     const { result } = renderHook(() => useUpdateTags());
     await act(() => result.current.bulkUpdateTags('query', ['tag1'], [], mockOnSuccess));

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
@@ -20,7 +20,7 @@ export const useUpdateTags = () => {
   const wrapRequest = useCallback(
     async (
       requestFn: () => Promise<any>,
-      onSuccess: () => void,
+      onSuccess: (hasCompleted?: boolean) => void,
       successMessage?: string,
       errorMessage?: string
     ) => {
@@ -30,14 +30,21 @@ export const useUpdateTags = () => {
         if (res.error) {
           throw res.error;
         }
+        const hasCompleted = !res.data.actionId;
         const message =
           successMessage ??
           i18n.translate('xpack.fleet.updateAgentTags.successNotificationTitle', {
             defaultMessage: 'Tags updated',
           });
-        notifications.toasts.addSuccess(message);
+        const submittedMessage = i18n.translate(
+          'xpack.fleet.agentReassignPolicy.submittedNotificationTitle',
+          {
+            defaultMessage: 'Tags update submitted',
+          }
+        );
+        notifications.toasts.addSuccess(hasCompleted ? message : submittedMessage);
 
-        onSuccess();
+        onSuccess(hasCompleted);
       } catch (error) {
         const errorTitle =
           errorMessage ??
@@ -73,7 +80,7 @@ export const useUpdateTags = () => {
       agents: string[] | string,
       tagsToAdd: string[],
       tagsToRemove: string[],
-      onSuccess: () => void,
+      onSuccess: (hasCompleted?: boolean) => void,
       successMessage?: string,
       errorMessage?: string
     ) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_update_tags.tsx
@@ -36,13 +36,7 @@ export const useUpdateTags = () => {
           i18n.translate('xpack.fleet.updateAgentTags.successNotificationTitle', {
             defaultMessage: 'Tags updated',
           });
-        const submittedMessage = i18n.translate(
-          'xpack.fleet.agentReassignPolicy.submittedNotificationTitle',
-          {
-            defaultMessage: 'Tags update submitted',
-          }
-        );
-        notifications.toasts.addSuccess(hasCompleted ? message : submittedMessage);
+        notifications.toasts.addSuccess(message);
 
         onSuccess(hasCompleted);
       } catch (error) {

--- a/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
@@ -144,7 +144,7 @@ export async function updateActionsForForceUnenroll(
   actionId: string,
   total: number
 ) {
-  // creating an unenroll so that force unenroll shows up in activity
+  // creating an action doc so that force unenroll shows up in activity
   await createAgentAction(esClient, {
     id: actionId,
     agents: [],

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags_action_runner.ts
@@ -6,16 +6,19 @@
  */
 
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
-
+import uuid from 'uuid';
 import { difference, uniq } from 'lodash';
 
 import type { Agent, BulkActionResult } from '../../types';
+
+import { appContextService } from '../app_context';
 
 import { ActionRunner } from './action_runner';
 
 import { errorsToResults, bulkUpdateAgents } from './crud';
 import { BulkActionTaskType } from './bulk_actions_resolver';
 import { filterHostedPolicies } from './filter_hosted_agents';
+import { bulkCreateAgentActionResults, createAgentAction } from './actions';
 
 export class UpdateAgentTagsActionRunner extends ActionRunner {
   protected async processAgents(agents: Agent[]): Promise<{ items: BulkActionResult[] }> {
@@ -24,7 +27,12 @@ export class UpdateAgentTagsActionRunner extends ActionRunner {
       this.esClient,
       agents,
       {},
-      { tagsToAdd: this.actionParams?.tagsToAdd, tagsToRemove: this.actionParams?.tagsToRemove },
+      {
+        tagsToAdd: this.actionParams?.tagsToAdd,
+        tagsToRemove: this.actionParams?.tagsToRemove,
+        actionId: this.actionParams.actionId,
+        total: this.actionParams.total,
+      },
       undefined,
       true
     );
@@ -47,6 +55,8 @@ export async function updateTagsBatch(
   options: {
     tagsToAdd: string[];
     tagsToRemove: string[];
+    actionId?: string;
+    total?: number;
   },
   agentIds?: string[],
   skipSuccess?: boolean
@@ -86,6 +96,44 @@ export async function updateTagsBatch(
       },
     }))
   );
+
+  const actionId = options.actionId ?? uuid();
+  const total = options.total ?? givenAgents.length;
+  const errorCount = Object.keys(errors).length;
+
+  // creating an action doc so that update tags  shows up in activity
+  await createAgentAction(esClient, {
+    id: actionId,
+    agents: [],
+    created_at: new Date().toISOString(),
+    type: 'UPDATE_TAGS',
+    total,
+  });
+  await bulkCreateAgentActionResults(
+    esClient,
+    filteredAgents.map((agent) => ({
+      agentId: agent.id,
+      actionId,
+    }))
+  );
+
+  if (errorCount > 0) {
+    appContextService
+      .getLogger()
+      .info(
+        `Skipping ${errorCount} agents, as failed validation (cannot modified tags on hosted agents)`
+      );
+
+    // writing out error result for those agents that failed validation, so the action is not going to stay in progress forever
+    await bulkCreateAgentActionResults(
+      esClient,
+      Object.keys(errors).map((agentId) => ({
+        agentId,
+        actionId,
+        error: errors[agentId].message,
+      }))
+    );
+  }
 
   return { items: errorsToResults(filteredAgents, errors, agentIds, skipSuccess) };
 }


### PR DESCRIPTION
## Summary

Fixing https://github.com/elastic/kibana/issues/136092

Similarly to force unenroll, added action doc on update tags action, and the corresponding success or error action results. This helps seeing the trace in Agent activity.

To verify:
- update tags on agents
- verify that the update tags action shows up in Agent activity

<img width="503" alt="image" src="https://user-images.githubusercontent.com/90178898/191724204-5307731b-ca55-4075-b842-5e0ae1c9bed4.png">

Added another improvement to update the selected list of tags immediately if the bulk update tags is async (for >10k agents). This helps to see the result immediately, because on the backend it takes 20-30s for the update tags to be done.

To verify:
- create >10k agent docs with `create_agents` script
- select all agents, apply a tag from the list
- check that the tag change is immediately visible in the list

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->