### PR TITLE
[Security Solution][Endpoint][Response Actions] Show correct number of items in response actions history

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/response_actions_log.test.tsx
@@ -344,26 +344,20 @@ describe('Response actions history', () => {
       );
 
       // should have 4 pages each of size 10.
-      expect(renderResult.getByTestId('pagination-button-0')).toHaveAttribute(
-        'aria-label',
-        'Page 1 of 4'
-      );
+      expect(getByTestId('pagination-button-0')).toHaveAttribute('aria-label', 'Page 1 of 4');
 
       // toggle page size popover
-      userEvent.click(renderResult.getByTestId('tablePaginationPopoverButton'));
+      userEvent.click(getByTestId('tablePaginationPopoverButton'));
       await waitForEuiPopoverOpen();
       // click size 20
-      userEvent.click(renderResult.getByTestId('tablePagination-20-rows'));
+      userEvent.click(getByTestId('tablePagination-20-rows'));
 
-      expect(renderResult.getByTestId(`${testPrefix}-endpointListTableTotal`)).toHaveTextContent(
+      expect(getByTestId(`${testPrefix}-endpointListTableTotal`)).toHaveTextContent(
         'Showing 1-20 of 33 response actions'
       );
 
       // should have only 2 pages each of size 20
-      expect(renderResult.getByTestId('pagination-button-0')).toHaveAttribute(
-        'aria-label',
-        'Page 1 of 2'
-      );
+      expect(getByTestId('pagination-button-0')).toHaveAttribute('aria-label', 'Page 1 of 2');
     });
 
     it('should show 1-1 record label when only 1 record', async () => {
@@ -545,8 +539,10 @@ describe('Response actions history', () => {
 
     it('should have a search bar', () => {
       render();
-      userEvent.click(renderResult.getByTestId(`${testPrefix}-${filterPrefix}-popoverButton`));
-      const searchBar = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
+
+      const { getByTestId } = renderResult;
+      userEvent.click(getByTestId(`${testPrefix}-${filterPrefix}-popoverButton`));
+      const searchBar = getByTestId(`${testPrefix}-${filterPrefix}-search`);
       expect(searchBar).toBeTruthy();
       expect(searchBar.querySelector('input')?.getAttribute('placeholder')).toEqual(
         'Search actions'
@@ -595,10 +591,10 @@ describe('Response actions history', () => {
     it('should have `clear all` button `disabled` when no selected values', () => {
       render();
 
-      userEvent.click(renderResult.getByTestId(`${testPrefix}-${filterPrefix}-popoverButton`));
-      const clearAllButton = renderResult.getByTestId(
-        `${testPrefix}-${filterPrefix}-clearAllButton`
-      );
+      const { getByTestId } = renderResult;
+
+      userEvent.click(getByTestId(`${testPrefix}-${filterPrefix}-popoverButton`));
+      const clearAllButton = getByTestId(`${testPrefix}-${filterPrefix}-clearAllButton`);
       expect(clearAllButton.hasAttribute('disabled')).toBeTruthy();
     });
   });

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -92,8 +92,8 @@ export const getActionListByStatus = async ({
     userIds,
     commands,
     statuses,
-    // for size 20 -> page 1: (0, 19), page 2: (20,39) ...etc
-    data: actionDetailsByStatus.slice((page - 1) * size, size * page - 1),
+    // for size 20 -> page 1: (0, 20), page 2: (20, 40) ...etc
+    data: actionDetailsByStatus.slice((page - 1) * size, size * page),
     total: actionDetailsByStatus.length,
   };
 };
@@ -251,7 +251,7 @@ const getActionDetailsList = async ({
   });
 
   // compute action details list for each action id
-  const actionDetails: ActionDetails[] = normalizedActionRequests.map((action) => {
+  const actionDetails: ActionListApiResponse['data'] = normalizedActionRequests.map((action) => {
     // pick only those responses that match the current action id
     const matchedResponses = categorizedResponses.filter((categorizedResponse) =>
       categorizedResponse.type === 'response'

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/mocks.ts
@@ -21,17 +21,22 @@ import {
 } from '../../../../common/endpoint/constants';
 
 export const createActionRequestsEsSearchResultsMock = (
-  agentIds?: string[]
+  agentIds?: string[],
+  isMultipleActions: boolean = false
 ): estypes.SearchResponse<LogsEndpointAction> => {
   const endpointActionGenerator = new EndpointActionGenerator('seed');
 
-  return endpointActionGenerator.toEsSearchResponse<LogsEndpointAction>([
-    endpointActionGenerator.generateActionEsHit({
-      EndpointActions: { action_id: '123' },
-      agent: { id: agentIds ? agentIds : 'agent-a' },
-      '@timestamp': '2022-04-27T16:08:47.449Z',
-    }),
-  ]);
+  return isMultipleActions
+    ? endpointActionGenerator.toEsSearchResponse<LogsEndpointAction>(
+        Array.from({ length: 23 }).map(() => endpointActionGenerator.generateActionEsHit())
+      )
+    : endpointActionGenerator.toEsSearchResponse<LogsEndpointAction>([
+        endpointActionGenerator.generateActionEsHit({
+          EndpointActions: { action_id: '123' },
+          agent: { id: agentIds ? agentIds : 'agent-a' },
+          '@timestamp': '2022-04-27T16:08:47.449Z',
+        }),
+      ]);
 };
 
 export const createActionResponsesEsSearchResultsMock = (


### PR DESCRIPTION
## Summary

When there are more items than the page size, the API was returning one less item when a status filter was selected. This commit fixes that.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->