### PR TITLE
[Synthetics] Update layout for ping monitor

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
@@ -24,7 +24,7 @@ export const SinglePingResult = ({ ping, loading }: { ping: Ping; loading: boole
   const responseStatus = !loading ? ping?.http?.response?.status_code : undefined;
 
   return (
-    <EuiDescriptionList type="responsiveColumn" compressed={true}>
+    <EuiDescriptionList type="column" compressed={true}>
       <EuiDescriptionListTitle>IP</EuiDescriptionListTitle>
       <EuiDescriptionListDescription>{ip}</EuiDescriptionListDescription>
       <EuiDescriptionListTitle>{DURATION_LABEL}</EuiDescriptionListTitle>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_details_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_details_panel.tsx
@@ -55,7 +55,7 @@ export const MonitorDetailsPanel = () => {
   return (
     <div css={wrapperStyle}>
       <EuiSpacer size="s" />
-      <EuiDescriptionList type="responsiveColumn" compressed={true}>
+      <EuiDescriptionList type="column" compressed={true}>
         <EuiDescriptionListTitle>{ENABLED_LABEL}</EuiDescriptionListTitle>
         <EuiDescriptionListDescription>
           {monitor && (

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
@@ -12,6 +12,7 @@ import { ReportTypes } from '@kbn/observability-plugin/public';
 import { useParams } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 
+import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { ClientPluginsStart } from '../../../../../plugin';
 export const StepDurationPanel = () => {
   const { observability } = useKibana<ClientPluginsStart>().services;
@@ -20,12 +21,16 @@ export const StepDurationPanel = () => {
 
   const { monitorId } = useParams<{ monitorId: string }>();
 
+  const { monitor } = useSelectedMonitor();
+
+  const isBrowser = monitor?.type === 'browser';
+
   return (
     <EuiPanel>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">
-            <h3>{DURATION_BY_STEP_LABEL}</h3>
+            <h3>{isBrowser ? DURATION_BY_STEP_LABEL : DURATION_BY_LOCATION}</h3>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem>
@@ -43,10 +48,10 @@ export const StepDurationPanel = () => {
           {
             name: DURATION_BY_STEP_LABEL,
             reportDefinitions: { 'monitor.id': [monitorId] },
-            selectedMetricField: 'synthetics.step.duration.us',
+            selectedMetricField: isBrowser ? 'synthetics.step.duration.us' : 'monitor.duration.us',
             dataType: 'synthetics',
             time: { from: 'now-24h/h', to: 'now' },
-            breakdown: 'synthetics.step.name.keyword',
+            breakdown: isBrowser ? 'synthetics.step.name.keyword' : 'observer.geo.name',
             operationType: 'last_value',
             seriesType: 'area_stacked',
           },
@@ -58,6 +63,10 @@ export const StepDurationPanel = () => {
 
 const DURATION_BY_STEP_LABEL = i18n.translate('xpack.synthetics.detailsPanel.durationByStep', {
   defaultMessage: 'Duration by step',
+});
+
+const DURATION_BY_LOCATION = i18n.translate('xpack.synthetics.detailsPanel.durationByLocation', {
+  defaultMessage: 'Duration by location',
 });
 
 const LAST_24H_LABEL = i18n.translate('xpack.synthetics.detailsPanel.last24Hours', {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
@@ -51,8 +51,8 @@ export const fetchSyntheticsMonitor = async ({
   )) as SavedObject<SyntheticsMonitor>;
 
   return {
-    id: savedObject.id,
     ...savedObject.attributes,
+    id: savedObject.id,
     updated_at: savedObject.updated_at,
   } as EncryptedSyntheticsSavedMonitor;
 };


### PR DESCRIPTION
## Summary

Update layout for ping monitor , instead of step duration just display monitor duration , also made improvement on description  group layout 

### After:
<img width="1577" alt="image" src="https://user-images.githubusercontent.com/3505601/194122218-a35bada6-f1c7-48f8-a94d-1fc8578e4c25.png">


### Before

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3505601/194122434-4c22aeb7-2be7-41e2-b08b-64236e62be0b.png">

