### PR TITLE
[ML] Fix kebab-case CSS attribute names.

### DIFF
--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/brush_badge.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/brush_badge.tsx
@@ -39,7 +39,7 @@ export const BrushBadge: FC<BrushBadgeProps> = ({
     <div
       css={{
         position: 'absolute',
-        'margin-left': `${marginLeft}px`,
+        marginLeft: `${marginLeft}px`,
       }}
     >
       <EuiToolTip

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
@@ -143,7 +143,7 @@ export const DFAnalyticsJobIdLink = ({ jobId }: { jobId: string }) => {
   });
 
   return (
-    <EuiLink href={href} css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }} title={jobId}>
+    <EuiLink href={href} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={jobId}>
       {jobId}
     </EuiLink>
   );

--- a/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
@@ -320,7 +320,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
             {menuPanels[0].items!.length > 0 ? (
               <EuiFlexItem
                 grow={false}
-                css={{ 'margin-left': 'auto !important', 'align-self': 'baseline' }}
+                css={{ marginLeft: 'auto !important', alignSelf: 'baseline' }}
               >
                 <EuiPopover
                   button={
@@ -368,7 +368,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
               </>
             )}
 
-            <EuiFlexItem grow={true} css={{ 'max-width': '500px' }}>
+            <EuiFlexItem grow={true} css={{ maxWidth: '500px' }}>
               <SeverityControl
                 value={severityUpdate ?? 0}
                 onChange={useCallback((update) => {

--- a/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
@@ -157,7 +157,7 @@ export const ExplorerQueryBar: FC<ExplorerQueryBarProps> = ({
 
   return (
     <EuiInputPopover
-      css={{ 'max-width': '100%' }}
+      css={{ maxWidth: '100%' }}
       closePopover={setErrorMessage.bind(null, undefined)}
       input={
         <QueryStringInput

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -421,8 +421,8 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
           <EuiFlexItem
             css={{
               width: '100%',
-              'overflow-y': 'auto',
-              'overflow-x': 'hidden',
+              overflowY: 'auto',
+              overflowX: 'hidden',
             }}
             grow={false}
           >

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/job_id_link.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/job_id_link.tsx
@@ -68,7 +68,7 @@ export const AnomalyDetectionJobIdLink = (props: AnomalyDetectionJobIdLinkProps)
       <EuiLink
         key={props.id}
         href={href}
-        css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }}
+        css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
         title={props.id}
       >
         {props.id}

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/model_link.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/model_link.tsx
@@ -21,7 +21,7 @@ export const TrainedModelLink: FC<TrainedModelLinkProps> = ({ id }) => {
   });
 
   return (
-    <EuiLink href={href} css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }} title={id}>
+    <EuiLink href={href} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={id}>
       {id}
     </EuiLink>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_field_selector/styles.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_field_selector/styles.ts
@@ -9,7 +9,7 @@ import { CSSObject } from '@emotion/react';
 
 export const useStyles = () => {
   const comboBox: CSSObject = {
-    'max-width': '400px',
+    maxWidth: '400px',
     width: '400px',
   };
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_field_selector/styles.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_field_selector/styles.ts
@@ -9,7 +9,7 @@ import { CSSObject } from '@emotion/react';
 
 export const useStyles = () => {
   const comboBox: CSSObject = {
-    maxWidth: '400px',
+    'max-width': '400px',
     width: '400px',
   };
 


### PR DESCRIPTION
## Summary

Fixes CSS attributes to be `camelCase` instead of `kebab-case`. This is not caught during linting yet but shows up in Kibana logs like this:

```
 np bld    log   [17:27:28.261] [warning][@kbn/optimizer] worker stderr Using kebab-case for css properties in objects is not supported. Did you mean textOverflow?
 np bld    log   [17:27:29.407] [warning][@kbn/optimizer] worker stderr Using kebab-case for css properties in objects is not supported. Did you mean marginLeft?
 np bld    log   [17:27:29.407] [warning][@kbn/optimizer] worker stderr Using kebab-case for css properties in objects is not supported. Did you mean alignSelf?
 np bld    log   [17:27:29.412] [warning][@kbn/optimizer] worker stderr Using kebab-case for css properties in objects is not supported. Did you mean maxWidth?
 ```

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
