### PR TITLE
[Maps] Fix third party maps source developer example

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_tilemap_source.js
+++ b/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_tilemap_source.js
@@ -41,15 +41,18 @@ export class KibanaTilemapSource extends AbstractSource {
       },
     ];
   }
+
   isSourceStale(mbSource, sourceData) {
     if (!sourceData.url) {
       return false;
     }
     return mbSource.tiles?.[0] !== sourceData.url;
   }
+
   async canSkipSourceUpdate() {
     return false;
   }
+
   async getUrlTemplate() {
     const tilemap = getKibanaTileMap();
     if (!tilemap.url) {

--- a/x-pack/plugins/maps/public/classes/sources/wms_source/wms_source.js
+++ b/x-pack/plugins/maps/public/classes/sources/wms_source/wms_source.js
@@ -27,15 +27,18 @@ export class WMSSource extends AbstractSource {
       styles,
     };
   }
+
   isSourceStale(mbSource, sourceData) {
     if (!sourceData.url) {
       return false;
     }
     return mbSource.tiles?.[0] !== sourceData.url;
   }
+
   async canSkipSourceUpdate() {
     return false;
   }
+
   async getImmutableProperties() {
     return [
       { label: getDataSourceLabel(), value: sourceTitle },

--- a/x-pack/plugins/maps/public/index.ts
+++ b/x-pack/plugins/maps/public/index.ts
@@ -35,6 +35,7 @@ export type { MapEmbeddable, MapEmbeddableInput, MapEmbeddableOutput } from './e
 export type { EMSTermJoinConfig, SampleValuesConfig } from './ems_autosuggest';
 
 export type { ITMSSource } from './classes/sources/tms_source';
+export type { IRasterSource } from './classes/sources/raster_source';
 
 export type {
   GetFeatureActionsArgs,


### PR DESCRIPTION
## Summary

Adds `canSkipSourceUpdate` and `isSourceStale` methods to the third party maps source developer example.

Starting with PR #141829 raster tile sources must have `canSkipSourceUpdate` and `isSourceStale` methods to check if the source URL needs to change. This PR updates the third party maps source developer example.

To test this PR, start kibana with `yarn start --run-examples`. Then open the Maps app and add the "Weather" layer to the map. Set the time picker to the last 2 hours. Then open the Time slider and step through the timeslices. The weather radar should change slightly for each slice.