### PR TITLE
[Fleet] Point APM bundling process at package storage v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,6 +132,7 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/test/fleet_api_integration @elastic/fleet
 /x-pack/test/fleet_cypress @elastic/fleet
 /x-pack/test/fleet_functional @elastic/fleet
+/src/dev/build/tasks/bundle_fleet_packages.ts
 
 # APM
 /x-pack/plugins/apm/  @elastic/apm-ui

--- a/src/dev/build/tasks/bundle_fleet_packages.ts
+++ b/src/dev/build/tasks/bundle_fleet_packages.ts
@@ -15,6 +15,10 @@ import { Task, read, downloadToDisk, unzipBuffer, createZipFile } from '../lib';
 
 const BUNDLED_PACKAGES_DIR = 'x-pack/plugins/fleet/target/bundled_packages';
 
+// APM needs to directly request its versions from Package Storage v2 - this should
+// be removed when Package Storage v2 is in production
+const PACKAGE_STORAGE_V2_URL = 'https://epr-v2.ea-web.elastic.dev';
+
 interface FleetPackage {
   name: string;
   version: string;
@@ -64,7 +68,12 @@ export const BundleFleetPackages: Task = {
         }
 
         const archivePath = `${fleetPackage.name}-${versionToWrite}.zip`;
-        const archiveUrl = `${eprUrl}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+        let archiveUrl = `${eprUrl}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+
+        // Point APM to package storage v2
+        if (fleetPackage.name === 'apm') {
+          archiveUrl = `${PACKAGE_STORAGE_V2_URL}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+        }
 
         const destination = build.resolvePath(BUNDLED_PACKAGES_DIR, archivePath);
 


### PR DESCRIPTION
## Summary

Explicitly request APM from Package Storage v2 when bundling Fleet packages. This prevents 404s from APM's preview builds, which currently only exist on v2.

This will fix failing builds on the following PR's:

- https://github.com/elastic/kibana/pull/141818
- https://github.com/elastic/kibana/pull/141820

