### PR TITLE
[APM] Use bundled version of APM integration

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
@@ -59,8 +59,6 @@ export class ApmSynthtraceKibanaClient {
     password: string
   ) {
     const url = `${kibanaUrl}/api/fleet/epm/packages/apm`;
-    console.log({ url });
-
     const response = await fetch(url, {
       method: 'GET',
       headers: {
@@ -72,7 +70,6 @@ export class ApmSynthtraceKibanaClient {
     });
     const json = (await response.json()) as { item: { latestVersion: string } };
     const { latestVersion } = json.item;
-    console.log({ latestVersion });
     return latestVersion;
   }
 

--- a/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
@@ -52,6 +52,7 @@ export class ApmSynthtraceKibanaClient {
       return kibanaUrl;
     });
   }
+
   async fetchLatestApmPackageVersion(
     kibanaUrl: string,
     version: string,
@@ -61,12 +62,7 @@ export class ApmSynthtraceKibanaClient {
     const url = `${kibanaUrl}/api/fleet/epm/packages/apm`;
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        Authorization: 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'kbn-xsrf': 'kibana',
-      },
+      headers: kibanaHeaders(username, password),
     });
     const json = (await response.json()) as { item: { latestVersion: string } };
     const { latestVersion } = json.item;
@@ -82,12 +78,7 @@ export class ApmSynthtraceKibanaClient {
     );
     const response = await fetch(`${kibanaUrl}/api/fleet/epm/packages/apm/${packageVersion}`, {
       method: 'POST',
-      headers: {
-        Authorization: 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'kbn-xsrf': 'kibana',
-      },
+      headers: kibanaHeaders(username, password),
       body: '{"force":true}',
     });
 
@@ -102,4 +93,13 @@ export class ApmSynthtraceKibanaClient {
       this.logger.info(`Installed apm package ${packageVersion}`);
     } else this.logger.error(responseJson);
   }
+}
+
+function kibanaHeaders(username: string, password: string) {
+  return {
+    Authorization: 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'kbn-xsrf': 'kibana',
+  };
 }


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/pull/141462

Use the bundled version of APM integration instead of querying the remote EPR api.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->