### PR TITLE
Fix indefinite loading and handling of state pings for Last test run and  Test Runs panels.

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
@@ -18,8 +18,8 @@ import { formatTestDuration } from '../../../utils/monitor_test_result/test_time
 
 export const SinglePingResult = ({ ping, loading }: { ping: Ping; loading: boolean }) => {
   const ip = !loading ? ping?.resolve?.ip : undefined;
-  const durationUs = !loading ? ping?.monitor?.duration?.us : undefined;
-  const rtt = !loading ? ping?.resolve?.rtt?.us : undefined;
+  const durationUs = !loading ? ping?.monitor?.duration?.us ?? NaN : NaN;
+  const rtt = !loading ? ping?.resolve?.rtt?.us ?? NaN : NaN;
   const url = !loading ? ping?.url?.full : undefined;
   const responseStatus = !loading ? ping?.http?.response?.status_code : undefined;
 
@@ -29,10 +29,12 @@ export const SinglePingResult = ({ ping, loading }: { ping: Ping; loading: boole
       <EuiDescriptionListDescription>{ip}</EuiDescriptionListDescription>
       <EuiDescriptionListTitle>{DURATION_LABEL}</EuiDescriptionListTitle>
       <EuiDescriptionListDescription>
-        {formatTestDuration(durationUs)}
+        {isNaN(durationUs) ? '' : formatTestDuration(durationUs)}
       </EuiDescriptionListDescription>
       <EuiDescriptionListTitle>rtt</EuiDescriptionListTitle>
-      <EuiDescriptionListDescription>{formatTestDuration(rtt)}</EuiDescriptionListDescription>
+      <EuiDescriptionListDescription>
+        {isNaN(rtt) ? '' : formatTestDuration(rtt)}
+      </EuiDescriptionListDescription>
       <EuiDescriptionListTitle>URL</EuiDescriptionListTitle>
       <EuiDescriptionListDescription>{url}</EuiDescriptionListDescription>
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
@@ -31,7 +31,6 @@ import {
 import { useSyntheticsSettingsContext } from '../../../contexts/synthetics_settings_context';
 
 import { sortPings } from '../../../utils/monitor_test_result/sort_pings';
-import { checkIsStalePing } from '../../../utils/monitor_test_result/check_pings';
 import { selectPingsLoading, selectMonitorRecentPings, selectPingsError } from '../../../state';
 import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/status_badge';
 import { isStepEnd } from '../../common/monitor_test_result/browser_steps_list';
@@ -56,8 +55,6 @@ export const LastTenTestRuns = () => {
   const { monitor } = useSelectedMonitor();
 
   const isBrowserMonitor = monitor?.[ConfigKey.MONITOR_TYPE] === DataStream.BROWSER;
-  const hasStalePings = checkIsStalePing(monitor, pings?.[0]);
-  const loading = hasStalePings || pingsLoading;
 
   const sorting: EuiTableSortingType<Ping> = {
     sort: {
@@ -146,12 +143,12 @@ export const LastTenTestRuns = () => {
       </EuiFlexGroup>
       <EuiBasicTable
         compressed={false}
-        loading={loading}
+        loading={pingsLoading}
         columns={columns}
         error={pingsError?.body?.message}
-        items={hasStalePings ? [] : sortedPings}
+        items={sortedPings}
         noItemsMessage={
-          loading
+          pingsLoading
             ? i18n.translate('xpack.synthetics.monitorDetails.loadingTestRuns', {
                 defaultMessage: 'Loading test runs...',
               })

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -28,7 +28,6 @@ import {
   EncryptedSyntheticsSavedMonitor,
   Ping,
 } from '../../../../../../common/runtime_types';
-import { checkIsStalePing } from '../../../utils/monitor_test_result/check_pings';
 import { formatTestRunAt } from '../../../utils/monitor_test_result/test_time_formats';
 
 import { useSyntheticsSettingsContext } from '../../../contexts';
@@ -50,8 +49,7 @@ export const LastTestRun = () => {
     latestPing?.monitor?.check_group
   );
 
-  const hasStalePings = checkIsStalePing(monitor, latestPing);
-  const loading = hasStalePings || stepsLoading || pingsLoading;
+  const loading = stepsLoading || pingsLoading;
 
   return (
     <EuiPanel css={{ minHeight: 356 }}>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -6,13 +6,16 @@
  */
 
 import { createReducer } from '@reduxjs/toolkit';
+import { EncryptedSyntheticsSavedMonitor, Ping } from '../../../../../common/runtime_types';
+import { checkIsStalePing } from '../../utils/monitor_test_result/check_pings';
+
 import { IHttpSerializedFetchError } from '../utils/http_error';
+
 import {
   getMonitorRecentPingsAction,
   setMonitorDetailsLocationAction,
   getMonitorAction,
 } from './actions';
-import { EncryptedSyntheticsSavedMonitor, Ping } from '../../../../../common/runtime_types';
 
 export interface MonitorDetailsState {
   pings: Ping[];
@@ -38,8 +41,9 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       state.selectedLocationId = action.payload;
     })
 
-    .addCase(getMonitorRecentPingsAction.get, (state) => {
+    .addCase(getMonitorRecentPingsAction.get, (state, action) => {
       state.loading = true;
+      state.pings = state.pings.filter((ping) => !checkIsStalePing(action.payload.monitorId, ping));
     })
     .addCase(getMonitorRecentPingsAction.success, (state, action) => {
       state.pings = action.payload.pings;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/monitor_test_result/check_pings.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/monitor_test_result/check_pings.ts
@@ -5,18 +5,15 @@
  * 2.0.
  */
 
-import { EncryptedSyntheticsSavedMonitor, Ping } from '../../../../../common/runtime_types';
+import { Ping } from '../../../../../common/runtime_types';
 
 /**
  * Checks if the loaded/cached pings are of the current selected monitors
  */
-export function checkIsStalePing(
-  monitor: EncryptedSyntheticsSavedMonitor | null,
-  ping: Ping | undefined
-) {
-  if (!monitor?.id || !ping?.monitor?.id) {
+export function checkIsStalePing(monitorOrConfigId: string | undefined, ping: Ping | undefined) {
+  if (!monitorOrConfigId || !ping?.monitor?.id) {
     return true;
   }
 
-  return monitor.id !== ping.monitor.id && monitor.id !== ping.config_id;
+  return monitorOrConfigId !== ping.monitor.id && monitorOrConfigId !== ping.config_id;
 }


### PR DESCRIPTION
Fixes #142113

## Summary

For monitors which never ran (no pings/results are available in index), Synthetics UI -> Monitor Details -> Summary -> *Last test run* / *Test Runs* stayed in _loading_ state forever. This PR fixes that behavior.

### How to test
1. Consult the associated issue and try to reproduce the steps and make sure you don't end up in a state mentioned in the issue.
2. Additionally, create a monitor with disabled state and check the Summary page and make sure everything is in order.
3. Enable the monitor and immediately visit he Summary Page and make sure everything looks fine.
4. You can also use this [deployment](https://p.elstc.co/paste/dvMaM6y8#ffl5H68w+2qGrd+kazamhy0OMaTREKDbg-fFtZHcSo4) for testing (if it is still avaiable) using your elastic credentials.

### Screenshots
Now, when pings/results aren't available, the Summary page will look like:
<img width="1139" alt="Screenshot 2022-10-03 at 00 51 13" src="https://user-images.githubusercontent.com/2748376/193480286-bfc5b5c0-6d11-4d11-9351-b6ce1e672b80.png">
<img width="1140" alt="Screenshot 2022-10-03 at 00 58 08" src="https://user-images.githubusercontent.com/2748376/193480292-44bffdb3-4551-4d57-952d-d2512846f872.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->