### PR TITLE
[Alerting][Docs] Adding link to ES docs for CCS setup

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -101,7 +101,7 @@ modifies the rule, it will begin running with increased privileges.
 
 [float]
 [[alerting-ccs-setup]]
-=== CCS
+=== {ccs-cap}
 
-If you want to use alerting rules in a cross-cluster setup, you must configure 
-{ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for cross-cluster search and Kibana]
+If you want to use alerting rules with {ccs}, you must configure 
+{ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for {ccs-init} and {kib}].

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -98,3 +98,10 @@ user without those privileges updates the rule, the rule will no longer
 function. Conversely, if a user with greater or administrator privileges 
 modifies the rule, it will begin running with increased privileges.
 ==============================================
+
+[float]
+[[alerting-ccs-setup]]
+=== CCS
+
+If you want to use alerting rules in a cross-cluster setup, you must configure 
+{es-ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for cross-cluster search and Kibana]

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -104,4 +104,4 @@ modifies the rule, it will begin running with increased privileges.
 === CCS
 
 If you want to use alerting rules in a cross-cluster setup, you must configure 
-{es-ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for cross-cluster search and Kibana]
+{ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for cross-cluster search and Kibana]


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/121334

## Summary

There are specific instructions for setting up roles in the local and remote cluster in a CCS setup to get alerting rules to work. The Elasticsearch team has already done a good job of explaining how to configure the correct privileges. This PR adds a link to those docs from the Alerting setup instructions.


<!--ONMERGE {"backportTargets":["7.15","7.17","8.0","8.1","8.2","8.3","8.4","8.5"]} ONMERGE-->