### PR TITLE
[ci/jest] use production react builds

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -55,8 +55,8 @@ module.exports = {
     // on CI, use the production build of react(-dom) which disables warning logging that nobody is paying attention to in CI anyway
     ...(process.env.CI
       ? {
-          react: '<rootDir>/node_modules/react/cjs/react.production.min.js',
-          'react-dom': '<rootDir>/node_modules/react-dom/cjs/react-dom.production.min.js',
+          '^react$': '<rootDir>/node_modules/react/cjs/react.production.min.js',
+          '^react-dom$': '<rootDir>/node_modules/react-dom/cjs/react-dom.production.min.js',
         }
       : {}),
   },

--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -52,6 +52,13 @@ module.exports = {
         `<rootDir>/${repoRelativeDir}$1`,
       ])
     ),
+    // on CI, use the production build of react(-dom) which disables warning logging that nobody is paying attention to in CI anyway
+    ...(process.env.CI
+      ? {
+          react: '<rootDir>/node_modules/react/cjs/react.production.min.js',
+          'react-dom': '<rootDir>/node_modules/react-dom/cjs/react-dom.production.min.js',
+        }
+      : {}),
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader


### PR DESCRIPTION
When running Jest in CI, there are a number of warnings logged which just muddy up the output and are never actually used. To disable these I'd like to force load the `react` and `react-dom` production builds using the Jest `moduleNameMapper` config.