### PR TITLE
[ML] [Test] Explain Log Rate Spikes: Compression flag (8.4.2)

### DIFF
--- a/examples/response_stream/common/api/reducer_stream/request_body_schema.ts
+++ b/examples/response_stream/common/api/reducer_stream/request_body_schema.ts
@@ -13,5 +13,7 @@ export const reducerStreamRequestBodySchema = schema.object({
   simulateErrors: schema.maybe(schema.boolean()),
   /** Maximum timeout between streaming messages. */
   timeout: schema.maybe(schema.number()),
+  /** Setting to override headers derived compression */
+  compressResponse: schema.maybe(schema.boolean()),
 });
 export type ReducerStreamRequestBodySchema = TypeOf<typeof reducerStreamRequestBodySchema>;

--- a/examples/response_stream/common/api/simple_string_stream/request_body_schema.ts
+++ b/examples/response_stream/common/api/simple_string_stream/request_body_schema.ts
@@ -11,6 +11,8 @@ import { schema, TypeOf } from '@kbn/config-schema';
 export const simpleStringStreamRequestBodySchema = schema.object({
   /** Maximum timeout between streaming messages. */
   timeout: schema.number(),
+  /** Setting to override headers derived compression */
+  compressResponse: schema.maybe(schema.boolean()),
 });
 export type SimpleStringStreamRequestBodySchema = TypeOf<
   typeof simpleStringStreamRequestBodySchema

