### PR TITLE
Removing esArchiver from bulkCreate

### DIFF
--- a/x-pack/test/saved_object_api_integration/common/suites/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/common/suites/bulk_create.ts
@@ -6,7 +6,6 @@
  */
 
 import expect from '@kbn/expect';
-import { SuperTest } from 'supertest';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES, ALL_SPACES_ID } from '../lib/spaces';
@@ -17,6 +16,8 @@ import {
   getRedactedNamespaces,
 } from '../lib/saved_object_test_utils';
 import { ExpectResponseBody, TestCase, TestDefinition, TestSuite, TestUser } from '../lib/types';
+import { FtrProviderContext } from '../ftr_provider_context';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 
 const {
   DEFAULT: { spaceId: DEFAULT_SPACE_ID },
@@ -85,7 +86,10 @@ const createRequest = ({ type, id, initialNamespaces }: BulkCreateTestCase) => (
   ...(initialNamespaces && { initialNamespaces }),
 });
 
-export function bulkCreateTestSuiteFactory(esArchiver: any, supertest: SuperTest<any>) {
+export function bulkCreateTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
+
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_create');
   const expectResponseBody =
     (
@@ -193,16 +197,31 @@ export function bulkCreateTestSuiteFactory(esArchiver: any, supertest: SuperTest
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+        });
+
+        after(async () => {
+          await testDataLoader.deleteFtrSpaces();
+          await testDataLoader.deleteFtrSavedObjectsData();
+        });
 
         const attrs = { attributes: { [NEW_ATTRIBUTE_KEY]: NEW_ATTRIBUTE_VAL } };
 

--- a/x-pack/test/saved_object_api_integration/security_and_spaces/apis/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/security_and_spaces/apis/bulk_create.ts
@@ -113,12 +113,9 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   return { normalTypes, crossNamespace, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
+export default function (context: FtrProviderContext) {
   const { addTests, createTestDefinitions, expectSavedObjectForbidden } =
-    bulkCreateTestSuiteFactory(esArchiver, supertest);
+    bulkCreateTestSuiteFactory(context);
   const createTests = (overwrite: boolean, spaceId: string, user: TestUser) => {
     const { normalTypes, crossNamespace, hiddenType, allTypes } = createTestCases(
       overwrite,

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/bulk_create.ts
@@ -103,11 +103,8 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   ];
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = bulkCreateTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = bulkCreateTestSuiteFactory(context);
   const createTests = (overwrite: boolean, spaceId: string) => {
     const testCases = createTestCases(overwrite, spaceId);
     return createTestDefinitions(testCases, false, overwrite, {


### PR DESCRIPTION
## Summary

Removing `esArchiver` from the bulk_create suit of functional tests

## Flaky Test Runner Results
[security_and_spaces/config_basic](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1358) x 50 ✅
[security_and_spaces/config_trial](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1359)  x 50 ✅
[spaces_only/config](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1360)  x 50 ✅

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->