### PR TITLE
[Lens] Fixes the Search functions input on the formula documentation popover

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -845,7 +845,6 @@ export function FormulaEditor({
                         anchorPosition="leftCenter"
                         isOpen={isHelpOpen}
                         closePopover={() => setIsHelpOpen(false)}
-                        ownFocus={false}
                         button={
                           <EuiButtonIcon
                             className="lnsFormula__editorHelp lnsFormula__editorHelp--overlay"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/142314

With removing the `ownFocus: false` it fixes the problem.  My best guess is that something changed in EUI. I can't see any regression on removing this.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/17003240/193271328-ff8cd680-2402-4c31-8396-f026aed6e585.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->