### PR TITLE
[Uptime] Fix flaky overview test

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/lib/helper/rtl_helpers.tsx
@@ -27,6 +27,7 @@ import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { KibanaContextProvider, KibanaServices } from '@kbn/kibana-react-plugin/public';
 import { triggersActionsUiMock } from '@kbn/triggers-actions-ui-plugin/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { mockState } from '../__mocks__/uptime_store.mock';
 import { MountWithReduxProvider } from './helper_with_redux';
 import { AppState } from '../../state';
@@ -137,6 +138,7 @@ export const mockCore: () => Partial<CoreStart> = () => {
       },
       ExploratoryViewEmbeddable: () => <div>Embeddable exploratory view</div>,
     },
+    unifiedSearch: unifiedSearchPluginMock.createStartContract(),
   };
 
   return core;

--- a/x-pack/plugins/synthetics/public/legacy_uptime/pages/overview.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/pages/overview.test.tsx
@@ -9,8 +9,7 @@ import React from 'react';
 import { OverviewPageComponent } from './overview';
 import { render } from '../lib/helper/rtl_helpers';
 
-// FLAKY: https://github.com/elastic/kibana/issues/131346
-describe.skip('MonitorPage', () => {
+describe('MonitorPage', () => {
   it('renders expected elements for valid props', async () => {
     const { findByText, findByPlaceholderText } = render(<OverviewPageComponent />);
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/131346
Inject unified search mock into jest tests to fix flaky test !!



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->