--- a/examples/response_stream/public/containers/app/pages/page_reducer_stream/index.tsx
+++ b/examples/response_stream/public/containers/app/pages/page_reducer_stream/index.tsx
@@ -44,13 +44,14 @@ export const PageReducerStream: FC = () => {
   const basePath = http?.basePath.get() ?? '';
 
   const [simulateErrors, setSimulateErrors] = useState(false);
+  const [compressResponse, setCompressResponse] = useState(true);
 
   const { dispatch, start, cancel, data, errors, isCancelled, isRunning } = useFetchStream<
     ApiReducerStream,
     typeof basePath
   >(
     `${basePath}/internal/response_stream/reducer_stream`,
-    { simulateErrors },
+    { compressResponse, simulateErrors },
     { reducer: reducerStreamReducer, initialState }
   );
 
@@ -142,6 +143,13 @@ export const PageReducerStream: FC = () => {
           label="Simulate errors (gets applied to new streams only, not currently running ones)."
           checked={simulateErrors}
           onChange={(e) => setSimulateErrors(!simulateErrors)}
+          compressed
+        />
+        <EuiCheckbox
+          id="responseStreamCompressionCheckbox"
+          label="Toggle compression setting for response stream."
+          checked={compressResponse}
+          onChange={(e) => setCompressResponse(!compressResponse)}
           compressed
         />
       </EuiText>

--- a/examples/response_stream/public/containers/app/pages/page_simple_string_stream/index.tsx
+++ b/examples/response_stream/public/containers/app/pages/page_simple_string_stream/index.tsx
@@ -6,9 +6,17 @@
  * Side Public License, v 1.
  */
 
-import React, { FC } from 'react';
+import React, { useState, FC } from 'react';
 
-import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 
 import { useFetchStream } from '@kbn/aiops-utils';
 
@@ -21,10 +29,15 @@ export const PageSimpleStringStream: FC = () => {
   const { core } = useDeps();
   const basePath = core.http?.basePath.get() ?? '';
 
+  const [compressResponse, setCompressResponse] = useState(true);
+
   const { dispatch, errors, start, cancel, data, isRunning } = useFetchStream<
     ApiSimpleStringStream,
     typeof basePath
-  >(`${basePath}/internal/response_stream/simple_string_stream`, { timeout: 500 });
+  >(`${basePath}/internal/response_stream/simple_string_stream`, {
+    compressResponse,
+    timeout: 500,
+  });
 
   const onClickHandler = async () => {
     if (isRunning) {
@@ -57,6 +70,14 @@ export const PageSimpleStringStream: FC = () => {
           </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiCheckbox
+        id="responseStreamCompressionCheckbox"
+        label="Toggle compression setting for response stream."
+        checked={compressResponse}
+        onChange={(e) => setCompressResponse(!compressResponse)}
+        compressed
+      />
       <EuiSpacer />
       <EuiText>
         <p>{data}</p>

--- a/examples/response_stream/server/routes/reducer_stream.ts
+++ b/examples/response_stream/server/routes/reducer_stream.ts
@@ -41,7 +41,8 @@ export const defineReducerStreamRoute = (router: IRouter, logger: Logger) => {
 
       const { end, push, responseWithHeaders } = streamFactory<ReducerStreamApiAction>(
         request.headers,
-        logger
+        logger,
+        request.body.compressResponse
       );
 
       const entities = [

--- a/examples/response_stream/server/routes/single_string_stream.ts
+++ b/examples/response_stream/server/routes/single_string_stream.ts
@@ -35,7 +35,11 @@ export const defineSimpleStringStreamRoute = (router: IRouter, logger: Logger) =
         shouldStop = true;
       });
 
-      const { end, push, responseWithHeaders } = streamFactory(request.headers, logger);
+      const { end, push, responseWithHeaders } = streamFactory(
+        request.headers,
+        logger,
+        request.body.compressResponse
+      );
 
       const text =
         'Elasticsearch is a search engine based on the Lucene library. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents. Elasticsearch is developed in Java and is dual-licensed under the source-available Server Side Public License and the Elastic license, while other parts fall under the proprietary (source-available) Elastic License. Official clients are available in Java, .NET (C#), PHP, Python, Apache Groovy, Ruby and many other languages. According to the DB-Engines ranking, Elasticsearch is the most popular enterprise search engine.';

--- a/x-pack/packages/ml/aiops_utils/src/stream_factory.ts
+++ b/x-pack/packages/ml/aiops_utils/src/stream_factory.ts
@@ -46,25 +46,33 @@ interface StreamFactoryReturnType<T = unknown> {
  * for gzip compression depending on provided request headers.
  *
  * @param headers - Request headers.
+ * @param logger - Kibana logger.
+ * @param compressOverride - Optional flag to override header based compression setting.
+ *
  * @returns An object with stream attributes and methods.
  */
 export function streamFactory<T = string>(
   headers: Headers,
-  logger: Logger
+  logger: Logger,
+  compressOverride?: boolean
 ): StreamFactoryReturnType<T>;
 /**
  * Sets up a response stream with support for gzip compression depending on provided
  * request headers. Any non-string data pushed to the stream will be stream as NDJSON.
  *
  * @param headers - Request headers.
+ * @param logger - Kibana logger.
+ * @param compressOverride - Optional flag to override header based compression setting.
+ *
  * @returns An object with stream attributes and methods.
  */
 export function streamFactory<T = unknown>(
   headers: Headers,
-  logger: Logger
+  logger: Logger,
+  compressOverride = true
 ): StreamFactoryReturnType<T> {
   let streamType: StreamType;
-  const isCompressed = acceptCompression(headers);
+  const isCompressed = compressOverride && acceptCompression(headers);
 
   const stream = isCompressed ? zlib.createGzip() : new ResponseStream();
 

--- a/x-pack/plugins/aiops/common/api/explain_log_rate_spikes/schema.ts
+++ b/x-pack/plugins/aiops/common/api/explain_log_rate_spikes/schema.ts
@@ -20,6 +20,8 @@ export const aiopsExplainLogRateSpikesSchema = schema.object({
   deviationMax: schema.number(),
   /** The index to query for log rate spikes */
   index: schema.string(),
+  /** Setting to override headers derived compression */
+  compressResponse: schema.maybe(schema.boolean()),
 });
 
 export type AiopsExplainLogRateSpikesSchema = TypeOf<typeof aiopsExplainLogRateSpikesSchema>;

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -76,6 +76,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
       timeFieldName: dataView.timeFieldName ?? '',
       index: dataView.title,
       ...windowParameters,
+      compressResponse: false,
     },
     { reducer: streamReducer, initialState }
   );

--- a/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
+++ b/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
@@ -72,7 +72,8 @@ export const defineExplainLogRateSpikesRoute = (
 
       const { end, push, responseWithHeaders } = streamFactory<AiopsExplainLogRateSpikesApiAction>(
         request.headers,
-        logger
+        logger,
+        request.body.compressResponse
       );
 
       function endWithUpdatedLoadingState() {


### PR DESCRIPTION
WIP/TEST Do not merge.

Branched off `v8.4.2`.

## Summary

- Adds a request body override flag to enforce or disable response compression.
- Adds integration tests to test response streams without compression.
