### PR TITLE
[Lens] Move quickfunction documentation button

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -640,6 +640,11 @@ export function DimensionEditor(props: DimensionEditorProps) {
         label={
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
+              {i18n.translate('xpack.lens.indexPattern.functionsLabel', {
+                defaultMessage: 'Functions',
+              })}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <EuiPopover
                 anchorPosition="rightUp"
                 button={helpButton}
@@ -679,11 +684,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
                   />
                 </EuiPanel>
               </EuiPopover>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              {i18n.translate('xpack.lens.indexPattern.functionsLabel', {
-                defaultMessage: 'Functions',
-              })}
             </EuiFlexItem>
           </EuiFlexGroup>
         }


### PR DESCRIPTION
Follow-up of https://github.com/elastic/kibana/pull/141399

Moves the quickfunction documentation button behind the "Functions" label:
<img width="503" alt="Screenshot 2022-10-04 at 17 26 43" src="https://user-images.githubusercontent.com/1508364/193860971-f4081971-7d5a-46f5-826f-315cb62238d0.png">
