### PR TITLE
[Enterprise Search] [Behavioural analytics] BUG hide UI settings option

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/index.tsx
@@ -29,8 +29,7 @@ export const Analytics: React.FC<InitialAppData> = (props) => {
   const incompatibleVersions = isVersionMismatch(enterpriseSearchVersion, kibanaVersion);
   const { uiSettings } = useValues(KibanaLogic);
 
-  const analyticsSectionEnabled =
-    uiSettings?.get<boolean>(enableBehavioralAnalyticsSection) ?? false;
+  const analyticsSectionEnabled = uiSettings?.get<boolean>(enableBehavioralAnalyticsSection, false);
 
   if (!analyticsSectionEnabled) {
     return <AnalyticsFeatureDisabledError />;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -86,7 +86,10 @@ describe('useEnterpriseSearchContentNav', () => {
         name: 'Search',
       },
     ]);
-    expect(mockKibanaValues.uiSettings.get).toHaveBeenCalledWith(enableBehavioralAnalyticsSection);
+    expect(mockKibanaValues.uiSettings.get).toHaveBeenCalledWith(
+      enableBehavioralAnalyticsSection,
+      false
+    );
   });
 
   it('excludes legacy products when the user has no access to them', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -27,8 +27,7 @@ import { generateNavLink } from './nav_link_helpers';
 export const useEnterpriseSearchNav = () => {
   const { productAccess, uiSettings } = useValues(KibanaLogic);
 
-  const analyticsSectionEnabled =
-    uiSettings?.get<boolean>(enableBehavioralAnalyticsSection) ?? false;
+  const analyticsSectionEnabled = uiSettings?.get<boolean>(enableBehavioralAnalyticsSection, false);
 
   const navItems: Array<EuiSideNavItemType<unknown>> = [
     {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -72,7 +72,8 @@ export class EnterpriseSearchPlugin implements Plugin {
     const { cloud } = plugins;
 
     const bahavioralAnalyticsEnabled = core.uiSettings?.get<boolean>(
-      enableBehavioralAnalyticsSection
+      enableBehavioralAnalyticsSection,
+      false
     );
 
     core.application.register({

--- a/x-pack/plugins/enterprise_search/server/ui_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/ui_settings.ts
@@ -5,29 +5,9 @@
  * 2.0.
  */
 
-import { schema } from '@kbn/config-schema';
 import { UiSettingsParams } from '@kbn/core/types';
-import { i18n } from '@kbn/i18n';
-
-import {
-  enterpriseSearchFeatureId,
-  enableBehavioralAnalyticsSection,
-} from '../common/ui_settings_keys';
 
 /**
  * uiSettings definitions for Enterprise Search
  */
-export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
-  [enableBehavioralAnalyticsSection]: {
-    category: [enterpriseSearchFeatureId],
-    description: i18n.translate('xpack.enterpriseSearch.uiSettings.analytics.description', {
-      defaultMessage: 'Enable the new Analytics section in Enterprise Search.',
-    }),
-    name: i18n.translate('xpack.enterpriseSearch.uiSettings.analytics.name', {
-      defaultMessage: 'Enable Behavioral Analytics',
-    }),
-    requiresPageReload: true,
-    schema: schema.boolean(),
-    value: false,
-  },
-};
+export const uiSettings: Record<string, UiSettingsParams<boolean>> = {};


### PR DESCRIPTION
## Summary

- Fixes https://github.com/elastic/enterprise-search-team/issues/2876 
- This is to fix a "bug" where its felt too visible. This change will only allow the customer to enable it via the ui-settings REST APIs

