### PR TITLE
[Files] Update the download method on the files client

### DIFF
--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -123,7 +123,7 @@ export function createFilesClient({
         body: args.body as BodyInit,
       });
     },
-    getDownloadHref: ({ fileKind: kind, id }) => {
+    getDownloadHref: ({ kind, id }) => {
       return `${http.basePath.prepend(apiRoutes.getDownloadRoute(scopedFileKind ?? kind, id))}`;
     },
     share: ({ kind, fileId, name, validUntil }) => {

--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -123,7 +123,7 @@ export function createFilesClient({
         body: args.body as BodyInit,
       });
     },
-    getDownloadHref: ({ kind, id }) => {
+    getDownloadHref: ({ fileKind: kind, id }) => {
       return `${http.basePath.prepend(apiRoutes.getDownloadRoute(scopedFileKind ?? kind, id))}`;
     },
     share: ({ kind, fileId, name, validUntil }) => {

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { FileJSON } from '../common';
 import type {
   FindFilesHttpEndpoint,
   FileShareHttpEndpoint,
@@ -117,8 +116,19 @@ export interface FilesClient extends GlobalEndpoints {
   /**
    * Get a string for downloading a file that can be passed to a button element's
    * href for download.
+   *
+   * @param args - get download URL args
    */
-  getDownloadHref: (file: FileJSON) => string;
+  getDownloadHref: (args: {
+    /**
+     * ID of the file
+     */
+    id: string;
+    /**
+     * Kind of the file
+     */
+    kind: string;
+  }) => string;
   /**
    * Share a file by creating a new file share instance.
    *

--- a/x-pack/plugins/files/public/types.ts
+++ b/x-pack/plugins/files/public/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { FileJSON } from '../common';
 import type {
   FindFilesHttpEndpoint,
   FileShareHttpEndpoint,
@@ -119,16 +120,7 @@ export interface FilesClient extends GlobalEndpoints {
    *
    * @param args - get download URL args
    */
-  getDownloadHref: (args: {
-    /**
-     * ID of the file
-     */
-    id: string;
-    /**
-     * Kind of the file
-     */
-    kind: string;
-  }) => string;
+  getDownloadHref: (args: Pick<FileJSON, 'id' | 'fileKind'>) => string;
   /**
    * Share a file by creating a new file share instance.
    *


### PR DESCRIPTION
## Summary

Changes the `getDownloadHref` type to accept `Pick<FileJSON, 'id' | 'fileKind'>` instead of requiring full file JSON object.