### PR TITLE
[TIP] Add copy to clipboard feature

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
@@ -8,6 +8,7 @@
 import React, { useState, VFC } from 'react';
 import { EuiButtonIcon, EuiContextMenuPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 import { FilterInContextMenu } from '../../../../query_bar/components/filter_in';
 import { FilterOutContextMenu } from '../../../../query_bar/components/filter_out';
 import { AddToTimelineContextMenu } from '../../../../timeline/components/add_to_timeline';
@@ -16,6 +17,7 @@ export const POPOVER_BUTTON_TEST_ID = 'tiBarchartPopoverButton';
 export const TIMELINE_BUTTON_TEST_ID = 'tiBarchartTimelineButton';
 export const FILTER_IN_BUTTON_TEST_ID = 'tiBarchartFilterInButton';
 export const FILTER_OUT_BUTTON_TEST_ID = 'tiBarchartFilterOutButton';
+export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'tiBarchartCopyToClipboardButton';
 
 const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.barChart.popover', {
   defaultMessage: 'More actions',
@@ -42,6 +44,7 @@ export const IndicatorBarchartLegendAction: VFC<IndicatorBarchartLegendActionPro
     <FilterInContextMenu data={data} field={field} data-test-subj={FILTER_IN_BUTTON_TEST_ID} />,
     <FilterOutContextMenu data={data} field={field} data-test-subj={FILTER_OUT_BUTTON_TEST_ID} />,
     <AddToTimelineContextMenu data={data} field={field} data-test-subj={TIMELINE_BUTTON_TEST_ID} />,
+    <CopyToClipboardContextMenu value={data} data-test-subj={COPY_TO_CLIPBOARD_BUTTON_TEST_ID} />,
   ];
 
   return (

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/__snapshots__/copy_to_clipboard.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/__snapshots__/copy_to_clipboard.test.tsx.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CopyToClipboardButtonEmpty /> <CopyToClipboardContextMenu /> should render one EuiButtonEmtpy 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="euiToolTipAnchor"
+      >
+        <button
+          aria-label="Copy to clipboard"
+          class="euiButtonEmpty euiButtonEmpty--primary"
+          data-test-subj="abc"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="copyClipboard"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Copy to clipboard
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        aria-label="Copy to clipboard"
+        class="euiButtonEmpty euiButtonEmpty--primary"
+        data-test-subj="abc"
+        type="button"
+      >
+        <span
+          class="euiButtonContent euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonContent__icon"
+            color="inherit"
+            data-euiicon-type="copyClipboard"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Copy to clipboard
+          </span>
+        </span>
+      </button>
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`<CopyToClipboardButtonEmpty /> <CopyToClipboardContextMenu /> should render one EuiContextMenuItem (for EuiContextMenu use) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="euiToolTipAnchor"
+      >
+        <button
+          class="euiContextMenuItem euiContextMenuItem--small"
+          data-test-subj="abc"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenu__icon"
+              color="inherit"
+              data-euiicon-type="copyClipboard"
+            />
+            <span
+              class="euiContextMenuItem__text"
+            >
+              Copy to clipboard
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        class="euiContextMenuItem euiContextMenuItem--small"
+        data-test-subj="abc"
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenu__icon"
+            color="inherit"
+            data-euiicon-type="copyClipboard"
+          />
+          <span
+            class="euiContextMenuItem__text"
+          >
+            Copy to clipboard
+          </span>
+        </span>
+      </button>
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.stories.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { EuiContextMenuPanel } from '@elastic/eui';
+import { CopyToClipboardButtonEmpty, CopyToClipboardContextMenu } from '.';
+
+export default {
+  title: 'CopyToClipboard',
+};
+
+const mockValue: string = 'Text copied!';
+
+export const ButtonEmpty: Story<void> = () => {
+  return <CopyToClipboardButtonEmpty value={mockValue} />;
+};
+
+export const ContextMenu: Story<void> = () => {
+  const items = [<CopyToClipboardContextMenu value={mockValue} />];
+
+  return <EuiContextMenuPanel items={items} />;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CopyToClipboardButtonEmpty, CopyToClipboardContextMenu } from '.';
+
+const mockValue: string = 'Text copied';
+
+const mockTestId: string = 'abc';
+
+describe('<CopyToClipboardButtonEmpty /> <CopyToClipboardContextMenu />', () => {
+  it('should render one EuiButtonEmtpy', () => {
+    const component = render(
+      <CopyToClipboardButtonEmpty value={mockValue} data-test-subj={mockTestId} />
+    );
+
+    expect(component.getByTestId(mockTestId)).toBeInTheDocument();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render one EuiContextMenuItem (for EuiContextMenu use)', () => {
+    const component = render(
+      <CopyToClipboardContextMenu value={mockValue} data-test-subj={mockTestId} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { VFC } from 'react';
+import { EuiButtonEmpty, EuiContextMenuItem, EuiCopy } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const COPY_ICON = 'copyClipboard';
+const COPY_TITLE = i18n.translate(
+  'xpack.threatIntelligence.indicators.table.copyToClipboardLabel',
+  {
+    defaultMessage: 'Copy to clipboard',
+  }
+);
+
+export interface CopyToClipboardProps {
+  /**
+   * Value to copy to clipboard.
+   */
+  value: string;
+  /**
+   * Used for unit and e2e tests.
+   */
+  ['data-test-subj']?: string;
+}
+
+/**
+ * Takes a string and copies it to the clipboard.
+ *
+ * This component renders an {@link EuiButtonEmpty}.
+ *
+ * @returns An EuiCopy element
+ */
+export const CopyToClipboardButtonEmpty: VFC<CopyToClipboardProps> = ({
+  value,
+  'data-test-subj': dataTestSub,
+}) => (
+  <EuiCopy textToCopy={value}>
+    {(copy) => (
+      <EuiButtonEmpty
+        aria-label={COPY_TITLE}
+        iconType={COPY_ICON}
+        iconSize="s"
+        color="primary"
+        onClick={copy}
+        data-test-subj={dataTestSub}
+      >
+        {COPY_TITLE}
+      </EuiButtonEmpty>
+    )}
+  </EuiCopy>
+);
+
+/**
+ * Takes a string and copies it to the clipboard.
+ *
+ * This component is to be used in an EuiContextMenu.
+ *
+ * @returns filter in {@link EuiContextMenuItem} for a context menu
+ */
+export const CopyToClipboardContextMenu: VFC<CopyToClipboardProps> = ({
+  value,
+  'data-test-subj': dataTestSub,
+}) => (
+  <EuiCopy textToCopy={value}>
+    {(copy) => (
+      <EuiContextMenuItem
+        key="copyToClipboard"
+        icon={COPY_ICON}
+        size="s"
+        onClick={copy}
+        data-test-subj={dataTestSub}
+      >
+        {COPY_TITLE}
+      </EuiContextMenuItem>
+    )}
+  </EuiCopy>
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/index.ts
@@ -5,9 +5,4 @@
  * 2.0.
  */
 
-export * from './actions_row_cell';
-export * from './cell_actions';
-export * from './cell_renderer';
-export * from './cell_popover_renderer';
-export * from './field_browser';
-export * from './open_flyout_button';
+export * from './copy_to_clipboard';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
@@ -5,17 +5,31 @@
  * 2.0.
  */
 
-import React, { VFC } from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import React, { useState, VFC } from 'react';
+import {
+  EuiButtonIcon,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { FilterInButtonIcon } from '../../../../query_bar/components/filter_in';
 import { FilterOutButtonIcon } from '../../../../query_bar/components/filter_out';
-import { AddToTimelineButtonIcon } from '../../../../timeline/components/add_to_timeline';
+import { AddToTimelineContextMenu } from '../../../../timeline/components/add_to_timeline';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils/field_value';
+import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 
 export const TIMELINE_BUTTON_TEST_ID = 'TimelineButton';
 export const FILTER_IN_BUTTON_TEST_ID = 'FilterInButton';
 export const FILTER_OUT_BUTTON_TEST_ID = 'FilterOutButton';
+export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'CopyToClipboardButton';
+export const POPOVER_BUTTON_TEST_ID = 'PopoverButton';
+
+const MORE_ACTIONS_BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.more-actions.popover', {
+  defaultMessage: 'More actions',
+});
 
 interface IndicatorValueActions {
   /**
@@ -37,6 +51,8 @@ export const IndicatorValueActions: VFC<IndicatorValueActions> = ({
   field,
   'data-test-subj': dataTestSubj,
 }) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+
   const { key, value } = getIndicatorFieldAndValue(indicator, field);
   if (!fieldAndValueValid(key, value)) {
     return null;
@@ -45,12 +61,39 @@ export const IndicatorValueActions: VFC<IndicatorValueActions> = ({
   const filterInTestId = `${dataTestSubj}${FILTER_IN_BUTTON_TEST_ID}`;
   const filterOutTestId = `${dataTestSubj}${FILTER_OUT_BUTTON_TEST_ID}`;
   const timelineTestId = `${dataTestSubj}${TIMELINE_BUTTON_TEST_ID}`;
+  const copyToClipboardTestId = `${dataTestSubj}${COPY_TO_CLIPBOARD_BUTTON_TEST_ID}`;
+  const popoverTestId = `${dataTestSubj}${POPOVER_BUTTON_TEST_ID}`;
+
+  const popoverItems = [
+    <AddToTimelineContextMenu data={indicator} field={field} data-test-subj={timelineTestId} />,
+    <CopyToClipboardContextMenu value={value as string} data-test-subj={copyToClipboardTestId} />,
+  ];
 
   return (
     <EuiFlexGroup justifyContent="center" alignItems="center">
       <FilterInButtonIcon data={indicator} field={field} data-test-subj={filterInTestId} />
       <FilterOutButtonIcon data={indicator} field={field} data-test-subj={filterOutTestId} />
-      <AddToTimelineButtonIcon data={indicator} field={field} data-test-subj={timelineTestId} />
+      <EuiPopover
+        data-test-subj={popoverTestId}
+        button={
+          <EuiToolTip content={MORE_ACTIONS_BUTTON_LABEL}>
+            <EuiButtonIcon
+              aria-label={MORE_ACTIONS_BUTTON_LABEL}
+              iconType="boxesHorizontal"
+              iconSize="s"
+              size="xs"
+              onClick={() => setPopover((prevIsPopoverOpen) => !prevIsPopoverOpen)}
+              style={{ height: '100%' }}
+            />
+          </EuiToolTip>
+        }
+        isOpen={isPopoverOpen}
+        closePopover={() => setPopover(false)}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenuPanel size="s" items={popoverItems} />
+      </EuiPopover>
     </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_popover_renderer.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_popover_renderer.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiDataGridCellPopoverElementProps,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopoverTitle,
+} from '@elastic/eui';
+import React from 'react';
+import { CopyToClipboardButtonEmpty } from '../../copy_to_clipboard/copy_to_clipboard';
+import { FilterInButtonEmpty } from '../../../../query_bar/components/filter_in';
+import { FilterOutButtonEmpty } from '../../../../query_bar/components/filter_out';
+import { AddToTimelineButtonEmpty } from '../../../../timeline/components/add_to_timeline';
+import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils/field_value';
+import { Indicator } from '../../../../../../common/types/indicator';
+import { Pagination } from '../../../services/fetch_indicators';
+import { useStyles } from './styles';
+
+export const CELL_POPOVER_TIMELINE_BUTTON_TEST_ID = 'tiIndicatorsTableCellPopoverTimelineButton';
+export const CELL_POPOVER_FILTER_IN_BUTTON_TEST_ID = 'tiIndicatorsTableCellPopoverFilterInButton';
+export const CELL_POPOVER_FILTER_OUT_BUTTON_TEST_ID = 'tiIndicatorsTableCellPopoverFilterOutButton';
+
+/**
+ * Used for the Indicators table cellActions column property.
+ *
+ * @param indicators array of {@link Indicator}
+ * @param pagination information about table current page
+ */
+export const cellPopoverRendererFactory =
+  (indicators: Indicator[], pagination: Pagination) =>
+  (props: EuiDataGridCellPopoverElementProps) => {
+    const styles = useStyles();
+
+    const { rowIndex, columnId } = props;
+
+    const indicator = indicators[rowIndex % pagination.pageSize];
+    const { key, value } = getIndicatorFieldAndValue(indicator, columnId);
+    if (!fieldAndValueValid(key, value)) {
+      return <></>;
+    }
+
+    return (
+      <>
+        <EuiPopoverTitle paddingSize="m" css={styles.popoverMaxWidth}>
+          {value}
+        </EuiPopoverTitle>
+        <EuiFlexGroup gutterSize="none">
+          <EuiFlexItem>
+            <FilterInButtonEmpty
+              data={indicator}
+              field={key}
+              data-test-subj={CELL_POPOVER_TIMELINE_BUTTON_TEST_ID}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <FilterOutButtonEmpty
+              data={indicator}
+              field={key}
+              data-test-subj={CELL_POPOVER_FILTER_IN_BUTTON_TEST_ID}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup gutterSize="none">
+          <EuiFlexItem>
+            <AddToTimelineButtonEmpty
+              data={indicator}
+              field={key}
+              data-test-subj={CELL_POPOVER_FILTER_OUT_BUTTON_TEST_ID}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup gutterSize="none">
+          <EuiFlexItem>
+            <CopyToClipboardButtonEmpty value={value as string} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/styles.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/styles.ts
@@ -5,9 +5,15 @@
  * 2.0.
  */
 
-export * from './actions_row_cell';
-export * from './cell_actions';
-export * from './cell_renderer';
-export * from './cell_popover_renderer';
-export * from './field_browser';
-export * from './open_flyout_button';
+import { CSSObject } from '@emotion/react';
+
+export const useStyles = () => {
+  const popoverMaxWidth: CSSObject = {
+    'max-width': '240px',
+    'word-break': 'break-word',
+  };
+
+  return {
+    popoverMaxWidth,
+  };
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
@@ -19,7 +19,7 @@ import {
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDataGridColumn } from '@elastic/eui/src/components/datagrid/data_grid_types';
-import { CellActions, cellRendererFactory } from './components';
+import { CellActions, cellPopoverRendererFactory, cellRendererFactory } from './components';
 import { BrowserFields, SecuritySolutionDataViewBase } from '../../../../types';
 import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { EmptyState } from '../../../../components/empty_state';
@@ -75,6 +75,11 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
   const renderCellValue = useMemo(
     () => cellRendererFactory(pagination.pageIndex * pagination.pageSize),
     [pagination.pageIndex, pagination.pageSize]
+  );
+
+  const renderCellPopoverValue = useMemo(
+    () => cellPopoverRendererFactory(indicators, pagination),
+    [indicators, pagination]
   );
 
   const indicatorTableContextValue = useMemo<IndicatorsTableContextValue>(
@@ -177,6 +182,7 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
           leadingControlColumns={leadingControlColumns}
           rowCount={indicatorCount}
           renderCellValue={renderCellValue}
+          renderCellPopover={renderCellPopoverValue}
           toolbarVisibility={toolbarOptions}
           pagination={{
             ...pagination,
@@ -197,6 +203,7 @@ export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
     isFetching,
     leadingControlColumns,
     renderCellValue,
+    renderCellPopoverValue,
     toolbarOptions,
     pagination,
     onChangeItemsPerPage,

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/__snapshots__/filter_in.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/__snapshots__/filter_in.test.tsx.snap
@@ -223,6 +223,119 @@ Object {
 }
 `;
 
+exports[`<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction /> should render one EuiButtonEmpty 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="euiToolTipAnchor"
+      >
+        <button
+          aria-label="Filter In"
+          class="euiButtonEmpty euiButtonEmpty--primary"
+          data-test-subj="abc"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="plusInCircle"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Filter In
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        aria-label="Filter In"
+        class="euiButtonEmpty euiButtonEmpty--primary"
+        data-test-subj="abc"
+        type="button"
+      >
+        <span
+          class="euiButtonContent euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonContent__icon"
+            color="inherit"
+            data-euiicon-type="plusInCircle"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Filter In
+          </span>
+        </span>
+      </button>
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction /> should render one EuiButtonIcon 1`] = `
 Object {
   "asFragment": [Function],
@@ -340,9 +453,7 @@ Object {
           <span
             class="euiContextMenuItem__text"
           >
-            <span>
-              Filter In
-            </span>
+            Filter In
           </span>
         </span>
       </button>
@@ -364,9 +475,7 @@ Object {
         <span
           class="euiContextMenuItem__text"
         >
-          <span>
-            Filter In
-          </span>
+          Filter In
         </span>
       </span>
     </button>

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.test.tsx
@@ -11,7 +11,12 @@ import { EuiButtonIcon } from '@elastic/eui';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { useIndicatorsFiltersContext } from '../../../indicators/hooks/use_indicators_filters_context';
 import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indicators_filters_context';
-import { FilterInButtonIcon, FilterInContextMenu, FilterInCellAction } from '.';
+import {
+  FilterInButtonEmpty,
+  FilterInButtonIcon,
+  FilterInCellAction,
+  FilterInContextMenu,
+} from '.';
 
 jest.mock('../../../indicators/hooks/use_indicators_filters_context');
 
@@ -43,6 +48,15 @@ describe('<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction />'
   it('should render one EuiButtonIcon', () => {
     const component = render(
       <FilterInButtonIcon data={mockIndicator} field={mockField} data-test-subj={mockTestId} />
+    );
+
+    expect(component.getByTestId(mockTestId)).toBeInTheDocument();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render one EuiButtonEmpty', () => {
+    const component = render(
+      <FilterInButtonEmpty data={mockIndicator} field={mockField} data-test-subj={mockTestId} />
     );
 
     expect(component.getByTestId(mockTestId)).toBeInTheDocument();

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.tsx
@@ -8,17 +8,13 @@
 import React, { VFC } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonEmpty, EuiButtonIcon, EuiContextMenuItem, EuiToolTip } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { useFilterInOut } from '../../hooks/use_filter_in_out';
 import { FilterIn } from '../../utils/filter';
 import { Indicator } from '../../../../../common/types/indicator';
 import { useStyles } from './styles';
 
 const ICON_TYPE = 'plusInCircle';
-const ICON_TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterInButtonIcon', {
-  defaultMessage: 'Filter In',
-});
-const CELL_ACTION_TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterInCellAction', {
+const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterIn', {
   defaultMessage: 'Filter In',
 });
 
@@ -62,9 +58,9 @@ export const FilterInButtonIcon: VFC<FilterInProps> = ({
   }
 
   return (
-    <EuiToolTip content={ICON_TITLE}>
+    <EuiToolTip content={TITLE}>
       <EuiButtonIcon
-        aria-label={ICON_TITLE}
+        aria-label={TITLE}
         iconType={ICON_TYPE}
         iconSize="s"
         size="xs"
@@ -79,9 +75,42 @@ export const FilterInButtonIcon: VFC<FilterInProps> = ({
 /**
  * Retrieves the indicator's field and value, then creates a new {@link Filter} and adds it to the {@link FilterManager}.
  *
+ * This component renders an {@link EuiButtonEmpty}.
+ *
+ * @returns filter in button empty
+ */
+export const FilterInButtonEmpty: VFC<FilterInProps> = ({
+  data,
+  field,
+  'data-test-subj': dataTestSub,
+}) => {
+  const { filterFn } = useFilterInOut({ indicator: data, field, filterType: FilterIn });
+  if (!filterFn) {
+    return <></>;
+  }
+
+  return (
+    <EuiToolTip content={TITLE}>
+      <EuiButtonEmpty
+        aria-label={TITLE}
+        iconType={ICON_TYPE}
+        iconSize="s"
+        color="primary"
+        onClick={filterFn}
+        data-test-subj={dataTestSub}
+      >
+        {TITLE}
+      </EuiButtonEmpty>
+    </EuiToolTip>
+  );
+};
+
+/**
+ * Retrieves the indicator's field and value, then creates a new {@link Filter} and adds it to the {@link FilterManager}.
+ *
  * This component is to be used in an EuiContextMenu.
  *
- * @returns filter in item for a context menu
+ * @returns filter in {@link EuiContextMenuItem} for a context menu
  */
 export const FilterInContextMenu: VFC<FilterInProps> = ({
   data,
@@ -101,10 +130,7 @@ export const FilterInContextMenu: VFC<FilterInProps> = ({
       onClick={filterFn}
       data-test-subj={dataTestSub}
     >
-      <FormattedMessage
-        id="xpack.threatIntelligence.queryBar.filterInContextMenu"
-        defaultMessage="Filter In"
-      />
+      {TITLE}
     </EuiContextMenuItem>
   );
 };
@@ -130,10 +156,11 @@ export const FilterInCellAction: VFC<FilterInCellActionProps> = ({
   }
 
   return (
-    <EuiToolTip content={CELL_ACTION_TITLE}>
+    <EuiToolTip content={TITLE}>
       <div data-test-subj={dataTestSub} css={styles.button}>
-        {/* @ts-ignore*/}
-        <Component aria-label={CELL_ACTION_TITLE} iconType={ICON_TYPE} onClick={filterFn} />
+        <Component aria-label={TITLE} iconType={ICON_TYPE} onClick={filterFn}>
+          {TITLE}
+        </Component>
       </div>
     </EuiToolTip>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/__snapshots__/filter_out.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/__snapshots__/filter_out.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render an empty component (wrong data input) 1`] = `
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render an empty component (wrong data input) 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -61,7 +61,7 @@ Object {
 }
 `;
 
