### PR TITLE
[Security Solution] [Cases] Bugfix, properly encode `externalId` json

### DIFF
--- a/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.test.ts
@@ -474,6 +474,75 @@ describe('Cases webhook service', () => {
       expect(requestMock).not.toHaveBeenCalled();
       expect(res).toBeUndefined();
     });
+    test('properly encodes external system id as string in request body', async () => {
+      requestMock.mockImplementation(() =>
+        createAxiosResponse({
+          data: {
+            id: '1',
+            key: 'CK-1',
+          },
+        })
+      );
+      service = createExternalService(
+        actionId,
+        {
+          config: {
+            ...config,
+            createCommentJson: '{"body":{{{case.comment}}},"id":{{{external.system.id}}}}',
+          },
+          secrets,
+        },
+        logger,
+        configurationUtilities
+      );
+      await service.createComment(commentReq);
+      expect(requestMock).toHaveBeenCalledWith({
+        axios,
+        logger,
+        method: CasesWebhookMethods.POST,
+        configurationUtilities,
+        url: 'https://coolsite.net/issue/1/comment',
+        data: `{"body":"comment","id":"1"}`,
+      });
+    });
+    test('properly encodes external system id as number in request body', async () => {
+      const commentReq2 = {
+        incidentId: 1 as unknown as string,
+        comment: {
+          comment: 'comment',
+          commentId: 'comment-1',
+        },
+      };
+      requestMock.mockImplementation(() =>
+        createAxiosResponse({
+          data: {
+            id: '1',
+            key: 'CK-1',
+          },
+        })
+      );
+      service = createExternalService(
+        actionId,
+        {
+          config: {
+            ...config,
+            createCommentJson: '{"body":{{{case.comment}}},"id":{{{external.system.id}}}}',
+          },
+          secrets,
+        },
+        logger,
+        configurationUtilities
+      );
+      await service.createComment(commentReq2);
+      expect(requestMock).toHaveBeenCalledWith({
+        axios,
+        logger,
+        method: CasesWebhookMethods.POST,
+        configurationUtilities,
+        url: 'https://coolsite.net/issue/1/comment',
+        data: `{"body":"comment","id":1}`,
+      });
+    });
   });
 
   describe('bad urls', () => {

--- a/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.test.ts
@@ -474,6 +474,7 @@ describe('Cases webhook service', () => {
       expect(requestMock).not.toHaveBeenCalled();
       expect(res).toBeUndefined();
     });
+
     test('properly encodes external system id as string in request body', async () => {
       requestMock.mockImplementation(() =>
         createAxiosResponse({
@@ -505,6 +506,7 @@ describe('Cases webhook service', () => {
         data: `{"body":"comment","id":"1"}`,
       });
     });
+
     test('properly encodes external system id as number in request body', async () => {
       const commentReq2 = {
         incidentId: 1 as unknown as string,

--- a/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.ts
@@ -190,6 +190,7 @@ export const createExternalService = (
           },
         },
       });
+
       const normalizedUrl = validateAndNormalizeUrl(
         `${updateUrl}`,
         configurationUtilities,
@@ -197,6 +198,7 @@ export const createExternalService = (
       );
 
       const { tags, title, description } = incident;
+
       const json = renderMustacheStringNoEscape(updateIncidentJson, {
         ...stringifyObjValues({
           title,
@@ -211,6 +213,7 @@ export const createExternalService = (
       });
 
       validateJson(json, 'Update case JSON body');
+
       const res = await request({
         axios: axiosInstance,
         method: updateIncidentMethod,
@@ -223,7 +226,9 @@ export const createExternalService = (
       throwDescriptiveErrorIfResponseIsNotValid({
         res,
       });
+
       const updatedIncident = await getIncident(incidentId as string);
+
       const viewUrl = renderMustacheStringNoEscape(viewIncidentUrl, {
         external: {
           system: {
@@ -232,11 +237,13 @@ export const createExternalService = (
           },
         },
       });
+
       const normalizedViewUrl = validateAndNormalizeUrl(
         `${viewUrl}`,
         configurationUtilities,
         'View case URL'
       );
+
       return {
         id: incidentId,
         title: updatedIncident.title,
@@ -253,6 +260,7 @@ export const createExternalService = (
       if (!createCommentUrl || !createCommentJson || !createCommentMethod) {
         return;
       }
+
       const commentUrl = renderMustacheStringNoEscape(createCommentUrl, {
         external: {
           system: {
@@ -260,11 +268,13 @@ export const createExternalService = (
           },
         },
       });
+
       const normalizedUrl = validateAndNormalizeUrl(
         `${commentUrl}`,
         configurationUtilities,
         'Create comment URL'
       );
+
       const json = renderMustacheStringNoEscape(createCommentJson, {
         ...stringifyObjValues({ comment: comment.comment }),
         external: {
@@ -273,7 +283,9 @@ export const createExternalService = (
           },
         },
       });
+
       validateJson(json, 'Create comment JSON body');
+
       const res = await request({
         axios: axiosInstance,
         method: createCommentMethod,

--- a/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/cases/cases_webhook/service.ts
@@ -205,7 +205,7 @@ export const createExternalService = (
         }),
         external: {
           system: {
-            id: incidentId,
+            id: JSON.stringify(incidentId),
           },
         },
       });
@@ -269,7 +269,7 @@ export const createExternalService = (
         ...stringifyObjValues({ comment: comment.comment }),
         external: {
           system: {
-            id: incidentId,
+            id: JSON.stringify(incidentId),
           },
         },
       });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/140017

To use `renderMustacheStringNoEscape`, every variable object value needs to be stringified. The `external.system.id` was not stringified, thus was producing malformed JSON. By stringifying the id, we get the value expected.

