### PR TITLE
feat(slo): Handle updating SLO

### DIFF
--- a/x-pack/plugins/observability/server/assets/constants.ts
+++ b/x-pack/plugins/observability/server/assets/constants.ts
@@ -12,4 +12,5 @@ export const SLO_RESOURCES_VERSION = 1;
 export const SLO_INGEST_PIPELINE_NAME = `${SLO_INDEX_TEMPLATE_NAME}.monthly`;
 export const SLO_DESTINATION_INDEX_NAME = `${SLO_INDEX_TEMPLATE_NAME}-v${SLO_RESOURCES_VERSION}`;
 
-export const getSLOTransformId = (sloId: string) => `slo-${sloId}`;
+export const getSLOTransformId = (sloId: string, sloRevision: number) =>
+  `slo-${sloId}-${sloRevision}`;

--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -12,22 +12,23 @@ import {
   DefaultTransformManager,
   KibanaSavedObjectsSLORepository,
   GetSLO,
+  UpdateSLO,
 } from '../../services/slo';
-
 import {
   ApmTransactionDurationTransformGenerator,
   ApmTransactionErrorRateTransformGenerator,
   TransformGenerator,
 } from '../../services/slo/transform_generators';
-import { SLITypes } from '../../types/models';
+import { IndicatorTypes } from '../../types/models';
 import {
   createSLOParamsSchema,
   deleteSLOParamsSchema,
   getSLOParamsSchema,
+  updateSLOParamsSchema,
 } from '../../types/rest_specs';
 import { createObservabilityServerRoute } from '../create_observability_server_route';
 
