### PR TITLE
[eslint/imports/no-boundary-crossing] don't allow package tests to import outside of packages

### DIFF
--- a/packages/kbn-eslint-plugin-imports/src/rules/no_boundary_crossing.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_boundary_crossing.ts
@@ -19,15 +19,17 @@ import { getSourcePath } from '../helpers/source';
 import { getRepoSourceClassifier } from '../helpers/repo_source_classifier';
 import { getImportResolver } from '../get_import_resolver';
 
-const IMPORTABLE_FROM: Record<ModuleType, ModuleType[] | '*'> = {
+const ANY_FILE_IN_BAZEL = Symbol();
+
+const IMPORTABLE_FROM: Record<ModuleType, ModuleType[] | typeof ANY_FILE_IN_BAZEL> = {
   'non-package': ['non-package', 'server package', 'browser package', 'common package', 'static'],
   'server package': ['common package', 'server package', 'static'],
   'browser package': ['common package', 'browser package', 'static'],
   'common package': ['common package', 'static'],
 
   static: [],
-  'tests or mocks': '*',
-  tooling: '*',
+  'tests or mocks': ANY_FILE_IN_BAZEL,
+  tooling: ANY_FILE_IN_BAZEL,
 };
 
 const toList = (strings: string[]) => {
@@ -87,6 +89,7 @@ export const NoBoundaryCrossingRule: Rule.RuleModule = {
     },
     messages: {
       TYPE_MISMATCH: `"{{importedType}}" code can not be imported from "{{ownType}}" code.{{suggestion}}`,
+      FILE_OUTSIDE_OF_PACKAGE: `"{{ownType}}" code can import any code already within packages, but not files outside of packages.`,
     },
   },
   create(context) {
@@ -98,12 +101,7 @@ export const NoBoundaryCrossingRule: Rule.RuleModule = {
     const self = classifier.classify(sourcePath);
     const importable = IMPORTABLE_FROM[self.type];
 
-    if (importable === '*') {
-      // don't check imports in files which can import anything
-      return {};
-    }
-
-    return visitAllImportStatements((req, { node, importer }) => {
+    return visitAllImportStatements((req, { node, importer, type }) => {
       if (
         req === null ||
         // we can ignore imports using the raw-loader, they will need to be resolved but can be managed on a case by case basis
@@ -120,6 +118,27 @@ export const NoBoundaryCrossingRule: Rule.RuleModule = {
       }
 
       const imported = classifier.classify(result.absolute);
+
+      if (importable === ANY_FILE_IN_BAZEL) {
+        if (type === 'jest' && imported.repoRel === 'package.json') {
+          // we allow jest.mock() calls to mock out the `package.json` file... it's a very
+          // specific exception for a very specific implementation
+          return;
+        }
+
+        if (self.pkgInfo?.isBazelPackage ? imported.pkgInfo?.isBazelPackage : true) {
+          return;
+        }
+
+        context.report({
+          node: node as ESTree.Node,
+          messageId: 'FILE_OUTSIDE_OF_PACKAGE',
+          data: {
+            ownType: self.type,
+          },
+        });
+        return;
+      }
 
       if (!importable.includes(imported.type)) {
         context.report({

--- a/packages/kbn-repo-source-classifier/src/pkg_info.ts
+++ b/packages/kbn-repo-source-classifier/src/pkg_info.ts
@@ -13,4 +13,6 @@ export interface PkgInfo {
   rel: string;
   /** Absolute path to the package directory */
   pkgDir: string;
+  /** Is the package a bazel package? If false, then the package is a "synthetic" plugin package */
+  isBazelPackage: boolean;
 }

--- a/packages/kbn-repo-source-classifier/src/repo_path.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_path.ts
@@ -93,6 +93,7 @@ export class RepoPath {
           pkgDir,
           pkgId,
           rel,
+          isBazelPackage: this.resolver.isBazelPackage(pkgId),
         };
       }
     }

--- a/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/header/header.test.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/header/header.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
 
+import { getExceptionListItemSchemaMock } from '../../test_helpers/exception_list_item_schema.mock';
 import * as i18n from '../translations';
 import { ExceptionItemCardHeader } from './header';
 import { fireEvent, render } from '@testing-library/react';

--- a/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/index.test.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/index.test.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import { ExceptionItemCard } from '.';
-import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
-import { getCommentsArrayMock } from '@kbn/lists-plugin/common/schemas/types/comment.mock';
+import { getExceptionListItemSchemaMock } from '../test_helpers/exception_list_item_schema.mock';
+import { getCommentsArrayMock } from '../test_helpers/comments.mock';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 
 const ruleReferences: unknown[] = [

--- a/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/meta/meta.test.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/meta/meta.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
+import { getExceptionListItemSchemaMock } from '../../test_helpers/exception_list_item_schema.mock';
 
 import { ExceptionItemCardMetaInfo } from './meta';
 import { RuleReference } from '../../types';

--- a/packages/kbn-securitysolution-exception-list-components/src/exception_items/exception_items.test.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/exception_items/exception_items.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
+import { getExceptionListItemSchemaMock } from '../test_helpers/exception_list_item_schema.mock';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 
 import { ExceptionItems } from './exception_items';

--- a/packages/kbn-securitysolution-exception-list-components/src/test_helpers/comments.mock.ts
+++ b/packages/kbn-securitysolution-exception-list-components/src/test_helpers/comments.mock.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Comment, CommentsArray } from '@kbn/securitysolution-io-ts-list-types';
+
+export const getCommentsMock = (): Comment => ({
+  comment: 'some old comment',
+  created_at: '2020-04-20T15:25:31.830Z',
+  created_by: 'some user',
+  id: 'uuid_here',
+});
+
+export const getCommentsArrayMock = (): CommentsArray => [getCommentsMock(), getCommentsMock()];

--- a/packages/kbn-securitysolution-exception-list-components/src/test_helpers/exception_list_item_schema.mock.ts
+++ b/packages/kbn-securitysolution-exception-list-components/src/test_helpers/exception_list_item_schema.mock.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+
+export const getExceptionListItemSchemaMock = (
+  overrides?: Partial<ExceptionListItemSchema>
+): ExceptionListItemSchema => ({
+  _version: undefined,
+  comments: [],
+  created_at: '2020-04-20T15:25:31.830Z',
+  created_by: 'some user',
+  description: 'some description',
+  entries: [
+    {
+      entries: [
+        { field: 'nested.field', operator: 'included', type: 'match', value: 'some value' },
+      ],
+      field: 'some.parentField',
+      type: 'nested',
+    },
+    { field: 'some.not.nested.field', operator: 'included', type: 'match', value: 'some value' },
+  ],
+  id: '1',
+  item_id: 'endpoint_list_item',
+  list_id: 'endpoint_list_id',
+  meta: {},
+  name: 'some name',
+  namespace_type: 'single',
+  os_types: [],
+  tags: ['user added string for a tag', 'malware'],
+  tie_breaker_id: '6a76b69d-80df-4ab2-8c3e-85f466b06a0e',
+  type: 'simple',
+  updated_at: '2020-04-20T15:25:31.830Z',
+  updated_by: 'some user',
+  ...(overrides || {}),
+});


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/140985 new tests were written in a package that depend on plugin code. This shouldn't have been allowed by our `no_boundary_crossing` eslint rule, but it was because the rule previously allowed test code to import anything.

This PR splits the `tests or mocks` source class into `package tests or mocks` and `non-package tests or mocks`. `non-package tests or mocks` can still import any file. `package tests or mocks` can only import other packages or `package tests or mocks` code.

@WafaaNasr for now I've copied the mocks used into the package. If you'd like to move those mocks to a separate package so they could be used by both the plugin and other packages I'md ask that you do that as a follow up PR.