### PR TITLE
Update the risk score documentation links to use the official documentation

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -465,10 +465,6 @@ export enum BulkActionsDryRunErrCode {
   MACHINE_LEARNING_INDEX_PATTERN = 'MACHINE_LEARNING_INDEX_PATTERN',
 }
 
-export const RISKY_HOSTS_EXTERNAL_DOC_LINK =
-  'https://www.github.com/elastic/detection-rules/blob/main/docs/experimental-machine-learning/host-risk-score.md';
-export const RISKY_USERS_EXTERNAL_DOC_LINK =
-  'https://www.github.com/elastic/detection-rules/blob/main/docs/experimental-machine-learning/user-risk-score.md';
 export const RISKY_HOSTS_DOC_LINK =
   'https://www.elastic.co/guide/en/security/current/host-risk-score.html';
 export const RISKY_USERS_DOC_LINK =

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/host_risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/host_risk_summary.tsx
@@ -41,7 +41,6 @@ const HostRiskSummaryComponent: React.FC<{
               values={{
                 hostRiskScoreDocumentationLink: (
                   <RiskScoreDocLink
-                    external={false}
                     riskScoreEntity={RiskScoreEntity.host}
                     title={
                       <FormattedMessage

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/user_risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/user_risk_summary.tsx
@@ -41,7 +41,6 @@ const UserRiskSummaryComponent: React.FC<{
               values={{
                 userRiskScoreDocumentationLink: (
                   <RiskScoreDocLink
-                    external={false}
                     riskScoreEntity={RiskScoreEntity.user}
                     title={
                       <FormattedMessage

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_disabled/host_risk_score_disabled.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_disabled/host_risk_score_disabled.tsx
@@ -38,7 +38,7 @@ const EntityAnalyticsHostRiskScoreDisableComponent = ({
         body={
           <>
             {i18n.ENABLE_HOST_RISK_SCORE_DESCRIPTION}{' '}
-            <RiskScoreDocLink external={false} riskScoreEntity={RiskScoreEntity.host} />
+            <RiskScoreDocLink riskScoreEntity={RiskScoreEntity.host} />
           </>
         }
         actions={

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_disabled/user_risk_score.disabled.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_disabled/user_risk_score.disabled.tsx
@@ -38,7 +38,7 @@ const EntityAnalyticsUserRiskScoreDisableComponent = ({
         body={
           <>
             {i18n.ENABLE_USER_RISK_SCORE_DESCRIPTION}{' '}
-            <RiskScoreDocLink external={false} riskScoreEntity={RiskScoreEntity.user} />
+            <RiskScoreDocLink riskScoreEntity={RiskScoreEntity.user} />
           </>
         }
         actions={

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_doc_link.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_doc_link.tsx
@@ -7,35 +7,22 @@
 
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
-import {
-  RISKY_HOSTS_DOC_LINK,
-  RISKY_HOSTS_EXTERNAL_DOC_LINK,
-  RISKY_USERS_DOC_LINK,
-  RISKY_USERS_EXTERNAL_DOC_LINK,
-} from '../../../../../common/constants';
+import { RISKY_HOSTS_DOC_LINK, RISKY_USERS_DOC_LINK } from '../../../../../common/constants';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 import { LEARN_MORE } from '../../../../overview/components/entity_analytics/host_risk_score/translations';
 
 const RiskScoreDocLinkComponent = ({
-  external,
   riskScoreEntity,
   title,
 }: {
-  external: boolean;
   riskScoreEntity: RiskScoreEntity;
   title?: string | React.ReactNode;
 }) => {
-  const externalLink =
-    riskScoreEntity === RiskScoreEntity.user
-      ? RISKY_USERS_EXTERNAL_DOC_LINK
-      : RISKY_HOSTS_EXTERNAL_DOC_LINK;
-
   const docLink =
     riskScoreEntity === RiskScoreEntity.user ? RISKY_USERS_DOC_LINK : RISKY_HOSTS_DOC_LINK;
 
-  const link = external ? externalLink : docLink;
   return (
-    <EuiLink target="_blank" rel="noopener nofollow noreferrer" href={link} external={external}>
+    <EuiLink target="_blank" rel="noopener nofollow noreferrer" href={docLink}>
       {title ? title : LEARN_MORE}
     </EuiLink>
   );

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_upgrade_button.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/risk_score_upgrade_button.tsx
@@ -94,7 +94,6 @@ const RiskScoreUpgradeButtonComponent = ({
           onConfirm={upgradeRiskScore}
           cancelButtonText={
             <RiskScoreDocLink
-              external={false}
               riskScoreEntity={riskScoreEntity}
               title={
                 <FormattedMessage

--- a/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/use_risk_score_toast_content.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/risk_score/risk_score_onboarding/use_risk_score_toast_content.tsx
@@ -21,7 +21,7 @@ export const useRiskScoreToastContent = (riskScoreEntity: RiskScoreEntity) => {
   const renderDocLink = useCallback(
     (message: string) => (
       <>
-        {message} <RiskScoreDocLink external={false} riskScoreEntity={riskScoreEntity} />
+        {message} <RiskScoreDocLink riskScoreEntity={riskScoreEntity} />
       </>
     ),
     [riskScoreEntity]

--- a/x-pack/plugins/security_solution/public/hosts/components/host_risk_information/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/host_risk_information/index.tsx
@@ -131,7 +131,6 @@ const HostRiskInformationFlyout = ({ handleOnClose }: { handleOnClose: () => voi
           values={{
             HostRiskScoreDocumentationLink: (
               <RiskScoreDocLink
-                external={false}
                 riskScoreEntity={RiskScoreEntity.host}
                 title={
                   <FormattedMessage

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/index.tsx
@@ -36,7 +36,6 @@ export const HostsKpiComponent = React.memo<HostsKpiProps>(
                   <>
                     {i18n.LEARN_MORE}{' '}
                     <RiskScoreDocLink
-                      external={false}
                       riskScoreEntity={RiskScoreEntity.host}
                       title={i18n.HOST_RISK_DATA}
                     />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/host_risk_score/index.tsx
@@ -30,7 +30,7 @@ import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { hostsActions } from '../../../../hosts/store';
 import { RiskScoreDonutChart } from '../common/risk_score_donut_chart';
 import { BasicTableWithoutBorderBottom } from '../common/basic_table_without_border_bottom';
-import { RISKY_HOSTS_EXTERNAL_DOC_LINK } from '../../../../../common/constants';
+import { RISKY_HOSTS_DOC_LINK } from '../../../../../common/constants';
 import { EntityAnalyticsHostRiskScoreDisable } from '../../../../common/components/risk_score/risk_score_disabled/host_risk_score_disabled';
 import { RiskScoreHeaderTitle } from '../../../../common/components/risk_score/risk_score_onboarding/risk_score_header_title';
 import { RiskScoresNoDataDetected } from '../../../../common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected';
@@ -147,7 +147,7 @@ const EntityAnalyticsHostRiskScoresComponent = () => {
               <EuiFlexItem>
                 <EuiButtonEmpty
                   rel="noopener nofollow noreferrer"
-                  href={RISKY_HOSTS_EXTERNAL_DOC_LINK}
+                  href={RISKY_HOSTS_DOC_LINK}
                   target="_blank"
                 >
                   {i18n.LEARN_MORE}

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/user_risk_score/index.tsx
@@ -30,7 +30,7 @@ import { getTabsOnUsersUrl } from '../../../../common/components/link_to/redirec
 import { RiskScoreDonutChart } from '../common/risk_score_donut_chart';
 import { BasicTableWithoutBorderBottom } from '../common/basic_table_without_border_bottom';
 
-import { RISKY_USERS_EXTERNAL_DOC_LINK } from '../../../../../common/constants';
+import { RISKY_USERS_DOC_LINK } from '../../../../../common/constants';
 import { EntityAnalyticsUserRiskScoreDisable } from '../../../../common/components/risk_score/risk_score_disabled/user_risk_score.disabled';
 import { RiskScoreHeaderTitle } from '../../../../common/components/risk_score/risk_score_onboarding/risk_score_header_title';
 import { RiskScoresNoDataDetected } from '../../../../common/components/risk_score/risk_score_onboarding/risk_score_no_data_detected';
@@ -146,7 +146,7 @@ const EntityAnalyticsUserRiskScoresComponent = () => {
               <EuiFlexItem>
                 <EuiButtonEmpty
                   rel="noopener nofollow noreferrer"
-                  href={RISKY_USERS_EXTERNAL_DOC_LINK}
+                  href={RISKY_USERS_DOC_LINK}
                   target="_blank"
                 >
                   {i18n.LEARN_MORE}

--- a/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/kpi_users/index.tsx
@@ -38,7 +38,6 @@ export const UsersKpiComponent = React.memo<UsersKpiProps>(
                   <>
                     {i18n.LEARN_MORE}{' '}
                     <RiskScoreDocLink
-                      external={false}
                       riskScoreEntity={RiskScoreEntity.user}
                       title={i18n.USER_RISK_DATA}
                     />

--- a/x-pack/plugins/security_solution/public/users/components/user_risk_information/index.tsx
+++ b/x-pack/plugins/security_solution/public/users/components/user_risk_information/index.tsx
@@ -108,7 +108,6 @@ const UserRiskInformationFlyout = ({ handleOnClose }: { handleOnClose: () => voi
           values={{
             UserRiskScoreDocumentationLink: (
               <RiskScoreDocLink
-                external={false}
                 riskScoreEntity={RiskScoreEntity.user}
                 title={
                   <FormattedMessage


### PR DESCRIPTION
## Summary

Update risk score links to only send users to the official elastic documentation.
Now that users can easily install the risk score module the development documentation isn't relevant anymore.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->