### PR TITLE
[Security Solution][Exceptions] - Make exceptions read only when displaying deleted rule details

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.test.tsx
@@ -109,6 +109,7 @@ describe('ExceptionsViewer', () => {
             ],
           }}
           listType={ExceptionListTypeEnum.DETECTION}
+          isViewReadOnly={false}
         />
       </TestProviders>
     );
@@ -146,6 +147,7 @@ describe('ExceptionsViewer', () => {
             ],
           }}
           listType={ExceptionListTypeEnum.DETECTION}
+          isViewReadOnly={false}
         />
       </TestProviders>
     );
@@ -183,6 +185,7 @@ describe('ExceptionsViewer', () => {
             ],
           }}
           listType={ExceptionListTypeEnum.ENDPOINT}
+          isViewReadOnly={false}
         />
       </TestProviders>
     );
@@ -226,6 +229,7 @@ describe('ExceptionsViewer', () => {
             ],
           }}
           listType={ExceptionListTypeEnum.DETECTION}
+          isViewReadOnly={false}
         />
       </TestProviders>
     );
@@ -268,6 +272,7 @@ describe('ExceptionsViewer', () => {
           ],
         }}
         listType={ExceptionListTypeEnum.DETECTION}
+        isViewReadOnly={false}
       />
     );
 
@@ -301,6 +306,7 @@ describe('ExceptionsViewer', () => {
           ],
         }}
         listType={ExceptionListTypeEnum.DETECTION}
+        isViewReadOnly={false}
       />
     );
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.tsx
@@ -75,12 +75,15 @@ export interface GetExceptionItemProps {
 interface ExceptionsViewerProps {
   rule: Rule | null;
   listType: ExceptionListTypeEnum;
+  /* Used for when displaying exceptions for a rule that has since been deleted, forcing read only view */
+  isViewReadOnly: boolean;
   onRuleChange?: () => void;
 }
 
 const ExceptionsViewerComponent = ({
   rule,
   listType,
+  isViewReadOnly,
   onRuleChange,
 }: ExceptionsViewerProps): JSX.Element => {
   const { services } = useKibana();
@@ -337,8 +340,8 @@ const ExceptionsViewerComponent = ({
 
   // User privileges checks
   useEffect((): void => {
-    setReadOnly(!canUserCRUD || !hasIndexWrite);
-  }, [setReadOnly, canUserCRUD, hasIndexWrite]);
+    setReadOnly(isViewReadOnly || !canUserCRUD || !hasIndexWrite);
+  }, [setReadOnly, isViewReadOnly, canUserCRUD, hasIndexWrite]);
 
   useEffect(() => {
     if (exceptionListsToQuery.length > 0) {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/translations.ts
@@ -157,7 +157,7 @@ export const referenceErrorMessage = (referenceCount: number) =>
 export const EXCEPTION_LIST_SEARCH_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.all.exceptions.searchPlaceholder',
   {
-    defaultMessage: 'Search by name or list_id',
+    defaultMessage: 'Search by name or list id',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -871,6 +871,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                     rule={rule}
                     listType={ExceptionListTypeEnum.DETECTION}
                     onRuleChange={refreshRule}
+                    isViewReadOnly={!isExistingRule}
                     data-test-subj="exceptionTab"
                   />
                 </Route>
@@ -881,6 +882,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                     rule={rule}
                     listType={ExceptionListTypeEnum.ENDPOINT}
                     onRuleChange={refreshRule}
+                    isViewReadOnly={!isExistingRule}
                     data-test-subj="endpointExceptionsTab"
                   />
                 </Route>


### PR DESCRIPTION
## Summary

Addresses [141899](https://github.com/elastic/kibana/issues/141899).

When displaying a rule that has since been deleted, the exception tabs will render as read only.

<img width="1580" alt="Screen Shot 2022-09-29 at 10 58 05 AM" src="https://user-images.githubusercontent.com/10927944/193107711-5581021e-7092-430d-a2f1-81e1b888eddb.png">

Also took opportunity to address follow up copy edit from https://github.com/elastic/kibana/pull/141682#discussion_r983687797

<img width="408" alt="Screen Shot 2022-09-29 at 10 59 29 AM" src="https://user-images.githubusercontent.com/10927944/193107815-07ecc5a7-4106-4e5d-a4d5-0708fa2a38b4.png">


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->