### PR TITLE
[Fleet] updated openapi for bulk action responses

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -616,7 +616,6 @@
           "in": "query"
         }
       ],
-      "required": true,
       "post": {
         "summary": "Packages - Install",
         "tags": [],
@@ -1253,6 +1252,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "properties": {
+                    "actionId": {
+                      "type": "string",
+                      "description": "action id when running in async mode (>10k agents)"
+                    }
+                  },
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
@@ -1842,6 +1847,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "properties": {
+                    "actionId": {
+                      "type": "string",
+                      "description": "action id when running in async mode (>10k agents)"
+                    }
+                  },
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
@@ -1918,6 +1929,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "properties": {
+                    "actionId": {
+                      "type": "string",
+                      "description": "action id when running in async mode (>10k agents)"
+                    }
+                  },
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
@@ -2001,6 +2018,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "properties": {
+                    "actionId": {
+                      "type": "string",
+                      "description": "action id when running in async mode (>10k agents)"
+                    }
+                  },
                   "additionalProperties": {
                     "type": "object",
                     "properties": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -381,7 +381,6 @@ paths:
         name: ignoreUnverified
         description: Ignore if the package is fails signature verification
         in: query
-    required: true
     post:
       summary: Packages - Install
       tags: []
@@ -772,6 +771,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  actionId:
+                    type: string
+                    description: action id when running in async mode (>10k agents)
                 additionalProperties:
                   type: object
                   properties:
@@ -1139,6 +1142,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  actionId:
+                    type: string
+                    description: action id when running in async mode (>10k agents)
                 additionalProperties:
                   type: object
                   properties:
@@ -1185,6 +1192,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  actionId:
+                    type: string
+                    description: action id when running in async mode (>10k agents)
                 additionalProperties:
                   type: object
                   properties:
@@ -1236,6 +1247,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  actionId:
+                    type: string
+                    description: action id when running in async mode (>10k agents)
                 additionalProperties:
                   type: object
                   properties:
@@ -1332,7 +1347,7 @@ paths:
           name: full
           description: >-
             When set to true, retrieve the related package policies for each
-            agent policy/
+            agent policy.
       description: ''
     post:
       summary: Agent policy - Create

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_reassign.yaml
@@ -8,6 +8,10 @@ post:
           application/json:
             schema:
               type: object
+              properties:
+                actionId: 
+                  type: string
+                  description: action id when running in async mode (>10k agents)
               additionalProperties:
                 type: object
                 properties:

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_unenroll.yaml
@@ -8,6 +8,10 @@ post:
           application/json:
             schema:
               type: object
+              properties:
+                actionId: 
+                  type: string
+                  description: action id when running in async mode (>10k agents)
               additionalProperties:
                 type: object
                 properties:

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_update_tags.yaml
@@ -8,6 +8,10 @@ post:
           application/json:
             schema:
               type: object
+              properties:
+                actionId: 
+                  type: string
+                  description: action id when running in async mode (>10k agents)
               additionalProperties:
                 type: object
                 properties:

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_upgrade.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_upgrade.yaml
@@ -8,6 +8,10 @@ post:
         application/json:
           schema:
               type: object
+              properties:
+                actionId: 
+                  type: string
+                  description: action id when running in async mode (>10k agents)
               additionalProperties:
                 type: object
                 properties:

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -72,13 +72,15 @@ export interface PostBulkAgentUnenrollRequest {
   };
 }
 
-export type PostBulkAgentUnenrollResponse = Record<
+export type BulkAgentAction = Record<
   Agent['id'],
   {
     success: boolean;
     error?: string;
   }
->;
+> & { actionId?: string };
+
+export type PostBulkAgentUnenrollResponse = BulkAgentAction;
 
 export interface PostAgentUpgradeRequest {
   params: {
@@ -100,13 +102,7 @@ export interface PostBulkAgentUpgradeRequest {
   };
 }
 
-export type PostBulkAgentUpgradeResponse = Record<
-  Agent['id'],
-  {
-    success: boolean;
-    error?: string;
-  }
->;
+export type PostBulkAgentUpgradeResponse = BulkAgentAction;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PostAgentUpgradeResponse {}
@@ -129,21 +125,9 @@ export interface PostBulkAgentReassignRequest {
   };
 }
 
-export type PostBulkAgentReassignResponse = Record<
-  Agent['id'],
-  {
-    success: boolean;
-    error?: string;
-  }
->;
+export type PostBulkAgentReassignResponse = BulkAgentAction;
 
-export type PostBulkUpdateAgentTagsResponse = Record<
-  Agent['id'],
-  {
-    success: boolean;
-    error?: string;
-  }
->;
+export type PostBulkUpdateAgentTagsResponse = BulkAgentAction;
 
 export interface DeleteAgentRequest {
   params: {


### PR DESCRIPTION
## Summary

Updated OpenAPI spec to reflect changes made for https://github.com/elastic/kibana/issues/141567

`/bulk_reassign, /bulk_unenroll, /bulk_upgrade, /bulk_update_tags` can return now an `actionId` instead of object with agent ids, in case of async execution.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->