### PR TITLE
Add xpack.cloud.gain_sight config

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -179,6 +179,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cloud.full_story.org_id (any)',
         // No PII. Just the list of event types we want to forward to FullStory.
         'xpack.cloud.full_story.eventTypesAllowlist (array)',
+        'xpack.cloud.gain_sight.enabled (boolean)',
+        'xpack.cloud.gain_sight.org_id (any)',
         'xpack.cloud.id (string)',
         'xpack.cloud.organization_url (string)',
         'xpack.cloud.profile_url (string)',

--- a/x-pack/plugins/cloud/server/config.test.ts
+++ b/x-pack/plugins/cloud/server/config.test.ts
@@ -34,4 +34,31 @@ describe('xpack.cloud config', () => {
       ).not.toThrow();
     });
   });
+
+  describe('gain_sight', () => {
+    it('allows org_id when enabled: false', () => {
+      expect(() =>
+        config.schema.validate({ gain_sight: { enabled: false, org_id: 'asdf' } })
+      ).not.toThrow();
+    });
+
+    it('rejects undefined or empty org_id when enabled: true', () => {
+      expect(() =>
+        config.schema.validate({ gain_sight: { enabled: true } })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"[gain_sight.org_id]: expected value of type [string] but got [undefined]"`
+      );
+      expect(() =>
+        config.schema.validate({ gain_sight: { enabled: true, org_id: '' } })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"[gain_sight.org_id]: value has length [0] but it must have a minimum length of [1]."`
+      );
+    });
+
+    it('accepts org_id when enabled: true', () => {
+      expect(() =>
+        config.schema.validate({ gain_sight: { enabled: true, org_id: 'asdf' } })
+      ).not.toThrow();
+    });
+  });
 });

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -31,6 +31,16 @@ const fullStoryConfigSchema = schema.object({
   }),
 });
 
+const gainSightConfigSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+  org_id: schema.conditional(
+    schema.siblingRef('enabled'),
+    true,
+    schema.string({ minLength: 1 }),
+    schema.maybe(schema.string())
+  ),
+});
+
 const chatConfigSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
   chatURL: schema.maybe(schema.string()),
@@ -44,6 +54,7 @@ const configSchema = schema.object({
   cname: schema.maybe(schema.string()),
   deployment_url: schema.maybe(schema.string()),
   full_story: fullStoryConfigSchema,
+  gain_sight: gainSightConfigSchema,
   id: schema.maybe(schema.string()),
   organization_url: schema.maybe(schema.string()),
   profile_url: schema.maybe(schema.string()),
@@ -58,6 +69,7 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
     cname: true,
     deployment_url: true,
     full_story: true,
+    gain_sight: true,
     id: true,
     organization_url: true,
     profile_url: true,


### PR DESCRIPTION
## Summary

This PR add two new configurations coming from cloud. The values will be used to instrument the gainsight code in cloud

- `xpack.cloud.gain_sight.org_id`
- `xpack.cloud.gain_sight.enabled`


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)

