### PR TITLE
[TIP] Extract useFilters logic to a shared context

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/common/mocks/mock_indicators_filters_context.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/mock_indicators_filters_context.tsx
@@ -6,11 +6,19 @@
  */
 
 import { FilterManager } from '@kbn/data-plugin/public';
-import { IndicatorsFiltersContextValue } from '../../modules/indicators/context';
+import { IndicatorsFiltersContextValue } from '../../modules/indicators/containers/indicators_filters/context';
 
 export const mockIndicatorsFiltersContext: IndicatorsFiltersContextValue = {
   filterManager: {
     getFilters: () => [],
     setFilters: () => {},
   } as unknown as FilterManager,
+  filters: [],
+  filterQuery: {
+    language: 'kuery',
+    query: '',
+  },
+  handleSavedQuery: () => {},
+  handleSubmitQuery: () => {},
+  handleSubmitTimeRange: () => {},
 };

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
@@ -16,7 +16,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { mockIndicatorsFiltersContext } from './mock_indicators_filters_context';
 import { SecuritySolutionContext } from '../../containers/security_solution_context';
 import { getSecuritySolutionContextMock } from './mock_security_context';
-import { IndicatorsFiltersContext } from '../../modules/indicators/context';
+import { IndicatorsFiltersContext } from '../../modules/indicators/containers/indicators_filters/context';
 import { FieldTypesContext } from '../../containers/field_types_provider';
 import { generateFieldTypeMap } from './mock_field_type_map';
 import { mockUiSettingsService } from './mock_kibana_ui_settings_service';

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/test_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/test_providers.tsx
@@ -18,12 +18,13 @@ import { createTGridMocks } from '@kbn/timelines-plugin/public/mock';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import { KibanaContext } from '../../hooks/use_kibana';
 import { SecuritySolutionPluginContext } from '../../types';
 import { getSecuritySolutionContextMock } from './mock_security_context';
 import { mockUiSetting } from './mock_kibana_ui_settings_service';
 import { SecuritySolutionContext } from '../../containers/security_solution_context';
-import { IndicatorsFiltersContext } from '../../modules/indicators/context';
+import { IndicatorsFiltersContext } from '../../modules/indicators/containers/indicators_filters/context';
 import { mockIndicatorsFiltersContext } from './mock_indicators_filters_context';
 import { FieldTypesContext } from '../../containers/field_types_provider';
 import { generateFieldTypeMap } from './mock_field_type_map';
@@ -128,23 +129,25 @@ export const mockedServices = {
 };
 
 export const TestProvidersComponent: FC = ({ children }) => (
-  <InspectorContext.Provider value={{ requests: new RequestAdapter() }}>
-    <QueryClientProvider client={new QueryClient()}>
-      <FieldTypesContext.Provider value={generateFieldTypeMap()}>
-        <EuiThemeProvider>
-          <SecuritySolutionContext.Provider value={mockSecurityContext}>
-            <KibanaContext.Provider value={{ services: mockedServices } as any}>
-              <I18nProvider>
-                <IndicatorsFiltersContext.Provider value={mockIndicatorsFiltersContext}>
-                  {children}
-                </IndicatorsFiltersContext.Provider>
-              </I18nProvider>
-            </KibanaContext.Provider>
-          </SecuritySolutionContext.Provider>
-        </EuiThemeProvider>
-      </FieldTypesContext.Provider>
-    </QueryClientProvider>
-  </InspectorContext.Provider>
+  <MemoryRouter>
+    <InspectorContext.Provider value={{ requests: new RequestAdapter() }}>
+      <QueryClientProvider client={new QueryClient()}>
+        <FieldTypesContext.Provider value={generateFieldTypeMap()}>
+          <EuiThemeProvider>
+            <SecuritySolutionContext.Provider value={mockSecurityContext}>
+              <KibanaContext.Provider value={{ services: mockedServices } as any}>
+                <I18nProvider>
+                  <IndicatorsFiltersContext.Provider value={mockIndicatorsFiltersContext}>
+                    {children}
+                  </IndicatorsFiltersContext.Provider>
+                </I18nProvider>
+              </KibanaContext.Provider>
+            </SecuritySolutionContext.Provider>
+          </EuiThemeProvider>
+        </FieldTypesContext.Provider>
+      </QueryClientProvider>
+    </InspectorContext.Provider>
+  </MemoryRouter>
 );
 
 export type MockedSearch = jest.Mocked<typeof mockedServices.data.search>;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/fields_table/fields_table.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/fields_table/fields_table.stories.tsx
