### PR TITLE
[TIP] Support category pre-selection inside the FieldsBrowser component

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.test.tsx
@@ -36,7 +36,9 @@ describe('<IndicatorsFieldBrowser />', () => {
         columnIds: [],
         onResetColumns: stub,
         onToggleColumn: stub,
-        options: {},
+        options: {
+          preselectedCategoryIds: ['threat'],
+        },
       })
     );
   });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.tsx
@@ -29,6 +29,8 @@ export const IndicatorsFieldBrowser: VFC<IndicatorsFieldBrowserProps> = ({
     columnIds,
     onResetColumns,
     onToggleColumn,
-    options: {},
+    options: {
+      preselectedCategoryIds: ['threat'],
+    },
   });
 };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/field_browser.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/field_browser.test.tsx
@@ -121,4 +121,25 @@ describe('FieldsBrowser', () => {
     const result = renderComponent({ isEventViewer, width: FIELD_BROWSER_WIDTH });
     expect(result.getByTestId('show-field-browser')).toBeInTheDocument();
   });
+
+  describe('options.preselectedCategoryIds', () => {
+    it("should render fields list narrowed to preselected category id's", async () => {
+      const agentFieldsCount = Object.keys(mockBrowserFields.agent?.fields || {}).length;
+
+      // Narrowing the selection to 'agent' only
+      const result = renderComponent({ options: { preselectedCategoryIds: ['agent'] } });
+
+      result.getByTestId('show-field-browser').click();
+
+      // Wait for the modal to open
+      await waitFor(() => {
+        expect(result.getByTestId('fields-browser-container')).toBeInTheDocument();
+      });
+
+      // Check if there are only 4 fields in the table
+      expect(result.queryByTestId('field-table')?.querySelectorAll('tbody tr')).toHaveLength(
+        agentFieldsCount
+      );
+    });
+  });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/field_browser.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/field_browser.tsx
@@ -31,6 +31,11 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
   options,
   width,
 }) => {
+  const initialCategories = useMemo(
+    () => options?.preselectedCategoryIds ?? [],
+    [options?.preselectedCategoryIds]
+  );
+
   const customizeColumnsButtonRef = useRef<HTMLButtonElement | null>(null);
   /** all field names shown in the field browser must contain this string (when specified) */
   const [filterInput, setFilterInput] = useState('');
@@ -43,7 +48,7 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
   /** when true, show a spinner in the input to indicate the field browser is searching for matching field names */
   const [isSearching, setIsSearching] = useState(false);
   /** this category will be displayed in the right-hand pane of the field browser */
-  const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>(initialCategories);
   /** show the field browser */
   const [show, setShow] = useState(false);
 
@@ -93,9 +98,9 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
     setFilteredBrowserFields(null);
     setFilterSelectedEnabled(false);
     setIsSearching(false);
-    setSelectedCategoryIds([]);
+    setSelectedCategoryIds(initialCategories);
     setShow(false);
-  }, []);
+  }, [initialCategories]);
 
   /** Invoked when the user types in the filter input */
   const updateFilter = useCallback(

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/field_browser/types.ts
@@ -34,6 +34,10 @@ export type GetFieldTableColumns = (params: {
 export interface FieldBrowserOptions {
   createFieldButton?: CreateFieldComponent;
   getFieldTableColumns?: GetFieldTableColumns;
+  /**
+   * Categories that should be selected initially
+   */
+  preselectedCategoryIds?: string[];
 }
 
 export interface FieldBrowserProps {


### PR DESCRIPTION
## Summary

This resolves https://github.com/elastic/security-team/issues/5007

How it looks like in the context of Threat Intelligence plugin:

[156b5944-2539-4459-976f-caa142b56018.webm](https://user-images.githubusercontent.com/11671118/194010834-9ca12b3d-03eb-473b-b69f-c668fd8a6611.webm)

You can see that the initial set of selected categories can be adjusted with the options property:

![image](https://user-images.githubusercontent.com/11671118/194011075-694bdd3d-eba6-4cb2-afca-a85a284539ca.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
