### PR TITLE
[Files] Use mime type on `Blob` object

### DIFF
--- a/x-pack/plugins/files/public/components/upload_file/upload_state.test.ts
+++ b/x-pack/plugins/files/public/components/upload_file/upload_state.test.ts
@@ -35,7 +35,7 @@ describe('UploadState', () => {
 
   it('calls file client with expected arguments', async () => {
     testScheduler.run(({ expectObservable, cold, flush }) => {
-      const file1 = { name: 'test.png', size: 1 } as File;
+      const file1 = { name: 'test.png', size: 1, type: 'image/png' } as File;
 
       uploadState.setFiles([file1]);
 
@@ -113,7 +113,7 @@ describe('UploadState', () => {
       filesClient.delete.mockReturnValue(of(undefined) as any);
 
       const file1 = { name: 'test' } as File;
-      const file2 = { name: 'test 2.png' } as File;
+      const file2 = { name: 'test 2.png', type: 'image/png' } as File;
 
       uploadState.setFiles([file1, file2]);
 

--- a/x-pack/plugins/files/public/components/upload_file/upload_state.ts
+++ b/x-pack/plugins/files/public/components/upload_file/upload_state.ts
@@ -169,13 +169,13 @@ export class UploadState {
 
     file$.setState({ status: 'uploading', error: undefined });
 
-    const { name, mime } = parseFileName(file.name);
+    const { name } = parseFileName(file.name);
 
     return from(
       this.client.create({
         kind: this.fileKind.id,
         name,
-        mimeType: mime,
+        mimeType: file.type,
         meta: meta as Record<string, unknown>,
       })
     ).pipe(
@@ -194,7 +194,7 @@ export class UploadState {
             kind: this.fileKind.id,
             abortSignal,
             selfDestructOnAbort: true,
-            contentType: mime,
+            contentType: file.type,
           })
         );
       }),

--- a/x-pack/plugins/files/public/components/upload_file/upload_state.ts
+++ b/x-pack/plugins/files/public/components/upload_file/upload_state.ts
@@ -170,12 +170,13 @@ export class UploadState {
     file$.setState({ status: 'uploading', error: undefined });
 
     const { name } = parseFileName(file.name);
+    const mime = file.type || undefined;
 
     return from(
       this.client.create({
         kind: this.fileKind.id,
         name,
-        mimeType: file.type,
+        mimeType: mime,
         meta: meta as Record<string, unknown>,
       })
     ).pipe(
@@ -194,7 +195,7 @@ export class UploadState {
             kind: this.fileKind.id,
             abortSignal,
             selfDestructOnAbort: true,
-            contentType: file.type,
+            contentType: mime,
           })
         );
       }),

--- a/x-pack/plugins/files/public/components/upload_file/util/parse_file_name.test.ts
+++ b/x-pack/plugins/files/public/components/upload_file/util/parse_file_name.test.ts
@@ -11,28 +11,24 @@ describe('parseFileName', () => {
   test('file.png', () => {
     expect(parseFileName('file.png')).toEqual({
       name: 'file',
-      mime: 'image/png',
     });
   });
 
   test('  Something_*  really -=- strange.abc.wav', () => {
     expect(parseFileName('  Something_*  really -=- strange.abc.wav')).toEqual({
       name: 'Something__  really ___ strange_abc',
-      mime: 'audio/wave',
     });
   });
 
   test('!@#$%^&*()', () => {
     expect(parseFileName('!@#$%^&*()')).toEqual({
       name: '__________',
-      mime: undefined,
     });
   });
 
   test('reallylong.repeat(100).dmg', () => {
     expect(parseFileName('reallylong'.repeat(100) + '.dmg')).toEqual({
       name: 'reallylong'.repeat(100).slice(0, 256),
-      mime: 'application/x-apple-diskimage',
     });
   });
 });

--- a/x-pack/plugins/files/public/components/upload_file/util/parse_file_name.ts
+++ b/x-pack/plugins/files/public/components/upload_file/util/parse_file_name.ts
@@ -5,11 +5,8 @@
  * 2.0.
  */
 
-import mime from 'mime-types';
-
 interface Result {
   name: string;
-  mime?: string;
 }
 
 export function parseFileName(fileName: string): Result {
@@ -19,6 +16,5 @@ export function parseFileName(fileName: string): Result {
       .trim()
       .slice(0, 256)
       .replace(/[^a-z0-9\s]/gi, '_'), // replace invalid chars
-    mime: mime.lookup(fileName) || undefined,
   };
 }


### PR DESCRIPTION
## Summary

Rather use the [`blob.type`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/type) than `mime-types` browser side.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
