### PR TITLE
[RAM] rmv public validation around our search strategy for alerts

### DIFF
--- a/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.test.ts
+++ b/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.test.ts
@@ -8,11 +8,7 @@ import { of } from 'rxjs';
 import { merge } from 'lodash';
 import { loggerMock } from '@kbn/logging-mocks';
 import { AlertConsumers } from '@kbn/rule-data-utils';
-import {
-  ruleRegistrySearchStrategyProvider,
-  EMPTY_RESPONSE,
-  RULE_SEARCH_STRATEGY_NAME,
-} from './search_strategy';
+import { ruleRegistrySearchStrategyProvider, EMPTY_RESPONSE } from './search_strategy';
 import { ruleDataServiceMock } from '../rule_data_plugin_service/rule_data_plugin_service.mock';
 import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
 import { SearchStrategyDependencies } from '@kbn/data-plugin/server';

--- a/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.test.ts
+++ b/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.test.ts
@@ -385,48 +385,6 @@ describe('ruleRegistrySearchStrategyProvider()', () => {
     ).toStrictEqual([{ test: { order: 'desc' } }]);
   });
 
-  it('should reject, to the best of our ability, public requests', async () => {
-    (getIsKibanaRequest as jest.Mock).mockImplementation(() => {
-      return false;
-    });
-    const request: RuleRegistrySearchRequest = {
-      featureIds: [AlertConsumers.LOGS],
-      sort: [
-        {
-          test: {
-            order: 'desc',
-          },
-        },
-      ],
-    };
-    const options = {};
-    const deps = {
-      request: {},
-    };
-
-    const strategy = ruleRegistrySearchStrategyProvider(
-      data,
-      ruleDataService,
-      alerting,
-      logger,
-      security,
-      spaces
-    );
-
-    let err = null;
-    try {
-      await strategy
-        .search(request, options, deps as unknown as SearchStrategyDependencies)
-        .toPromise();
-    } catch (e) {
-      err = e;
-    }
-    expect(err).not.toBeNull();
-    expect(err.message).toBe(
-      `The ${RULE_SEARCH_STRATEGY_NAME} search strategy is currently only available for internal use.`
-    );
-  });
-
   it('passes the query ids if provided', async () => {
     const request: RuleRegistrySearchRequest = {
       featureIds: [AlertConsumers.SIEM],

--- a/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.ts
+++ b/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import { map, mergeMap, catchError } from 'rxjs/operators';
-import Boom from '@hapi/boom';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger } from '@kbn/core/server';
 import { from, of } from 'rxjs';

--- a/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.ts
+++ b/x-pack/plugins/rule_registry/server/search_strategy/search_strategy.ts
@@ -25,7 +25,6 @@ import { Dataset } from '../rule_data_plugin_service/index_options';
 import { MAX_ALERT_SEARCH_SIZE } from '../../common/constants';
 import { AlertAuditAction, alertAuditEvent } from '..';
 import { getSpacesFilter, getAuthzFilter } from '../lib';
-import { getIsKibanaRequest } from '../lib/get_is_kibana_request';
 
 export const EMPTY_RESPONSE: RuleRegistrySearchResponse = {
   rawResponse: {} as RuleRegistrySearchResponse['rawResponse'],
@@ -47,13 +46,6 @@ export const ruleRegistrySearchStrategyProvider = (
   const requestUserEs = data.search.getSearchStrategy(ENHANCED_ES_SEARCH_STRATEGY);
   return {
     search: (request, options, deps) => {
-      // We want to ensure this request came from our UI. We can't really do this
-      // but we have a best effort we can try
-      if (!getIsKibanaRequest(deps.request.headers)) {
-        throw Boom.notFound(
-          `The ${RULE_SEARCH_STRATEGY_NAME} search strategy is currently only available for internal use.`
-        );
-      }
       // SIEM uses RBAC fields in their alerts but also utilizes ES DLS which
       // is different than every other solution so we need to special case
       // those requests.

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/search_strategy.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/search_strategy.ts
@@ -110,24 +110,6 @@ export default ({ getService }: FtrProviderContext) => {
         const second = result.rawResponse.hits.hits[1].fields?.['kibana.alert.evaluation.value'];
         expect(first > second).to.be(true);
       });
-
-      it('should reject public requests', async () => {
-        const result = await secureBsearch.send<RuleRegistrySearchResponseWithErrors>({
-          supertestWithoutAuth,
-          auth: {
-            username: logsOnlySpacesAll.username,
-            password: logsOnlySpacesAll.password,
-          },
-          options: {
-            featureIds: [AlertConsumers.LOGS],
-          },
-          strategy: 'privateRuleRegistryAlertsSearchStrategy',
-        });
-        expect(result.statusCode).to.be(500);
-        expect(result.message).to.be(
-          `The privateRuleRegistryAlertsSearchStrategy search strategy is currently only available for internal use.`
-        );
-      });
     });
 
     describe('siem', () => {


### PR DESCRIPTION
## Summary

We got this [SDH](https://github.com/elastic/sdh-kibana/issues/3237), we talked about it internally and realize that we should remove this check since this API is internal already. It will be really annoying for our cloud and even more for on-prem users with proxy set up.



<!--ONMERGE {"backportTargets":["8.4","8.5"]} ONMERGE-->