### PR TITLE
[Security Solution][DOCS][8.1] Cases and rules support for SN connectors

### DIFF
--- a/docs/management/connectors/action-types/servicenow-itom.asciidoc
+++ b/docs/management/connectors/action-types/servicenow-itom.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow ITOM</titleabbrev>
 ++++
 
-The {sn} ITOM connector uses the https://docs.servicenow.com/bundle/rome-it-operations-management/page/product/event-management/task/send-events-via-web-service.html[Event API] to create {sn} events.
+The {sn} ITOM connector uses the https://docs.servicenow.com/bundle/rome-it-operations-management/page/product/event-management/task/send-events-via-web-service.html[Event API] to create {sn} events. You can use the connector for rule actions.
 
 [float]
 [[servicenow-itom-connector-prerequisites]]

--- a/docs/management/connectors/action-types/servicenow-itom.asciidoc
+++ b/docs/management/connectors/action-types/servicenow-itom.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow ITOM</titleabbrev>
 ++++
 
-The {sn} ITOM connector uses the https://docs.servicenow.com/bundle/rome-it-operations-management/page/product/event-management/task/send-events-via-web-service.html[Event API] to create {sn} events. You can use the connector for rule actions.
+The {sn-itom} connector uses the https://docs.servicenow.com/bundle/rome-it-operations-management/page/product/event-management/task/send-events-via-web-service.html[Event API] to create {sn} events. You can use the connector for rule actions.
 
 [float]
 [[servicenow-itom-connector-prerequisites]]

--- a/docs/management/connectors/action-types/servicenow-sir.asciidoc
+++ b/docs/management/connectors/action-types/servicenow-sir.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow SecOps</titleabbrev>
 ++++
 
-The {sn} SecOps connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} security incidents.
+The {sn} SecOps connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} security incidents. You can use the connector for rule actions and cases.
 
 [float]
 [[servicenow-sir-connector-prerequisites]]

--- a/docs/management/connectors/action-types/servicenow-sir.asciidoc
+++ b/docs/management/connectors/action-types/servicenow-sir.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow SecOps</titleabbrev>
 ++++
 
-The {sn} SecOps connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} security incidents. You can use the connector for rule actions and cases.
+The {sn-sir} connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} security incidents. You can use the connector for rule actions and cases.
 
 [float]
 [[servicenow-sir-connector-prerequisites]]

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow ITSM</titleabbrev>
 ++++
 
-The {sn} ITSM connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} incidents. You can use the connector for rule actions and cases.
+The {sn-itsm} connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} incidents. You can use the connector for rule actions and cases.
 
 [float]
 [[servicenow-itsm-connector-prerequisites]]

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>ServiceNow ITSM</titleabbrev>
 ++++
 
-The {sn} ITSM connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} incidents.
+The {sn} ITSM connector uses the https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_ImportSetAPI[Import Set API] to create {sn} incidents. You can use the connector for rule actions and cases.
 
 [float]
 [[servicenow-itsm-connector-prerequisites]]


### PR DESCRIPTION
Fixes part of https://github.com/elastic/security-docs/issues/1493. In this PR, I added a line that described whether the ServiceNow connector could be used for cases, rule actions, or both. 

Previews:
- https://kibana_142351.docs-preview.app.elstc.co/guide/en/kibana/8.1/servicenow-action-type.html
- https://kibana_142351.docs-preview.app.elstc.co/guide/en/kibana/8.1/servicenow-itom-action-type.html
- https://kibana_142351.docs-preview.app.elstc.co/guide/en/kibana/8.1/servicenow-sir-action-type.html