### PR TITLE
Fix curl script in Reporting documentation

### DIFF
--- a/docs/user/reporting/script-example.asciidoc
+++ b/docs/user/reporting/script-example.asciidoc
@@ -3,7 +3,7 @@ URL that you use to download the report. Use the `GET` method in the HTTP reques
 
 To queue CSV report generation using the `POST` URL with cURL:
 
-["source","sh",subs="attributes"]
+[source,curl]
 ---------------------------------------------------------
 curl \
 -XPOST \ <1>
@@ -11,7 +11,6 @@ curl \
 -H 'kbn-xsrf: true' \ <3>
 'http://0.0.0.0:5601/api/reporting/generate/csv?jobParams=...' <4>
 ---------------------------------------------------------
-// CONSOLE
 
 <1> The required `POST` method.
 <2> The user credentials for a user with permission to access {kib} and {report-features}.
@@ -20,7 +19,7 @@ curl \
 
 An example response for a successfully queued report:
 
-[source,json]
+[source,js]
 ---------------------------------------------------------
 {
   "path": "/api/reporting/jobs/download/jxzaofkc0ykpf4062305t068", <1>
@@ -35,7 +34,6 @@ An example response for a successfully queued report:
   }
 }
 ---------------------------------------------------------
-// CONSOLE
 
 <1> The relative path on the {kib} host for downloading the report.
 <2> (Not included in the example) Internal representation of the reporting job, as found in the `.reporting-*` index.


### PR DESCRIPTION
## Summary

Fixes an error in the [reporting documentation](https://www.elastic.co/guide/en/kibana/master/automating-report-generation.html#use-a-script) where "Copy as curl" returns a malformed curl command.

As pointed out in [this Discuss post](https://discuss.elastic.co/t/generate-reports-from-a-script-in-csv-is-not-working/314876/3?u=nickpeihl), the "Copy as curl" button returns a malformed curl command like:

```sh
curl -X POST "localhost:9200/\?pretty" -H 'Content-Type: application/json' -d'
-u elastic \ 
-H \u0027kbn-xsrf: true\u0027 \ 
\u0027http://0.0.0.0:5601/api/reporting/generate/csv?jobParams=...\u0027
'
```

The `-u`, `-H` and URL are inserted after a `-d` flag which causes curl to fail. Since this is a native curl command the code block should not be wrapped with the "Copy as curl" component in the documentation. 

Additionally, the response example from the curl command should also not be wrapped in the component.

<!--ONMERGE {"backportTargets":["7.14","7.15","7.16","7.17","8.0","8.1","8.2","8.3","8.4","8.5"]} ONMERGE-->