### PR TITLE
[DOCS] Fix link in list of Kibana plugins

### DIFF
--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -660,7 +660,7 @@ in their infrastructure.
 
 |{kib-repo}blob/{branch}/x-pack/plugins/task_manager/README.md[taskManager]
 |The task manager is a generic system for running background tasks.
-Documentation: https://www.elastic.co/guide/en/kibana/master/task-manager-production-considerations.html
+Documentation: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/telemetry_collection_xpack/README.md[telemetryCollectionXpack]

--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -660,7 +660,6 @@ in their infrastructure.
 
 |{kib-repo}blob/{branch}/x-pack/plugins/task_manager/README.md[taskManager]
 |The task manager is a generic system for running background tasks.
-Documentation: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/telemetry_collection_xpack/README.md[telemetryCollectionXpack]

--- a/x-pack/plugins/task_manager/README.md
+++ b/x-pack/plugins/task_manager/README.md
@@ -1,7 +1,7 @@
 # Kibana task manager
 
 The task manager is a generic system for running background tasks.
-Documentation: https://www.elastic.co/guide/en/kibana/master/task-manager-production-considerations.html
+Documentation: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
 
 It supports:
 - Single-run and recurring tasks

--- a/x-pack/plugins/task_manager/README.md
+++ b/x-pack/plugins/task_manager/README.md
@@ -1,6 +1,7 @@
 # Kibana task manager
 
 The task manager is a generic system for running background tasks.
+
 Documentation: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
 
 It supports:


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/issues/2518, which is fixing hard-coded links to "master".

This PR changes the URL in the readme from "master" to "current". It also adds an end of line, so that the documentation link is not used in the [autogenerated plugin docs](https://www.elastic.co/guide/en/kibana/master/plugin-list.html#plugin-list).

<!--ONMERGE {"backportTargets":["7.12","7.13","7.14","7.15","7.16","7.17","8.0","8.1","8.2","8.3","8.4","8.5"]} ONMERGE-->