### PR TITLE
[APM] Migrate api tests to use apm api client

### DIFF
--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -71,7 +71,7 @@ as uiSettings within the code.
 
 |{kib-repo}blob/{branch}/src/plugins/data_views/README.mdx[dataViews]
 |The data views API provides a consistent method of structuring and formatting documents
-and field lists across the various Kibana apps. Its typically used in conjunction with
+and field lists across the various Kibana apps. It's typically used in conjunction with
 <DocLink id="kibDevTutorialDataSearchAndSessions" section="high-level-search" text="SearchSource" /> for composing queries.
 
 

--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -26,17 +26,6 @@ export interface ApmFtrConfig {
   kibanaConfig?: Record<string, string | string[]>;
 }
 
-function getLegacySupertestClient(kibanaServer: UrlObject, username: ApmUsername) {
-  return async (context: InheritedFtrProviderContext) => {
-    const url = format({
-      ...kibanaServer,
-      auth: `${username}:${APM_TEST_PASSWORD}`,
-    });
-
-    return supertest(url);
-  };
-}
-
 async function getApmApiClient({
   kibanaServer,
   username,
@@ -125,15 +114,6 @@ export function createTestConfig(config: ApmFtrConfig) {
           };
         },
         ml: MachineLearningAPIProvider,
-        // legacy clients
-        legacySupertestAsApmWriteUser: getLegacySupertestClient(
-          kibanaServer,
-          ApmUsername.editorUser
-        ),
-        legacySupertestAsApmReadUserWithoutMlAccess: getLegacySupertestClient(
-          kibanaServer,
-          ApmUsername.apmReadUserWithoutMlAccess
-        ),
       },
       junit: {
         reportName: `APM API Integration tests (${name})`,

--- a/x-pack/test/apm_api_integration/common/registry.ts
+++ b/x-pack/test/apm_api_integration/common/registry.ts
@@ -104,8 +104,7 @@ export function RegistryProvider({ getService }: FtrProviderContext) {
 
       const esArchiver = getService('esArchiver');
       const logger = getService('log');
-
-      const supertest = getService('legacySupertestAsApmWriteUser');
+      const ml = getService('ml');
 
       const logWithTimer = () => {
         const start = process.hrtime();
@@ -148,7 +147,7 @@ export function RegistryProvider({ getService }: FtrProviderContext) {
                 );
 
                 // sync jobs from .ml-config to .kibana SOs
-                await supertest.get('/api/ml/saved_objects/sync').set('kbn-xsrf', 'foo');
+                await ml.syncMlJobs();
               }
               if (condition.archives.length) {
                 log('Loaded all archives');

--- a/x-pack/test/apm_api_integration/common/registry.ts
+++ b/x-pack/test/apm_api_integration/common/registry.ts
@@ -12,6 +12,7 @@ import { maybe } from '@kbn/apm-plugin/common/utils/maybe';
 import { joinByKey } from '@kbn/apm-plugin/common/utils/join_by_key';
 import { APMFtrConfigName } from '../configs';
 import { FtrProviderContext } from './ftr_provider_context';
+import { ApmUsername, APM_TEST_PASSWORD } from '@kbn/apm-plugin/server/test_helpers/create_apm_users/authentication';
 
 type ArchiveName =
   | 'apm_8.0.0'
@@ -104,7 +105,7 @@ export function RegistryProvider({ getService }: FtrProviderContext) {
 
       const esArchiver = getService('esArchiver');
       const logger = getService('log');
-      const ml = getService('ml');
+      const supertest = getService('supertest');
 
       const logWithTimer = () => {
         const start = process.hrtime();
@@ -147,7 +148,7 @@ export function RegistryProvider({ getService }: FtrProviderContext) {
                 );
 
                 // sync jobs from .ml-config to .kibana SOs
-                await ml.syncMlJobs();
+                await supertest.get('/api/ml/saved_objects/sync').set('kbn-xsrf', 'foo').auth(ApmUsername.editorUser, APM_TEST_PASSWORD);
               }
               if (condition.archives.length) {
                 log('Loaded all archives');

--- a/x-pack/test/apm_api_integration/common/registry.ts
+++ b/x-pack/test/apm_api_integration/common/registry.ts
@@ -10,9 +10,12 @@ import { castArray, groupBy } from 'lodash';
 import callsites from 'callsites';
 import { maybe } from '@kbn/apm-plugin/common/utils/maybe';
 import { joinByKey } from '@kbn/apm-plugin/common/utils/join_by_key';
+import {
+  ApmUsername,
+  APM_TEST_PASSWORD,
+} from '@kbn/apm-plugin/server/test_helpers/create_apm_users/authentication';
 import { APMFtrConfigName } from '../configs';
 import { FtrProviderContext } from './ftr_provider_context';
-import { ApmUsername, APM_TEST_PASSWORD } from '@kbn/apm-plugin/server/test_helpers/create_apm_users/authentication';
 
 type ArchiveName =
   | 'apm_8.0.0'
@@ -148,7 +151,10 @@ export function RegistryProvider({ getService }: FtrProviderContext) {
                 );
 
                 // sync jobs from .ml-config to .kibana SOs
-                await supertest.get('/api/ml/saved_objects/sync').set('kbn-xsrf', 'foo').auth(ApmUsername.editorUser, APM_TEST_PASSWORD);
+                await supertest
+                  .get('/api/ml/saved_objects/sync')
+                  .set('kbn-xsrf', 'foo')
+                  .auth(ApmUsername.editorUser, APM_TEST_PASSWORD);
               }
               if (condition.archives.length) {
                 log('Loaded all archives');

--- a/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
@@ -7,10 +7,11 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../common/ftr_provider_context';
+import { APIClientRequestParamsOf } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 
 export default function featureControlsTests({ getService }: FtrProviderContext) {
   const registry = getService('registry');
-  const supertest = getService('legacySupertestAsApmWriteUser');
+  const apmApiClient = getService("apmApiClient");
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
   const spaces = getService('spaces');
@@ -40,6 +41,26 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     expectResponse: (result: any) => void;
     onExpectationFail?: () => Promise<any>;
   }
+
+  function createAgent(body: APIClientRequestParamsOf<'PUT /api/apm/settings/agent-configuration'>['params']['body']) {
+    return apmApiClient.writeUser({
+      endpoint: 'PUT /api/apm/settings/agent-configuration',
+      params: {
+        body,
+      }
+    });
+  };
+
+  function deleteAgent(body: APIClientRequestParamsOf<'DELETE /api/apm/settings/agent-configuration'>['params']['body']) {
+    return apmApiClient.writeUser({
+      endpoint: 'DELETE /api/apm/settings/agent-configuration',
+      params: {
+        body,
+      }
+    });
+  };
+
+
   const endpoints: Endpoint[] = [
     {
       // this doubles as a smoke test for the _inspect query parameter
@@ -200,28 +221,6 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
       .catch((error: any) => ({ error, response: undefined }));
   }
 
-  async function executeAsAdmin({ method = 'get', url, body }: Endpoint['req'], spaceId?: string) {
-    const basePath = spaceId ? `/s/${spaceId}` : '';
-    const fullPath = `${basePath}${url}`;
-    let request = supertest[method](fullPath);
-
-    // json body
-    if (body) {
-      request = request.send(body);
-    }
-
-    const response = await request.set('kbn-xsrf', 'foo');
-
-    const { status } = response;
-    if (status !== 200) {
-      throw new Error(`Endpoint: ${method} ${fullPath}
-      Status code: ${status}
-      Response: ${response.body.message}`);
-    }
-
-    return response;
-  }
-
   async function executeRequests({
     username,
     password,
@@ -268,23 +267,14 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     };
     before(async () => {
       log.info(`Creating agent configuration`);
-      await executeAsAdmin({
-        method: 'put',
-        url: '/api/apm/settings/agent-configuration',
-        body: config,
-      });
+      await createAgent(config);
       log.info(`Agent configuration created`);
     });
 
     after(async () => {
       log.info('deleting agent configuration');
-      await executeAsAdmin({
-        method: 'delete',
-        url: `/api/apm/settings/agent-configuration`,
-        body: {
-          service: config.service,
-        },
-      });
+      await deleteAgent({ service: config.service });
+      log.info('Agent configuration deleted');
     });
 
     it(`APIs can't be accessed by logstash_read user`, async () => {

--- a/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
@@ -6,12 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../common/ftr_provider_context';
 import { APIClientRequestParamsOf } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import { FtrProviderContext } from '../common/ftr_provider_context';
 
 export default function featureControlsTests({ getService }: FtrProviderContext) {
   const registry = getService('registry');
-  const apmApiClient = getService("apmApiClient");
+  const apmApiClient = getService('apmApiClient');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
   const spaces = getService('spaces');
@@ -42,24 +42,27 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     onExpectationFail?: () => Promise<any>;
   }
 
-  function createAgent(body: APIClientRequestParamsOf<'PUT /api/apm/settings/agent-configuration'>['params']['body']) {
+  function createAgent(
+    body: APIClientRequestParamsOf<'PUT /api/apm/settings/agent-configuration'>['params']['body']
+  ) {
     return apmApiClient.writeUser({
       endpoint: 'PUT /api/apm/settings/agent-configuration',
       params: {
         body,
-      }
+      },
     });
-  };
+  }
 
-  function deleteAgent(body: APIClientRequestParamsOf<'DELETE /api/apm/settings/agent-configuration'>['params']['body']) {
+  function deleteAgent(
+    body: APIClientRequestParamsOf<'DELETE /api/apm/settings/agent-configuration'>['params']['body']
+  ) {
     return apmApiClient.writeUser({
       endpoint: 'DELETE /api/apm/settings/agent-configuration',
       params: {
         body,
-      }
+      },
     });
-  };
-
+  }
 
   const endpoints: Endpoint[] = [
     {

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
@@ -30,7 +30,7 @@ export default function apiTest({ getService }: FtrProviderContext) {
   }
 
   function deleteJobs(jobIds: string[]) {
-    return ml.deleteMlJobs(jobIds);
+    return Promise.allSettled(jobIds.map(jobId => ml.deleteAnomalyDetectionJobES(jobId)));
   }
 
   registry.when('ML jobs', { config: 'trial', archives: [] }, () => {

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
@@ -12,7 +12,7 @@ import { FtrProviderContext } from '../../../common/ftr_provider_context';
 export default function apiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
   const apmApiClient = getService('apmApiClient');
-  const legacyWriteUserClient = getService('legacySupertestAsApmWriteUser');
+  const ml = getService('ml');
 
   function getJobs() {
     return apmApiClient.writeUser({
@@ -30,17 +30,14 @@ export default function apiTest({ getService }: FtrProviderContext) {
   }
 
   function deleteJobs(jobIds: string[]) {
-    return legacyWriteUserClient
-      .post(`/api/ml/jobs/delete_jobs`)
-      .send({ jobIds })
-      .set('kbn-xsrf', 'foo');
+    return ml.deleteMlJobs(jobIds);
   }
 
   registry.when('ML jobs', { config: 'trial', archives: [] }, () => {
     describe('when user has write access to ML', () => {
       after(async () => {
         const res = await getJobs();
-        const jobIds = res.body.jobs.map((job: any) => job.job_id);
+        const jobIds = res.body.jobs.map((job: any) => job.jobId);
         await deleteJobs(jobIds);
       });
 

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.spec.ts
@@ -30,7 +30,7 @@ export default function apiTest({ getService }: FtrProviderContext) {
   }
 
   function deleteJobs(jobIds: string[]) {
-    return Promise.allSettled(jobIds.map(jobId => ml.deleteAnomalyDetectionJobES(jobId)));
+    return Promise.allSettled(jobIds.map((jobId) => ml.deleteAnomalyDetectionJobES(jobId)));
   }
 
   registry.when('ML jobs', { config: 'trial', archives: [] }, () => {

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1463,24 +1463,5 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug('Module set up');
       return module;
     },
-
-    async deleteMlJobs(jobIds: string[]) {
-      log.debug(`Deleting ml jobs ids [${jobIds.join(',')}]`);
-      const { body, status } = await kbnSupertest
-        .post('/api/ml/jobs/delete_jobs')
-        .set(COMMON_REQUEST_HEADERS)
-        .send({ jobIds });
-      this.assertResponseStatusCode(200, status, body);
-
-      log.debug('> ml jobs deleted');
-    },
-
-    async syncMlJobs() {
-      log.debug('Syncing ml jobs');
-      const { body, status } = await kbnSupertest.get('/api/ml/saved_objects/sync');
-      this.assertResponseStatusCode(200, status, body);
-
-      log.debug('> ml jobs synced');
-    },
   };
 }

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1464,7 +1464,7 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       return module;
     },
 
-    async deleteMlJobs(jobIds: string []) {
+    async deleteMlJobs(jobIds: string[]) {
       log.debug(`Deleting ml jobs ids [${jobIds.join(',')}]`);
       const { body, status } = await kbnSupertest
         .post('/api/ml/jobs/delete_jobs')
@@ -1477,8 +1477,7 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async syncMlJobs() {
       log.debug('Syncing ml jobs');
-      const { body, status } = await kbnSupertest
-        .get('/api/ml/saved_objects/sync');
+      const { body, status } = await kbnSupertest.get('/api/ml/saved_objects/sync');
       this.assertResponseStatusCode(200, status, body);
 
       log.debug('> ml jobs synced');

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1463,5 +1463,25 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug('Module set up');
       return module;
     },
+
+    async deleteMlJobs(jobIds: string []) {
+      log.debug(`Deleting ml jobs ids [${jobIds.join(',')}]`);
+      const { body, status } = await kbnSupertest
+        .post('/api/ml/jobs/delete_jobs')
+        .set(COMMON_REQUEST_HEADERS)
+        .send({ jobIds });
+      this.assertResponseStatusCode(200, status, body);
+
+      log.debug('> ml jobs deleted');
+    },
+
+    async syncMlJobs() {
+      log.debug('Syncing ml jobs');
+      const { body, status } = await kbnSupertest
+        .get('/api/ml/saved_objects/sync');
+      this.assertResponseStatusCode(200, status, body);
+
+      log.debug('> ml jobs synced');
+    },
   };
 }


### PR DESCRIPTION
Relates to [111308](https://github.com/elastic/kibana/issues/111308).

Removed the usage of:
- `legacySupertestAsApmWriteUser`
- `legacySupertestAsApmReadUserWithoutMlAccess`
