### PR TITLE
[8.5][Behavioural analytics] Fix analytics js file path on integration screen

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate.tsx
@@ -49,7 +49,7 @@ export const AnalyticsCollectionIntegrate: React.FC<AnalyticsCollectionIntegrate
       description: analyticsDNSUrl,
     },
   ];
-  const webclientSrc = getEnterpriseSearchUrl('/analytics.js');
+  const webclientSrc = getEnterpriseSearchUrl('/analytics/client.js');
 
   return (
     <>


### PR DESCRIPTION
### Description
In order to show proper information and allow users to load the analytics js file properly, it's required to show a proper js file URL.

This PR is dedicated to fixing the analytics js client URL on the Analytics Integration page

### Related PRs
https://github.com/elastic/ent-search/pull/6910