### PR TITLE
[8.5] [TSVB][Lens]Fix conversion from static value in timeseries to reference line in lens (#142453)

### DIFF
--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/xy/layers.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/xy/layers.ts
@@ -23,7 +23,7 @@ import { DataViewsPublicPluginStart, DataView } from '@kbn/data-plugin/public/da
 import { fetchIndexPattern } from '../../../../../common/index_patterns_utils';
 import { ICON_TYPES_MAP } from '../../../../application/visualizations/constants';
 import { SUPPORTED_METRICS } from '../../metrics';
-import type { Annotation, Metric, Panel } from '../../../../../common/types';
+import type { Annotation, Metric, Panel, Series } from '../../../../../common/types';
 import { getSeriesAgg } from '../../series';
 import {
   isPercentileRanksColumnWithMeta,
@@ -41,6 +41,10 @@ function getPalette(palette: PaletteOutput): PaletteOutput {
   return !palette || palette.name === 'gradient' || palette.name === 'rainbow'
     ? { name: 'default', type: 'palette' }
     : palette;
+}
+
+function getAxisMode(series: Series, model: Panel): YAxisMode {
+  return (series.separate_axis ? series.axis_position : model.axis_position) as YAxisMode;
 }
 
 function getColor(
@@ -68,7 +72,8 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
 export const getLayers = async (
   dataSourceLayers: Record<number, Layer>,
   model: Panel,
-  dataViews: DataViewsPublicPluginStart
+  dataViews: DataViewsPublicPluginStart,
+  isSingleAxis: boolean = false
 ): Promise<XYLayerConfig[]> => {
   const nonAnnotationsLayers: XYLayerConfig[] = Object.keys(dataSourceLayers).map((key) => {
     const series = model.series[parseInt(key, 10)];
@@ -83,13 +88,13 @@ export const getLayers = async (
     const metricColumns = dataSourceLayer.columns.filter(
       (l) => !l.isBucketed && l.columnId !== referenceColumnId
     );
-    const isReferenceLine = metrics.length === 1 && metrics[0].type === 'static';
+    const isReferenceLine =
+      metricColumns.length === 1 && metricColumns[0].operationType === 'static_value';
     const splitAccessor = dataSourceLayer.columns.find(
       (column) => column.isBucketed && column.isSplit
     )?.columnId;
     const chartType = getChartType(series, model.type);
     const commonProps = {
-      seriesType: chartType,
       layerId: dataSourceLayer.layerId,
       accessors: metricColumns.map((metricColumn) => {
         return metricColumn.columnId;
@@ -101,19 +106,19 @@ export const getLayers = async (
         return {
           forAccessor: metricColumn.columnId,
           color: getColor(metricColumn, metric!, series.color, splitAccessor),
-          axisMode: (series.separate_axis
-            ? series.axis_position
-            : model.axis_position) as YAxisMode,
+          axisMode: isReferenceLine // reference line should be assigned to axis with real data
+            ? model.series.some((s) => s.id !== series.id && getAxisMode(s, model) === 'right')
+              ? 'right'
+              : 'left'
+            : isSingleAxis
+            ? 'left'
+            : getAxisMode(series, model),
           ...(isReferenceLine && {
-            fill: chartType === 'area' ? FillTypes.BELOW : FillTypes.NONE,
+            fill: chartType.includes('area') ? FillTypes.BELOW : FillTypes.NONE,
+            lineWidth: series.line_width,
           }),
         };
       }),
-      xAccessor: dataSourceLayer.columns.find((column) => column.isBucketed && !column.isSplit)
-        ?.columnId,
-      splitAccessor,
-      collapseFn: seriesAgg,
-      palette: getPalette(series.palette as PaletteOutput),
     };
     if (isReferenceLine) {
       return {
@@ -122,8 +127,14 @@ export const getLayers = async (
       };
     } else {
       return {
+        seriesType: chartType,
         layerType: 'data',
         ...commonProps,
+        xAccessor: dataSourceLayer.columns.find((column) => column.isBucketed && !column.isSplit)
+          ?.columnId,
+        splitAccessor,
+        collapseFn: seriesAgg,
+        palette: getPalette(series.palette as PaletteOutput),
       };
     }
   });

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.test.ts
@@ -112,6 +112,19 @@ describe('convertToLens', () => {
     expect(mockGetBucketsColumns).toBeCalledTimes(1);
   });
 
+  test('should return null for static value with buckets', async () => {
+    mockGetBucketsColumns.mockReturnValue([{}]);
+    mockGetMetricsColumns.mockReturnValue([
+      {
+        operationType: 'static_value',
+      },
+    ]);
+    const result = await convertToLens(model);
+    expect(result).toBeNull();
+    expect(mockGetMetricsColumns).toBeCalledTimes(1);
+    expect(mockGetBucketsColumns).toBeCalledTimes(1);
+  });
+
   test('should return state for valid model', async () => {
     const result = await convertToLens(model);
     expect(result).toBeDefined();

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.ts
@@ -88,11 +88,21 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (model: Panel
       return null;
     }
 
+    const isReferenceLine =
+      metricsColumns.length === 1 && metricsColumns[0].operationType === 'static_value';
+
+    // only static value without split is supported
+    if (isReferenceLine && bucketsColumns.length) {
+      return null;
+    }
+
     const layerId = uuid();
     extendedLayers[layerIdx] = {
       indexPatternId,
       layerId,
-      columns: [...metricsColumns, dateHistogramColumn, ...bucketsColumns],
+      columns: isReferenceLine
+        ? [...metricsColumns]
+        : [...metricsColumns, dateHistogramColumn, ...bucketsColumns],
       columnOrder: [],
     };
   }

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
@@ -79,7 +79,7 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (model, timeR
     };
   }
 
-  const configLayers = await getLayers(extendedLayers, model, dataViews);
+  const configLayers = await getLayers(extendedLayers, model, dataViews, true);
 
   return {
     type: 'lnsXY',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[TSVB][Lens]Fix conversion from static value in timeseries to reference line in lens (#142453)](https://github.com/elastic/kibana/pull/142453)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Uladzislau Lasitsa","email":"vlad.lasitsa@gmail.com"},"sourceCommit":{"committedDate":"2022-10-04T12:00:59Z","message":"[TSVB][Lens]Fix conversion from static value in timeseries to reference line in lens (#142453)\n\n* Fix conversion static value in timeseries to reference line in lens\r\n\r\n* Doesn't allow convert static value with split\r\n\r\n* Fix condition\r\n\r\n* Ignore axis position from model for top n\r\n\r\n* Added tests\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8e770bb6080b99b5437b22b22fc0d07c68e4c504","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:TSVB","Team:VisEditors","release_note:skip","Feature:Lens","backport:prev-minor","v8.5.0","v8.6.0"],"number":142453,"url":"https://github.com/elastic/kibana/pull/142453","mergeCommit":{"message":"[TSVB][Lens]Fix conversion from static value in timeseries to reference line in lens (#142453)\n\n* Fix conversion static value in timeseries to reference line in lens\r\n\r\n* Doesn't allow convert static value with split\r\n\r\n* Fix condition\r\n\r\n* Ignore axis position from model for top n\r\n\r\n* Added tests\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8e770bb6080b99b5437b22b22fc0d07c68e4c504"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/142453","number":142453,"mergeCommit":{"message":"[TSVB][Lens]Fix conversion from static value in timeseries to reference line in lens (#142453)\n\n* Fix conversion static value in timeseries to reference line in lens\r\n\r\n* Doesn't allow convert static value with split\r\n\r\n* Fix condition\r\n\r\n* Ignore axis position from model for top n\r\n\r\n* Added tests\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8e770bb6080b99b5437b22b22fc0d07c68e4c504"}}]}] BACKPORT-->