### PR TITLE
Update renovate.json with new backport labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -125,7 +125,7 @@
       ],
       "reviewers": ["team:kibana-security"],
       "matchBaseBranches": ["main"],
-      "labels": ["Team:Security", "release_note:skip", "auto-backport"],
+      "labels": ["Team:Security", "release_note:skip", "backport:all-open"],
       "enabled": true
     },
     {


### PR DESCRIPTION
Use `backport:all-open` instead of the deprecated `auto-backport` label.
