### PR TITLE
[CI] Use 4 parallel ESLint jobs

### DIFF
--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -16,9 +16,9 @@ echo '--- Lint: eslint'
 # after possibly commiting fixed files to the repo
 set +e;
 if is_pr && ! is_auto_commit_disabled; then
-  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache --fix
+  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 4 node scripts/eslint --no-cache --fix
 else
-  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 6 node scripts/eslint --no-cache
+  git ls-files | grep -E '\.(js|mjs|ts|tsx)$' | xargs -n 250 -P 4 node scripts/eslint --no-cache
 fi
 
 eslint_exit=$?


### PR DESCRIPTION
We're seeing some odd flakiness with ESLint on CI

https://buildkite.com/elastic/kibana-on-merge/builds/22145#0183a956-8408-41ec-96fd-fb3fa37a2ae8

```
Error: .eslintrc.js » @kbn/eslint-config » ./javascript.js#overrides[0]:
	Configuration for rule "camelcase" is invalid:
Unexpected token ','
```

The only thing that we came up with was the seemingly high CPU. So, we're dropping the parallelization to test the assumption. This takes the lining task to ~32minutes from ~29.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->