### PR TITLE
[journeys] add a short delay after loading data

### DIFF
--- a/packages/kbn-journeys/journey/journey_ftr_harness.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_harness.ts
@@ -120,12 +120,19 @@ export class JourneyFtrHarness {
     await Promise.all([
       this.setupApm(),
       this.setupBrowserAndPage(),
-      asyncForEach(this.journeyConfig.getEsArchives(), async (esArchive) => {
-        await this.esArchiver.load(esArchive);
-      }),
-      asyncForEach(this.journeyConfig.getKbnArchives(), async (kbnArchive) => {
-        await this.kibanaServer.importExport.load(kbnArchive);
-      }),
+      (async () => {
+        await Promise.all([
+          asyncForEach(this.journeyConfig.getEsArchives(), async (esArchive) => {
+            await this.esArchiver.load(esArchive);
+          }),
+          asyncForEach(this.journeyConfig.getKbnArchives(), async (kbnArchive) => {
+            await this.kibanaServer.importExport.load(kbnArchive);
+          }),
+        ]);
+
+        // wait after loading the data, before doing any querying in tests
+        await setTimeout(10_000);
+      })(),
     ]);
   }
 


### PR DESCRIPTION
Our journeys saw a marked change in performance this morning after https://github.com/elastic/kibana/pull/140680 was merged. This PR shouldn't have made any impact on the performance, so we're trying to find the minor differences and understand what might have caused this. In several metrics we're seeing "time to data" stats increase, and one thing that might be causing this the the fact that we used to load esArchives and kbnArchives during service initialization, but now we're loading these archives in a `before()` hook.

I think this might be why queries run a little slower, maybe we should wait a little bit after indexing the data?

In order to try and reproduce this situation I'd like to add a 10 second delay after loading esArchives and kbnArchives and see if that impacts times at all.