### PR TITLE
[Fleet] Respect `default_field: false` when generating index settings

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
@@ -48,6 +48,11 @@ describe('buildDefaultSettings', () => {
           name: 'field5Wildcard',
           type: 'wildcard',
         },
+        {
+          name: 'field6NotDefault',
+          type: 'keyword',
+          default_field: false,
+        },
       ],
     });
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
@@ -11,19 +11,20 @@ import type { Field, Fields } from '../../fields/field';
 const QUERY_DEFAULT_FIELD_TYPES = ['keyword', 'text', 'match_only_text', 'wildcard'];
 const QUERY_DEFAULT_FIELD_LIMIT = 1024;
 
-const flattenFieldsToNameAndType = (
+const flattenAndExtractFields = (
   fields: Fields,
   path: string = ''
-): Array<Pick<Field, 'name' | 'type'>> => {
-  let newFields: Array<Pick<Field, 'name' | 'type'>> = [];
+): Array<Pick<Field, 'name' | 'type' | 'default_field'>> => {
+  let newFields: Array<Pick<Field, 'name' | 'type' | 'default_field'>> = [];
   fields.forEach((field) => {
     const fieldName = path ? `${path}.${field.name}` : field.name;
     newFields.push({
       name: fieldName,
       type: field.type,
+      default_field: field.default_field,
     });
     if (field.fields && field.fields.length) {
-      newFields = newFields.concat(flattenFieldsToNameAndType(field.fields, fieldName));
+      newFields = newFields.concat(flattenAndExtractFields(field.fields, fieldName));
     }
   });
   return newFields;
@@ -45,8 +46,9 @@ export function buildDefaultSettings({
   const logger = appContextService.getLogger();
   // Find all field names to set `index.query.default_field` to, which will be
   // the first 1024 keyword or text fields
-  const defaultFields = flattenFieldsToNameAndType(fields).filter(
-    (field) => field.type && QUERY_DEFAULT_FIELD_TYPES.includes(field.type)
+  const defaultFields = flattenAndExtractFields(fields).filter(
+    (field) =>
+      field.type && QUERY_DEFAULT_FIELD_TYPES.includes(field.type) && field.default_field !== false
   );
   if (defaultFields.length > QUERY_DEFAULT_FIELD_LIMIT) {
     logger.warn(

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -37,6 +37,7 @@ export interface Field {
   include_in_root?: boolean;
   null_value?: string;
   dimension?: boolean;
+  default_field?: boolean;
 
   // Meta fields
   metric_type?: string;


### PR DESCRIPTION
## Summary

Fixes #139073. This PR makes sure Fleet recognizes `default_field: false` on field definitions and does not add those fields to the index setting `query.default_field` list even if the field meets other criteria.

## Test
Install Endpoint package, then look at the `logs-endpoint.alerts@package` component template. The field `Target.process.thread.Ext.parameter_bytes_compressed` should _not_ be present on the list of default fields.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->