-const transformGenerators: Record<SLITypes, TransformGenerator> = {
+const transformGenerators: Record<IndicatorTypes, TransformGenerator> = {
   'slo.apm.transaction_duration': new ApmTransactionDurationTransformGenerator(),
   'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
 };
@@ -48,6 +49,26 @@ const createSLORoute = createObservabilityServerRoute({
     const createSLO = new CreateSLO(resourceInstaller, repository, transformManager);
 
     const response = await createSLO.execute(params.body);
+
+    return response;
+  },
+});
+
+const updateSLORoute = createObservabilityServerRoute({
+  endpoint: 'PUT /api/observability/slos/{id}',
+  options: {
+    tags: [],
+  },
+  params: updateSLOParamsSchema,
+  handler: async ({ context, params, logger }) => {
+    const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+    const soClient = (await context.core).savedObjects.client;
+
+    const repository = new KibanaSavedObjectsSLORepository(soClient);
+    const transformManager = new DefaultTransformManager(transformGenerators, esClient, logger);
+    const updateSLO = new UpdateSLO(repository, transformManager, esClient);
+
+    const response = await updateSLO.execute(params.path.id, params.body);
 
     return response;
   },
@@ -89,4 +110,9 @@ const getSLORoute = createObservabilityServerRoute({
   },
 });
 
-export const slosRouteRepository = { ...createSLORoute, ...getSLORoute, ...deleteSLORoute };
+export const slosRouteRepository = {
+  ...createSLORoute,
+  ...updateSLORoute,
+  ...getSLORoute,
+  ...deleteSLORoute,
+};

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -20,8 +20,8 @@ export class CreateSLO {
     private transformManager: TransformManager
   ) {}
 
-  public async execute(sloParams: CreateSLOParams): Promise<CreateSLOResponse> {
-    const slo = this.toSLO(sloParams);
+  public async execute(params: CreateSLOParams): Promise<CreateSLOResponse> {
+    const slo = this.toSLO(params);
 
     await this.resourceInstaller.ensureCommonResourcesInstalled();
     await this.repository.save(slo);
@@ -48,10 +48,14 @@ export class CreateSLO {
     return this.toResponse(slo);
   }
 
-  private toSLO(sloParams: CreateSLOParams): SLO {
+  private toSLO(params: CreateSLOParams): SLO {
+    const now = new Date();
     return {
-      ...sloParams,
+      ...params,
       id: uuid.v1(),
+      revision: 1,
+      created_at: now,
+      updated_at: now,
     };
   }
 

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
@@ -30,12 +30,17 @@ describe('DeleteSLO', () => {
   describe('happy path', () => {
     it('removes the transform, the roll up data and the SLO from the repository', async () => {
       const slo = createSLO(createAPMTransactionErrorRateIndicator());
+      mockRepository.findById.mockResolvedValueOnce(slo);
 
       await deleteSLO.execute(slo.id);
 
       expect(mockRepository.findById).toHaveBeenCalledWith(slo.id);
-      expect(mockTransformManager.stop).toHaveBeenCalledWith(getSLOTransformId(slo.id));
-      expect(mockTransformManager.uninstall).toHaveBeenCalledWith(getSLOTransformId(slo.id));
+      expect(mockTransformManager.stop).toHaveBeenCalledWith(
+        getSLOTransformId(slo.id, slo.revision)
+      );
+      expect(mockTransformManager.uninstall).toHaveBeenCalledWith(
+        getSLOTransformId(slo.id, slo.revision)
+      );
       expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           index: `${SLO_INDEX_TEMPLATE_NAME}*`,

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -19,15 +19,14 @@ export class DeleteSLO {
   ) {}
 
   public async execute(sloId: string): Promise<void> {
-    // ensure the slo exists on the request's space.
-    await this.repository.findById(sloId);
+    const slo = await this.repository.findById(sloId);
 
-    const sloTransformId = getSLOTransformId(sloId);
+    const sloTransformId = getSLOTransformId(slo.id, slo.revision);
     await this.transformManager.stop(sloTransformId);
     await this.transformManager.uninstall(sloTransformId);
 
-    await this.deleteRollupData(sloId);
-    await this.repository.deleteById(sloId);
+    await this.deleteRollupData(slo.id);
+    await this.repository.deleteById(slo.id);
   }
 
   private async deleteRollupData(sloId: string): Promise<void> {

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -6,10 +6,15 @@
  */
 
 import uuid from 'uuid';
-import { SLI, SLO } from '../../../types/models';
+import {
+  APMTransactionDurationIndicator,
+  APMTransactionErrorRateIndicator,
+  Indicator,
+  SLO,
+} from '../../../types/models';
 import { CreateSLOParams } from '../../../types/rest_specs';
 
-const commonSLO: Omit<CreateSLOParams, 'indicator'> = {
+const defaultSLO: Omit<SLO, 'indicator' | 'id' | 'created_at' | 'updated_at'> = {
   name: 'irrelevant',
   description: 'irrelevant',
   time_window: {
@@ -20,20 +25,29 @@ const commonSLO: Omit<CreateSLOParams, 'indicator'> = {
   objective: {
     target: 0.999,
   },
+  revision: 1,
 };
 
-export const createSLOParams = (indicator: SLI): CreateSLOParams => ({
-  ...commonSLO,
+export const createSLOParams = (indicator: Indicator): CreateSLOParams => ({
+  ...defaultSLO,
   indicator,
 });
 
-export const createSLO = (indicator: SLI): SLO => ({
-  ...commonSLO,
-  id: uuid.v1(),
-  indicator,
-});
+export const createSLO = (indicator: Indicator): SLO => {
+  const now = new Date();
+  return {
+    ...defaultSLO,
+    id: uuid.v1(),
+    indicator,
+    revision: 1,
+    created_at: now,
+    updated_at: now,
+  };
+};
 
-export const createAPMTransactionErrorRateIndicator = (params = {}): SLI => ({
+export const createAPMTransactionErrorRateIndicator = (
+  params: Partial<APMTransactionErrorRateIndicator['params']> = {}
+): Indicator => ({
   type: 'slo.apm.transaction_error_rate',
   params: {
     environment: 'irrelevant',
@@ -45,7 +59,9 @@ export const createAPMTransactionErrorRateIndicator = (params = {}): SLI => ({
   },
 });
 
-export const createAPMTransactionDurationIndicator = (params = {}): SLI => ({
+export const createAPMTransactionDurationIndicator = (
+  params: Partial<APMTransactionDurationIndicator['params']> = {}
+): Indicator => ({
   type: 'slo.apm.transaction_duration',
   params: {
     environment: 'irrelevant',

--- a/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
@@ -49,6 +49,9 @@ describe('GetSLO', () => {
           duration: '7d',
           is_rolling: true,
         },
+        created_at: slo.created_at,
+        updated_at: slo.updated_at,
+        revision: slo.revision,
       });
     });
   });

--- a/x-pack/plugins/observability/server/services/slo/get_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_slo.ts
@@ -26,6 +26,9 @@ export class GetSLO {
       time_window: slo.time_window,
       budgeting_method: slo.budgeting_method,
       objective: slo.objective,
+      revision: slo.revision,
+      created_at: slo.created_at,
+      updated_at: slo.updated_at,
     };
   }
 }

--- a/x-pack/plugins/observability/server/services/slo/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/index.ts
@@ -11,3 +11,4 @@ export * from './transform_manager';
 export * from './create_slo';
 export * from './delete_slo';
 export * from './get_slo';
+export * from './update_slo';

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -20,11 +20,7 @@ const SOME_SLO = createSLO(createAPMTransactionDurationIndicator());
 function aStoredSLO(slo: SLO): SavedObject<StoredSLO> {
   return {
     id: slo.id,
-    attributes: {
-      ...slo,
-      updated_at: new Date().toISOString(),
-      created_at: new Date().toISOString(),
-    },
+    attributes: slo,
     type: SO_SLO_TYPE,
     references: [],
   };

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -69,7 +69,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
         updated_at: expect.anything(),
         created_at: expect.anything(),
       }),
-      { id: SOME_SLO.id }
+      { id: SOME_SLO.id, overwrite: true }
     );
   });
 

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.ts
@@ -22,24 +22,15 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
   constructor(private soClient: SavedObjectsClientContract) {}
 
   async save(slo: SLO): Promise<SLO> {
-    const now = new Date().toISOString();
-    const savedSLO = await this.soClient.create<StoredSLO>(
-      SO_SLO_TYPE,
-      {
-        ...slo,
-        created_at: now,
-        updated_at: now,
-      },
-      { id: slo.id }
-    );
+    const savedSLO = await this.soClient.create<StoredSLO>(SO_SLO_TYPE, slo, { id: slo.id });
 
-    return toSLOModel(savedSLO.attributes);
+    return savedSLO.attributes;
   }
 
   async findById(id: string): Promise<SLO> {
     try {
       const slo = await this.soClient.get<StoredSLO>(SO_SLO_TYPE, id);
-      return toSLOModel(slo.attributes);
+      return slo.attributes;
     } catch (err) {
       if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
         throw new SLONotFound(`SLO [${id}] not found`);
@@ -58,16 +49,4 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
       throw err;
     }
   }
-}
-
-function toSLOModel(slo: StoredSLO): SLO {
-  return {
-    id: slo.id,
-    name: slo.name,
-    description: slo.description,
-    indicator: slo.indicator,
-    time_window: slo.time_window,
-    budgeting_method: slo.budgeting_method,
-    objective: slo.objective,
-  };
 }

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.ts
@@ -22,7 +22,10 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
   constructor(private soClient: SavedObjectsClientContract) {}
 
   async save(slo: SLO): Promise<SLO> {
-    const savedSLO = await this.soClient.create<StoredSLO>(SO_SLO_TYPE, slo, { id: slo.id });
+    const savedSLO = await this.soClient.create<StoredSLO>(SO_SLO_TYPE, slo, {
+      id: slo.id,
+      overwrite: true,
+    });
 
     return savedSLO.attributes;
   }

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -82,6 +82,11 @@ Object {
           "field": "slo.id",
         },
       },
+      "slo.revision": Object {
+        "terms": Object {
+          "field": "slo.revision",
+        },
+      },
     },
   },
   "settings": Object {
@@ -126,6 +131,12 @@ Object {
           "source": Any<String>,
         },
         "type": "keyword",
+      },
+      "slo.revision": Object {
+        "script": Object {
+          "source": "emit(1)",
+        },
+        "type": "long",
       },
     },
   },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -87,6 +87,11 @@ Object {
           "field": "slo.id",
         },
       },
+      "slo.revision": Object {
+        "terms": Object {
+          "field": "slo.revision",
+        },
+      },
     },
   },
   "settings": Object {
@@ -131,6 +136,12 @@ Object {
           "source": Any<String>,
         },
         "type": "keyword",
+      },
+      "slo.revision": Object {
+        "script": Object {
+          "source": "emit(1)",
+        },
+        "type": "long",
       },
     },
   },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.test.ts
@@ -19,9 +19,12 @@ describe('APM Transaction Duration Transform Generator', () => {
       transform_id: expect.any(String),
       source: { runtime_mappings: { 'slo.id': { script: { source: expect.any(String) } } } },
     });
-    expect(transform.transform_id).toEqual(`slo-${anSLO.id}`);
+    expect(transform.transform_id).toEqual(`slo-${anSLO.id}-${anSLO.revision}`);
     expect(transform.source.runtime_mappings!['slo.id']).toMatchObject({
       script: { source: `emit('${anSLO.id}')` },
+    });
+    expect(transform.source.runtime_mappings!['slo.revision']).toMatchObject({
+      script: { source: `emit(${anSLO.revision})` },
     });
   });
 

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -10,71 +10,67 @@ import {
   MappingRuntimeFieldType,
   TransformPutTransformRequest,
 } from '@elastic/elasticsearch/lib/api/types';
-import { ALL_VALUE } from '../../../types/schema';
+import { ALL_VALUE, apmTransactionDurationIndicatorSchema } from '../../../types/schema';
 import {
   SLO_DESTINATION_INDEX_NAME,
   SLO_INGEST_PIPELINE_NAME,
   getSLOTransformId,
 } from '../../../assets/constants';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
-import {
-  SLO,
-  apmTransactionDurationSLOSchema,
-  APMTransactionDurationSLO,
-} from '../../../types/models';
+import { SLO, APMTransactionDurationIndicator } from '../../../types/models';
 import { TransformGenerator } from '.';
 
 const APM_SOURCE_INDEX = 'metrics-apm*';
 
 export class ApmTransactionDurationTransformGenerator implements TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
-    if (!apmTransactionDurationSLOSchema.is(slo)) {
+    if (!apmTransactionDurationIndicatorSchema.is(slo.indicator)) {
       throw new Error(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
     }
 
     return getSLOTransformTemplate(
       this.buildTransformId(slo),
-      this.buildSource(slo),
+      this.buildSource(slo, slo.indicator),
       this.buildDestination(),
       this.buildGroupBy(),
-      this.buildAggregations(slo)
+      this.buildAggregations(slo.indicator)
     );
   }
 
-  private buildTransformId(slo: APMTransactionDurationSLO): string {
+  private buildTransformId(slo: SLO): string {
     return getSLOTransformId(slo.id, slo.revision);
   }
 
-  private buildSource(slo: APMTransactionDurationSLO) {
+  private buildSource(slo: SLO, indicator: APMTransactionDurationIndicator) {
     const queryFilter = [];
-    if (slo.indicator.params.service !== ALL_VALUE) {
+    if (indicator.params.service !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'service.name': slo.indicator.params.service,
+          'service.name': indicator.params.service,
         },
       });
     }
 
-    if (slo.indicator.params.environment !== ALL_VALUE) {
+    if (indicator.params.environment !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'service.environment': slo.indicator.params.environment,
+          'service.environment': indicator.params.environment,
         },
       });
     }
 
-    if (slo.indicator.params.transaction_name !== ALL_VALUE) {
+    if (indicator.params.transaction_name !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'transaction.name': slo.indicator.params.transaction_name,
+          'transaction.name': indicator.params.transaction_name,
         },
       });
     }
 
