### PR TITLE
[Security Solution] Fix failing policy test by updating integration name

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
@@ -24,8 +24,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const policyTestResources = getService('policyTestResources');
   const endpointTestResources = getService('endpointTestResources');
 
-  // Failing: See https://github.com/elastic/kibana/issues/141532
-  describe.skip('When on the Endpoint Policy List Page', () => {
+  describe('When on the Endpoint Policy List Page', () => {
     before(async () => {
       const endpointPackage = await policyTestResources.getEndpointPackage();
       await endpointTestResources.setMetadataTransformFrequency('1s', endpointPackage.version);
@@ -42,7 +41,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await fleetButton.click();
         await testSubjects.existOrFail('createPackagePolicy_pageTitle');
         expect(await testSubjects.getVisibleText('createPackagePolicy_pageTitle')).to.equal(
-          'Add Endpoint and Cloud Security integration'
+          'Add Elastic Defend integration'
         );
       });
       it('navigates back to the policy list page', async () => {


### PR DESCRIPTION
## Summary

Fixes this failing test: https://github.com/elastic/kibana/issues/141532

We updated the integration policy name and it cause a test to fail.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->