### PR TITLE
[Profiling] Fix UI discrepancies in frame information window

### DIFF
--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -95,7 +95,7 @@ export interface StackFrameMetadata {
   // StackTrace.Type
   FrameType: FrameType;
 
-  // StackFrame.LineNumber?
+  // StackTrace.AddressOrLine
   AddressOrLine: number;
   // StackFrame.FunctionName
   FunctionName: string;

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/flamegraph_information_window.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/flamegraph_information_window.tsx
@@ -25,7 +25,6 @@ interface Props {
     exeFileName: string;
     addressOrLine: number;
     functionName: string;
-    functionOffset: number;
     sourceFileName: string;
     sourceLine: number;
     countInclusive: number;
@@ -115,7 +114,6 @@ export function FlamegraphInformationWindow({ onClose, frame, totalSamples, tota
     exeFileName,
     addressOrLine,
     functionName,
-    functionOffset,
     sourceFileName,
     sourceLine,
     countInclusive,
@@ -128,7 +126,6 @@ export function FlamegraphInformationWindow({ onClose, frame, totalSamples, tota
     exeFileName,
     addressOrLine,
     functionName,
-    functionOffset,
     sourceFileName,
     sourceLine,
   });

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/flamegraph_information_window.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/flamegraph_information_window.tsx
@@ -15,14 +15,19 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { NOT_AVAILABLE_LABEL } from '../../../common';
 import { getImpactRows } from './get_impact_rows';
+import { getInformationRows } from './get_information_rows';
 
 interface Props {
   frame?: {
+    fileID: string;
+    frameType: number;
     exeFileName: string;
+    addressOrLine: number;
     functionName: string;
+    functionOffset: number;
     sourceFileName: string;
+    sourceLine: number;
     countInclusive: number;
     countExclusive: number;
   };
@@ -104,7 +109,29 @@ export function FlamegraphInformationWindow({ onClose, frame, totalSamples, tota
     );
   }
 
-  const { exeFileName, functionName, sourceFileName, countInclusive, countExclusive } = frame;
+  const {
+    fileID,
+    frameType,
+    exeFileName,
+    addressOrLine,
+    functionName,
+    functionOffset,
+    sourceFileName,
+    sourceLine,
+    countInclusive,
+    countExclusive,
+  } = frame;
+
+  const informationRows = getInformationRows({
+    fileID,
+    frameType,
+    exeFileName,
+    addressOrLine,
+    functionName,
+    functionOffset,
+    sourceFileName,
+    sourceLine,
+  });
 
   const impactRows = getImpactRows({
     countInclusive,
@@ -117,30 +144,7 @@ export function FlamegraphInformationWindow({ onClose, frame, totalSamples, tota
     <FlamegraphFrameInformationPanel onClose={onClose}>
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <KeyValueList
-            rows={[
-              {
-                label: i18n.translate(
-                  'xpack.profiling.flameGraphInformationWindow.executableLabel',
-                  { defaultMessage: 'Executable' }
-                ),
-                value: exeFileName || NOT_AVAILABLE_LABEL,
-              },
-              {
-                label: i18n.translate('xpack.profiling.flameGraphInformationWindow.functionLabel', {
-                  defaultMessage: 'Function',
-                }),
-                value: functionName || NOT_AVAILABLE_LABEL,
-              },
-              {
-                label: i18n.translate(
-                  'xpack.profiling.flameGraphInformationWindow.sourceFileLabel',
-                  { defaultMessage: 'Source file' }
-                ),
-                value: sourceFileName || NOT_AVAILABLE_LABEL,
-              },
-            ]}
-          />
+          <KeyValueList rows={informationRows} />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFlexGroup direction="column">

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/get_information_rows.ts
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/get_information_rows.ts
@@ -15,7 +15,6 @@ export function getInformationRows({
   exeFileName,
   addressOrLine,
   functionName,
-  functionOffset,
   sourceFileName,
   sourceLine,
 }: {
@@ -24,12 +23,11 @@ export function getInformationRows({
   exeFileName: string;
   addressOrLine: number;
   functionName: string;
-  functionOffset: number;
   sourceFileName: string;
   sourceLine: number;
 }) {
   const executable = fileID === '' && addressOrLine === 0 ? 'root' : exeFileName;
-  const functionSourceLine = functionOffset > 0 ? ` (+${sourceLine - functionOffset})` : '';
+  const sourceLineNumber = sourceLine > 0 ? `#${sourceLine}` : '';
 
   const informationRows = [];
 
@@ -53,14 +51,14 @@ export function getInformationRows({
     label: i18n.translate('xpack.profiling.flameGraphInformationWindow.functionLabel', {
       defaultMessage: 'Function',
     }),
-    value: functionName ? `${functionName}${functionSourceLine}` : NOT_AVAILABLE_LABEL,
+    value: functionName || NOT_AVAILABLE_LABEL,
   });
 
   informationRows.push({
     label: i18n.translate('xpack.profiling.flameGraphInformationWindow.sourceFileLabel', {
       defaultMessage: 'Source file',
     }),
-    value: sourceFileName || NOT_AVAILABLE_LABEL,
+    value: sourceFileName ? `${sourceFileName}${sourceLineNumber}` : NOT_AVAILABLE_LABEL,
   });
 
   return informationRows;

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/get_information_rows.ts
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/get_information_rows.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { NOT_AVAILABLE_LABEL } from '../../../common';
+import { describeFrameType } from '../../../common/profiling';
+
+export function getInformationRows({
+  fileID,
+  frameType,
+  exeFileName,
+  addressOrLine,
+  functionName,
+  functionOffset,
+  sourceFileName,
+  sourceLine,
+}: {
+  fileID: string;
+  frameType: number;
+  exeFileName: string;
+  addressOrLine: number;
+  functionName: string;
+  functionOffset: number;
+  sourceFileName: string;
+  sourceLine: number;
+}) {
+  const executable = fileID === '' && addressOrLine === 0 ? 'root' : exeFileName;
+  const functionSourceLine = functionOffset > 0 ? ` (+${sourceLine - functionOffset})` : '';
+
+  const informationRows = [];
+
+  if (executable) {
+    informationRows.push({
+      label: i18n.translate('xpack.profiling.flameGraphInformationWindow.executableLabel', {
+        defaultMessage: 'Executable',
+      }),
+      value: executable,
+    });
+  } else {
+    informationRows.push({
+      label: i18n.translate('xpack.profiling.flameGraphInformationWindow.frameTypeLabel', {
+        defaultMessage: 'Frame type',
+      }),
+      value: describeFrameType(frameType),
+    });
+  }
+
+  informationRows.push({
+    label: i18n.translate('xpack.profiling.flameGraphInformationWindow.functionLabel', {
+      defaultMessage: 'Function',
+    }),
+    value: functionName ? `${functionName}${functionSourceLine}` : NOT_AVAILABLE_LABEL,
+  });
+
+  informationRows.push({
+    label: i18n.translate('xpack.profiling.flameGraphInformationWindow.sourceFileLabel', {
+      defaultMessage: 'Source file',
+    }),
+    value: sourceFileName || NOT_AVAILABLE_LABEL,
+  });
+
+  return informationRows;
+}

--- a/x-pack/plugins/profiling/public/components/flamegraph.tsx
+++ b/x-pack/plugins/profiling/public/components/flamegraph.tsx
@@ -195,7 +195,6 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({
           exeFileName: primaryFlamegraph.ExeFilename[highlightedVmIndex],
           addressOrLine: primaryFlamegraph.AddressOrLine[highlightedVmIndex],
           functionName: primaryFlamegraph.FunctionName[highlightedVmIndex],
-          functionOffset: primaryFlamegraph.FunctionOffset[highlightedVmIndex],
           sourceFileName: primaryFlamegraph.SourceFilename[highlightedVmIndex],
           sourceLine: primaryFlamegraph.SourceLine[highlightedVmIndex],
           countInclusive: primaryFlamegraph.CountInclusive[highlightedVmIndex],

--- a/x-pack/plugins/profiling/public/components/flamegraph.tsx
+++ b/x-pack/plugins/profiling/public/components/flamegraph.tsx
@@ -190,9 +190,14 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({
   const selected: undefined | React.ComponentProps<typeof FlamegraphInformationWindow>['frame'] =
     primaryFlamegraph && highlightedVmIndex !== undefined
       ? {
+          fileID: primaryFlamegraph.FileID[highlightedVmIndex],
+          frameType: primaryFlamegraph.FrameType[highlightedVmIndex],
           exeFileName: primaryFlamegraph.ExeFilename[highlightedVmIndex],
-          sourceFileName: primaryFlamegraph.SourceFilename[highlightedVmIndex],
+          addressOrLine: primaryFlamegraph.AddressOrLine[highlightedVmIndex],
           functionName: primaryFlamegraph.FunctionName[highlightedVmIndex],
+          functionOffset: primaryFlamegraph.FunctionOffset[highlightedVmIndex],
+          sourceFileName: primaryFlamegraph.SourceFilename[highlightedVmIndex],
+          sourceLine: primaryFlamegraph.SourceLine[highlightedVmIndex],
           countInclusive: primaryFlamegraph.CountInclusive[highlightedVmIndex],
           countExclusive: primaryFlamegraph.CountExclusive[highlightedVmIndex],
         }


### PR DESCRIPTION
## Summary

This PR addresses three small missing UI features in the frame information window:

* clicking on root frame should show the relevant data (raised by @rockdaboot in [#141909](https://github.com/elastic/kibana/pull/141909))

![image](https://user-images.githubusercontent.com/6038/194186752-438a052b-455b-40d0-8140-db669bca82e4.png)

* frame type should be shown when the executable name is unavailable

* function offset should be shown after the function when available

![image](https://user-images.githubusercontent.com/6038/194186765-359cc1ba-658d-45f4-aebc-610c1b15e4e9.png)

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->