### PR TITLE
[Security Solution][Endpoint] Removes endpoint package from the excluded_packages list

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
@@ -131,7 +131,7 @@ describe('getInstallPkgRouteOptions', () => {
 
     expect(getInstallPkgRouteOptions(opts)).toEqual(['fleet', expectedOptions]);
   });
-  it('should not navigate to steps app for endpoint', () => {
+  it('should navigate to steps app for endpoint', () => {
     const opts = {
       currentPath: 'currentPath',
       integration: 'myintegration',
@@ -144,7 +144,7 @@ describe('getInstallPkgRouteOptions', () => {
     const expectedRedirectURl = '/detail/endpoint-1.0.0/policies?integration=myintegration';
 
     const expectedOptions = {
-      path: '/integrations/endpoint-1.0.0/add-integration/myintegration',
+      path: '/integrations/endpoint-1.0.0/add-integration/myintegration?useMultiPageLayout',
       state: {
         onCancelUrl: 'currentPath',
         onCancelNavigateTo: [

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -13,7 +13,6 @@ const EXCLUDED_PACKAGES = [
   'apm',
   'cloud_security_posture',
   'dga',
-  'endpoint',
   'fleet_server',
   'kubernetes',
   'osquery_manager',


### PR DESCRIPTION
## Summary

Removes the  `endpoint` package from the `excluded_packages` list in order to show the new onboarding flow for cloud deployments:

![elastic defend new onboarding workflow in cloud](https://user-images.githubusercontent.com/15727784/192299406-6dbdd408-a3e3-42bc-bf9e-a58d4d772a23.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
