### PR TITLE
[SecuritySolution] Don't show process ancestry insights in some cases

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.test.tsx
@@ -61,7 +61,7 @@ jest.mock('../../../hooks/use_experimental_features', () => ({
 }));
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
-const data: TimelineEventsDetailsItem[] = [
+const dataWithoutAgentType: TimelineEventsDetailsItem[] = [
   {
     category: 'process',
     field: 'process.entity_id',
@@ -79,6 +79,16 @@ const data: TimelineEventsDetailsItem[] = [
     field: 'kibana.alert.rule.parameters.index',
     isObjectArray: false,
     values: ['fakeindex'],
+  },
+];
+
+const data: TimelineEventsDetailsItem[] = [
+  ...dataWithoutAgentType,
+  {
+    category: 'agent',
+    field: 'agent.type',
+    isObjectArray: false,
+    values: ['endpoint'],
   },
 ];
 
@@ -123,9 +133,11 @@ describe('Insights', () => {
 
   describe('with feature flag enabled', () => {
     describe('with platinum license', () => {
-      it('should show insights for related alerts by process ancestry', () => {
+      beforeAll(() => {
         licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
+      });
 
+      it('should show insights for related alerts by process ancestry', () => {
         render(
           <TestProviders>
             <Insights browserFields={{}} eventId="test" data={data} timelineId="" />
@@ -136,6 +148,23 @@ describe('Insights', () => {
         expect(
           screen.queryByRole('link', { name: new RegExp(i18n.ALERT_UPSELL) })
         ).not.toBeInTheDocument();
+      });
+
+      describe('without process ancestry info', () => {
+        it('should not show the related alerts by process ancestry insights module', () => {
+          render(
+            <TestProviders>
+              <Insights
+                browserFields={{}}
+                eventId="test"
+                data={dataWithoutAgentType}
+                timelineId=""
+              />
+            </TestProviders>
+          );
+
+          expect(screen.queryByTestId('related-alerts-by-ancestry')).not.toBeInTheDocument();
+        });
       });
     });
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.tsx
@@ -40,7 +40,6 @@ export const Insights = React.memo<Props>(
       'insightsRelatedAlertsByProcessAncestry'
     );
     const hasAtLeastPlatinum = useLicense().isPlatinumPlus();
-    const processEntityField = find({ category: 'process', field: 'process.entity_id' }, data);
     const originalDocumentId = find(
       { category: 'kibana', field: 'kibana.alert.ancestors.id' },
       data
@@ -49,7 +48,12 @@ export const Insights = React.memo<Props>(
       { category: 'kibana', field: 'kibana.alert.rule.parameters.index' },
       data
     );
-    const hasProcessEntityInfo = hasData(processEntityField);
+    const agentTypeField = find({ category: 'agent', field: 'agent.type' }, data);
+    const eventModuleField = find({ category: 'event', field: 'event.module' }, data);
+    const processEntityField = find({ category: 'process', field: 'process.entity_id' }, data);
+    const hasProcessEntityInfo =
+      hasData(processEntityField) &&
+      hasCorrectAgentTypeAndEventModule(agentTypeField, eventModuleField);
 
     const processSessionField = find(
       { category: 'process', field: 'process.entry_leader.entity_id' },
@@ -146,5 +150,18 @@ export const Insights = React.memo<Props>(
     );
   }
 );
+
+function hasCorrectAgentTypeAndEventModule(
+  agentTypeField?: TimelineEventsDetailsItem,
+  eventModuleField?: TimelineEventsDetailsItem
+): boolean {
+  return (
+    hasData(agentTypeField) &&
+    (agentTypeField.values[0] === 'endpoint' ||
+      (agentTypeField.values[0] === 'winlogbeat' &&
+        hasData(eventModuleField) &&
+        eventModuleField.values[0] === 'sysmon'))
+  );
+}
 
 Insights.displayName = 'Insights';


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/140636 describes an issue where the related alerts by ancestry insight module is shown, even though there is no ancestry data available for that alert.

This happens because we were not taking into account all the required fields to show process ancestry information. This has been fixed in this PR.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->