### PR TITLE
[APM] Add getByTestSubj command for e2e tests

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/feature_flag/comparison.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/feature_flag/comparison.cy.ts
@@ -36,19 +36,19 @@ describe('Comparison feature flag', () => {
     it('shows the comparison feature enabled in services overview', () => {
       cy.visitKibana('/app/apm/services');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('not.be.disabled');
     });
 
     it('shows the comparison feature enabled in dependencies overview', () => {
       cy.visitKibana('/app/apm/dependencies');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('not.be.disabled');
     });
 
     it('shows the comparison feature disabled in service map overview page', () => {
       cy.visitKibana('/app/apm/service-map');
       cy.get('input[type="checkbox"]#comparison').should('be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('not.be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('not.be.disabled');
     });
   });
 
@@ -71,7 +71,7 @@ describe('Comparison feature flag', () => {
     it('shows the comparison feature disabled in services overview', () => {
       cy.visitKibana('/app/apm/services');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('be.disabled');
     });
 
     it('shows the comparison feature disabled in dependencies overview page', () => {
@@ -81,13 +81,13 @@ describe('Comparison feature flag', () => {
       cy.visitKibana('/app/apm/dependencies');
       cy.wait('@topDependenciesRequest');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('be.disabled');
     });
 
     it('shows the comparison feature disabled in service map overview page', () => {
       cy.visitKibana('/app/apm/service-map');
       cy.get('input[type="checkbox"]#comparison').should('not.be.checked');
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('be.disabled');
     });
   });
 });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/integration_settings/integration_policy.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/integration_settings/integration_policy.cy.ts
@@ -60,21 +60,19 @@ describe('when navigating to integration page', () => {
     cy.visitKibana(integrationsPath);
 
     // open integration policy form
-    cy.get('[data-test-subj="integration-card:epr:apm:featured').click();
+    cy.getByTestSubj('integration-card:epr:apm:featured').click();
     cy.contains('Elastic APM in Fleet').click();
     cy.contains('a', 'APM integration').click();
-    cy.get('[data-test-subj="addIntegrationPolicyButton"]').click();
+    cy.getByTestSubj('addIntegrationPolicyButton').click();
   });
 
   it('checks validators for required fields', () => {
     const requiredFields = policyFormFields.filter((field) => field.required);
 
     requiredFields.map((field) => {
-      cy.get(`[data-test-subj="${field.selector}"`).clear();
-      cy.get('[data-test-subj="createPackagePolicySaveButton"').should(
-        'be.disabled'
-      );
-      cy.get(`[data-test-subj="${field.selector}"`).type(field.value);
+      cy.getByTestSubj(field.selector).clear();
+      cy.getByTestSubj('createPackagePolicySaveButton').should('be.disabled');
+      cy.getByTestSubj(field.selector).type(field.value);
     });
   });
 

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/settings/agent_configurations.cy.ts
@@ -90,7 +90,7 @@ describe('Agent configuration', () => {
       '/api/apm/settings/agent-configuration/environments?*'
     ).as('serviceEnvironmentApi');
     cy.contains('Create configuration').click();
-    cy.get('[data-test-subj="serviceNameComboBox"]')
+    cy.getByTestSubj('serviceNameComboBox')
       .click()
       .type('opbeans-node')
       .type('{enter}');
@@ -98,7 +98,7 @@ describe('Agent configuration', () => {
     cy.contains('opbeans-node').realClick();
     cy.wait('@serviceEnvironmentApi');
 
-    cy.get('[data-test-subj="serviceEnviromentComboBox"]')
+    cy.getByTestSubj('serviceEnviromentComboBox')
       .click({ force: true })
       .type('prod')
       .type('{enter}');
@@ -115,14 +115,11 @@ describe('Agent configuration', () => {
       '/api/apm/settings/agent-configuration/environments'
     ).as('serviceEnvironmentApi');
     cy.contains('Create configuration').click();
-    cy.get('[data-test-subj="serviceNameComboBox"]')
-      .click()
-      .type('All')
-      .type('{enter}');
+    cy.getByTestSubj('serviceNameComboBox').click().type('All').type('{enter}');
     cy.contains('All').realClick();
     cy.wait('@serviceEnvironmentApi');
 
-    cy.get('[data-test-subj="serviceEnviromentComboBox"]')
+    cy.getByTestSubj('serviceEnviromentComboBox')
       .click({ force: true })
       .type('All');
 

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/settings/custom_links.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/settings/custom_links.cy.ts
@@ -52,7 +52,7 @@ describe('Custom links', () => {
 
   it('creates custom link', () => {
     cy.visitKibana(basePath);
-    const emptyPrompt = cy.get('[data-test-subj="customLinksEmptyPrompt"]');
+    const emptyPrompt = cy.getByTestSubj('customLinksEmptyPrompt');
     cy.contains('Create custom link').click();
     cy.contains('Create link');
     cy.contains('Save').should('be.disabled');
@@ -63,7 +63,7 @@ describe('Custom links', () => {
     emptyPrompt.should('not.exist');
     cy.contains('foo');
     cy.contains('https://foo.com');
-    cy.get('[data-test-subj="editCustomLink"]').click();
+    cy.getByTestSubj('editCustomLink').click();
     cy.contains('Delete').click();
   });
 
@@ -71,14 +71,14 @@ describe('Custom links', () => {
     cy.visitKibana(basePath);
 
     // wait for empty prompt
-    cy.get('[data-test-subj="customLinksEmptyPrompt"]').should('be.visible');
+    cy.getByTestSubj('customLinksEmptyPrompt').should('be.visible');
 
     cy.contains('Create custom link').click();
-    cy.get('[data-test-subj="filter-0"]').select('service.name');
+    cy.getByTestSubj('filter-0').select('service.name');
     cy.get(
       '[data-test-subj="service.name.value"] [data-test-subj="comboBoxSearchInput"]'
     ).type('foo');
-    cy.get('[data-test-subj="filter-0"]').select('service.environment');
+    cy.getByTestSubj('filter-0').select('service.environment');
     cy.get(
       '[data-test-subj="service.environment.value"] [data-test-subj="comboBoxInput"]'
     ).should('not.contain', 'foo');

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/storage_explorer/storage_explorer.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/power_user/storage_explorer/storage_explorer.cy.ts
@@ -85,7 +85,7 @@ describe('Storage Explorer', () => {
     });
 
     it('renders the storage timeseries chart', () => {
-      cy.get('[data-test-subj="storageExplorerTimeseriesChart"]');
+      cy.getByTestSubj('storageExplorerTimeseriesChart');
     });
 
     it('has a list of services and environments', () => {
@@ -115,7 +115,7 @@ describe('Storage Explorer', () => {
     it('with the correct environment when changing the environment', () => {
       cy.wait(mainAliasNames);
 
-      cy.get('[data-test-subj="environmentFilter"]').type('production');
+      cy.getByTestSubj('environmentFilter').type('production');
 
       cy.contains('button', 'production').click({ force: true });
 
@@ -148,7 +148,7 @@ describe('Storage Explorer', () => {
     it('with the correct lifecycle phase when changing the lifecycle phase', () => {
       cy.wait(mainAliasNames);
 
-      cy.get('[data-test-subj="storageExplorerLifecyclePhaseSelect"]').click();
+      cy.getByTestSubj('storageExplorerLifecyclePhaseSelect').click();
       cy.contains('button', 'Warm').click();
 
       cy.expectAPIsToHaveBeenCalledWith({
@@ -180,13 +180,13 @@ describe('Storage Explorer', () => {
       cy.wait(mainAliasNames);
       cy.contains('opbeans-node');
 
-      cy.get('[data-test-subj="storageDetailsButton_opbeans-node"]').click();
-      cy.get('[data-test-subj="loadingSpinner"]').should('be.visible');
+      cy.getByTestSubj('storageDetailsButton_opbeans-node').click();
+      cy.getByTestSubj('loadingSpinner').should('be.visible');
       cy.wait('@storageDetailsRequest');
 
       cy.contains('Service storage details');
-      cy.get('[data-test-subj="storageExplorerTimeseriesChart"]');
-      cy.get('[data-test-subj="serviceStorageDetailsTable"]');
+      cy.getByTestSubj('storageExplorerTimeseriesChart');
+      cy.getByTestSubj('serviceStorageDetailsTable');
     });
   });
 });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/deep_links.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/deep_links.cy.ts
@@ -11,7 +11,7 @@ describe('APM deep links', () => {
   });
   it('navigates to apm links on search elastic', () => {
     cy.visitKibana('/');
-    cy.get('[data-test-subj="nav-search-input"]').type('APM');
+    cy.getByTestSubj('nav-search-input').type('APM');
     cy.contains('APM');
     cy.contains('APM / Services');
     cy.contains('APM / Traces');
@@ -23,17 +23,17 @@ describe('APM deep links', () => {
     cy.contains('APM').click({ force: true });
     cy.url().should('include', '/apm/services');
 
-    cy.get('[data-test-subj="nav-search-input"]').type('APM');
+    cy.getByTestSubj('nav-search-input').type('APM');
     // navigates to services page
     cy.contains('APM / Services').click({ force: true });
     cy.url().should('include', '/apm/services');
 
-    cy.get('[data-test-subj="nav-search-input"]').type('APM');
+    cy.getByTestSubj('nav-search-input').type('APM');
     // navigates to traces page
     cy.contains('APM / Traces').click({ force: true });
     cy.url().should('include', '/apm/traces');
 
-    cy.get('[data-test-subj="nav-search-input"]').type('APM');
+    cy.getByTestSubj('nav-search-input').type('APM');
     // navigates to service maps
     cy.contains('APM / Service Map').click({ force: true });
     cy.url().should('include', '/apm/service-map');

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/dependencies.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/dependencies.cy.ts
@@ -66,9 +66,9 @@ describe('Dependencies', () => {
         })}`
       );
 
-      cy.get('[data-test-subj="latencyChart"]');
-      cy.get('[data-test-subj="throughputChart"]');
-      cy.get('[data-test-subj="errorRateChart"]');
+      cy.getByTestSubj('latencyChart');
+      cy.getByTestSubj('throughputChart');
+      cy.getByTestSubj('errorRateChart');
 
       cy.contains('opbeans-java').click({ force: true });
 

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/error_details.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/error_details.cy.ts
@@ -68,13 +68,13 @@ describe('Error details', () => {
       it('shows errors distribution chart', () => {
         cy.visitKibana(errorDetailsPageHref);
         cy.contains('Error group 00000');
-        cy.get('[data-test-subj="errorDistribution"]').contains('Occurrences');
+        cy.getByTestSubj('errorDistribution').contains('Occurrences');
       });
 
       it('shows top erroneous transactions table', () => {
         cy.visitKibana(errorDetailsPageHref);
         cy.contains('Top 5 affected transactions');
-        cy.get('[data-test-subj="topErroneousTransactionsTable"]')
+        cy.getByTestSubj('topErroneousTransactionsTable')
           .contains('a', 'GET /apple 🍎')
           .click();
         cy.url().should('include', 'opbeans-java/transactions/view');

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/errors_page.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/errors_page.cy.ts
@@ -81,14 +81,14 @@ describe('Errors page', () => {
 
       it('clicking on type adds a filter in the kuerybar', () => {
         cy.visitKibana(javaServiceErrorsPageHref);
-        cy.get('[data-test-subj="headerFilterKuerybar"]')
+        cy.getByTestSubj('headerFilterKuerybar')
           .invoke('val')
           .should('be.empty');
         // `force: true` because Cypress says the element is 0x0
         cy.contains('exception 0').click({
           force: true,
         });
-        cy.get('[data-test-subj="headerFilterKuerybar"]')
+        cy.getByTestSubj('headerFilterKuerybar')
           .its('length')
           .should('be.gt', 0);
         cy.get('table')
@@ -158,7 +158,7 @@ describe('Check detailed statistics API with multiple errors', () => {
         ])
       );
     });
-    cy.get('[data-test-subj="pagination-button-1"]').click();
+    cy.getByTestSubj('pagination-button-1').click();
     cy.wait('@errorsDetailedStatistics').then((payload) => {
       expect(payload.request.body.groupIds).eql(
         JSON.stringify([

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/home.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/home.cy.ts
@@ -69,7 +69,7 @@ describe('Home page', () => {
       cy.contains('Services');
       cy.contains('opbeans-rum').click({ force: true });
 
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'page-load'
       );

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_inventory/header_filters/header_filters.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_inventory/header_filters/header_filters.cy.ts
@@ -44,7 +44,7 @@ describe('Service inventory - header filters', () => {
       cy.contains('Services');
       cy.contains('opbeans-node');
       cy.contains('service 1');
-      cy.get('[data-test-subj="headerFilterKuerybar"]')
+      cy.getByTestSubj('headerFilterKuerybar')
         .type(`service.name: "${specialServiceName}"`)
         .type('{enter}');
       cy.contains('service 1');

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_inventory/service_inventory.cy.ts
@@ -93,7 +93,7 @@ describe('Service inventory', () => {
     it('with the correct environment when changing the environment', () => {
       cy.wait(mainAliasNames);
 
-      cy.get('[data-test-subj="environmentFilter"]').type('production');
+      cy.getByTestSubj('environmentFilter').type('production');
 
       cy.contains('button', 'production').click();
 
@@ -175,7 +175,7 @@ describe('Service inventory', () => {
           ])
         );
       });
-      cy.get('[data-test-subj="pagination-button-1"]').click();
+      cy.getByTestSubj('pagination-button-1').click();
       cy.wait('@detailedStatisticsRequest').then((payload) => {
         expect(payload.request.body.serviceNames).eql(
           JSON.stringify([

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/errors_table.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/errors_table.cy.ts
@@ -50,16 +50,12 @@ describe('Errors table', () => {
 
   it('clicking on type adds a filter in the kuerybar and navigates to errors page', () => {
     cy.visitKibana(serviceOverviewHref);
-    cy.get('[data-test-subj="headerFilterKuerybar"]')
-      .invoke('val')
-      .should('be.empty');
+    cy.getByTestSubj('headerFilterKuerybar').invoke('val').should('be.empty');
     // `force: true` because Cypress says the element is 0x0
     cy.contains('Exception').click({
       force: true,
     });
-    cy.get('[data-test-subj="headerFilterKuerybar"]')
-      .its('length')
-      .should('be.gt', 0);
+    cy.getByTestSubj('headerFilterKuerybar').its('length').should('be.gt', 0);
     cy.get('table').find('td:contains("Exception")').should('have.length', 1);
   });
 

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/header_filters.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/header_filters.cy.ts
@@ -77,13 +77,13 @@ describe('Service overview - header filters', () => {
       cy.visitKibana(serviceOverviewHref);
       cy.contains('opbeans-node');
       cy.url().should('not.include', 'transactionType');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'request'
       );
-      cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
+      cy.getByTestSubj('headerFilterTransactionType').select('Worker');
       cy.url().should('include', 'transactionType=Worker');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
@@ -94,7 +94,7 @@ describe('Service overview - header filters', () => {
         cy.intercept('GET', endpoint).as(name);
       });
       cy.visitKibana(serviceOverviewHref);
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'request'
       );
@@ -104,9 +104,9 @@ describe('Service overview - header filters', () => {
         value: 'transactionType=request',
       });
 
-      cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
+      cy.getByTestSubj('headerFilterTransactionType').select('Worker');
       cy.url().should('include', 'transactionType=Worker');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
@@ -129,18 +129,12 @@ describe('Service overview - header filters', () => {
         })
       );
       cy.contains('opbeans-java');
-      cy.get('[data-test-subj="headerFilterKuerybar"]').type('transaction.n');
+      cy.getByTestSubj('headerFilterKuerybar').type('transaction.n');
       cy.contains('transaction.name');
-      cy.get('[data-test-subj="suggestionContainer"]')
-        .find('li')
-        .first()
-        .click();
-      cy.get('[data-test-subj="headerFilterKuerybar"]').type(':');
-      cy.get('[data-test-subj="suggestionContainer"]')
-        .find('li')
-        .first()
-        .click();
-      cy.get('[data-test-subj="headerFilterKuerybar"]').type('{enter}');
+      cy.getByTestSubj('suggestionContainer').find('li').first().click();
+      cy.getByTestSubj('headerFilterKuerybar').type(':');
+      cy.getByTestSubj('suggestionContainer').find('li').first().click();
+      cy.getByTestSubj('headerFilterKuerybar').type('{enter}');
       cy.url().should('include', '&kuery=transaction.name');
     });
   });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/instances_table.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/instances_table.cy.ts
@@ -63,7 +63,7 @@ describe('Instances table', () => {
     it('shows empty message', () => {
       cy.visitKibana(testServiveHref);
       cy.contains('test-service');
-      cy.get('[data-test-subj="serviceInstancesTableContainer"]').contains(
+      cy.getByTestSubj('serviceInstancesTableContainer').contains(
         'No instances found'
       );
     });
@@ -77,9 +77,7 @@ describe('Instances table', () => {
     it('hides instances table', () => {
       cy.visitKibana(serviceRumOverviewHref);
       cy.contains('opbeans-rum');
-      cy.get('[data-test-subj="serviceInstancesTableContainer"]').should(
-        'not.exist'
-      );
+      cy.getByTestSubj('serviceInstancesTableContainer').should('not.exist');
     });
   });
 
@@ -109,10 +107,8 @@ describe('Instances table', () => {
       cy.contains(serviceNodeName);
 
       cy.wait('@instancesDetailsRequest');
-      cy.get(
-        `[data-test-subj="instanceDetailsButton_${serviceNodeName}"]`
-      ).realClick();
-      cy.get('[data-test-subj="loadingSpinner"]').should('be.visible');
+      cy.getByTestSubj(`instanceDetailsButton_${serviceNodeName}`).realClick();
+      cy.getByTestSubj('loadingSpinner').should('be.visible');
       cy.wait('@instanceDetailsRequest').then(() => {
         cy.contains('Service');
       });
@@ -130,9 +126,7 @@ describe('Instances table', () => {
       cy.contains(serviceNodeName);
 
       cy.wait('@instancesDetailsRequest');
-      cy.get(
-        `[data-test-subj="instanceActionsButton_${serviceNodeName}"]`
-      ).click();
+      cy.getByTestSubj(`instanceActionsButton_${serviceNodeName}`).click();
       cy.contains('Pod logs');
       cy.contains('Pod metrics');
       // cy.contains('Container logs');

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/service_overview.cy.ts
@@ -109,13 +109,13 @@ describe('Service Overview', () => {
       cy.contains('opbeans-node');
       // set skipFailures to true to not fail the test when there are accessibility failures
       checkA11y({ skipFailures: true });
-      cy.get('[data-test-subj="latencyChart"]');
-      cy.get('[data-test-subj="throughput"]');
-      cy.get('[data-test-subj="transactionsGroupTable"]');
-      cy.get('[data-test-subj="serviceOverviewErrorsTable"]');
-      cy.get('[data-test-subj="dependenciesTable"]');
-      cy.get('[data-test-subj="instancesLatencyDistribution"]');
-      cy.get('[data-test-subj="serviceOverviewInstancesTable"]');
+      cy.getByTestSubj('latencyChart');
+      cy.getByTestSubj('throughput');
+      cy.getByTestSubj('transactionsGroupTable');
+      cy.getByTestSubj('serviceOverviewErrorsTable');
+      cy.getByTestSubj('dependenciesTable');
+      cy.getByTestSubj('instancesLatencyDistribution');
+      cy.getByTestSubj('serviceOverviewInstancesTable');
     });
   });
 
@@ -134,17 +134,17 @@ describe('Service Overview', () => {
 
       cy.wait('@transactionTypesRequest');
 
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'request'
       );
-      cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').select('Worker');
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
       cy.contains('Transactions').click();
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
@@ -159,18 +159,18 @@ describe('Service Overview', () => {
       cy.visitKibana(baseUrl);
 
       cy.wait('@transactionTypesRequest');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'request'
       );
-      cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').select('Worker');
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
 
       cy.contains('View transactions').click();
-      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      cy.getByTestSubj('headerFilterTransactionType').should(
         'have.value',
         'Worker'
       );
@@ -226,7 +226,7 @@ describe('Service Overview', () => {
         'suggestionsRequest'
       );
 
-      cy.get('[data-test-subj="environmentFilter"] input').type('production', {
+      cy.getByTestSubj('environmentFilter').find('input').type('production', {
         force: true,
       });
 
@@ -235,9 +235,7 @@ describe('Service Overview', () => {
         value: 'fieldValue=production',
       });
 
-      cy.get(
-        '[data-test-subj="comboBoxOptionsList environmentFilter-optionsList"]'
-      )
+      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList')
         .contains('production')
         .click({ force: true });
 
@@ -271,11 +269,11 @@ describe('Service Overview', () => {
     });
 
     it('when selecting a different comparison window', () => {
-      cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1d');
+      cy.getByTestSubj('comparisonSelect').should('have.value', '1d');
 
       // selects another comparison type
-      cy.get('[data-test-subj="comparisonSelect"]').select('1w');
-      cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1w');
+      cy.getByTestSubj('comparisonSelect').select('1w');
+      cy.getByTestSubj('comparisonSelect').should('have.value', '1w');
       cy.expectAPIsToHaveBeenCalledWith({
         apisIntercepted: aliasNamesWithComparison,
         value: 'offset',

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/time_comparison.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/service_overview/time_comparison.cy.ts
@@ -101,18 +101,18 @@ describe('Service overview: Time Comparison', () => {
     cy.visitKibana(serviceOverviewPath);
     cy.contains('opbeans-java');
     // opens the page with "Day before" selected
-    cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1d');
+    cy.getByTestSubj('comparisonSelect').should('have.value', '1d');
 
     // selects another comparison type
-    cy.get('[data-test-subj="comparisonSelect"]').select('1w');
-    cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1w');
+    cy.getByTestSubj('comparisonSelect').select('1w');
+    cy.getByTestSubj('comparisonSelect').should('have.value', '1w');
   });
 
   it('changes comparison type when a new time range is selected', () => {
     cy.visitKibana(serviceOverviewHref);
     cy.contains('opbeans-java');
     // Time comparison default value
-    cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1d');
+    cy.getByTestSubj('comparisonSelect').should('have.value', '1d');
     cy.contains('Day before');
     cy.contains('Week before');
 
@@ -121,17 +121,14 @@ describe('Service overview: Time Comparison', () => {
       '2021-10-20T00:00:00.000Z'
     );
 
-    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.getByTestSubj('superDatePickerApplyTimeButton').click();
 
-    cy.get('[data-test-subj="comparisonSelect"]').should(
-      'have.value',
-      '864000000ms'
-    );
-    cy.get('[data-test-subj="comparisonSelect"]').should(
+    cy.getByTestSubj('comparisonSelect').should('have.value', '864000000ms');
+    cy.getByTestSubj('comparisonSelect').should(
       'not.contain.text',
       'Day before'
     );
-    cy.get('[data-test-subj="comparisonSelect"]').should(
+    cy.getByTestSubj('comparisonSelect').should(
       'not.contain.text',
       'Week before'
     );
@@ -141,17 +138,14 @@ describe('Service overview: Time Comparison', () => {
     cy.contains('Week before');
 
     cy.changeTimeRange('Last 24 hours');
-    cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1d');
+    cy.getByTestSubj('comparisonSelect').should('have.value', '1d');
     cy.contains('Day before');
     cy.contains('Week before');
 
     cy.changeTimeRange('Last 7 days');
-    cy.get('[data-test-subj="comparisonSelect"]').should('have.value', '1w');
-    cy.get('[data-test-subj="comparisonSelect"]').should(
-      'contain.text',
-      'Week before'
-    );
-    cy.get('[data-test-subj="comparisonSelect"]').should(
+    cy.getByTestSubj('comparisonSelect').should('have.value', '1w');
+    cy.getByTestSubj('comparisonSelect').should('contain.text', 'Week before');
+    cy.getByTestSubj('comparisonSelect').should(
       'not.contain.text',
       'Day before'
     );
@@ -170,7 +164,7 @@ describe('Service overview: Time Comparison', () => {
     );
     cy.contains('opbeans-java');
     cy.wait('@throughputChartRequest');
-    cy.get('[data-test-subj="throughput"]')
+    cy.getByTestSubj('throughput')
       .get('#echHighlighterClipPath__throughput')
       .realHover({ position: 'center' });
     cy.contains('Week before');
@@ -186,17 +180,17 @@ describe('Service overview: Time Comparison', () => {
       cy.contains('opbeans-java');
 
       // Comparison is enabled by default
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.enabled');
+      cy.getByTestSubj('comparisonSelect').should('be.enabled');
 
       // toggles off comparison
       cy.contains('Comparison').click();
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('be.disabled');
     });
 
     it('calls APIs without comparison time range', () => {
       cy.visitKibana(serviceOverviewHref);
 
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.enabled');
+      cy.getByTestSubj('comparisonSelect').should('be.enabled');
       const offset = `offset=1d`;
 
       // When the page loads it fetches all APIs with comparison time range
@@ -212,7 +206,7 @@ describe('Service overview: Time Comparison', () => {
 
       // toggles off comparison
       cy.contains('Comparison').click();
-      cy.get('[data-test-subj="comparisonSelect"]').should('be.disabled');
+      cy.getByTestSubj('comparisonSelect').should('be.disabled');
       // When comparison is disabled APIs are called withou comparison time range
       cy.wait(apisToIntercept.map(({ name }) => `@${name}`)).then(
         (interceptions) => {

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transaction_details/span_links.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transaction_details/span_links.cy.ts
@@ -50,8 +50,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction A').click();
         cy.contains('2 Span links');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerInternalOnlyIds.spanAId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerInternalOnlyIds.spanAId}`
         ).realHover();
         cy.contains('2 Span links found');
         cy.contains('2 incoming');
@@ -64,8 +64,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction B').click();
         cy.contains('2 Span links');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerExternalOnlyIds.spanBId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerExternalOnlyIds.spanBId}`
         ).realHover();
         cy.contains('2 Span links found');
         cy.contains('1 incoming');
@@ -78,8 +78,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction C').click();
         cy.contains('2 Span links');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerConsumerIds.transactionCId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerConsumerIds.transactionCId}`
         ).realHover();
         cy.contains('2 Span links found');
         cy.contains('1 incoming');
@@ -92,8 +92,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction C').click();
         cy.contains('1 Span link');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerConsumerIds.spanCId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerConsumerIds.spanCId}`
         ).realHover();
         cy.contains('1 Span link found');
         cy.contains('1 incoming');
@@ -106,8 +106,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction D').click();
         cy.contains('2 Span links');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerMultipleIds.transactionDId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerMultipleIds.transactionDId}`
         ).realHover();
         cy.contains('2 Span links found');
         cy.contains('0 incoming');
@@ -120,8 +120,8 @@ describe('Span links', () => {
         );
         cy.contains('Transaction D').click();
         cy.contains('2 Span links');
-        cy.get(
-          `[data-test-subj="spanLinksBadge_${ids.producerMultipleIds.spanEId}"]`
+        cy.getByTestSubj(
+          `spanLinksBadge_${ids.producerMultipleIds.spanEId}`
         ).realHover();
         cy.contains('2 Span links found');
         cy.contains('0 incoming');
@@ -136,7 +136,7 @@ describe('Span links', () => {
         );
         cy.contains('Transaction A').click();
         cy.contains('Span A').click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
         cy.contains('producer-consumer')
           .should('have.attr', 'href')
           .and('include', '/services/producer-consumer/overview');
@@ -155,7 +155,7 @@ describe('Span links', () => {
             'include',
             `link-to/transaction/${ids.producerMultipleIds.transactionDId}?waterfallItemId=${ids.producerMultipleIds.transactionDId}`
           );
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').should(
+        cy.getByTestSubj('spanLinkTypeSelect').should(
           'contain.text',
           'Outgoing links (0)'
         );
@@ -167,7 +167,7 @@ describe('Span links', () => {
         );
         cy.contains('Transaction B').click();
         cy.contains('Span B').click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
 
         cy.contains('consumer-multiple')
           .should('have.attr', 'href')
@@ -178,9 +178,7 @@ describe('Span links', () => {
             'include',
             `link-to/transaction/${ids.producerMultipleIds.transactionDId}?waterfallItemId=${ids.producerMultipleIds.spanEId}`
           );
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').select(
-          'Outgoing links (1)'
-        );
+        cy.getByTestSubj('spanLinkTypeSelect').select('Outgoing links (1)');
         cy.contains('Unknown');
         cy.contains('trace#1-span#1');
       });
@@ -193,7 +191,7 @@ describe('Span links', () => {
         cy.get(
           `[aria-controls="${ids.producerConsumerIds.transactionCId}"]`
         ).click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
 
         cy.contains('consumer-multiple')
           .should('have.attr', 'href')
@@ -205,9 +203,7 @@ describe('Span links', () => {
             `link-to/transaction/${ids.producerMultipleIds.transactionDId}?waterfallItemId=${ids.producerMultipleIds.spanEId}`
           );
 
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').select(
-          'Outgoing links (1)'
-        );
+        cy.getByTestSubj('spanLinkTypeSelect').select('Outgoing links (1)');
         cy.contains('producer-internal-only')
           .should('have.attr', 'href')
           .and('include', '/services/producer-internal-only/overview');
@@ -225,7 +221,7 @@ describe('Span links', () => {
         );
         cy.contains('Transaction C').click();
         cy.contains('Span C').click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
 
         cy.contains('consumer-multiple')
           .should('have.attr', 'href')
@@ -237,7 +233,7 @@ describe('Span links', () => {
             `link-to/transaction/${ids.producerMultipleIds.transactionDId}?waterfallItemId=${ids.producerMultipleIds.transactionDId}`
           );
 
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').should(
+        cy.getByTestSubj('spanLinkTypeSelect').should(
           'contain.text',
           'Outgoing links (0)'
         );
@@ -251,7 +247,7 @@ describe('Span links', () => {
         cy.get(
           `[aria-controls="${ids.producerMultipleIds.transactionDId}"]`
         ).click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
 
         cy.contains('producer-consumer')
           .should('have.attr', 'href')
@@ -273,7 +269,7 @@ describe('Span links', () => {
             `link-to/transaction/${ids.producerInternalOnlyIds.transactionAId}?waterfallItemId=${ids.producerInternalOnlyIds.spanAId}`
           );
 
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').should(
+        cy.getByTestSubj('spanLinkTypeSelect').should(
           'contain.text',
           'Incoming links (0)'
         );
@@ -285,7 +281,7 @@ describe('Span links', () => {
         );
         cy.contains('Transaction D').click();
         cy.contains('Span E').click();
-        cy.get('[data-test-subj="spanLinksTab"]').click();
+        cy.getByTestSubj('spanLinksTab').click();
 
         cy.contains('producer-external-only')
           .should('have.attr', 'href')
@@ -307,7 +303,7 @@ describe('Span links', () => {
             `link-to/transaction/${ids.producerConsumerIds.transactionCId}?waterfallItemId=${ids.producerConsumerIds.transactionCId}`
           );
 
-        cy.get('[data-test-subj="spanLinkTypeSelect"]').should(
+        cy.getByTestSubj('spanLinkTypeSelect').should(
           'contain.text',
           'Incoming links (0)'
         );

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transaction_details/transaction_details.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transaction_details/transaction_details.cy.ts
@@ -42,15 +42,15 @@ describe('Transaction details', () => {
 
   it('shows transaction name and transaction charts', () => {
     cy.contains('h2', 'GET /api/product');
-    cy.get('[data-test-subj="latencyChart"]');
-    cy.get('[data-test-subj="throughput"]');
-    cy.get('[data-test-subj="transactionBreakdownChart"]');
-    cy.get('[data-test-subj="errorRate"]');
+    cy.getByTestSubj('latencyChart');
+    cy.getByTestSubj('throughput');
+    cy.getByTestSubj('transactionBreakdownChart');
+    cy.getByTestSubj('errorRate');
   });
 
   it('shows top errors table', () => {
     cy.contains('Top 5 errors');
-    cy.get('[data-test-subj="topErrorsForTransactionTable"]')
+    cy.getByTestSubj('topErrorsForTransactionTable')
       .contains('a', '[MockError] Foo')
       .click();
     cy.url().should('include', 'opbeans-java/errors');
@@ -58,7 +58,7 @@ describe('Transaction details', () => {
 
   describe('when navigating to a trace sample', () => {
     it('keeps the same trace sample after reloading the page', () => {
-      cy.get('[data-test-subj="pagination-button-last"]').click();
+      cy.getByTestSubj('pagination-button-last').click();
       cy.url().then((url) => {
         cy.reload();
         cy.url().should('eq', url);

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transactions_overview/transactions_overview.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/transactions_overview/transactions_overview.cy.ts
@@ -49,17 +49,17 @@ describe('Transactions Overview', () => {
 
   it('persists transaction type selected when navigating to Overview tab', () => {
     cy.visitKibana(serviceTransactionsHref);
-    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+    cy.getByTestSubj('headerFilterTransactionType').should(
       'have.value',
       'request'
     );
-    cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
-    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+    cy.getByTestSubj('headerFilterTransactionType').select('Worker');
+    cy.getByTestSubj('headerFilterTransactionType').should(
       'have.value',
       'Worker'
     );
     cy.get('a[href*="/app/apm/services/opbeans-node/overview"]').click();
-    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+    cy.getByTestSubj('headerFilterTransactionType').should(
       'have.value',
       'Worker'
     );

--- a/x-pack/plugins/apm/ftr_e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/support/commands.ts
@@ -52,15 +52,19 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add('getByTestSubj', (selector: string) => {
+  return cy.get(`[data-test-subj="${selector}"]`);
+});
+
 Cypress.Commands.add('changeTimeRange', (value: string) => {
-  cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]').click();
+  cy.getByTestSubj('superDatePickerToggleQuickMenuButton').click();
   cy.contains(value).click();
 });
 
 Cypress.Commands.add('visitKibana', (url: string) => {
   cy.visit(url);
-  cy.get('[data-test-subj="kbnLoadingMessage"]').should('exist');
-  cy.get('[data-test-subj="kbnLoadingMessage"]').should('not.exist', {
+  cy.getByTestSubj('kbnLoadingMessage').should('exist');
+  cy.getByTestSubj('kbnLoadingMessage').should('not.exist', {
     timeout: 50000,
   });
 });
@@ -70,13 +74,13 @@ Cypress.Commands.add(
   (start: string, end: string) => {
     const format = 'MMM D, YYYY @ HH:mm:ss.SSS';
 
-    cy.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').click();
-    cy.get('[data-test-subj="superDatePickerAbsoluteDateInput"]')
+    cy.getByTestSubj('superDatePickerstartDatePopoverButton').click();
+    cy.getByTestSubj('superDatePickerAbsoluteDateInput')
       .eq(0)
       .clear({ force: true })
       .type(moment(start).format(format), { force: true });
-    cy.get('[data-test-subj="superDatePickerendDatePopoverButton"]').click();
-    cy.get('[data-test-subj="superDatePickerAbsoluteDateInput"]')
+    cy.getByTestSubj('superDatePickerendDatePopoverButton').click();
+    cy.getByTestSubj('superDatePickerAbsoluteDateInput')
       .eq(1)
       .clear({ force: true })
       .type(moment(end).format(format), { force: true });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/support/types.d.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/support/types.d.ts
@@ -22,5 +22,6 @@ declare namespace Cypress {
       value: string;
     }): void;
     updateAdvancedSettings(settings: Record<string, unknown>): void;
+    getByTestSubj(selector: string): Chainable<JQuery<Element>>;
   }
 }


### PR DESCRIPTION
## Summary
There are many instances where testSubjects are used to get DOM elements in e2e tests. This PR adds a `getByTestSubj` command to replace usages of `cy.get('[data-test-subj="${selector}"]')`.