### PR TITLE
[TIP] Add full screen feature for indicators table

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/__snapshots__/use_toolbar_options.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/__snapshots__/use_toolbar_options.test.tsx.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useToolbarOptions() should return correct value for 0 indicators total 1`] = `
+Object {
+  "additionalControls": Object {
+    "left": Object {
+      "append": <IndicatorsFieldBrowser
+        browserFields={Object {}}
+        columnIds={Array []}
+        onResetColumns={[Function]}
+        onToggleColumn={[Function]}
+      />,
+      "prepend": <EuiText
+        size="xs"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        <React.Fragment>
+          -
+        </React.Fragment>
+      </EuiText>,
+    },
+    "right": <EuiButtonIcon
+      data-test-subj="tiIndicatorsGridInspect"
+      iconType="inspect"
+      onClick={[Function]}
+      title="Inspect"
+    />,
+  },
+  "showDisplaySelector": false,
+  "showFullScreenSelector": true,
+}
+`;
+
+exports[`useToolbarOptions() should return correct value for 25 indicators total 1`] = `
+Object {
+  "additionalControls": Object {
+    "left": Object {
+      "append": <IndicatorsFieldBrowser
+        browserFields={Object {}}
+        columnIds={Array []}
+        onResetColumns={[Function]}
+        onToggleColumn={[Function]}
+      />,
+      "prepend": <EuiText
+        size="xs"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        <React.Fragment>
+          Showing 
+          1
+          -
+          25
+           of
+           
+          25
+           indicators
+        </React.Fragment>
+      </EuiText>,
+    },
+    "right": <EuiButtonIcon
+      data-test-subj="tiIndicatorsGridInspect"
+      iconType="inspect"
+      onClick={[Function]}
+      title="Inspect"
+    />,
+  },
+  "showDisplaySelector": false,
+  "showFullScreenSelector": true,
+}
+`;
+
+exports[`useToolbarOptions() should return correct value for 50 indicators total 1`] = `
+Object {
+  "additionalControls": Object {
+    "left": Object {
+      "append": <IndicatorsFieldBrowser
+        browserFields={Object {}}
+        columnIds={Array []}
+        onResetColumns={[Function]}
+        onToggleColumn={[Function]}
+      />,
+      "prepend": <EuiText
+        size="xs"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        <React.Fragment>
+          Showing 
+          26
+          -
+          50
+           of
+           
+          50
+           indicators
+        </React.Fragment>
+      </EuiText>,
+    },
+    "right": <EuiButtonIcon
+      data-test-subj="tiIndicatorsGridInspect"
+      iconType="inspect"
+      onClick={[Function]}
+      title="Inspect"
+    />,
+  },
+  "showDisplaySelector": false,
+  "showFullScreenSelector": true,
+}
+`;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { TestProvidersComponent } from '../../../../../common/mocks/test_providers';
-import { renderHook } from '@testing-library/react-hooks';
-import { useToolbarOptions } from './use_toolbar_options';
+import { TestProvidersComponent } from "../../../../../common/mocks/test_providers";
+import { renderHook } from "@testing-library/react-hooks";
+import { useToolbarOptions } from "./use_toolbar_options";
 
 describe('useToolbarOptions()', () => {
   it('should return correct value for 0 indicators total', () => {
@@ -25,40 +25,7 @@ describe('useToolbarOptions()', () => {
       { wrapper: TestProvidersComponent }
     );
 
-    expect(result.result.current).toMatchInlineSnapshot(`
-      Object {
-        "additionalControls": Object {
-          "left": Object {
-            "append": <IndicatorsFieldBrowser
-              browserFields={Object {}}
-              columnIds={Array []}
-              onResetColumns={[Function]}
-              onToggleColumn={[Function]}
-            />,
-            "prepend": <EuiText
-              size="xs"
-              style={
-                Object {
-                  "display": "inline",
-                }
-              }
-            >
-              <React.Fragment>
-                -
-              </React.Fragment>
-            </EuiText>,
-          },
-          "right": <EuiButtonIcon
-            data-test-subj="tiIndicatorsGridInspect"
-            iconType="inspect"
-            onClick={[Function]}
-            title="Inspect"
-          />,
-        },
-        "showDisplaySelector": false,
-        "showFullScreenSelector": true,
-      }
-    `);
+    expect(result.result.current).toMatchSnapshot();
   });
 
   it('should return correct value for 25 indicators total', () => {
@@ -76,47 +43,7 @@ describe('useToolbarOptions()', () => {
       { wrapper: TestProvidersComponent }
     );
 
-    expect(result.result.current).toMatchInlineSnapshot(`
-      Object {
-        "additionalControls": Object {
-          "left": Object {
-            "append": <IndicatorsFieldBrowser
-              browserFields={Object {}}
-              columnIds={Array []}
-              onResetColumns={[Function]}
-              onToggleColumn={[Function]}
-            />,
-            "prepend": <EuiText
-              size="xs"
-              style={
-                Object {
-                  "display": "inline",
-                }
-              }
-            >
-              <React.Fragment>
-                Showing
-                1
-                -
-                25
-                 of
-
-                25
-                 indicators
-              </React.Fragment>
-            </EuiText>,
-          },
-          "right": <EuiButtonIcon
-            data-test-subj="tiIndicatorsGridInspect"
-            iconType="inspect"
-            onClick={[Function]}
-            title="Inspect"
-          />,
-        },
-        "showDisplaySelector": false,
-        "showFullScreenSelector": true,
-      }
-    `);
+    expect(result.result.current).toMatchSnapshot();
   });
 
   it('should return correct value for 50 indicators total', () => {
@@ -134,46 +61,6 @@ describe('useToolbarOptions()', () => {
       { wrapper: TestProvidersComponent }
     );
 
-    expect(result.result.current).toMatchInlineSnapshot(`
-      Object {
-        "additionalControls": Object {
-          "left": Object {
-            "append": <IndicatorsFieldBrowser
-              browserFields={Object {}}
-              columnIds={Array []}
-              onResetColumns={[Function]}
-              onToggleColumn={[Function]}
-            />,
-            "prepend": <EuiText
-              size="xs"
-              style={
-                Object {
-                  "display": "inline",
-                }
-              }
-            >
-              <React.Fragment>
-                Showing
-                26
-                -
-                50
-                 of
-
-                50
-                 indicators
-              </React.Fragment>
-            </EuiText>,
-          },
-          "right": <EuiButtonIcon
-            data-test-subj="tiIndicatorsGridInspect"
-            iconType="inspect"
-            onClick={[Function]}
-            title="Inspect"
-          />,
-        },
-        "showDisplaySelector": false,
-        "showFullScreenSelector": true,
-      }
-    `);
+    expect(result.result.current).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
@@ -56,7 +56,7 @@ describe('useToolbarOptions()', () => {
           />,
         },
         "showDisplaySelector": false,
-        "showFullScreenSelector": false,
+        "showFullScreenSelector": true,
       }
     `);
   });
