### PR TITLE
Ensures the pipeline and ML panels are evenly sized

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -30,7 +30,7 @@ export const SearchIndexPipelines: React.FC = () => {
     <>
       <EuiSpacer />
       <EuiFlexGroup direction="row">
-        <EuiFlexItem>
+        <EuiFlexItem grow={5}>
           <DataPanel
             hasBorder
             footerDocLink={
@@ -64,7 +64,7 @@ export const SearchIndexPipelines: React.FC = () => {
             <IngestPipelinesCard />
           </DataPanel>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={5}>
           <DataPanel
             hasBorder
             footerDocLink={


### PR DESCRIPTION
## Summary

### Before
<img width="1152" alt="holler- Brave Browser-2022-09-22 at 11 23@2x" src="https://user-images.githubusercontent.com/739960/191823137-fa6c53ec-074f-4692-bb5c-55400c403544.png">

### After
<img width="1155" alt="holler- Brave Browser-2022-09-22 at 11 24@2x" src="https://user-images.githubusercontent.com/739960/191823206-04224c08-052d-444d-b444-f670da7b512b.png">

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->