### PR TITLE
wait for vis update before asserting formatting change

### DIFF
--- a/x-pack/test/functional/apps/lens/group1/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/group1/smokescreen.ts
@@ -504,6 +504,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.editDimensionFormat('Number');
       await PageObjects.lens.closeDimensionEditor();
 
+      await PageObjects.lens.waitForVisualization();
+
       const values = await Promise.all(
         range(0, 6).map((index) => PageObjects.lens.getDatatableCellText(index, 1))
       );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/141535
Fixes https://github.com/elastic/kibana/issues/141539

By waiting for the vis to update before asserting

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->