### PR TITLE
[Synthetics UI] Serialize errors before sending to redux store to prevent warnings

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/index_status/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/index_status/actions.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { createAction } from '@reduxjs/toolkit';
 import { StatesIndexStatus } from '../../../../../common/runtime_types';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 export const getIndexStatus = createAction<void>('[INDEX STATUS] GET');
 export const getIndexStatusSuccess = createAction<StatesIndexStatus>('[INDEX STATUS] GET SUCCESS');
-export const getIndexStatusFail = createAction<IHttpFetchError>('[INDEX STATUS] GET FAIL');
+export const getIndexStatusFail =
+  createAction<IHttpSerializedFetchError>('[INDEX STATUS] GET FAIL');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/index_status/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/index_status/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { createReducer } from '@reduxjs/toolkit';
-import { IHttpSerializedFetchError, serializeHttpFetchError } from '../utils/http_error';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 import { StatesIndexStatus } from '../../../../../common/runtime_types';
 
 import { getIndexStatus, getIndexStatusSuccess, getIndexStatusFail } from './actions';
@@ -33,7 +33,7 @@ export const indexStatusReducer = createReducer(initialState, (builder) => {
       state.loading = false;
     })
     .addCase(getIndexStatusFail, (state, action) => {
-      state.error = serializeHttpFetchError(action.payload);
+      state.error = action.payload;
       state.loading = false;
     });
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import { createReducer } from '@reduxjs/toolkit';
-import { IHttpSerializedFetchError, serializeHttpFetchError } from '../utils/http_error';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 import {
   getMonitorRecentPingsAction,
   setMonitorDetailsLocationAction,
@@ -47,7 +46,7 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       state.loading = false;
     })
     .addCase(getMonitorRecentPingsAction.fail, (state, action) => {
-      state.error = serializeHttpFetchError(action.payload as IHttpFetchError<ResponseErrorBody>);
+      state.error = action.payload;
       state.loading = false;
     })
 
@@ -59,7 +58,7 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       state.syntheticsMonitorLoading = false;
     })
     .addCase(getMonitorAction.fail, (state, action) => {
-      state.error = serializeHttpFetchError(action.payload as IHttpFetchError<ResponseErrorBody>);
+      state.error = action.payload;
       state.syntheticsMonitorLoading = false;
     });
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/actions.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { IHttpFetchError } from '@kbn/core-http-browser';
 import { createAction } from '@reduxjs/toolkit';
 import {
   EncryptedSyntheticsMonitor,
   MonitorManagementListResult,
 } from '../../../../../common/runtime_types';
 import { createAsyncAction } from '../utils/actions';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import { MonitorListPageState } from './models';
 
@@ -29,7 +29,8 @@ export const fetchUpsertSuccessAction = createAction<{
   id: string;
   attributes: { enabled: boolean };
 }>('fetchUpsertMonitorSuccess');
-export const fetchUpsertFailureAction = createAction<{ id: string; error: IHttpFetchError }>(
-  'fetchUpsertMonitorFailure'
-);
+export const fetchUpsertFailureAction = createAction<{
+  id: string;
+  error: IHttpSerializedFetchError;
+}>('fetchUpsertMonitorFailure');
 export const clearMonitorUpsertStatus = createAction<string>('clearMonitorUpsertStatus');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/effects.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { IHttpFetchError } from '@kbn/core-http-browser';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { call, put, takeEvery, takeLeading } from 'redux-saga/effects';
 import { fetchEffectFactory } from '../utils/fetch_effect';
+import { serializeHttpFetchError } from '../utils/http_error';
 import {
   fetchMonitorListAction,
   fetchUpsertFailureAction,
@@ -40,7 +40,7 @@ export function* upsertMonitorEffect() {
         );
       } catch (error) {
         yield put(
-          fetchUpsertFailureAction({ id: action.payload.id, error: error as IHttpFetchError })
+          fetchUpsertFailureAction({ id: action.payload.id, error: serializeHttpFetchError(error) })
         );
       }
     }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_list/index.ts
@@ -10,7 +10,7 @@ import { FETCH_STATUS } from '@kbn/observability-plugin/public';
 
 import { ConfigKey, MonitorManagementListResult } from '../../../../../common/runtime_types';
 
