### PR TITLE
[APM] Adding tech preview on the logs tab for AWS lambda service

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -318,6 +318,9 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
       label: i18n.translate('xpack.apm.home.serviceLogsTabLabel', {
         defaultMessage: 'Logs',
       }),
+      append: isServerlessAgent(runtimeName) ? (
+        <TechnicalPreviewBadge icon="beaker" />
+      ) : undefined,
       hidden:
         !agentName || isRumAgentName(agentName) || isMobileAgentName(agentName),
     },

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -267,9 +267,9 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
       label: i18n.translate('xpack.apm.serviceDetails.metricsTabLabel', {
         defaultMessage: 'Metrics',
       }),
-      append: isServerlessAgent(runtimeName) ? (
+      append: isServerlessAgent(runtimeName) && (
         <TechnicalPreviewBadge icon="beaker" />
-      ) : undefined,
+      ),
       hidden: isMetricsTabHidden({
         agentName,
         runtimeName,
@@ -318,9 +318,9 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
       label: i18n.translate('xpack.apm.home.serviceLogsTabLabel', {
         defaultMessage: 'Logs',
       }),
-      append: isServerlessAgent(runtimeName) ? (
+      append: isServerlessAgent(runtimeName) && (
         <TechnicalPreviewBadge icon="beaker" />
-      ) : undefined,
+      ),
       hidden:
         !agentName || isRumAgentName(agentName) || isMobileAgentName(agentName),
     },


### PR DESCRIPTION
@akhileshpok requested to add the tech preview icon on the `Logs` tab in the AWS lambda services since this is going to be available out-of-the-box by the extension.

AWS LAMBDA SERVICE:
<img width="1245" alt="Screen Shot 2022-10-04 at 9 44 33 AM" src="https://user-images.githubusercontent.com/55978943/193836301-6aa76108-5764-4f1a-a310-3c5b3b62031b.png">


Other agents:
<img width="1111" alt="Screen Shot 2022-10-04 at 9 44 41 AM" src="https://user-images.githubusercontent.com/55978943/193836341-1d97e9ea-7bad-4319-8150-3cfd33d3a8bb.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->