### PR TITLE
[Enterprise Search] Only show Pipelines curl example for API indices

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
@@ -26,6 +26,7 @@ import { KibanaLogic } from '../../../../shared/kibana';
 import { LicensingLogic } from '../../../../shared/licensing';
 import { CreateCustomPipelineApiLogic } from '../../../api/index/create_custom_pipeline_api_logic';
 import { FetchCustomPipelineApiLogic } from '../../../api/index/fetch_custom_pipeline_api_logic';
+import { isApiIndex } from '../../../utils/indices';
 import { CurlRequest } from '../components/curl_request/curl_request';
 import { IndexViewLogic } from '../index_view_logic';
 
@@ -36,7 +37,7 @@ import { PipelinesLogic } from './pipelines_logic';
 export const IngestPipelinesCard: React.FC = () => {
   const { indexName } = useValues(IndexViewLogic);
 
-  const { canSetPipeline, pipelineState, showModal } = useValues(PipelinesLogic);
+  const { canSetPipeline, index, pipelineState, showModal } = useValues(PipelinesLogic);
   const { closeModal, openModal, setPipelineState, savePipeline } = useActions(PipelinesLogic);
   const { makeRequest: fetchCustomPipeline } = useActions(FetchCustomPipelineApiLogic);
   const { makeRequest: createCustomPipeline } = useActions(CreateCustomPipelineApiLogic);
@@ -97,22 +98,24 @@ export const IngestPipelinesCard: React.FC = () => {
               </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiAccordion
-                    buttonContent={i18n.translate(
-                      'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.accordion.label',
-                      { defaultMessage: 'View sample cURL request' }
-                    )}
-                    id="ingestPipelinesCurlAccordion"
-                  >
-                    <CurlRequest
-                      document={{ body: 'body', title: 'Title' }}
-                      indexName={indexName}
-                      pipeline={pipelineState}
-                    />
-                  </EuiAccordion>
-                </EuiFlexItem>
+              <EuiFlexGroup justifyContent="flexEnd">
+                {isApiIndex(index) && (
+                  <EuiFlexItem>
+                    <EuiAccordion
+                      buttonContent={i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.accordion.label',
+                        { defaultMessage: 'View sample cURL request' }
+                      )}
+                      id="ingestPipelinesCurlAccordion"
+                    >
+                      <CurlRequest
+                        document={{ body: 'body', title: 'Title' }}
+                        indexName={indexName}
+                        pipeline={pipelineState}
+                      />
+                    </EuiAccordion>
+                  </EuiFlexItem>
+                )}
                 <EuiFlexItem grow={false}>
                   <EuiBadge color="hollow">
                     {i18n.translate(


### PR DESCRIPTION
## Summary

Hiding the curl example for Connector and Crawler indices, as we don't want users ingesting using this method.

![image](https://user-images.githubusercontent.com/2479295/192582992-f2a3c6ed-c991-4568-b4d4-d6e47c58d024.png)

![image](https://user-images.githubusercontent.com/2479295/192583037-e4f91331-231c-498a-99fc-74f0a6be01f4.png)

![image](https://user-images.githubusercontent.com/2479295/192583058-612f95a6-84f3-494a-b941-867510d27285.png)



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->