### PR TITLE
[Files] Remove limitation to of using `.kibana` indices

### DIFF
--- a/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/x-pack/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -49,10 +49,6 @@ export class ElasticsearchBlobStorageClient implements BlobStorageClient {
      */
     private readonly uploadSemaphore = ElasticsearchBlobStorageClient.defaultSemaphore
   ) {
-    assert(
-      this.index.startsWith('.kibana'),
-      `Elasticsearch blob store index name must start with ".kibana", got ${this.index}.`
-    );
     assert(this.uploadSemaphore, `No default semaphore provided and no semaphore was passed in.`);
   }
 


### PR DESCRIPTION
## Summary

This is a limit that is already imposed by elasticsearch. The initial idea was to handle it in Kibana with a nicer message, but this is preventing use of non .kibana system indices at the moment, which is/will be possible.