### PR TITLE
[Fleet] Show devtools request to create an agent policy in package policy create editor

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -599,7 +599,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         defaultMessage: 'This Kibana request creates a new package policy.',
       }),
     ];
-  }, [packagePolicy, newAgentPolicy, withSysMonitoring]);
+  }, [packagePolicy, newAgentPolicy, withSysMonitoring, selectedPolicyTab]);
 
   // Display package error if there is one
   if (packageInfoError) {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -79,7 +79,10 @@ import {
   SelectedPolicyTab,
   StepSelectHosts,
 } from '../components';
-import { generateCreatePackagePolicyDevToolsRequest } from '../../services';
+import {
+  generateCreatePackagePolicyDevToolsRequest,
+  generateCreateAgentPolicyDevToolsRequest,
+} from '../../services';
 
 import { CreatePackagePolicySinglePageLayout, PostInstallAddAgentModal } from './components';
 
@@ -568,13 +571,35 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     !HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo?.name ?? '') &&
     isShowDevtoolRequestExperimentEnabled;
 
-  const devtoolRequest = useMemo(
-    () =>
+  const [devtoolRequest, devtoolRequestDescription] = useMemo(() => {
+    if (selectedPolicyTab === SelectedPolicyTab.NEW) {
+      const packagePolicyIsSystem = packagePolicy?.package?.name === FLEET_SYSTEM_PACKAGE;
+      return [
+        `${generateCreateAgentPolicyDevToolsRequest(
+          newAgentPolicy,
+          withSysMonitoring && !packagePolicyIsSystem
+        )}\n\n${generateCreatePackagePolicyDevToolsRequest({
+          ...packagePolicy,
+        })}`,
+        i18n.translate(
+          'xpack.fleet.createPackagePolicy.devtoolsRequestWithAgentPolicyDescription',
+          {
+            defaultMessage:
+              'These Kibana requests creates a new agent policy and a new package policy.',
+          }
+        ),
+      ];
+    }
+
+    return [
       generateCreatePackagePolicyDevToolsRequest({
         ...packagePolicy,
       }),
-    [packagePolicy]
-  );
+      i18n.translate('xpack.fleet.createPackagePolicy.devtoolsRequestDescription', {
+        defaultMessage: 'This Kibana request creates a new package policy.',
+      }),
+    ];
+  }, [packagePolicy, newAgentPolicy, withSysMonitoring]);
 
   // Display package error if there is one
   if (packageInfoError) {
@@ -650,12 +675,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
                   <EuiFlexItem grow={false}>
                     <DevtoolsRequestFlyoutButton
                       request={devtoolRequest}
-                      description={i18n.translate(
-                        'xpack.fleet.createPackagePolicy.devtoolsRequestDescription',
-                        {
-                          defaultMessage: 'This Kibana request creates a new package policy.',
-                        }
-                      )}
+                      description={devtoolRequestDescription}
                       btnProps={{
                         color: 'ghost',
                       }}


### PR DESCRIPTION
Resolve #141019

In the package policy editor we added a button to preview the equivalent API request, the request where not correct in the case the user is creating an agent policy inline.

That PR fix that by previewing two requests instead of just the package policy one: one for the agent policy creation one for the package policy 

## UI changes


#### With inline agent policy creation
<img width="799" alt="Screen Shot 2022-09-23 at 11 09 59 AM" src="https://user-images.githubusercontent.com/1336873/191994295-936b73f1-7fa3-46c8-98b8-5fb7fb719509.png">


#### With an existing agent policy
<img width="805" alt="Screen Shot 2022-09-23 at 11 13 50 AM" src="https://user-images.githubusercontent.com/1336873/191994418-b8f1a05f-691c-4111-a393-b76f464e0481.png">



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->