### PR TITLE
[Fleet] Agent activity bugfixes 

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-
+import styled from 'styled-components';
 import { fromKueryExpression } from '@kbn/es-query';
 
 import type { FieldSpec } from '@kbn/data-plugin/common';
@@ -19,6 +19,12 @@ import { useStartServices } from '../hooks';
 import { INDEX_NAME, AGENTS_PREFIX } from '../constants';
 
 const HIDDEN_FIELDS = [`${AGENTS_PREFIX}.actions`, '_id', '_index'];
+
+const NoWrapQueryStringInput = styled(QueryStringInput)`
+  .kbnQueryBar__textarea {
+    white-space: nowrap;
+  }
+`;
 
 interface Props {
   value: string;
@@ -88,7 +94,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
   }, [data.dataViews, fieldPrefix, indexPattern]);
 
   return (
-    <QueryStringInput
+    <NoWrapQueryStringInput
       iconType="search"
       disableLanguageSwitcher={true}
       indexPatterns={

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_button.tsx
@@ -27,55 +27,52 @@ export const AgentActivityButton: React.FC<{
     setAgentActivityTourState(showAgentActivityTour);
   }, [showAgentActivityTour, setAgentActivityTourState]);
 
-  const button = (
-    <EuiButtonEmpty
-      onClick={() => {
-        onClickAgentActivity();
-        setAgentActivityTourState({ isOpen: false });
-      }}
-      data-test-subj="agentActivityButton"
-      iconType="clock"
-    >
-      <FormattedMessage
-        id="xpack.fleet.agentList.agentActivityButton"
-        defaultMessage="Agent activity"
-      />
-    </EuiButtonEmpty>
-  );
-
   const onFinish = () => {
     setAgentActivityTourState({ isOpen: false });
     setTourAsHidden();
   };
 
-  return isTourHidden ? (
-    button
-  ) : (
-    <EuiTourStep
-      content={
-        <EuiText>
+  return (
+    <>
+      <EuiTourStep
+        content={
+          <EuiText>
+            <FormattedMessage
+              id="xpack.fleet.agentActivityButton.tourContent"
+              defaultMessage="Review in progress, completed, and scheduled agent action activity history here anytime."
+            />
+          </EuiText>
+        }
+        isStepOpen={!isTourHidden && agentActivityTourState.isOpen}
+        onFinish={onFinish}
+        minWidth={360}
+        maxWidth={360}
+        step={1}
+        stepsTotal={1}
+        title={
           <FormattedMessage
-            id="xpack.fleet.agentActivityButton.tourContent"
-            defaultMessage="Review in progress, completed, and scheduled agent action activity history here anytime."
+            id="xpack.fleet.agentActivityButton.tourTitle"
+            defaultMessage="Agent activity history"
           />
-        </EuiText>
-      }
-      isStepOpen={agentActivityTourState.isOpen}
-      onFinish={onFinish}
-      minWidth={360}
-      maxWidth={360}
-      step={1}
-      stepsTotal={1}
-      title={
+        }
+        anchorPosition="upCenter"
+        footerAction={<EuiButtonEmpty onClick={onFinish}>OK</EuiButtonEmpty>}
+        anchor="#agentActivityButton"
+      />
+      <EuiButtonEmpty
+        onClick={() => {
+          onClickAgentActivity();
+          setAgentActivityTourState({ isOpen: false });
+        }}
+        data-test-subj="agentActivityButton"
+        iconType="clock"
+        id="agentActivityButton"
+      >
         <FormattedMessage
-          id="xpack.fleet.agentActivityButton.tourTitle"
-          defaultMessage="Agent activity history"
+          id="xpack.fleet.agentList.agentActivityButton"
+          defaultMessage="Agent activity"
         />
-      }
-      anchorPosition="upCenter"
-      footerAction={<EuiButtonEmpty onClick={onFinish}>OK</EuiButtonEmpty>}
-    >
-      {button}
-    </EuiTourStep>
+      </EuiButtonEmpty>
+    </>
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -252,6 +252,8 @@ const actionNames: {
   ACTION: { inProgressText: 'Actioning', completedText: 'actioned', cancelledText: 'action' },
 };
 
+const getAction = (type?: string) => actionNames[type ?? 'ACTION'] ?? actionNames.ACTION;
+
 const inProgressTitleColor = '#0077CC';
 
 const formattedTime = (time?: string) => {
@@ -276,7 +278,7 @@ const inProgressTitle = (action: ActionStatus) => (
           ? action.nbAgentsActioned
           : action.nbAgentsActioned - action.nbAgentsAck + ' of ' + action.nbAgentsActioned,
       agents: action.nbAgentsActioned === 1 ? 'agent' : 'agents',
-      inProgressText: actionNames[action.type ?? 'ACTION'].inProgressText,
+      inProgressText: getAction(action.type).inProgressText,
       reassignText:
         action.type === 'POLICY_REASSIGN' && action.newPolicyId ? `to ${action.newPolicyId}` : '',
       upgradeText: action.type === 'UPGRADE' ? `to version ${action.version}` : '',
@@ -306,7 +308,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
               ? action.nbAgentsAck
               : action.nbAgentsAck + ' of ' + action.nbAgentsActioned,
           agents: action.nbAgentsActioned === 1 ? 'agent' : 'agents',
-          completedText: actionNames[action.type ?? 'ACTION'].completedText,
+          completedText: getAction(action.type).completedText,
         }}
       />
     </EuiText>
@@ -384,7 +386,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
             id="xpack.fleet.agentActivityFlyout.cancelledTitle"
             defaultMessage="Agent {cancelledText} cancelled"
             values={{
-              cancelledText: actionNames[action.type ?? 'ACTION'].cancelledText,
+              cancelledText: getAction(action.type).cancelledText,
             }}
           />
         </EuiText>
@@ -410,7 +412,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
             id="xpack.fleet.agentActivityFlyout.expiredTitle"
             defaultMessage="Agent {expiredText} expired"
             values={{
-              expiredText: actionNames[action.type ?? 'ACTION'].cancelledText,
+              expiredText: getAction(action.type).cancelledText,
             }}
           />
         </EuiText>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -328,6 +328,25 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                 </EuiFilterButton>
               </EuiFilterGroup>
             </EuiFlexItem>
+            {selectedAgents.length === 0 && (
+              <EuiFlexItem>
+                <EuiToolTip
+                  content={
+                    <FormattedMessage
+                      id="xpack.fleet.agentList.addFleetServerButton.tooltip"
+                      defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
+                    />
+                  }
+                >
+                  <EuiButton onClick={onClickAddFleetServer} data-test-subj="addFleetServerButton">
+                    <FormattedMessage
+                      id="xpack.fleet.agentList.addFleetServerButton"
+                      defaultMessage="Add Fleet Server"
+                    />
+                  </EuiButton>
+                </EuiToolTip>
+              </EuiFlexItem>
+            )}
             <EuiFlexItem>
               <AgentActivityButton
                 onClickAgentActivity={onClickAgentActivity}
@@ -335,45 +354,23 @@ export const SearchAndFilterBar: React.FunctionComponent<{
               />
             </EuiFlexItem>
             {selectedAgents.length === 0 && (
-              <>
-                <EuiFlexItem>
-                  <EuiToolTip
-                    content={
-                      <FormattedMessage
-                        id="xpack.fleet.agentList.addFleetServerButton.tooltip"
-                        defaultMessage="Fleet Server is a component of the Elastic Stack used to centrally manage Elastic Agents"
-                      />
-                    }
-                  >
-                    <EuiButton
-                      onClick={onClickAddFleetServer}
-                      data-test-subj="addFleetServerButton"
-                    >
-                      <FormattedMessage
-                        id="xpack.fleet.agentList.addFleetServerButton"
-                        defaultMessage="Add Fleet Server"
-                      />
-                    </EuiButton>
-                  </EuiToolTip>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiToolTip
-                    content={
-                      <FormattedMessage
-                        id="xpack.fleet.agentList.addAgentButton.tooltip"
-                        defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
-                      />
-                    }
-                  >
-                    <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
-                      <FormattedMessage
-                        id="xpack.fleet.agentList.addButton"
-                        defaultMessage="Add agent"
-                      />
-                    </EuiButton>
-                  </EuiToolTip>
-                </EuiFlexItem>
-              </>
+              <EuiFlexItem>
+                <EuiToolTip
+                  content={
+                    <FormattedMessage
+                      id="xpack.fleet.agentList.addAgentButton.tooltip"
+                      defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack"
+                    />
+                  }
+                >
+                  <EuiButton fill onClick={onClickAddAgent} data-test-subj="addAgentButton">
+                    <FormattedMessage
+                      id="xpack.fleet.agentList.addButton"
+                      defaultMessage="Add agent"
+                    />
+                  </EuiButton>
+                </EuiToolTip>
+              </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>
               <AgentBulkActions

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -547,6 +547,11 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
     },
   ];
 
+  const refreshAgents = ({ refreshTags = false }: { refreshTags?: boolean } = {}) => {
+    fetchData({ refreshTags });
+    setShowAgentActivityTour({ isOpen: true });
+  };
+
   return (
     <>
       {isAgentActivityFlyoutOpen ? (
@@ -576,7 +581,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             agents={[agentToReassign]}
             onClose={() => {
               setAgentToReassign(undefined);
-              fetchData();
+              refreshAgents();
             }}
           />
         </EuiPortal>
@@ -588,7 +593,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             agentCount={1}
             onClose={() => {
               setAgentToUnenroll(undefined);
-              fetchData({ refreshTags: true });
+              refreshAgents({ refreshTags: true });
             }}
             useForceUnenroll={agentToUnenroll.status === 'unenrolling'}
             hasFleetServer={agentToUnenrollHasFleetServer}
@@ -602,7 +607,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             agentCount={1}
             onClose={() => {
               setAgentToUpgrade(undefined);
-              fetchData();
+              refreshAgents();
             }}
           />
         </EuiPortal>
@@ -614,7 +619,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           selectedTags={agentToAddRemoveTags?.tags ?? []}
           button={tagsPopoverButton!}
           onTagsUpdated={() => {
-            fetchData();
+            refreshAgents();
           }}
           onClosePopover={() => {
             setShowTagsAddRemove(false);
@@ -651,10 +656,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         selectionMode={selectionMode}
         currentQuery={kuery}
         selectedAgents={selectedAgents}
-        refreshAgents={({ refreshTags = false }: { refreshTags?: boolean } = {}) => {
-          Promise.all([fetchData({ refreshTags })]);
-          setShowAgentActivityTour({ isOpen: true });
-        }}
+        refreshAgents={refreshAgents}
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
         onClickAddFleetServer={onClickAddFleetServer}
         visibleAgents={agents}


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/140911

Agent activity tour was not showing up when taking row actions on single agent, fixed that.

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/90178898/191931458-2c59a916-88f8-4657-ace8-355278c03d5d.png">
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/90178898/191931496-a29ffea8-6ebd-4a63-8ba2-71feb96da7ef.png">


Fix https://github.com/elastic/kibana/issues/141196

Changed the order of buttons so that `Agent activity` button is not jumping to another place when the action causes agents to be deselected.

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/90178898/191931379-d005da5e-fab7-4fa9-b749-4b89e1980ebf.png">


Fix https://github.com/elastic/kibana/issues/141374

Made the search placeholder text visible.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/90178898/191931075-e2f105a5-0410-4e50-ac17-8a5c40453116.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->