### PR TITLE
[RAM] Fix bulk edit getFilter not returning excluded ids filter when no rules list filter

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_bulk_edit_select.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_bulk_edit_select.test.tsx
@@ -86,6 +86,22 @@ describe('useBulkEditSelectTest', () => {
     expect(result.current.getFilter()).toEqual(null);
   });
 
+  it('getFilter should return rule list filter when selecting all with excluded ids', async () => {
+    const { result } = renderHook(() =>
+      useBulkEditSelect({
+        items,
+        totalItemCount: 4,
+      })
+    );
+
+    act(() => {
+      result.current.onSelectAll();
+      result.current.onSelectRow(items[0]);
+    });
+
+    expect(result.current.getFilter()?.arguments.length).toEqual(1);
+  });
+
   it('getFilter should return rule list filter when selecting all', async () => {
     const { result } = renderHook(() =>
       useBulkEditSelect({

--- a/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_bulk_edit_select.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_bulk_edit_select.tsx
@@ -192,14 +192,13 @@ export function useBulkEditSelect(props: UseBulkEditSelectProps) {
       });
 
       if (idsToExclude && idsToExclude.length) {
+        const excludeFilter = fromKueryExpression(
+          `NOT (${idsToExclude.map((id) => `alert.id: "alert:${id}"`).join(' or ')})`
+        );
         if (ruleFilterKueryNode) {
-          return nodeBuilder.and([
-            ruleFilterKueryNode,
-            fromKueryExpression(
-              `NOT (${idsToExclude.map((id) => `alert.id: "alert:${id}"`).join(' or ')})`
-            ),
-          ]);
+          return nodeBuilder.and([ruleFilterKueryNode, excludeFilter]);
         }
+        return excludeFilter;
       }
 
       return ruleFilterKueryNode;


### PR DESCRIPTION
Fixes a small bug where the excluded ids filter was not being returned when there is no rules list filter.

Steps to verify this fix:
  - Create multiple rules in management -> rules and connectors 
  - Select all rules by clicking 'Select all x rules'
  - Unselect a few rules
  - Bulk snooze
  
Only the selected rules should be snoozed.

![image](https://user-images.githubusercontent.com/74562234/192693678-4ea4ecf3-eb23-4872-a4a2-24b26678e746.png)

Only the selected rules should be snoozed 

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->