### PR TITLE
changed order of update agents and actions

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/actions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.ts
@@ -123,16 +123,6 @@ export async function cancelAgentAction(esClient: ElasticsearchClient, actionId:
     if (!hit._source || !hit._source.agents || !hit._source.action_id) {
       continue;
     }
-    await createAgentAction(esClient, {
-      id: cancelActionId,
-      type: 'CANCEL',
-      agents: hit._source.agents,
-      data: {
-        target_id: hit._source.action_id,
-      },
-      created_at: now,
-      expiration: hit._source.expiration,
-    });
     if (hit._source.type === 'UPGRADE') {
       await bulkUpdateAgents(
         esClient,
@@ -145,6 +135,16 @@ export async function cancelAgentAction(esClient: ElasticsearchClient, actionId:
         }))
       );
     }
+    await createAgentAction(esClient, {
+      id: cancelActionId,
+      type: 'CANCEL',
+      agents: hit._source.agents,
+      data: {
+        target_id: hit._source.action_id,
+      },
+      created_at: now,
+      expiration: hit._source.expiration,
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary

Backport fix to 8.4
https://github.com/elastic/elastic-agent/issues/760#issuecomment-1263624914

Changing the order in action handlers, so we are always updating agents index first, before actions index. This prevents a race condition between Kibana and Fleet Server picking up the action.
