### PR TITLE
[RAM] Fix snooze schedule always showing dtstart instead of next occurrence

### DIFF
--- a/x-pack/plugins/alerting/common/index.ts
+++ b/x-pack/plugins/alerting/common/index.ts
@@ -22,6 +22,7 @@ export * from './rule_notify_when_type';
 export * from './parse_duration';
 export * from './execution_log_types';
 export * from './rule_snooze_type';
+export * from './rrule_from_snooze';
 
 export interface AlertingFrameworkHealth {
   isSufficientlySecure: boolean;

--- a/x-pack/plugins/alerting/common/rrule_from_snooze.ts
+++ b/x-pack/plugins/alerting/common/rrule_from_snooze.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RRule, ByWeekday, Weekday, rrulestr } from 'rrule';
+import { SnoozeRRule } from './rule_snooze_type';
+
+export const parseByWeekday = (byweekday: Array<string | number>): ByWeekday[] => {
+  const rRuleString = `RRULE:BYDAY=${byweekday.join(',')}`;
+  const parsedRRule = rrulestr(rRuleString);
+  return parsedRRule.origOptions.byweekday as ByWeekday[];
+};
+
+export const getRRuleFromSnooze = (rRule: SnoozeRRule) => {
+  return new RRule({
+    ...rRule,
+    dtstart: new Date(rRule.dtstart),
+    until: rRule.until ? new Date(rRule.until) : null,
+    wkst: rRule.wkst ? Weekday.fromStr(rRule.wkst) : null,
+    byweekday: rRule.byweekday ? parseByWeekday(rRule.byweekday) : null,
+  });
+};

--- a/x-pack/plugins/alerting/common/rule_snooze_type.ts
+++ b/x-pack/plugins/alerting/common/rule_snooze_type.ts
@@ -7,7 +7,7 @@
 
 import type { WeekdayStr } from 'rrule';
 
-type SnoozeRRule = Partial<RRuleRecord> & Pick<RRuleRecord, 'dtstart' | 'tzid'>;
+export type SnoozeRRule = Partial<RRuleRecord> & Pick<RRuleRecord, 'dtstart' | 'tzid'>;
 
 export interface RuleSnoozeSchedule {
   duration: number;

--- a/x-pack/plugins/alerting/server/lib/snooze/is_snooze_active.ts
+++ b/x-pack/plugins/alerting/server/lib/snooze/is_snooze_active.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { RRule, ByWeekday, Weekday, rrulestr } from 'rrule';
 import { RuleSnoozeSchedule } from '../../types';
+import { getRRuleFromSnooze } from '../../../common';
 
 const MAX_TIMESTAMP = 8640000000000000;
 
@@ -31,15 +31,7 @@ export function isSnoozeActive(snooze: RuleSnoozeSchedule) {
 
   // Check to see if now is during a recurrence of the snooze
   try {
-    const rRuleOptions = {
-      ...rRule,
-      dtstart: new Date(rRule.dtstart),
-      until: rRule.until ? new Date(rRule.until) : null,
-      wkst: rRule.wkst ? Weekday.fromStr(rRule.wkst) : null,
-      byweekday: rRule.byweekday ? parseByWeekday(rRule.byweekday) : null,
-    };
-
-    const recurrenceRule = new RRule(rRuleOptions);
+    const recurrenceRule = getRRuleFromSnooze(rRule);
     const lastOccurrence = recurrenceRule.before(new Date(now), true);
     if (!lastOccurrence) return null;
     // Check if the current recurrence has been skipped manually
@@ -52,10 +44,4 @@ export function isSnoozeActive(snooze: RuleSnoozeSchedule) {
   }
 
   return null;
-}
-
-export function parseByWeekday(byweekday: Array<string | number>): ByWeekday[] {
-  const rRuleString = `RRULE:BYDAY=${byweekday.join(',')}`;
-  const parsedRRule = rrulestr(rRuleString);
-  return parsedRRule.origOptions.byweekday as ByWeekday[];
 }

--- a/x-pack/plugins/alerting/server/lib/snooze/is_snooze_expired.ts
+++ b/x-pack/plugins/alerting/server/lib/snooze/is_snooze_expired.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { RRule, Weekday } from 'rrule';
 import { RuleSnoozeSchedule } from '../../types';
-import { isSnoozeActive, parseByWeekday } from './is_snooze_active';
+import { isSnoozeActive } from './is_snooze_active';
+import { getRRuleFromSnooze } from '../../../common';
 
 export function isSnoozeExpired(snooze: RuleSnoozeSchedule) {
   if (isSnoozeActive(snooze)) {
@@ -18,15 +18,7 @@ export function isSnoozeExpired(snooze: RuleSnoozeSchedule) {
   // Check to see if the snooze has another upcoming occurrence in the future
 
   try {
-    const rRuleOptions = {
-      ...rRule,
-      dtstart: new Date(rRule.dtstart),
-      until: rRule.until ? new Date(rRule.until) : null,
-      wkst: rRule.wkst ? Weekday.fromStr(rRule.wkst) : null,
-      byweekday: rRule.byweekday ? parseByWeekday(rRule.byweekday) : null,
-    };
-
-    const recurrenceRule = new RRule(rRuleOptions);
+    const recurrenceRule = getRRuleFromSnooze(rRule);
     const nextOccurrence = recurrenceRule.after(new Date(now), true);
     return !nextOccurrence;
   } catch (e) {


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/136429

Fixes a bug where we always showed the start date of a snooze schedule. Now we will attempt to get the schedule's next occurrence. Also restructures some `alerting` code to be shareable. 

Please take a look at the unit test as it demonstrates some of the possible cases. Feel free to comment with any other test cases that I should cover with this PR. 

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios