### PR TITLE
[Fleet] Do not set ignore_above for index:false

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -6,12 +6,12 @@ exports[`EPM template tests loading base.yml: base.yml 1`] = `
     "user": {
       "properties": {
         "auid": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 1024
         },
         "euid": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 1024
         }
       }
     },
@@ -32,12 +32,12 @@ exports[`EPM template tests loading base.yml: base.yml 1`] = `
     "nested": {
       "properties": {
         "bar": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 1024
         },
         "baz": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 1024
         }
       }
     },
@@ -115,8 +115,8 @@ exports[`EPM template tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
     "coredns": {
       "properties": {
         "id": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "keyword",
+          "ignore_above": 1024
         },
         "query": {
           "properties": {
@@ -124,28 +124,28 @@ exports[`EPM template tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
               "type": "long"
             },
             "class": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             }
           }
         },
         "response": {
           "properties": {
             "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "flags": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "size": {
               "type": "long"
@@ -439,12 +439,12 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         "diskio": {
           "properties": {
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "read": {
               "properties": {
@@ -573,16 +573,16 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
               "type": "long"
             },
             "device_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "mount_point": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "files": {
               "type": "long"
@@ -797,8 +797,8 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         "network": {
           "properties": {
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "out": {
               "properties": {
@@ -876,12 +876,12 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         "process": {
           "properties": {
             "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "cmdline": {
-              "ignore_above": 2048,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 2048
             },
             "cpu": {
               "properties": {
@@ -967,22 +967,22 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
             "cgroup": {
               "properties": {
                 "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 },
                 "path": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 },
                 "cpu": {
                   "properties": {
                     "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "cfs": {
                       "properties": {
@@ -1045,12 +1045,12 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
                 "cpuacct": {
                   "properties": {
                     "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "total": {
                       "properties": {
@@ -1082,12 +1082,12 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
                 "memory": {
                   "properties": {
                     "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "mem": {
                       "properties": {
@@ -1306,12 +1306,12 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
                 "blkio": {
                   "properties": {
                     "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "keyword",
+                      "ignore_above": 1024
                     },
                     "total": {
                       "properties": {
@@ -1360,20 +1360,20 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         "raid": {
           "properties": {
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "status": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "level": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "sync_action": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "disks": {
               "properties": {
@@ -1424,24 +1424,24 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
                   "type": "long"
                 },
                 "host": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 },
                 "etld_plus_one": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 },
                 "host_error": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 }
               }
             },
             "process": {
               "properties": {
                 "cmdline": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "keyword",
+                  "ignore_above": 1024
                 }
               }
             },
@@ -1536,42 +1536,42 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         "users": {
           "properties": {
             "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "seat": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "service": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "remote": {
               "type": "boolean"
             },
             "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "scope": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "leader": {
               "type": "long"
             },
             "remote_host": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             }
           }
         }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
@@ -8,6 +8,7 @@
 import type { Field } from '../../fields/field';
 
 const DEFAULT_SCALING_FACTOR = 1000;
+const DEFAULT_IGNORE_ABOVE = 1024;
 
 interface Properties {
   [key: string]: any;
@@ -43,6 +44,30 @@ export function scaledFloat(field: Field): Properties {
 export function histogram(field: Field): Properties {
   const fieldProps = getDefaultProperties(field);
   fieldProps.type = 'histogram';
+
+  return fieldProps;
+}
+
+export function keyword(field: Field): Properties {
+  const fieldProps = getDefaultProperties(field);
+  fieldProps.type = 'keyword';
+
+  if (field.ignore_above) {
+    fieldProps.ignore_above = field.ignore_above;
+  } else {
+    fieldProps.ignore_above = DEFAULT_IGNORE_ABOVE;
+  }
+  if (field.normalizer) {
+    fieldProps.normalizer = field.normalizer;
+  }
+  if (field.dimension) {
+    fieldProps.time_series_dimension = field.dimension;
+    delete fieldProps.ignore_above;
+  }
+
+  if (field.index === false || field.doc_values === false) {
+    delete fieldProps.ignore_above;
+  }
 
   return fieldProps;
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -177,7 +177,6 @@ describe('EPM template', () => {
     const keywordWithIndexFalseMapping = {
       properties: {
         keywordIndexFalse: {
-          ignore_above: 1024,
           type: 'keyword',
           doc_values: false,
         },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -371,23 +371,6 @@ function generateMultiFields(fields: Fields): MultiFields {
   return multiFields;
 }
 
-function generateKeywordMapping(field: Field): IndexTemplateMapping {
-  const mapping: IndexTemplateMapping = {
-    ignore_above: DEFAULT_IGNORE_ABOVE,
-  };
-  if (field.index !== false && field.doc_values !== false && field.ignore_above) {
-    mapping.ignore_above = field.ignore_above;
-  }
-  if (field.normalizer) {
-    mapping.normalizer = field.normalizer;
-  }
-  if (field.dimension) {
-    mapping.time_series_dimension = field.dimension;
-    delete mapping.ignore_above;
-  }
-  return mapping;
-}
-
 function generateTextMapping(field: Field): IndexTemplateMapping {
   const mapping: IndexTemplateMapping = {};
   if (field.analyzer) {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -24,7 +24,7 @@ import {
 import { getESAssetMetadata } from '../meta';
 import { retryTransientEsErrors } from '../retry';
 
-import { getDefaultProperties, histogram, scaledFloat } from './mappings';
+import { getDefaultProperties, histogram, keyword, scaledFloat } from './mappings';
 
 interface Properties {
   [key: string]: any;
@@ -261,8 +261,7 @@ function _generateMappings(
             fieldProps = { ...fieldProps, ...generateDynamicAndEnabled(field), type: 'object' };
             break;
           case 'keyword':
-            const keywordMapping = generateKeywordMapping(field);
-            fieldProps = { ...fieldProps, ...keywordMapping, type: 'keyword' };
+            fieldProps = keyword(field);
             if (field.multi_fields) {
               fieldProps.fields = generateMultiFields(field.multi_fields);
             }
@@ -359,7 +358,7 @@ function generateMultiFields(fields: Fields): MultiFields {
           multiFields[f.name] = { ...generateTextMapping(f), type: f.type };
           break;
         case 'keyword':
-          multiFields[f.name] = { ...generateKeywordMapping(f), type: f.type };
+          multiFields[f.name] = keyword(f);
           break;
         case 'long':
         case 'double':
@@ -376,7 +375,7 @@ function generateKeywordMapping(field: Field): IndexTemplateMapping {
   const mapping: IndexTemplateMapping = {
     ignore_above: DEFAULT_IGNORE_ABOVE,
   };
-  if (field.ignore_above) {
+  if (field.index !== false && field.doc_values !== false && field.ignore_above) {
     mapping.ignore_above = field.ignore_above;
   }
   if (field.normalizer) {


### PR DESCRIPTION
## Summary

Resolve #136982

When we generate `keyword` mappings we should not set `ignore_above` for field with `index:false` or `doc_values:false`
That PR fix that, and did some refacto to allow better unit testing.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->