### PR TITLE
[Enterprise Search] Allow empty nextSyncConfig field in register connector request

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -114,7 +114,7 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
           connectorId: schema.string(),
         }),
         body: schema.object({
-          nextSyncConfig: schema.string(),
+          nextSyncConfig: schema.maybe(schema.string()),
         }),
       },
     },


### PR DESCRIPTION
## Summary

This was causing errors for our Logic files which did not submit this field along with their request after this was introduced.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->