### PR TITLE
[Fleet] Check bundled packages when querying package info in getInfo API

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -158,9 +158,7 @@ describe('fetch package', () => {
 });
 
 describe('getLicensePath', () => {
-  beforeEach(() => {
-    MockArchive.getPathParts = jest.requireActual('../archive').getPathParts;
-  });
+  MockArchive.getPathParts = jest.requireActual('../archive').getPathParts;
 
   it('returns first license path if found', () => {
     const path = getLicensePath([

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -7,12 +7,15 @@
 
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 
-import { PackageNotFoundError } from '../../../errors';
+import { PackageNotFoundError, RegistryResponseError } from '../../../errors';
+
+import * as Archive from '../archive';
 
 import {
   splitPkgKey,
   fetchFindLatestPackageOrUndefined,
   fetchFindLatestPackageOrThrow,
+  fetchInfo,
   getLicensePath,
 } from '.';
 
@@ -21,6 +24,11 @@ const mockLogger = mockLoggerFactory.get('mock logger');
 
 const mockGetBundledPackageByName = jest.fn();
 const mockFetchUrl = jest.fn();
+
+const MockArchive = Archive as jest.Mocked<typeof Archive>;
+
+jest.mock('../archive');
+
 jest.mock('../..', () => ({
   appContextService: {
     getLogger: () => mockLogger,
@@ -150,6 +158,10 @@ describe('fetch package', () => {
 });
 
 describe('getLicensePath', () => {
+  beforeEach(() => {
+    MockArchive.getPathParts = jest.requireActual('../archive').getPathParts;
+  });
+
   it('returns first license path if found', () => {
     const path = getLicensePath([
       '/package/good-1.0.0/NOTICE.txt',
@@ -169,5 +181,42 @@ describe('getLicensePath', () => {
       '/package/good-1.0.0/docs/README.md',
     ]);
     expect(path).toEqual(undefined);
+  });
+});
+
+describe('fetchInfo', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockFetchUrl.mockRejectedValueOnce(new RegistryResponseError('Not found', 404));
+    mockGetBundledPackageByName.mockResolvedValueOnce({
+      name: 'test-package',
+      version: '1.0.0',
+      buffer: Buffer.from(''),
+    });
+    MockArchive.generatePackageInfoFromArchiveBuffer.mockResolvedValueOnce({
+      paths: [],
+      packageInfo: {
+        name: 'test-package',
+        title: 'Test Package',
+        version: '1.0.0',
+        description: 'Test package',
+        owner: { github: 'elastic' },
+        format_version: '1.0.0',
+      },
+    });
+  });
+
+  it('falls back to bundled package when one exists', async () => {
+    const fetchedInfo = await fetchInfo('test-package', '1.0.0');
+    expect(fetchedInfo).toBeTruthy();
+  });
+
+  it('throws when no corresponding bundled package exists', async () => {
+    try {
+      await fetchInfo('test-package', '1.0.0');
+    } catch (e) {
+      expect(e).toBeInstanceOf(PackageNotFoundError);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/139567

Check bundled packages on disk for the exact name/version of a given package when requesting packages through the `get package info` Fleet API.

## To test

- Add bundled packages to `x-pack/plugins/fleet/target` directory (see detailed steps in linked PR)
- Make a request to the `get package info` API without a version specified
- Ensure the latest version of the package returned is the bundled one so long as its semver exceeds the latest package from the registry

```
GET http://localhost:5601/kyle/api/fleet/epm/packages/apm
User-Agent: vscode-restclient
Authorization: Basic elastic:changeme
Content-Type: application/json
kbn-xsrf: xxx
```

![image](https://user-images.githubusercontent.com/6766512/191786583-1a82169d-e7fc-40f0-bc96-1cddd0d6b9c1.png)

cc @sqren 

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->