### PR TITLE
[Profiling] Simplify query post-processing and flamegraph response

### DIFF
--- a/x-pack/plugins/profiling/common/callee.test.ts
+++ b/x-pack/plugins/profiling/common/callee.test.ts
@@ -6,18 +6,18 @@
  */
 
 import { sum } from 'lodash';
-import { createCallerCalleeGraph } from './callercallee';
+import { createCalleeTree } from './callee';
 
 import { events, stackTraces, stackFrames, executables } from './__fixtures__/stacktraces';
 
-describe('Caller-callee operations', () => {
+describe('Callee operations', () => {
   test('1', () => {
     const totalSamples = sum([...events.values()]);
 
-    const graph = createCallerCalleeGraph(events, stackTraces, stackFrames, executables);
+    const tree = createCalleeTree(events, stackTraces, stackFrames, executables);
 
-    expect(graph.root.Samples).toEqual(totalSamples);
-    expect(graph.root.CountInclusive).toEqual(totalSamples);
-    expect(graph.root.CountExclusive).toEqual(0);
+    expect(tree.root.Samples).toEqual(totalSamples);
+    expect(tree.root.CountInclusive).toEqual(totalSamples);
+    expect(tree.root.CountExclusive).toEqual(0);
   });
 });

--- a/x-pack/plugins/profiling/common/callee.test.ts
+++ b/x-pack/plugins/profiling/common/callee.test.ts
@@ -13,11 +13,12 @@ import { events, stackTraces, stackFrames, executables } from './__fixtures__/st
 describe('Callee operations', () => {
   test('1', () => {
     const totalSamples = sum([...events.values()]);
+    const totalFrames = sum([...stackTraces.values()].map((trace) => trace.FrameIDs.length));
 
-    const tree = createCalleeTree(events, stackTraces, stackFrames, executables);
+    const tree = createCalleeTree(events, stackTraces, stackFrames, executables, totalFrames);
 
-    expect(tree.root.Samples).toEqual(totalSamples);
-    expect(tree.root.CountInclusive).toEqual(totalSamples);
-    expect(tree.root.CountExclusive).toEqual(0);
+    expect(tree.Samples[0]).toEqual(totalSamples);
+    expect(tree.CountInclusive[0]).toEqual(totalSamples);
+    expect(tree.CountExclusive[0]).toEqual(0);
   });
 });

--- a/x-pack/plugins/profiling/common/callee.ts
+++ b/x-pack/plugins/profiling/common/callee.ts
@@ -102,10 +102,8 @@ function insertNode(
   return node;
 }
 
-// createCalleeTree creates a tree in the internal representation from a
-// StackFrameMetadata that identifies the "centered" function and the trace
-// results that provide traces and the number of times that the trace has
-// been seen.
+// createCalleeTree creates a tree from the trace results, the number of
+// times that the trace has been seen, and the respective metadata.
 //
 // The resulting data structure contains all of the data, but is not yet in the
 // form most easily digestible by others.
@@ -126,9 +124,9 @@ export function createCalleeTree(
     return t1.localeCompare(t2);
   });
 
-  // Walk through all traces that contain the root. Increment the count of the
-  // root by the count of that trace. Walk "down" the trace (through the callees)
-  // and add the count of the trace to each callee.
+  // Walk through all traces. Increment the count of the root by the count of
+  // that trace. Walk "down" the trace (through the callees) and add the count
+  // of the trace to each callee.
 
   for (const stackTraceID of sortedStackTraceIDs) {
     // The slice of frames is ordered so that the leaf function is at the
@@ -192,22 +190,4 @@ export function createCalleeTree(
   tree.CountInclusive[0] = tree.Samples[0];
 
   return tree;
-}
-
-export function sortEdges(tree: CalleeTree, node: NodeID): NodeID[] {
-  const sortedNodes = new Array<NodeID>(tree.Edges[node].size);
-  let i = 0;
-  for (const [_, n] of tree.Edges[node]) {
-    sortedNodes[i] = n;
-    i++;
-  }
-  return sortedNodes.sort((n1, n2) => {
-    if (tree.Samples[n1] > tree.Samples[n2]) {
-      return -1;
-    }
-    if (tree.Samples[n1] < tree.Samples[n2]) {
-      return 1;
-    }
-    return tree.ID[n1].localeCompare(tree.ID[n2]);
-  });
 }

--- a/x-pack/plugins/profiling/common/callee.ts
+++ b/x-pack/plugins/profiling/common/callee.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import fnv from 'fnv-plus';
+
 import { createFrameGroupID, FrameGroupID } from './frame_group';
 import {
   createStackFrameMetadata,
@@ -27,7 +29,7 @@ export interface CalleeTree {
   Size: number;
   Edges: Array<Map<FrameGroupID, NodeID>>;
 
-  FrameGroupID: FrameGroupID[];
+  ID: string[];
   FrameType: number[];
   FrameID: StackFrameID[];
   FileID: FileID[];
@@ -50,7 +52,7 @@ function initCalleeTree(capacity: number): CalleeTree {
   const tree: CalleeTree = {
     Size: 1,
     Edges: new Array(capacity),
-    FrameGroupID: new Array(capacity),
+    ID: new Array(capacity),
     FrameType: new Array(capacity),
     FrameID: new Array(capacity),
     FileID: new Array(capacity),
@@ -61,7 +63,8 @@ function initCalleeTree(capacity: number): CalleeTree {
   };
 
   tree.Edges[0] = new Map<FrameGroupID, NodeID>();
-  tree.FrameGroupID[0] = frameGroupID;
+
+  tree.ID[0] = fnv.fast1a64utf(frameGroupID).toString();
   tree.FrameType[0] = metadata.FrameType;
   tree.FrameID[0] = metadata.FrameID;
   tree.FileID[0] = metadata.FileID;
@@ -84,7 +87,8 @@ function insertNode(
 
   tree.Edges[parent].set(frameGroupID, node);
   tree.Edges[node] = new Map<FrameGroupID, NodeID>();
-  tree.FrameGroupID[node] = frameGroupID;
+
+  tree.ID[node] = fnv.fast1a64utf(`${tree.ID[parent]}${frameGroupID}`).toString();
   tree.FrameType[node] = metadata.FrameType;
   tree.FrameID[node] = metadata.FrameID;
   tree.FileID[node] = metadata.FileID;
@@ -204,6 +208,6 @@ export function sortEdges(tree: CalleeTree, node: NodeID): NodeID[] {
     if (tree.Samples[n1] < tree.Samples[n2]) {
       return 1;
     }
-    return tree.FrameGroupID[n1].localeCompare(tree.FrameGroupID[n2]);
+    return tree.ID[n1].localeCompare(tree.ID[n2]);
   });
 }

--- a/x-pack/plugins/profiling/common/callercallee.ts
+++ b/x-pack/plugins/profiling/common/callercallee.ts
@@ -8,6 +8,8 @@
 import { createFrameGroup, createFrameGroupID, FrameGroupID } from './frame_group';
 import {
   createStackFrameMetadata,
+  emptyExecutable,
+  emptyStackFrame,
   emptyStackTrace,
   Executable,
   FileID,
@@ -108,8 +110,8 @@ export function createCallerCalleeGraph(
       const frameID = stackTrace.FrameIDs[i];
       const fileID = stackTrace.FileIDs[i];
       const addressOrLine = stackTrace.AddressOrLines[i];
-      const frame = stackFrames.get(frameID)!;
-      const executable = executables.get(fileID)!;
+      const frame = stackFrames.get(frameID) ?? emptyStackFrame;
+      const executable = executables.get(fileID) ?? emptyExecutable;
 
       const frameGroup = createFrameGroup(
         fileID,

--- a/x-pack/plugins/profiling/common/callercallee.ts
+++ b/x-pack/plugins/profiling/common/callercallee.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createFrameGroup, createFrameGroupID, FrameGroupID } from './frame_group';
+import { createFrameGroupID, FrameGroupID } from './frame_group';
 import {
   createStackFrameMetadata,
   emptyExecutable,
@@ -66,14 +66,13 @@ export function createCallerCalleeGraph(
 ): CallerCalleeGraph {
   // Create a root node for the graph
   const rootFrame = createStackFrameMetadata();
-  const rootFrameGroup = createFrameGroup(
+  const rootFrameGroupID = createFrameGroupID(
     rootFrame.FileID,
     rootFrame.AddressOrLine,
     rootFrame.ExeFileName,
     rootFrame.SourceFilename,
     rootFrame.FunctionName
   );
-  const rootFrameGroupID = createFrameGroupID(rootFrameGroup);
   const root = createCallerCalleeNode(rootFrame, rootFrameGroupID, 0);
   const graph: CallerCalleeGraph = { root, size: 1 };
 
@@ -113,14 +112,13 @@ export function createCallerCalleeGraph(
       const frame = stackFrames.get(frameID) ?? emptyStackFrame;
       const executable = executables.get(fileID) ?? emptyExecutable;
 
-      const frameGroup = createFrameGroup(
+      const frameGroupID = createFrameGroupID(
         fileID,
         addressOrLine,
         executable.FileName,
         frame.FileName,
         frame.FunctionName
       );
-      const frameGroupID = createFrameGroupID(frameGroup);
 
       let node = currentNode.Callees.get(frameGroupID);
 

--- a/x-pack/plugins/profiling/common/flamegraph.test.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sum } from 'lodash';
+import { createCalleeTree } from './callee';
+import { createColumnarViewModel, createFlameGraph } from './flamegraph';
+
+import { events, stackTraces, stackFrames, executables } from './__fixtures__/stacktraces';
+
+describe('Flamegraph operations', () => {
+  test('1', () => {
+    const totalSamples = sum([...events.values()]);
+    const totalFrames = sum([...stackTraces.values()].map((trace) => trace.FrameIDs.length));
+
+    const tree = createCalleeTree(events, stackTraces, stackFrames, executables, totalFrames);
+    const graph = createFlameGraph(tree, 60, totalSamples, totalSamples);
+
+    expect(graph.Size).toEqual(totalFrames - 2);
+
+    const viewModel1 = createColumnarViewModel(graph);
+
+    expect(sum(viewModel1.color)).toBeGreaterThan(0);
+
+    const viewModel2 = createColumnarViewModel(graph, false);
+
+    expect(sum(viewModel2.color)).toEqual(0);
+  });
+});

--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -6,35 +6,23 @@
  */
 
 import { ColumnarViewModel } from '@elastic/charts';
-import { CalleeTree, sortEdges } from './callee';
 
-interface ColumnarCallee {
-  Label: string[];
-  Value: number[];
-  X: number[];
-  Y: number[];
-  Color: number[];
-  CountInclusive: number[];
-  CountExclusive: number[];
+import { CalleeTree } from './callee';
+
+export interface ElasticFlameGraph {
+  Size: number;
+  Edges: number[][];
+
   ID: string[];
+  FrameType: number[];
   FrameID: string[];
   ExecutableID: string[];
-}
-
-export interface FlameGraph {
   Label: string[];
-  Value: number[];
-  Position: number[];
-  Size: number[];
-  Color: number[];
+
+  Samples: number[];
   CountInclusive: number[];
   CountExclusive: number[];
-  ID: string[];
-  FrameID: string[];
-  ExecutableID: string[];
-}
 
-export interface ElasticFlameGraph extends FlameGraph {
   TotalSeconds: number;
   TotalTraces: number;
   SampledTraces: number;
@@ -93,96 +81,119 @@ function normalize(n: number, lower: number, upper: number): number {
   return (n - lower) / (upper - lower);
 }
 
-// createColumnarCallee flattens the intermediate representation of the tree
-// into a columnar format that is more compact than JSON. This representation
-// will later need to be normalized into the response ultimately consumed by
-// the flamegraph.
-export function createColumnarCallee(tree: CalleeTree): ColumnarCallee {
-  const size = tree.Size;
-  const columnar: ColumnarCallee = {
-    Label: tree.Label.slice(0, size),
-    Value: tree.Samples.slice(0, size),
-    X: new Array<number>(size),
-    Y: new Array<number>(size),
-    Color: new Array<number>(size * 4),
-    CountInclusive: tree.CountInclusive.slice(0, size),
-    CountExclusive: tree.CountExclusive.slice(0, size),
-    ID: tree.ID.slice(0, size),
-    FrameID: tree.FrameID.slice(0, size),
-    ExecutableID: tree.FileID.slice(0, size),
+// createFlameGraph encapsulates the tree representation into a serialized form.
+export function createFlameGraph(
+  tree: CalleeTree,
+  totalSeconds: number,
+  totalTraces: number,
+  sampledTraces: number
+): ElasticFlameGraph {
+  const graph: ElasticFlameGraph = {
+    Size: tree.Size,
+    Edges: new Array<number[]>(tree.Size),
+
+    ID: tree.ID.slice(0, tree.Size),
+    Label: tree.Label.slice(0, tree.Size),
+    FrameID: tree.FrameID.slice(0, tree.Size),
+    FrameType: tree.FrameType.slice(0, tree.Size),
+    ExecutableID: tree.FileID.slice(0, tree.Size),
+
+    Samples: tree.Samples.slice(0, tree.Size),
+    CountInclusive: tree.CountInclusive.slice(0, tree.Size),
+    CountExclusive: tree.CountExclusive.slice(0, tree.Size),
+
+    TotalSeconds: totalSeconds,
+    TotalTraces: totalTraces,
+    SampledTraces: sampledTraces,
   };
+
+  for (let i = 0; i < tree.Size; i++) {
+    let j = 0;
+    const nodes = new Array<number>(tree.Edges[i].size);
+    for (const [, n] of tree.Edges[i]) {
+      nodes[j] = n;
+      j++;
+    }
+    graph.Edges[i] = nodes;
+  }
+
+  return graph;
+}
+
+// createColumnarViewModel normalizes the columnar representation into a form
+// consumed by the flamegraph in the UI.
+export function createColumnarViewModel(
+  flamegraph: ElasticFlameGraph,
+  assignColors: boolean = true
+): ColumnarViewModel {
+  const numNodes = flamegraph.Size;
+  const xs = new Float32Array(numNodes);
+  const ys = new Float32Array(numNodes);
 
   const queue = [{ x: 0, depth: 1, node: 0 }];
 
   while (queue.length > 0) {
     const { x, depth, node } = queue.pop()!;
 
-    columnar.X[node] = x;
-    columnar.Y[node] = depth;
-
-    const [red, green, blue, alpha] = rgbToRGBA(frameTypeToRGB(tree.FrameType[node], x));
-    const j = 4 * node;
-    columnar.Color[j] = red;
-    columnar.Color[j + 1] = green;
-    columnar.Color[j + 2] = blue;
-    columnar.Color[j + 3] = alpha;
+    xs[node] = x;
+    ys[node] = depth;
 
     // For a deterministic result we have to walk the callees in a deterministic
     // order. A deterministic result allows deterministic UI views, something
     // that users expect.
-    const children = sortEdges(tree, node);
+    const children = flamegraph.Edges[node].sort((n1, n2) => {
+      if (flamegraph.Samples[n1] > flamegraph.Samples[n2]) {
+        return -1;
+      }
+      if (flamegraph.Samples[n1] < flamegraph.Samples[n2]) {
+        return 1;
+      }
+      return flamegraph.ID[n1].localeCompare(flamegraph.ID[n2]);
+    });
 
     let delta = 0;
     for (const child of children) {
-      delta += columnar.Value[child];
+      delta += flamegraph.Samples[child];
     }
 
     for (let i = children.length - 1; i >= 0; i--) {
-      delta -= columnar.Value[children[i]];
+      delta -= flamegraph.Samples[children[i]];
       queue.push({ x: x + delta, depth: depth + 1, node: children[i] });
     }
   }
 
-  return columnar;
-}
+  const colors = new Float32Array(numNodes * 4);
 
-// createFlameGraph normalizes the intermediate columnar representation into the
-// response ultimately consumed by the flamegraph in the UI.
-export function createFlameGraph(columnar: ColumnarCallee): FlameGraph {
-  const graph: FlameGraph = {
-    Label: [],
-    Value: [],
-    Position: [],
-    Size: [],
-    Color: [],
-    CountInclusive: [],
-    CountExclusive: [],
-    ID: [],
-    FrameID: [],
-    ExecutableID: [],
-  };
-
-  graph.Label = columnar.Label;
-  graph.Value = columnar.Value;
-  graph.Color = columnar.Color;
-  graph.CountInclusive = columnar.CountInclusive;
-  graph.CountExclusive = columnar.CountExclusive;
-  graph.ID = columnar.ID;
-  graph.FrameID = columnar.FrameID;
-  graph.ExecutableID = columnar.ExecutableID;
-
-  const maxX = columnar.Value[0];
-  const maxY = columnar.Y.reduce((max, n) => (n > max ? n : max), 0);
-
-  for (let i = 0; i < columnar.X.length; i++) {
-    const x = normalize(columnar.X[i], 0, maxX);
-    const y = normalize(maxY - columnar.Y[i], 0, maxY);
-    graph.Position.push(x, y);
+  if (assignColors) {
+    for (let i = 0; i < numNodes; i++) {
+      const rgba = rgbToRGBA(frameTypeToRGB(flamegraph.FrameType[i], xs[i]));
+      colors.set(rgba, 4 * i);
+    }
   }
 
-  graph.Size = graph.Value.map((n) => normalize(n, 0, maxX));
+  const position = new Float32Array(numNodes * 2);
+  const maxX = flamegraph.Samples[0];
+  const maxY = ys.reduce((max, n) => (n > max ? n : max), 0);
 
-  return graph;
+  for (let i = 0; i < numNodes; i++) {
+    const j = 2 * i;
+    position[j] = normalize(xs[i], 0, maxX);
+    position[j + 1] = normalize(maxY - ys[i], 0, maxY);
+  }
+
+  const size = new Float32Array(numNodes);
+
+  for (let i = 0; i < numNodes; i++) {
+    size[i] = normalize(flamegraph.Samples[i], 0, maxX);
+  }
+
+  return {
+    label: flamegraph.Label.slice(0, numNodes),
+    value: Float64Array.from(flamegraph.Samples.slice(0, numNodes)),
+    color: colors,
+    position0: position,
+    position1: position,
+    size0: size,
+    size1: size,
+  } as ColumnarViewModel;
 }
-
-export function createColumnarViewModel() {}

--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import fnv from 'fnv-plus';
+import { ColumnarViewModel } from '@elastic/charts';
 import { CalleeTree, sortEdges } from './callee';
 
 interface ColumnarCallee {
@@ -107,15 +107,15 @@ export function createColumnarCallee(tree: CalleeTree): ColumnarCallee {
     Color: new Array<number>(size * 4),
     CountInclusive: tree.CountInclusive.slice(0, size),
     CountExclusive: tree.CountExclusive.slice(0, size),
-    ID: new Array<string>(size),
+    ID: tree.ID.slice(0, size),
     FrameID: tree.FrameID.slice(0, size),
     ExecutableID: tree.FileID.slice(0, size),
   };
 
-  const queue = [{ x: 0, depth: 1, node: 0, parentID: 'root' }];
+  const queue = [{ x: 0, depth: 1, node: 0 }];
 
   while (queue.length > 0) {
-    const { x, depth, node, parentID } = queue.pop()!;
+    const { x, depth, node } = queue.pop()!;
 
     columnar.X[node] = x;
     columnar.Y[node] = depth;
@@ -126,10 +126,6 @@ export function createColumnarCallee(tree: CalleeTree): ColumnarCallee {
     columnar.Color[j + 1] = green;
     columnar.Color[j + 2] = blue;
     columnar.Color[j + 3] = alpha;
-
-    const id = fnv.fast1a64utf(`${parentID}${tree.FrameGroupID[node]}`).toString();
-
-    columnar.ID[node] = id;
 
     // For a deterministic result we have to walk the callees in a deterministic
     // order. A deterministic result allows deterministic UI views, something
@@ -143,7 +139,7 @@ export function createColumnarCallee(tree: CalleeTree): ColumnarCallee {
 
     for (let i = children.length - 1; i >= 0; i--) {
       delta -= columnar.Value[children[i]];
-      queue.push({ x: x + delta, depth: depth + 1, node: children[i], parentID: id });
+      queue.push({ x: x + delta, depth: depth + 1, node: children[i] });
     }
   }
 
@@ -188,3 +184,5 @@ export function createFlameGraph(columnar: ColumnarCallee): FlameGraph {
 
   return graph;
 }
+
+export function createColumnarViewModel() {}

--- a/x-pack/plugins/profiling/common/frame_group.test.ts
+++ b/x-pack/plugins/profiling/common/frame_group.test.ts
@@ -5,40 +5,116 @@
  * 2.0.
  */
 
-import { createFrameGroup, createFrameGroupID } from './frame_group';
+import { createFrameGroupID } from './frame_group';
 
-const nonSymbolizedFrameGroups = [
-  createFrameGroup('0x0123456789ABCDEF', 102938, '', '', ''),
-  createFrameGroup('0x0123456789ABCDEF', 1234, '', '', ''),
-  createFrameGroup('0x0102030405060708', 1234, '', '', ''),
+const nonSymbolizedTests = [
+  {
+    params: {
+      fileID: '0x0123456789ABCDEF',
+      addressOrLine: 102938,
+      exeFilename: '',
+      sourceFilename: '',
+      functionName: '',
+    },
+    expected: 'empty;0x0123456789ABCDEF;102938',
+  },
+  {
+    params: {
+      fileID: '0x0123456789ABCDEF',
+      addressOrLine: 1234,
+      exeFilename: 'libpthread',
+      sourceFilename: '',
+      functionName: '',
+    },
+    expected: 'empty;0x0123456789ABCDEF;1234',
+  },
 ];
 
-const elfSymbolizedFrameGroups = [
-  createFrameGroup('0x0123456789ABCDEF', 0, 'libc', '', 'strlen()'),
-  createFrameGroup('0xFEDCBA9876543210', 0, 'libc', '', 'strtok()'),
-  createFrameGroup('0xFEDCBA9876543210', 0, 'myapp', '', 'main()'),
+const elfSymbolizedTests = [
+  {
+    params: {
+      fileID: '0x0123456789ABCDEF',
+      addressOrLine: 0,
+      exeFilename: 'libc',
+      sourceFilename: '',
+      functionName: 'strlen()',
+    },
+    expected: 'elf;libc;strlen()',
+  },
+  {
+    params: {
+      fileID: '0xFEDCBA9876543210',
+      addressOrLine: 8888,
+      exeFilename: 'libc',
+      sourceFilename: '',
+      functionName: 'strtok()',
+    },
+    expected: 'elf;libc;strtok()',
+  },
 ];
 
-const symbolizedFrameGroups = [
-  createFrameGroup('', 0, 'chrome', 'strlen()', 'strlen()'),
-  createFrameGroup('', 0, 'dockerd', 'main()', 'createTask()'),
-  createFrameGroup('', 0, 'oom_reaper', 'main()', 'crash()'),
+const symbolizedTests = [
+  {
+    params: {
+      fileID: '',
+      addressOrLine: 0,
+      exeFilename: 'chrome',
+      sourceFilename: 'strlen()',
+      functionName: 'strlen()',
+    },
+    expected: 'full;chrome;strlen();strlen()',
+  },
+  {
+    params: {
+      fileID: '',
+      addressOrLine: 0,
+      exeFilename: 'oom_reaper',
+      sourceFilename: 'main()',
+      functionName: 'crash()',
+    },
+    expected: 'full;oom_reaper;crash();main()',
+  },
 ];
 
 describe('Frame group operations', () => {
   describe('check serialization for', () => {
     test('non-symbolized frame', () => {
-      expect(createFrameGroupID(nonSymbolizedFrameGroups[0])).toEqual(
-        'empty;0x0123456789ABCDEF;102938'
-      );
+      for (const test of nonSymbolizedTests) {
+        const frameGroupID = createFrameGroupID(
+          test.params.fileID,
+          test.params.addressOrLine,
+          test.params.exeFilename,
+          test.params.sourceFilename,
+          test.params.functionName
+        );
+        expect(frameGroupID).toEqual(test.expected);
+      }
     });
 
     test('non-symbolized ELF frame', () => {
-      expect(createFrameGroupID(elfSymbolizedFrameGroups[0])).toEqual('elf;libc;strlen()');
+      for (const test of elfSymbolizedTests) {
+        const frameGroupID = createFrameGroupID(
+          test.params.fileID,
+          test.params.addressOrLine,
+          test.params.exeFilename,
+          test.params.sourceFilename,
+          test.params.functionName
+        );
+        expect(frameGroupID).toEqual(test.expected);
+      }
     });
 
     test('symbolized frame', () => {
-      expect(createFrameGroupID(symbolizedFrameGroups[0])).toEqual('full;chrome;strlen();strlen()');
+      for (const test of symbolizedTests) {
+        const frameGroupID = createFrameGroupID(
+          test.params.fileID,
+          test.params.addressOrLine,
+          test.params.exeFilename,
+          test.params.sourceFilename,
+          test.params.functionName
+        );
+        expect(frameGroupID).toEqual(test.expected);
+      }
     });
   });
 });

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -9,12 +9,6 @@ import { StackFrameMetadata } from './profiling';
 
 export type FrameGroupID = string;
 
-enum FrameGroupName {
-  EMPTY = 'empty',
-  ELF = 'elf',
-  FULL = 'full',
-}
-
 // createFrameGroupID is the "standard" way of grouping frames, by commonly
 // shared group identifiers.
 //
@@ -29,12 +23,12 @@ export function createFrameGroupID(
   functionName: StackFrameMetadata['FunctionName']
 ): FrameGroupID {
   if (functionName === '') {
-    return `${FrameGroupName.EMPTY};${fileID};${addressOrLine}`;
+    return `empty;${fileID};${addressOrLine}`;
   }
 
   if (sourceFilename === '') {
-    return `${FrameGroupName.ELF};${exeFilename};${functionName}`;
+    return `elf;${exeFilename};${functionName}`;
   }
 
-  return `${FrameGroupName.FULL};${exeFilename};${functionName};${sourceFilename}`;
+  return `full;${exeFilename};${functionName};${sourceFilename}`;
 }

--- a/x-pack/plugins/profiling/common/frame_group.ts
+++ b/x-pack/plugins/profiling/common/frame_group.ts
@@ -15,80 +15,26 @@ enum FrameGroupName {
   FULL = 'full',
 }
 
-interface BaseFrameGroup {
-  readonly name: FrameGroupName;
-}
-
-interface EmptyFrameGroup extends BaseFrameGroup {
-  readonly name: FrameGroupName.EMPTY;
-  readonly fileID: StackFrameMetadata['FileID'];
-  readonly addressOrLine: StackFrameMetadata['AddressOrLine'];
-}
-
-interface ElfFrameGroup extends BaseFrameGroup {
-  readonly name: FrameGroupName.ELF;
-  readonly fileID: StackFrameMetadata['FileID'];
-  readonly exeFilename: StackFrameMetadata['ExeFileName'];
-  readonly functionName: StackFrameMetadata['FunctionName'];
-}
-
-interface FullFrameGroup extends BaseFrameGroup {
-  readonly name: FrameGroupName.FULL;
-  readonly exeFilename: StackFrameMetadata['ExeFileName'];
-  readonly functionName: StackFrameMetadata['FunctionName'];
-  readonly sourceFilename: StackFrameMetadata['SourceFilename'];
-}
-
-export type FrameGroup = EmptyFrameGroup | ElfFrameGroup | FullFrameGroup;
-
-// createFrameGroup is the "standard" way of grouping frames, by commonly
+// createFrameGroupID is the "standard" way of grouping frames, by commonly
 // shared group identifiers.
 //
 // For ELF-symbolized frames, group by FunctionName, ExeFileName and FileID.
 // For non-symbolized frames, group by FileID and AddressOrLine.
 // otherwise group by ExeFileName, SourceFilename and FunctionName.
-export function createFrameGroup(
+export function createFrameGroupID(
   fileID: StackFrameMetadata['FileID'],
   addressOrLine: StackFrameMetadata['AddressOrLine'],
   exeFilename: StackFrameMetadata['ExeFileName'],
   sourceFilename: StackFrameMetadata['SourceFilename'],
   functionName: StackFrameMetadata['FunctionName']
-): FrameGroup {
+): FrameGroupID {
   if (functionName === '') {
-    return {
-      name: FrameGroupName.EMPTY,
-      fileID,
-      addressOrLine,
-    } as EmptyFrameGroup;
+    return `${FrameGroupName.EMPTY};${fileID};${addressOrLine}`;
   }
 
   if (sourceFilename === '') {
-    return {
-      name: FrameGroupName.ELF,
-      fileID,
-      exeFilename,
-      functionName,
-    } as ElfFrameGroup;
+    return `${FrameGroupName.ELF};${exeFilename};${functionName}`;
   }
 
-  return {
-    name: FrameGroupName.FULL,
-    exeFilename,
-    functionName,
-    sourceFilename,
-  } as FullFrameGroup;
-}
-
-export function createFrameGroupID(frameGroup: FrameGroup): FrameGroupID {
-  switch (frameGroup.name) {
-    case FrameGroupName.EMPTY:
-      return `${frameGroup.name};${frameGroup.fileID};${frameGroup.addressOrLine}`;
-      break;
-    case FrameGroupName.ELF:
-      return `${frameGroup.name};${frameGroup.exeFilename};${frameGroup.functionName}`;
-      break;
-    case FrameGroupName.FULL:
-      return `${frameGroup.name};${frameGroup.exeFilename};${frameGroup.functionName};${frameGroup.sourceFilename}`;
-      break;
-  }
+  return `${FrameGroupName.FULL};${exeFilename};${functionName};${sourceFilename}`;
 }

--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import * as t from 'io-ts';
-import { createFrameGroup, createFrameGroupID, FrameGroupID } from './frame_group';
+import { createFrameGroupID, FrameGroupID } from './frame_group';
 import {
   createStackFrameMetadata,
   emptyExecutable,
@@ -71,14 +71,13 @@ export function createTopNFunctions(
       const frame = stackFrames.get(frameID) ?? emptyStackFrame;
       const executable = executables.get(fileID) ?? emptyExecutable;
 
-      const frameGroup = createFrameGroup(
+      const frameGroupID = createFrameGroupID(
         fileID,
         addressOrLine,
         executable.FileName,
         frame.FileName,
         frame.FunctionName
       );
-      const frameGroupID = createFrameGroupID(frameGroup);
 
       let topNFunction = topNFunctions.get(frameGroupID);
 

--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -8,6 +8,8 @@ import * as t from 'io-ts';
 import { createFrameGroup, createFrameGroupID, FrameGroupID } from './frame_group';
 import {
   createStackFrameMetadata,
+  emptyExecutable,
+  emptyStackFrame,
   emptyStackTrace,
   Executable,
   FileID,
@@ -66,8 +68,8 @@ export function createTopNFunctions(
       const frameID = stackTrace.FrameIDs[i];
       const fileID = stackTrace.FileIDs[i];
       const addressOrLine = stackTrace.AddressOrLines[i];
-      const frame = stackFrames.get(frameID)!;
-      const executable = executables.get(fileID)!;
+      const frame = stackFrames.get(frameID) ?? emptyStackFrame;
+      const executable = executables.get(fileID) ?? emptyExecutable;
 
       const frameGroup = createFrameGroup(
         fileID,

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -28,18 +28,20 @@ export enum FrameType {
   JavaScript,
 }
 
+const frameTypeDescriptions = {
+  [FrameType.Unsymbolized]: '<unsymbolized frame>',
+  [FrameType.Python]: 'Python',
+  [FrameType.PHP]: 'PHP',
+  [FrameType.Native]: 'Native',
+  [FrameType.Kernel]: 'Kernel',
+  [FrameType.JVM]: 'JVM/Hotspot',
+  [FrameType.Ruby]: 'Ruby',
+  [FrameType.Perl]: 'Perl',
+  [FrameType.JavaScript]: 'JavaScript',
+};
+
 export function describeFrameType(ft: FrameType): string {
-  return {
-    [FrameType.Unsymbolized]: '<unsymbolized frame>',
-    [FrameType.Python]: 'Python',
-    [FrameType.PHP]: 'PHP',
-    [FrameType.Native]: 'Native',
-    [FrameType.Kernel]: 'Kernel',
-    [FrameType.JVM]: 'JVM/Hotspot',
-    [FrameType.Ruby]: 'Ruby',
-    [FrameType.Perl]: 'Perl',
-    [FrameType.JavaScript]: 'JavaScript',
-  }[ft];
+  return frameTypeDescriptions[ft];
 }
 
 export interface StackTraceEvent {

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -69,9 +69,21 @@ export interface StackFrame {
   SourceType: number;
 }
 
+export const emptyStackFrame: StackFrame = {
+  FileName: '',
+  FunctionName: '',
+  FunctionOffset: 0,
+  LineNumber: 0,
+  SourceType: 0,
+};
+
 export interface Executable {
   FileName: string;
 }
+
+export const emptyExecutable: Executable = {
+  FileName: '',
+};
 
 export interface StackFrameMetadata {
   // StackTrace.FrameID
@@ -221,8 +233,8 @@ export function groupStackFrameMetadataByStackTrace(
       const frameID = trace.FrameIDs[i];
       const fileID = trace.FileIDs[i];
       const addressOrLine = trace.AddressOrLines[i];
-      const frame = stackFrames.get(frameID)!;
-      const executable = executables.get(fileID)!;
+      const frame = stackFrames.get(frameID) ?? emptyStackFrame;
+      const executable = executables.get(fileID) ?? emptyExecutable;
 
       frameMetadata[i] = createStackFrameMetadata({
         FrameID: frameID,

--- a/x-pack/plugins/profiling/public/components/flamegraph.tsx
+++ b/x-pack/plugins/profiling/public/components/flamegraph.tsx
@@ -226,9 +226,9 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({
           exeFileName: highlightedFrame.ExeFileName,
           sourceFileName: highlightedFrame.SourceFilename,
           functionName: highlightedFrame.FunctionName,
-          samples: primaryFlamegraph.Value[highlightedVmIndex],
+          samples: primaryFlamegraph.Samples[highlightedVmIndex],
           childSamples:
-            primaryFlamegraph.Value[highlightedVmIndex] -
+            primaryFlamegraph.Samples[highlightedVmIndex] -
             primaryFlamegraph.CountExclusive[highlightedVmIndex],
         }
       : undefined;
@@ -275,7 +275,7 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({
 
                       const valueIndex = props.values[0].valueAccessor as number;
                       const label = primaryFlamegraph.Label[valueIndex];
-                      const samples = primaryFlamegraph.Value[valueIndex];
+                      const samples = primaryFlamegraph.Samples[valueIndex];
                       const countInclusive = primaryFlamegraph.CountInclusive[valueIndex];
                       const countExclusive = primaryFlamegraph.CountExclusive[valueIndex];
                       const nodeID = primaryFlamegraph.ID[valueIndex];
@@ -291,8 +291,8 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({
                           comparisonCountInclusive={comparisonNode?.CountInclusive}
                           comparisonCountExclusive={comparisonNode?.CountExclusive}
                           totalSamples={totalSamples}
-                          comparisonTotalSamples={comparisonFlamegraph?.Value[0]}
-                          comparisonSamples={comparisonNode?.Value}
+                          comparisonTotalSamples={comparisonFlamegraph?.Samples[0]}
+                          comparisonSamples={comparisonNode?.Samples}
                         />
                       );
                     },

--- a/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
+++ b/x-pack/plugins/profiling/public/utils/get_flamegraph_model/index.ts
@@ -4,10 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ColumnarViewModel } from '@elastic/charts';
 import d3 from 'd3';
 import { sum, uniqueId } from 'lodash';
-import { ElasticFlameGraph, FlameGraphComparisonMode, rgbToRGBA } from '../../../common/flamegraph';
+import {
+  createColumnarViewModel,
+  ElasticFlameGraph,
+  FlameGraphComparisonMode,
+  rgbToRGBA,
+} from '../../../common/flamegraph';
 import { getInterpolationValue } from './get_interpolation_value';
 
 const nullColumnarViewModel = {
@@ -37,21 +41,19 @@ export function getFlamegraphModel({
 }) {
   const comparisonNodesById: Record<
     string,
-    { Value: number; CountInclusive: number; CountExclusive: number }
+    { Samples: number; CountInclusive: number; CountExclusive: number }
   > = {};
 
   if (!primaryFlamegraph || !primaryFlamegraph.Label || primaryFlamegraph.Label.length === 0) {
     return { key: uniqueId(), viewModel: nullColumnarViewModel, comparisonNodesById };
   }
 
-  let colors: number[] | undefined = primaryFlamegraph.Color;
+  const viewModel = createColumnarViewModel(primaryFlamegraph, comparisonFlamegraph === undefined);
 
   if (comparisonFlamegraph) {
-    colors = [];
-
     comparisonFlamegraph.ID.forEach((nodeID, index) => {
       comparisonNodesById[nodeID] = {
-        Value: comparisonFlamegraph.Value[index],
+        Samples: comparisonFlamegraph.Samples[index],
         CountInclusive: comparisonFlamegraph.CountInclusive[index],
         CountExclusive: comparisonFlamegraph.CountExclusive[index],
       };
@@ -86,8 +88,8 @@ export function getFlamegraphModel({
         : primaryFlamegraph.TotalSeconds / comparisonFlamegraph.TotalSeconds;
 
     primaryFlamegraph.ID.forEach((nodeID, index) => {
-      const samples = primaryFlamegraph.Value[index];
-      const comparisonSamples = comparisonNodesById[nodeID]?.Value as number | undefined;
+      const samples = primaryFlamegraph.Samples[index];
+      const comparisonSamples = comparisonNodesById[nodeID]?.Samples as number | undefined;
 
       const foreground =
         comparisonMode === FlameGraphComparisonMode.Absolute ? samples : samples / totalSamples;
@@ -110,26 +112,14 @@ export function getFlamegraphModel({
           ? positiveChangeInterpolator(interpolationValue)
           : negativeChangeInterpolator(Math.abs(interpolationValue));
 
-      colors!.push(...rgbToRGBA(Number(nodeColor.replace('#', '0x'))));
+      const rgba = rgbToRGBA(Number(nodeColor.replace('#', '0x')));
+      viewModel.color.set(rgba, 4 * index);
     });
   }
 
-  const value = new Float64Array(primaryFlamegraph.Value);
-  const position = new Float32Array(primaryFlamegraph.Position);
-  const size = new Float32Array(primaryFlamegraph.Size);
-  const color = new Float32Array(colors);
-
   return {
     key: uniqueId(),
-    viewModel: {
-      label: primaryFlamegraph.Label,
-      value,
-      color,
-      position0: position,
-      position1: position,
-      size0: size,
-      size1: size,
-    } as ColumnarViewModel,
+    viewModel,
     comparisonNodesById,
   };
 }

--- a/x-pack/plugins/profiling/server/routes/flamechart.ts
+++ b/x-pack/plugins/profiling/server/routes/flamechart.ts
@@ -42,17 +42,30 @@ export function registerFlameChartSearchRoute({ router, logger }: RouteRegisterP
         });
         const totalSeconds = timeTo - timeFrom;
 
-        const { stackTraces, executables, stackFrames, eventsIndex, totalCount, stackTraceEvents } =
-          await getExecutablesAndStackTraces({
-            logger,
-            client: createProfilingEsClient({ request, esClient }),
-            filter,
-            sampleSize: targetSampleSize,
-          });
+        const {
+          stackTraces,
+          executables,
+          stackFrames,
+          eventsIndex,
+          totalCount,
+          totalFrames,
+          stackTraceEvents,
+        } = await getExecutablesAndStackTraces({
+          logger,
+          client: createProfilingEsClient({ request, esClient }),
+          filter,
+          sampleSize: targetSampleSize,
+        });
 
         const flamegraph = await withProfilingSpan('create_flamegraph', async () => {
           const t0 = Date.now();
-          const tree = createCalleeTree(stackTraceEvents, stackTraces, stackFrames, executables);
+          const tree = createCalleeTree(
+            stackTraceEvents,
+            stackTraces,
+            stackFrames,
+            executables,
+            totalFrames
+          );
           logger.info(`creating callee tree took ${Date.now() - t0} ms`);
 
           const t1 = Date.now();

--- a/x-pack/plugins/profiling/server/routes/get_executables_and_stacktraces.ts
+++ b/x-pack/plugins/profiling/server/routes/get_executables_and_stacktraces.ts
@@ -68,7 +68,7 @@ export async function getExecutablesAndStackTraces({
       stackTraceEvents.set(id, Math.floor(count / (eventsIndex.sampleRate * p)));
     }
 
-    const { stackTraces, stackFrameDocIDs, executableDocIDs } = await mgetStackTraces({
+    const { stackTraces, totalFrames, stackFrameDocIDs, executableDocIDs } = await mgetStackTraces({
       logger,
       client,
       events: stackTraceEvents,
@@ -86,6 +86,7 @@ export async function getExecutablesAndStackTraces({
         stackFrames,
         stackTraceEvents,
         totalCount,
+        totalFrames,
         eventsIndex,
       };
     });

--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -18,6 +18,8 @@ import {
   ProfilingStackTrace,
 } from '../../common/elasticsearch';
 import {
+  emptyExecutable,
+  emptyStackFrame,
   Executable,
   FileID,
   StackFrame,
@@ -352,13 +354,7 @@ export async function mgetStackFrames({
       });
       framesFound++;
     } else {
-      stackFrames.set(frame._id, {
-        FileName: '',
-        FunctionName: '',
-        FunctionOffset: 0,
-        LineNumber: 0,
-        SourceType: 0,
-      });
+      stackFrames.set(frame._id, emptyStackFrame);
     }
   }
   logger.info(`processing data took ${Date.now() - t0} ms`);
@@ -403,9 +399,7 @@ export async function mgetExecutables({
       });
       exeFound++;
     } else {
-      executables.set(exe._id, {
-        FileName: '',
-      });
+      executables.set(exe._id, emptyExecutable);
     }
   }
   logger.info(`processing data took ${Date.now() - t0} ms`);

--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -312,7 +312,7 @@ export async function mgetStackTraces({
     );
   }
 
-  return { stackTraces, stackFrameDocIDs, executableDocIDs };
+  return { stackTraces, totalFrames, stackFrameDocIDs, executableDocIDs };
 }
 
 export async function mgetStackFrames({


### PR DESCRIPTION
This PR simplifies the work needed to create the flamechart data and continues to reduce the overall CPU and memory usage.

I used the following principles as a rough guide for this PR:

* only do required work on the KIbana server
* only send data necessary to build `ColumnarViewModel`
* only send data necessary to support differential flamegraphs
* use typed arrays whenever possible for additional performance
* minimize copying between intermediate data structures

#### Summary

To generate the flamechart data after querying Elasticsearch, we now use this simplified pipeline:

1. callee tree using a compact yet hierarchical representation instead of recursive structures
2. flamegraph (JSON-compatible format)
3. columnar view model (interface used by flamechart in UI)

The first and second steps happens on the Kibana server. The third step happens in the Kibana UI. This reduces but doesn't eliminate server contention for multiple requests.

This PR also contains this work:

* refactored and added minor micro-optimizations
* removed frame group and callers from intermediate structures as they are no longer needed

These updates lay the groundwork for future improvements and features.

#### Benchmarks

All metrics are in milliseconds.

| Experiment | Seconds | Minimum | Q1     | Median | Q3     | P90    | P95     | P99     | Maximum |
|------------|---------|---------|--------|--------|--------|--------|---------|---------|---------|
| main       |     900 |    2137 |   2198 |   2232 |   2260 |   2292 |    2320 |    2433 |    2722 |
| main       |    1800 |    2276 |   2332 |   2358 |   2392 |   2472 |    2532 |    2634 |    2637 |
| main       |    3600 |    1850 |   1889 |   1914 |   1943 |   1982 |    2019 |    2068 |    2107 |
| main       |   86400 |    2435 |   2483 |   2502 |   2546 |   2579 |    2671 |    2764 |    2820 |
| PR         |     900 |  -8.33% | -6.73% | -7.30% | -7.17% | -7.59% |  -7.63% |  -8.59% | -10.98% |
| PR         |    1800 |  -7.47% | -7.55% | -7.38% | -7.57% | -9.26% |  -9.20% | -10.40% |  -9.82% |
| PR         |    3600 |  -8.59% | -8.52% | -8.67% | -8.90% | -8.98% |  -9.56% |  -8.56% |  -5.84% |
| PR         |   86400 | -10.47% | -8.01% | -7.51% | -7.89% | -7.75% | -10.00% |  -8.76% |  -6.06% |

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->