### PR TITLE
[Expressions] Fix expressions chain invocation not to stop on partial results error

### DIFF
--- a/src/plugins/expressions/common/execution/execution.ts
+++ b/src/plugins/expressions/common/execution/execution.ts
@@ -295,87 +295,86 @@ export class Execution<
   }
 
   invokeChain<ChainOutput = unknown>(
-    chainArr: ExpressionAstFunction[],
+    [head, ...tail]: ExpressionAstFunction[],
     input: unknown
-  ): Observable<ChainOutput> {
+  ): Observable<ChainOutput | ExpressionValueError> {
+    if (!head) {
+      return of(input as ChainOutput);
+    }
+
     return of(input).pipe(
-      ...(chainArr.map((link) =>
-        switchMap((currentInput) => {
-          const { function: fnName, arguments: fnArgs } = link;
-          const fn = getByAlias(
-            this.state.get().functions,
-            fnName,
-            this.execution.params.namespace
-          );
+      switchMap((currentInput) => {
+        const { function: fnName, arguments: fnArgs } = head;
+        const fn = getByAlias(this.state.get().functions, fnName, this.execution.params.namespace);
 
-          if (!fn) {
-            throw createError({
-              name: 'fn not found',
-              message: i18n.translate('expressions.execution.functionNotFound', {
-                defaultMessage: `Function {fnName} could not be found.`,
-                values: {
-                  fnName,
-                },
-              }),
-            });
-          }
-
-          if (fn.disabled) {
-            throw createError({
-              name: 'fn is disabled',
-              message: i18n.translate('expressions.execution.functionDisabled', {
-                defaultMessage: `Function {fnName} is disabled.`,
-                values: {
-                  fnName,
-                },
-              }),
-            });
-          }
-
-          if (fn.deprecated) {
-            this.logger?.warn(`Function '${fnName}' is deprecated`);
-          }
-
-          if (this.execution.params.debug) {
-            link.debug = {
-              args: {},
-              duration: 0,
-              fn: fn.name,
-              input: currentInput,
-              success: true,
-            };
-          }
-
-          const timeStart = this.execution.params.debug ? now() : 0;
-
-          // `resolveArgs` returns an object because the arguments themselves might
-          // actually have `then` or `subscribe` methods which would be treated as a `Promise`
-          // or an `Observable` accordingly.
-          return this.resolveArgs(fn, currentInput, fnArgs).pipe(
-            tap((args) => this.execution.params.debug && Object.assign(link.debug, { args })),
-            switchMap((args) => this.invokeFunction(fn, currentInput, args)),
-            switchMap((output) => (getType(output) === 'error' ? throwError(output) : of(output))),
-            tap((output) => this.execution.params.debug && Object.assign(link.debug, { output })),
-            catchError((rawError) => {
-              const error = createError(rawError);
-              error.error.message = `[${fnName}] > ${error.error.message}`;
-
-              if (this.execution.params.debug) {
-                Object.assign(link.debug, { error, rawError, success: false });
-              }
-
-              return throwError(error);
+        if (!fn) {
+          throw createError({
+            name: 'fn not found',
+            message: i18n.translate('expressions.execution.functionNotFound', {
+              defaultMessage: `Function {fnName} could not be found.`,
+              values: {
+                fnName,
+              },
             }),
-            finalize(() => {
-              if (this.execution.params.debug) {
-                Object.assign(link.debug, { duration: now() - timeStart });
-              }
-            })
-          );
-        })
-      ) as Parameters<Observable<unknown>['pipe']>),
+          });
+        }
+
+        if (fn.disabled) {
+          throw createError({
+            name: 'fn is disabled',
+            message: i18n.translate('expressions.execution.functionDisabled', {
+              defaultMessage: `Function {fnName} is disabled.`,
+              values: {
+                fnName,
+              },
+            }),
+          });
+        }
+
+        if (fn.deprecated) {
+          this.logger?.warn(`Function '${fnName}' is deprecated`);
+        }
+
+        if (this.execution.params.debug) {
+          head.debug = {
+            args: {},
+            duration: 0,
+            fn: fn.name,
+            input: currentInput,
+            success: true,
+          };
+        }
+
+        const timeStart = this.execution.params.debug ? now() : 0;
+
+        // `resolveArgs` returns an object because the arguments themselves might
+        // actually have `then` or `subscribe` methods which would be treated as a `Promise`
+        // or an `Observable` accordingly.
+        return this.resolveArgs(fn, currentInput, fnArgs).pipe(
+          tap((args) => this.execution.params.debug && Object.assign(head.debug, { args })),
+          switchMap((args) => this.invokeFunction(fn, currentInput, args)),
+          switchMap((output) => (getType(output) === 'error' ? throwError(output) : of(output))),
+          tap((output) => this.execution.params.debug && Object.assign(head.debug, { output })),
+          switchMap((output) => this.invokeChain<ChainOutput>(tail, output)),
+          catchError((rawError) => {
+            const error = createError(rawError);
+            error.error.message = `[${fnName}] > ${error.error.message}`;
+
+            if (this.execution.params.debug) {
+              Object.assign(head.debug, { error, rawError, success: false });
+            }
+
+            return of(error);
+          }),
+          finalize(() => {
+            if (this.execution.params.debug) {
+              Object.assign(head.debug, { duration: now() - timeStart });
+            }
+          })
+        );
+      }),
       catchError((error) => of(error))
-    ) as Observable<ChainOutput>;
+    );
   }
 
   invokeFunction<Fn extends ExpressionFunction>(


### PR DESCRIPTION
## Summary

Resolves #141673.

## Release note
Fixed expressions executor stopping on failing partially emitted result. The bug was causing errors in some datatable functions following the `esdocs` and `essql` functions.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->