### PR TITLE
[Guided onboarding] Added Guided onboarding to the Fleet plugin

### DIFF
--- a/src/plugins/guided_onboarding/public/constants/guides_config/security.ts
+++ b/src/plugins/guided_onboarding/public/constants/guides_config/security.ts
@@ -21,6 +21,11 @@ export const securityConfig: GuideConfig = {
         'Nullam ligula enim, malesuada a finibus vel, cursus sed risus.',
         'Vivamus pretium, elit dictum lacinia aliquet, libero nibh dictum enim, a rhoncus leo magna in sapien.',
       ],
+      integration: 'endpoint',
+      location: {
+        appID: 'integrations',
+        path: '/browse/security',
+      },
     },
     {
       id: 'rules',

--- a/src/plugins/guided_onboarding/public/mocks.tsx
+++ b/src/plugins/guided_onboarding/public/mocks.tsx
@@ -11,13 +11,17 @@ import { GuidedOnboardingPluginStart } from '.';
 
 const apiServiceMock: jest.Mocked<GuidedOnboardingPluginStart> = {
   guidedOnboardingApi: {
+    setup: jest.fn(),
+    fetchActiveGuideState$: () => new BehaviorSubject(undefined),
+    fetchAllGuidesState: jest.fn(),
+    updateGuideState: jest.fn(),
+    activateGuide: jest.fn(),
+    completeGuide: jest.fn(),
+    isGuideStepActive$: () => new BehaviorSubject(false),
+    startGuideStep: jest.fn(),
+    completeGuideStep: jest.fn(),
     isGuidedOnboardingActiveForIntegration$: () => new BehaviorSubject(false),
     completeGuidedOnboardingForIntegration: jest.fn(),
-    isGuideStepActive$: () => new BehaviorSubject(false),
-    completeGuideStep: jest.fn(),
-    fetchGuideState$: jest.fn(),
-    updateGuideState: jest.fn(),
-    setup: jest.fn(),
   },
 };
 

--- a/src/plugins/guided_onboarding/public/mocks.tsx
+++ b/src/plugins/guided_onboarding/public/mocks.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+jest.mock('./services/api');
+import { ApiService } from './services/api';
+
+const mockApi = ApiService as unknown as jest.Mocked<ApiService>;
+import { GuidedOnboardingPluginStart } from '.';
+
+const startMock: jest.Mocked<GuidedOnboardingPluginStart> = {
+  guidedOnboardingApi: mockApi,
+};
+
+export const guidedOnboardingMock = {
+  createSetup: () => {},
+  createStart: () => startMock,
+};

--- a/src/plugins/guided_onboarding/public/mocks.tsx
+++ b/src/plugins/guided_onboarding/public/mocks.tsx
@@ -6,17 +6,22 @@
  * Side Public License, v 1.
  */
 
-jest.mock('./services/api');
-import { ApiService } from './services/api';
-
-const mockApi = ApiService as unknown as jest.Mocked<ApiService>;
+import { BehaviorSubject } from 'rxjs';
 import { GuidedOnboardingPluginStart } from '.';
 
-const startMock: jest.Mocked<GuidedOnboardingPluginStart> = {
-  guidedOnboardingApi: mockApi,
+const apiServiceMock: jest.Mocked<GuidedOnboardingPluginStart> = {
+  guidedOnboardingApi: {
+    isGuidedOnboardingActiveForIntegration$: () => new BehaviorSubject(false),
+    completeGuidedOnboardingForIntegration: jest.fn(),
+    isGuideStepActive$: () => new BehaviorSubject(false),
+    completeGuideStep: jest.fn(),
+    fetchGuideState$: jest.fn(),
+    updateGuideState: jest.fn(),
+    setup: jest.fn(),
+  },
 };
 
 export const guidedOnboardingMock = {
   createSetup: () => {},
-  createStart: () => startMock,
+  createStart: () => apiServiceMock,
 };

--- a/src/plugins/guided_onboarding/public/services/api.mocks.ts
+++ b/src/plugins/guided_onboarding/public/services/api.mocks.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { GuideState } from '../../common/types';
+
+export const searchAddDataActiveState: GuideState = {
+  guideId: 'search',
+  isActive: true,
+  status: 'in_progress',
+  steps: [
+    {
+      id: 'add_data',
+      status: 'active',
+    },
+    {
+      id: 'browse_docs',
+      status: 'inactive',
+    },
+    {
+      id: 'search_experience',
+      status: 'inactive',
+    },
+  ],
+};
+
+export const searchAddDataInProgressState: GuideState = {
+  isActive: true,
+  status: 'in_progress',
+  steps: [
+    {
+      id: 'add_data',
+      status: 'in_progress',
+    },
+    {
+      id: 'browse_docs',
+      status: 'inactive',
+    },
+    {
+      id: 'search_experience',
+      status: 'inactive',
+    },
+  ],
+  guideId: 'search',
+};
+
+export const securityAddDataInProgressState: GuideState = {
+  guideId: 'security',
+  status: 'in_progress',
+  isActive: true,
+  steps: [
+    {
+      id: 'add_data',
+      status: 'in_progress',
+    },
+    {
+      id: 'rules',
+      status: 'inactive',
+    },
+  ],
+};
+
+export const securityRulesActivesState: GuideState = {
+  guideId: 'security',
+  isActive: true,
+  status: 'in_progress',
+  steps: [
+    {
+      id: 'add_data',
+      status: 'complete',
+    },
+    {
+      id: 'rules',
+      status: 'active',
+    },
+  ],
+};
+
+export const noGuideActiveState: GuideState = {
+  guideId: 'security',
+  status: 'in_progress',
+  isActive: false,
+  steps: [
+    {
+      id: 'add_data',
+      status: 'in_progress',
+    },
+    {
+      id: 'rules',
+      status: 'inactive',
+    },
+  ],
+};

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -10,8 +10,8 @@ import { HttpSetup } from '@kbn/core/public';
 import { BehaviorSubject, map, from, concatMap, of, Observable, firstValueFrom } from 'rxjs';
 
 import { API_BASE_PATH } from '../../common';
-import { GuidedOnboardingApi, GuidedOnboardingState, UseCase } from '../types';
-import { getNextStep, isIntegrationInGuideStep, isLastStep } from './helpers';
+import { GuidedOnboardingApi, GuidedOnboardingState } from '../types';
+import { isIntegrationInGuideStep, isLastStep } from './helpers';
 import { API_BASE_PATH } from '../../common/constants';
 import type { GuideState, GuideId, GuideStep, GuideStepIds } from '../../common/types';
 import { isLastStep, getGuideConfig } from './helpers';

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -300,6 +300,32 @@ export class ApiService {
 
     return undefined;
   }
+
+  /**
+   * An observable with the boolean value if the guided onboarding is currently active for the integration.
+   * Returns true, if the passed integration is used in the current guide's step.
+   * Returns false otherwise.
+   * @param {string} guideID the integration ID (package key) to check for in the guided onboarding config
+   * @return {Observable} an observable with the boolean value
+   */
+  public isGuidedOnboardingActiveForIntegration$(integration?: string): Observable<boolean> {
+    return this.fetchGuideState$().pipe(
+      map((state) => {
+        return isIntegrationInGuideStep(state, integration);
+      })
+    );
+  }
+
+  public async completeGuidedOnboardingForIntegration(integration?: string) {
+    if (integration) {
+      const currentState = await firstValueFrom(this.fetchGuideState$());
+      const isIntegrationStepActive = isIntegrationInGuideStep(currentState, integration);
+      if (isIntegrationStepActive) {
+        return await this.completeGuideStep(currentState.activeGuide, currentState.activeStep);
+      }
+    }
+    return undefined;
+  }
 }
 
 export const apiService = new ApiService();

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -108,8 +108,8 @@ export class ApiService implements GuidedOnboardingApi {
   /**
    * Activates a guide by guideId
    * This is useful for the onboarding landing page, when a user selects a guide to start or continue
-   * @param {GuideId} guideID the id of the guide (one of search, observability, security)
-   * @param {GuideState} guideState (optional) the selected guide state, if it exists (i.e., if a user is continuing a guide)
+   * @param {GuideId} guideId the id of the guide (one of search, observability, security)
+   * @param {GuideState} guide (optional) the selected guide state, if it exists (i.e., if a user is continuing a guide)
    * @return {Promise} a promise with the updated guide state
    */
   public async activateGuide(
@@ -156,7 +156,7 @@ export class ApiService implements GuidedOnboardingApi {
    * Completes a guide
    * Updates the overall guide status to 'complete', and marks it as inactive
    * This is useful for the dropdown panel, when the user clicks the "Continue using Elastic" button after completing all steps
-   * @param {GuideId} guideID the id of the guide (one of search, observability, security)
+   * @param {GuideId} guideId the id of the guide (one of search, observability, security)
    * @return {Promise} a promise with the updated guide state
    */
   public async completeGuide(guideId: GuideId): Promise<{ state: GuideState } | undefined> {
@@ -311,7 +311,7 @@ export class ApiService implements GuidedOnboardingApi {
    * An observable with the boolean value if the guided onboarding is currently active for the integration.
    * Returns true, if the passed integration is used in the current guide's step.
    * Returns false otherwise.
-   * @param {string} guideID the integration ID (package key) to check for in the guided onboarding config
+   * @param {string} integration the integration (package name) to check for in the guided onboarding config
    * @return {Observable} an observable with the boolean value
    */
   public isGuidedOnboardingActiveForIntegration$(integration?: string): Observable<boolean> {

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -9,11 +9,14 @@
 import { HttpSetup } from '@kbn/core/public';
 import { BehaviorSubject, map, from, concatMap, of, Observable, firstValueFrom } from 'rxjs';
 
+import { API_BASE_PATH } from '../../common';
+import { GuidedOnboardingApi, GuidedOnboardingState, UseCase } from '../types';
+import { getNextStep, isIntegrationInGuideStep, isLastStep } from './helpers';
 import { API_BASE_PATH } from '../../common/constants';
 import type { GuideState, GuideId, GuideStep, GuideStepIds } from '../../common/types';
 import { isLastStep, getGuideConfig } from './helpers';
 
-export class ApiService {
+export class ApiService implements GuidedOnboardingApi {
   private client: HttpSetup | undefined;
   private onboardingGuideState$!: BehaviorSubject<GuideState | undefined>;
   public isGuidePanelOpen$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -316,7 +319,9 @@ export class ApiService {
     );
   }
 
-  public async completeGuidedOnboardingForIntegration(integration?: string) {
+  public async completeGuidedOnboardingForIntegration(
+    integration?: string
+  ): Promise<{ state: GuidedOnboardingState } | undefined> {
     if (integration) {
       const currentState = await firstValueFrom(this.fetchGuideState$());
       const isIntegrationStepActive = isIntegrationInGuideStep(currentState, integration);

--- a/src/plugins/guided_onboarding/public/services/helpers.test.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.test.ts
@@ -7,14 +7,15 @@
  */
 
 import { guidesConfig } from '../constants/guides_config';
-import { isLastStep } from './helpers';
-import { GuidedOnboardingState } from '../types';
-import { getNextStep, isIntegrationInGuideStep, isLastStep } from './helpers';
+import { isIntegrationInGuideStep, isLastStep } from './helpers';
+import {
+  noGuideActiveState,
+  securityAddDataInProgressState,
+  securityRulesActivesState,
+} from './api.mocks';
 
 const searchGuide = 'search';
 const firstStep = guidesConfig[searchGuide].steps[0].id;
-const lastStep = guidesConfig[searchGuide].steps[2].id;
-const secondStep = guidesConfig[searchGuide].steps[1].id;
 const lastStep = guidesConfig[searchGuide].steps[guidesConfig[searchGuide].steps.length - 1].id;
 
 describe('GuidedOnboarding ApiService helpers', () => {
@@ -31,54 +32,25 @@ describe('GuidedOnboarding ApiService helpers', () => {
     });
   });
 
-  describe('getNextStep', () => {
-    it('returns id of the next step', () => {
-      const result = getNextStep(searchGuide, firstStep);
-      expect(result).toEqual(secondStep);
-    });
-
-    it('returns undefined if the params are not part of the config', () => {
-      const result = getNextStep('some_guide', 'some_step');
-      expect(result).toBeUndefined();
-    });
-
-    it(`returns undefined if it's the last step`, () => {
-      const result = getNextStep(searchGuide, lastStep);
-      expect(result).toBeUndefined();
-    });
-  });
-
   describe('isIntegrationInGuideStep', () => {
-    const securityAddDataState: GuidedOnboardingState = {
-      activeGuide: 'security',
-      activeStep: 'add_data',
-    };
     it('return true if the integration is defined in the guide step config', () => {
-      const result = isIntegrationInGuideStep(securityAddDataState, 'endpoint');
+      const result = isIntegrationInGuideStep(securityAddDataInProgressState, 'endpoint');
       expect(result).toBe(true);
     });
     it('returns false if a different integration is defined in the guide step', () => {
-      const result = isIntegrationInGuideStep(securityAddDataState, 'kubernetes');
+      const result = isIntegrationInGuideStep(securityAddDataInProgressState, 'kubernetes');
       expect(result).toBe(false);
     });
     it('returns false if no integration is defined in the guide step', () => {
-      const securityRulesState: GuidedOnboardingState = {
-        activeGuide: 'security',
-        activeStep: 'rules',
-      };
-      const result = isIntegrationInGuideStep(securityRulesState, 'endpoint');
+      const result = isIntegrationInGuideStep(securityRulesActivesState, 'endpoint');
       expect(result).toBe(false);
     });
     it('returns false if no guide is active', () => {
-      const noGuideState: GuidedOnboardingState = {
-        activeGuide: 'unset',
-        activeStep: 'unset',
-      };
-      const result = isIntegrationInGuideStep(noGuideState, 'endpoint');
+      const result = isIntegrationInGuideStep(noGuideActiveState, 'endpoint');
       expect(result).toBe(false);
     });
     it('returns false if no integration passed', () => {
-      const result = isIntegrationInGuideStep(securityAddDataState);
+      const result = isIntegrationInGuideStep(securityAddDataInProgressState);
       expect(result).toBe(false);
     });
   });

--- a/src/plugins/guided_onboarding/public/services/helpers.test.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.test.ts
@@ -8,10 +8,14 @@
 
 import { guidesConfig } from '../constants/guides_config';
 import { isLastStep } from './helpers';
+import { GuidedOnboardingState } from '../types';
+import { getNextStep, isIntegrationInGuideStep, isLastStep } from './helpers';
 
 const searchGuide = 'search';
 const firstStep = guidesConfig[searchGuide].steps[0].id;
 const lastStep = guidesConfig[searchGuide].steps[2].id;
+const secondStep = guidesConfig[searchGuide].steps[1].id;
+const lastStep = guidesConfig[searchGuide].steps[guidesConfig[searchGuide].steps.length - 1].id;
 
 describe('GuidedOnboarding ApiService helpers', () => {
   // this test suite depends on the guides config
@@ -23,6 +27,58 @@ describe('GuidedOnboarding ApiService helpers', () => {
 
     it('returns false if the passed params are not for the last step', () => {
       const result = isLastStep(searchGuide, firstStep);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getNextStep', () => {
+    it('returns id of the next step', () => {
+      const result = getNextStep(searchGuide, firstStep);
+      expect(result).toEqual(secondStep);
+    });
+
+    it('returns undefined if the params are not part of the config', () => {
+      const result = getNextStep('some_guide', 'some_step');
+      expect(result).toBeUndefined();
+    });
+
+    it(`returns undefined if it's the last step`, () => {
+      const result = getNextStep(searchGuide, lastStep);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('isIntegrationInGuideStep', () => {
+    const securityAddDataState: GuidedOnboardingState = {
+      activeGuide: 'security',
+      activeStep: 'add_data',
+    };
+    it('return true if the integration is defined in the guide step config', () => {
+      const result = isIntegrationInGuideStep(securityAddDataState, 'endpoint');
+      expect(result).toBe(true);
+    });
+    it('returns false if a different integration is defined in the guide step', () => {
+      const result = isIntegrationInGuideStep(securityAddDataState, 'kubernetes');
+      expect(result).toBe(false);
+    });
+    it('returns false if no integration is defined in the guide step', () => {
+      const securityRulesState: GuidedOnboardingState = {
+        activeGuide: 'security',
+        activeStep: 'rules',
+      };
+      const result = isIntegrationInGuideStep(securityRulesState, 'endpoint');
+      expect(result).toBe(false);
+    });
+    it('returns false if no guide is active', () => {
+      const noGuideState: GuidedOnboardingState = {
+        activeGuide: 'unset',
+        activeStep: 'unset',
+      };
+      const result = isIntegrationInGuideStep(noGuideState, 'endpoint');
+      expect(result).toBe(false);
+    });
+    it('returns false if no integration passed', () => {
+      const result = isIntegrationInGuideStep(securityAddDataState);
       expect(result).toBe(false);
     });
   });

--- a/src/plugins/guided_onboarding/public/services/helpers.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.ts
@@ -6,10 +6,9 @@
  * Side Public License, v 1.
  */
 
-import type { GuideId } from '../../common/types';
+import type { GuideId, GuideState, GuideStepIds } from '../../common/types';
 import { guidesConfig } from '../constants/guides_config';
-import type { GuideConfig, StepConfig } from '../types';
-import { GuideConfig, GuidedOnboardingState, StepConfig } from '../types';
+import { GuideConfig, StepConfig } from '../types';
 
 export const getGuideConfig = (guideID?: string): GuideConfig | undefined => {
   if (guideID && Object.keys(guidesConfig).includes(guideID)) {
@@ -35,23 +34,25 @@ export const isLastStep = (guideID: string, stepID: string): boolean => {
   return false;
 };
 
-export const getNextStep = (guideID: string, stepID: string): string | undefined => {
-  const guide = getGuideConfig(guideID);
-  const activeStepIndex = getStepIndex(guideID, stepID);
-  if (activeStepIndex > -1 && guide?.steps[activeStepIndex + 1]) {
-    return guide?.steps[activeStepIndex + 1].id;
+export const getInProgressStepId = (state: GuideState): GuideStepIds | undefined => {
+  const inProgressStep = state.steps.find((step) => step.status === 'in_progress');
+  return inProgressStep ? inProgressStep.id : undefined;
+};
+
+const getInProgressStepConfig = (state: GuideState): StepConfig | undefined => {
+  const inProgressStepId = getInProgressStepId(state);
+  if (inProgressStepId) {
+    const config = getGuideConfig(state.guideId);
+    if (config) {
+      return config.steps.find((step) => step.id === inProgressStepId);
+    }
   }
 };
 
-const getStepConfig = (guideID: string, stepID: string): StepConfig | undefined => {
-  const guide = getGuideConfig(guideID);
-  return guide?.steps.find((step) => step.id === stepID);
-};
-
-export const isIntegrationInGuideStep = (
-  state: GuidedOnboardingState,
-  integration?: string
-): boolean => {
-  const stepConfig = getStepConfig(state.activeGuide, state.activeStep);
-  return stepConfig ? stepConfig.integration === integration : false;
+export const isIntegrationInGuideStep = (state: GuideState, integration?: string): boolean => {
+  if (state.isActive) {
+    const stepConfig = getInProgressStepConfig(state);
+    return stepConfig ? stepConfig.integration === integration : false;
+  }
+  return false;
 };

--- a/src/plugins/guided_onboarding/public/services/helpers.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.ts
@@ -9,6 +9,7 @@
 import type { GuideId } from '../../common/types';
 import { guidesConfig } from '../constants/guides_config';
 import type { GuideConfig, StepConfig } from '../types';
+import { GuideConfig, GuidedOnboardingState, StepConfig, UseCase } from '../types';
 
 export const getGuideConfig = (guideID?: string): GuideConfig | undefined => {
   if (guideID && Object.keys(guidesConfig).includes(guideID)) {
@@ -32,4 +33,25 @@ export const isLastStep = (guideID: string, stepID: string): boolean => {
     return activeStepIndex === stepsNumber - 1;
   }
   return false;
+};
+
+export const getNextStep = (guideID: string, stepID: string): string | undefined => {
+  const guide = getGuideConfig(guideID);
+  const activeStepIndex = getStepIndex(guideID, stepID);
+  if (activeStepIndex > -1 && guide?.steps[activeStepIndex + 1]) {
+    return guide?.steps[activeStepIndex + 1].id;
+  }
+};
+
+const getStepConfig = (guideID: string, stepID: string): StepConfig | undefined => {
+  const guide = getGuideConfig(guideID);
+  return guide?.steps.find((step) => step.id === stepID);
+};
+
+export const isIntegrationInGuideStep = (
+  state: GuidedOnboardingState,
+  integration?: string
+): boolean => {
+  const stepConfig = getStepConfig(state.activeGuide, state.activeStep);
+  return stepConfig ? stepConfig.integration === integration : false;
 };

--- a/src/plugins/guided_onboarding/public/services/helpers.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.ts
@@ -9,7 +9,7 @@
 import type { GuideId } from '../../common/types';
 import { guidesConfig } from '../constants/guides_config';
 import type { GuideConfig, StepConfig } from '../types';
-import { GuideConfig, GuidedOnboardingState, StepConfig, UseCase } from '../types';
+import { GuideConfig, GuidedOnboardingState, StepConfig } from '../types';
 
 export const getGuideConfig = (guideID?: string): GuideConfig | undefined => {
   if (guideID && Object.keys(guidesConfig).includes(guideID)) {

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -6,15 +6,17 @@
  * Side Public License, v 1.
  */
 
+import { Observable } from 'rxjs';
 import { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import { GuideId, GuideStepIds, StepStatus } from '../common/types';
 import { ApiService } from './services/api';
+import { HttpSetup } from '@kbn/core/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GuidedOnboardingPluginSetup {}
 
 export interface GuidedOnboardingPluginStart {
-  guidedOnboardingApi?: ApiService;
+  guidedOnboardingApi?: GuidedOnboardingApi;
 }
 
 export interface AppPluginStartDependencies {
@@ -24,6 +26,25 @@ export interface AppPluginStartDependencies {
 export interface ClientConfigType {
   ui: boolean;
 }
+export interface GuidedOnboardingApi {
+  setup: (httpClient: HttpSetup) => void;
+  fetchGuideState$: () => Observable<GuidedOnboardingState>;
+  updateGuideState: (
+    newState: GuidedOnboardingState
+  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
+  isGuideStepActive$: (guideID: string, stepID: string) => Observable<boolean>;
+  completeGuideStep: (
+    guideID: string,
+    stepID: string
+  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
+  isGuidedOnboardingActiveForIntegration$: (integration?: string) => Observable<boolean>;
+  completeGuidedOnboardingForIntegration: (
+    integration?: string
+  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
+}
+
+export type UseCase = 'observability' | 'security' | 'search';
+export type StepStatus = 'incomplete' | 'complete' | 'in_progress';
 
 export interface StepConfig {
   id: GuideStepIds;

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -8,9 +8,8 @@
 
 import { Observable } from 'rxjs';
 import { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
-import { GuideId, GuideStepIds, StepStatus } from '../common/types';
-import { ApiService } from './services/api';
 import { HttpSetup } from '@kbn/core/public';
+import { GuideId, GuideStepIds, StepStatus } from '../common/types';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GuidedOnboardingPluginSetup {}

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -34,6 +34,7 @@ export interface StepConfig {
     path: string;
   };
   status?: StepStatus;
+  integration?: string;
 }
 export interface GuideConfig {
   title: string;

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -9,7 +9,7 @@
 import { Observable } from 'rxjs';
 import { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import { HttpSetup } from '@kbn/core/public';
-import { GuideId, GuideStepIds, StepStatus } from '../common/types';
+import { GuideId, GuideState, GuideStepIds, StepStatus } from '../common/types';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GuidedOnboardingPluginSetup {}
@@ -25,25 +25,34 @@ export interface AppPluginStartDependencies {
 export interface ClientConfigType {
   ui: boolean;
 }
+
 export interface GuidedOnboardingApi {
   setup: (httpClient: HttpSetup) => void;
-  fetchGuideState$: () => Observable<GuidedOnboardingState>;
+  fetchActiveGuideState$: () => Observable<GuideState | undefined>;
+  fetchAllGuidesState: () => Promise<{ state: GuideState[] } | undefined>;
   updateGuideState: (
-    newState: GuidedOnboardingState
-  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
-  isGuideStepActive$: (guideID: string, stepID: string) => Observable<boolean>;
+    newState: GuideState,
+    panelState: boolean
+  ) => Promise<{ state: GuideState } | undefined>;
+  activateGuide: (
+    guideId: GuideId,
+    guide?: GuideState
+  ) => Promise<{ state: GuideState } | undefined>;
+  completeGuide: (guideId: GuideId) => Promise<{ state: GuideState } | undefined>;
+  isGuideStepActive$: (guideId: GuideId, stepId: GuideStepIds) => Observable<boolean>;
+  startGuideStep: (
+    guideId: GuideId,
+    stepId: GuideStepIds
+  ) => Promise<{ state: GuideState } | undefined>;
   completeGuideStep: (
-    guideID: string,
-    stepID: string
-  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
+    guideId: GuideId,
+    stepId: GuideStepIds
+  ) => Promise<{ state: GuideState } | undefined>;
   isGuidedOnboardingActiveForIntegration$: (integration?: string) => Observable<boolean>;
   completeGuidedOnboardingForIntegration: (
     integration?: string
-  ) => Promise<{ state: GuidedOnboardingState } | undefined>;
+  ) => Promise<{ state: GuideState } | undefined>;
 }
-
-export type UseCase = 'observability' | 'security' | 'search';
-export type StepStatus = 'incomplete' | 'complete' | 'in_progress';
 
 export interface StepConfig {
   id: GuideStepIds;

--- a/x-pack/plugins/fleet/.storybook/context/index.tsx
+++ b/x-pack/plugins/fleet/.storybook/context/index.tsx
@@ -15,6 +15,7 @@ import { I18nProvider } from '@kbn/i18n-react';
 
 import { CoreScopedHistory } from '@kbn/core/public';
 import { getStorybookContextProvider } from '@kbn/custom-integrations-plugin/storybook';
+import { guidedOnboardingMock } from '@kbn/guided-onboarding-plugin/public/mocks';
 
 import { IntegrationsAppContext } from '../../public/applications/integrations/app';
 import type { FleetConfigType, FleetStartServices } from '../../public/plugin';
@@ -110,6 +111,7 @@ export const StorybookContext: React.FC<{ storyContext?: Parameters<DecoratorFn>
           writeIntegrationPolicies: true,
         },
       },
+      guidedOnboarding: guidedOnboardingMock.createStart(),
     }),
     [isCloudEnabled]
   );

--- a/x-pack/plugins/fleet/kibana.json
+++ b/x-pack/plugins/fleet/kibana.json
@@ -8,7 +8,7 @@
   "server": true,
   "ui": true,
   "configPath": ["xpack", "fleet"],
-  "requiredPlugins": ["licensing", "data", "encryptedSavedObjects", "navigation", "customIntegrations", "share", "spaces", "security", "unifiedSearch", "savedObjectsTagging", "taskManager"],
+  "requiredPlugins": ["licensing", "data", "encryptedSavedObjects", "navigation", "customIntegrations", "share", "spaces", "security", "unifiedSearch", "savedObjectsTagging", "taskManager", "guidedOnboarding"],
   "optionalPlugins": ["features", "cloud", "usageCollection", "home", "globalSearch", "telemetry", "discover", "ingestPipelines"],
   "extraPublicDirs": ["common"],
   "requiredBundles": ["kibanaReact", "cloudChat", "esUiShared", "infra", "kibanaUtils", "usageCollection", "unifiedSearch"]

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/confirm_incoming_data_with_preview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/confirm_incoming_data_with_preview.tsx
@@ -27,9 +27,7 @@ import type { SearchHit } from '@kbn/es-types';
 
 import styled from 'styled-components';
 
-import { useIsGuidedOnboardingActive } from '../../../../../../integrations/sections/epm/screens/detail/hooks';
-
-import { useStartServices } from '../../../../../../../hooks';
+import { useStartServices, useIsGuidedOnboardingActive } from '../../../../../../../hooks';
 
 import type { PackageInfo } from '../../../../../../../../common';
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/confirm_incoming_data_with_preview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/confirm_incoming_data_with_preview.tsx
@@ -27,6 +27,10 @@ import type { SearchHit } from '@kbn/es-types';
 
 import styled from 'styled-components';
 
+import { useIsGuidedOnboardingActive } from '../../../../../../integrations/sections/epm/screens/detail/hooks';
+
+import { useStartServices } from '../../../../../../../hooks';
+
 import type { PackageInfo } from '../../../../../../../../common';
 
 import {
@@ -136,8 +140,15 @@ export const ConfirmIncomingDataWithPreview: React.FunctionComponent<Props> = ({
   );
   const { enrolledAgents, numAgentsWithData } = useGetAgentIncomingData(incomingData, packageInfo);
 
+  const isGuidedOnboardingActive = useIsGuidedOnboardingActive(packageInfo?.name);
+  const { guidedOnboarding } = useStartServices();
   if (!isLoading && enrolledAgents > 0 && numAgentsWithData > 0) {
     setAgentDataConfirmed(true);
+    if (isGuidedOnboardingActive) {
+      guidedOnboarding.guidedOnboardingApi?.completeGuidedOnboardingForIntegration(
+        packageInfo?.name
+      );
+    }
   }
   if (!agentDataConfirmed) {
     return (

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
@@ -18,7 +18,7 @@ const getTourConfig = (packageKey: string, tourType: TourType) => {
         defaultMessage: 'Add Elastic Defend',
       }),
       description: i18n.translate('xpack.fleet.guidedOnboardingTour.endpointButton.description', {
-        defaultMessage: 'In the next steps we’ll help you get setup with some sensible defaults.',
+        defaultMessage: 'In just a few steps, configure your data with our recommended defaults. You can change this later.',
       }),
     };
   }

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
@@ -18,7 +18,8 @@ const getTourConfig = (packageKey: string, tourType: TourType) => {
         defaultMessage: 'Add Elastic Defend',
       }),
       description: i18n.translate('xpack.fleet.guidedOnboardingTour.endpointButton.description', {
-        defaultMessage: 'In just a few steps, configure your data with our recommended defaults. You can change this later.',
+        defaultMessage:
+          'In just a few steps, configure your data with our recommended defaults. You can change this later.',
       }),
     };
   }

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent, ReactElement } from 'react';
 import { EuiButton, EuiText, EuiTourStep } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -28,6 +28,7 @@ export const WithGuidedOnboardingTour: FunctionComponent<{
   packageKey: string;
   isGuidedOnboardingActive: boolean;
   tourType: TourType;
+  children: ReactElement;
 }> = ({ packageKey, isGuidedOnboardingActive, tourType, children }) => {
   const [isGuidedOnboardingTourOpen, setIsGuidedOnboardingTourOpen] =
     useState<boolean>(isGuidedOnboardingActive);

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/with_guided_onboarding_tour.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import type { FunctionComponent } from 'react';
+import { EuiButton, EuiText, EuiTourStep } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+type TourType = 'addIntegrationButton' | 'integrationsList';
+const getTourConfig = (packageKey: string, tourType: TourType) => {
+  if (packageKey.startsWith('endpoint') && tourType === 'addIntegrationButton') {
+    return {
+      title: i18n.translate('xpack.fleet.guidedOnboardingTour.endpointButton.title', {
+        defaultMessage: 'Add Elastic Defend',
+      }),
+      description: i18n.translate('xpack.fleet.guidedOnboardingTour.endpointButton.description', {
+        defaultMessage: 'In the next steps we’ll help you get setup with some sensible defaults.',
+      }),
+    };
+  }
+  return null;
+};
+export const WithGuidedOnboardingTour: FunctionComponent<{
+  packageKey: string;
+  isGuidedOnboardingActive: boolean;
+  tourType: TourType;
+}> = ({ packageKey, isGuidedOnboardingActive, tourType, children }) => {
+  const [isGuidedOnboardingTourOpen, setIsGuidedOnboardingTourOpen] =
+    useState<boolean>(isGuidedOnboardingActive);
+  useEffect(() => {
+    setIsGuidedOnboardingTourOpen(isGuidedOnboardingActive);
+  }, [isGuidedOnboardingActive]);
+  const config = getTourConfig(packageKey, tourType);
+
+  return config ? (
+    <EuiTourStep
+      content={<EuiText>{config.description}</EuiText>}
+      isStepOpen={isGuidedOnboardingTourOpen}
+      maxWidth={350}
+      onFinish={() => setIsGuidedOnboardingTourOpen(false)}
+      step={1}
+      stepsTotal={1}
+      title={config.title}
+      anchorPosition="rightUp"
+      footerAction={
+        <EuiButton onClick={() => setIsGuidedOnboardingTourOpen(false)} size="s" color="success">
+          {i18n.translate('xpack.fleet.guidedOnboardingTour.nextButtonLabel', {
+            defaultMessage: 'Next',
+          })}
+        </EuiButton>
+      }
+    >
+      {children}
+    </EuiTourStep>
+  ) : (
+    <>{children}</>
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/index.ts
@@ -6,4 +6,3 @@
  */
 
 export { useIsFirstTimeAgentUser } from './use_is_first_time_agent_user';
-export { useIsGuidedOnboardingActive } from './use_is_guided_onboarding_active';

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { useIsFirstTimeAgentUser } from './use_is_first_time_agent_user';
+export { useIsGuidedOnboardingActive } from './use_is_guided_onboarding_active';

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
@@ -10,37 +10,15 @@ import useObservable from 'react-use/lib/useObservable';
 
 import { useStartServices } from '../../../../../hooks';
 
-const isElasticDefendIntegration = (packageKey: string): boolean => {
-  // TODO change to a regex
-  return packageKey.startsWith('endpoint');
-};
-
-const isKubernetesIntegration = (packageKey: string): boolean => {
-  // TODO change to a regex
-  return packageKey.startsWith('kubernetes');
-};
-
-// currently, we're only checking for endpoint and kubernetes integrations
-// for security and observability guides
-const getGuideStepByIntegration = (packageKey: string) => {
-  if (isElasticDefendIntegration(packageKey)) {
-    return { guideID: 'security', stepID: 'add_data' };
-  }
-  if (isKubernetesIntegration(packageKey)) {
-    return { guideID: 'observability', stepID: 'add_data' };
-  }
-  return { guideID: '', stepID: '' };
-};
-export const useIsGuidedOnboardingActive = (packageKey: string): boolean => {
+export const useIsGuidedOnboardingActive = (packageName?: string): boolean => {
   const [result, setResult] = useState<boolean>(false);
   const { guidedOnboarding } = useStartServices();
-  const { guideID, stepID } = getGuideStepByIntegration(packageKey);
-  const isGuidedOnboardingStepActive = useObservable(
-    guidedOnboarding.guidedOnboardingApi!.isGuideStepActive$(guideID, stepID)
+  const isGuidedOnboardingActiveForIntegration = useObservable(
+    guidedOnboarding.guidedOnboardingApi!.isGuidedOnboardingActiveForIntegration$(packageName)
   );
   useEffect(() => {
-    setResult(!!isGuidedOnboardingStepActive);
-  }, [isGuidedOnboardingStepActive]);
+    setResult(!!isGuidedOnboardingActiveForIntegration);
+  }, [isGuidedOnboardingActiveForIntegration]);
 
   return result;
 };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+
+import { useStartServices } from '../../../../../hooks';
+
+const isElasticDefendIntegration = (packageKey: string): boolean => {
+  // TODO change to a regex
+  return packageKey.startsWith('endpoint');
+};
+
+const isKubernetesIntegration = (packageKey: string): boolean => {
+  // TODO change to a regex
+  return packageKey.startsWith('kubernetes');
+};
+
+// currently, we're only checking for endpoint and kubernetes integrations
+// for security and observability guides
+const getGuideStepByIntegration = (packageKey: string) => {
+  if (isElasticDefendIntegration(packageKey)) {
+    return { guideID: 'security', stepID: 'add_data' };
+  }
+  if (isKubernetesIntegration(packageKey)) {
+    return { guideID: 'observability', stepID: 'add_data' };
+  }
+  return { guideID: '', stepID: '' };
+};
+export const useIsGuidedOnboardingActive = (packageKey: string): boolean => {
+  const [result, setResult] = useState<boolean>(false);
+  const { guidedOnboarding } = useStartServices();
+  const { guideID, stepID } = getGuideStepByIntegration(packageKey);
+  const isGuidedOnboardingStepActive = useObservable(
+    guidedOnboarding.guidedOnboardingApi!.isGuideStepActive$(guideID, stepID)
+  );
+  useEffect(() => {
+    setResult(!!isGuidedOnboardingStepActive);
+  }, [isGuidedOnboardingStepActive]);
+
+  return result;
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_guided_onboarding_active.ts
@@ -8,13 +8,18 @@
 import { useEffect, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 
+import { of } from 'rxjs';
+
 import { useStartServices } from '../../../../../hooks';
 
 export const useIsGuidedOnboardingActive = (packageName?: string): boolean => {
   const [result, setResult] = useState<boolean>(false);
   const { guidedOnboarding } = useStartServices();
   const isGuidedOnboardingActiveForIntegration = useObservable(
-    guidedOnboarding.guidedOnboardingApi!.isGuidedOnboardingActiveForIntegration$(packageName)
+    // if guided onboarding is not available, return false
+    guidedOnboarding.guidedOnboardingApi
+      ? guidedOnboarding.guidedOnboardingApi.isGuidedOnboardingActiveForIntegration$(packageName)
+      : of(false)
   );
   useEffect(() => {
     setResult(!!isGuidedOnboardingActiveForIntegration);

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -47,7 +47,9 @@ import { Error, Loading, HeaderReleaseBadge } from '../../../../components';
 import type { WithHeaderLayoutProps } from '../../../../layouts';
 import { WithHeaderLayout } from '../../../../layouts';
 
-import { useIsFirstTimeAgentUser } from './hooks';
+import { WithGuidedOnboardingTour } from './components/with_guided_onboarding_tour';
+
+import { useIsFirstTimeAgentUser, useIsGuidedOnboardingActive } from './hooks';
 import { getInstallPkgRouteOptions } from './utils';
 import {
   IntegrationAgentPolicyCount,
@@ -154,6 +156,7 @@ export function Detail() {
 
   const { isFirstTimeAgentUser = false, isLoading: firstTimeUserLoading } =
     useIsFirstTimeAgentUser();
+  const isGuidedOnboardingActive = useIsGuidedOnboardingActive(pkgkey);
 
   // Refresh package info when status change
   const [oldPackageInstallStatus, setOldPackageStatus] = useState(packageInstallStatus);
@@ -292,6 +295,7 @@ export function Detail() {
         isCloud,
         isExperimentalAddIntegrationPageEnabled,
         isFirstTimeAgentUser,
+        isGuidedOnboardingActive,
         pkgkey,
       });
 
@@ -305,6 +309,7 @@ export function Detail() {
       isCloud,
       isExperimentalAddIntegrationPageEnabled,
       isFirstTimeAgentUser,
+      isGuidedOnboardingActive,
       pathname,
       pkgkey,
       search,
@@ -349,19 +354,25 @@ export function Detail() {
               { isDivider: true },
               {
                 content: (
-                  <AddIntegrationButton
-                    userCanInstallPackages={userCanInstallPackages}
-                    href={getHref('add_integration_to_policy', {
-                      pkgkey,
-                      ...(integration ? { integration } : {}),
-                      ...(agentPolicyIdFromContext
-                        ? { agentPolicyId: agentPolicyIdFromContext }
-                        : {}),
-                    })}
-                    missingSecurityConfiguration={missingSecurityConfiguration}
-                    packageName={integrationInfo?.title || packageInfo.title}
-                    onClick={handleAddIntegrationPolicyClick}
-                  />
+                  <WithGuidedOnboardingTour
+                    packageKey={pkgkey}
+                    tourType={'addIntegrationButton'}
+                    isGuidedOnboardingActive={isGuidedOnboardingActive}
+                  >
+                    <AddIntegrationButton
+                      userCanInstallPackages={userCanInstallPackages}
+                      href={getHref('add_integration_to_policy', {
+                        pkgkey,
+                        ...(integration ? { integration } : {}),
+                        ...(agentPolicyIdFromContext
+                          ? { agentPolicyId: agentPolicyIdFromContext }
+                          : {}),
+                      })}
+                      missingSecurityConfiguration={missingSecurityConfiguration}
+                      packageName={integrationInfo?.title || packageInfo.title}
+                      onClick={handleAddIntegrationPolicyClick}
+                    />
+                  </WithGuidedOnboardingTour>
                 ),
               },
             ].map((item, index) => (
@@ -385,6 +396,7 @@ export function Detail() {
       packageInfo,
       updateAvailable,
       isInstalled,
+      isGuidedOnboardingActive,
       userCanInstallPackages,
       getHref,
       pkgkey,

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -39,7 +39,7 @@ import {
 } from '../../../../hooks';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import { ExperimentalFeaturesService } from '../../../../services';
-import { useGetPackageInfoByKey, useLink, useAgentPolicyContext } from '../../../../hooks';
+import { useGetPackageInfoByKey, useLink, useAgentPolicyContext, useIsGuidedOnboardingActive } from '../../../../hooks';
 import { pkgKeyFromPackageInfo } from '../../../../services';
 import type { DetailViewPanelName, PackageInfo } from '../../../../types';
 import { InstallStatus } from '../../../../types';
@@ -49,7 +49,7 @@ import { WithHeaderLayout } from '../../../../layouts';
 
 import { WithGuidedOnboardingTour } from './components/with_guided_onboarding_tour';
 
-import { useIsFirstTimeAgentUser, useIsGuidedOnboardingActive } from './hooks';
+import { useIsFirstTimeAgentUser } from './hooks';
 import { getInstallPkgRouteOptions } from './utils';
 import {
   IntegrationAgentPolicyCount,

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -39,7 +39,12 @@ import {
 } from '../../../../hooks';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import { ExperimentalFeaturesService } from '../../../../services';
-import { useGetPackageInfoByKey, useLink, useAgentPolicyContext, useIsGuidedOnboardingActive } from '../../../../hooks';
+import {
+  useGetPackageInfoByKey,
+  useLink,
+  useAgentPolicyContext,
+  useIsGuidedOnboardingActive,
+} from '../../../../hooks';
 import { pkgKeyFromPackageInfo } from '../../../../services';
 import type { DetailViewPanelName, PackageInfo } from '../../../../types';
 import { InstallStatus } from '../../../../types';

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -156,7 +156,7 @@ export function Detail() {
 
   const { isFirstTimeAgentUser = false, isLoading: firstTimeUserLoading } =
     useIsFirstTimeAgentUser();
-  const isGuidedOnboardingActive = useIsGuidedOnboardingActive(pkgkey);
+  const isGuidedOnboardingActive = useIsGuidedOnboardingActive(pkgName);
 
   // Refresh package info when status change
   const [oldPackageInstallStatus, setOldPackageStatus] = useState(packageInstallStatus);

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.test.ts
@@ -22,6 +22,7 @@ describe('getInstallPkgRouteOptions', () => {
       integration: 'myintegration',
       pkgkey: 'myintegration-1.0.0',
       isFirstTimeAgentUser: false,
+      isGuidedOnboardingActive: false,
       isCloud: false,
       isExperimentalAddIntegrationPageEnabled: false,
     };
@@ -51,6 +52,7 @@ describe('getInstallPkgRouteOptions', () => {
       pkgkey: 'myintegration-1.0.0',
       agentPolicyId: '12345',
       isFirstTimeAgentUser: false,
+      isGuidedOnboardingActive: false,
       isCloud: false,
       isExperimentalAddIntegrationPageEnabled: false,
     };
@@ -78,6 +80,7 @@ describe('getInstallPkgRouteOptions', () => {
       integration: 'myintegration',
       pkgkey: 'myintegration-1.0.0',
       isFirstTimeAgentUser: true,
+      isGuidedOnboardingActive: false,
       isCloud: true,
       isExperimentalAddIntegrationPageEnabled: true,
     };
@@ -105,6 +108,7 @@ describe('getInstallPkgRouteOptions', () => {
       integration: 'myintegration',
       pkgkey: 'apm-1.0.0',
       isFirstTimeAgentUser: true,
+      isGuidedOnboardingActive: false,
       isCloud: true,
       isExperimentalAddIntegrationPageEnabled: true,
     };
@@ -137,6 +141,7 @@ describe('getInstallPkgRouteOptions', () => {
       integration: 'myintegration',
       pkgkey: 'endpoint-1.0.0',
       isFirstTimeAgentUser: true,
+      isGuidedOnboardingActive: false,
       isCloud: true,
       isExperimentalAddIntegrationPageEnabled: true,
     };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -29,6 +29,7 @@ interface GetInstallPkgRouteOptionsParams {
   isCloud: boolean;
   isExperimentalAddIntegrationPageEnabled: boolean;
   isFirstTimeAgentUser: boolean;
+  isGuidedOnboardingActive: boolean;
 }
 
 const isPackageExemptFromStepsLayout = (pkgkey: string) =>
@@ -45,13 +46,14 @@ export const getInstallPkgRouteOptions = ({
   isFirstTimeAgentUser,
   isCloud,
   isExperimentalAddIntegrationPageEnabled,
+  isGuidedOnboardingActive,
 }: GetInstallPkgRouteOptionsParams): [string, { path: string; state: unknown }] => {
   const integrationOpts: { integration?: string } = integration ? { integration } : {};
   const packageExemptFromStepsLayout = isPackageExemptFromStepsLayout(pkgkey);
   const useMultiPageLayout =
     isExperimentalAddIntegrationPageEnabled &&
     isCloud &&
-    isFirstTimeAgentUser &&
+    (isFirstTimeAgentUser || isGuidedOnboardingActive) &&
     !packageExemptFromStepsLayout;
   const path = pagePathGetters.add_integration_to_policy({
     pkgkey,

--- a/x-pack/plugins/fleet/public/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/hooks/index.ts
@@ -28,3 +28,4 @@ export * from './use_agent_policy_refresh';
 export * from './use_package_installations';
 export * from './use_agent_enrollment_flyout_data';
 export * from './use_flyout_context';
+export { useIsGuidedOnboardingActive } from './use_is_guided_onboarding_active';

--- a/x-pack/plugins/fleet/public/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/hooks/index.ts
@@ -28,4 +28,4 @@ export * from './use_agent_policy_refresh';
 export * from './use_package_installations';
 export * from './use_agent_enrollment_flyout_data';
 export * from './use_flyout_context';
-export { useIsGuidedOnboardingActive } from './use_is_guided_onboarding_active';
+export * from './use_is_guided_onboarding_active';

--- a/x-pack/plugins/fleet/public/hooks/use_is_guided_onboarding_active.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_is_guided_onboarding_active.ts
@@ -10,7 +10,7 @@ import useObservable from 'react-use/lib/useObservable';
 
 import { of } from 'rxjs';
 
-import { useStartServices } from '../../../../../hooks';
+import { useStartServices } from '.';
 
 export const useIsGuidedOnboardingActive = (packageName?: string): boolean => {
   const [result, setResult] = useState<boolean>(false);

--- a/x-pack/plugins/fleet/public/mock/fleet_start_services.tsx
+++ b/x-pack/plugins/fleet/public/mock/fleet_start_services.tsx
@@ -13,6 +13,8 @@ import { coreMock } from '@kbn/core/public/mocks';
 import type { IStorage } from '@kbn/kibana-utils-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 
+import { guidedOnboardingMock } from '@kbn/guided-onboarding-plugin/public/mocks';
+
 import { setHttpClient } from '../hooks/use_request';
 
 import type { FleetAuthz } from '../../common';
@@ -90,6 +92,7 @@ export const createStartServices = (basePath: string = '/mock'): MockedFleetStar
     },
     storage: new Storage(createMockStore()) as jest.Mocked<Storage>,
     authz: fleetAuthzMock,
+    guidedOnboarding: guidedOnboardingMock.createStart(),
   };
 
   configureStartServices(startServices);

--- a/x-pack/plugins/fleet/public/plugin.ts
+++ b/x-pack/plugins/fleet/public/plugin.ts
@@ -44,6 +44,7 @@ import type { CloudSetup } from '@kbn/cloud-plugin/public';
 import type { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/public';
 
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public';
 
 import { PLUGIN_ID, INTEGRATIONS_PLUGIN_ID, setupRouteService, appRoutesService } from '../common';
 import { calculateAuthz, calculatePackagePrivilegesFromCapabilities } from '../common/authz';
@@ -101,6 +102,7 @@ export interface FleetStartDeps {
   share: SharePluginStart;
   cloud?: CloudStart;
   usageCollection?: UsageCollectionStart;
+  guidedOnboarding: GuidedOnboardingPluginStart;
 }
 
 export interface FleetStartServices extends CoreStart, Exclude<FleetStartDeps, 'cloud'> {
@@ -110,6 +112,7 @@ export interface FleetStartServices extends CoreStart, Exclude<FleetStartDeps, '
   discover?: DiscoverStart;
   spaces?: SpacesPluginStart;
   authz: FleetAuthz;
+  guidedOnboarding: GuidedOnboardingPluginStart;
 }
 
 export class FleetPlugin implements Plugin<FleetSetup, FleetStart, FleetSetupDeps, FleetStartDeps> {

--- a/x-pack/plugins/fleet/tsconfig.json
+++ b/x-pack/plugins/fleet/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../licensing/tsconfig.json" },
     { "path": "../../../src/plugins/data/tsconfig.json" },
     { "path": "../encrypted_saved_objects/tsconfig.json" },
+    {"path":  "../../../src/plugins/guided_onboarding/tsconfig.json"},
 
     // optionalPlugins from ./kibana.json
     { "path": "../security/tsconfig.json" },


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/140610, https://github.com/elastic/kibana/issues/138646
Partially addresses https://github.com/elastic/kibana/issues/139712

This PR is a part of the Guided onboarding work for 8.6, specifically these changes are important for the Security guide, the "Add data" step. When this step is active, the Integrations detail page for Elastic Defend will display a EUI tour pointing out the "Add integration" button. Also this button will redirect the user to the new Agent flow not only for the first agent install, but for repeat install as well. Other conditions for the new Agent flow are unchanged and it seems safe to redirect the user to the new flow even if they already have an Agent installed. The last change is on the data confirmation page. If the data step is active, the confirmation page will send a signal to the Guided onboarding plugin to mark the step as completed when the incoming data is detected. 

The e2e UI tests will be addressed in a follow up PR (see https://github.com/elastic/kibana/issues/138568).

### How to test
<details>
1. Add this code to the `KIBANA/config/kibana.dev.yml` file

```
# needed for the Fleet server
server.host: 0.0.0.0
xpack.fleet.agents.enabled: true
xpack.fleet.packages:
  - name: fleet_server
    version: latest
xpack.fleet.agentPolicies:
  - name: Fleet Server policy
    id: fleet-server-policy
    description: Fleet server policy
    namespace: default
    package_policies:
      - name: Fleet Server
        package:
          name: fleet_server

# needed to imitate Cloud deployments
xpack.cloud.id: 'testID'

# needed to enable guided onboarding plugin
guidedOnboarding.ui: true
```

2. Start ES with this command 

```
yarn es snapshot --license trial -E xpack.security.authc.api_key.enabled=true -E xpack.security.authc.token.enabled=true -E path.data=/tmp/es-data -E http.host=0.0.0.0
``` 

3. Start Kibana with this command 

```
yarn start --run-examples
```

4. Start your docker app
5. Start the Fleet server with this command (I was testing with the version 8.4.2)

```
docker run -e KIBANA_HOST=http://192.168.65.2:5601 -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme -e ELASTICSEARCH_HOST=http://192.168.65.2:9200 -e KIBANA_FLEET_SETUP=1 -e FLEET_SERVER_ENABLE=1 -e FLEET_SERVER_POLICY_ID=fleet-server-policy -p 8220:8220 docker.elastic.co/beats/elastic-agent:8.4.2
```

6. In Kibana, navigate to `http://localhost:5601/app/guidedOnboardingExample` and start the **Security** guide. Make sure the green guided onboarding button is displayed in the header and the first step is active. 

7. In the guided onboarding checklist panel, click the "Start" button in the first step. Or alternatively navigate to `http://localhost:5601/app/integrations/browse/security`. Click the Elastic Defend card to open the details page. 
8. On the Elastic Defend details page, make sure the EUI tour is displayed. 
9. When clicking on the "Add integration" button, make sure the new Agent flow is used.
10. Complete the flow and make sure, when the incoming data is detected, the guided onboarding step is marked completed. 
11. Delete the integration and restart the **Security** guide, but don't delete the installed Agent. Make sure the new flow is still used when installing the integration.

</details>

### Screenshots

#### EUI tour on the details page

<img width="1365" alt="Screenshot 2022-10-03 at 10 05 14" src="https://user-images.githubusercontent.com/6585477/193534857-05a93001-dd6a-4a54-9ba0-07cec9d54de8.png">

#### The data step is marked completed

<img width="1365" alt="Screenshot 2022-10-03 at 10 04 41" src="https://user-images.githubusercontent.com/6585477/193534828-ce4b1f3b-53d6-4f47-bf9f-9a0d301b4e85.png">



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


