### PR TITLE
[Enterprise Search] pipelines copy tweaks

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipeline_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipeline_modal.tsx
@@ -25,6 +25,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { DEFAULT_PIPELINE_NAME } from '../../../../../../common/constants';
 
@@ -91,21 +92,43 @@ export const IngestPipelineModal: React.FC<IngestPipelineModalProps> = ({
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
                 <EuiText color="subdued" size="s">
-                  {displayOnly
-                    ? i18n.translate(
-                        'xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyAPIText',
-                        {
-                          defaultMessage:
-                            'This pipeline runs automatically on all Crawler and Connector indices created through Enterprise Search. To use this configuration on API-based indices you can use the sample cURL request below.',
-                        }
-                      )
-                    : i18n.translate(
-                        'xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyConnectorText',
-                        {
-                          defaultMessage:
-                            'This pipeline runs automatically on all Crawler and Connector indices created through Enterprise Search.',
-                        }
-                      )}
+                  {displayOnly ? (
+                    <>
+                      <p>
+                        <FormattedMessage
+                          id="xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyAPIText"
+                          defaultMessage="{apiIndex} Changes made to the settings below are for reference only. These settings will not be persisted to your index or pipeline."
+                          values={{
+                            apiIndex: (
+                              <strong>
+                                {i18n.translate(
+                                  'xpack.enterpriseSearch.content.index.pipelines.ingestModal.apiIndex',
+                                  { defaultMessage: 'This is an API-based index.' }
+                                )}
+                              </strong>
+                            ),
+                          }}
+                        />
+                      </p>
+                      <p>
+                        {i18n.translate(
+                          'xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyAPITextCont',
+                          {
+                            defaultMessage:
+                              "In order to use this pipeline on your API-based indices you'll need to explicitly reference it in your API requests.",
+                          }
+                        )}
+                      </p>
+                    </>
+                  ) : (
+                    i18n.translate(
+                      'xpack.enterpriseSearch.content.index.pipelines.ingestModal.modalBodyConnectorText',
+                      {
+                        defaultMessage:
+                          'This pipeline runs automatically on all Crawler and Connector indices created through Enterprise Search.',
+                      }
+                    )
+                  )}
                 </EuiText>
               </EuiFlexItem>
               <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -15,6 +15,7 @@ import { i18n } from '@kbn/i18n';
 
 import { DataPanel } from '../../../../shared/data_panel/data_panel';
 import { docLinks } from '../../../../shared/doc_links';
+import { isApiIndex } from '../../../utils/indices';
 
 import { IngestPipelinesCard } from './ingest_pipelines_card';
 import { AddMLInferencePipelineButton } from './ml_inference/add_ml_inference_button';
@@ -23,9 +24,15 @@ import { MlInferencePipelineProcessorsCard } from './ml_inference_pipeline_proce
 import { PipelinesLogic } from './pipelines_logic';
 
 export const SearchIndexPipelines: React.FC = () => {
-  const { showAddMlInferencePipelineModal } = useValues(PipelinesLogic);
+  const {
+    showAddMlInferencePipelineModal,
+    hasIndexIngestionPipeline,
+    index,
+    pipelineState: { name: pipelineName },
+  } = useValues(PipelinesLogic);
   const { closeAddMlInferencePipelineModal, openAddMlInferencePipelineModal } =
     useActions(PipelinesLogic);
+  const apiIndex = isApiIndex(index);
 
   return (
     <>
@@ -54,12 +61,23 @@ export const SearchIndexPipelines: React.FC = () => {
                 )}
               </h2>
             }
-            subtitle={i18n.translate(
-              'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.subtitle',
-              {
-                defaultMessage: 'Ingest pipelines optimize your index for search applications',
-              }
-            )}
+            subtitle={
+              apiIndex
+                ? i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.apiIndexSubtitle',
+                    {
+                      defaultMessage:
+                        "Ingest pipelines optimize your index for search applications. If you'd like to use these pipelines in your API-based index, you'll need to reference them explicitly in your API requests.",
+                    }
+                  )
+                : i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.subtitle',
+                    {
+                      defaultMessage:
+                        'Ingest pipelines optimize your index for search applications',
+                    }
+                  )
+            }
             iconType="logstashInput"
           >
             <IngestPipelinesCard />
@@ -88,13 +106,26 @@ export const SearchIndexPipelines: React.FC = () => {
                 )}
               </h2>
             }
-            subtitle={i18n.translate(
-              'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitle',
-              {
-                defaultMessage:
-                  'Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline',
-              }
-            )}
+            subtitle={
+              apiIndex && hasIndexIngestionPipeline
+                ? i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitleAPIindex',
+                    {
+                      defaultMessage:
+                        "Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline. In order to use these pipeline on API-based indices you'll need to reference the {pipelineName} pipeline in your API requests.",
+                      values: {
+                        pipelineName,
+                      },
+                    }
+                  )
+                : i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitle',
+                    {
+                      defaultMessage:
+                        'Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline',
+                    }
+                  )
+            }
             iconType="compute"
             action={
               <AddMLInferencePipelineButton onClick={() => openAddMlInferencePipelineModal()} />


### PR DESCRIPTION
## Summary

Updated copy on the pipelines tab and modal when using an API-based index to explicitly call-out required actions in API requests to run the ingest pipeline.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/1972968/193339433-462e4d2b-87f4-452f-bce2-4f68fbf7e78e.png">
<img width="631" alt="image" src="https://user-images.githubusercontent.com/1972968/193339464-467b5df3-a4ad-4564-ae4c-3517ca02d606.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->