@@ -95,12 +95,12 @@ describe('useToolbarOptions()', () => {
               }
             >
               <React.Fragment>
-                Showing 
+                Showing
                 1
                 -
                 25
                  of
-                 
+
                 25
                  indicators
               </React.Fragment>
@@ -114,7 +114,7 @@ describe('useToolbarOptions()', () => {
           />,
         },
         "showDisplaySelector": false,
-        "showFullScreenSelector": false,
+        "showFullScreenSelector": true,
       }
     `);
   });
@@ -153,12 +153,12 @@ describe('useToolbarOptions()', () => {
               }
             >
               <React.Fragment>
-                Showing 
+                Showing
                 26
                 -
                 50
                  of
-                 
+
                 50
                  indicators
               </React.Fragment>
@@ -172,7 +172,7 @@ describe('useToolbarOptions()', () => {
           />,
         },
         "showDisplaySelector": false,
-        "showFullScreenSelector": false,
+        "showFullScreenSelector": true,
       }
     `);
   });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.test.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { TestProvidersComponent } from "../../../../../common/mocks/test_providers";
-import { renderHook } from "@testing-library/react-hooks";
-import { useToolbarOptions } from "./use_toolbar_options";
+import { TestProvidersComponent } from '../../../../../common/mocks/test_providers';
+import { renderHook } from '@testing-library/react-hooks';
+import { useToolbarOptions } from './use_toolbar_options';
 
 describe('useToolbarOptions()', () => {
   it('should return correct value for 0 indicators total', () => {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_table/hooks/use_toolbar_options.tsx
@@ -41,7 +41,7 @@ export const useToolbarOptions = ({
   return useMemo(
     () => ({
       showDisplaySelector: false,
-      showFullScreenSelector: false,
+      showFullScreenSelector: true,
       additionalControls: {
         left: {
           prepend: (


### PR DESCRIPTION
## Summary

This PR enables the full screen mode on the indicators table.

https://user-images.githubusercontent.com/17276605/193660597-f39d7552-87f1-459c-817d-377d25ee73e5.mov

Fixes https://github.com/elastic/security-team/issues/4546

### Checklist

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))