### PR TITLE
[APM] Fix APM search bar (8.4 backport only)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_inventory.stories.tsx
@@ -40,7 +40,7 @@ const stories: Meta<{}> = {
         },
         notifications: { toasts: { add: () => {}, addWarning: () => {} } },
         uiSettings: { get: () => [] },
-        dataViews: { get: async () => {} },
+        dataViews: { create: async () => {} },
       } as unknown as CoreStart;
 
       const KibanaReactContext = createKibanaReactContext(coreMock);

--- a/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
@@ -15,6 +15,7 @@ import { ApmServiceContextProvider } from '../../context/apm_service/apm_service
 import { UrlParamsProvider } from '../../context/url_params_context/url_params_context';
 import type { ApmUrlParams } from '../../context/url_params_context/types';
 import * as useFetcherHook from '../../hooks/use_fetcher';
+import * as useApmDataViewHook from '../../hooks/use_apm_data_view';
 import * as useServiceTransactionTypesHook from '../../context/apm_service/use_service_transaction_types_fetcher';
 import { renderWithTheme } from '../../utils/test_helpers';
 import { fromQuery } from './links/url_helpers';
@@ -44,6 +45,11 @@ function setup({
   jest
     .spyOn(useServiceTransactionTypesHook, 'useServiceTransactionTypesFetcher')
     .mockReturnValue(serviceTransactionTypes);
+
+  // mock data view
+  jest
+    .spyOn(useApmDataViewHook, 'useApmDataView')
+    .mockReturnValue({ dataView: undefined });
 
   jest.spyOn(useFetcherHook, 'useFetcher').mockReturnValue({} as any);
 

--- a/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
@@ -7,19 +7,9 @@
 
 import { DataView } from '@kbn/data-views-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
 import { useEffect, useState } from 'react';
-import { APM_STATIC_DATA_VIEW_ID } from '../../common/data_view_constants';
-import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
 import { ApmPluginStartDeps } from '../plugin';
 import { callApmApi } from '../services/rest/create_call_apm_api';
-
-async function createStaticApmDataView() {
-  const res = await callApmApi('POST /internal/apm/data_view/static', {
-    signal: null,
-  });
-  return res.dataView;
-}
 
 async function getApmDataViewTitle() {
   const res = await callApmApi('GET /internal/apm/data_view/title', {
@@ -30,37 +20,16 @@ async function getApmDataViewTitle() {
 
 export function useApmDataView() {
   const { services } = useKibana<ApmPluginStartDeps>();
-  const { core } = useApmPluginContext();
   const [dataView, setDataView] = useState<DataView | undefined>();
-
-  const canCreateDataView =
-    core.application.capabilities.savedObjectsManagement.edit;
 
   useEffect(() => {
     async function fetchDataView() {
-      try {
-        // load static data view
-        return await services.dataViews.get(APM_STATIC_DATA_VIEW_ID);
-      } catch (e) {
-        // re-throw if an unhandled error occurred
-        const notFound = e instanceof SavedObjectNotFound;
-        if (!notFound) {
-          throw e;
-        }
-
-        // create static data view if user has permissions
-        if (canCreateDataView) {
-          return createStaticApmDataView();
-        } else {
-          // or create dynamic data view if user does not have permissions to create a static
-          const title = await getApmDataViewTitle();
-          return services.dataViews.create({ title });
-        }
-      }
+      const title = await getApmDataViewTitle();
+      return services.dataViews.create({ title });
     }
 
-    fetchDataView().then((dv) => setDataView(dv));
-  }, [canCreateDataView, services.dataViews]);
+    fetchDataView().then(setDataView);
+  }, [services.dataViews]);
 
   return { dataView };
 }


### PR DESCRIPTION
Related issue: https://github.com/elastic/kibana/issues/140964
Manual backport of: https://github.com/elastic/kibana/pull/141101

This fixes a problem with the search bar in APM, that caused suggestions to not show up in non-default spaces. This does not fix the problem where navigating to Discover from APM in a non-default space breaks. This issue is only fixed in 8.5+ (https://github.com/elastic/kibana/pull/141101)