### PR TITLE
[Cases] Unksip case deletion sub privilege test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
@@ -17,8 +17,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const cases = getService('cases');
 
-  // Failing: See https://github.com/elastic/kibana/issues/140547
-  describe.skip('cases deletion sub privilege', () => {
+  describe('cases deletion sub privilege', () => {
     before(async () => {
       await createUsersAndRoles(getService, users, roles);
       await PageObjects.security.forceLogout();


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/141204 fixed the flaky test (https://github.com/elastic/kibana/issues/140547) but I did not backport to 8.5. This resulted in flakiness on the 8.5 branch and it got skipped again in the 8.5 and the main branches. This PR https://github.com/elastic/kibana/pull/141352 backports the fix to 8.5 and the current PR un skips the test as it is fixed.

Flaky test runner (100 times): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1306

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->