### PR TITLE
[Lens] Improve performance for large formulas

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/math.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/math.test.ts
@@ -1,0 +1,352 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TinymathAST } from '@kbn/tinymath';
+import { IndexPattern } from '../../../../types';
+import { IndexPatternLayer } from '../../../types';
+import { MathIndexPatternColumn, mathOperation } from './math';
+
+function createLayerWithMathColumn(tinymathAst: string | TinymathAST): IndexPatternLayer {
+  return {
+    columnOrder: ['myColumnId'],
+    columns: {
+      myColumnId: {
+        label: 'Math',
+        dataType: 'number',
+        operationType: 'math',
+        isBucketed: false,
+        scale: 'ratio',
+        params: {
+          tinymathAst,
+        },
+        references: [],
+      } as MathIndexPatternColumn,
+    },
+    // Each layer is tied to the index pattern that created it
+    indexPatternId: 'myIndexPattern',
+  };
+}
+
+describe('math operation', () => {
+  describe('toExpression / formula rewrite', () => {
+    it('should use primitive signs rather than function names for the 4 basic operations', () => {
+      const tinymathAst = {
+        type: 'function',
+        name: 'add',
+        args: [
+          {
+            type: 'function',
+            name: 'add',
+            args: [
+              {
+                type: 'function',
+                name: 'add',
+                args: [
+                  {
+                    type: 'function',
+                    name: 'add',
+                    args: [
+                      {
+                        type: 'function',
+                        name: 'add',
+                        args: [
+                          {
+                            type: 'function',
+                            name: 'add',
+                            args: [
+                              {
+                                type: 'function',
+                                name: 'add',
+                                args: [
+                                  {
+                                    type: 'function',
+                                    name: 'add',
+                                    args: [
+                                      {
+                                        type: 'function',
+                                        name: 'add',
+                                        args: [
+                                          {
+                                            type: 'function',
+                                            name: 'add',
+                                            args: [
+                                              {
+                                                type: 'function',
+                                                name: 'add',
+                                                args: [
+                                                  {
+                                                    type: 'function',
+                                                    name: 'add',
+                                                    args: [
+                                                      {
+                                                        type: 'function',
+                                                        name: 'add',
+                                                        args: [
+                                                          {
+                                                            type: 'function',
+                                                            name: 'add',
+                                                            args: [
+                                                              {
+                                                                type: 'function',
+                                                                name: 'add',
+                                                                args: [
+                                                                  {
+                                                                    type: 'function',
+                                                                    name: 'add',
+                                                                    args: ['columnX0', 'columnX1'],
+                                                                  },
+                                                                  'columnX2',
+                                                                ],
+                                                              },
+                                                              'columnX3',
+                                                            ],
+                                                          },
+                                                          'columnX4',
+                                                        ],
+                                                      },
+                                                      'columnX5',
+                                                    ],
+                                                  },
+                                                  'columnX6',
+                                                ],
+                                              },
+                                              'columnX7',
+                                            ],
+                                          },
+                                          'columnX8',
+                                        ],
+                                      },
+                                      'columnX9',
+                                    ],
+                                  },
+                                  'columnX10',
+                                ],
+                              },
+                              'columnX11',
+                            ],
+                          },
+                          'columnX12',
+                        ],
+                      },
+                      'columnX13',
+                    ],
+                  },
+                  'columnX14',
+                ],
+              },
+              'columnX15',
+            ],
+          },
+          'columnX16',
+        ],
+        location: {
+          min: 0,
+          max: 218,
+        },
+        text: 'sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes)',
+      } as unknown as TinymathAST;
+
+      const expression = mathOperation.toExpression(
+        createLayerWithMathColumn(tinymathAst),
+        'myColumnId',
+        {} as IndexPattern
+      );
+
+      expect(expression).toEqual([
+        {
+          type: 'function',
+          function: 'mathColumn',
+          arguments: {
+            id: ['myColumnId'],
+            name: ['Math'],
+            expression: [
+              '(((((((((((((((("columnX0" + "columnX1") + "columnX2") + "columnX3") + "columnX4") + "columnX5") + "columnX6") + "columnX7") + "columnX8") + "columnX9") + "columnX10") + "columnX11") + "columnX12") + "columnX13") + "columnX14") + "columnX15") + "columnX16")',
+            ],
+            onError: ['null'],
+          },
+        },
+      ]);
+    });
+
+    it('should preserve grouping when rewriting the formula', () => {
+      const tinymathAst = {
+        type: 'function',
+        name: 'add',
+        args: [
+          'columnX0',
+          {
+            type: 'function',
+            name: 'divide',
+            args: [
+              {
+                type: 'function',
+                name: 'subtract',
+                args: ['columnX1', 'columnX2'],
+                location: {
+                  min: 14,
+                  max: 37,
+                },
+                text: 'sum(bytes) - sum(bytes)',
+              },
+              {
+                type: 'function',
+                name: 'subtract',
+                args: [
+                  'columnX3',
+                  {
+                    type: 'function',
+                    name: 'multiply',
+                    args: ['columnX4', 'columnX5'],
+                    location: {
+                      min: 54,
+                      max: 78,
+                    },
+                    text: ' sum(bytes) * sum(bytes)',
+                  },
+                ],
+                location: {
+                  min: 42,
+                  max: 78,
+                },
+                text: 'sum(bytes) - sum(bytes) * sum(bytes)',
+              },
+            ],
+            location: {
+              min: 12,
+              max: 79,
+            },
+            text: ' (sum(bytes) - sum(bytes)) / (sum(bytes) - sum(bytes) * sum(bytes))',
+          },
+        ],
+        location: {
+          min: 0,
+          max: 79,
+        },
+        // Explicit grouping here
+        text: 'sum(bytes) + (sum(bytes) - sum(bytes)) / (sum(bytes) - sum(bytes) * sum(bytes))',
+      } as unknown as TinymathAST;
+
+      const expression = mathOperation.toExpression(
+        createLayerWithMathColumn(tinymathAst),
+        'myColumnId',
+        {} as IndexPattern
+      );
+
+      expect(expression).toEqual([
+        {
+          type: 'function',
+          function: 'mathColumn',
+          arguments: {
+            id: ['myColumnId'],
+            name: ['Math'],
+            expression: [
+              `("columnX0" + (("columnX1" - "columnX2") / ("columnX3" - ("columnX4" * "columnX5"))))`,
+            ],
+            onError: ['null'],
+          },
+        },
+      ]);
+    });
+
+    it('should keep not optimizable functions as is', () => {
+      const tinymathAst = {
+        type: 'function',
+        name: 'pick_max',
+        args: [
+          {
+            type: 'function',
+            name: 'pick_min',
+            args: ['columnX0', 'columnX1'],
+            location: {
+              min: 9,
+              max: 41,
+            },
+            text: 'pick_min(sum(bytes), sum(bytes))',
+          },
+          {
+            type: 'function',
+            name: 'abs',
+            args: ['columnX2'],
+            location: {
+              min: 43,
+              max: 58,
+            },
+            text: 'abs(sum(bytes))',
+          },
+        ],
+        location: {
+          min: 0,
+          max: 59,
+        },
+        text: 'pick_max(pick_min(sum(bytes), sum(bytes)), abs(sum(bytes)))',
+      } as unknown as TinymathAST;
+
+      const expression = mathOperation.toExpression(
+        createLayerWithMathColumn(tinymathAst),
+        'myColumnId',
+        {} as IndexPattern
+      );
+
+      expect(expression).toEqual([
+        {
+          type: 'function',
+          function: 'mathColumn',
+          arguments: {
+            id: ['myColumnId'],
+            name: ['Math'],
+            expression: [`max(min("columnX0","columnX1"),abs("columnX2"))`],
+            onError: ['null'],
+          },
+        },
+      ]);
+    });
+
+    it('should work with literals', () => {
+      const tinymathAst = {
+        type: 'function',
+        name: 'add',
+        args: [
+          5,
+          {
+            type: 'function',
+            name: 'divide',
+            args: [3, 8],
+            location: {
+              min: 3,
+              max: 9,
+            },
+            text: ' 3 / 8',
+          },
+        ],
+        location: {
+          min: 0,
+          max: 9,
+        },
+        text: '5 + 3 / 8',
+      } as TinymathAST;
+
+      const expression = mathOperation.toExpression(
+        createLayerWithMathColumn(tinymathAst),
+        'myColumnId',
+        {} as IndexPattern
+      );
+
+      expect(expression).toEqual([
+        {
+          type: 'function',
+          function: 'mathColumn',
+          arguments: {
+            id: ['myColumnId'],
+            name: ['Math'],
+            expression: [`(5 + (3 / 8))`],
+            onError: ['null'],
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/math.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/math.tsx
@@ -72,6 +72,13 @@ export const mathOperation: OperationDefinition<MathIndexPatternColumn, 'managed
   },
 };
 
+const optimizableFnsMap: Record<string, string> = {
+  add: '+',
+  subtract: '-',
+  multiply: '*',
+  divide: '/',
+};
+
 function astToString(ast: TinymathAST | string): string | number {
   if (typeof ast === 'number') {
     return ast;
@@ -88,6 +95,10 @@ function astToString(ast: TinymathAST | string): string | number {
       return `${ast.name}='${ast.value}'`;
     }
     return `${ast.name}=${ast.value}`;
+  }
+  if (optimizableFnsMap[ast.name]) {
+    // make sure to preserve the right grouping here adding explicit brackets
+    return `(${ast.args.map(astToString).join(` ${optimizableFnsMap[ast.name]} `)})`;
   }
   return `${getUnprefixedName(ast.name)}(${ast.args.map(astToString).join(',')})`;
 }


### PR DESCRIPTION
## Summary

Fixes #140875

Formulas are parsed multiple times during their own lifecycle before rendering, but somehow the expression parsing step seems to be very slow (really slow!):

![tinymath_performance_explanation](https://user-images.githubusercontent.com/924948/191779069-cc8f1825-77f2-4f0d-8cdb-4555fa12a9da.png)

Check in particular the aggregated time of 5,96 seconds (!) for this basic formulas like this:

```
sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes)
```

As noted in the linked issue that formula is rewritten as this new formula:

```
add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add("3e090ea6-3faa-4941-902d-19bed42ead83X0","3e090ea6-3faa-4941-902d-19bed42ead83X1"),"3e090ea6-3faa-4941-902d-19bed42ead83X2"),"3e090ea6-3faa-4941-902d-19bed42ead83X3"),"3e090ea6-3faa-4941-902d-19bed42ead83X4"),"3e090ea6-3faa-4941-902d-19bed42ead83X5"),"3e090ea6-3faa-4941-902d-19bed42ead83X6"),"3e090ea6-3faa-4941-902d-19bed42ead83X7"),"3e090ea6-3faa-4941-902d-19bed42ead83X8"),"3e090ea6-3faa-4941-902d-19bed42ead83X9"),"3e090ea6-3faa-4941-902d-19bed42ead83X10"),"3e090ea6-3faa-4941-902d-19bed42ead83X11"),"3e090ea6-3faa-4941-902d-19bed42ead83X12"),"3e090ea6-3faa-4941-902d-19bed42ead83X13"),"3e090ea6-3faa-4941-902d-19bed42ead83X14"),"3e090ea6-3faa-4941-902d-19bed42ead83X15"),"3e090ea6-3faa-4941-902d-19bed42ead83X16")
```

After this rewriting performances get really bad, probably [due to some recursion issue in the peg(gy) library](https://github.com/pegjs/pegjs/issues/623) used to generate the parser from the grammar - or rather non idiomatic way the tinymath grammar has been written.
Rewriting the grammar seemed not a trivial task, therefore the way the formula is rewritten has been targeted.

The idea here is to "flatten" the rewritten formula, but only the `add` function accepts more than 2 arguments (i.e. `add( arg1, arg2, arg3, arg4, ....)`). The intuition is that the first parsing timings were pretty good, so why not reuse the same technique there?
So here's the PR implementation to use the `+`/`-`/`*`/`/` math operations instead of their long versions, which proved to be way faster: in fact the grammar is highly optimized to parse those 4 symbols vs the functions counterpart.

New implementation is now in line with the monaco editor performance with few ms of parsing time (see overall timing of ~15ms!):

<img width="434" alt="Screenshot 2022-09-22 at 16 44 46" src="https://user-images.githubusercontent.com/924948/191780901-74606372-36c5-4883-a070-9825ba098cc3.png">

Taking as example the previous formula:

```
sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes) + sum(bytes)
```

The new rewrite will be something like:

```
(((((((((((((((("c87d5ed7-39f7-46f0-b81c-f04938586c17X0" + "c87d5ed7-39f7-46f0-b81c-f04938586c17X1") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X2") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X3") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X4") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X5") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X6") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X7") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X8") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X9") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X10") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X11") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X12") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X13") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X14") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X15") + "c87d5ed7-39f7-46f0-b81c-f04938586c17X16")
```

Round brackets in the new rewrite are used to preserve the original explicit grouping (i.e. `sum(bytes) + (sum(bytes) - sum(bytes)) / (sum(bytes) - sum(bytes) * sum(bytes))`) and avoid issues.

From user perspective results will appear now few seconds earlier.

Before:

![large_formula_fix_before](https://user-images.githubusercontent.com/924948/191781121-af782148-94bf-4644-9fb5-f328df1c07e7.gif)

After:

![large_formula_fix_add](https://user-images.githubusercontent.com/924948/191781168-d12aa873-e876-4e6a-ad00-ac60dd856129.gif)

This fix does not affect only single operations cases (as in the issue example), rather any mixed combination of the 4 basic operations:

![large_formula_fix](https://user-images.githubusercontent.com/924948/191781330-93d47dd3-6764-4e7a-9300-1cadc0c3f092.gif)

**Note** this is only a client side parsing step optimization. For further formulas requests optimization see #140859

**Note 2** this fix is not a general solution for nesting performance issue, which has to be tackled at grammar level. A formula like the following will still suffer of performance issues: ```pick_min(pick_max(abs(sqrt(log(fix(floor(sum(bytes)))))), 5), 10)```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
