### PR TITLE
[ResponseOps][Cases] Updating no matches text

### DIFF
--- a/x-pack/plugins/cases/public/components/user_profiles/no_matches.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_profiles/no_matches.test.tsx
@@ -13,6 +13,6 @@ describe('NoMatches', () => {
   it('renders the no matches messages', () => {
     render(<NoMatches />);
 
-    expect(screen.getByText('No matching users with required access.'));
+    expect(screen.getByText("User doesn't exist or is unavailable"));
   });
 });

--- a/x-pack/plugins/cases/public/components/user_profiles/no_matches.tsx
+++ b/x-pack/plugins/cases/public/components/user_profiles/no_matches.tsx
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText, EuiTextAlign } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiTextAlign,
+} from '@elastic/eui';
 import React from 'react';
 import * as i18n from './translations';
 
@@ -25,11 +33,18 @@ const NoMatchesComponent: React.FC = () => {
       <EuiFlexItem grow={false}>
         <EuiTextAlign textAlign="center">
           <EuiText size="s" color="default">
-            <strong>{i18n.NO_MATCHING_USERS}</strong>
+            <strong>{i18n.USER_DOES_NOT_EXIST}</strong>
             <br />
           </EuiText>
           <EuiText size="s" color="subdued">
-            {i18n.TRY_MODIFYING_SEARCH}
+            {i18n.MODIFY_SEARCH}
+            <br />
+            <EuiLink
+              href="https://www.elastic.co/guide/en/security/current/case-permissions.html"
+              target="_blank"
+            >
+              {i18n.LEARN_PRIVILEGES_GRANT_ACCESS}
+            </EuiLink>
           </EuiText>
         </EuiTextAlign>
       </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/user_profiles/translations.ts
+++ b/x-pack/plugins/cases/public/components/user_profiles/translations.ts
@@ -44,12 +44,19 @@ export const ASSIGNEES = i18n.translate('xpack.cases.userProfile.assigneesTitle'
   defaultMessage: 'Assignees',
 });
 
-export const NO_MATCHING_USERS = i18n.translate('xpack.cases.userProfiles.noMatchingUsers', {
-  defaultMessage: 'No matching users with required access.',
+export const USER_DOES_NOT_EXIST = i18n.translate('xpack.cases.userProfiles.userDoesNotExist', {
+  defaultMessage: "User doesn't exist or is unavailable",
 });
 
-export const TRY_MODIFYING_SEARCH = i18n.translate('xpack.cases.userProfiles.tryModifyingSearch', {
-  defaultMessage: 'Try modifying your search.',
+export const LEARN_PRIVILEGES_GRANT_ACCESS = i18n.translate(
+  'xpack.cases.userProfiles.learnPrivileges',
+  {
+    defaultMessage: 'Learn what privileges grant access to cases.',
+  }
+);
+
+export const MODIFY_SEARCH = i18n.translate('xpack.cases.userProfiles.modifySearch', {
+  defaultMessage: "Modify your search or check the user's privileges.",
 });
 
 export const INVALID_ASSIGNEES = i18n.translate('xpack.cases.create.invalidAssignees', {


### PR DESCRIPTION
This PR updates the text when no users are returned from the assignees popover.

Fixes: https://github.com/elastic/kibana/issues/141359

![image](https://user-images.githubusercontent.com/56361221/192588833-55a6ea1e-e07d-4ecd-9cdc-c5cbc85c0ec4.png)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->