### PR TITLE
[Uptime] Un-skip alert flaky test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/uptime/alert_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/uptime/alert_flyout.ts
@@ -142,8 +142,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/g
-    describe.skip('tls alert', function () {
+    describe('tls alert', function () {
       const DEFAULT_DATE_START = 'Sep 10, 2019 @ 12:40:08.078';
       const DEFAULT_DATE_END = 'Sep 11, 2019 @ 19:40:08.078';
       let alerts: any;
@@ -185,7 +184,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       it('has created a valid alert with expected parameters', async () => {
         let alert: any;
-        await retry.tryForTime(15000, async () => {
+        await retry.tryForTime(60 * 1000, async () => {
           const apiResponse = await supertest.get(`/api/alerts/_find?search=${alertId}`);
           const alertsFromThisTest = apiResponse.body.data.filter(
             ({ name }: { name: string }) => name === alertId


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/133916

Un-skip alert flaky test


Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1366

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->