### PR TITLE
[Fleet] Update unenroll logic to account for new API key fields

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -94,7 +94,12 @@ interface AgentBase {
 export interface Agent extends AgentBase {
   id: string;
   access_api_key?: string;
+  // @deprecated
   default_api_key_history?: FleetServerAgent['default_api_key_history'];
+  outputs?: Array<{
+    api_key_id: string;
+    to_retire_api_key_ids?: FleetServerAgent['default_api_key_history']
+  }>;
   status?: AgentStatus;
   packages: string[];
   sort?: Array<number | string | null>;

--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -98,7 +98,7 @@ export interface Agent extends AgentBase {
   default_api_key_history?: FleetServerAgent['default_api_key_history'];
   outputs?: Array<{
     api_key_id: string;
-    to_retire_api_key_ids?: FleetServerAgent['default_api_key_history']
+    to_retire_api_key_ids?: FleetServerAgent['default_api_key_history'];
   }>;
   status?: AgentStatus;
   packages: string[];

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -334,15 +334,12 @@ describe('invalidateAPIKeysForAgents', () => {
         outputs: [
           {
             api_key_id: 'outputApiKey1',
-            to_retire_api_key_ids: [
-              { id: 'outputApiKeyRetire1' },
-              { id: 'outputApiKeyRetire2' },
-            ]
+            to_retire_api_key_ids: [{ id: 'outputApiKeyRetire1' }, { id: 'outputApiKeyRetire2' }],
           },
           {
             api_key_id: 'outputApiKey2',
-          }
-        ]
+          },
+        ],
       } as any,
     ]);
 

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -331,6 +331,18 @@ describe('invalidateAPIKeysForAgents', () => {
             id: 'defaultApiKeyHistory2',
           },
         ],
+        outputs: [
+          {
+            api_key_id: 'outputApiKey1',
+            to_retire_api_key_ids: [
+              { id: 'outputApiKeyRetire1' },
+              { id: 'outputApiKeyRetire2' },
+            ]
+          },
+          {
+            api_key_id: 'outputApiKey2',
+          }
+        ]
       } as any,
     ]);
 
@@ -340,6 +352,10 @@ describe('invalidateAPIKeysForAgents', () => {
       'defaultApiKey1',
       'defaultApiKeyHistory1',
       'defaultApiKeyHistory2',
+      'outputApiKey1',
+      'outputApiKeyRetire1',
+      'outputApiKeyRetire2',
+      'outputApiKey2',
     ]);
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
@@ -215,6 +215,16 @@ export async function invalidateAPIKeysForAgents(agents: Agent[]) {
     if (agent.default_api_key_history) {
       agent.default_api_key_history.forEach((apiKey) => keys.push(apiKey.id));
     }
+    if (agent.outputs) {
+      agent.outputs.forEach(output => {
+        if (output.api_key_id) {
+          keys.push(output.api_key_id)
+        }
+        if (output.to_retire_api_key_ids) {
+          output.to_retire_api_key_ids.forEach((apiKey) => keys.push(apiKey.id));
+        }
+      })
+    }
     return keys;
   }, []);
 

--- a/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
@@ -216,14 +216,14 @@ export async function invalidateAPIKeysForAgents(agents: Agent[]) {
       agent.default_api_key_history.forEach((apiKey) => keys.push(apiKey.id));
     }
     if (agent.outputs) {
-      agent.outputs.forEach(output => {
+      agent.outputs.forEach((output) => {
         if (output.api_key_id) {
-          keys.push(output.api_key_id)
+          keys.push(output.api_key_id);
         }
         if (output.to_retire_api_key_ids) {
           output.to_retire_api_key_ids.forEach((apiKey) => keys.push(apiKey.id));
         }
-      })
+      });
     }
     return keys;
   }, []);


### PR DESCRIPTION
## Summary

In https://github.com/elastic/fleet-server/pull/1879 the fields used to track output API keys changed, but we didn't yet update the force unenroll logic in Kibana to match. This fixes that. You can view the new schema for these fields here: https://github.com/elastic/fleet-server/blob/main/model/schema.json#L372-L404

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->