### PR TITLE
[Lens] Explore field in Discover

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.test.tsx
@@ -9,9 +9,11 @@ import React, { ReactElement } from 'react';
 import { ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { EuiLoadingSpinner, EuiPopover } from '@elastic/eui';
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import { InnerFieldItem, FieldItemProps } from './field_item';
 import { coreMock } from '@kbn/core/public/mocks';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { findTestSubject } from '@elastic/eui/lib/test';
 import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { IndexPattern } from '../types';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
@@ -47,6 +49,11 @@ const mockedServices = {
   fieldFormats: fieldFormatsServiceMock.createStartContract(),
   charts: chartPluginMock.createSetupContract(),
   uiSettings: coreMock.createStart().uiSettings,
+  discover: {
+    locator: {
+      getRedirectUrl: jest.fn(() => 'discover_url'),
+    },
+  } as unknown as DiscoverStart,
 };
 
 const InnerFieldItemWrapper: React.FC<FieldItemProps> = (props) => {
@@ -413,5 +420,19 @@ describe('IndexPattern Field Item', () => {
     expect(wrapper.find(EuiPopover).prop('isOpen')).toEqual(true);
     expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(0);
     expect(wrapper.find(FieldStats).text()).toBe('Analysis is not available for this field.');
+  });
+
+  it('should display Explore in discover button', async () => {
+    const wrapper = await mountWithIntl(<InnerFieldItemWrapper {...defaultProps} />);
+
+    await clickField(wrapper, 'bytes');
+
+    await wrapper.update();
+
+    const exploreInDiscoverBtn = findTestSubject(
+      wrapper,
+      'lnsFieldListPanel-exploreInDiscover-bytes'
+    );
+    expect(exploreInDiscoverBtn.length).toBe(1);
   });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.test.tsx
@@ -435,4 +435,29 @@ describe('IndexPattern Field Item', () => {
     );
     expect(exploreInDiscoverBtn.length).toBe(1);
   });
+
+  it('should not display Explore in discover button for a geo_point field', async () => {
+    const wrapper = await mountWithIntl(
+      <InnerFieldItemWrapper
+        {...defaultProps}
+        field={{
+          name: 'geo_point',
+          displayName: 'geo_point',
+          type: 'geo_point',
+          aggregatable: true,
+          searchable: true,
+        }}
+      />
+    );
+
+    await clickField(wrapper, 'geo_point');
+
+    await wrapper.update();
+
+    const exploreInDiscoverBtn = findTestSubject(
+      wrapper,
+      'lnsFieldListPanel-exploreInDiscover-geo_point'
+    );
+    expect(exploreInDiscoverBtn.length).toBe(0);
+  });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -20,7 +20,6 @@ import {
   EuiTitle,
   EuiToolTip,
   EuiButton,
-  EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -442,9 +441,8 @@ function FieldItemPopoverContents(props: FieldItemProps) {
           return params.element;
         }}
       />
-      {exploreInDiscover && (
-        <>
-          <EuiSpacer size="s" />
+      {exploreInDiscover && field.type !== 'geo_point' && field.type !== 'geo_shape' && (
+        <EuiPopoverFooter>
           <EuiButton
             fullWidth
             size="s"
@@ -455,7 +453,7 @@ function FieldItemPopoverContents(props: FieldItemProps) {
               defaultMessage: 'Explore values in Discover',
             })}
           </EuiButton>
-        </>
+        </EuiPopoverFooter>
       )}
     </>
   );

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -447,6 +447,7 @@ function FieldItemPopoverContents(props: FieldItemProps) {
             fullWidth
             size="s"
             href={exploreInDiscover}
+            target="_blank"
             data-test-subj={`lnsFieldListPanel-exploreInDiscover-${field.name}`}
           >
             {i18n.translate('xpack.lens.indexPattern.fieldExploreInDiscover', {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -19,6 +19,8 @@ import {
   EuiText,
   EuiTitle,
   EuiToolTip,
+  EuiButton,
+  EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -30,7 +32,7 @@ import { DataViewField } from '@kbn/data-views-plugin/common';
 import { ChartsPluginSetup } from '@kbn/charts-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { AddFieldFilterHandler, FieldStats } from '@kbn/unified-field-list-plugin/public';
-import { generateFilters } from '@kbn/data-plugin/public';
+import { generateFilters, getEsQueryConfig } from '@kbn/data-plugin/public';
 import { DragDrop, DragDropIdentifier } from '../drag_drop';
 import { DatasourceDataPanelProps, DataType } from '../types';
 import { DOCUMENT_FIELD_NAME } from '../../common';
@@ -41,6 +43,7 @@ import { VisualizeGeoFieldButton } from './visualize_geo_field_button';
 import type { LensAppServices } from '../app_plugin/types';
 import { debouncedComponent } from '../debounced_component';
 import { getFieldType } from './pure_utils';
+import { combineQueryAndFilters } from '../app_plugin/show_underlying_data';
 
 export interface FieldItemProps {
   core: DatasourceDataPanelProps['core'];
@@ -347,6 +350,41 @@ function FieldItemPopoverContents(props: FieldItemProps) {
     />
   );
 
+  const exploreInDiscover = useMemo(() => {
+    const meta = {
+      id: indexPattern.id,
+      columns: [field.name],
+      filters: {
+        enabled: {
+          lucene: [],
+          kuery: [],
+        },
+        disabled: {
+          lucene: [],
+          kuery: [],
+        },
+      },
+    };
+    const { filters: newFilters, query: newQuery } = combineQueryAndFilters(
+      query,
+      filters,
+      meta,
+      [indexPattern],
+      getEsQueryConfig(services.uiSettings)
+    );
+
+    if (!services.discover) {
+      return;
+    }
+    return services.discover.locator!.getRedirectUrl({
+      dataViewSpec: indexPattern?.spec,
+      timeRange: services.data.query.timefilter.timefilter.getTime(),
+      filters: newFilters,
+      query: newQuery,
+      columns: meta.columns,
+    });
+  }, [field.name, filters, indexPattern, query, services]);
+
   if (hideDetails) {
     return panelHeader;
   }
@@ -404,6 +442,21 @@ function FieldItemPopoverContents(props: FieldItemProps) {
           return params.element;
         }}
       />
+      {exploreInDiscover && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiButton
+            fullWidth
+            size="s"
+            href={exploreInDiscover}
+            data-test-subj={`lnsFieldListPanel-exploreInDiscover-${field.name}`}
+          >
+            {i18n.translate('xpack.lens.indexPattern.fieldExploreInDiscover', {
+              defaultMessage: 'Explore values in Discover',
+            })}
+          </EuiButton>
+        </>
+      )}
     </>
   );
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
@@ -8,6 +8,7 @@
 import type { CoreSetup } from '@kbn/core/public';
 import { createStartServicesGetter, Storage } from '@kbn/kibana-utils-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { ExpressionsSetup } from '@kbn/expressions-plugin/public';
 import type { ChartsPluginSetup } from '@kbn/charts-plugin/public';
@@ -30,6 +31,7 @@ export interface IndexPatternDatasourceSetupPlugins {
 export interface IndexPatternDatasourceStartPlugins {
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
+  discover?: DiscoverStart;
   fieldFormats: FieldFormatsStart;
   dataViewFieldEditor: IndexPatternFieldEditorStart;
   dataViews: DataViewsPublicPluginStart;
@@ -62,7 +64,7 @@ export class IndexPatternDatasource {
 
       const [
         coreStart,
-        { dataViewFieldEditor, uiActions, data, fieldFormats, dataViews, unifiedSearch },
+        { dataViewFieldEditor, uiActions, data, fieldFormats, dataViews, unifiedSearch, discover },
       ] = await core.getStartServices();
 
       return getIndexPatternDatasource({
@@ -71,6 +73,7 @@ export class IndexPatternDatasource {
         storage: new Storage(localStorage),
         data,
         unifiedSearch,
+        discover,
         dataViews,
         charts,
         dataViewFieldEditor,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -11,6 +11,7 @@ import { I18nProvider } from '@kbn/i18n-react';
 import type { CoreStart, SavedObjectReference } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { TimeRange } from '@kbn/es-query';
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { flatten, isEqual } from 'lodash';
@@ -130,6 +131,7 @@ export function getIndexPatternDatasource({
   storage,
   data,
   unifiedSearch,
+  discover,
   dataViews,
   fieldFormats,
   charts,
@@ -140,6 +142,7 @@ export function getIndexPatternDatasource({
   storage: IStorageWrapper;
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
+  discover?: DiscoverStart;
   dataViews: DataViewsPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   charts: ChartsPluginSetup;
@@ -282,6 +285,7 @@ export function getIndexPatternDatasource({
                 fieldFormats,
                 charts,
                 unifiedSearch,
+                discover,
               }}
             >
               <IndexPatternDataPanel


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/141443

This PR displays an "Explore in Discover" button on the field popover that navigates the users back to Discover with this column selected.

<img width="554" alt="image" src="https://user-images.githubusercontent.com/17003240/193004118-e29868aa-e60b-46e0-8e15-de350ce31992.png">

Note: I am not displaying the button for geo fields. These fields navigate to Maps for both Lens and Discover apps.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)