### PR TITLE
[Enterprise Search] Removing link from native connector advanced configuration steps

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_advanced_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_advanced_configuration.tsx
@@ -16,7 +16,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { generateEncodedPath } from '../../../../../shared/encode_path_params';
-import { EuiLinkTo, EuiButtonTo } from '../../../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../../../shared/react_router_helpers';
 
 import { SEARCH_INDEX_TAB_PATH } from '../../../../routes';
 import { IndexNameLogic } from '../../index_name_logic';
@@ -31,19 +31,7 @@ export const NativeConnectorAdvancedConfiguration: React.FC = () => {
         <EuiText size="s">
           <FormattedMessage
             id="xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.description"
-            defaultMessage="Finalize your connector by triggering a one time sync, or setting a {schedulingLink}."
-            values={{
-              schedulingLink: (
-                <EuiLinkTo to={'' /* TODO docLinks */}>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.recurringScheduleLinkLabel',
-                    {
-                      defaultMessage: 'recurring sync schedule',
-                    }
-                  )}
-                </EuiLinkTo>
-              ),
-            }}
+            defaultMessage="Finalize your connector by triggering a one time sync, or setting a recurring sync schedule."
           />
         </EuiText>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

We have a button right below this link, so we're just axing it rather than linking to docs or the scheduling page


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->