### PR TITLE
[DOCS] Fix broken link in ML sync API

### DIFF
--- a/docs/api/machine-learning/sync.asciidoc
+++ b/docs/api/machine-learning/sync.asciidoc
@@ -9,7 +9,7 @@ Synchronizes {kib} saved objects for {ml} jobs and trained models.
 [NOTE]
 ====
 For the most up-to-date API details, refer to the
-{kib-repo}/tree/{branch}/x-pack/plugins/ml/common/openapi[open API specification]. For a preview, check out <<machine-learning-apis>>.
+{kib-repo}/tree/{branch}/x-pack/plugins/ml/common/openapi[open API specification].
 ====
 
 [[machine-learning-api-sync-request]]


### PR DESCRIPTION
## Summary

This PR removes a broken link that was introduced in https://github.com/elastic/kibana/pull/142244
