### PR TITLE
[Cases] Test assignees section on upgrade test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/cases/upgrade.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/upgrade.ts
@@ -18,6 +18,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const testSubjects = getService('testSubjects');
   const find = getService('find');
+  const toasts = getService('toasts');
 
   const updateConnector = async (id: string, req: Record<string, unknown>) => {
     const { body: connector } = await supertest
@@ -74,6 +75,10 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
 
     describe('Case view page', function () {
+      it('does not show any error toasters', async () => {
+        expect(await toasts.getToastCount()).to.be(0);
+      });
+
       it('shows the title correctly', async () => {
         const title = await testSubjects.find('header-page-title');
         expect(await title.getVisibleText()).equal('Upgrade test in Kibana');
@@ -274,6 +279,10 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
       it('shows the add comment button', async () => {
         await testSubjects.exists('submit-comment');
+      });
+
+      it('shows the assignees section', async () => {
+        await testSubjects.exists('case-view-assignees');
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR adds a test that asserts that the assignees' sections in being shown correctly after an upgrade.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
