### PR TITLE
[Enterprise Search] Add ent-search-docs-team as codeowners of Enterprise Search internal doclinks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -350,6 +350,7 @@ x-pack/examples/files_example @elastic/kibana-app-services
 # Enterprise Search
 /x-pack/plugins/enterprise_search @elastic/enterprise-search-frontend
 /x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
+/x-pack/plugins/enterprise_search/public/applications/shared/doc_links @elastic/ent-search-docs-team
 
 # Management Experience - Deployment Management
 /src/plugins/dev_tools/ @elastic/platform-deployment-management


### PR DESCRIPTION
## Summary

We want to make sure they're automatically tagged in PR reviews.  Requested by @chriscressman 



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->