### PR TITLE
[watcher] disable jest config in CI, it's regularly failing

### DIFF
--- a/.buildkite/disabled_jest_configs.json
+++ b/.buildkite/disabled_jest_configs.json
@@ -1,0 +1,3 @@
+[
+  "x-pack/plugins/watcher/jest.config.js"
+]

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -15,6 +15,8 @@ import { load as loadYaml } from 'js-yaml';
 import { BuildkiteClient, BuildkiteStep } from '../buildkite';
 import { CiStatsClient, TestGroupRunOrderResponse } from './client';
 
+import DISABLED_JEST_CONFIGS from '../../disabled_jest_configs.json';
+
 type RunGroup = TestGroupRunOrderResponse['types'][0];
 
 const getRequiredEnv = (name: string) => {
@@ -220,6 +222,7 @@ export async function pickTestGroupRunOrder() {
     ? globby.sync(['**/jest.config.js', '!**/__fixtures__/**'], {
         cwd: process.cwd(),
         absolute: false,
+        ignore: DISABLED_JEST_CONFIGS,
       })
     : [];
 


### PR DESCRIPTION
Part of dealing with increased jest flakiness: https://github.com/elastic/kibana/issues/141477

Issue created for @elastic/platform-deployment-management to fix and unskip the config in https://github.com/elastic/kibana/issues/141686.