### PR TITLE
[ftr/startServers] resolve relative config arguments at CLI

### DIFF
--- a/packages/kbn-test/src/functional_tests/start_servers/flags.test.ts
+++ b/packages/kbn-test/src/functional_tests/start_servers/flags.test.ts
@@ -6,12 +6,18 @@
  * Side Public License, v 1.
  */
 
+import Path from 'path';
+
 import { getFlags, FlagsReader } from '@kbn/dev-cli-runner';
 import { createAnyInstanceSerializer, createAbsolutePathSerializer } from '@kbn/jest-serializers';
+import { REPO_ROOT } from '@kbn/utils';
+
 import { EsVersion } from '../../functional_test_runner';
 import { parseFlags, FLAG_OPTIONS } from './flags';
 
 jest.mock('uuid', () => ({ v4: () => 'some-uuid' }));
+
+const cwdMock = (process.cwd = jest.fn().mockReturnValue(REPO_ROOT));
 
 expect.addSnapshotSerializer(
   createAnyInstanceSerializer(EsVersion, (v: EsVersion) => `EsVersion ${v.toString()}`)
@@ -23,10 +29,27 @@ const defaults = getFlags(['--config=foo'], FLAG_OPTIONS);
 const test = (opts: Record<string, string | string[] | boolean | undefined>) =>
   parseFlags(new FlagsReader({ ...defaults, ...opts }));
 
+beforeEach(() => {
+  cwdMock.mockReturnValue(REPO_ROOT);
+});
+
 it('parses a subset of the flags from runTests', () => {
   expect(test({ config: 'foo' })).toMatchInlineSnapshot(`
     Object {
-      "config": "foo",
+      "config": <absolute path>/foo,
+      "esFrom": undefined,
+      "esVersion": <EsVersion 9.9.9>,
+      "installDir": undefined,
+      "logsDir": undefined,
+    }
+  `);
+});
+
+it('respects the cwd of the script', () => {
+  cwdMock.mockReturnValue(Path.resolve(REPO_ROOT, 'x-pack'));
+  expect(test({ config: 'foo' })).toMatchInlineSnapshot(`
+    Object {
+      "config": <absolute path>/x-pack/foo,
       "esFrom": undefined,
       "esVersion": <EsVersion 9.9.9>,
       "installDir": undefined,

--- a/packages/kbn-test/src/functional_tests/start_servers/flags.ts
+++ b/packages/kbn-test/src/functional_tests/start_servers/flags.ts
@@ -31,8 +31,8 @@ export const FLAG_OPTIONS: FlagOptions = {
 
 export function parseFlags(flags: FlagsReader) {
   const configs = [
-    ...(flags.arrayOfStrings('config') ?? []),
-    ...(flags.arrayOfStrings('journey') ?? []),
+    ...(flags.arrayOfPaths('config') ?? []),
+    ...(flags.arrayOfPaths('journey') ?? []),
   ];
   if (configs.length !== 1) {
     throw createFlagError(`expected exactly one --config or --journey flag`);


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/140680 I introduced a bug that caused `node scripts/functional_tests_server` to not resolve relative paths correctly. This PR ensures that `--config` and `--journey` arguments are resolved based on the cwd of the process at the CLI so that we're passing around absolute paths, making it irrelevant where the script is called from.