### PR TITLE
Fix wrong Critical Hosts and Critical Users count colour

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
@@ -28,7 +28,7 @@ import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 
 const StyledEuiTitle = styled(EuiTitle)`
-  color: ${({ theme: { eui } }) => eui.euiColorVis9};
+  color: ${({ theme: { eui } }) => eui.euiColorDanger};
 `;
 
 const HOST_RISK_QUERY_ID = 'hostRiskScoreKpiQuery';


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/141910

## Summary
<img width="1524" alt="Screenshot 2022-09-27 at 16 46 56" src="https://user-images.githubusercontent.com/1490444/192559088-43642fa2-5c47-422c-b93c-e7a59b4ddecc.png">






<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->