### PR TITLE
[ML] api/ml/jobs/jobs api tests

### DIFF
--- a/x-pack/test/api_integration/apis/ml/jobs/index.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/index.ts
@@ -23,5 +23,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./stop_datafeeds'));
     loadTestFile(require.resolve('./stop_datafeeds_spaces'));
     loadTestFile(require.resolve('./get_groups'));
+    loadTestFile(require.resolve('./jobs'));
   });
 }

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { CombinedJobWithStats } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { MULTI_METRIC_JOB_CONFIG, SINGLE_METRIC_JOB_CONFIG, DATAFEED_CONFIG } from './common_jobs';
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  const testSetupJobConfigs = [SINGLE_METRIC_JOB_CONFIG, MULTI_METRIC_JOB_CONFIG];
+
+  const testCalendarsConfigs = [
+    {
+      calendar_id: `test_get_cal_1`,
+      job_ids: ['multi-metric'],
+      description: `Test calendar 1`,
+    },
+    {
+      calendar_id: `test_get_cal_2`,
+      job_ids: [MULTI_METRIC_JOB_CONFIG.job_id, 'multi-metric'],
+      description: `Test calendar 2`,
+    },
+    {
+      calendar_id: `test_get_cal_3`,
+      job_ids: ['brand-new-group'],
+      description: `Test calendar 3`,
+    },
+  ];
+
+  async function runGetJobsRequest(
+    user: USER,
+    requestBody: object,
+    expectedResponsecode: number
+  ): Promise<CombinedJobWithStats[]> {
+    const { body, status } = await supertest
+      .post('/api/ml/jobs/jobs')
+      .auth(user, ml.securityCommon.getPasswordForUser(user))
+      .set(COMMON_REQUEST_HEADERS)
+      .send(requestBody);
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
+
+    return body;
+  }
+
+  const expectedJobProperties = [
+    {
+      jobId: MULTI_METRIC_JOB_CONFIG.job_id,
+      datafeedId: `datafeed-${MULTI_METRIC_JOB_CONFIG.job_id}`,
+      calendarIds: ['test_get_cal_1', 'test_get_cal_2'],
+      groups: ['farequote', 'automated', 'multi-metric'],
+      modelBytes: 0,
+      datafeedTotalSearchTimeMs: 0,
+    },
+    {
+      jobId: SINGLE_METRIC_JOB_CONFIG.job_id,
+      datafeedId: `datafeed-${SINGLE_METRIC_JOB_CONFIG.job_id}`,
+      calendarIds: undefined,
+      groups: ['farequote', 'automated', 'single-metric'],
+      modelBytes: 0,
+      datafeedTotalSearchTimeMs: 0,
+    },
+  ];
+
+  describe('get combined jobs with stats', function () {
+    before(async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      for (const job of testSetupJobConfigs) {
+        await ml.api.createAnomalyDetectionJob(job);
+        await ml.api.createDatafeed({
+          ...DATAFEED_CONFIG,
+          datafeed_id: `datafeed-${job.job_id}`,
+          job_id: job.job_id,
+        });
+      }
+
+      for (const cal of testCalendarsConfigs) {
+        await ml.api.createCalendar(cal.calendar_id, cal);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+    });
+
+    it('returns expected list of combined jobs with stats', async () => {
+      const jobs = await runGetJobsRequest(USER.ML_VIEWER, {}, 200);
+
+      jobs.forEach((job, i) => {
+        expect(job.job_id).to.eql(
+          expectedJobProperties[i].jobId,
+          `job id should be equal to ${JSON.stringify(expectedJobProperties[i].jobId)})`
+        );
+        expect(job.datafeed_config.datafeed_id).to.eql(
+          expectedJobProperties[i].datafeedId,
+          `datafeed id should be equal to ${JSON.stringify(expectedJobProperties[i].datafeedId)})`
+        );
+        expect(job.calendars).to.eql(
+          expectedJobProperties[i].calendarIds,
+          `calendars should be equal to ${JSON.stringify(expectedJobProperties[i].calendarIds)})`
+        );
+        expect(job.groups).to.eql(
+          expectedJobProperties[i].groups,
+          `groups should be equal to ${JSON.stringify(expectedJobProperties[i].groups)})`
+        );
+        expect(job.model_size_stats.model_bytes).to.eql(
+          expectedJobProperties[i].modelBytes,
+          `model_bytes should be equal to ${JSON.stringify(expectedJobProperties[i].modelBytes)})`
+        );
+        expect(job.datafeed_config.timing_stats.total_search_time_ms).to.eql(
+          expectedJobProperties[i].datafeedTotalSearchTimeMs,
+          `datafeed total_search_time_ms should be equal to ${JSON.stringify(
+            expectedJobProperties[i].datafeedTotalSearchTimeMs
+          )})`
+        );
+      });
+    });
+  });
+};


### PR DESCRIPTION
Adds a test which calls `/api/ml/jobs/jobs` and confirms that it contains jobs, jobs stats, datafeeds, datafeed stats and calendars.
Also adds jobs to a different space and ensures jobs in default space and specific space are correct.

Part of https://github.com/elastic/kibana/issues/137573

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->