-exports[`<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render an empty component (wrong field input) 1`] = `
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render an empty component (wrong field input) 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -122,7 +122,7 @@ Object {
 }
 `;
 
-exports[`<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one Component (for EuiDataGrid use) 1`] = `
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one Component (for EuiDataGrid use) 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -223,7 +223,120 @@ Object {
 }
 `;
 
-exports[`<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one EuiButtonIcon 1`] = `
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one EuiButtonEmpty 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="euiToolTipAnchor"
+      >
+        <button
+          aria-label="Filter Out"
+          class="euiButtonEmpty euiButtonEmpty--primary"
+          data-test-subj="abc"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="minusInCircle"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Filter Out
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        aria-label="Filter Out"
+        class="euiButtonEmpty euiButtonEmpty--primary"
+        data-test-subj="abc"
+        type="button"
+      >
+        <span
+          class="euiButtonContent euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonContent__icon"
+            color="inherit"
+            data-euiicon-type="minusInCircle"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Filter Out
+          </span>
+        </span>
+      </button>
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one EuiButtonIcon 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -320,7 +433,7 @@ Object {
 }
 `;
 
-exports[`<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one EuiContextMenuItem (for EuiContextMenu use) 1`] = `
+exports[`<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid /> should render one EuiContextMenuItem (for EuiContextMenu use) 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -340,9 +453,7 @@ Object {
           <span
             class="euiContextMenuItem__text"
           >
-            <span>
-              Filter Out
-            </span>
+            Filter Out
           </span>
         </span>
       </button>
@@ -364,9 +475,7 @@ Object {
         <span
           class="euiContextMenuItem__text"
         >
-          <span>
-            Filter Out
-          </span>
+          Filter Out
         </span>
       </span>
     </button>

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.test.tsx
@@ -11,7 +11,12 @@ import { EuiButtonIcon } from '@elastic/eui';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { useIndicatorsFiltersContext } from '../../../indicators/hooks/use_indicators_filters_context';
 import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indicators_filters_context';
-import { FilterOutButtonIcon, FilterOutContextMenu, FilterOutCellAction } from '.';
+import {
+  FilterOutButtonEmpty,
+  FilterOutButtonIcon,
+  FilterOutCellAction,
+  FilterOutContextMenu,
+} from '.';
 
 jest.mock('../../../indicators/hooks/use_indicators_filters_context');
 
@@ -21,7 +26,7 @@ const mockField: string = 'threat.feed.name';
 
 const mockTestId: string = 'abc';
 
-describe('<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid />', () => {
+describe('<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu /> <FilterOutDataGrid />', () => {
   beforeEach(() => {
     (
       useIndicatorsFiltersContext as jest.MockedFunction<typeof useIndicatorsFiltersContext>
@@ -43,6 +48,15 @@ describe('<FilterOutButtonIcon /> <FilterOutContextMenu /> <FilterOutDataGrid />
   it('should render one EuiButtonIcon', () => {
     const component = render(
       <FilterOutButtonIcon data={mockIndicator} field={mockField} data-test-subj={mockTestId} />
+    );
+
+    expect(component.getByTestId(mockTestId)).toBeInTheDocument();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render one EuiButtonEmpty', () => {
+    const component = render(
+      <FilterOutButtonEmpty data={mockIndicator} field={mockField} data-test-subj={mockTestId} />
     );
 
     expect(component.getByTestId(mockTestId)).toBeInTheDocument();

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.tsx
@@ -8,17 +8,13 @@
 import React, { VFC } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButtonEmpty, EuiButtonIcon, EuiContextMenuItem, EuiToolTip } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { useFilterInOut } from '../../hooks/use_filter_in_out';
 import { FilterOut } from '../../utils/filter';
 import { Indicator } from '../../../../../common/types/indicator';
 import { useStyles } from './styles';
 
 const ICON_TYPE = 'minusInCircle';
-const ICON_TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterOutButtonIcon', {
-  defaultMessage: 'Filter Out',
-});
-const CELL_ACTION_TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterOutCellAction', {
+const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterOut', {
   defaultMessage: 'Filter Out',
 });
 
@@ -62,9 +58,9 @@ export const FilterOutButtonIcon: VFC<FilterOutProps> = ({
   }
 
   return (
-    <EuiToolTip content={ICON_TITLE}>
+    <EuiToolTip content={TITLE}>
       <EuiButtonIcon
-        aria-label={ICON_TITLE}
+        aria-label={TITLE}
         iconType={ICON_TYPE}
         iconSize="s"
         size="xs"
@@ -79,9 +75,42 @@ export const FilterOutButtonIcon: VFC<FilterOutProps> = ({
 /**
  * Retrieves the indicator's field and value, then creates a new {@link Filter} and adds it to the {@link FilterManager}.
  *
+ * This component renders an {@link EuiButtonEmpty}.
+ *
+ * @returns filter out button empty
+ */
+export const FilterOutButtonEmpty: VFC<FilterOutProps> = ({
+  data,
+  field,
+  'data-test-subj': dataTestSub,
+}) => {
+  const { filterFn } = useFilterInOut({ indicator: data, field, filterType: FilterOut });
+  if (!filterFn) {
+    return <></>;
+  }
+
+  return (
+    <EuiToolTip content={TITLE}>
+      <EuiButtonEmpty
+        aria-label={TITLE}
+        iconType={ICON_TYPE}
+        iconSize="s"
+        color="primary"
+        onClick={filterFn}
+        data-test-subj={dataTestSub}
+      >
+        {TITLE}
+      </EuiButtonEmpty>
+    </EuiToolTip>
+  );
+};
+
+/**
+ * Retrieves the indicator's field and value, then creates a new {@link Filter} and adds it to the {@link FilterManager}.
+ *
  * This component is to be used in an EuiContextMenu.
  *
- * @returns filter in item for a context menu
+ * @returns filter in {@link EuiContextMenuItem} for a context menu
  */
 export const FilterOutContextMenu: VFC<FilterOutProps> = ({
   data,
@@ -101,10 +130,7 @@ export const FilterOutContextMenu: VFC<FilterOutProps> = ({
       onClick={filterFn}
       data-test-subj={dataTestSub}
     >
-      <FormattedMessage
-        id="xpack.threatIntelligence.queryBar.filterOutContextMenu"
-        defaultMessage="Filter Out"
-      />
+      {TITLE}
     </EuiContextMenuItem>
   );
 };
@@ -130,10 +156,11 @@ export const FilterOutCellAction: VFC<FilterOutCellActionProps> = ({
   }
 
   return (
-    <EuiToolTip content={CELL_ACTION_TITLE}>
+    <EuiToolTip content={TITLE}>
       <div data-test-subj={dataTestSub} css={styles.button}>
-        {/* @ts-ignore*/}
-        <Component aria-label={CELL_ACTION_TITLE} iconType={ICON_TYPE} onClick={filterFn} />
+        <Component aria-label={TITLE} iconType={ICON_TYPE} onClick={filterFn}>
+          {TITLE}
+        </Component>
       </div>
     </EuiToolTip>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
@@ -8,10 +8,14 @@
 import React, { useRef, VFC } from 'react';
 import { DataProvider } from '@kbn/timelines-plugin/common';
 import { AddToTimelineButtonProps } from '@kbn/timelines-plugin/public';
-import { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui/src/components/button';
-import { EuiContextMenuItem, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiFlexItem,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { generateDataProvider } from '../../utils/data_provider';
 import {
   fieldAndValueValid,
@@ -22,16 +26,10 @@ import { Indicator } from '../../../../../common/types/indicator';
 import { useStyles } from './styles';
 import { useAddToTimeline } from '../../hooks/use_add_to_timeline';
 
-const BUTTON_ICON_TOOLTIP = i18n.translate(
-  'xpack.threatIntelligence.timeline.addToTimelineButtonIcon',
-  { defaultMessage: 'Add to Timeline' }
-);
-const CELL_ACTION_TOOLTIP = i18n.translate(
-  'xpack.threatIntelligence.timeline.addToTimelineCellAction',
-  {
-    defaultMessage: 'Add to Timeline',
-  }
-);
+const ICON_TYPE = 'timeline';
+const TITLE = i18n.translate('xpack.threatIntelligence.timeline.addToTimeline', {
+  defaultMessage: 'Add to Timeline',
+});
 
 export interface AddToTimelineProps {
   /**
@@ -77,7 +75,7 @@ export const AddToTimelineButtonIcon: VFC<AddToTimelineProps> = ({
   }
 
   return (
-    <EuiToolTip content={BUTTON_ICON_TOOLTIP}>
+    <EuiToolTip content={TITLE}>
       <EuiFlexItem data-test-subj={dataTestSubj}>
         {addToTimelineButton(addToTimelineProps)}
       </EuiFlexItem>
@@ -89,9 +87,68 @@ export const AddToTimelineButtonIcon: VFC<AddToTimelineProps> = ({
  * Add to timeline feature, leverages the built-in functionality retrieves from the timeLineService (see ThreatIntelligenceSecuritySolutionContext in x-pack/plugins/threat_intelligence/public/types.ts)
  * Clicking on the button will add a key-value pair to an Untitled timeline.
  *
+ * This component is renders an {@link EuiButtonEmpty}.
+ *
+ * @returns add to timeline button or an empty component
+ */
+export const AddToTimelineButtonEmpty: VFC<AddToTimelineProps> = ({
+  data,
+  field,
+  'data-test-subj': dataTestSubj,
+}) => {
+  const styles = useStyles();
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const addToTimelineButton =
+    useKibana().services.timelines.getHoverActions().getAddToTimelineButton;
+
+  const { key, value } =
+    typeof data === 'string' ? { key: field, value: data } : getIndicatorFieldAndValue(data, field);
+
+  if (!fieldAndValueValid(key, value)) {
+    return <></>;
+  }
+
+  const dataProvider: DataProvider[] = [generateDataProvider(key, value as string)];
+
+  const addToTimelineProps: AddToTimelineButtonProps = {
+    dataProvider,
+    field: key,
+    ownFocus: false,
+  };
+
+  // Use case is for the barchart legend (for example).
+  // We can't use the addToTimelineButton directly because the UI doesn't work in a EuiContextMenu.
+  // We hide it and use the defaultFocusedButtonRef props to programmatically click it.
+  addToTimelineProps.defaultFocusedButtonRef = buttonRef;
+
+  return (
+    <>
+      <div css={styles.displayNone}>{addToTimelineButton(addToTimelineProps)}</div>
+      <EuiToolTip content={TITLE}>
+        <EuiButtonEmpty
+          aria-label={TITLE}
+          iconType={ICON_TYPE}
+          iconSize="s"
+          color="primary"
+          onClick={() => buttonRef.current?.click()}
+          data-test-subj={dataTestSubj}
+        >
+          {TITLE}
+        </EuiButtonEmpty>
+      </EuiToolTip>
+    </>
+  );
+};
+
+/**
+ * Add to timeline feature, leverages the built-in functionality retrieves from the timeLineService (see ThreatIntelligenceSecuritySolutionContext in x-pack/plugins/threat_intelligence/public/types.ts)
+ * Clicking on the button will add a key-value pair to an Untitled timeline.
+ *
  * This component is to be used in an EuiContextMenu.
  *
- * @returns add to timeline item for a context menu
+ * @returns add to timeline {@link EuiContextMenuItem} for a context menu
  */
 export const AddToTimelineContextMenu: VFC<AddToTimelineProps> = ({
   data,
@@ -130,15 +187,12 @@ export const AddToTimelineContextMenu: VFC<AddToTimelineProps> = ({
       <div css={styles.displayNone}>{addToTimelineButton(addToTimelineProps)}</div>
       <EuiContextMenuItem
         key="addToTimeline"
-        icon="timeline"
+        icon={ICON_TYPE}
         size="s"
         onClick={() => contextMenuRef.current?.click()}
         data-test-subj={dataTestSubj}
       >
-        <FormattedMessage
-          id="xpack.threatIntelligence.timeline.addToTimelineContextMenu"
-          defaultMessage="Add to Timeline"
-        />
+        {TITLE}
       </EuiContextMenuItem>
     </>
   );
@@ -168,7 +222,7 @@ export const AddToTimelineCellAction: VFC<AddToTimelineCellActionProps> = ({
   addToTimelineProps.Component = Component;
 
   return (
-    <EuiToolTip content={CELL_ACTION_TOOLTIP}>
+    <EuiToolTip content={TITLE}>
       <EuiFlexItem data-test-subj={dataTestSubj}>
         {addToTimelineButton(addToTimelineProps)}
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR adds the copy to clipboard feature to the Threat Intelligence plugin.
Here are the places the copy capability has been added:
- indicators table cellActions: we had to use a custom `renderCellPopover` (as mentioned in [the doc](https://elastic.github.io/eui/#/tabular-content/data-grid-cells-popovers) when using a custom `renderCellValue`)
- add to barchart context menu
- add to flyout (in the overview tab and the table tab)

To guarantee a good user experience, this PR also adds the other features to the Indicators table cellActions popover (see image below).
![Screen Shot 2022-10-04 at 5 00 06 PM](https://user-images.githubusercontent.com/17276605/193938179-957b7b3b-790d-47fb-bd45-679c3e21eed2.png)

Similarly to `FilterIn`, `FilterOut` and `AddToTimeline` components, this PR adds 2 new `CopyToClipboard` components: one as an `EuiButtonEmpty` and the second as an `EuiContextMenu`.

https://user-images.githubusercontent.com/17276605/193938048-c8c0a9ea-7acf-4714-817d-af7dd8e11686.mov

Fixes https://github.com/elastic/security-team/issues/4548

## To do
- add e2e tests

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
