### PR TITLE
[ResponseOps][Cases] Fix duplicate alerts test

### DIFF
--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
@@ -55,8 +55,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  // Failing: See https://github.com/elastic/kibana/issues/139626
-  describe.skip('find_cases', () => {
+  describe('find_cases', () => {
     describe('basic tests', () => {
       afterEach(async () => {
         await deleteAllCaseItems(es);
@@ -350,7 +349,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await deleteAllCaseItems(es);
       });
 
-      it('correctly counts alerts ignoring duplicates', async () => {
+      it.only('correctly counts alerts ignoring duplicates', async () => {
         const postedCase = await createCase(supertest, postCaseReq);
         /**
          * Adds three comments of type alerts.
@@ -369,6 +368,11 @@ export default ({ getService }: FtrProviderContext): void => {
               owner: 'securitySolutionFixture',
             },
           });
+
+          // There is potential for the alert index to not be refreshed by the time the second comment is created
+          // which could attempt to update the alert status again and will encounter a conflict so this will
+          // ensure that the index is up to date before we try to update the next alert status
+          await es.indices.refresh({ index: defaultSignalsIndex });
         }
 
         const patchedCase = await createComment({

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
@@ -349,7 +349,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await deleteAllCaseItems(es);
       });
 
-      it.only('correctly counts alerts ignoring duplicates', async () => {
+      it('correctly counts alerts ignoring duplicates', async () => {
         const postedCase = await createCase(supertest, postCaseReq);
         /**
          * Adds three comments of type alerts.


### PR DESCRIPTION
This PR fixes a flaky test that I believe was failing because the Elasticsearch index was not being refreshed before another update request is being made.

Fixes: https://github.com/elastic/kibana/issues/138540
Fixes: https://github.com/elastic/kibana/issues/139626

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1291

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->