### PR TITLE
Expression renderer: Make sure progress bar is visible

### DIFF
--- a/src/plugins/expressions/public/react_expression_renderer/react_expression_renderer.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer/react_expression_renderer.tsx
@@ -57,7 +57,9 @@ export function ReactExpressionRenderer({
   return (
     <div {...dataAttrs} className={classes}>
       {isEmpty && <EuiLoadingChart mono size="l" />}
-      {isLoading && <EuiProgress size="xs" color="accent" position="absolute" />}
+      {isLoading && (
+        <EuiProgress size="xs" color="accent" position="absolute" style={{ zIndex: 1 }} />
+      )}
       {!isLoading && error && renderError?.(error.message, error)}
       <div className="expExpressionRenderer__expression" style={expressionStyles} ref={nodeRef} />
     </div>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/141912

If the visualization is using absolute positioning as well, the progress bar might be shown _behind_ the chart itself (this happens for the new metric visualization which is using absolute positioning for the background.

This PR fixes this by lifting the progress bar to a higher z index. This does not break other absolutely positioned components like tooltips:
<img width="1560" alt="Screenshot 2022-10-05 at 10 19 47" src="https://user-images.githubusercontent.com/1508364/194014806-56663f68-b93f-4241-aef5-234576420d56.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->