### PR TITLE
[ML] Explain Log Rate Spikes:  update more groups badge for clarity

### DIFF
--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -235,7 +235,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
             'xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.groupColumnTooltip',
             {
               defaultMessage:
-                'Displays field values unique to the group. Expand row to see all values.',
+                'Displays field/value pairs unique to the group. Expand row to see all field/value pairs.',
             }
           )}
         >
@@ -280,7 +280,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
                 +{Object.keys(repeatedValues).length}{' '}
                 <FormattedMessage
                   id="xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.moreLabel"
-                  defaultMessage="more field names and values also appearing in other groups"
+                  defaultMessage="more field/value pairs also appearing in other groups"
                 />
               </EuiBadge>
               <EuiSpacer size="xs" />

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -280,7 +280,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
                 +{Object.keys(repeatedValues).length}{' '}
                 <FormattedMessage
                   id="xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.moreLabel"
-                  defaultMessage="more"
+                  defaultMessage="more field names and values also appearing in other groups"
                 />
               </EuiBadge>
               <EuiSpacer size="xs" />


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/142626

This PR updates the group badge copy representing more groups not immediately shown in the row. Instead of `+ 5 more`, for example, the badge now  reads`+5 more field names and values also appearing in other groups`

This language is consistent with the tooltip copy for that column. 

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/6446462/194371015-879d818f-c82c-4f7f-a731-79c41b8736e5.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->