### PR TITLE
Fixing Failing test: X-Pack Alerting API Integration Tests.x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable·ts - alerting api integration security and spaces enabled Alerts - Group 1 alerts disable superuser at space1 should still be able to disable alert when AAD is broken

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
@@ -109,21 +109,23 @@ export default function createDisableAlertTests({ getService }: FtrProviderConte
               expect(response.body).to.eql('');
 
               // task should still exist but be disabled
-              const taskRecord2 = await getScheduledTask(createdAlert.scheduled_task_id);
-              expect(taskRecord2.type).to.eql('task');
-              expect(taskRecord2.task.taskType).to.eql('alerting:test.noop');
-              expect(JSON.parse(taskRecord2.task.params)).to.eql({
-                alertId: createdAlert.id,
-                spaceId: space.id,
-                consumer: 'alertsFixture',
-              });
-              expect(taskRecord2.task.enabled).to.eql(false);
-              // Ensure AAD isn't broken
-              await checkAAD({
-                supertest,
-                spaceId: space.id,
-                type: 'alert',
-                id: createdAlert.id,
+              await retry.try(async () => {
+                const taskRecord2 = await getScheduledTask(createdAlert.scheduled_task_id);
+                expect(taskRecord2.type).to.eql('task');
+                expect(taskRecord2.task.taskType).to.eql('alerting:test.noop');
+                expect(JSON.parse(taskRecord2.task.params)).to.eql({
+                  alertId: createdAlert.id,
+                  spaceId: space.id,
+                  consumer: 'alertsFixture',
+                });
+                expect(taskRecord2.task.enabled).to.eql(false);
+                // Ensure AAD isn't broken
+                await checkAAD({
+                  supertest,
+                  spaceId: space.id,
+                  type: 'alert',
+                  id: createdAlert.id,
+                });
               });
               break;
             default:
@@ -294,15 +296,17 @@ export default function createDisableAlertTests({ getService }: FtrProviderConte
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');
               // task should still exist but be disabled
-              const taskRecord = await getScheduledTask(createdAlert.scheduled_task_id);
-              expect(taskRecord.type).to.eql('task');
-              expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
-              expect(JSON.parse(taskRecord.task.params)).to.eql({
-                alertId: createdAlert.id,
-                spaceId: space.id,
-                consumer: 'alerts',
+              await retry.try(async () => {
+                const taskRecord = await getScheduledTask(createdAlert.scheduled_task_id);
+                expect(taskRecord.type).to.eql('task');
+                expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
+                expect(JSON.parse(taskRecord.task.params)).to.eql({
+                  alertId: createdAlert.id,
+                  spaceId: space.id,
+                  consumer: 'alerts',
+                });
+                expect(taskRecord.task.enabled).to.eql(false);
               });
-              expect(taskRecord.task.enabled).to.eql(false);
               break;
             default:
               throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
@@ -365,15 +369,17 @@ export default function createDisableAlertTests({ getService }: FtrProviderConte
               expect(response.statusCode).to.eql(204);
               expect(response.body).to.eql('');
               // task should still exist but be disabled
-              const taskRecord2 = await getScheduledTask(createdAlert.scheduled_task_id);
-              expect(taskRecord2.type).to.eql('task');
-              expect(taskRecord2.task.taskType).to.eql('alerting:test.noop');
-              expect(JSON.parse(taskRecord2.task.params)).to.eql({
-                alertId: createdAlert.id,
-                spaceId: space.id,
-                consumer: 'alertsFixture',
+              await retry.try(async () => {
+                const taskRecord2 = await getScheduledTask(createdAlert.scheduled_task_id);
+                expect(taskRecord2.type).to.eql('task');
+                expect(taskRecord2.task.taskType).to.eql('alerting:test.noop');
+                expect(JSON.parse(taskRecord2.task.params)).to.eql({
+                  alertId: createdAlert.id,
+                  spaceId: space.id,
+                  consumer: 'alertsFixture',
+                });
+                expect(taskRecord2.task.enabled).to.eql(false);
               });
-              expect(taskRecord2.task.enabled).to.eql(false);
               break;
             default:
               throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
@@ -26,8 +26,7 @@ export default function createDisableAlertTests({ getService }: FtrProviderConte
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/140797
-  describe.skip('disable', () => {
+  describe('disable', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     after(() => objectRemover.removeAll());


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/140747, https://github.com/elastic/kibana/issues/140979, https://github.com/elastic/kibana/issues/140797

## Summary

Adding a retry.try since it seems sometimes when we're checking if a rule task has been disabled, it may not yet be set to `enabled:fase` yet.

Flaky test runner runs: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1346