### PR TITLE
[ResponseOps][Alerting] Fixing flaky test in x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
@@ -235,8 +235,9 @@ export default function createAlertingAndActionsTelemetryTests({ getService }: F
       // number of action executions broken down by connector type
       expect(telemetry.count_actions_executions_by_type_per_day['test.throw'] > 0).to.be(true);
 
-      // average execution time - just checking for non-zero as we can't set an exact number
-      expect(telemetry.avg_execution_time_per_day > 0).to.be(true);
+      // average execution time - just checking for a positive number as we can't set an exact number
+      // if the time is less than 1ms it will round down to 0
+      expect(telemetry.avg_execution_time_per_day >= 0).to.be(true);
 
       // average execution time broken down by rule type
       expect(telemetry.avg_execution_time_by_type_per_day['test.throw'] > 0).to.be(true);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/140973

## Summary

Fixes flaky test Group 2 Alerting and Actions Telemetry telemetry should retrieve telemetry data in the expected format in `x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry·ts`
Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1345
### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
