### PR TITLE
[8.5] [Session View] fix missing metadata info from text-output events

### DIFF
--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/index.tsx
@@ -66,10 +66,10 @@ export const SessionViewDetailPanel = ({
         }),
         content: (
           <DetailPanelMetadataTab
-            processHost={selectedProcess?.events[0]?.host}
-            processContainer={selectedProcess?.events[0]?.container}
-            processOrchestrator={selectedProcess?.events[0]?.orchestrator}
-            processCloud={selectedProcess?.events[0]?.cloud}
+            processHost={selectedProcess?.getDetails()?.host}
+            processContainer={selectedProcess?.getDetails()?.container}
+            processOrchestrator={selectedProcess?.getDetails()?.orchestrator}
+            processCloud={selectedProcess?.getDetails()?.cloud}
           />
         ),
       },


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

[[Terminal Output] Metadata tab empty for interactive sessions, possibly text_output events causing grief](https://github.com/elastic/kibana/issues/142000)

Metadata tab info was missing due to referencing a list of aggregated process events `selectedProcess.events`.  The text-outputs events don't contain any metadata properties. When we grabbed the first event `selectedProcess.events[0]`,  which was a  text-ouput event, the metadata tab will be missing info. To fix this issue, we need to retrieve the most recent processed event that contains meta data using `selectedProcess.getDetails()`.

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/17135495/193162006-1cfdef10-ce61-413c-a524-d16006f5cb41.png">
<img width="406" alt="image" src="https://user-images.githubusercontent.com/17135495/193163353-225c579d-17d7-47fe-b230-fc8addec7d97.png">



### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->