### PR TITLE
[Enterprise Search] align ml inference processor state

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/pipelines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/pipelines.ts
@@ -7,6 +7,9 @@
 
 export interface InferencePipeline {
   isDeployed: boolean;
+  isAllocated: boolean;
+  modelState?: string;
+  modelStateReason?: string;
   pipelineName: string;
   types: string[];
 }

--- a/x-pack/plugins/enterprise_search/common/types/pipelines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/pipelines.ts
@@ -6,10 +6,16 @@
  */
 
 export interface InferencePipeline {
-  isDeployed: boolean;
-  isAllocated: boolean;
-  modelState?: string;
+  modelState: TrainedModelState;
   modelStateReason?: string;
   pipelineName: string;
   types: string[];
+}
+
+export enum TrainedModelState {
+  NotDeployed = '',
+  Starting = 'starting',
+  Stopping = 'stopping',
+  Started = 'started',
+  Failed = 'failed',
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
@@ -13,15 +13,13 @@ import { shallow } from 'enzyme';
 
 import { EuiBadge, EuiPanel, EuiTitle } from '@elastic/eui';
 
-import { InferencePipeline } from '../../../../../../common/types/pipelines';
+import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
 
 import { InferencePipelineCard } from './inference_pipeline_card';
 import { TrainedModelHealth } from './ml_model_health';
 
 export const DEFAULT_VALUES: InferencePipeline = {
-  isAllocated: true,
-  isDeployed: true,
-  modelState: 'started',
+  modelState: TrainedModelState.Started,
   pipelineName: 'Sample Processor',
   types: ['pytorch'],
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
@@ -11,14 +11,18 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiBadge, EuiHealth, EuiPanel, EuiTitle } from '@elastic/eui';
+import { EuiBadge, EuiPanel, EuiTitle } from '@elastic/eui';
+
+import { InferencePipeline } from '../../../../../../common/types/pipelines';
 
 import { InferencePipelineCard } from './inference_pipeline_card';
+import { TrainedModelHealth } from './ml_model_health';
 
-export const DEFAULT_VALUES = {
+export const DEFAULT_VALUES: InferencePipeline = {
+  isAllocated: true,
   isDeployed: true,
+  modelState: 'started',
   pipelineName: 'Sample Processor',
-  trainedModelName: 'example_trained_model',
   types: ['pytorch'],
 };
 
@@ -34,8 +38,6 @@ describe('InferencePipelineCard', () => {
     expect(wrapper.find(EuiPanel)).toHaveLength(1);
     expect(wrapper.find(EuiTitle)).toHaveLength(1);
     expect(wrapper.find(EuiBadge)).toHaveLength(1);
-
-    const health = wrapper.find(EuiHealth);
-    expect(health.prop('children')).toEqual('Deployed');
+    expect(wrapper.find(TrainedModelHealth)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -26,7 +26,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { InferencePipeline } from '../../../../../../common/types/pipelines';
+import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
 import { CANCEL_BUTTON_LABEL, DELETE_BUTTON_LABEL } from '../../../../shared/constants';
 import { HttpLogic } from '../../../../shared/http';
 import { ML_MANAGE_TRAINED_MODELS_PATH } from '../../../routes';
@@ -128,7 +128,7 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => 
                 <EuiFlexItem grow={false}>
                   <TrainedModelHealth {...pipeline} />
                 </EuiFlexItem>
-                {pipeline.modelState === undefined && (
+                {pipeline.modelState === TrainedModelState.NotDeployed && (
                   <EuiFlexItem grow={false} style={{ paddingRight: '1rem' }}>
                     <EuiToolTip
                       position="top"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -12,15 +12,16 @@ import { useActions, useValues } from 'kea';
 import {
   EuiBadge,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiConfirmModal,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHealth,
   EuiPanel,
   EuiPopover,
   EuiPopoverTitle,
   EuiText,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -28,15 +29,13 @@ import { i18n } from '@kbn/i18n';
 import { InferencePipeline } from '../../../../../../common/types/pipelines';
 import { CANCEL_BUTTON_LABEL, DELETE_BUTTON_LABEL } from '../../../../shared/constants';
 import { HttpLogic } from '../../../../shared/http';
+import { ML_MANAGE_TRAINED_MODELS_PATH } from '../../../routes';
 import { IndexNameLogic } from '../index_name_logic';
 
+import { TrainedModelHealth } from './ml_model_health';
 import { PipelinesLogic } from './pipelines_logic';
 
-export const InferencePipelineCard: React.FC<InferencePipeline> = ({
-  pipelineName,
-  isDeployed,
-  types,
-}) => {
+export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => {
   const { http } = useValues(HttpLogic);
   const { indexName } = useValues(IndexNameLogic);
   const [isPopOverOpen, setIsPopOverOpen] = useState(false);
@@ -46,10 +45,7 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = ({
     setShowConfirmDelete(true);
     setIsPopOverOpen(false);
   };
-
-  const deployedText = i18n.translate('xpack.enterpriseSearch.inferencePipelineCard.isDeployed', {
-    defaultMessage: 'Deployed',
-  });
+  const { pipelineName, types } = pipeline;
 
   const actionButton = (
     <EuiButtonEmpty
@@ -128,10 +124,26 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = ({
         <EuiFlexItem>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFlexGroup gutterSize="m" justifyContent="flexEnd">
-                {isDeployed && (
-                  <EuiFlexItem grow={false}>
-                    <EuiHealth color="success">{deployedText}</EuiHealth>
+              <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="flexEnd">
+                <EuiFlexItem grow={false}>
+                  <TrainedModelHealth {...pipeline} />
+                </EuiFlexItem>
+                {pipeline.modelState === undefined && (
+                  <EuiFlexItem grow={false} style={{ paddingRight: '1rem' }}>
+                    <EuiToolTip
+                      position="top"
+                      content={i18n.translate(
+                        'xpack.enterpriseSearch.inferencePipelineCard.modelState.notDeployed.fixLink',
+                        { defaultMessage: 'Fix issue in Trained Models' }
+                      )}
+                    >
+                      <EuiButtonIcon
+                        href={http.basePath.prepend(ML_MANAGE_TRAINED_MODELS_PATH)}
+                        display="base"
+                        size="xs"
+                        iconType="wrench"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 )}
                 {types.map((type) => (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
@@ -13,7 +13,7 @@ import { shallow } from 'enzyme';
 
 import { EuiHealth } from '@elastic/eui';
 
-import { InferencePipeline } from '../../../../../../common/types/pipelines';
+import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
 
 import { TrainedModelHealth } from './ml_model_health';
 
@@ -24,17 +24,14 @@ describe('TrainedModelHealth', () => {
   });
 
   const commonModelData: InferencePipeline = {
-    isAllocated: false,
-    isDeployed: false,
+    modelState: TrainedModelState.NotDeployed,
     pipelineName: 'Sample Processor',
     types: ['pytorch'],
   };
   it('renders model started', () => {
     const pipeline: InferencePipeline = {
       ...commonModelData,
-      isAllocated: true,
-      isDeployed: true,
-      modelState: 'started',
+      modelState: TrainedModelState.Started,
     };
     const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
     const health = wrapper.find(EuiHealth);
@@ -53,7 +50,7 @@ describe('TrainedModelHealth', () => {
   it('renders model stopping', () => {
     const pipeline: InferencePipeline = {
       ...commonModelData,
-      modelState: 'stopping',
+      modelState: TrainedModelState.Stopping,
     };
     const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
     const health = wrapper.find(EuiHealth);
@@ -63,7 +60,7 @@ describe('TrainedModelHealth', () => {
   it('renders model starting', () => {
     const pipeline: InferencePipeline = {
       ...commonModelData,
-      modelState: 'starting',
+      modelState: TrainedModelState.Starting,
     };
     const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
     const health = wrapper.find(EuiHealth);
@@ -73,7 +70,7 @@ describe('TrainedModelHealth', () => {
   it('renders model failed', () => {
     const pipeline: InferencePipeline = {
       ...commonModelData,
-      modelState: 'failed',
+      modelState: TrainedModelState.Failed,
       modelStateReason: 'Model start boom.',
     };
     const wrapper = shallow(<TrainedModelHealth {...pipeline} />);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiHealth } from '@elastic/eui';
+
+import { InferencePipeline } from '../../../../../../common/types/pipelines';
+
+import { TrainedModelHealth } from './ml_model_health';
+
+describe('TrainedModelHealth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues({});
+  });
+
+  const commonModelData: InferencePipeline = {
+    isAllocated: false,
+    isDeployed: false,
+    pipelineName: 'Sample Processor',
+    types: ['pytorch'],
+  };
+  it('renders model started', () => {
+    const pipeline: InferencePipeline = {
+      ...commonModelData,
+      isAllocated: true,
+      isDeployed: true,
+      modelState: 'started',
+    };
+    const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
+    const health = wrapper.find(EuiHealth);
+    expect(health.prop('children')).toEqual('Started');
+    expect(health.prop('color')).toEqual('success');
+  });
+  it('renders model not deployed', () => {
+    const pipeline: InferencePipeline = {
+      ...commonModelData,
+    };
+    const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
+    const health = wrapper.find(EuiHealth);
+    expect(health.prop('children')).toEqual('Not deployed');
+    expect(health.prop('color')).toEqual('danger');
+  });
+  it('renders model stopping', () => {
+    const pipeline: InferencePipeline = {
+      ...commonModelData,
+      modelState: 'stopping',
+    };
+    const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
+    const health = wrapper.find(EuiHealth);
+    expect(health.prop('children')).toEqual('Stopping');
+    expect(health.prop('color')).toEqual('warning');
+  });
+  it('renders model starting', () => {
+    const pipeline: InferencePipeline = {
+      ...commonModelData,
+      modelState: 'starting',
+    };
+    const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
+    const health = wrapper.find(EuiHealth);
+    expect(health.prop('children')).toEqual('Starting');
+    expect(health.prop('color')).toEqual('warning');
+  });
+  it('renders model failed', () => {
+    const pipeline: InferencePipeline = {
+      ...commonModelData,
+      modelState: 'failed',
+      modelStateReason: 'Model start boom.',
+    };
+    const wrapper = shallow(<TrainedModelHealth {...pipeline} />);
+    const health = wrapper.find(EuiHealth);
+    expect(health.prop('children')).toEqual('Deployment failed');
+    expect(health.prop('color')).toEqual('danger');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiHealth, EuiToolTip } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { InferencePipeline } from '../../../../../../common/types/pipelines';
+
+const modelStartedText = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.started',
+  {
+    defaultMessage: 'Started',
+  }
+);
+const modelStartedTooltip = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.started.tooltip',
+  {
+    defaultMessage: 'This trained model is running and fully available',
+  }
+);
+const modelStartingText = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.starting',
+  {
+    defaultMessage: 'Starting',
+  }
+);
+const modelStartingTooltip = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.starting.tooltip',
+  {
+    defaultMessage:
+      'This trained model is in the process of starting up and will be available shortly',
+  }
+);
+const modelStoppingText = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.stopping',
+  {
+    defaultMessage: 'Stopping',
+  }
+);
+const modelStoppingTooltip = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.stopping.tooltip',
+  {
+    defaultMessage:
+      'This trained model is in the process of shutting down and is currently unavailable',
+  }
+);
+const modelDeploymentFailedText = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.deploymentFailed',
+  {
+    defaultMessage: 'Deployment failed',
+  }
+);
+const modelNotDeployedText = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.notDeployed',
+  {
+    defaultMessage: 'Not deployed',
+  }
+);
+const modelNotDeployedTooltip = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.modelState.notDeployed.tooltip',
+  {
+    defaultMessage:
+      'This trained model is not currently deployed. Visit the trained models page to make changes',
+  }
+);
+
+export const TrainedModelHealth: React.FC<InferencePipeline> = ({
+  modelState,
+  modelStateReason,
+}) => {
+  let modelHealth: {
+    healthColor: string;
+    healthText: React.ReactNode;
+    tooltipText: React.ReactNode;
+  } = {
+    healthColor: 'danger',
+    healthText: modelNotDeployedText,
+    tooltipText: modelNotDeployedTooltip,
+  };
+  switch (modelState) {
+    case 'started':
+      modelHealth = {
+        healthColor: 'success',
+        healthText: modelStartedText,
+        tooltipText: modelStartedTooltip,
+      };
+      break;
+    case 'stopping':
+      modelHealth = {
+        healthColor: 'warning',
+        healthText: modelStoppingText,
+        tooltipText: modelStoppingTooltip,
+      };
+      break;
+    case 'starting':
+      modelHealth = {
+        healthColor: 'warning',
+        healthText: modelStartingText,
+        tooltipText: modelStartingTooltip,
+      };
+      break;
+    case 'failed':
+      modelHealth = {
+        healthColor: 'danger',
+        healthText: modelDeploymentFailedText,
+        tooltipText: (
+          <FormattedMessage
+            id="xpack.enterpriseSearch.inferencePipelineCard.modelState.deploymentFailed.tooltip"
+            defaultMessage="The trained model failed to deploy. {reason}"
+            values={{
+              reason: modelStateReason
+                ? i18n.translate(
+                    'xpack.enterpriseSearch.inferencePipelineCard.modelState.deploymentFailed.tooltip.reason',
+                    {
+                      defaultMessage: 'Reason: {modelStateReason}',
+                      values: {
+                        modelStateReason,
+                      },
+                    }
+                  )
+                : '',
+            }}
+          />
+        ),
+      };
+      break;
+  }
+  return (
+    <EuiToolTip content={modelHealth.tooltipText}>
+      <EuiHealth color={modelHealth.healthColor}>{modelHealth.healthText}</EuiHealth>
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
@@ -12,7 +12,7 @@ import { EuiHealth, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { InferencePipeline } from '../../../../../../common/types/pipelines';
+import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
 
 const modelStartedText = i18n.translate(
   'xpack.enterpriseSearch.inferencePipelineCard.modelState.started',
@@ -80,34 +80,30 @@ export const TrainedModelHealth: React.FC<InferencePipeline> = ({
     healthColor: string;
     healthText: React.ReactNode;
     tooltipText: React.ReactNode;
-  } = {
-    healthColor: 'danger',
-    healthText: modelNotDeployedText,
-    tooltipText: modelNotDeployedTooltip,
   };
   switch (modelState) {
-    case 'started':
+    case TrainedModelState.Started:
       modelHealth = {
         healthColor: 'success',
         healthText: modelStartedText,
         tooltipText: modelStartedTooltip,
       };
       break;
-    case 'stopping':
+    case TrainedModelState.Stopping:
       modelHealth = {
         healthColor: 'warning',
         healthText: modelStoppingText,
         tooltipText: modelStoppingTooltip,
       };
       break;
-    case 'starting':
+    case TrainedModelState.Starting:
       modelHealth = {
         healthColor: 'warning',
         healthText: modelStartingText,
         tooltipText: modelStartingTooltip,
       };
       break;
-    case 'failed':
+    case TrainedModelState.Failed:
       modelHealth = {
         healthColor: 'danger',
         healthText: modelDeploymentFailedText,
@@ -130,6 +126,13 @@ export const TrainedModelHealth: React.FC<InferencePipeline> = ({
             }}
           />
         ),
+      };
+      break;
+    case TrainedModelState.NotDeployed:
+      modelHealth = {
+        healthColor: 'danger',
+        healthText: modelNotDeployedText,
+        tooltipText: modelNotDeployedTooltip,
       };
       break;
   }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
@@ -21,3 +21,5 @@ export const SEARCH_INDEX_PATH = `${SEARCH_INDICES_PATH}/:indexName`;
 export const SEARCH_INDEX_TAB_PATH = `${SEARCH_INDEX_PATH}/:tabId`;
 export const SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH = `${SEARCH_INDEX_PATH}/crawler/domains/:domainId`;
 export const SEARCH_INDEX_SELECT_CONNECTOR_PATH = `${SEARCH_INDEX_PATH}/select_connector`;
+
+export const ML_MANAGE_TRAINED_MODELS_PATH = '/app/ml/trained_models';

--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_ml_inference_pipeline_processors.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_ml_inference_pipeline_processors.test.ts
@@ -9,7 +9,7 @@ import { MlTrainedModelConfig } from '@elastic/elasticsearch/lib/api/typesWithBo
 import { ElasticsearchClient } from '@kbn/core/server';
 import { BUILT_IN_MODEL_TAG } from '@kbn/ml-plugin/common/constants/data_frame_analytics';
 
-import { InferencePipeline } from '../../../common/types/pipelines';
+import { InferencePipeline, TrainedModelState } from '../../../common/types/pipelines';
 
 import {
   fetchAndAddTrainedModelData,
@@ -223,20 +223,17 @@ const mockGetTrainedModelStats = {
 
 const trainedModelDataObject: Record<string, InferencePipeline> = {
   'trained-model-id-1': {
-    isAllocated: false,
-    isDeployed: false,
+    modelState: TrainedModelState.NotDeployed,
     pipelineName: 'ml-inference-pipeline-1',
     types: ['lang_ident', 'ner'],
   },
   'trained-model-id-2': {
-    isAllocated: true,
-    isDeployed: true,
+    modelState: TrainedModelState.Started,
     pipelineName: 'ml-inference-pipeline-2',
     types: ['pytorch', 'ner'],
   },
   'ml-inference-pipeline-3': {
-    isAllocated: false,
-    isDeployed: false,
+    modelState: TrainedModelState.NotDeployed,
     pipelineName: 'ml-inference-pipeline-3',
     types: ['lang_ident', 'ner'],
   },
@@ -296,17 +293,15 @@ describe('fetchPipelineProcessorInferenceData lib function', () => {
   it('should return the inference processor data for the pipelines', async () => {
     mockClient.ingest.getPipeline.mockImplementation(() => Promise.resolve(mockGetPipeline2));
 
-    const expected = [
+    const expected: InferencePipelineData[] = [
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-1',
         trainedModelName: 'trained-model-id-1',
         types: [],
       },
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-2',
         trainedModelName: 'trained-model-id-2',
         types: [],
@@ -382,24 +377,20 @@ describe('getMlModelConfigsForModelIds lib function', () => {
       Promise.resolve(mockGetTrainedModelStats)
     );
 
-    const input = {
+    const input: Record<string, InferencePipelineData> = {
       'trained-model-id-1': {
-        isAllocated: true,
-        isDeployed: true,
-        modelState: 'started',
+        modelState: TrainedModelState.Started,
         pipelineName: '',
         trainedModelName: 'trained-model-id-1',
         types: ['pytorch', 'ner'],
       },
       'trained-model-id-2': {
-        isAllocated: true,
-        isDeployed: true,
-        modelState: 'started',
+        modelState: TrainedModelState.Started,
         pipelineName: '',
         trainedModelName: 'trained-model-id-2',
         types: ['pytorch', 'ner'],
       },
-    } as Record<string, InferencePipeline>;
+    };
 
     const expected = {
       'trained-model-id-2': input['trained-model-id-2'],
@@ -440,29 +431,25 @@ describe('fetchAndAddTrainedModelData lib function', () => {
 
     const pipelines: InferencePipelineData[] = [
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-1',
         trainedModelName: 'trained-model-id-1',
         types: [],
       },
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-2',
         trainedModelName: 'trained-model-id-2',
         types: [],
       },
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-3',
         trainedModelName: 'trained-model-id-3',
         types: [],
       },
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-4',
         trainedModelName: 'trained-model-id-4',
         types: [],
@@ -471,33 +458,26 @@ describe('fetchAndAddTrainedModelData lib function', () => {
 
     const expected: InferencePipelineData[] = [
       {
-        isAllocated: false,
-        isDeployed: false,
+        modelState: TrainedModelState.NotDeployed,
         pipelineName: 'ml-inference-pipeline-1',
         trainedModelName: 'trained-model-id-1',
         types: ['lang_ident', 'ner'],
       },
       {
-        isAllocated: true,
-        isDeployed: true,
-        modelState: 'started',
+        modelState: TrainedModelState.Started,
         pipelineName: 'ml-inference-pipeline-2',
         trainedModelName: 'trained-model-id-2',
         types: ['pytorch', 'ner'],
       },
       {
-        isAllocated: true,
-        isDeployed: false,
-        modelState: 'failed',
+        modelState: TrainedModelState.Failed,
         modelStateReason: 'something is wrong, boom',
         pipelineName: 'ml-inference-pipeline-3',
         trainedModelName: 'trained-model-id-3',
         types: ['pytorch', 'text_classification'],
       },
       {
-        isAllocated: true,
-        isDeployed: false,
-        modelState: 'starting',
+        modelState: TrainedModelState.Starting,
         pipelineName: 'ml-inference-pipeline-4',
         trainedModelName: 'trained-model-id-4',
         types: ['pytorch', 'fill_mask'],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_ml_inference_pipeline_processors.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_ml_inference_pipeline_processors.ts
@@ -58,6 +58,7 @@ export const fetchPipelineProcessorInferenceData = async (
       const trainedModelName = inferenceProcessor?.inference?.model_id;
       if (trainedModelName)
         pipelineProcessorData.push({
+          isAllocated: false,
           isDeployed: false,
           pipelineName: pipelineProcessorName,
           trainedModelName,
@@ -98,6 +99,7 @@ export const getMlModelConfigsForModelIds = async (
 
     if (trainedModelNames.includes(trainedModelName)) {
       modelConfigs[trainedModelName] = {
+        isAllocated: false,
         isDeployed: false,
         pipelineName: '',
         trainedModelName,
@@ -110,7 +112,12 @@ export const getMlModelConfigsForModelIds = async (
     const trainedModelName = trainedModelStats.model_id;
     if (modelConfigs.hasOwnProperty(trainedModelName)) {
       const isDeployed = trainedModelStats.deployment_stats?.state === 'started';
+      const isAllocated =
+        (trainedModelStats.deployment_stats?.allocation_status?.allocation_count ?? 0) > 0;
       modelConfigs[trainedModelName].isDeployed = isDeployed;
+      modelConfigs[trainedModelName].isAllocated = isAllocated;
+      modelConfigs[trainedModelName].modelState = trainedModelStats.deployment_stats?.state;
+      modelConfigs[trainedModelName].modelStateReason = trainedModelStats.deployment_stats?.reason;
     }
   });
 
@@ -131,11 +138,14 @@ export const fetchAndAddTrainedModelData = async (
     if (!model) {
       return data;
     }
-    const { types, isDeployed } = model;
+    const { types, isDeployed, isAllocated, modelState, modelStateReason } = model;
     return {
       ...data,
       types,
       isDeployed,
+      isAllocated,
+      modelState,
+      modelStateReason,
     };
   });
 };


### PR DESCRIPTION
## Summary

updated how we render the state of the ml inference processor state to be inline with the trained model state. This will ensure we give the user more information if the model is in a state that will cause an error.

<img width="1689" alt="image" src="https://user-images.githubusercontent.com/1972968/192369925-100a4567-2caa-4be8-889f-4e288e54da68.png">

<img width="1689" alt="image" src="https://user-images.githubusercontent.com/1972968/192369747-8bab6f7e-f372-4e18-bd88-6f0aa7d74cff.png">
trained models button link tooltip
<img width="1689" alt="image" src="https://user-images.githubusercontent.com/1972968/192369819-4892b7d3-7e10-49cf-8897-99a732c83b8e.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->