### PR TITLE
[Security Solution] Update e2e tests to work with detection rules installed from a Fleet package

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -94,13 +94,13 @@ import {
   getNewThreatIndicatorRule,
   getNewRule,
   getNewThresholdRule,
-  totalNumberOfPrebuiltRules,
   getMachineLearningRule,
   getNewTermsRule,
 } from '../../objects/rule';
 import { getIndicatorMatchTimelineTemplate } from '../../objects/timeline';
 
 import { esArchiverResetKibana } from '../../tasks/es_archiver';
+import { getAvailablePrebuiltRulesCount } from '../../tasks/api_calls/prebuilt_rules';
 
 const RULE_NAME = 'Custom rule for bulk actions';
 
@@ -189,7 +189,9 @@ describe('Detection rules, bulk edit', () => {
       clickAddTagsMenuItem();
       waitForMixedRulesBulkEditModal(expectedNumberOfCustomRulesToBeEdited);
 
-      checkPrebuiltRulesCannotBeModified(totalNumberOfPrebuiltRules);
+      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        checkPrebuiltRulesCannotBeModified(availablePrebuiltRulesCount);
+      });
 
       // user can proceed with custom rule editing
       cy.get(MODAL_CONFIRMATION_BTN)
@@ -210,7 +212,9 @@ describe('Detection rules, bulk edit', () => {
       clickAddTagsMenuItem();
       waitForMixedRulesBulkEditModal(expectedNumberOfCustomRulesToBeEdited);
 
-      checkPrebuiltRulesCannotBeModified(totalNumberOfPrebuiltRules);
+      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        checkPrebuiltRulesCannotBeModified(availablePrebuiltRulesCount);
+      });
 
       // user cancels action and modal disappears
       cancelConfirmationModal();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules.cy.ts
@@ -5,39 +5,34 @@
  * 2.0.
  */
 
-import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../common/constants';
-import { rawRules } from '../../../server/lib/detection_engine/rules/prepackaged_rules';
 import {
   COLLAPSED_ACTION_BTN,
   ELASTIC_RULES_BTN,
-  pageSelector,
   RELOAD_PREBUILT_RULES_BTN,
   RULES_EMPTY_PROMPT,
-  RULE_SWITCH,
   RULES_MONITORING_TABLE,
+  RULES_ROW,
+  RULES_TABLE,
+  RULE_SWITCH,
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
-  RULE_NAME,
 } from '../../screens/alerts_detection_rules';
 import {
+  confirmRulesDelete,
   deleteFirstRule,
   deleteSelectedRules,
+  disableSelectedRules,
+  enableSelectedRules,
   loadPrebuiltDetectionRules,
   reloadDeletedRules,
+  selectAllRules,
   selectNumberOfRules,
   waitForPrebuiltDetectionRulesToBeLoaded,
-  selectAllRules,
-  confirmRulesDelete,
-  enableSelectedRules,
-  waitForRuleToChangeStatus,
-  disableSelectedRules,
-  changeRowsPerPageTo,
+  waitForRuleToUpdate,
 } from '../../tasks/alerts_detection_rules';
