### PR TITLE
[Fleet] Fix upgrade one agent should check fleet server version too

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -62,7 +62,7 @@ export default function (providerContext: FtrProviderContext) {
       beforeEach(async () => {
         await supertest.post(`/api/fleet/agent_policies`).set('kbn-xsrf', 'kibana').send({
           name: 'Fleet Server policy 1',
-          policy_id: 'fleet-server-policy',
+          id: 'fleet-server-policy',
           namespace: 'default',
           has_fleet_server: true,
         });
@@ -111,17 +111,15 @@ export default function (providerContext: FtrProviderContext) {
         expect(typeof res.body.item.upgrade_started_at).to.be('string');
       });
 
-      it.only('should allow to upgrade a Fleet server agent to a version > fleet server version', async () => {
+      it('should allow to upgrade a Fleet server agent to a version > fleet server version', async () => {
         const kibanaVersion = await kibanaServer.version.get();
-        const { body } = await supertest
+        await supertest
           .post(`/api/fleet/agents/agentWithFS/upgrade`)
           .set('kbn-xsrf', 'xxx')
           .send({
             version: kibanaVersion,
-          });
-        // .expect(200);
-
-        console.log(body);
+          })
+          .expect(200);
 
         const res = await supertest.get(`/api/fleet/agents/agentWithFS`).set('kbn-xsrf', 'xxx');
         expect(typeof res.body.item.upgrade_started_at).to.be('string');
@@ -354,7 +352,7 @@ export default function (providerContext: FtrProviderContext) {
       beforeEach(async () => {
         await supertest.post(`/api/fleet/agent_policies`).set('kbn-xsrf', 'kibana').send({
           name: 'Fleet Server policy 1',
-          policy_id: 'fleet-server-policy',
+          id: 'fleet-server-policy',
           namespace: 'default',
           has_fleet_server: true,
         });

--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -56,7 +56,7 @@ export default function (providerContext: FtrProviderContext) {
       await esArchiver.unload('x-pack/test/functional/es_archives/fleet/agents');
     });
 
-    describe.only('one agent', () => {
+    describe('one agent', () => {
       const fleetServerVersion = '7.16.0';
 
       beforeEach(async () => {
@@ -100,7 +100,7 @@ export default function (providerContext: FtrProviderContext) {
           },
         });
         await supertest
-          .post(`/api/fleet/agents/agentWithFS/upgrade`)
+          .post(`/api/fleet/agents/agent1/upgrade`)
           .set('kbn-xsrf', 'xxx')
           .send({
             version: fleetServerVersion,

--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -111,15 +111,17 @@ export default function (providerContext: FtrProviderContext) {
         expect(typeof res.body.item.upgrade_started_at).to.be('string');
       });
 
-      it('should allow to upgrade a Fleet server agent to a version > fleet server version', async () => {
+      it.only('should allow to upgrade a Fleet server agent to a version > fleet server version', async () => {
         const kibanaVersion = await kibanaServer.version.get();
-        await supertest
+        const { body } = await supertest
           .post(`/api/fleet/agents/agentWithFS/upgrade`)
           .set('kbn-xsrf', 'xxx')
           .send({
             version: kibanaVersion,
-          })
-          .expect(200);
+          });
+        // .expect(200);
+
+        console.log(body);
 
         const res = await supertest.get(`/api/fleet/agents/agentWithFS`).set('kbn-xsrf', 'xxx');
         expect(typeof res.body.item.upgrade_started_at).to.be('string');

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -80,6 +80,7 @@ export async function generateAgent(
         elastic: {
           agent: {
             version,
+            upgradeable: true,
           },
         },
       },

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -69,6 +69,7 @@ export async function generateAgent(
 
   await es.index({
     index: '.fleet-agents',
+    id,
     body: {
       id,
       active: true,


### PR DESCRIPTION
## Summary

Resolve #141773

We should not allow to upgrade an agent to a version higher than Fleet server version, this is already checked in the bulk upgrade codepath, but the codepath to upgrade one agent is a little different.

That PR fix that and add some integration tests to cover that scenario.


<!--ONMERGE {"backportTargets":["8.4","8.5"]} ONMERGE-->