### PR TITLE
[Dashboard] Fix pinned filters being backed up into Session Storage

### DIFF
--- a/src/plugins/dashboard/public/application/lib/diff_dashboard_state.ts
+++ b/src/plugins/dashboard/public/application/lib/diff_dashboard_state.ts
@@ -101,11 +101,16 @@ export const diffDashboardState = async ({
     getEmbeddable
   );
   const optionsAreEqual = getOptionsAreEqual(originalState.options, newState.options);
-  const filtersAreEqual = getFiltersAreEqual(originalState.filters, newState.filters, true);
   const controlGroupIsEqual = persistableControlGroupInputIsEqual(
     originalState.controlGroupInput,
     newState.controlGroupInput
   );
+
+  const filterStateDiff = getFiltersAreEqual(originalState.filters, newState.filters, true)
+    ? {}
+    : {
+        filters: newState.filters.filter((f) => !isFilterPinned(f)),
+      };
 
   const timeStatediff = getTimeSettingsAreEqual({
     currentTimeRestore: newState.timeRestore,
@@ -117,9 +122,9 @@ export const diffDashboardState = async ({
   return {
     ...commonStateDiff,
     ...(panelsAreEqual ? {} : { panels: newState.panels }),
-    ...(filtersAreEqual ? {} : { filters: newState.filters }),
     ...(optionsAreEqual ? {} : { options: newState.options }),
     ...(controlGroupIsEqual ? {} : { controlGroupInput: newState.controlGroupInput }),
+    ...filterStateDiff,
     ...timeStatediff,
   };
 };
@@ -174,7 +179,7 @@ const getFiltersAreEqual = (
   ignorePinned?: boolean
 ): boolean => {
   return compareFilters(
-    filtersA,
+    ignorePinned ? filtersA.filter((f) => !isFilterPinned(f)) : filtersA,
     ignorePinned ? filtersB.filter((f) => !isFilterPinned(f)) : filtersB,
     COMPARE_ALL_OPTIONS
   );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/142161 by ensuring that no Pinned filters are backed up into session storage, and that no pinned filters are considered `unsaved changes`.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->