### PR TITLE
[DOCS] Removes tag from 8.4.3 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,8 +39,6 @@ Review important information about the {kib} 8.4.x releases.
 [[release-notes-8.4.3]]
 == {kib} 8.4.3
 
-coming::[8.4.3]
-
 Review the following information about the {kib} 8.4.3 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 8.4.3 release notes.

