### PR TITLE
[8.5] [Graph] Fix guidance panel appearing for a moment when saving Graph (#141228)

### DIFF
--- a/x-pack/plugins/graph/public/components/workspace_layout/workspace_layout.test.tsx
+++ b/x-pack/plugins/graph/public/components/workspace_layout/workspace_layout.test.tsx
@@ -11,9 +11,15 @@ import { WorkspaceLayoutComponent } from '.';
 import { coreMock } from '@kbn/core/public/mocks';
 import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import { NavigationPublicPluginStart as NavigationStart } from '@kbn/navigation-plugin/public';
-import { GraphSavePolicy, GraphWorkspaceSavedObject, IndexPatternProvider } from '../../types';
+import {
+  GraphSavePolicy,
+  GraphWorkspaceSavedObject,
+  IndexPatternProvider,
+  Workspace,
+} from '../../types';
 import { OverlayStart, Capabilities } from '@kbn/core/public';
 import { SharingSavedObjectProps } from '../../helpers/use_workspace_loader';
+import { GraphVisualization } from '../graph_visualization';
 
 jest.mock('react-router-dom', () => {
   const useLocation = () => ({
@@ -45,6 +51,7 @@ describe('workspace_layout', () => {
       aliasTargetId: '',
     } as SharingSavedObjectProps,
     spaces: spacesPluginMock.createStartContract(),
+    workspace: {} as unknown as Workspace,
   };
   it('should display conflict notification if outcome is conflict', () => {
     shallow(
@@ -59,5 +66,45 @@ describe('workspace_layout', () => {
       otherObjectId: 'conflictId',
       otherObjectPath: '#/workspace/conflictId?query={}',
     });
+  });
+  it('should not show GraphVisualization when workspaceInitialized is false, savedWorkspace.id is undefined, and savedWorkspace.isSaving is false', () => {
+    const component = shallow(
+      <WorkspaceLayoutComponent
+        {...defaultProps}
+        workspaceInitialized={false}
+        savedWorkspace={{ id: undefined, isSaving: false } as GraphWorkspaceSavedObject}
+      />
+    );
+    expect(component.find(GraphVisualization).exists()).toBe(false);
+  });
+  it('should show GraphVisualization when workspaceInitialized is true', () => {
+    const component = shallow(
+      <WorkspaceLayoutComponent
+        {...defaultProps}
+        workspaceInitialized={true}
+        savedWorkspace={{ id: undefined, isSaving: false } as GraphWorkspaceSavedObject}
+      />
+    );
+    expect(component.find(GraphVisualization).exists()).toBe(true);
+  });
+  it('should show GraphVisualization when savedWorkspace.id is defined', () => {
+    const component = shallow(
+      <WorkspaceLayoutComponent
+        {...defaultProps}
+        workspaceInitialized={false}
+        savedWorkspace={{ id: 'test', isSaving: false } as GraphWorkspaceSavedObject}
+      />
+    );
+    expect(component.find(GraphVisualization).exists()).toBe(true);
+  });
+  it('should show GraphVisualization when savedWorkspace.isSaving is true', () => {
+    const component = shallow(
+      <WorkspaceLayoutComponent
+        {...defaultProps}
+        workspaceInitialized={false}
+        savedWorkspace={{ id: undefined, isSaving: true } as GraphWorkspaceSavedObject}
+      />
+    );
+    expect(component.find(GraphVisualization).exists()).toBe(true);
   });
 });

--- a/x-pack/plugins/graph/public/components/workspace_layout/workspace_layout.tsx
+++ b/x-pack/plugins/graph/public/components/workspace_layout/workspace_layout.tsx
@@ -91,7 +91,11 @@ export const WorkspaceLayoutComponent = ({
   const search = useLocation().search;
   const urlQuery = new URLSearchParams(search).get('query');
 
-  const isInitialized = Boolean(workspaceInitialized || savedWorkspace.id);
+  // savedWorkspace.id gets set to null while saving a copy of an existing
+  // workspace, so we need to check for savedWorkspace.isSaving as well
+  const isInitialized = Boolean(
+    workspaceInitialized || savedWorkspace.id || savedWorkspace.isSaving
+  );
 
   const selectSelected = useCallback((node: WorkspaceNode) => {
     selectedNode.current = node;

--- a/x-pack/plugins/graph/public/helpers/saved_workspace_utils.test.ts
+++ b/x-pack/plugins/graph/public/helpers/saved_workspace_utils.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { GraphWorkspaceSavedObject } from '../types';
+import { saveSavedWorkspace } from './saved_workspace_utils';
+
+const core = coreMock.createStart();
+
+describe('saved_workspace_utils', () => {
+  describe('saveSavedWorkspace', () => {
+    it('should delete the savedWorkspace id and set isSaving to true immediately when copyOnSave is true', async () => {
+      const savedWorkspace = {
+        id: '123',
+        title: 'my workspace',
+        lastSavedTitle: 'my workspace',
+        migrationVersion: {},
+        wsState: '{ "indexPattern": "my-index-pattern" }',
+        getEsType: () => 'graph-workspace',
+        copyOnSave: true,
+        isSaving: false,
+      } as GraphWorkspaceSavedObject;
+      const promise = saveSavedWorkspace(
+        savedWorkspace,
+        {},
+        {
+          savedObjectsClient: {
+            ...core.savedObjects.client,
+            find: jest.fn().mockResolvedValue({ savedObjects: [] }),
+            create: jest.fn().mockResolvedValue({ id: '456' }),
+          },
+          overlays: core.overlays,
+        }
+      );
+      expect(savedWorkspace.id).toBe(undefined);
+      expect(savedWorkspace.isSaving).toBe(true);
+      const id = await promise;
+      expect(id).toBe('456');
+      expect(savedWorkspace.id).toBe('456');
+      expect(savedWorkspace.isSaving).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Graph] Fix guidance panel appearing for a moment when saving Graph (#141228)](https://github.com/elastic/kibana/pull/141228)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2022-09-22T13:22:18Z","message":"[Graph] Fix guidance panel appearing for a moment when saving Graph (#141228)\n\n* [Discover] Fix issue where workspace switches to uninitialized briefly when saving as copy in Graph\r\n\r\n* [Graph] Add Jest tests for Graph workspace saving bug","sha":"b026d2c84d25be61293dd2212c29780efedafceb","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Feature:Graph","Team:DataDiscovery","v8.5.0","v8.6.0"],"number":141228,"url":"https://github.com/elastic/kibana/pull/141228","mergeCommit":{"message":"[Graph] Fix guidance panel appearing for a moment when saving Graph (#141228)\n\n* [Discover] Fix issue where workspace switches to uninitialized briefly when saving as copy in Graph\r\n\r\n* [Graph] Add Jest tests for Graph workspace saving bug","sha":"b026d2c84d25be61293dd2212c29780efedafceb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/141428","number":141428,"state":"OPEN"},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/141228","number":141228,"mergeCommit":{"message":"[Graph] Fix guidance panel appearing for a moment when saving Graph (#141228)\n\n* [Discover] Fix issue where workspace switches to uninitialized briefly when saving as copy in Graph\r\n\r\n* [Graph] Add Jest tests for Graph workspace saving bug","sha":"b026d2c84d25be61293dd2212c29780efedafceb"}}]}] BACKPORT-->