### PR TITLE
Fixing flaky `runSoon` test

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
@@ -26,8 +26,7 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
   const retry = getService('retry');
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/141864
-  describe.skip('disable', () => {
+  describe('disable', () => {
     const objectRemover = new ObjectRemover(supertestWithoutAuth);
     const ruleUtils = new RuleUtils({ space: Spaces.space1, supertestWithoutAuth });
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
@@ -51,15 +51,17 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       await ruleUtils.disable(createdRule.id);
 
       // task doc should still exist but be disabled
-      const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
-      expect(taskRecord.type).to.eql('task');
-      expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
-      expect(JSON.parse(taskRecord.task.params)).to.eql({
-        alertId: createdRule.id,
-        spaceId: Spaces.space1.id,
-        consumer: 'alertsFixture',
+      await retry.try(async () => {
+        const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
+        expect(taskRecord.type).to.eql('task');
+        expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
+        expect(JSON.parse(taskRecord.task.params)).to.eql({
+          alertId: createdRule.id,
+          spaceId: Spaces.space1.id,
+          consumer: 'alertsFixture',
+        });
+        expect(taskRecord.task.enabled).to.eql(false);
       });
-      expect(taskRecord.task.enabled).to.eql(false);
 
       // Ensure AAD isn't broken
       await checkAAD({
@@ -195,15 +197,17 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
           .expect(204);
 
         // task doc should still exist but be disabled
-        const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
-        expect(taskRecord.type).to.eql('task');
-        expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
-        expect(JSON.parse(taskRecord.task.params)).to.eql({
-          alertId: createdRule.id,
-          spaceId: Spaces.space1.id,
-          consumer: 'alertsFixture',
+        await retry.try(async () => {
+          const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
+          expect(taskRecord.type).to.eql('task');
+          expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
+          expect(JSON.parse(taskRecord.task.params)).to.eql({
+            alertId: createdRule.id,
+            spaceId: Spaces.space1.id,
+            consumer: 'alertsFixture',
+          });
+          expect(taskRecord.task.enabled).to.eql(false);
         });
-        expect(taskRecord.task.enabled).to.eql(false);
 
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/disable.ts
@@ -26,7 +26,8 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
   const retry = getService('retry');
   const supertest = getService('supertest');
 
-  describe('disable', () => {
+  // Failing: See https://github.com/elastic/kibana/issues/141864
+  describe.skip('disable', () => {
     const objectRemover = new ObjectRemover(supertestWithoutAuth);
     const ruleUtils = new RuleUtils({ space: Spaces.space1, supertestWithoutAuth });
 
@@ -51,17 +52,15 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       await ruleUtils.disable(createdRule.id);
 
       // task doc should still exist but be disabled
-      await retry.try(async () => {
-        const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
-        expect(taskRecord.type).to.eql('task');
-        expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
-        expect(JSON.parse(taskRecord.task.params)).to.eql({
-          alertId: createdRule.id,
-          spaceId: Spaces.space1.id,
-          consumer: 'alertsFixture',
-        });
-        expect(taskRecord.task.enabled).to.eql(false);
+      const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
+      expect(taskRecord.type).to.eql('task');
+      expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
+      expect(JSON.parse(taskRecord.task.params)).to.eql({
+        alertId: createdRule.id,
+        spaceId: Spaces.space1.id,
+        consumer: 'alertsFixture',
       });
+      expect(taskRecord.task.enabled).to.eql(false);
 
       // Ensure AAD isn't broken
       await checkAAD({
@@ -197,17 +196,15 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
           .expect(204);
 
         // task doc should still exist but be disabled
-        await retry.try(async () => {
-          const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
-          expect(taskRecord.type).to.eql('task');
-          expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
-          expect(JSON.parse(taskRecord.task.params)).to.eql({
-            alertId: createdRule.id,
-            spaceId: Spaces.space1.id,
-            consumer: 'alertsFixture',
-          });
-          expect(taskRecord.task.enabled).to.eql(false);
+        const taskRecord = await getScheduledTask(createdRule.scheduled_task_id);
+        expect(taskRecord.type).to.eql('task');
+        expect(taskRecord.task.taskType).to.eql('alerting:test.noop');
+        expect(JSON.parse(taskRecord.task.params)).to.eql({
+          alertId: createdRule.id,
+          spaceId: Spaces.space1.id,
+          consumer: 'alertsFixture',
         });
+        expect(taskRecord.task.enabled).to.eql(false);
 
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/run_soon.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/run_soon.ts
@@ -35,7 +35,7 @@ export default function createRunSoonTests({ getService }: FtrProviderContext) {
 
     it('should successfully run rule where scheduled task id is different than rule id', async () => {
       await retry.try(async () => {
-        // Sometimes the rule may already be running. Try until it isn't
+        // Sometimes the rule may already be running, which returns a 200. Try until it isn't
         const response = await supertest
           .post(`${getUrlPrefix(``)}/internal/alerting/rule/${LOADED_RULE_ID}/_run_soon`)
           .set('kbn-xsrf', 'foo');
@@ -52,10 +52,13 @@ export default function createRunSoonTests({ getService }: FtrProviderContext) {
       expect(response.status).to.eql(200);
       objectRemover.add('default', response.body.id, 'rule', 'alerting');
 
-      const runSoonResponse = await supertest
-        .post(`${getUrlPrefix(``)}/internal/alerting/rule/${response.body.id}/_run_soon`)
-        .set('kbn-xsrf', 'foo');
-      expect(runSoonResponse.status).to.eql(204);
+      await retry.try(async () => {
+        // Sometimes the rule may already be running, which returns a 200. Try until it isn't
+        const runSoonResponse = await supertest
+          .post(`${getUrlPrefix(``)}/internal/alerting/rule/${response.body.id}/_run_soon`)
+          .set('kbn-xsrf', 'foo');
+        expect(runSoonResponse.status).to.eql(204);
+      });
     });
 
     it('should return message when task does not exist for rule', async () => {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/run_soon.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/run_soon.ts
@@ -18,8 +18,7 @@ export default function createRunSoonTests({ getService }: FtrProviderContext) {
   const es = getService('es');
   const esArchiver = getService('esArchiver');
 
-  // Failing: See https://github.com/elastic/kibana/issues/142564
-  describe.skip('runSoon', () => {
+  describe('runSoon', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/142564

## Summary

Adding retries to run soon test. Sometimes when calling runSoon, the rule is already running and will return a 200, not a 204. Retrying until we get expected 204.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1361


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->