### PR TITLE
[7.17] Removing esArchiver and using new data loader (#140807)

### DIFF
--- a/x-pack/test/spaces_api_integration/common/suites/resolve_copy_to_space_conflicts.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/resolve_copy_to_space_conflicts.ts
@@ -6,13 +6,13 @@
  */
 
 import expect from '@kbn/expect';
-import { SuperTest } from 'supertest';
-import { EsArchiver } from '@kbn/es-archiver';
 import { SavedObject } from 'src/core/server';
 import { DEFAULT_SPACE_ID } from '../../../../plugins/spaces/common/constants';
 import { CopyResponse } from '../../../../plugins/spaces/server/lib/copy_to_spaces';
 import { getUrlPrefix } from '../lib/space_test_utils';
 import { DescribeFn, TestDefinitionAuthentication } from '../lib/types';
+import { FtrProviderContext } from '../ftr_provider_context';
+import { getTestDataLoader } from '../lib/test_data_loader';
 
 type TestResponse = Record<string, any>;
 
@@ -51,11 +51,11 @@ const getDestinationSpace = (originSpaceId?: string) => {
   return DEFAULT_SPACE_ID;
 };
 
-export function resolveCopyToSpaceConflictsSuite(
-  esArchiver: EsArchiver,
-  supertestWithAuth: SuperTest<any>,
-  supertestWithoutAuth: SuperTest<any>
-) {
+export function resolveCopyToSpaceConflictsSuite(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertestWithAuth = context.getService('supertest');
+  const supertestWithoutAuth = context.getService('supertestWithoutAuth');
+
   const getVisualizationAtSpace = async (spaceId: string): Promise<SavedObject<any>> => {
     return supertestWithAuth
       .get(`${getUrlPrefix(spaceId)}/api/saved_objects/visualization/cts_vis_3`)
@@ -432,16 +432,8 @@ export function resolveCopyToSpaceConflictsSuite(
         });
 
         describe('single-namespace types', () => {
-          beforeEach(() =>
-            esArchiver.load(
-              'x-pack/test/spaces_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-            )
-          );
-          afterEach(() =>
-            esArchiver.unload(
-              'x-pack/test/spaces_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-            )
-          );
+          beforeEach(async () => await testDataLoader.beforeEach());
+          afterEach(async () => await testDataLoader.afterEach());
 
           const dashboardObject = { type: 'dashboard', id: 'cts_dashboard' };
           const visualizationObject = { type: 'visualization', id: 'cts_vis_3' };
@@ -530,16 +522,8 @@ export function resolveCopyToSpaceConflictsSuite(
         const includeReferences = false;
         const createNewCopies = false;
         describe(`multi-namespace types with "overwrite" retry`, () => {
-          before(() =>
-            esArchiver.load(
-              'x-pack/test/spaces_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-            )
-          );
-          after(() =>
-            esArchiver.unload(
-              'x-pack/test/spaces_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-            )
-          );
+          before(async () => await testDataLoader.beforeEach());
+          after(async () => await testDataLoader.afterEach());
 
           const testCases = tests.multiNamespaceTestCases();
           testCases.forEach(({ testTitle, objects, retries, statusCode, response }) => {

--- a/x-pack/test/spaces_api_integration/security_and_spaces/apis/resolve_copy_to_space_conflicts.ts
+++ b/x-pack/test/spaces_api_integration/security_and_spaces/apis/resolve_copy_to_space_conflicts.ts
@@ -11,11 +11,7 @@ import { resolveCopyToSpaceConflictsSuite } from '../../common/suites/resolve_co
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
-export default function resolveCopyToSpaceConflictsTestSuite({ getService }: FtrProviderContext) {
-  const supertestWithoutAuth = getService('supertestWithoutAuth');
-  const supertestWithAuth = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
+export default function resolveCopyToSpaceConflictsTestSuite(context: FtrProviderContext) {
   const {
     resolveCopyToSpaceConflictsTest,
     createExpectNonOverriddenResponseWithReferences,
@@ -28,7 +24,7 @@ export default function resolveCopyToSpaceConflictsTestSuite({ getService }: Ftr
     createExpectUnauthorizedAtSpaceWithoutReferencesResult,
     createMultiNamespaceTestCases,
     NON_EXISTENT_SPACE_ID,
-  } = resolveCopyToSpaceConflictsSuite(esArchiver, supertestWithAuth, supertestWithoutAuth);
+  } = resolveCopyToSpaceConflictsSuite(context);
 
   describe('resolve copy to spaces conflicts', () => {
     [

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/resolve_copy_to_space_conflicts.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/resolve_copy_to_space_conflicts.ts
@@ -5,15 +5,11 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { resolveCopyToSpaceConflictsSuite } from '../../common/suites/resolve_copy_to_space_conflicts';
 
 // eslint-disable-next-line import/no-default-export
-export default function resolveCopyToSpaceConflictsTestSuite({ getService }: FtrProviderContext) {
-  const supertestWithoutAuth = getService('supertestWithoutAuth');
-  const supertestWithAuth = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
+export default function resolveCopyToSpaceConflictsTestSuite(context: FtrProviderContext) {
   const {
     resolveCopyToSpaceConflictsTest,
     createExpectNonOverriddenResponseWithReferences,
@@ -23,7 +19,7 @@ export default function resolveCopyToSpaceConflictsTestSuite({ getService }: Ftr
     createMultiNamespaceTestCases,
     NON_EXISTENT_SPACE_ID,
     originSpaces,
-  } = resolveCopyToSpaceConflictsSuite(esArchiver, supertestWithAuth, supertestWithoutAuth);
+  } = resolveCopyToSpaceConflictsSuite(context);
 
   describe('resolve copy to spaces conflicts', () => {
     originSpaces.forEach((spaceId) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Removing esArchiver and using new data loader (#140807)](https://github.com/elastic/kibana/pull/140807)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-09-21T15:39:50Z","message":"Removing esArchiver and using new data loader (#140807)\n\n* Removing esArchiver and using new data loader\r\n\r\n* [CI] Auto-commit changed files from 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix'\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Thomas Watson <watson@elastic.co>","sha":"516b18fdacb9f8ad0c2dead20647d19e4610d02b","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v8.5.0","v8.4.3"],"number":140807,"url":"https://github.com/elastic/kibana/pull/140807","mergeCommit":{"message":"Removing esArchiver and using new data loader (#140807)\n\n* Removing esArchiver and using new data loader\r\n\r\n* [CI] Auto-commit changed files from 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix'\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Thomas Watson <watson@elastic.co>","sha":"516b18fdacb9f8ad0c2dead20647d19e4610d02b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.5.0","labelRegex":"^v8.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/140807","number":140807,"mergeCommit":{"message":"Removing esArchiver and using new data loader (#140807)\n\n* Removing esArchiver and using new data loader\r\n\r\n* [CI] Auto-commit changed files from 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix'\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Thomas Watson <watson@elastic.co>","sha":"516b18fdacb9f8ad0c2dead20647d19e4610d02b"}},{"branch":"8.4","label":"v8.4.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/141259","number":141259,"state":"MERGED","mergeCommit":{"sha":"87fe782094533238bb601b156553f96e1ae4aade","message":"Removing esArchiver and using new data loader (#140807) (#141259)\n\n* Removing esArchiver and using new data loader\n\n* [CI] Auto-commit changed files from 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix'\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Thomas Watson <watson@elastic.co>\n(cherry picked from commit 516b18fdacb9f8ad0c2dead20647d19e4610d02b)\n\nCo-authored-by: Kurt <kc13greiner@users.noreply.github.com>"}}]}] BACKPORT-->