### PR TITLE
[Security Solution] use endpoint rbac for process operations

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
@@ -108,37 +108,28 @@ describe('Endpoint Authz service', () => {
       });
     });
 
-    describe('endpoint rbac is enabled', () => {
-      describe('canIsolateHost', () => {
-        it('should be true if packagePrivilege.writeHostIsolation is true', () => {
-          fleetAuthz.packagePrivileges!.endpoint.actions.writeHostIsolation.executePackageAction =
-            true;
-          const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
-          expect(authz.canIsolateHost).toBe(true);
-        });
-
-        it('should be false if packagePrivilege.writeHostIsolation is false', () => {
-          fleetAuthz.packagePrivileges!.endpoint.actions.writeHostIsolation.executePackageAction =
-            false;
-          const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
-          expect(authz.canIsolateHost).toBe(false);
-        });
+    describe('and endpoint rbac is enabled', () => {
+      it.each<[EndpointAuthzKeyList[number], string]>([
+        ['canIsolateHost', 'writeHostIsolation'],
+        ['canUnIsolateHost', 'writeHostIsolation'],
+        ['canKillProcess', 'writeProcessOperations'],
+        ['canSuspendProcess', 'writeProcessOperations'],
+        ['canGetRunningProcesses', 'writeProcessOperations'],
+      ])('%s should be true if `packagePrivilege.%s` is `true`', (auth) => {
+        const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
+        expect(authz[auth]).toBe(true);
       });
 
-      describe('canUnIsolateHost', () => {
-        it('should be true if packagePrivilege.writeHostIsolation is true', () => {
-          fleetAuthz.packagePrivileges!.endpoint.actions.writeHostIsolation.executePackageAction =
-            true;
-          const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
-          expect(authz.canUnIsolateHost).toBe(true);
-        });
-
-        it('should be false if packagePrivilege.writeHostIsolation is false', () => {
-          fleetAuthz.packagePrivileges!.endpoint.actions.writeHostIsolation.executePackageAction =
-            false;
-          const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
-          expect(authz.canUnIsolateHost).toBe(false);
-        });
+      it.each<[EndpointAuthzKeyList[number], string]>([
+        ['canIsolateHost', 'writeHostIsolation'],
+        ['canUnIsolateHost', 'writeHostIsolation'],
+        ['canKillProcess', 'writeProcessOperations'],
+        ['canSuspendProcess', 'writeProcessOperations'],
+        ['canGetRunningProcesses', 'writeProcessOperations'],
+      ])('%s should be false if `packagePrivilege.%s` is `false`', (auth, privilege) => {
+        fleetAuthz.packagePrivileges!.endpoint.actions[privilege].executePackageAction = false;
+        const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true);
+        expect(authz[auth]).toBe(false);
       });
     });
   });

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
@@ -22,7 +22,6 @@ export const calculateEndpointAuthz = (
   licenseService: LicenseService,
   fleetAuthz: FleetAuthz,
   userRoles: MaybeImmutable<string[]>,
-  // to be used in follow-up PRs
   isEndpointRbacEnabled: boolean = false
 ): EndpointAuthz => {
   const isPlatinumPlusLicense = licenseService.isPlatinumPlus();
@@ -32,17 +31,21 @@ export const calculateEndpointAuthz = (
     ? fleetAuthz.packagePrivileges?.endpoint?.actions?.writeHostIsolation?.executePackageAction ||
       false
     : hasEndpointManagementAccess;
+  const canWriteProcessOperations = isEndpointRbacEnabled
+    ? fleetAuthz.packagePrivileges?.endpoint?.actions?.writeProcessOperations
+        ?.executePackageAction || false
+    : hasEndpointManagementAccess;
 
   return {
     canAccessFleet: fleetAuthz?.fleet.all ?? userRoles.includes('superuser'),
     canAccessEndpointManagement: hasEndpointManagementAccess,
     canCreateArtifactsByPolicy: hasEndpointManagementAccess && isPlatinumPlusLicense,
     // Response Actions
-    canIsolateHost: isPlatinumPlusLicense && canIsolateHost,
+    canIsolateHost: canIsolateHost && isPlatinumPlusLicense,
     canUnIsolateHost: canIsolateHost,
-    canKillProcess: hasEndpointManagementAccess && isEnterpriseLicense,
-    canSuspendProcess: hasEndpointManagementAccess && isEnterpriseLicense,
-    canGetRunningProcesses: hasEndpointManagementAccess && isEnterpriseLicense,
+    canKillProcess: canWriteProcessOperations && isEnterpriseLicense,
+    canSuspendProcess: canWriteProcessOperations && isEnterpriseLicense,
+    canGetRunningProcesses: canWriteProcessOperations && isEnterpriseLicense,
     canAccessResponseConsole: hasEndpointManagementAccess && isEnterpriseLicense,
   };
 };


### PR DESCRIPTION
## Summary

Use endpoint rbac for process operations (`canKillProcess` | `canSuspendProcess` | `canGetRunningProcesses`).


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
