### PR TITLE
[Enterprise Search] Remove Minutes from connector scheduling frequency dropdown

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -177,6 +177,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                 setScheduling({ ...scheduling, interval: expression });
                 setHasChanges(true);
               }}
+              frequencyBlockList={['MINUTE']}
             />
           </EuiFlexItem>
           <EuiFlexItem>


### PR DESCRIPTION
## Summary

To reduce likelihood of sync collision issues

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->