-    if (slo.indicator.params.transaction_type !== ALL_VALUE) {
+    if (indicator.params.transaction_type !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'transaction.type': slo.indicator.params.transaction_type,
+          'transaction.type': indicator.params.transaction_type,
         },
       });
     }
@@ -158,8 +154,8 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
     };
   }
 
-  private buildAggregations(slo: APMTransactionDurationSLO) {
-    const truncatedThreshold = Math.trunc(slo.indicator.params['threshold.us']);
+  private buildAggregations(indicator: APMTransactionDurationIndicator) {
+    const truncatedThreshold = Math.trunc(indicator.params['threshold.us']);
 
     return {
       _numerator: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -42,7 +42,7 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
   }
 
   private buildTransformId(slo: APMTransactionDurationSLO): string {
-    return getSLOTransformId(slo.id);
+    return getSLOTransformId(slo.id, slo.revision);
   }
 
   private buildSource(slo: APMTransactionDurationSLO) {
@@ -88,6 +88,12 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
             source: `emit('${slo.id}')`,
           },
         },
+        'slo.revision': {
+          type: 'long' as MappingRuntimeFieldType,
+          script: {
+            source: `emit(${slo.revision})`,
+          },
+        },
       },
       query: {
         bool: {
@@ -116,6 +122,11 @@ export class ApmTransactionDurationTransformGenerator implements TransformGenera
       'slo.id': {
         terms: {
           field: 'slo.id',
+        },
+      },
+      'slo.revision': {
+        terms: {
+          field: 'slo.revision',
         },
       },
       '@timestamp': {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
@@ -19,9 +19,12 @@ describe('APM Transaction Error Rate Transform Generator', () => {
       transform_id: expect.any(String),
       source: { runtime_mappings: { 'slo.id': { script: { source: expect.any(String) } } } },
     });
-    expect(transform.transform_id).toEqual(`slo-${anSLO.id}`);
+    expect(transform.transform_id).toEqual(`slo-${anSLO.id}-${anSLO.revision}`);
     expect(transform.source.runtime_mappings!['slo.id']).toMatchObject({
       script: { source: `emit('${anSLO.id}')` },
+    });
+    expect(transform.source.runtime_mappings!['slo.revision']).toMatchObject({
+      script: { source: `emit(${anSLO.revision})` },
     });
   });
 

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -44,7 +44,7 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
   }
 
   private buildTransformId(slo: APMTransactionErrorRateSLO): string {
-    return getSLOTransformId(slo.id);
+    return getSLOTransformId(slo.id, slo.revision);
   }
 
   private buildSource(slo: APMTransactionErrorRateSLO) {
@@ -90,6 +90,12 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
             source: `emit('${slo.id}')`,
           },
         },