+import { getAvailablePrebuiltRulesCount } from '../../tasks/api_calls/prebuilt_rules';
+import { cleanKibana, deleteAlertsAndRules } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
-
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
-
-import { totalNumberOfPrebuiltRules } from '../../objects/rule';
-import { cleanKibana } from '../../tasks/common';
 
 describe('Prebuilt rules', () => {
   before(() => {
@@ -45,32 +40,25 @@ describe('Prebuilt rules', () => {
     login();
   });
 
+  beforeEach(() => {
+    deleteAlertsAndRules();
+    visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
+  });
+
   describe('Alerts rules, prebuilt rules', () => {
     it('Loads prebuilt rules', () => {
-      const rowsPerPage = 100;
-      const expectedNumberOfRules = totalNumberOfPrebuiltRules;
-      const expectedNumberOfPages = Math.ceil(totalNumberOfPrebuiltRules / rowsPerPage);
-      const expectedElasticRulesBtnText = `Elastic rules (${expectedNumberOfRules})`;
+      // Check that the rules table contains rules
+      cy.get(RULES_TABLE).find(RULES_ROW).should('have.length.gte', 1);
 
-      visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-      loadPrebuiltDetectionRules();
-      waitForPrebuiltDetectionRulesToBeLoaded();
-
-      cy.get(ELASTIC_RULES_BTN).should('have.text', expectedElasticRulesBtnText);
-
-      changeRowsPerPageTo(rowsPerPage);
-
-      cy.request({ url: DETECTION_ENGINE_RULES_URL_FIND }).then(({ body }) => {
-        // Assert the total number of loaded rules equals the expected number of in-memory rules
-        expect(body.total).to.equal(rawRules.length);
-        // Assert the table was refreshed with the rules returned by the API request
-        const ruleNames = rawRules.map((rule) => rule.name);
-        cy.get(RULE_NAME).each(($item) => {
-          expect($item.text()).to.be.oneOf(ruleNames);
-        });
+      // Check the correct count of prebuilt rules is displayed
+      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        cy.get(ELASTIC_RULES_BTN).should(
+          'have.text',
+          `Elastic rules (${availablePrebuiltRulesCount})`
+        );
       });
-
-      cy.get(pageSelector(expectedNumberOfPages)).should('exist');
     });
 
     context('Rule monitoring table', () => {
@@ -79,31 +67,27 @@ describe('Prebuilt rules', () => {
 
         cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
         enableSelectedRules();
-        waitForRuleToChangeStatus();
+        waitForRuleToUpdate();
         cy.get(RULE_SWITCH).should('have.attr', 'aria-checked', 'true');
 
         selectAllRules();
         disableSelectedRules();
-        waitForRuleToChangeStatus();
+        waitForRuleToUpdate();
         cy.get(RULE_SWITCH).should('have.attr', 'aria-checked', 'false');
       });
     });
   });
 
   describe('Actions with prebuilt rules', () => {
-    before(() => {
-      visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-    });
-
     context('Rules table', () => {
       it('Allows to enable/disable all rules at once', () => {
         selectAllRules();
         enableSelectedRules();
-        waitForRuleToChangeStatus();
+        waitForRuleToUpdate();
         cy.get(RULE_SWITCH).should('have.attr', 'aria-checked', 'true');
 
         disableSelectedRules();
-        waitForRuleToChangeStatus();
+        waitForRuleToUpdate();
         cy.get(RULE_SWITCH).should('have.attr', 'aria-checked', 'false');
       });
 
@@ -117,55 +101,58 @@ describe('Prebuilt rules', () => {
       });
 
       it('Deletes and recovers one rule', () => {
-        const expectedNumberOfRulesAfterDeletion = totalNumberOfPrebuiltRules - 1;
-        const expectedNumberOfRulesAfterRecovering = totalNumberOfPrebuiltRules;
+        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+          const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 1;
+          const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;
 
-        visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-        deleteFirstRule();
+          deleteFirstRule();
 
-        cy.get(ELASTIC_RULES_BTN).should(
-          'have.text',
-          `Elastic rules (${expectedNumberOfRulesAfterDeletion})`
-        );
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should('exist');
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should('have.text', 'Install 1 Elastic prebuilt rule ');
+          cy.get(ELASTIC_RULES_BTN).should(
+            'have.text',
+            `Elastic rules (${expectedNumberOfRulesAfterDeletion})`
+          );
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should('exist');
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should('have.text', 'Install 1 Elastic prebuilt rule ');
 
-        reloadDeletedRules();
+          reloadDeletedRules();
 
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should('not.exist');
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should('not.exist');
 
-        cy.get(ELASTIC_RULES_BTN).should(
-          'have.text',
-          `Elastic rules (${expectedNumberOfRulesAfterRecovering})`
-        );
+          cy.get(ELASTIC_RULES_BTN).should(
+            'have.text',
+            `Elastic rules (${expectedNumberOfRulesAfterRecovering})`
+          );
+        });
       });
 
       it('Deletes and recovers more than one rule', () => {
-        const numberOfRulesToBeSelected = 2;
-        const expectedNumberOfRulesAfterDeletion = totalNumberOfPrebuiltRules - 2;
-        const expectedNumberOfRulesAfterRecovering = totalNumberOfPrebuiltRules;
+        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+          const numberOfRulesToBeSelected = 2;
+          const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 2;
+          const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;
 
-        selectNumberOfRules(numberOfRulesToBeSelected);
-        deleteSelectedRules();
+          selectNumberOfRules(numberOfRulesToBeSelected);
+          deleteSelectedRules();
 
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should('exist');
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should(
-          'have.text',
-          `Install ${numberOfRulesToBeSelected} Elastic prebuilt rules `
-        );
-        cy.get(ELASTIC_RULES_BTN).should(
-          'have.text',
-          `Elastic rules (${expectedNumberOfRulesAfterDeletion})`
-        );
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should('exist');
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should(
+            'have.text',
+            `Install ${numberOfRulesToBeSelected} Elastic prebuilt rules `
+          );
+          cy.get(ELASTIC_RULES_BTN).should(
+            'have.text',
+            `Elastic rules (${expectedNumberOfRulesAfterDeletion})`
+          );
 
-        reloadDeletedRules();
+          reloadDeletedRules();
 
-        cy.get(RELOAD_PREBUILT_RULES_BTN).should('not.exist');
+          cy.get(RELOAD_PREBUILT_RULES_BTN).should('not.exist');
 
-        cy.get(ELASTIC_RULES_BTN).should(
-          'have.text',
-          `Elastic rules (${expectedNumberOfRulesAfterRecovering})`
-        );
+          cy.get(ELASTIC_RULES_BTN).should(
+            'have.text',
+            `Elastic rules (${expectedNumberOfRulesAfterRecovering})`
+          );
+        });
       });
 
       it('Allows to delete all rules at once', () => {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/related_integrations.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/related_integrations.cy.ts
@@ -33,7 +33,7 @@ import {
   goToTheRuleDetailsOf,
   openIntegrationsPopover,
   waitForRulesTableToShow,
-  waitForRuleToChangeStatus,
+  waitForRuleToUpdate,
 } from '../../tasks/alerts_detection_rules';
 
 /*
@@ -184,7 +184,7 @@ describe('Related integrations', () => {
           '{"package":"system","version":"1.17.0"}{"package":"aws","integration":"cloudtrail","version":"1.17.0"}{"package":"aws","integration":"cloudfront","version":"1.17.0"}{"package":"aws","integration":"unknown","version":"1.17.0"}';
 
         enableRule(firstRule);
-        waitForRuleToChangeStatus();
+        waitForRuleToUpdate();
         goToTheRuleDetailsOf(rule.name);
         waitForAlertsToPopulate();
         expandFirstAlert();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_selection.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_selection.cy.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { totalNumberOfPrebuiltRules } from '../../objects/rule';
 import {
   SELECTED_RULES_NUMBER_LABEL,
   SELECT_ALL_RULES_BTN,
@@ -16,6 +15,7 @@ import {
   unselectNumberOfRules,
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../tasks/alerts_detection_rules';
+import { getAvailablePrebuiltRulesCount } from '../../tasks/api_calls/prebuilt_rules';
 import { cleanKibana } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
@@ -46,7 +46,9 @@ describe('Rules selection', () => {
 
     cy.get(SELECT_ALL_RULES_BTN).click();
 
-    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', totalNumberOfPrebuiltRules);
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
+    });
 
     const bulkSelectButton = cy.get(SELECT_ALL_RULES_BTN);
 
@@ -56,7 +58,9 @@ describe('Rules selection', () => {
     // Current selection should be 0 rules
     cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
     // Bulk selection button should be back to displaying all rules
-    cy.get(SELECT_ALL_RULES_BTN).should('contain.text', totalNumberOfPrebuiltRules);
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
+    });
   });
 
   it('should correctly update the selection label when rules are bulk selected and then unselected via the table select all checkbox', () => {
@@ -65,7 +69,9 @@ describe('Rules selection', () => {
 
     cy.get(SELECT_ALL_RULES_BTN).click();
 
-    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', totalNumberOfPrebuiltRules);
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
+    });
 
     // Un-select all rules via the Un-select All checkbox from the table
     cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
@@ -73,6 +79,8 @@ describe('Rules selection', () => {
     // Current selection should be 0 rules
     cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
     // Bulk selection button should be back to displaying all rules
-    cy.get(SELECT_ALL_RULES_BTN).should('contain.text', totalNumberOfPrebuiltRules);
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
+    });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/sorting.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/sorting.cy.ts
@@ -21,7 +21,7 @@ import {
   goToPage,
   sortByEnabledRules,
   waitForRulesTableToBeLoaded,
-  waitForRuleToChangeStatus,
+  waitForRuleToUpdate,
 } from '../../tasks/alerts_detection_rules';
 import { login, visit } from '../../tasks/login';
 
@@ -50,9 +50,9 @@ describe('Alerts detection rules', () => {
     waitForRulesTableToBeLoaded();
 
     enableRule(SECOND_RULE);
-    waitForRuleToChangeStatus();
+    waitForRuleToUpdate();
     enableRule(FOURTH_RULE);
-    waitForRuleToChangeStatus();
+    waitForRuleToUpdate();
 
     cy.get(RULE_SWITCH).eq(SECOND_RULE).should('have.attr', 'role', 'switch');
     cy.get(RULE_SWITCH).eq(FOURTH_RULE).should('have.attr', 'role', 'switch');

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -6,14 +6,11 @@
  */
 
 import type { Throttle } from '@kbn/securitysolution-io-ts-alerting-types';
-import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules';
 import { getMockThreatData } from '../../public/detections/mitre/mitre_tactics_techniques';
 import type { CompleteTimeline } from './timeline';
 import { getTimeline, getIndicatorMatchTimelineTemplate } from './timeline';
 import type { FullResponseSchema } from '../../common/detection_engine/schemas/request';
 import type { Connectors } from './connector';
-
-export const totalNumberOfPrebuiltRules = rawRules.length;
 
 const ccsRemoteName: string = Cypress.env('CCS_REMOTE_NAME');
 

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -60,6 +60,7 @@ import {
 import { EUI_CHECKBOX } from '../screens/common/controls';
 import { ALL_ACTIONS } from '../screens/rule_details';
 import { LOADING_INDICATOR } from '../screens/security_header';
+import { waitTillPrebuiltRulesReadyToInstall } from './api_calls/prebuilt_rules';
 
 export const enableRule = (rulePosition: number) => {
   cy.get(RULE_SWITCH).eq(rulePosition).click({ force: true });
@@ -132,16 +133,19 @@ export const deleteRuleFromDetailsPage = () => {
 };
 
 export const duplicateSelectedRules = () => {
+  cy.log('Duplicate selected rules');
   cy.get(BULK_ACTIONS_BTN).click({ force: true });
   cy.get(DUPLICATE_RULE_BULK_BTN).click();
 };
 
 export const enableSelectedRules = () => {
+  cy.log('Enable selected rules');
   cy.get(BULK_ACTIONS_BTN).click({ force: true });
   cy.get(ENABLE_RULE_BULK_BTN).click();
 };
 
 export const disableSelectedRules = () => {
+  cy.log('Disable selected rules');
   cy.get(BULK_ACTIONS_BTN).click({ force: true });
   cy.get(DISABLE_RULE_BULK_BTN).click();
 };
@@ -169,7 +173,9 @@ export const goToTheRuleDetailsOf = (ruleName: string) => {
 };
 
 export const loadPrebuiltDetectionRules = () => {
-  cy.get(LOAD_PREBUILT_RULES_BTN)
+  cy.log('load prebuilt detection rules');
+  waitTillPrebuiltRulesReadyToInstall();
+  cy.get(LOAD_PREBUILT_RULES_BTN, { timeout: 300000 })
     .should('be.enabled')
     .pipe(($el) => $el.trigger('click'))
     .should('be.disabled');
@@ -179,7 +185,9 @@ export const loadPrebuiltDetectionRules = () => {
  * load prebuilt rules by clicking button on page header
  */
 export const loadPrebuiltDetectionRulesFromHeaderBtn = () => {
-  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN).click().should('not.exist');
+  cy.log('load prebuilt detection rules from header');
+  waitTillPrebuiltRulesReadyToInstall();
+  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN, { timeout: 300000 }).click().should('not.exist');
 };
 
 export const openIntegrationsPopover = () => {
@@ -231,11 +239,13 @@ export const unselectNumberOfRules = (numberOfRules: number) => {
 };
 
 export const selectAllRules = () => {
+  cy.log('Select all rules');
   cy.get(SELECT_ALL_RULES_BTN).contains('Select all').click();
   cy.get(SELECT_ALL_RULES_BTN).contains('Clear');
 };
 
 export const clearAllRuleSelection = () => {
+  cy.log('Clear all rules selection');
   cy.get(SELECT_ALL_RULES_BTN).contains('Clear').click();
   cy.get(SELECT_ALL_RULES_BTN).contains('Select all');
 };
@@ -291,14 +301,21 @@ export const waitForRulesTableToBeRefreshed = () => {
 };
 
 export const waitForPrebuiltDetectionRulesToBeLoaded = () => {
-  cy.get(LOAD_PREBUILT_RULES_BTN).should('not.exist');
+  cy.log('Wait for prebuilt rules to be loaded');
+  cy.get(LOAD_PREBUILT_RULES_BTN, { timeout: 300000 }).should('not.exist');
   cy.get(RULES_TABLE).should('exist');
   cy.get(RULES_TABLE_REFRESH_INDICATOR).should('not.exist');
 };
 
-export const waitForRuleToChangeStatus = () => {
-  cy.get(RULE_SWITCH_LOADER).should('exist');
-  cy.get(RULE_SWITCH_LOADER).should('not.exist');
+/**
+ * Wait till the rules on the rules management page get updated, i.e., there are
+ * no rules with the loading indicator on the page. Rules display a loading
+ * indicator after some actions such as enable, disable, or bulk actions.
+ */
+export const waitForRuleToUpdate = () => {
+  cy.log('Wait for rules to update');
+  cy.get(RULE_SWITCH_LOADER, { timeout: 300000 }).should('exist');
+  cy.get(RULE_SWITCH_LOADER, { timeout: 300000 }).should('not.exist');
 };
 
 export const checkAutoRefresh = (ms: number, condition: string) => {

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -1,0 +1,29 @@
+import { PrePackagedRulesStatusResponse } from '../../../public/detections/containers/detection_engine/rules/types';
+
+export const getPrebuiltRulesStatus = () => {
+  return cy.request<PrePackagedRulesStatusResponse>({
+    method: 'GET',
+    url: 'api/detection_engine/rules/prepackaged/_status',
+    headers: { 'kbn-xsrf': 'cypress-creds' },
+  });
+};
+
+export const getAvailablePrebuiltRulesCount = () => {
+  cy.log('Get prebuilt rules count');
+  return getPrebuiltRulesStatus().then(({ body }) => {
+    const prebuiltRulesCount = body.rules_installed + body.rules_not_installed;
+
+    return prebuiltRulesCount;
+  });
+};
+
+export const waitTillPrebuiltRulesReadyToInstall = () => {
+  cy.waitUntil(
+    () => {
+      return getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+        return availablePrebuiltRulesCount > 0;
+      });
+    },
+    { interval: 100, timeout: 60000 }
+  );
+};

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -1,4 +1,11 @@
-import { PrePackagedRulesStatusResponse } from '../../../public/detections/containers/detection_engine/rules/types';
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PrePackagedRulesStatusResponse } from '../../../public/detections/containers/detection_engine/rules/types';
 
 export const getPrebuiltRulesStatus = () => {
   return cy.request<PrePackagedRulesStatusResponse>({

--- a/x-pack/plugins/security_solution/cypress/tasks/common.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/common.ts
@@ -63,6 +63,7 @@ export const cleanKibana = () => {
 };
 
 export const deleteAlertsAndRules = () => {
+  cy.log('Delete all alerts and rules');
   const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
 
   cy.request({
@@ -74,6 +75,7 @@ export const deleteAlertsAndRules = () => {
     },
     failOnStatusCode: false,
     headers: { 'kbn-xsrf': 'cypress-creds-via-config' },
+    timeout: 300000,
   });
 
   cy.request('POST', `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`, {


### PR DESCRIPTION
### Summary

This PR prepares Cypress tests to work with prebuilt detection rules installed from a Fleet package as the filesystem distribution method of prebuilt rules will be removed in future releases (see https://github.com/elastic/kibana/issues/139926).

Notable changes:

1. Before installing prebuilt rules, call `waitTillPrepackagedRulesReadyToInstall()` to ensure they are available because it could take some time to install the Fleet package with rules (it happens automatically on the initial page load).
2. Total prebuilt rules count is no longer known. In tests, we should call `getPrepackagedRulesCount()` to fetch the total number of prebuilt rules via API.