### PR TITLE
[Enterprise Search] fix ml inference with api index

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines_card.tsx
@@ -85,7 +85,7 @@ export const IngestPipelinesCard: React.FC = () => {
               <EuiFlexGroup alignItems="center">
                 <EuiFlexItem>
                   <EuiTitle size="xs">
-                    <h4>{pipelineState.name}</h4>
+                    <h4>{pipelineName}</h4>
                   </EuiTitle>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -33,12 +33,8 @@ import { PipelinesJSONConfigurations } from './pipelines_json_configurations';
 import { PipelinesLogic } from './pipelines_logic';
 
 export const SearchIndexPipelines: React.FC = () => {
-  const {
-    showAddMlInferencePipelineModal,
-    hasIndexIngestionPipeline,
-    index,
-    pipelineState: { name: pipelineName },
-  } = useValues(PipelinesLogic);
+  const { showAddMlInferencePipelineModal, hasIndexIngestionPipeline, index, pipelineName } =
+    useValues(PipelinesLogic);
   const { closeAddMlInferencePipelineModal, openAddMlInferencePipelineModal } =
     useActions(PipelinesLogic);
   const apiIndex = isApiIndex(index);
@@ -133,7 +129,7 @@ export const SearchIndexPipelines: React.FC = () => {
                     'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitleAPIindex',
                     {
                       defaultMessage:
-                        "Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline. In order to use these pipeline on API-based indices you'll need to reference the {pipelineName} pipeline in your API requests.",
+                        "Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline. In order to use these pipelines on API-based indices you'll need to reference the {pipelineName} pipeline in your API requests.",
                       values: {
                         pipelineName,
                       },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -90,6 +90,10 @@ type PipelinesActions = Pick<
     FetchCustomPipelineApiLogicArgs,
     FetchCustomPipelineApiLogicResponse
   >['makeRequest'];
+  fetchCustomPipelineSuccess: Actions<
+    FetchCustomPipelineApiLogicArgs,
+    FetchCustomPipelineApiLogicResponse
+  >['apiSuccess'];
   fetchDefaultPipeline: Actions<undefined, FetchDefaultPipelineResponse>['makeRequest'];
   fetchDefaultPipelineSuccess: Actions<undefined, FetchDefaultPipelineResponse>['apiSuccess'];
   fetchIndexApiSuccess: Actions<FetchIndexApiParams, FetchIndexApiResponse>['apiSuccess'];
@@ -143,7 +147,7 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       FetchDefaultPipelineApiLogic,
       ['apiSuccess as fetchDefaultPipelineSuccess', 'makeRequest as fetchDefaultPipeline'],
       FetchCustomPipelineApiLogic,
-      ['makeRequest as fetchCustomPipeline'],
+      ['apiSuccess as fetchCustomPipelineSuccess', 'makeRequest as fetchCustomPipeline'],
       FetchMlInferencePipelineProcessorsApiLogic,
       [
         'makeRequest as fetchMlInferenceProcessors',
@@ -303,16 +307,12 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       (index: ElasticsearchIndexWithIngestion) => !isApiIndex(index),
     ],
     canUseMlInferencePipeline: [
-      () => [
-        selectors.canSetPipeline,
-        selectors.hasIndexIngestionPipeline,
-        selectors.pipelineState,
-      ],
+      () => [selectors.hasIndexIngestionPipeline, selectors.pipelineState, selectors.index],
       (
-        canSetPipeline: boolean,
         hasIndexIngestionPipeline: boolean,
-        pipelineState: IngestPipelineParams
-      ) => canSetPipeline && hasIndexIngestionPipeline && pipelineState.run_ml_inference,
+        pipelineState: IngestPipelineParams,
+        index: ElasticsearchIndexWithIngestion
+      ) => hasIndexIngestionPipeline && (pipelineState.run_ml_inference || isApiIndex(index)),
     ],
     defaultPipelineValues: [
       () => [selectors.defaultPipelineValuesData],


### PR DESCRIPTION
## Summary

Updates the the Pipelines logic to ensure you can configure ml inference pipelines with api-based indices.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->