### PR TITLE
[8.5] [APM] Require `track_total_hits` param in ES request (#140938)

### DIFF
--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
@@ -74,6 +74,7 @@ export const getDestinationMap = ({
         events: [ProcessorEvent.span],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {
@@ -144,6 +145,7 @@ export const getDestinationMap = ({
           events: [ProcessorEvent.transaction],
         },
         body: {
+          track_total_hits: false,
           query: {
             bool: {
               filter: [

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
@@ -61,7 +61,7 @@ describe('APMEventClient', () => {
           apm: {
             events: [],
           },
-          body: { size: 0 },
+          body: { size: 0, track_total_hits: false },
         });
 
         return res.ok({ body: 'ok' });

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
@@ -43,6 +43,7 @@ export type APMEventESSearchRequest = Omit<ESSearchRequest, 'index'> & {
   };
   body: {
     size: number;
+    track_total_hits: boolean | number;
   };
 };
 

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/unpack_processor_events.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/unpack_processor_events.test.ts
@@ -15,6 +15,7 @@ describe('unpackProcessorEvents', () => {
     const request = {
       apm: { events: ['transaction', 'error'] },
       body: {
+        track_total_hits: false,
         size: 0,
         query: { bool: { filter: [{ terms: { foo: 'bar' } }] } },
       },

--- a/x-pack/plugins/apm/server/lib/helpers/service_metrics/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/service_metrics/index.ts
@@ -53,6 +53,7 @@ export async function getHasAggregatedServicesMetrics({
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: 1,
         size: 1,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
@@ -102,7 +102,7 @@ describe('setupRequest', () => {
       const { apmEventClient } = await setupRequest(mockResources);
       await apmEventClient.search('foo', {
         apm: { events: [ProcessorEvent.transaction] },
-        body: { size: 10 },
+        body: { track_total_hits: 10_000, size: 10 },
       });
 
       expect(
@@ -111,6 +111,7 @@ describe('setupRequest', () => {
         {
           index: ['apm-*'],
           body: {
+            track_total_hits: 10000,
             size: 10,
             query: {
               bool: {
@@ -166,7 +167,7 @@ describe('with includeFrozen=false', () => {
       apm: {
         events: [],
       },
-      body: { size: 10 },
+      body: { track_total_hits: 10_000, size: 10 },
     });
 
     const params =
@@ -188,7 +189,7 @@ describe('with includeFrozen=true', () => {
 
     await apmEventClient.search('foo', {
       apm: { events: [] },
-      body: { size: 10 },
+      body: { track_total_hits: 10_000, size: 10 },
     });
 
     const params =

--- a/x-pack/plugins/apm/server/lib/helpers/spans/get_is_using_service_destination_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/spans/get_is_using_service_destination_metrics.ts
@@ -78,6 +78,7 @@ export async function getIsUsingServiceDestinationMetrics({
           events: [getProcessorEventForServiceDestinationStatistics(true)],
         },
         body: {
+          track_total_hits: 1,
           size: 1,
           terminate_after: 1,
           query: {

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/__snapshots__/get_is_using_transaction_events.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/__snapshots__/get_is_using_transaction_events.test.ts.snap
@@ -32,8 +32,9 @@ Object {
       },
     },
     "size": 1,
+    "terminate_after": 1,
+    "track_total_hits": 1,
   },
-  "terminate_after": 1,
 }
 `;
 
@@ -57,8 +58,9 @@ Object {
       },
     },
     "size": 1,
+    "terminate_after": 1,
+    "track_total_hits": 1,
   },
-  "terminate_after": 1,
 }
 `;
 
@@ -85,8 +87,9 @@ Array [
           },
         },
         "size": 1,
+        "terminate_after": 1,
+        "track_total_hits": 1,
       },
-      "terminate_after": 1,
     },
   ],
   Array [
@@ -104,6 +107,7 @@ Array [
           },
         },
         "size": 0,
+        "track_total_hits": 1,
       },
       "terminate_after": 1,
     },

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
@@ -64,6 +64,7 @@ async function getHasTransactions({
       events: [ProcessorEvent.transaction],
     },
     body: {
+      track_total_hits: 1,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/index.ts
@@ -35,6 +35,8 @@ export async function getHasAggregatedTransactions({
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: 1,
+        terminate_after: 1,
         size: 1,
         query: {
           bool: {
@@ -46,7 +48,6 @@ export async function getHasAggregatedTransactions({
           },
         },
       },
-      terminate_after: 1,
     }
   );
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_coldstart_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_coldstart_rate.ts
@@ -81,6 +81,7 @@ export async function getColdstartRate({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: { bool: { filter } },
       aggs: {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
@@ -90,6 +90,7 @@ export async function getFailedTransactionRate({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: { bool: { filter } },
       aggs: {

--- a/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_duration.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_duration.ts
@@ -87,7 +87,7 @@ export async function getTransactionDurationChartPreview({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
-    body: { size: 0, query, aggs },
+    body: { size: 0, track_total_hits: false, query, aggs },
   };
   const resp = await apmEventClient.search(
     'get_transaction_duration_chart_preview',

--- a/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_error_count.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_error_count.ts
@@ -47,7 +47,7 @@ export async function getTransactionErrorCountChartPreview({
 
   const params = {
     apm: { events: [ProcessorEvent.error] },
-    body: { size: 0, query, aggs },
+    body: { size: 0, track_total_hits: false, query, aggs },
   };
 
   const resp = await apmEventClient.search(

--- a/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_error_rate.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/chart_preview/get_transaction_error_rate.ts
@@ -48,6 +48,7 @@ export async function getTransactionErrorRateChartPreview({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation.ts
@@ -47,6 +47,7 @@ export const fetchDurationCorrelation = async ({
       events: [eventType],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: getCommonCorrelationsQuery({
         start,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_field_candidates.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_field_candidates.ts
@@ -65,6 +65,7 @@ export const fetchDurationFieldCandidates = async ({
         events: [eventType],
       },
       body: {
+        track_total_hits: false,
         fields: ['*'],
         _source: false,
         query: getCommonCorrelationsQuery({

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_fractions.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_fractions.ts
@@ -39,6 +39,7 @@ export const fetchDurationFractions = async ({
       events: [eventType],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: getCommonCorrelationsQuery({
         start,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
@@ -75,6 +75,7 @@ export const fetchDurationHistogramRangeSteps = async ({
         events: [getEventType(chartType, searchMetrics)],
       },
       body: {
+        track_total_hits: 1,
         size: 0,
         query: getCommonCorrelationsQuery({
           start,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_ranges.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_ranges.ts
@@ -62,6 +62,7 @@ export const fetchDurationRanges = async ({
       events: [getEventType(chartType, searchMetrics)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: getCommonCorrelationsQuery({
         start,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_failed_events_correlation_p_values.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_failed_events_correlation_p_values.ts
@@ -53,6 +53,7 @@ export const fetchFailedEventsCorrelationPValues = async ({
         events: [eventType],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_field_value_pairs.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_field_value_pairs.ts
@@ -42,6 +42,7 @@ export const fetchFieldValuePairs = async ({
               events: [eventType],
             },
             body: {
+              track_total_hits: false,
               size: 0,
               query: getCommonCorrelationsQuery({
                 start,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_error_rate_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_error_rate_charts_for_dependency.ts
@@ -66,6 +66,7 @@ export async function getErrorRateChartsForDependency({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_latency_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_latency_charts_for_dependency.ts
@@ -63,6 +63,7 @@ export async function getLatencyChartsForDependency({
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_metadata_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_metadata_for_dependency.ts
@@ -31,6 +31,7 @@ export async function getMetadataForDependency({
         events: [ProcessorEvent.span],
       },
       body: {
+        track_total_hits: false,
         size: 1,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_throughput_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_throughput_charts_for_dependency.ts
@@ -70,6 +70,7 @@ export async function getThroughputChartsForDependency({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_operations.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_operations.ts
@@ -97,6 +97,7 @@ export async function getTopDependencyOperations({
         events: [ProcessorEvent.span],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_spans.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_spans.ts
@@ -76,6 +76,7 @@ export async function getTopDependencySpans({
         events: [ProcessorEvent.span],
       },
       body: {
+        track_total_hits: false,
         size: MAX_NUM_SPANS,
         query: {
           bool: {
@@ -123,6 +124,7 @@ export async function getTopDependencySpans({
         events: [ProcessorEvent.transaction],
       },
       body: {
+        track_total_hits: false,
         size: transactionIds.length,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/environments/__snapshots__/get_all_environments.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/environments/__snapshots__/get_all_environments.test.ts.snap
@@ -31,6 +31,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -66,6 +67,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/environments/__snapshots__/get_environments.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/environments/__snapshots__/get_environments.test.ts.snap
@@ -40,6 +40,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -79,6 +80,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/environments/get_all_environments.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_all_environments.ts
@@ -50,6 +50,7 @@ export async function getAllEnvironments({
       // use timeout + min_doc_count to return as early as possible
       // if filter is not defined to prevent timeouts
       ...(!serviceName ? { timeout: '1ms' } : {}),
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/environments/get_environments.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_environments.ts
@@ -50,6 +50,7 @@ export async function getEnvironments({
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/errors/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/errors/__snapshots__/queries.test.ts.snap
@@ -53,6 +53,7 @@ Object {
         },
       },
     ],
+    "track_total_hits": true,
   },
 }
 `;
@@ -116,6 +117,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -184,6 +186,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/errors/distribution/__snapshots__/get_buckets.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/__snapshots__/get_buckets.test.ts.snap
@@ -50,6 +50,7 @@ Array [
           },
         },
         "size": 0,
+        "track_total_hits": false,
       },
     },
   ],

--- a/x-pack/plugins/apm/server/routes/errors/distribution/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/__snapshots__/queries.test.ts.snap
@@ -42,6 +42,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -93,6 +94,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.ts
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.ts
@@ -44,6 +44,7 @@ export async function getBuckets({
       events: [ProcessorEvent.error],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/errors/erroneous_transactions/get_top_erroneous_transactions.ts
+++ b/x-pack/plugins/apm/server/routes/errors/erroneous_transactions/get_top_erroneous_transactions.ts
@@ -70,6 +70,7 @@ async function getTopErroneousTransactions({
       events: [ProcessorEvent.error],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_detailed_statistics.ts
@@ -65,6 +65,7 @@ export async function getErrorGroupDetailedStatistics({
         events: [ProcessorEvent.error],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -70,6 +70,7 @@ export async function getErrorGroupMainStatistics({
         events: [ProcessorEvent.error],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample.ts
@@ -41,6 +41,7 @@ export async function getErrorGroupSample({
       events: [ProcessorEvent.error as const],
     },
     body: {
+      track_total_hits: true,
       size: 1,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/event_metadata/get_event_metadata.ts
+++ b/x-pack/plugins/apm/server/routes/event_metadata/get_event_metadata.ts
@@ -52,6 +52,7 @@ export async function getEventMetadata({
       events: [processorEvent],
     },
     body: {
+      track_total_hits: false,
       query: {
         bool: { filter },
       },

--- a/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
+++ b/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
@@ -22,6 +22,7 @@ export async function hasHistoricalAgentData(setup: Setup) {
       ],
     },
     body: {
+      track_total_hits: 1,
       size: 0,
     },
   };

--- a/x-pack/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -38,6 +38,7 @@ export const getInfrastructureData = async ({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/metrics/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/metrics/__snapshots__/queries.test.ts.snap
@@ -89,6 +89,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -180,6 +181,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -338,6 +340,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -429,6 +432,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -510,6 +514,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -609,6 +614,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -706,6 +712,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -870,6 +877,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -967,6 +975,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1054,6 +1063,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1142,6 +1152,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1228,6 +1239,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1381,6 +1393,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1467,6 +1480,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;
@@ -1543,6 +1557,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": 1,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
@@ -65,6 +65,7 @@ export async function fetchAndTransformGcMetrics({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/active_instances.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/active_instances.ts
@@ -53,6 +53,7 @@ export async function getActiveInstances({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/compute_usage.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/compute_usage.ts
@@ -74,6 +74,7 @@ export async function getComputeUsage({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/metrics/fetch_and_transform_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/fetch_and_transform_metrics.ts
@@ -92,6 +92,7 @@ export async function fetchAndTransformMetrics<T extends MetricAggs>({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: 1,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/observability_overview/get_service_count.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/get_service_count.ts
@@ -33,6 +33,7 @@ export async function getServiceCount({
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/observability_overview/get_transactions_per_minute.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/get_transactions_per_minute.ts
@@ -44,6 +44,7 @@ export async function getTransactionsPerMinute({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/observability_overview/has_data.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/has_data.ts
@@ -21,6 +21,7 @@ export async function getHasData({ setup }: { setup: Setup }) {
       },
       terminate_after: 1,
       body: {
+        track_total_hits: 1,
         size: 0,
       },
     };

--- a/x-pack/plugins/apm/server/routes/service_groups/get_services_counts.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/get_services_counts.ts
@@ -42,6 +42,7 @@ export async function getServicesCounts({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: 0,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
@@ -40,6 +40,7 @@ export async function lookupServices({
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
@@ -33,6 +33,7 @@ export async function fetchServicePathsFromTraceIds(
       events: [ProcessorEvent.span, ProcessorEvent.transaction],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map.ts
@@ -116,6 +116,7 @@ async function getServicesData(
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_dependency_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_dependency_node_info.ts
@@ -73,6 +73,7 @@ export function getServiceMapDependencyNodeInfo({
           events: [ProcessorEvent.metric],
         },
         body: {
+          track_total_hits: false,
           size: 0,
           query: {
             bool: {

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
@@ -174,6 +174,7 @@ async function getTransactionStats({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {
@@ -256,6 +257,7 @@ async function getCpuStats({
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {
@@ -319,6 +321,7 @@ function getMemoryStats({
             events: [ProcessorEvent.metric],
           },
           body: {
+            track_total_hits: false,
             size: 0,
             query: {
               bool: {

--- a/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
@@ -80,6 +80,7 @@ export async function getTraceSampleIds({
       events,
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query,
       aggs: {

--- a/x-pack/plugins/apm/server/routes/service_nodes/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/service_nodes/__snapshots__/queries.test.ts.snap
@@ -53,6 +53,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -116,6 +117,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -192,6 +194,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/service_nodes/get_service_nodes.ts
+++ b/x-pack/plugins/apm/server/routes/service_nodes/get_service_nodes.ts
@@ -45,6 +45,7 @@ const getServiceNodes = async ({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/services/__snapshots__/queries.test.ts.snap
@@ -11,6 +11,7 @@ Object {
   },
   "body": Object {
     "size": 0,
+    "track_total_hits": 1,
   },
   "terminate_after": 1,
 }
@@ -66,6 +67,7 @@ Object {
         "order": "desc",
       },
     },
+    "track_total_hits": 1,
   },
   "terminate_after": 1,
 }
@@ -152,6 +154,7 @@ Array [
         },
       },
       "size": 0,
+      "track_total_hits": false,
     },
   },
   Object {
@@ -213,6 +216,7 @@ Array [
         },
       },
       "size": 0,
+      "track_total_hits": false,
     },
   },
 ]
@@ -255,6 +259,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
+++ b/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
@@ -52,6 +52,7 @@ export async function getDerivedServiceAnnotations({
           ],
         },
         body: {
+          track_total_hits: false,
           size: 0,
           query: {
             bool: {
@@ -83,6 +84,7 @@ export async function getDerivedServiceAnnotations({
             ],
           },
           body: {
+            track_total_hits: false,
             size: 1,
             query: {
               bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_agent.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_agent.ts
@@ -48,6 +48,7 @@ export async function getServiceAgent({
       ],
     },
     body: {
+      track_total_hits: 1,
       size: 1,
       _source: [AGENT_NAME, SERVICE_RUNTIME_NAME],
       query: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
@@ -47,6 +47,7 @@ export async function getServiceInstanceMetadataDetails({
           events: [ProcessorEvent.metric],
         },
         body: {
+          track_total_hits: false,
           terminate_after: 1,
           size: 1,
           query: {
@@ -69,6 +70,7 @@ export async function getServiceInstanceMetadataDetails({
           events: [ProcessorEvent.transaction],
         },
         body: {
+          track_total_hits: false,
           terminate_after: 1,
           size: 1,
           query: { bool: { filter } },
@@ -87,6 +89,7 @@ export async function getServiceInstanceMetadataDetails({
           events: [getProcessorEventForTransactions(true)],
         },
         body: {
+          track_total_hits: false,
           terminate_after: 1,
           size: 1,
           query: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_system_metric_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_system_metric_statistics.ts
@@ -145,6 +145,7 @@ export async function getServiceInstancesSystemMetricStatistics<
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_transaction_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_transaction_statistics.ts
@@ -160,7 +160,7 @@ export async function getServiceInstancesTransactionStatistics<
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
-      body: { size: 0, query, aggs },
+      body: { size: 0, track_total_hits: false, query, aggs },
     }
   );
 

--- a/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
@@ -105,6 +105,7 @@ export async function getServiceMetadataDetails({
       ],
     },
     body: {
+      track_total_hits: 1,
       size: 1,
       _source: [SERVICE, AGENT, HOST, CONTAINER, KUBERNETES, CLOUD],
       query: { bool: { filter, should } },

--- a/x-pack/plugins/apm/server/routes/services/get_service_metadata_icons.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_metadata_icons.ts
@@ -71,6 +71,7 @@ export async function getServiceMetadataIcons({
       ],
     },
     body: {
+      track_total_hits: 1,
       size: 1,
       _source: [
         KUBERNETES,

--- a/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
@@ -45,6 +45,7 @@ export async function getServiceNodeMetadata({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_group_detailed_statistics.ts
@@ -93,6 +93,7 @@ export async function getServiceTransactionGroupDetailedStatistics({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_groups.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_groups.ts
@@ -70,6 +70,7 @@ export async function getServiceTransactionGroups({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_types.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_types.ts
@@ -36,6 +36,7 @@ export async function getServiceTransactionTypes({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
@@ -59,6 +59,7 @@ export async function getServiceAggregatedTransactionStats({
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
@@ -78,6 +78,7 @@ export async function getServiceTransactionStats({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_services_from_error_and_metric_documents.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_services_from_error_and_metric_documents.ts
@@ -47,6 +47,7 @@ export async function getServicesFromErrorAndMetricDocuments({
         events: [ProcessorEvent.metric, ProcessorEvent.error],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
@@ -82,6 +82,7 @@ export async function getServiceAggregatedTransactionDetailedStats({
         events: [ProcessorEvent.metric],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
@@ -80,6 +80,7 @@ export async function getServiceTransactionDetailedStats({
         ],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/services/get_throughput.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_throughput.ts
@@ -68,6 +68,7 @@ export async function getThroughput({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/__snapshots__/queries.test.ts.snap
@@ -115,6 +115,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_name_by_service.ts
@@ -29,6 +29,7 @@ export async function getAgentNameByService({
       ],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/__snapshots__/get_transaction.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/__snapshots__/get_transaction.test.ts.snap
@@ -43,6 +43,7 @@ Object {
       },
     },
     "size": 1,
+    "track_total_hits": false,
   },
   "terminate_after": 1,
 }
@@ -62,6 +63,7 @@ Object {
       },
     },
     "size": 1,
+    "track_total_hits": false,
   },
   "terminate_after": 1,
 }

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.ts
@@ -37,6 +37,7 @@ export async function getTransaction({
       events: [ProcessorEvent.transaction as const],
     },
     body: {
+      track_total_hits: false,
       size: 1,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/span_links/get_linked_children.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_linked_children.ts
@@ -49,6 +49,7 @@ async function fetchLinkedChildrenOfSpan({
       },
       _source: [SPAN_LINKS, TRACE_ID, SPAN_ID, PROCESSOR_EVENT, TRANSACTION_ID],
       body: {
+        track_total_hits: false,
         size: 1000,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/span_links/get_linked_parents.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_linked_parents.ts
@@ -40,6 +40,7 @@ export async function getLinkedParentsOfSpan({
     },
     _source: [SPAN_LINKS],
     body: {
+      track_total_hits: false,
       size: 1,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/span_links/get_span_links_details.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_span_links_details.ts
@@ -68,6 +68,7 @@ async function fetchSpanLinksDetails({
       AGENT_NAME,
     ],
     body: {
+      track_total_hits: false,
       size: 1000,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_aggregation.ts
+++ b/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_aggregation.ts
@@ -42,6 +42,7 @@ export async function getSuggestionsWithTermsAggregation({
         ],
       },
       body: {
+        track_total_hits: false,
         timeout: '1500ms',
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
@@ -38,6 +38,7 @@ Object {
       },
     },
     "size": 1000,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/traces/get_top_traces_primary_stats.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_top_traces_primary_stats.ts
@@ -67,6 +67,7 @@ export async function getTopTracesPrimaryStats({
           ],
         },
         body: {
+          track_total_hits: false,
           size: 0,
           query: {
             bool: {

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -36,6 +36,7 @@ export async function getTraceItems(
       events: [ProcessorEvent.error],
     },
     body: {
+      track_total_hits: false,
       size: maxTraceItems,
       query: {
         bool: {
@@ -54,6 +55,7 @@ export async function getTraceItems(
       events: [ProcessorEvent.span, ProcessorEvent.transaction],
     },
     body: {
+      track_total_hits: maxTraceItems + 1,
       size: maxTraceItems,
       query: {
         bool: {
@@ -71,7 +73,6 @@ export async function getTraceItems(
         { [TRANSACTION_DURATION]: { order: 'desc' as const } },
         { [SPAN_DURATION]: { order: 'desc' as const } },
       ] as Sort,
-      track_total_hits: true,
     },
   });
 

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_samples_by_query.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_samples_by_query.ts
@@ -54,6 +54,7 @@ export async function getTraceSamplesByQuery({
             ],
           },
           body: {
+            track_total_hits: false,
             size: 0,
             query: {
               bool: {
@@ -121,6 +122,7 @@ export async function getTraceSamplesByQuery({
         events: [ProcessorEvent.transaction],
       },
       body: {
+        track_total_hits: false,
         size: 0,
         query: {
           bool: {

--- a/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -25,6 +25,7 @@ Object {
       },
     },
     "size": 1,
+    "track_total_hits": false,
   },
 }
 `;
@@ -149,6 +150,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -278,6 +280,7 @@ Object {
       },
     },
     "size": 0,
+    "track_total_hits": false,
   },
 }
 `;
@@ -343,6 +346,7 @@ Object {
       },
     },
     "size": 500,
+    "track_total_hits": false,
   },
 }
 `;

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -98,6 +98,7 @@ export async function getTransactionBreakdown({
       events: [ProcessorEvent.metric],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
@@ -83,6 +83,7 @@ function searchLatency({
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
+      track_total_hits: false,
       size: 0,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_transaction/index.ts
@@ -34,6 +34,7 @@ export async function getTransaction({
       events: [ProcessorEvent.transaction],
     },
     body: {
+      track_total_hits: false,
       size: 1,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/transactions/get_transaction_by_trace/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_transaction_by_trace/index.ts
@@ -23,6 +23,7 @@ export async function getRootTransactionByTraceId(
       events: [ProcessorEvent.transaction as const],
     },
     body: {
+      track_total_hits: false,
       size: 1,
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/routes/transactions/trace_samples/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/trace_samples/index.ts
@@ -78,6 +78,7 @@ export async function getTraceSamples({
       },
       _source: [TRANSACTION_ID, TRACE_ID, '@timestamp'],
       body: {
+        track_total_hits: false,
         query: {
           bool: {
             filter: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[APM] Require `track_total_hits` param in ES request (#140938)](https://github.com/elastic/kibana/pull/140938)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2022-09-23T14:54:41Z","message":"[APM] Require `track_total_hits` param in ES request (#140938)","sha":"e97158a265e0b761f34665410ef2fbfec6f5a426","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","release_note:skip","backport:skip","8.6 candidate","v8.6.0"],"number":140938,"url":"https://github.com/elastic/kibana/pull/140938","mergeCommit":{"message":"[APM] Require `track_total_hits` param in ES request (#140938)","sha":"e97158a265e0b761f34665410ef2fbfec6f5a426"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/140938","number":140938,"mergeCommit":{"message":"[APM] Require `track_total_hits` param in ES request (#140938)","sha":"e97158a265e0b761f34665410ef2fbfec6f5a426"}}]}] BACKPORT-->