### PR TITLE
[APM] Collect total number of service groups

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
@@ -1075,6 +1075,9 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                       "properties": {
                         "kuery_fields": {
                           "type": "keyword"
+                        },
+                        "total": {
+                          "type": "long"
                         }
                       }
                     },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -15,6 +15,7 @@ import { AGENT_NAMES, RUM_AGENT_NAMES } from '../../../../common/agent_name';
 import {
   SavedServiceGroup,
   APM_SERVICE_GROUP_SAVED_OBJECT_TYPE,
+  MAX_NUMBER_OF_SERVICE_GROUPS,
 } from '../../../../common/service_groups';
 import { getKueryFields } from '../../helpers/get_kuery_fields';
 import {
@@ -1134,7 +1135,7 @@ export const tasks: TelemetryTask[] = [
       const response = await savedObjectsClient.find<SavedServiceGroup>({
         type: APM_SERVICE_GROUP_SAVED_OBJECT_TYPE,
         page: 1,
-        perPage: 50,
+        perPage: MAX_NUMBER_OF_SERVICE_GROUPS,
         sortField: 'updated_at',
         sortOrder: 'desc',
       });
@@ -1148,6 +1149,7 @@ export const tasks: TelemetryTask[] = [
       return {
         service_groups: {
           kuery_fields: kueryFields,
+          total: response.total ?? 0,
         },
       };
     },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -235,7 +235,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
   },
   service_groups: {
     kuery_fields: { type: 'array', items: { type: 'keyword' } },
-    total: long
+    total: long,
   },
   per_service: { type: 'array', items: { ...apmPerServiceSchema } },
   tasks: {

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -235,6 +235,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
   },
   service_groups: {
     kuery_fields: { type: 'array', items: { type: 'keyword' } },
+    total: long
   },
   per_service: { type: 'array', items: { ...apmPerServiceSchema } },
   tasks: {

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -173,6 +173,7 @@ export interface APMUsage {
   };
   service_groups: {
     kuery_fields: string[];
+    total: number;
   };
   per_service: APMPerService[];
   tasks: Record<

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -4109,6 +4109,9 @@
               "items": {
                 "type": "keyword"
               }
+            },
+            "total": {
+              "type": "long"
             }
           }
         },


### PR DESCRIPTION
## Summary

part of https://github.com/elastic/kibana/issues/128621

Collects the total number of service groups. 

`total` field is added in the `service_groups` object

```
...
"service_groups": {
   "kuery_fields": [ 
      "service.language.name",
      "agent.name",
      "service.environment"
    ],
  "total": 3
},
...
```

### How to test locally


1. request `GET {KIBANA_HOST}/internal/apm/debug-telemetry`
2. look for service_groups



