### PR TITLE
Unskip uptime feature control test

### DIFF
--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -137,7 +137,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/104249
     describe('no uptime privileges', () => {
       before(async () => {
         await security.role.create('no_uptime_privileges_role', {

--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -138,7 +138,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     // FLAKY: https://github.com/elastic/kibana/issues/104249
-    describe.skip('no uptime privileges', () => {
+    describe('no uptime privileges', () => {
       before(async () => {
         await security.role.create('no_uptime_privileges_role', {
           elasticsearch: {


### PR DESCRIPTION
## Summary

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1302#_

Test doesn't seems flaky anymore passed 50/50 Runs

Fixes https://github.com/elastic/kibana/issues/104249

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->