### PR TITLE
[fleet] Use snapshot registry in dev mode

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -35,6 +35,7 @@ jest.mock('../..', () => ({
     getKibanaBranch: () => 'main',
     getKibanaVersion: () => '99.0.0',
     getConfig: () => ({}),
+    getIsProductionMode: () => false,
   },
 }));
 

--- a/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
@@ -20,8 +20,8 @@ const SNAPSHOT_REGISTRY_URL_CDN = 'https://epr-snapshot.elastic.co';
 // const SNAPSHOT_REGISTRY_URL_NO_CDN = 'https://epr-snapshot.ea-web.elastic.dev';
 
 const getDefaultRegistryUrl = (): string => {
-  const branch = appContextService.getKibanaBranch();
-  if (branch === 'main') {
+  const isProduction = appContextService.getIsProductionMode();
+  if (!isProduction) {
     return SNAPSHOT_REGISTRY_URL_CDN;
   } else if (appContextService.getKibanaVersion().includes('-SNAPSHOT')) {
     return STAGING_REGISTRY_URL_CDN;

--- a/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
@@ -21,7 +21,7 @@ const SNAPSHOT_REGISTRY_URL_CDN = 'https://epr-snapshot.elastic.co';
 
 const getDefaultRegistryUrl = (): string => {
   const isProduction = appContextService.getIsProductionMode();
-  if (!isProduction) {
+  if (!isProduction || branch === 'main') {
     return SNAPSHOT_REGISTRY_URL_CDN;
   } else if (appContextService.getKibanaVersion().includes('-SNAPSHOT')) {
     return STAGING_REGISTRY_URL_CDN;

--- a/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
@@ -20,6 +20,7 @@ const SNAPSHOT_REGISTRY_URL_CDN = 'https://epr-snapshot.elastic.co';
 // const SNAPSHOT_REGISTRY_URL_NO_CDN = 'https://epr-snapshot.ea-web.elastic.dev';
 
 const getDefaultRegistryUrl = (): string => {
+  const branch = appContextService.getKibanaBranch();
   const isProduction = appContextService.getIsProductionMode();
   if (!isProduction || branch === 'main') {
     return SNAPSHOT_REGISTRY_URL_CDN;


### PR DESCRIPTION
Related to: https://github.com/elastic/kibana/pull/141462

Fixes the error `unable to install apm package 8.5.0. Received status code: 404 and message: apm@8.5.0 not found`

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->