### PR TITLE
[Terminal Output] useMemo removed for simple calculations. changes to these props were …

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -99,8 +99,8 @@ export function ProcessTreeNode({
   }, [selectedProcess, process, childrenExpanded]);
 
   const alerts = process.getAlerts();
-  const hasAlerts = useMemo(() => !!alerts.length, [alerts]);
-  const hasOutputs = useMemo(() => process.hasOutput(), [process]);
+  const hasAlerts = !!alerts.length;
+  const hasOutputs = process.hasOutput();
   const hasInvestigatedAlert = useMemo(
     () =>
       !!(


### PR DESCRIPTION
…not picked up if new events changed their result

## Summary

Fixes an issue where a process in the tree would not show it's output button if it received an output event after it was rendered.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->