@@ -10,7 +10,7 @@ import { mockIndicatorsFiltersContext } from '../../../../../common/mocks/mock_i
 import { IndicatorFieldsTable } from '.';
 import { generateMockIndicator } from '../../../../../../common/types/indicator';
 import { StoryProvidersComponent } from '../../../../../common/mocks/story_providers';
-import { IndicatorsFiltersContext } from '../../../context';
+import { IndicatorsFiltersContext } from '../../../containers/indicators_filters';
 
 export default {
   component: IndicatorFieldsTable,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
@@ -14,7 +14,7 @@ import { mockUiSettingsService } from '../../../../common/mocks/mock_kibana_ui_s
 import { mockKibanaTimelinesService } from '../../../../common/mocks/mock_kibana_timelines_service';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { IndicatorsFlyout } from '.';
-import { IndicatorsFiltersContext } from '../../context';
+import { IndicatorsFiltersContext } from '../../containers/indicators_filters';
 
 export default {
   component: IndicatorsFlyout,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/block/block.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/block/block.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { IndicatorsFiltersContext } from '../../../../context';
+import { IndicatorsFiltersContext } from '../../../../containers/indicators_filters';
 import { StoryProvidersComponent } from '../../../../../../common/mocks/story_providers';
 import { generateMockIndicator } from '../../../../../../../common/types/indicator';
 import { IndicatorBlock } from '.';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.stories.tsx
@@ -10,7 +10,7 @@ import { Story } from '@storybook/react';
 import { StoryProvidersComponent } from '../../../../../common/mocks/story_providers';
 import { generateMockIndicator, Indicator } from '../../../../../../common/types/indicator';
 import { IndicatorsFlyoutOverview } from '.';
-import { IndicatorsFiltersContext } from '../../../context';
+import { IndicatorsFiltersContext } from '../../../containers/indicators_filters';
 
 export default {
   component: IndicatorsFlyoutOverview,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.stories.tsx
@@ -14,7 +14,7 @@ import { mockUiSettingsService } from '../../../../../common/mocks/mock_kibana_u
 import { mockKibanaTimelinesService } from '../../../../../common/mocks/mock_kibana_timelines_service';
 import { generateMockIndicator, Indicator } from '../../../../../../common/types/indicator';
 import { IndicatorsFlyoutTable } from '.';
-import { IndicatorsFiltersContext } from '../../../context';
+import { IndicatorsFiltersContext } from '../../../containers/indicators_filters';
 
 export default {
   component: IndicatorsFlyoutTable,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.stories.tsx
@@ -120,7 +120,16 @@ export const Default: Story<void> = () => {
     <StoryProvidersComponent
       kibana={{ data: dataServiceMock, uiSettings: uiSettingsMock, timelines: timelinesMock }}
     >
-      <IndicatorsBarChartWrapper timeRange={mockTimeRange} indexPattern={mockIndexPattern} />
+      <IndicatorsBarChartWrapper
+        dateRange={{ min: moment(), max: moment() }}
+        timeRange={mockTimeRange}
+        indexPattern={mockIndexPattern}
+        series={[]}
+        field={''}
+        onFieldChange={function (value: string): void {
+          throw new Error('Function not implemented.');
+        }}
+      />
     </StoryProvidersComponent>
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.test.tsx
@@ -13,6 +13,7 @@ import { TestProvidersComponent } from '../../../../common/mocks/test_providers'
 import { IndicatorsBarChartWrapper } from './indicators_barchart_wrapper';
 import { DEFAULT_TIME_RANGE } from '../../../query_bar/hooks/use_filters/utils';
 import { useFilters } from '../../../query_bar/hooks/use_filters';
+import moment from 'moment';
 
 jest.mock('../../../query_bar/hooks/use_filters');
 
@@ -47,7 +48,14 @@ describe('<IndicatorsBarChartWrapper />', () => {
   it('should render barchart and field selector dropdown', () => {
     const component = render(
       <TestProvidersComponent>
-        <IndicatorsBarChartWrapper indexPattern={mockIndexPattern} timeRange={mockTimeRange} />
+        <IndicatorsBarChartWrapper
+          dateRange={{ max: moment(), min: moment() }}
+          series={[]}
+          field=""
+          onFieldChange={jest.fn()}
+          indexPattern={mockIndexPattern}
+          timeRange={mockTimeRange}
+        />
       </TestProvidersComponent>
     );
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_barchart_wrapper/indicators_barchart_wrapper.tsx
@@ -9,11 +9,12 @@ import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { TimeRange } from '@kbn/es-query';
+import { TimeRangeBounds } from '@kbn/data-plugin/common';
 import { SecuritySolutionDataViewBase } from '../../../../types';
 import { RawIndicatorFieldId } from '../../../../../common/types/indicator';
-import { useAggregatedIndicators } from '../../hooks/use_aggregated_indicators';
 import { IndicatorsFieldSelector } from '../indicators_field_selector/indicators_field_selector';
 import { IndicatorsBarChart } from '../indicators_barchart/indicators_barchart';
+import { ChartSeries } from '../../services/fetch_aggregated_indicators';
 
 const DEFAULT_FIELD = RawIndicatorFieldId.Feed;
 
@@ -26,6 +27,14 @@ export interface IndicatorsBarChartWrapperProps {
    * List of fields coming from the Security Solution sourcerer data view, passed down to the {@link IndicatorFieldSelector} to populate the dropdown.
    */
   indexPattern: SecuritySolutionDataViewBase;
+
+  series: ChartSeries[];
+
+  dateRange: TimeRangeBounds;
+
+  field: string;
+
+  onFieldChange: (value: string) => void;
 }
 
 /**
@@ -33,11 +42,7 @@ export interface IndicatorsBarChartWrapperProps {
  * and handles retrieving aggregated indicator data.
  */
 export const IndicatorsBarChartWrapper = memo<IndicatorsBarChartWrapperProps>(
-  ({ timeRange, indexPattern }) => {
-    const { dateRange, indicators, selectedField, onFieldChange } = useAggregatedIndicators({
-      timeRange,
-    });
-
+  ({ timeRange, indexPattern, series, dateRange, field, onFieldChange }) => {
     return (
       <>
         <EuiFlexGroup justifyContent={'spaceBetween'}>
@@ -60,7 +65,7 @@ export const IndicatorsBarChartWrapper = memo<IndicatorsBarChartWrapperProps>(
           </EuiFlexItem>
         </EuiFlexGroup>
         {timeRange ? (
-          <IndicatorsBarChart indicators={indicators} dateRange={dateRange} field={selectedField} />
+          <IndicatorsBarChart indicators={series} dateRange={dateRange} field={field} />
         ) : (
           <></>
         )}

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/indicators_table.stories.tsx
@@ -11,7 +11,7 @@ import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indi
 import { StoryProvidersComponent } from '../../../../common/mocks/story_providers';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { IndicatorsTable } from './indicators_table';
-import { IndicatorsFiltersContext } from '../../context';
+import { IndicatorsFiltersContext } from '../../containers/indicators_filters/context';
 import { DEFAULT_COLUMNS } from './hooks/use_column_settings';
 
 export default {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/context.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/context.ts
@@ -6,13 +6,18 @@
  */
 
 import { createContext } from 'react';
-import { FilterManager } from '@kbn/data-plugin/public';
+import { FilterManager, SavedQuery } from '@kbn/data-plugin/public';
+import { Filter, Query, TimeRange } from '@kbn/es-query';
 
 export interface IndicatorsFiltersContextValue {
-  /**
-   * FilterManager is used to interact with KQL bar.
-   */
+  timeRange?: TimeRange;
+  filters: Filter[];
+  filterQuery: Query;
+  handleSavedQuery: (savedQuery: SavedQuery | undefined) => void;
+  handleSubmitTimeRange: (timeRange?: TimeRange) => void;
+  handleSubmitQuery: (filterQuery: Query) => void;
   filterManager: FilterManager;
+  savedQuery?: SavedQuery;
 }
 
 export const IndicatorsFiltersContext = createContext<IndicatorsFiltersContextValue | undefined>(

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './indicators_filters';
+
+export * from './context';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/indicators_filters.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/indicators_filters/indicators_filters.tsx
@@ -5,26 +5,105 @@
  * 2.0.
  */
 
-import React, { ReactNode, VFC } from 'react';
-import { FilterManager } from '@kbn/data-plugin/public';
-import { IndicatorsFiltersContext, IndicatorsFiltersContextValue } from '../../context';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { SavedQuery } from '@kbn/data-plugin/common';
+import { Filter, Query, TimeRange } from '@kbn/es-query';
+import deepEqual from 'fast-deep-equal';
+import { IndicatorsFiltersContext, IndicatorsFiltersContextValue } from './context';
+import { useKibana } from '../../../../hooks/use_kibana';
 
-export interface IndicatorsFiltersProps {
-  /**
-   * Get {@link FilterManager} from the useFilters hook and save it in context to use within the indicators table.
-   */
-  filterManager: FilterManager;
-  /**
-   * Component(s) to be displayed inside
-   */
-  children: ReactNode;
-}
+import {
+  DEFAULT_QUERY,
+  DEFAULT_TIME_RANGE,
+  encodeState,
+  FILTERS_QUERYSTRING_NAMESPACE,
+  stateFromQueryParams,
+} from '../../../query_bar/hooks/use_filters/utils';
 
 /**
  * Container used to wrap components and share the {@link FilterManager} through React context.
  */
-export const IndicatorsFilters: VFC<IndicatorsFiltersProps> = ({ filterManager, children }) => {
-  const contextValue: IndicatorsFiltersContextValue = { filterManager };
+export const IndicatorsFilters: FC = ({ children }) => {
+  const { pathname: browserPathName, search } = useLocation();
+  const history = useHistory();
+  const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>(undefined);
+
+  const {
+    services: {
+      data: {
+        query: { filterManager },
+      },
+    },
+  } = useKibana();
+
+  // Filters are picked using the UI widgets
+  const [filters, setFilters] = useState<Filter[]>([]);
+
+  // Time range is self explanatory
+  const [timeRange, setTimeRange] = useState<TimeRange | undefined>(DEFAULT_TIME_RANGE);
+
+  // filterQuery is raw kql query that user can type in to filter results
+  const [filterQuery, setFilterQuery] = useState<Query>(DEFAULT_QUERY);
+
+  // Serialize filters into query string
+  useEffect(() => {
+    const filterStateAsString = encodeState({ filters, filterQuery, timeRange });
+    if (!deepEqual(filterManager.getFilters(), filters)) {
+      filterManager.setFilters(filters);
+    }
+
+    history.replace({
+      pathname: browserPathName,
+      search: `${FILTERS_QUERYSTRING_NAMESPACE}=${filterStateAsString}`,
+    });
+  }, [browserPathName, filterManager, filterQuery, filters, history, timeRange]);
+
+  // Sync filterManager to local state (after they are changed from the ui)
+  useEffect(() => {
+    const subscription = filterManager.getUpdates$().subscribe(() => {
+      setFilters(filterManager.getFilters());
+    });
+
+    return () => subscription.unsubscribe();
+  }, [filterManager]);
+
+  // Update local state with filter values from the url (on initial mount)
+  useEffect(() => {
+    const {
+      filters: filtersFromQuery,
+      timeRange: timeRangeFromQuery,
+      filterQuery: filterQueryFromQuery,
+    } = stateFromQueryParams(search);
+
+    setTimeRange(timeRangeFromQuery);
+    setFilterQuery(filterQueryFromQuery);
+    setFilters(filtersFromQuery);
+
+    // We only want to have it done on initial render with initial 'search' value;
+    // that is why 'search' is ommited from the deps array
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterManager]);
+
+  const onSavedQuery = useCallback(
+    (newSavedQuery: SavedQuery | undefined) => setSavedQuery(newSavedQuery),
+    []
+  );
+
+  const contextValue: IndicatorsFiltersContextValue = useMemo(
+    () => ({
+      timeRange,
+      filters,
+      filterQuery,
+      handleSavedQuery: onSavedQuery,
+      handleSubmitTimeRange: setTimeRange,
+      handleSubmitQuery: setFilterQuery,
+      filterManager,
+      savedQuery,
+    }),
+    [filterManager, filterQuery, filters, onSavedQuery, savedQuery, timeRange]
+  );
 
   return (
     <IndicatorsFiltersContext.Provider value={contextValue}>

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
@@ -12,32 +12,21 @@ import {
   mockedTimefilterService,
   TestProvidersComponent,
 } from '../../../common/mocks/test_providers';
-import { useFilters } from '../../query_bar/hooks/use_filters';
 import { createFetchAggregatedIndicators } from '../services/fetch_aggregated_indicators';
 
 jest.mock('../services/fetch_aggregated_indicators');
-jest.mock('../../query_bar/hooks/use_filters');
 
 const useAggregatedIndicatorsParams: UseAggregatedIndicatorsParam = {
   timeRange: DEFAULT_TIME_RANGE,
+  filters: [],
+  filterQuery: { language: 'kuery', query: '' },
 };
 
-const stub = () => {};
-
 const renderUseAggregatedIndicators = () =>
-  renderHook((props) => useAggregatedIndicators(props), {
+  renderHook((props: UseAggregatedIndicatorsParam) => useAggregatedIndicators(props), {
     initialProps: useAggregatedIndicatorsParams,
     wrapper: TestProvidersComponent,
   });
-
-const initialFiltersValue = {
-  filters: [],
-  filterQuery: { language: 'kuery', query: '' },
-  filterManager: {} as any,
-  handleSavedQuery: stub,
-  handleSubmitQuery: stub,
-  handleSubmitTimeRange: stub,
-};
 
 describe('useAggregatedIndicators()', () => {
   beforeEach(jest.clearAllMocks);
@@ -56,14 +45,12 @@ describe('useAggregatedIndicators()', () => {
     (createFetchAggregatedIndicators as MockedCreateFetchAggregatedIndicators).mockReturnValue(
       aggregatedIndicatorsQuery
     );
-
-    (useFilters as jest.MockedFunction<typeof useFilters>).mockReturnValue(initialFiltersValue);
   });
 
   it('should create and call the aggregatedIndicatorsQuery correctly', async () => {
     aggregatedIndicatorsQuery.mockResolvedValue([]);
 
-    const { rerender } = renderUseAggregatedIndicators();
+    const { result, rerender } = renderUseAggregatedIndicators();
 
     // indicators service and the query should be called just once
     expect(
@@ -81,14 +68,12 @@ describe('useAggregatedIndicators()', () => {
       expect.any(AbortSignal)
     );
 
-    // After filter values change, the hook will be re-rendered and should call the query function again, with
-    // updated values
-    (useFilters as jest.MockedFunction<typeof useFilters>).mockReturnValue({
-      ...initialFiltersValue,
-      filterQuery: { language: 'kuery', query: "threat.indicator.type: 'file'" },
-    });
-
-    await act(async () => rerender());
+    await act(async () =>
+      rerender({
+        filterQuery: { language: 'kuery', query: "threat.indicator.type: 'file'" },
+        filters: [],
+      })
+    );
 
     expect(aggregatedIndicatorsQuery).toHaveBeenCalledTimes(2);
     expect(aggregatedIndicatorsQuery).toHaveBeenLastCalledWith(
@@ -97,5 +82,16 @@ describe('useAggregatedIndicators()', () => {
       }),
       expect.any(AbortSignal)
     );
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "dateRange": Object {
+          "max": "2022-01-02T00:00:00.000Z",
+          "min": "2022-01-01T00:00:00.000Z",
+        },
+        "onFieldChange": [Function],
+        "selectedField": "threat.feed.name",
+        "series": Array [],
+      }
+    `);
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.ts
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { TimeRange } from '@kbn/es-query';
+import { useQuery } from '@tanstack/react-query';
+import { Filter, Query, TimeRange } from '@kbn/es-query';
 import { useMemo, useState } from 'react';
 import { TimeRangeBounds } from '@kbn/data-plugin/common';
-import { useQuery } from '@tanstack/react-query';
 import { useInspector } from '../../../hooks/use_inspector';
-import { useFilters } from '../../query_bar/hooks/use_filters';
 import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 import { useKibana } from '../../../hooks/use_kibana';
 import { DEFAULT_TIME_RANGE } from '../../query_bar/hooks/use_filters/utils';
@@ -27,13 +26,15 @@ export interface UseAggregatedIndicatorsParam {
    * to query indicators for the Indicators barchart.
    */
   timeRange?: TimeRange;
+  filters: Filter[];
+  filterQuery: Query;
 }
 
 export interface UseAggregatedIndicatorsValue {
   /**
    * Array of {@link ChartSeries}, ready to be used in the Indicators barchart.
    */
-  indicators: ChartSeries[];
+  series: ChartSeries[];
   /**
    * Callback used by the IndicatorsFieldSelector component to query a new set of
    * aggregated indicators.
@@ -54,6 +55,8 @@ const DEFAULT_FIELD = RawIndicatorFieldId.Feed;
 
 export const useAggregatedIndicators = ({
   timeRange = DEFAULT_TIME_RANGE,
+  filters,
+  filterQuery,
 }: UseAggregatedIndicatorsParam): UseAggregatedIndicatorsValue => {
   const {
     services: {
@@ -66,7 +69,6 @@ export const useAggregatedIndicators = ({
   const { inspectorAdapters } = useInspector();
 
   const [field, setField] = useState<string>(DEFAULT_FIELD);
-  const { filters, filterQuery } = useFilters();
 
   const aggregatedIndicatorsQuery = useMemo(
     () =>
@@ -105,7 +107,7 @@ export const useAggregatedIndicators = ({
 
   return {
     dateRange,
-    indicators: data || [],
+    series: data || [],
     onFieldChange: setField,
     selectedField: field,
   };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
@@ -98,6 +98,27 @@ describe('useIndicators()', () => {
         }),
         expect.any(AbortSignal)
       );
+
+      expect(hookResult.result.current).toMatchInlineSnapshot(`
+        Object {
+          "handleRefresh": [Function],
+          "indicatorCount": 0,
+          "indicators": Array [],
+          "isFetching": true,
+          "isLoading": true,
+          "onChangeItemsPerPage": [Function],
+          "onChangePage": [Function],
+          "pagination": Object {
+            "pageIndex": 0,
+            "pageSize": 50,
+            "pageSizeOptions": Array [
+              10,
+              25,
+              50,
+            ],
+          },
+        }
+      `);
     });
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Filter, Query, TimeRange } from '@kbn/es-query';
 import { useQuery } from '@tanstack/react-query';
+import { EuiDataGridSorting } from '@elastic/eui';
 import { useInspector } from '../../../hooks/use_inspector';
 import { Indicator } from '../../../../common/types/indicator';
 import { useKibana } from '../../../hooks/use_kibana';
@@ -22,11 +23,15 @@ export interface UseIndicatorsParams {
   filterQuery: Query;
   filters: Filter[];
   timeRange?: TimeRange;
-  sorting: any[];
+  sorting: EuiDataGridSorting['columns'];
 }
 
 export interface UseIndicatorsValue {
   handleRefresh: () => void;
+
+  /**
+   * Array of {@link Indicator} ready to render inside the IndicatorTable component
+   */
   indicators: Indicator[];
   indicatorCount: number;
   pagination: Pagination;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators_filters_context.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators_filters_context.ts
@@ -6,7 +6,7 @@
  */
 
 import { useContext } from 'react';
-import { IndicatorsFiltersContext, IndicatorsFiltersContextValue } from '../context';
+import { IndicatorsFiltersContext, IndicatorsFiltersContextValue } from '../containers/indicators_filters/context';
 
 /**
  * Hook to retrieve {@link IndicatorsFiltersContext} (contains FilterManager)

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators_filters_context.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators_filters_context.ts
@@ -6,7 +6,10 @@
  */
 
 import { useContext } from 'react';
-import { IndicatorsFiltersContext, IndicatorsFiltersContextValue } from '../containers/indicators_filters/context';
+import {
+  IndicatorsFiltersContext,
+  IndicatorsFiltersContextValue,
+} from '../containers/indicators_filters/context';
 
 /**
  * Hook to retrieve {@link IndicatorsFiltersContext} (contains FilterManager)

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.test.tsx
@@ -27,7 +27,7 @@ describe('<IndicatorsPage />', () => {
       useAggregatedIndicators as jest.MockedFunction<typeof useAggregatedIndicators>
     ).mockReturnValue({
       dateRange: { min: moment(), max: moment() },
-      indicators: [],
+      series: [],
       selectedField: '',
       onFieldChange: () => {},
     });

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.stories.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indicators_filters_context';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
-import { IndicatorsFiltersContext } from '../../../indicators/context';
+import { IndicatorsFiltersContext } from '../../../indicators/containers/indicators_filters/context';
 import { FilterIn } from '.';
 
 export default {

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.stories.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indicators_filters_context';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
-import { IndicatorsFiltersContext } from '../../../indicators/context';
+import { IndicatorsFiltersContext } from '../../../indicators/containers/indicators_filters/context';
 import { FilterOut } from '.';
 
 export default {

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filters/use_filters.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filters/use_filters.test.tsx
@@ -9,28 +9,37 @@ import { mockUseKibanaForFilters } from '../../../../common/mocks/mock_use_kiban
 import { renderHook, act, RenderHookResult, Renderer } from '@testing-library/react-hooks';
 import { useFilters, UseFiltersValue } from './use_filters';
 
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { Filter } from '@kbn/es-query';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
+import React, { FC } from 'react';
+import { IndicatorsFilters } from '../../../indicators/containers/indicators_filters';
 
 jest.mock('react-router-dom', () => ({
-  useLocation: jest.fn().mockReturnValue({
-    search: '',
-  }),
+  MemoryRouter: ({ children }: any) => <>{children}</>,
+  useLocation: jest.fn().mockReturnValue({ pathname: '', search: '' }),
   useHistory: jest.fn().mockReturnValue({ replace: jest.fn() }),
 }));
+
+const FiltersWrapper: FC = ({ children }) => (
+  <TestProvidersComponent>
+    <IndicatorsFilters>{children}</IndicatorsFilters>{' '}
+  </TestProvidersComponent>
+);
+
+const renderUseFilters = () => renderHook(() => useFilters(), { wrapper: FiltersWrapper });
 
 describe('useFilters()', () => {
   let hookResult: RenderHookResult<{}, UseFiltersValue, Renderer<unknown>>;
   let mockRef: ReturnType<typeof mockUseKibanaForFilters>;
 
+  afterAll(() => jest.unmock('react-router-dom'));
+
   describe('when mounted', () => {
     beforeEach(async () => {
       mockRef = mockUseKibanaForFilters();
 
-      hookResult = renderHook(() => useFilters(), {
-        wrapper: TestProvidersComponent,
-      });
+      hookResult = renderUseFilters();
     });
 
     it('should have valid initial filterQuery value', () => {
@@ -44,9 +53,7 @@ describe('useFilters()', () => {
             '?indicators=(filterQuery:(language:kuery,query:%27threat.indicator.type%20:%20"file"%20%27),filters:!(),timeRange:(from:now/d,to:now/d))',
         });
 
-        hookResult = renderHook(() => useFilters(), {
-          wrapper: TestProvidersComponent,
-        });
+        hookResult = renderUseFilters();
 
         expect(hookResult.result.current.filterQuery).toMatchObject({
           language: 'kuery',
@@ -61,9 +68,7 @@ describe('useFilters()', () => {
     beforeEach(async () => {
       mockRef = mockUseKibanaForFilters();
 
-      hookResult = renderHook(() => useFilters(), {
-        wrapper: TestProvidersComponent,
-      });
+      hookResult = renderUseFilters();
 
       (useHistory as jest.Mock).mockReturnValue({ replace: historyReplace });
 

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filters/use_filters.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filters/use_filters.ts
@@ -5,110 +5,24 @@
  * 2.0.
  */
 
-import { Filter, Query, TimeRange } from '@kbn/es-query';
-import { useCallback, useEffect, useState } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
-import deepEqual from 'fast-deep-equal';
-import type { FilterManager, SavedQuery } from '@kbn/data-plugin/public';
-import { useKibana } from '../../../../hooks/use_kibana';
+import { useContext } from 'react';
 import {
-  DEFAULT_QUERY,
-  DEFAULT_TIME_RANGE,
-  encodeState,
-  FILTERS_QUERYSTRING_NAMESPACE,
-  stateFromQueryParams,
-} from './utils';
+  IndicatorsFiltersContext,
+  IndicatorsFiltersContextValue,
+} from '../../../indicators/containers/indicators_filters';
 
-export interface UseFiltersValue {
-  timeRange?: TimeRange;
-  filters: Filter[];
-  filterQuery: Query;
-  handleSavedQuery: (savedQuery: SavedQuery | undefined) => void;
-  handleSubmitTimeRange: (timeRange?: TimeRange) => void;
-  handleSubmitQuery: (filterQuery: Query) => void;
-  filterManager: FilterManager;
-  savedQuery?: SavedQuery;
-}
+export type UseFiltersValue = IndicatorsFiltersContextValue;
 
 /**
  * Custom react hook housing logic for KQL bar
  * @returns Filters and TimeRange for use with KQL bar
  */
-export const useFilters = (): UseFiltersValue => {
-  const { pathname: browserPathName, search } = useLocation();
-  const history = useHistory();
-  const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>(undefined);
+export const useFilters = () => {
+  const contextValue = useContext(IndicatorsFiltersContext);
 
-  const {
-    services: {
-      data: {
-        query: { filterManager },
-      },
-    },
-  } = useKibana();
+  if (!contextValue) {
+    throw new Error('Filters can only be used inside IndicatorFiltersContext');
+  }
 
-  // Filters are picked using the UI widgets
-  const [filters, setFilters] = useState<Filter[]>([]);
-
-  // Time range is self explanatory
-  const [timeRange, setTimeRange] = useState<TimeRange | undefined>(DEFAULT_TIME_RANGE);
-
-  // filterQuery is raw kql query that user can type in to filter results
-  const [filterQuery, setFilterQuery] = useState<Query>(DEFAULT_QUERY);
-
-  // Serialize filters into query string
-  useEffect(() => {
-    const filterStateAsString = encodeState({ filters, filterQuery, timeRange });
-    if (!deepEqual(filterManager.getFilters(), filters)) {
-      filterManager.setFilters(filters);
-    }
-
-    history.replace({
-      pathname: browserPathName,
-      search: `${FILTERS_QUERYSTRING_NAMESPACE}=${filterStateAsString}`,
-    });
-  }, [browserPathName, filterManager, filterQuery, filters, history, timeRange]);
-
-  // Sync filterManager to local state (after they are changed from the ui)
-  useEffect(() => {
-    const subscription = filterManager.getUpdates$().subscribe(() => {
-      setFilters(filterManager.getFilters());
-    });
-
-    return () => subscription.unsubscribe();
-  }, [filterManager]);
-
-  // Update local state with filter values from the url (on initial mount)
-  useEffect(() => {
-    const {
-      filters: filtersFromQuery,
-      timeRange: timeRangeFromQuery,
-      filterQuery: filterQueryFromQuery,
-    } = stateFromQueryParams(search);
-
-    setTimeRange(timeRangeFromQuery);
-    setFilterQuery(filterQueryFromQuery);
-    setFilters(filtersFromQuery);
-
-    // We only want to have it done on initial render with initial 'search' value;
-    // that is why 'search' is ommited from the deps array
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterManager]);
-
-  const onSavedQuery = useCallback(
-    (newSavedQuery: SavedQuery | undefined) => setSavedQuery(newSavedQuery),
-    []
-  );
-
-  return {
-    timeRange,
-    filters,
-    filterQuery,
-    handleSavedQuery: onSavedQuery,
-    handleSubmitTimeRange: setTimeRange,
-    handleSubmitQuery: setFilterQuery,
-    filterManager,
-    savedQuery,
-  };
+  return contextValue;
 };


### PR DESCRIPTION
## Summary
This PR moves the logic behind the `useFilters` hook into the shared context, so that it can be reused safely within the context of our plugin.

Other notable changes include some improvments made to the BarchartWrapper API - `useAggregatedIndicators` has been lifted up, with the chart receiving the series necessary to render via prop.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

