### PR TITLE
[Enterprise Search] add ml pipeline empty schema error

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -22,10 +22,28 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { docLinks } from '../../../../../shared/doc_links';
 
 import { MLInferenceLogic } from './ml_inference_logic';
+
+const NoSourceFieldsError: React.FC = () => (
+  <FormattedMessage
+    id="xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.sourceField.error"
+    defaultMessage="Selecting a source field is required for pipeline configuration, but this index does not have a field mapping. {learnMore}"
+    values={{
+      learnMore: (
+        <EuiLink href={docLinks.elasticsearchMapping} target="_blank" color="danger">
+          {i18n.translate(
+            'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.sourceField.error.docLink',
+            { defaultMessage: 'Learn more about field mapping' }
+          )}
+        </EuiLink>
+      ),
+    }}
+  />
+);
 
 export const ConfigurePipeline: React.FC = () => {
   const {
@@ -39,6 +57,7 @@ export const ConfigurePipeline: React.FC = () => {
   const { destinationField, modelID, pipelineName, sourceField } = configuration;
   const models = supportedMLModels ?? [];
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
+  const emptySourceFields = (sourceFields?.length ?? 0) === 0;
 
   return (
     <>
@@ -143,6 +162,8 @@ export const ConfigurePipeline: React.FC = () => {
                   defaultMessage: 'Source field',
                 }
               )}
+              error={emptySourceFields && <NoSourceFieldsError />}
+              isInvalid={emptySourceFields}
             >
               <EuiSelect
                 value={sourceField}


### PR DESCRIPTION
## Summary

Added an error for when there are no source fields available. Loaded a small set of default fields if we know its a connector index.

<img width="785" alt="image" src="https://user-images.githubusercontent.com/1972968/193910971-0ed50fe1-6d65-4bfe-b246-c8ad24c1b647.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->