### PR TITLE
Fix Next and Previous button on step screenshot carousel.

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor/ping_list/columns/ping_timestamp/ping_timestamp.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor/ping_list/columns/ping_timestamp/ping_timestamp.tsx
@@ -63,8 +63,11 @@ export const PingTimestamp = ({
 
   const [screenshotRef, setScreenshotRef] = useState<ScreenshotRefImageData | undefined>(undefined);
 
+  const isScreenshotRefValid = Boolean(
+    screenshotRef && screenshotRef?.ref?.screenshotRef?.synthetics?.step?.index === stepNumber
+  );
   const { data, loading } = useInProgressImage({
-    hasImage: Boolean(stepImages[stepNumber - 1]) || Boolean(screenshotRef),
+    hasImage: Boolean(stepImages[stepNumber - 1]) || isScreenshotRefValid,
     hasIntersected: Boolean(intersection && intersection.intersectionRatio === 1),
     stepStatus,
     imgPath,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/139049

## Summary

Fixes the Step Screenshot Carousel (Next and Previous) buttons on step screenshots preview overlay. Please see the associated issue for reproduction and testing.

Note, this PR fixes the bug under Uptime whereas the fix under Synthetics has already been done in another feature PR.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->