### PR TITLE
[APM] Removed isBeta property from SettingsSection interface since it was n…

### DIFF
--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/index.tsx
@@ -133,7 +133,6 @@ export function APMPolicyForm({ vars = {}, updateAPMPolicy }: Props) {
               }
             ),
             settings: tailSamplingSettings,
-            isBeta: false,
             isPlatinumLicence: true,
           },
         ]

--- a/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_form/index.tsx
@@ -92,7 +92,6 @@ export interface SettingsSection {
   title: string;
   subtitle?: string;
   settings: SettingsRow[];
-  isBeta?: boolean;
   isPlatinumLicence?: boolean;
 }
 


### PR DESCRIPTION
Closes [126576](https://github.com/elastic/kibana/issues/126576).

Beta badge was removed from template in [127747](https://github.com/elastic/kibana/pull/127747).

In this PR we are removing the `isBeta` unused property left behind.