-import { IHttpSerializedFetchError, serializeHttpFetchError } from '../utils/http_error';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import { MonitorListPageState } from './models';
 import {
@@ -58,7 +58,7 @@ export const monitorListReducer = createReducer(initialState, (builder) => {
     })
     .addCase(fetchMonitorListAction.fail, (state, action) => {
       state.loading = false;
-      state.error = serializeHttpFetchError(action.payload);
+      state.error = action.payload;
     })
     .addCase(fetchUpsertMonitorAction, (state, action) => {
       state.monitorUpsertStatuses[action.payload.id] = {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -9,7 +9,7 @@ import { createReducer } from '@reduxjs/toolkit';
 
 import { MonitorOverviewResult } from '../../../../../common/runtime_types';
 
-import { IHttpSerializedFetchError, serializeHttpFetchError } from '../utils/http_error';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import { MonitorOverviewPageState } from './models';
 import {
@@ -54,13 +54,13 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
     })
     .addCase(fetchMonitorOverviewAction.fail, (state, action) => {
       state.loading = false;
-      state.error = serializeHttpFetchError(action.payload);
+      state.error = action.payload;
     })
     .addCase(quietFetchOverviewAction.success, (state, action) => {
       state.data = action.payload;
     })
     .addCase(quietFetchOverviewAction.fail, (state, action) => {
-      state.error = serializeHttpFetchError(action.payload);
+      state.error = action.payload;
     })
     .addCase(setOverviewPerPageAction, (state, action) => {
       state.pageState = {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/service_locations/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/service_locations/actions.ts
@@ -7,10 +7,13 @@
 
 import { createAction } from '@reduxjs/toolkit';
 import { ServiceLocations, ThrottlingOptions } from '../../../../../common/runtime_types';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 export const getServiceLocations = createAction('[SERVICE LOCATIONS] GET');
 export const getServiceLocationsSuccess = createAction<{
   throttling: ThrottlingOptions | undefined;
   locations: ServiceLocations;
 }>('[SERVICE LOCATIONS] GET SUCCESS');
-export const getServiceLocationsFailure = createAction<Error>('[SERVICE LOCATIONS] GET FAILURE');
+export const getServiceLocationsFailure = createAction<IHttpSerializedFetchError>(
+  '[SERVICE LOCATIONS] GET FAILURE'
+);

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/service_locations/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/service_locations/index.ts
@@ -11,6 +11,7 @@ import {
   ServiceLocations,
   ThrottlingOptions,
 } from '../../../../../common/runtime_types';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import {
   getServiceLocations,
@@ -22,7 +23,7 @@ export interface ServiceLocationsState {
   locations: ServiceLocations;
   throttling: ThrottlingOptions | null;
   loading: boolean;
-  error: Error | null;
+  error: IHttpSerializedFetchError | null;
   locationsLoaded?: boolean;
 }
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/synthetics_enablement/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/synthetics_enablement/actions.ts
@@ -7,23 +7,24 @@
 
 import { createAction } from '@reduxjs/toolkit';
 import { MonitorManagementEnablementResult } from '../../../../../common/runtime_types';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 export const getSyntheticsEnablement = createAction('[SYNTHETICS_ENABLEMENT] GET');
 export const getSyntheticsEnablementSuccess = createAction<MonitorManagementEnablementResult>(
   '[SYNTHETICS_ENABLEMENT] GET SUCCESS'
 );
-export const getSyntheticsEnablementFailure = createAction<Error>(
+export const getSyntheticsEnablementFailure = createAction<IHttpSerializedFetchError>(
   '[SYNTHETICS_ENABLEMENT] GET FAILURE'
 );
 
 export const disableSynthetics = createAction('[SYNTHETICS_ENABLEMENT] DISABLE');
 export const disableSyntheticsSuccess = createAction<{}>('[SYNTHETICS_ENABLEMENT] DISABLE SUCCESS');
-export const disableSyntheticsFailure = createAction<Error>(
+export const disableSyntheticsFailure = createAction<IHttpSerializedFetchError>(
   '[SYNTHETICS_ENABLEMENT] DISABLE FAILURE'
 );
 
 export const enableSynthetics = createAction('[SYNTHETICS_ENABLEMENT] ENABLE');
 export const enableSyntheticsSuccess = createAction<{}>('[SYNTHETICS_ENABLEMENT] ENABLE SUCCESS');
-export const enableSyntheticsFailure = createAction<Error>(
+export const enableSyntheticsFailure = createAction<IHttpSerializedFetchError>(
   '[SYNTHETICS_ENABLEMENT] ENABLE FAILURE'
 );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/synthetics_enablement/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/synthetics_enablement/index.ts
@@ -18,10 +18,11 @@ import {
   getSyntheticsEnablementFailure,
 } from './actions';
 import { MonitorManagementEnablementResult } from '../../../../../common/runtime_types';
+import { IHttpSerializedFetchError } from '../utils/http_error';
 
 export interface SyntheticsEnablementState {
   loading: boolean;
-  error: Error | null;
+  error: IHttpSerializedFetchError | null;
   enablement: MonitorManagementEnablementResult | null;
 }
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
@@ -6,13 +6,13 @@
  */
 
 import { createAction } from '@reduxjs/toolkit';
-import type { IHttpFetchError } from '@kbn/core-http-browser';
+import type { IHttpSerializedFetchError } from './http_error';
 
 export function createAsyncAction<Payload, SuccessPayload>(actionStr: string) {
   return {
     get: createAction<Payload>(actionStr),
     success: createAction<SuccessPayload>(`${actionStr}_SUCCESS`),
-    fail: createAction<IHttpFetchError>(`${actionStr}_FAIL`),
+    fail: createAction<IHttpSerializedFetchError>(`${actionStr}_FAIL`),
   };
 }
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/fetch_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/fetch_effect.ts
@@ -8,6 +8,7 @@
 import { call, put } from 'redux-saga/effects';
 import { PayloadAction } from '@reduxjs/toolkit';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { IHttpSerializedFetchError, serializeHttpFetchError } from './http_error';
 
 /**
  * Factory function for a fetch effect. It expects three action creators,
@@ -23,7 +24,7 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 export function fetchEffectFactory<T, R, S, F>(
   fetch: (request: T) => Promise<R>,
   success: (response: R) => PayloadAction<S>,
-  fail: (error: IHttpFetchError) => PayloadAction<F>
+  fail: (error: IHttpSerializedFetchError) => PayloadAction<F>
 ) {
   return function* (action: PayloadAction<T>): Generator {
     try {
@@ -32,14 +33,14 @@ export function fetchEffectFactory<T, R, S, F>(
         // eslint-disable-next-line no-console
         console.error(response);
 
-        yield put(fail(response as IHttpFetchError));
+        yield put(fail(serializeHttpFetchError(response as IHttpFetchError)));
       } else {
         yield put(success(response as R));
       }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);
-      yield put(fail(error as IHttpFetchError));
+      yield put(fail(serializeHttpFetchError(error)));
     }
   };
 }

--- a/x-pack/plugins/synthetics/public/legacy_uptime/state/private_locations/index.ts
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/state/private_locations/index.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import { createReducer } from '@reduxjs/toolkit';
 import { AgentPolicy } from '@kbn/fleet-plugin/common';
+import { IHttpSerializedFetchError } from '../../../apps/synthetics/state';
 import {
   getAgentPoliciesAction,
   setAddingNewPrivateLocation,
@@ -24,7 +24,7 @@ export interface AgentPoliciesList {
 export interface AgentPoliciesState {
   data: AgentPoliciesList | null;
   loading: boolean;
-  error: IHttpFetchError<ResponseErrorBody> | null;
+  error: IHttpSerializedFetchError | null;
   isManageFlyoutOpen?: boolean;
   isAddingNewPrivateLocation?: boolean;
 }
@@ -47,7 +47,7 @@ export const agentPoliciesReducer = createReducer(initialState, (builder) => {
       state.loading = false;
     })
     .addCase(getAgentPoliciesAction.fail, (state, action) => {
-      state.error = action.payload as IHttpFetchError<ResponseErrorBody>;
+      state.error = action.payload;
       state.loading = false;
     })
     .addCase(setManageFlyoutOpen, (state, action) => {


### PR DESCRIPTION
## Summary

Resolves #140966.

Per the linked issue, we are receiving lots of messages from Redux in places where we attempt to supply objects of type `Error` or similar, non-serializable data to Redux.

In numerous reducers, we're already referencing a utility function that performs the serialization in some cases. I've deleted those usages and moved the serialization call into our general-purpose http request effect so that all the reducers can benefit. This did require numerous re-typings of our reducer contracts, but in many cases the error field is never actually referenced, or only referenced in a cursory way (i.e., is it truthy?), so the real-world impact on user-facing functionality is either negligible or altogether immaterial.

## Testing this PR

Choose an API endpoint used by Synthetics UI (one where there wasn't already serialization happening) and hardcode an error on the server side. On main, you should see an error logged in your browser's console like:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/18429259/193110654-ef0deef3-e6d9-4cdd-807d-f55f15c7db35.png">

Checkout this branch, refresh the page, and you should no longer see the error in the console.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->