### PR TITLE
[Uptime] handle index not found errors

### DIFF
--- a/x-pack/plugins/uptime/server/lib/lib.ts
+++ b/x-pack/plugins/uptime/server/lib/lib.ts
@@ -93,7 +93,7 @@ export function createUptimeESClient({
             esError,
             esRequestParams: esParams,
             esRequestStatus,
-            esResponse: res.body,
+            esResponse: res?.body,
             kibanaRequest: request!,
             operationName: operationName ?? '',
             startTime: startTimeNow,

--- a/x-pack/plugins/uptime/server/lib/requests/get_index_status.ts
+++ b/x-pack/plugins/uptime/server/lib/requests/get_index_status.ts
@@ -11,18 +11,30 @@ import { StatesIndexStatus } from '../../../common/runtime_types';
 export const getIndexStatus: UMElasticsearchQueryFn<{}, StatesIndexStatus> = async ({
   uptimeEsClient,
 }) => {
-  const {
-    indices,
-    result: {
-      body: {
-        _shards: { total },
-        count,
+  try {
+    const {
+      indices,
+      result: {
+        body: {
+          _shards: { total },
+          count,
+        },
       },
-    },
-  } = await uptimeEsClient.count({ terminateAfter: 1 });
-  return {
-    indices,
-    indexExists: total > 0,
-    docCount: count,
-  };
+    } = await uptimeEsClient.count({ terminateAfter: 1 });
+    return {
+      indices,
+      indexExists: total > 0,
+      docCount: count,
+    };
+  } catch (e) {
+    if (e.meta.statusCode === 404) {
+      // we don't throw an error for index not found
+      return {
+        indices: '',
+        indexExists: false,
+        docCount: 0,
+      };
+    }
+    throw e;
+  }
 };


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/140451

Backports the fix from https://github.com/elastic/kibana/pull/134018 to 7.17.

Handles index not found errors for Uptime with a getting started screen.

Before
![image](https://user-images.githubusercontent.com/11356435/193945832-1ee1e309-9789-4bb3-a52a-d3f6adb5e6c1.png)

After
<img width="1523" alt="Screen Shot 2022-10-04 at 6 55 45 PM" src="https://user-images.githubusercontent.com/11356435/193945501-6d7de6b7-41e6-4d85-814a-67388b0d084a.png">


### Testing
1. Navigate to Uptime settings page
2. Change the index template to `heartbeat`
3. Navigate to Uptime overview page. Confirm you see the no data view instead of an internal server error