### PR TITLE
Metric vis: wait for rendering before comparing filters

### DIFF
--- a/test/functional/apps/visualize/group2/_metric_chart.ts
+++ b/test/functional/apps/visualize/group2/_metric_chart.ts
@@ -184,6 +184,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.try(async function tryingForTime() {
           // click first metric bucket
           await PageObjects.visEditor.clickMetricByIndex(0);
+          await PageObjects.visChart.waitForVisualizationRenderingStabilized();
           filterCount = await filterBar.getFilterCount();
         });
         await filterBar.removeAllFilters();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/141537

by waiting for the click to take effect before grabbing the filter element count.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->