### PR TITLE
MongoDB Native Connector sync failing - Direct_connection configurabl…

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
@@ -57,6 +57,15 @@ export const NATIVE_CONNECTORS: NativeConnector[] = [
           }
         ),
       },
+      direct_connection: {
+        value: '',
+        label: i18n.translate(
+          'xpack.enterpriseSearch.content.nativeConnectors.mongodb.configuration.directConnectionLabel',
+          {
+            defaultMessage: 'Use direct connection (true/false)',
+          }
+        ),
+      },
     },
     name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.mongodb.name', {
       defaultMessage: 'MongoDB',


### PR DESCRIPTION
## Summary

MongoDB Native Connector sync failing - Direct_connection configurable field missing on Kibana side
https://github.com/elastic/enterprise-search-team/issues/2839

## Related PR for BE

* https://github.com/elastic/connectors-ruby/pull/337


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->