### PR TITLE
revert upgrade_status change

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -47,7 +47,7 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
       ? agent.policy_revision_idx
       : undefined;
 
-  if (!policyRevision || (agent.upgrade_started_at && agent.upgrade_status !== 'completed')) {
+  if (!policyRevision || (agent.upgrade_started_at && !agent.upgraded_at)) {
     return 'updating';
   }
 
@@ -75,7 +75,7 @@ export function getPreviousAgentStatusForOfflineAgents(
       ? agent.policy_revision_idx
       : undefined;
 
-  if (!policyRevision || (agent.upgrade_started_at && agent.upgrade_status !== 'completed')) {
+  if (!policyRevision || (agent.upgrade_started_at && !agent.upgraded_at)) {
     return 'updating';
   }
 }
@@ -109,7 +109,7 @@ export function buildKueryForOfflineAgents(path: string = ''): string {
 }
 
 export function buildKueryForUpgradingAgents(path: string = ''): string {
-  return `(${path}upgrade_started_at:*) and not (${path}upgrade_status:completed)`;
+  return `(${path}upgrade_started_at:*) and not (${path}upgraded_at:*)`;
 }
 
 export function buildKueryForUpdatingAgents(path: string = ''): string {

--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
@@ -25,7 +25,7 @@ export function isAgentUpgradeable(agent: Agent, kibanaVersion: string, versionT
     return false;
   }
   // check that the agent is not already in the process of updating
-  if (agent.upgrade_started_at && agent.upgrade_status !== 'completed') {
+  if (agent.upgrade_started_at && !agent.upgraded_at) {
     return false;
   }
   if (versionToUpgrade !== undefined) {

--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -75,9 +75,8 @@ interface AgentBase {
   enrolled_at: string;
   unenrolled_at?: string;
   unenrollment_started_at?: string;
-  upgraded_at?: string;
+  upgraded_at?: string | null;
   upgrade_started_at?: string | null;
-  upgrade_status?: 'started' | 'completed';
   access_api_key_id?: string;
   default_api_key?: string;
   default_api_key_id?: string;
@@ -188,15 +187,11 @@ export interface FleetServerAgent {
   /**
    * Date/time the Elastic Agent was last upgraded
    */
-  upgraded_at?: string;
+  upgraded_at?: string | null;
   /**
    * Date/time the Elastic Agent started the current upgrade
    */
   upgrade_started_at?: string | null;
-  /**
-   * Upgrade status
-   */
-  upgrade_status?: 'started' | 'completed';
   /**
    * ID of the API key the Elastic Agent must used to contact Fleet Server
    */

--- a/x-pack/plugins/fleet/server/services/agents/actions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.ts
@@ -242,8 +242,8 @@ export async function cancelAgentAction(esClient: ElasticsearchClient, actionId:
         hit._source.agents.map((agentId) => ({
           agentId,
           data: {
+            upgraded_at: null,
             upgrade_started_at: null,
-            upgrade_status: 'completed',
           },
         }))
       );

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
@@ -38,7 +38,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     expect(ids).toEqual(idsToAction);
     for (const doc of docs!) {
       expect(doc).toHaveProperty('upgrade_started_at');
-      expect(doc.upgrade_status).toEqual('started');
+      expect(doc.upgraded_at).toEqual(null);
     }
   });
   it('cannot upgrade from a hosted agent policy by default', async () => {
@@ -60,7 +60,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     expect(ids).toEqual(onlyRegular);
     for (const doc of docs!) {
       expect(doc).toHaveProperty('upgrade_started_at');
-      expect(doc.upgrade_status).toEqual('started');
+      expect(doc.upgraded_at).toEqual(null);
     }
 
     // hosted policy is updated in action results with error
@@ -98,7 +98,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     expect(ids).toEqual(idsToAction);
     for (const doc of docs!) {
       expect(doc).toHaveProperty('upgrade_started_at');
-      expect(doc.upgrade_status).toEqual('started');
+      expect(doc.upgraded_at).toEqual(null);
     }
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.ts
@@ -57,8 +57,8 @@ export async function sendUpgradeAgentAction({
     type: 'UPGRADE',
   });
   await updateAgent(esClient, agentId, {
+    upgraded_at: null,
     upgrade_started_at: now,
-    upgrade_status: 'started',
   });
 }
 

--- a/x-pack/plugins/fleet/server/services/agents/upgrade_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade_action_runner.ts
@@ -146,8 +146,8 @@ export async function upgradeBatch(
     agentsToUpdate.map((agent) => ({
       agentId: agent.id,
       data: {
+        upgraded_at: null,
         upgrade_started_at: now,
-        upgrade_status: 'started',
       },
     }))
   );

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -285,9 +285,7 @@ describe('test endpoint routes', () => {
                                   bool: {
                                     must_not: {
                                       bool: {
-                                        should: [
-                                          { match: { 'united.agent.upgrade_status': 'completed' } },
-                                        ],
+                                        should: [{ exists: { field: 'united.agent.upgraded_at' } }],
                                         minimum_should_match: 1,
                                       },
                                     },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
@@ -71,11 +71,7 @@ export const expectedCompleteUnitedIndexQuery = {
                                             must_not: {
                                               bool: {
                                                 should: [
-                                                  {
-                                                    match: {
-                                                      'united.agent.upgrade_status': 'completed',
-                                                    },
-                                                  },
+                                                  { exists: { field: 'united.agent.upgraded_at' } },
                                                 ],
                                                 minimum_should_match: 1,
                                               },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
@@ -93,7 +93,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const status = ['healthy'];
       const kuery = buildStatusesKuery(status);
       expect(kuery).toMatchInlineSnapshot(
-        `"(united.agent.last_checkin:*  AND not ((united.agent.last_checkin < now-300s) or ((((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*))))) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+        `"(united.agent.last_checkin:*  AND not ((united.agent.last_checkin < now-300s) or ((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*))))) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
       );
     });
 
@@ -115,7 +115,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const status = ['updating'];
       const kuery = buildStatusesKuery(status);
       expect(kuery).toMatchInlineSnapshot(
-        `"((((united.agent.upgrade_started_at:*) and not (united.agent.upgrade_status:completed)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+        `"((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
       );
     });
 


### PR DESCRIPTION
## Summary

As discussed in https://github.com/elastic/kibana/issues/139704#issuecomment-1259457256 reverting change in https://github.com/elastic/kibana/pull/140078 because the original lucene bug was fixed.


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->