### PR TITLE
[7.17] [ML] Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007)

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_anomalies_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_anomalies_container.tsx
@@ -32,6 +32,7 @@ interface ExplorerAnomaliesContainerProps {
   timefilter: TimefilterContract;
   onSelectEntity: (fieldName: string, fieldValue: string, operation: EntityFieldOperation) => void;
   showSelectedInterval?: boolean;
+  timeRange: { from: string; to: string } | undefined;
 }
 
 const tooManyBucketsCalloutMsg = i18n.translate(
@@ -53,6 +54,7 @@ export const ExplorerAnomaliesContainer: FC<ExplorerAnomaliesContainerProps> = (
   timefilter,
   onSelectEntity,
   showSelectedInterval,
+  timeRange,
 }) => {
   return (
     <>
@@ -84,6 +86,7 @@ export const ExplorerAnomaliesContainer: FC<ExplorerAnomaliesContainerProps> = (
               mlLocator,
               timeBuckets,
               timefilter,
+              timeRange,
               onSelectEntity,
               tooManyBucketsCalloutMsg,
               showSelectedInterval,

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -68,6 +68,7 @@ function ExplorerChartContainer({
   mlLocator,
   timeBuckets,
   timefilter,
+  timeRange,
   onSelectEntity,
   recentlyAccessed,
   tooManyBucketsCalloutMsg,
@@ -78,9 +79,24 @@ function ExplorerChartContainer({
   useEffect(() => {
     let isCancelled = false;
     const generateLink = async () => {
+      // Prioritize timeRange from embeddable panel or case
+      // Else use the time range from data plugins's timefilters service
+      let mergedTimeRange = timeRange;
+      const bounds = timefilter?.getActiveBounds();
+      if (!timeRange && bounds) {
+        mergedTimeRange = {
+          from: bounds.min.toISOString(),
+          to: bounds.max.toISOString(),
+        };
+      }
+
       if (!isCancelled && series.functionDescription !== ML_JOB_AGGREGATION.LAT_LONG) {
         try {
-          const singleMetricViewerLink = await getExploreSeriesLink(mlLocator, series, timefilter);
+          const singleMetricViewerLink = await getExploreSeriesLink(
+            mlLocator,
+            series,
+            mergedTimeRange
+          );
           setExplorerSeriesLink(singleMetricViewerLink);
         } catch (error) {
           setExplorerSeriesLink('');
@@ -91,7 +107,8 @@ function ExplorerChartContainer({
     return () => {
       isCancelled = true;
     };
-  }, [mlLocator, series]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mlLocator, series, timeRange]);
 
   const addToRecentlyAccessed = useCallback(() => {
     if (recentlyAccessed) {
@@ -237,6 +254,7 @@ export const ExplorerChartsContainerUI = ({
   mlLocator,
   timeBuckets,
   timefilter,
+  timeRange,
   onSelectEntity,
   tooManyBucketsCalloutMsg,
   showSelectedInterval,
@@ -294,6 +312,7 @@ export const ExplorerChartsContainerUI = ({
                 mlLocator={mlLocator}
                 timeBuckets={timeBuckets}
                 timefilter={timefilter}
+                timeRange={timeRange}
                 onSelectEntity={onSelectEntity}
                 recentlyAccessed={recentlyAccessed}
                 tooManyBucketsCalloutMsg={tooManyBucketsCalloutMsg}

--- a/x-pack/plugins/ml/public/application/util/chart_utils.js
+++ b/x-pack/plugins/ml/public/application/util/chart_utils.js
@@ -219,12 +219,9 @@ export function getChartType(config) {
   return chartType;
 }
 
-export async function getExploreSeriesLink(mlLocator, series, timefilter) {
+export async function getExploreSeriesLink(mlLocator, series, timeRange) {
   // Open the Single Metric dashboard over the same overall bounds and
   // zoomed in to the same time as the current chart.
-  const bounds = timefilter.getActiveBounds();
-  const from = bounds.min.toISOString(); // e.g. 2016-02-08T16:00:00.000Z
-  const to = bounds.max.toISOString();
 
   const zoomFrom = moment(series.plotEarliest).toISOString();
   const zoomTo = moment(series.plotLatest).toISOString();
@@ -251,11 +248,7 @@ export async function getExploreSeriesLink(mlLocator, series, timefilter) {
           pause: true,
           value: 0,
         },
-        timeRange: {
-          from: from,
-          to: to,
-          mode: 'absolute',
-        },
+        timeRange,
         zoom: {
           from: zoomFrom,
           to: zoomTo,

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/__snapshots__/embeddable_anomaly_charts_container.test.tsx.snap
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/__snapshots__/embeddable_anomaly_charts_container.test.tsx.snap
@@ -30,6 +30,7 @@ Object {
     "barTarget": undefined,
     "maxBars": undefined,
   },
+  "timeRange": undefined,
   "timefilter": Object {
     "calculateBounds": [MockFunction],
     "createFilter": [MockFunction],

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.test.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.test.tsx
@@ -163,7 +163,7 @@ describe('EmbeddableAnomalyChartsContainer', () => {
   });
 
   test('should render an error in case it could not fetch the ML charts data', async () => {
-    (useAnomalyChartsInputResolver as jest.Mock).mockReturnValueOnce({
+    (useAnomalyChartsInputResolver as jest.Mock).mockReturnValue({
       chartsData: undefined,
       isLoading: false,
       error: 'No anomalies',

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
@@ -10,6 +10,7 @@ import { EuiCallOut, EuiLoadingChart, EuiResizeObserver, EuiText } from '@elasti
 import { Observable } from 'rxjs';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { throttle } from 'lodash';
+import useObservable from 'react-use/lib/useObservable';
 import { useAnomalyChartsInputResolver } from './use_anomaly_charts_input_resolver';
 import type { IAnomalyChartsEmbeddable } from './anomaly_charts_embeddable';
 import type {
@@ -78,6 +79,8 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
       'dateFormat:scaled': uiSettings.get('dateFormat:scaled'),
     });
   }, []);
+
+  const input = useObservable(embeddableInput);
 
   useEffect(() => {
     onInputChange({
@@ -190,6 +193,7 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
               timefilter={timefilter}
               onSelectEntity={addEntityFieldFilter}
               showSelectedInterval={false}
+              timeRange={input?.timeRange}
             />
           )}
         </div>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ML] Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007)](https://github.com/elastic/kibana/pull/141007)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Quynh Nguyen (Quinn)","email":"43350163+qn895@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-09-21T22:17:42Z","message":"[ML] Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007)","sha":"a7bd74322b74053174534376469ee1f39e1238d7","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport pending",":ml","Feature:Anomaly Detection","backport:prev-minor","v8.5.0","v7.17.7","v8.4.3","v8.6.0"],"number":141007,"url":"https://github.com/elastic/kibana/pull/141007","mergeCommit":{"message":"[ML] Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007)","sha":"a7bd74322b74053174534376469ee1f39e1238d7"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/141319","number":141319,"state":"OPEN"},{"branch":"7.17","label":"v7.17.7","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.4","label":"v8.4.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/141513","number":141513,"state":"MERGED","mergeCommit":{"sha":"eb664c57556a88ec7148be3b8f6ae0671b6e8e81","message":"[ML][Merge conflicts]Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007) (#141513)"}},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/141007","number":141007,"mergeCommit":{"message":"[ML] Fix Open in Single Metric Viewer links not reflecting custom time range for Anomaly chart embeddables (#141007)","sha":"a7bd74322b74053174534376469ee1f39e1238d7"}}]}] BACKPORT-->