### PR TITLE
[Enterprise Search] Fix page responsiveness for smaller screen sizes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -29,7 +29,7 @@ export const SearchIndexPipelines: React.FC = () => {
   return (
     <>
       <EuiSpacer />
-      <EuiFlexGroup direction="row">
+      <EuiFlexGroup direction="row" wrap>
         <EuiFlexItem grow={5}>
           <DataPanel
             hasBorder

--- a/x-pack/plugins/enterprise_search/public/applications/shared/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/data_panel/data_panel.tsx
@@ -66,7 +66,12 @@ export const DataPanel: React.FC<Props> = ({
       <EuiSplitPanel.Inner>
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow>
-            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexGroup
+              className="eui-textNoWrap"
+              gutterSize="s"
+              alignItems="center"
+              responsive={false}
+            >
               {iconType && (
                 <EuiFlexItem grow={false}>
                   <EuiIcon type={iconType} />


### PR DESCRIPTION
## Summary

These fixes makes page wrap properly on smaller devices. It will fix word breaks on header and make both cards wrap properly when they don't fit the page.


Previously: 

https://user-images.githubusercontent.com/1410658/191797145-2b8c9abc-5d1b-4e1e-8526-ffe8723139f2.mov

Fixed: 

https://user-images.githubusercontent.com/1410658/191797213-c2531f5f-b287-471c-b632-c44b477cf99e.mov




### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
