### PR TITLE
[8.5] [Fleet] Point APM bundling process at package storage v2 (#141944)

### DIFF
--- a/src/dev/build/tasks/bundle_fleet_packages.ts
+++ b/src/dev/build/tasks/bundle_fleet_packages.ts
@@ -15,6 +15,10 @@ import { Task, read, downloadToDisk, unzipBuffer, createZipFile } from '../lib';
 
 const BUNDLED_PACKAGES_DIR = 'x-pack/plugins/fleet/target/bundled_packages';
 
+// APM needs to directly request its versions from Package Storage v2 - this should
+// be removed when Package Storage v2 is in production
+const PACKAGE_STORAGE_V2_URL = 'https://epr-v2.ea-web.elastic.dev';
+
 interface FleetPackage {
   name: string;
   version: string;
@@ -64,7 +68,12 @@ export const BundleFleetPackages: Task = {
         }
 
         const archivePath = `${fleetPackage.name}-${versionToWrite}.zip`;
-        const archiveUrl = `${eprUrl}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+        let archiveUrl = `${eprUrl}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+
+        // Point APM to package storage v2
+        if (fleetPackage.name === 'apm') {
+          archiveUrl = `${PACKAGE_STORAGE_V2_URL}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
+        }
 
         const destination = build.resolvePath(BUNDLED_PACKAGES_DIR, archivePath);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Fleet] Point APM bundling process at package storage v2 (#141944)](https://github.com/elastic/kibana/pull/141944)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kyle Pollich","email":"kyle.pollich@elastic.co"},"sourceCommit":{"committedDate":"2022-09-27T15:08:46Z","message":"[Fleet] Point APM bundling process at package storage v2 (#141944)\n\n* Point APM bundling process at package storage v2\r\n\r\n* Add Fleet as codeowner for bundled packages task","sha":"7e469af7c6881267f528b9a3d611244415f68269","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Fleet","v8.6.0"],"number":141944,"url":"https://github.com/elastic/kibana/pull/141944","mergeCommit":{"message":"[Fleet] Point APM bundling process at package storage v2 (#141944)\n\n* Point APM bundling process at package storage v2\r\n\r\n* Add Fleet as codeowner for bundled packages task","sha":"7e469af7c6881267f528b9a3d611244415f68269"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/141944","number":141944,"mergeCommit":{"message":"[Fleet] Point APM bundling process at package storage v2 (#141944)\n\n* Point APM bundling process at package storage v2\r\n\r\n* Add Fleet as codeowner for bundled packages task","sha":"7e469af7c6881267f528b9a3d611244415f68269"}}]}] BACKPORT-->