### PR TITLE
[Fleet] Simplify `skipArchive` behaviour for input packages

### DIFF
--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -204,6 +204,7 @@ export const createPackagePolicyHandler: FleetRequestHandler<
         pkgName: pkg.name,
         pkgVersion: pkg.version,
         ignoreUnverified: force,
+        skipArchive: true,
       });
       newPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(newPolicy, pkgInfo, {
         experimental_data_stream_features: pkg.experimental_data_stream_features,

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -204,7 +204,6 @@ export const createPackagePolicyHandler: FleetRequestHandler<
         pkgName: pkg.name,
         pkgVersion: pkg.version,
         ignoreUnverified: force,
-        // skipArchive: true,
       });
       newPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(newPolicy, pkgInfo, {
         experimental_data_stream_features: pkg.experimental_data_stream_features,

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -204,7 +204,7 @@ export const createPackagePolicyHandler: FleetRequestHandler<
         pkgName: pkg.name,
         pkgVersion: pkg.version,
         ignoreUnverified: force,
-        skipArchive: true,
+        // skipArchive: true,
       });
       newPackagePolicy = simplifiedPackagePolicytoNewPackagePolicy(newPolicy, pkgInfo, {
         experimental_data_stream_features: pkg.experimental_data_stream_features,

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -188,7 +188,6 @@ describe('When using EPM `get` services', () => {
         name: 'my-package',
         version: '1.0.0',
       } as RegistryPackage);
-      // TODO: is this mock needed?
       MockRegistry.fetchInfo.mockResolvedValue({
         name: 'my-package',
         version: '1.0.0',

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -188,6 +188,11 @@ describe('When using EPM `get` services', () => {
         name: 'my-package',
         version: '1.0.0',
       } as RegistryPackage);
+      // TODO: is this mock needed?
+      MockRegistry.fetchInfo.mockResolvedValue({
+        name: 'my-package',
+        version: '1.0.0',
+      } as RegistryPackage);
       MockRegistry.getPackage.mockResolvedValue({
         paths: [],
         packageInfo: {

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -292,7 +292,7 @@ export async function getPackageFromSource(options: {
     }
   } else {
     res = await Registry.getPackage(pkgName, pkgVersion, { ignoreUnverified });
-    logger.debug(`retrieved uninstalled package ${pkgName}-${pkgVersion}`);
+    logger.debug(`retrieved package ${pkgName}-${pkgVersion} from registry`);
   }
   if (!res) {
     throw new FleetError(`package info for ${pkgName}-${pkgVersion} does not exist`);

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -152,13 +152,12 @@ export async function getPackageInfo({
   // If same version is available in registry and skipArchive is true, use the info from the registry (faster),
   // otherwise build it from the archive
   let paths: string[];
-  let packageInfo: RegistryPackage | ArchivePackage | undefined = skipArchive
-    ? await Registry.fetchInfo(pkgName, resolvedPkgVersion).catch(() => undefined)
-    : undefined;
-
+  const registryInfo = await Registry.fetchInfo(pkgName, resolvedPkgVersion).catch(() => undefined);
+  let packageInfo;
   // We need to get input only packages from source to get all fields
   // see https://github.com/elastic/package-registry/issues/864
-  if (packageInfo && packageInfo.type !== 'input') {
+  if (registryInfo && skipArchive && registryInfo.type !== 'input') {
+    packageInfo = registryInfo;
     // Fix the paths
     paths =
       packageInfo.assets?.map((path) =>

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -265,7 +265,7 @@ async function getPackageInfoFromArchiveOrCache(
       archiveBuffer,
       ensureContentType(archivePath)
     );
-    setPackageInfo({ packageInfo, name, version });
+    setPackageInfo({ packageInfo: { ...packageInfo, download: archivePath }, name, version });
     return packageInfo;
   } else {
     return cachedInfo;

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -265,6 +265,8 @@ async function getPackageInfoFromArchiveOrCache(
       archiveBuffer,
       ensureContentType(archivePath)
     );
+    // set the download URL as it isn't contained in the manifest
+    // this allows us to re-download the archive during package install
     setPackageInfo({ packageInfo: { ...packageInfo, download: archivePath }, name, version });
     return packageInfo;
   } else {

--- a/x-pack/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get.ts
@@ -144,6 +144,18 @@ export default function (providerContext: FtrProviderContext) {
       expect(packageInfo.name).to.equal('apache');
       await uninstallPackage(testPkgName, testPkgVersion);
     });
+    it('should return all fields for input only packages', async function () {
+      // input packages have to get their package info from the manifest directly
+      // not from the package registry. This is because they contain a field the registry
+      // does not support
+      const res = await supertest
+        .get(`/api/fleet/epm/packages/integration_to_input/0.9.1`)
+        .expect(200);
+
+      const packageInfo = res.body.item;
+      expect(packageInfo.policy_templates.length).to.equal(1);
+      expect(packageInfo.policy_templates[0].vars).not.to.be(undefined);
+    });
     describe('Pkg verification', () => {
       it('should return validation error for unverified input only pkg', async function () {
         const res = await supertest.get(`/api/fleet/epm/packages/input_only/0.1.0`).expect(400);

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -446,6 +446,72 @@ export default function (providerContext: FtrProviderContext) {
       expect(policy.name).to.equal(nameWithWhitespace.trim());
     });
 
+    describe('input only packages', () => {
+      it('should return 400 if dataset not provided for input only pkg', async function () {
+        await supertest
+          .post(`/api/fleet/package_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            policy_id: agentPolicyId,
+            package: {
+              name: 'integration_to_input',
+              version: '0.9.1',
+            },
+            name: 'integration_to_input-1',
+            description: '',
+            namespace: 'default',
+            inputs: {
+              'logs-logfile': {
+                enabled: true,
+                streams: {
+                  'integration_to_input.logs': {
+                    enabled: true,
+                    vars: {
+                      paths: ['/tmp/test.log'],
+                      tags: ['tag1'],
+                      ignore_older: '72h',
+                    },
+                  },
+                },
+              },
+            },
+          })
+          .expect(400);
+      });
+      it('should successfully create an input only package policy with all required vars', async function () {
+        await supertest
+          .post(`/api/fleet/package_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            policy_id: agentPolicyId,
+            package: {
+              name: 'integration_to_input',
+              version: '0.9.1',
+            },
+            name: 'integration_to_input-2',
+            description: '',
+            namespace: 'default',
+            inputs: {
+              'logs-logfile': {
+                enabled: true,
+                streams: {
+                  'integration_to_input.logs': {
+                    enabled: true,
+                    vars: {
+                      paths: ['/tmp/test.log'],
+                      tags: ['tag1'],
+                      ignore_older: '72h',
+                      'data_stream.dataset': 'generic',
+                    },
+                  },
+                },
+              },
+            },
+          })
+          .expect(200);
+      });
+    });
+
     describe('Simplified package policy', () => {
       it('should work with valid values', async () => {
         await supertest


### PR DESCRIPTION
## Summary

Closes #137751 

Input packages always have to get their package info from the archive, as they contain fields in their manifest that the package registry API does not return. These fields are needed to create the package policy so we need to get info from the archive even when using the GET package info API (as opposed to just at install time)

Previously, I was ensuring that input packages get their information from the archive by using (unintuitively) the skipArchive flag, which meant we went to the registry to get the packageInfo, then checked if it was an input package, and if so we go and get the info from the archive. 

This PR simplifies that behaviour by always attempting to get the info from the registry first, regardless of skipArchive, then deciding whether to skip the archive. 

I have also added integration tests for input packages:
- Create valid pkg policy
- Create invalid pkg policy
- Get pkg info

## Does this conflict with #142353 "rely on package content during installation"?

This changes the behaviour for get package info, we still rely on the archive for installation. However, we should move to not using the registry at all for the get info API to unblock https://github.com/elastic/kibana/pull/131609, but this will be more work, and maybe need some work on the EPR side, I have created an issue for this https://github.com/elastic/kibana/issues/143198







