### PR TITLE
[Enterprise Search] Custom pipelines update optimistically on creation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
@@ -37,7 +37,8 @@ import { PipelinesLogic } from './pipelines_logic';
 export const IngestPipelinesCard: React.FC = () => {
   const { indexName } = useValues(IndexViewLogic);
 
-  const { canSetPipeline, index, pipelineState, showModal } = useValues(PipelinesLogic);
+  const { canSetPipeline, index, pipelineName, pipelineState, showModal } =
+    useValues(PipelinesLogic);
   const { closeModal, openModal, setPipelineState, savePipeline } = useActions(PipelinesLogic);
   const { makeRequest: fetchCustomPipeline } = useActions(FetchCustomPipelineApiLogic);
   const { makeRequest: createCustomPipeline } = useActions(CreateCustomPipelineApiLogic);
@@ -61,7 +62,7 @@ export const IngestPipelinesCard: React.FC = () => {
         indexName={indexName}
         isGated={isGated}
         isLoading={false}
-        pipeline={pipelineState}
+        pipeline={{ ...pipelineState, name: pipelineName }}
         savePipeline={savePipeline}
         setPipeline={setPipelineState}
         showModal={showModal}
@@ -111,7 +112,7 @@ export const IngestPipelinesCard: React.FC = () => {
                       <CurlRequest
                         document={{ body: 'body', title: 'Title' }}
                         indexName={indexName}
-                        pipeline={pipelineState}
+                        pipeline={{ ...pipelineState, name: pipelineName }}
                       />
                     </EuiAccordion>
                   </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
@@ -23,14 +23,17 @@ const DEFAULT_PIPELINE_VALUES = {
 const DEFAULT_VALUES = {
   canSetPipeline: true,
   canUseMlInferencePipeline: false,
+  customPipelineData: undefined,
   defaultPipelineValues: DEFAULT_PIPELINE_VALUES,
   defaultPipelineValuesData: undefined,
-  index: undefined,
-  mlInferencePipelineProcessors: undefined,
-  pipelineState: DEFAULT_PIPELINE_VALUES,
-  showModal: false,
-  showAddMlInferencePipelineModal: false,
   hasIndexIngestionPipeline: false,
+  index: undefined,
+  indexName: '',
+  mlInferencePipelineProcessors: undefined,
+  pipelineName: DEFAULT_PIPELINE_VALUES.name,
+  pipelineState: DEFAULT_PIPELINE_VALUES,
+  showAddMlInferencePipelineModal: false,
+  showModal: false,
 };
 
 describe('PipelinesLogic', () => {
@@ -69,6 +72,7 @@ describe('PipelinesLogic', () => {
           ...connectorIndex,
           connector: { ...connectorIndex.connector },
         },
+        indexName: 'connector',
       });
       expect(flashSuccessToast).toHaveBeenCalled();
       expect(PipelinesLogic.actions.fetchIndexApiSuccess).toHaveBeenCalledWith({
@@ -86,8 +90,9 @@ describe('PipelinesLogic', () => {
       });
       expect(PipelinesLogic.values).toEqual({
         ...DEFAULT_VALUES,
-        pipelineState: { ...DEFAULT_PIPELINE_VALUES, name: 'new_pipeline_name' },
         hasIndexIngestionPipeline: true,
+        pipelineName: 'new_pipeline_name',
+        pipelineState: { ...DEFAULT_PIPELINE_VALUES, name: 'new_pipeline_name' },
       });
     });
     describe('makeRequest', () => {
@@ -152,12 +157,14 @@ describe('PipelinesLogic', () => {
         expect(PipelinesLogic.values).toEqual({
           ...DEFAULT_VALUES,
           canUseMlInferencePipeline: true,
+          hasIndexIngestionPipeline: true,
           index: {
             ...connectorIndex,
             connector: { ...connectorIndex.connector, pipeline: newPipeline },
           },
+          indexName: 'connector',
+          pipelineName: 'new_pipeline_name',
           pipelineState: newPipeline,
-          hasIndexIngestionPipeline: true,
         });
       });
       it('should not set configState if modal is open', () => {
@@ -172,6 +179,7 @@ describe('PipelinesLogic', () => {
             ...connectorIndex,
             connector: { ...connectorIndex.connector, pipeline: newPipeline },
           },
+          indexName: 'connector',
           showModal: true,
         });
       });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -7,6 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
+import { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
 
 import { DEFAULT_PIPELINE_VALUES } from '../../../../../../common/constants';
@@ -105,11 +106,14 @@ type PipelinesActions = Pick<
 interface PipelinesValues {
   canSetPipeline: boolean;
   canUseMlInferencePipeline: boolean;
+  customPipelineData: Record<string, IngestPipeline | undefined>;
   defaultPipelineValues: IngestPipelineParams;
   defaultPipelineValuesData: IngestPipelineParams | null;
   hasIndexIngestionPipeline: boolean;
   index: FetchIndexApiResponse;
+  indexName: string;
   mlInferencePipelineProcessors: InferencePipeline[];
+  pipelineName: string;
   pipelineState: IngestPipelineParams;
   showAddMlInferencePipelineModal: boolean;
   showModal: boolean;
@@ -155,6 +159,8 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       ],
     ],
     values: [
+      FetchCustomPipelineApiLogic,
+      ['data as customPipelineData'],
       FetchDefaultPipelineApiLogic,
       ['data as defaultPipelineValuesData'],
       FetchIndexApiLogic,
@@ -290,15 +296,6 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       () => [selectors.index],
       (index: ElasticsearchIndexWithIngestion) => !isApiIndex(index),
     ],
-    defaultPipelineValues: [
-      () => [selectors.defaultPipelineValuesData],
-      (pipeline: IngestPipelineParams | null) => pipeline ?? DEFAULT_PIPELINE_VALUES,
-    ],
-    hasIndexIngestionPipeline: [
-      () => [selectors.pipelineState, selectors.defaultPipelineValues],
-      (pipelineState: IngestPipelineParams, defaultPipelineValues: IngestPipelineParams) =>
-        pipelineState.name !== defaultPipelineValues.name,
-    ],
     canUseMlInferencePipeline: [
       () => [
         selectors.canSetPipeline,
@@ -310,6 +307,24 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
         hasIndexIngestionPipeline: boolean,
         pipelineState: IngestPipelineParams
       ) => canSetPipeline && hasIndexIngestionPipeline && pipelineState.run_ml_inference,
+    ],
+    defaultPipelineValues: [
+      () => [selectors.defaultPipelineValuesData],
+      (pipeline: IngestPipelineParams | null) => pipeline ?? DEFAULT_PIPELINE_VALUES,
+    ],
+    hasIndexIngestionPipeline: [
+      () => [selectors.pipelineName, selectors.defaultPipelineValues],
+      (pipelineState: IngestPipelineParams, defaultPipelineValues: IngestPipelineParams) =>
+        pipelineState.name !== defaultPipelineValues.name,
+    ],
+    indexName: [
+      () => [selectors.index],
+      (index?: ElasticsearchIndexWithIngestion) => index?.name ?? '',
+    ],
+    pipelineName: [
+      () => [selectors.pipelineState, selectors.customPipelineData, selectors.indexName],
+      (pipelineState, customPipelineData, indexName) =>
+        customPipelineData && customPipelineData[indexName] ? indexName : pipelineState.name,
     ],
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -314,8 +314,8 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
     ],
     hasIndexIngestionPipeline: [
       () => [selectors.pipelineName, selectors.defaultPipelineValues],
-      (pipelineState: IngestPipelineParams, defaultPipelineValues: IngestPipelineParams) =>
-        pipelineState.name !== defaultPipelineValues.name,
+      (pipelineName: string, defaultPipelineValues: IngestPipelineParams) =>
+        pipelineName !== defaultPipelineValues.name,
     ],
     indexName: [
       () => [selectors.index],

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
@@ -29,11 +29,11 @@ describe('createIndexPipelineDefinitions util function', () => {
     jest.clearAllMocks();
   });
 
-  it('should create the pipelines', () => {
+  it('should create the pipelines', async () => {
     mockClient.ingest.putPipeline.mockImplementation(() => Promise.resolve({ acknowledged: true }));
-    expect(
+    await expect(
       createIndexPipelineDefinitions(indexName, mockClient as unknown as ElasticsearchClient)
-    ).toEqual(expectedResult);
+    ).resolves.toEqual(expectedResult);
     expect(mockClient.ingest.putPipeline).toHaveBeenCalledTimes(3);
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
@@ -27,24 +27,24 @@ export interface CreatedPipelines {
  * @param indexName the index for which the pipelines should be created.
  * @param esClient the Elasticsearch Client with which to create the pipelines.
  */
-export const createIndexPipelineDefinitions = (
+export const createIndexPipelineDefinitions = async (
   indexName: string,
   esClient: ElasticsearchClient
-): CreatedPipelines => {
+): Promise<CreatedPipelines> => {
   // TODO: add back descriptions (see: https://github.com/elastic/elasticsearch-specification/issues/1827)
-  esClient.ingest.putPipeline({
+  await esClient.ingest.putPipeline({
     description: `Enterprise Search Machine Learning Inference pipeline for the '${indexName}' index`,
     id: getInferencePipelineNameFromIndexName(indexName),
     processors: [],
     version: 1,
   });
-  esClient.ingest.putPipeline({
+  await esClient.ingest.putPipeline({
     description: `Enterprise Search customizable ingest pipeline for the '${indexName}' index`,
     id: `${indexName}@custom`,
     processors: [],
     version: 1,
   });
-  esClient.ingest.putPipeline({
+  await esClient.ingest.putPipeline({
     _meta: {
       managed: true,
       managed_by: 'Enterprise Search',


### PR DESCRIPTION
## Summary

This updates the create custom pipelines flow to optimistically update on creation, and makes the API wait for creation of pipelines before returning.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->