+        'slo.revision': {
+          type: 'long' as MappingRuntimeFieldType,
+          script: {
+            source: `emit(${slo.revision})`,
+          },
+        },
       },
       query: {
         bool: {
@@ -118,6 +124,11 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
       'slo.id': {
         terms: {
           field: 'slo.id',
+        },
+      },
+      'slo.revision': {
+        terms: {
+          field: 'slo.revision',
         },
       },
       '@timestamp': {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -10,7 +10,7 @@ import {
   MappingRuntimeFieldType,
   TransformPutTransformRequest,
 } from '@elastic/elasticsearch/lib/api/types';
-import { ALL_VALUE } from '../../../types/schema';
+import { ALL_VALUE, apmTransactionErrorRateIndicatorSchema } from '../../../types/schema';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
 import { TransformGenerator } from '.';
 import {
@@ -18,11 +18,7 @@ import {
   SLO_INGEST_PIPELINE_NAME,
   getSLOTransformId,
 } from '../../../assets/constants';
-import {
-  apmTransactionErrorRateSLOSchema,
-  APMTransactionErrorRateSLO,
-  SLO,
-} from '../../../types/models';
+import { APMTransactionErrorRateIndicator, SLO } from '../../../types/models';
 
 const APM_SOURCE_INDEX = 'metrics-apm*';
 const ALLOWED_STATUS_CODES = ['2xx', '3xx', '4xx', '5xx'];
@@ -30,53 +26,53 @@ const DEFAULT_GOOD_STATUS_CODES = ['2xx', '3xx', '4xx'];
 
 export class ApmTransactionErrorRateTransformGenerator implements TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
-    if (!apmTransactionErrorRateSLOSchema.is(slo)) {
+    if (!apmTransactionErrorRateIndicatorSchema.is(slo.indicator)) {
       throw new Error(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
     }
 
     return getSLOTransformTemplate(
       this.buildTransformId(slo),
-      this.buildSource(slo),
+      this.buildSource(slo, slo.indicator),
       this.buildDestination(),
       this.buildGroupBy(),
-      this.buildAggregations(slo)
+      this.buildAggregations(slo, slo.indicator)
     );
   }
 
-  private buildTransformId(slo: APMTransactionErrorRateSLO): string {
+  private buildTransformId(slo: SLO): string {
     return getSLOTransformId(slo.id, slo.revision);
   }
 
-  private buildSource(slo: APMTransactionErrorRateSLO) {
+  private buildSource(slo: SLO, indicator: APMTransactionErrorRateIndicator) {
     const queryFilter = [];
-    if (slo.indicator.params.service !== ALL_VALUE) {
+    if (indicator.params.service !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'service.name': slo.indicator.params.service,
+          'service.name': indicator.params.service,
         },
       });
     }
 
-    if (slo.indicator.params.environment !== ALL_VALUE) {
+    if (indicator.params.environment !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'service.environment': slo.indicator.params.environment,
+          'service.environment': indicator.params.environment,
         },
       });
     }
 
-    if (slo.indicator.params.transaction_name !== ALL_VALUE) {
+    if (indicator.params.transaction_name !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'transaction.name': slo.indicator.params.transaction_name,
+          'transaction.name': indicator.params.transaction_name,
         },
       });
     }
 
-    if (slo.indicator.params.transaction_type !== ALL_VALUE) {
+    if (indicator.params.transaction_type !== ALL_VALUE) {
       queryFilter.push({
         match: {
-          'transaction.type': slo.indicator.params.transaction_type,
+          'transaction.type': indicator.params.transaction_type,
         },
       });
     }
@@ -160,10 +156,8 @@ export class ApmTransactionErrorRateTransformGenerator implements TransformGener
     };
   }
 
-  private buildAggregations(slo: APMTransactionErrorRateSLO) {
-    const goodStatusCodesFilter = this.getGoodStatusCodesFilter(
-      slo.indicator.params.good_status_codes
-    );
+  private buildAggregations(slo: SLO, indicator: APMTransactionErrorRateIndicator) {
+    const goodStatusCodesFilter = this.getGoodStatusCodesFilter(indicator.params.good_status_codes);
 
     return {
       'slo.numerator': {

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
@@ -20,7 +20,7 @@ import {
   ApmTransactionErrorRateTransformGenerator,
   TransformGenerator,
 } from './transform_generators';
-import { SLO, SLITypes } from '../../types/models';
+import { SLO, IndicatorTypes } from '../../types/models';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 
 describe('TransformManager', () => {
@@ -36,7 +36,7 @@ describe('TransformManager', () => {
     describe('Unhappy path', () => {
       it('throws when no generator exists for the slo indicator type', async () => {
         // @ts-ignore defining only a subset of the possible SLI
-        const generators: Record<SLITypes, TransformGenerator> = {
+        const generators: Record<IndicatorTypes, TransformGenerator> = {
           'slo.apm.transaction_duration': new DummyTransformGenerator(),
         };
         const service = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -58,7 +58,7 @@ describe('TransformManager', () => {
 
       it('throws when transform generator fails', async () => {
         // @ts-ignore defining only a subset of the possible SLI
-        const generators: Record<SLITypes, TransformGenerator> = {
+        const generators: Record<IndicatorTypes, TransformGenerator> = {
           'slo.apm.transaction_duration': new FailTransformGenerator(),
         };
         const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -82,7 +82,7 @@ describe('TransformManager', () => {
 
     it('installs the transform', async () => {
       // @ts-ignore defining only a subset of the possible SLI
-      const generators: Record<SLITypes, TransformGenerator> = {
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
         'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
       };
       const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -98,7 +98,7 @@ describe('TransformManager', () => {
   describe('Start', () => {
     it('starts the transform', async () => {
       // @ts-ignore defining only a subset of the possible SLI
-      const generators: Record<SLITypes, TransformGenerator> = {
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
         'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
       };
       const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -112,7 +112,7 @@ describe('TransformManager', () => {
   describe('Stop', () => {
     it('stops the transform', async () => {
       // @ts-ignore defining only a subset of the possible SLI
-      const generators: Record<SLITypes, TransformGenerator> = {
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
         'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
       };
       const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -126,7 +126,7 @@ describe('TransformManager', () => {
   describe('Uninstall', () => {
     it('uninstalls the transform', async () => {
       // @ts-ignore defining only a subset of the possible SLI
-      const generators: Record<SLITypes, TransformGenerator> = {
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
         'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
       };
       const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
@@ -141,7 +141,7 @@ describe('TransformManager', () => {
         new EsErrors.ConnectionError('irrelevant')
       );
       // @ts-ignore defining only a subset of the possible SLI
-      const generators: Record<SLITypes, TransformGenerator> = {
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
         'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
       };
       const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
@@ -91,7 +91,7 @@ describe('TransformManager', () => {
       const transformId = await transformManager.install(slo);
 
       expect(esClientMock.transform.putTransform).toHaveBeenCalledTimes(1);
-      expect(transformId).toBe(`slo-${slo.id}`);
+      expect(transformId).toBe(`slo-${slo.id}-${slo.revision}`);
     });
   });
 

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.ts
@@ -7,7 +7,7 @@
 
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 
-import { SLO, SLITypes } from '../../types/models';
+import { SLO, IndicatorTypes } from '../../types/models';
 import { retryTransientEsErrors } from '../../utils/retry';
 import { TransformGenerator } from './transform_generators';
 
@@ -22,7 +22,7 @@ export interface TransformManager {
 
 export class DefaultTransformManager implements TransformManager {
   constructor(
-    private generators: Record<SLITypes, TransformGenerator>,
+    private generators: Record<IndicatorTypes, TransformGenerator>,
     private esClient: ElasticsearchClient,
     private logger: Logger
   ) {}

--- a/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core/server';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { getSLOTransformId } from '../../assets/constants';
+import { SLO } from '../../types/models';
+import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
+import { createSLORepositoryMock, createTransformManagerMock } from './mocks';
+import { SLORepository } from './slo_repository';
+import { TransformManager } from './transform_manager';
+import { UpdateSLO } from './update_slo';
+
+describe('UpdateSLO', () => {
+  let mockRepository: jest.Mocked<SLORepository>;
+  let mockTransformManager: jest.Mocked<TransformManager>;
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let updateSLO: UpdateSLO;
+
+  beforeEach(() => {
+    mockRepository = createSLORepositoryMock();
+    mockTransformManager = createTransformManagerMock();
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+    updateSLO = new UpdateSLO(mockRepository, mockTransformManager, mockEsClient);
+  });
+
+  describe('without breaking changes', () => {
+    it('updates the SLO saved object without revision bump', async () => {
+      const slo = createSLO(createAPMTransactionErrorRateIndicator());
+      mockRepository.findById.mockResolvedValueOnce(slo);
+
+      const newName = 'new slo name';
+      const response = await updateSLO.execute(slo.id, { name: newName });
+
+      expectTransformManagerNeverCalled();
+      expect(mockEsClient.deleteByQuery).not.toBeCalled();
+      expect(mockRepository.save).toBeCalledWith(
+        expect.objectContaining({ ...slo, name: newName, updated_at: expect.anything() })
+      );
+      expect(response.name).toBe(newName);
+      expect(response.updated_at).not.toBe(slo.updated_at);
+    });
+  });
+
+  describe('with breaking changes', () => {
+    it('removes the obsolete data from the SLO previous revision', async () => {
+      const slo = createSLO(createAPMTransactionErrorRateIndicator({ environment: 'development' }));
+      mockRepository.findById.mockResolvedValueOnce(slo);
+
+      const newIndicator = createAPMTransactionErrorRateIndicator({ environment: 'production' });
+      await updateSLO.execute(slo.id, { indicator: newIndicator });
+
+      expectDeletionOfObsoleteSLOData(slo);
+      expect(mockRepository.save).toBeCalledWith(
+        expect.objectContaining({
+          ...slo,
+          indicator: newIndicator,
+          revision: 2,
+          updated_at: expect.anything(),
+        })
+      );
+      expectInstallationOfNewSLOTransform();
+    });
+  });
+
+  function expectTransformManagerNeverCalled() {
+    expect(mockTransformManager.stop).not.toBeCalled();
+    expect(mockTransformManager.uninstall).not.toBeCalled();
+    expect(mockTransformManager.start).not.toBeCalled();
+    expect(mockTransformManager.install).not.toBeCalled();
+  }
+
+  function expectInstallationOfNewSLOTransform() {
+    expect(mockTransformManager.start).toBeCalled();
+    expect(mockTransformManager.install).toBeCalled();
+  }
+
+  function expectDeletionOfObsoleteSLOData(originalSlo: SLO) {
+    const transformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
+    expect(mockTransformManager.stop).toBeCalledWith(transformId);
+    expect(mockTransformManager.uninstall).toBeCalledWith(transformId);
+    expect(mockEsClient.deleteByQuery).toBeCalledWith(
+      expect.objectContaining({
+        query: {
+          bool: {
+            filter: [
+              { term: { 'slo.id': originalSlo.id } },
+              { term: { 'slo.revision': originalSlo.revision } },
+            ],
+          },
+        },
+      })
+    );
+  }
+});

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import deepEqual from 'fast-deep-equal';
+import { ElasticsearchClient } from '@kbn/core/server';
+
+import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
+import { UpdateSLOParams, UpdateSLOResponse } from '../../types/rest_specs';
+import { SLORepository } from './slo_repository';
+import { TransformManager } from './transform_manager';
+import { SLO } from '../../types/models';
+
+export class UpdateSLO {
+  constructor(
+    private repository: SLORepository,
+    private transformManager: TransformManager,
+    private esClient: ElasticsearchClient
+  ) {}
+
+  public async execute(sloId: string, params: UpdateSLOParams): Promise<UpdateSLOResponse> {
+    const originalSlo = await this.repository.findById(sloId);
+    const { hasBreakingChange, updatedSlo } = this.updateSLO(originalSlo, params);
+
+    if (hasBreakingChange) {
+      await this.deleteObsoleteSLORevisionData(originalSlo);
+
+      await this.repository.save(updatedSlo);
+      await this.transformManager.install(updatedSlo);
+      await this.transformManager.start(getSLOTransformId(updatedSlo.id, updatedSlo.revision));
+    } else {
+      await this.repository.save(updatedSlo);
+    }
+
+    return this.toResponse(updatedSlo);
+  }
+
+  private updateSLO(originalSlo: SLO, params: UpdateSLOParams) {
+    let hasBreakingChange = false;
+    const updatedSlo: SLO = Object.assign({}, originalSlo, params, { updated_at: new Date() });
+
+    if (!deepEqual(originalSlo.indicator, updatedSlo.indicator)) {
+      hasBreakingChange = true;
+    }
+
+    if (hasBreakingChange) {
+      updatedSlo.revision++;
+    }
+
+    return { hasBreakingChange, updatedSlo };
+  }
+
+  private async deleteObsoleteSLORevisionData(originalSlo: SLO) {
+    const originalSloTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
+    await this.transformManager.stop(originalSloTransformId);
+    await this.transformManager.uninstall(originalSloTransformId);
+    await this.deleteRollupData(originalSlo.id, originalSlo.revision);
+  }
+
+  private async deleteRollupData(sloId: string, sloRevision: number): Promise<void> {
+    await this.esClient.deleteByQuery({
+      index: `${SLO_INDEX_TEMPLATE_NAME}*`,
+      wait_for_completion: false,
+      query: {
+        bool: {
+          filter: [{ term: { 'slo.id': sloId } }, { term: { 'slo.revision': sloRevision } }],
+        },
+      },
+    });
+  }
+
+  private toResponse(slo: SLO): UpdateSLOResponse {
+    return {
+      id: slo.id,
+      name: slo.name,
+      description: slo.description,
+      indicator: slo.indicator,
+      budgeting_method: slo.budgeting_method,
+      time_window: slo.time_window,
+      objective: slo.objective,
+      created_at: slo.created_at,
+      updated_at: slo.updated_at,
+    };
+  }
+}

--- a/x-pack/plugins/observability/server/types/models/slo.ts
+++ b/x-pack/plugins/observability/server/types/models/slo.ts
@@ -30,28 +30,11 @@ const sloSchema = t.type({
   updated_at: dateType,
 });
 
-const apmTransactionErrorRateSLOSchema = t.intersection([
-  sloSchema,
-  t.type({ indicator: apmTransactionErrorRateIndicatorSchema }),
-]);
-
-const apmTransactionDurationSLOSchema = t.intersection([
-  sloSchema,
-  t.type({ indicator: apmTransactionDurationIndicatorSchema }),
-]);
-
 const storedSLOSchema = sloSchema;
 
-export {
-  sloSchema,
-  storedSLOSchema,
-  apmTransactionDurationSLOSchema,
-  apmTransactionErrorRateSLOSchema,
-};
+export { sloSchema, storedSLOSchema };
 
 type SLO = t.TypeOf<typeof sloSchema>;
-type APMTransactionErrorRateSLO = t.TypeOf<typeof apmTransactionErrorRateSLOSchema>;
-type APMTransactionDurationSLO = t.TypeOf<typeof apmTransactionDurationSLOSchema>;
 
 type APMTransactionErrorRateIndicator = t.TypeOf<typeof apmTransactionErrorRateIndicatorSchema>;
 type APMTransactionDurationIndicator = t.TypeOf<typeof apmTransactionDurationIndicatorSchema>;
@@ -62,8 +45,6 @@ type StoredSLO = t.TypeOf<typeof storedSLOSchema>;
 
 export type {
   SLO,
-  APMTransactionErrorRateSLO,
-  APMTransactionDurationSLO,
   Indicator,
   IndicatorTypes,
   APMTransactionErrorRateIndicator,

--- a/x-pack/plugins/observability/server/types/models/slo.ts
+++ b/x-pack/plugins/observability/server/types/models/slo.ts
@@ -9,17 +9,26 @@ import * as t from 'io-ts';
 import {
   apmTransactionDurationIndicatorSchema,
   apmTransactionErrorRateIndicatorSchema,
+  budgetingMethodSchema,
+  dateType,
   indicatorSchema,
   indicatorTypesSchema,
-  commonSLOSchema,
+  objectiveSchema,
+  rollingTimeWindowSchema,
 } from '../schema';
 
-const sloSchema = t.intersection([
-  commonSLOSchema,
-  t.type({
-    id: t.string,
-  }),
-]);
+const sloSchema = t.type({
+  id: t.string,
+  name: t.string,
+  description: t.string,
+  indicator: indicatorSchema,
+  time_window: rollingTimeWindowSchema,
+  budgeting_method: budgetingMethodSchema,
+  objective: objectiveSchema,
+  revision: t.number,
+  created_at: dateType,
+  updated_at: dateType,
+});
 
 const apmTransactionErrorRateSLOSchema = t.intersection([
   sloSchema,
@@ -31,26 +40,33 @@ const apmTransactionDurationSLOSchema = t.intersection([
   t.type({ indicator: apmTransactionDurationIndicatorSchema }),
 ]);
 
-const storedSLOSchema = t.intersection([
+const storedSLOSchema = sloSchema;
+
+export {
   sloSchema,
-  t.type({ created_at: t.string, updated_at: t.string }),
-]);
+  storedSLOSchema,
+  apmTransactionDurationSLOSchema,
+  apmTransactionErrorRateSLOSchema,
+};
 
 type SLO = t.TypeOf<typeof sloSchema>;
 type APMTransactionErrorRateSLO = t.TypeOf<typeof apmTransactionErrorRateSLOSchema>;
 type APMTransactionDurationSLO = t.TypeOf<typeof apmTransactionDurationSLOSchema>;
 
-type SLI = t.TypeOf<typeof indicatorSchema>;
-type SLITypes = t.TypeOf<typeof indicatorTypesSchema>;
+type APMTransactionErrorRateIndicator = t.TypeOf<typeof apmTransactionErrorRateIndicatorSchema>;
+type APMTransactionDurationIndicator = t.TypeOf<typeof apmTransactionDurationIndicatorSchema>;
+type Indicator = t.TypeOf<typeof indicatorSchema>;
+type IndicatorTypes = t.TypeOf<typeof indicatorTypesSchema>;
 
 type StoredSLO = t.TypeOf<typeof storedSLOSchema>;
 
-export { apmTransactionDurationSLOSchema, apmTransactionErrorRateSLOSchema };
 export type {
   SLO,
   APMTransactionErrorRateSLO,
   APMTransactionDurationSLO,
-  SLI,
-  SLITypes,
+  Indicator,
+  IndicatorTypes,
+  APMTransactionErrorRateIndicator,
+  APMTransactionDurationIndicator,
   StoredSLO,
 };

--- a/x-pack/plugins/observability/server/types/rest_specs/slo.ts
+++ b/x-pack/plugins/observability/server/types/rest_specs/slo.ts
@@ -50,6 +50,9 @@ const getSLOResponseSchema = t.type({
 });
 
 const updateSLOParamsSchema = t.type({
+  path: t.type({
+    id: t.string,
+  }),
   body: t.partial({
     name: t.string,
     description: t.string,
@@ -60,10 +63,29 @@ const updateSLOParamsSchema = t.type({
   }),
 });
 
+const updateSLOResponseSchema = t.type({
+  id: t.string,
+  name: t.string,
+  description: t.string,
+  indicator: indicatorSchema,
+  time_window: rollingTimeWindowSchema,
+  budgeting_method: budgetingMethodSchema,
+  objective: objectiveSchema,
+  created_at: dateType,
+  updated_at: dateType,
+});
+
 type CreateSLOParams = t.TypeOf<typeof createSLOParamsSchema.props.body>;
 type CreateSLOResponse = t.TypeOf<typeof createSLOResponseSchema>;
 type GetSLOResponse = t.TypeOf<typeof getSLOResponseSchema>;
 type UpdateSLOParams = t.TypeOf<typeof updateSLOParamsSchema.props.body>;
+type UpdateSLOResponse = t.TypeOf<typeof updateSLOResponseSchema>;
 
 export { createSLOParamsSchema, deleteSLOParamsSchema, getSLOParamsSchema, updateSLOParamsSchema };
-export type { CreateSLOParams, CreateSLOResponse, GetSLOResponse, UpdateSLOParams };
+export type {
+  CreateSLOParams,
+  CreateSLOResponse,
+  GetSLOResponse,
+  UpdateSLOParams,
+  UpdateSLOResponse,
+};

--- a/x-pack/plugins/observability/server/types/rest_specs/slo.ts
+++ b/x-pack/plugins/observability/server/types/rest_specs/slo.ts
@@ -6,10 +6,18 @@
  */
 
 import * as t from 'io-ts';
-import { commonSLOSchema } from '../schema';
+import { dateType, indicatorSchema } from '../schema';
+import { budgetingMethodSchema, objectiveSchema, rollingTimeWindowSchema } from '../schema/slo';
 
 const createSLOParamsSchema = t.type({
-  body: commonSLOSchema,
+  body: t.type({
+    name: t.string,
+    description: t.string,
+    indicator: indicatorSchema,
+    time_window: rollingTimeWindowSchema,
+    budgeting_method: budgetingMethodSchema,
+    objective: objectiveSchema,
+  }),
 });
 
 const createSLOResponseSchema = t.type({
@@ -28,11 +36,34 @@ const getSLOParamsSchema = t.type({
   }),
 });
 
-const getSLOResponseSchema = t.intersection([t.type({ id: t.string }), commonSLOSchema]);
+const getSLOResponseSchema = t.type({
+  id: t.string,
+  name: t.string,
+  description: t.string,
+  indicator: indicatorSchema,
+  time_window: rollingTimeWindowSchema,
+  budgeting_method: budgetingMethodSchema,
+  objective: objectiveSchema,
+  revision: t.number,
+  created_at: dateType,
+  updated_at: dateType,
+});
+
+const updateSLOParamsSchema = t.type({
+  body: t.partial({
+    name: t.string,
+    description: t.string,
+    indicator: indicatorSchema,
+    time_window: rollingTimeWindowSchema,
+    budgeting_method: budgetingMethodSchema,
+    objective: objectiveSchema,
+  }),
+});
 
 type CreateSLOParams = t.TypeOf<typeof createSLOParamsSchema.props.body>;
 type CreateSLOResponse = t.TypeOf<typeof createSLOResponseSchema>;
 type GetSLOResponse = t.TypeOf<typeof getSLOResponseSchema>;
+type UpdateSLOParams = t.TypeOf<typeof updateSLOParamsSchema.props.body>;
 
-export { createSLOParamsSchema, deleteSLOParamsSchema, getSLOParamsSchema };
-export type { CreateSLOParams, CreateSLOResponse, GetSLOResponse };
+export { createSLOParamsSchema, deleteSLOParamsSchema, getSLOParamsSchema, updateSLOParamsSchema };
+export type { CreateSLOParams, CreateSLOResponse, GetSLOResponse, UpdateSLOParams };

--- a/x-pack/plugins/observability/server/types/schema/common.ts
+++ b/x-pack/plugins/observability/server/types/schema/common.ts
@@ -5,10 +5,22 @@
  * 2.0.
  */
 
+import { either } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
 
 const ALL_VALUE = '*';
 
 const allOrAnyString = t.union([t.literal(ALL_VALUE), t.string]);
 
-export { allOrAnyString, ALL_VALUE };
+const dateType = new t.Type<Date, string, unknown>(
+  'DateTime',
+  (input: unknown): input is Date => input instanceof Date,
+  (input: unknown, context: t.Context) =>
+    either.chain(t.string.validate(input, context), (value: string) => {
+      const decoded = new Date(value);
+      return isNaN(decoded.getTime()) ? t.failure(input, context) : t.success(decoded);
+    }),
+  (date: Date): string => date.toISOString()
+);
+
+export { allOrAnyString, ALL_VALUE, dateType };

--- a/x-pack/plugins/observability/server/types/schema/indicators.ts
+++ b/x-pack/plugins/observability/server/types/schema/indicators.ts
@@ -8,7 +8,7 @@
 import * as t from 'io-ts';
 import { allOrAnyString } from './common';
 
-const apmTransactionDurationIndicatorTypeSchema = t.literal('slo.apm.transaction_duration');
+const apmTransactionDurationIndicatorTypeSchema = t.literal<string>('slo.apm.transaction_duration');
 
 const apmTransactionDurationIndicatorSchema = t.type({
   type: apmTransactionDurationIndicatorTypeSchema,
@@ -21,7 +21,9 @@ const apmTransactionDurationIndicatorSchema = t.type({
   }),
 });
 
-const apmTransactionErrorRateIndicatorTypeSchema = t.literal('slo.apm.transaction_error_rate');
+const apmTransactionErrorRateIndicatorTypeSchema = t.literal<string>(
+  'slo.apm.transaction_error_rate'
+);
 
 const apmTransactionErrorRateIndicatorSchema = t.type({
   type: apmTransactionErrorRateIndicatorTypeSchema,

--- a/x-pack/plugins/observability/server/types/schema/slo.ts
+++ b/x-pack/plugins/observability/server/types/schema/slo.ts
@@ -7,11 +7,9 @@
 
 import * as t from 'io-ts';
 
-import { indicatorSchema } from './indicators';
-
 const rollingTimeWindowSchema = t.type({
   duration: t.string,
-  is_rolling: t.literal(true),
+  is_rolling: t.literal<boolean>(true),
 });
 
 const budgetingMethodSchema = t.literal('occurrences');
@@ -20,13 +18,4 @@ const objectiveSchema = t.type({
   target: t.number,
 });
 
-const commonSLOSchema = t.type({
-  name: t.string,
-  description: t.string,
-  indicator: indicatorSchema,
-  time_window: rollingTimeWindowSchema,
-  budgeting_method: budgetingMethodSchema,
-  objective: objectiveSchema,
-});
-
-export { commonSLOSchema, rollingTimeWindowSchema, budgetingMethodSchema, objectiveSchema };
+export { rollingTimeWindowSchema, budgetingMethodSchema, objectiveSchema };


### PR DESCRIPTION
## 📝 Summary

Related to https://github.com/elastic/kibana/issues/141283

This PR introduces the slo revision and uses the tuple (slo.id, slo.revision) when creating the related Transform and aggregating the data.
It also introduces the route to update an existing slo along the application service handling the update.

As explained in the related [story](https://github.com/elastic/kibana/issues/141283), an edit can be breaking or non breaking. 
For non-breaking changes, i.e. editing anything but the indicator: we only need to update the saved object without bumping the slo revision.
For breaking changes, i.e. changing the indicator: we need to remove the previously aggregated data and transform (could become optional later with an extra parameter if we want to retain the previous data), create a new transform and start it.


## ✅ Manual testing


1. Create a new slo
2. Check revision in kibana saved object, expect revision === 1
3. Update the slo without breaking changes (change the name, time_window, objective...)
4. Get the slo 
5. Assert
   1. SLO data has been updated
   2. Transform is still running
   3. Check revision in kibana saved object, expect revision === 1
3. Update the slo with breaking changes (change the indicator's environment for example)
4. Get the slo 
5. Assert
   1. SLO data has been updated, including indicator
   2. Previous transform (named `slo-{id}-1`) has been deleted
   3. New transform (named `slo-{id}-2`) is running
   4. Check revision in kibana saved object, expect revision === 2
 


### ⚙️  Useful requests

<details><summary>Create SLO</summary>

```
curl --request POST \
  --url http://localhost:5601/mgx/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "My SLO Availability",
	"description": "99% o11y-app all services availablility",
	"indicator": {
		"type": "slo.apm.transaction_error_rate",
		"params": {
			"environment": "development",
			"service": "o11y-app",
			"transaction_type": "request",
			"transaction_name": "GET /flaky",
			"good_status_codes": ["2xx", "3xx"]
		}
	},
	"time_window": {
		"duration": "7d",
		"is_rolling": true
	},
	"budgeting_method": "occurrences",
	"objective": {
		"target": 0.95
	}
}'
```
</details>


<details><summary>Update SLO (without breaking changes)</summary>

```
curl --request PUT \
  --url http://localhost:5601/mgx/api/observability/slos/7a42fe70-4022-11ed-93fe-659ac997b883 \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "My Updated SLO",
	"time_window": {
		"duration": "30d",
		"is_rolling": true
	}
}'
```
</details>


<details><summary>Update SLO (with breaking changes)</summary>

```
curl --request PUT \
  --url http://localhost:5601/mgx/api/observability/slos/7a42fe70-4022-11ed-93fe-659ac997b883 \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "Updated SLO bis",
	"indicator": {
		"type": "slo.apm.transaction_error_rate",
		"params": {
			"environment": "production",
			"service": "o11y-app",
			"transaction_type": "*",
			"transaction_name": "GET /flaky",
			"good_status_codes": [
				"2xx",
				"3xx",
				"4xx"
			]
		}
	}
}'
```
</details>



<details><summary>Get SLO</summary>

```
curl --request GET \
  --url http://localhost:5601/mgx/api/observability/slos/7a42fe70-4022-11ed-93fe-659ac997b883 \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'kbn-xsrf: oui'
```
</details>
