### PR TITLE
[Uptime] Unskip flaky api test

### DIFF
--- a/x-pack/test/api_integration/apis/uptime/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/uptime/feature_controls.ts
@@ -145,8 +145,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
       }
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/136542
-    describe.skip('spaces', () => {
+    describe('spaces', () => {
       // the following tests create a user_1 which has uptime read access to space_1 and dashboard all access to space_2
       const space1Id = 'space_1';
       const space2Id = 'space_2';


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/136541
Fixes https://github.com/elastic/kibana/issues/136542


This was most likely an upstream es issue which got fixed recently https://github.com/elastic/elasticsearch/issues/90130


Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1354

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->