### PR TITLE
[Security Solution] Last execution gap duration format

### DIFF
--- a/x-pack/plugins/security_solution/kibana.json
+++ b/x-pack/plugins/security_solution/kibana.json
@@ -19,6 +19,7 @@
     "embeddable",
     "eventLog",
     "features",
+    "fieldFormats",
     "inspector",
     "kubernetesSecurity",
     "lens",

--- a/x-pack/plugins/security_solution/public/common/components/links/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/links/index.tsx
@@ -48,6 +48,9 @@ export const DEFAULT_NUMBER_OF_LINK = 5;
 /** The default max-height of the Reputation Links popover used to show "+n More" items (e.g. `+9 More`) */
 export const DEFAULT_MORE_MAX_HEIGHT = '200px';
 
+const isModified = (event: MouseEvent) =>
+  event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+
 // Internal Links
 const UserDetailsLinkComponent: React.FC<{
   children?: React.ReactNode;
@@ -543,6 +546,10 @@ export const useGetSecuritySolutionLinkProps = (): GetSecuritySolutionProps => {
       return {
         href: url,
         onClick: (ev: MouseEvent) => {
+          if (isModified(ev)) {
+            return;
+          }
+
           ev.preventDefault();
           navigateTo({ url });
           if (onClickProps) {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/use_columns.tsx
@@ -9,7 +9,7 @@ import type { EuiBasicTableColumn, EuiTableActionsColumnType } from '@elastic/eu
 import { EuiBadge, EuiLink, EuiText, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo } from 'react';
-import moment from 'moment';
+import { DurationFormat } from '@kbn/field-formats-plugin/common';
 import { IntegrationsPopover } from '../../../../components/rules/related_integrations/integrations_popover';
 import {
   DEFAULT_RELATIVE_DATE_THRESHOLD,
@@ -50,6 +50,11 @@ export type TableColumn = EuiBasicTableColumn<Rule> | EuiTableActionsColumnType<
 interface ColumnsProps {
   hasPermissions: boolean;
 }
+
+const durationFormat = new DurationFormat({
+  outputFormat: 'humanizePrecise',
+  outputPrecision: 0,
+});
 
 const useEnabledColumn = ({ hasPermissions }: ColumnsProps): TableColumn => {
   const hasMlPermissions = useHasMlPermissions();
@@ -388,7 +393,7 @@ export const useMonitoringColumns = ({ hasPermissions }: ColumnsProps): TableCol
         ),
         render: (value: DurationMetric | undefined) => (
           <EuiText data-test-subj="gap" size="s">
-            {value != null ? moment.duration(value, 'seconds').humanize() : getEmptyTagValue()}
+            {value != null ? durationFormat.convert(value) : getEmptyTagValue()}
           </EuiText>
         ),
         sortable: !!isInMemorySorting,


### PR DESCRIPTION
**Improves:** [#141363](https://github.com/elastic/kibana/pull/141363)

## Summary

Adopts `DurationFormat` formatter from `@kbn/field-formats-plugin/common` for the last execution gap column on the Rule Monitoring page. It allows to flexibly configure the formatted value and leverage proper i18n for the time units.


### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

