### PR TITLE
[APM] Adding telemetry to General settings and Labs

### DIFF
--- a/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
@@ -46,7 +46,7 @@ export function GeneralSettings() {
       const reloadPage = Object.keys(unsavedChanges).some((key) => {
         return settingsEditableConfig[key].requiresPageReload;
       });
-      await saveAll();
+      await saveAll({ trackMetricName: 'general_settings_save' });
       if (reloadPage) {
         window.location.reload();
       }

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/index.tsx
@@ -7,11 +7,19 @@
 
 import { EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useUiTracker } from '@kbn/observability-plugin/public';
 import { LabsFlyout } from './labs_flyout';
 
 export function Labs() {
   const [isOpen, setIsOpen] = useState(false);
+  const trackApmEvent = useUiTracker({ app: 'apm' });
+
+  useEffect(() => {
+    if (isOpen) {
+      trackApmEvent({ metric: 'labs_open' });
+    }
+  }, [isOpen, trackApmEvent]);
 
   function toggleFlyoutVisibility() {
     setIsOpen((state) => !state);

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/labs_flyout.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/labs/labs_flyout.tsx
@@ -54,7 +54,7 @@ export function LabsFlyout({ onClose }: Props) {
         return settingsEditableConfig[key].requiresPageReload;
       });
 
-      await saveAll();
+      await saveAll({ trackMetricName: 'labs_save' });
 
       if (reloadPage) {
         window.location.reload();


### PR DESCRIPTION
These actions are tracked:

- When the save button is clicked on the new General settings page
- When the Labs flyout is opened.
- When the save button is clicked on the Labs flyout.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->