### PR TITLE
[DOCS] Moves advanced settings page

### DIFF
--- a/docs/user/management.asciidoc
+++ b/docs/user/management.asciidoc
@@ -176,8 +176,6 @@ see the https://www.elastic.co/subscriptions[subscription page].
 
 --
 
-include::{kib-repo-dir}/management/advanced-options.asciidoc[]
-
 include::{kib-repo-dir}/management/cases/index.asciidoc[]
 
 include::{kib-repo-dir}/management/action-types.asciidoc[]
@@ -196,6 +194,10 @@ include::security/index.asciidoc[]
 
 include::{kib-repo-dir}/spaces/index.asciidoc[]
 
+include::{kib-repo-dir}/management/advanced-options.asciidoc[]
+
 include::{kib-repo-dir}/management/managing-tags.asciidoc[]
 
 include::{kib-repo-dir}/management/watcher-ui/index.asciidoc[]
+
+


### PR DESCRIPTION
## Summary

Moves the Advanced settings page to where is appears in the Kibana main menu.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->