### PR TITLE
[APM] Remove check for infra data

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import { isEmpty } from 'lodash';
-import { EuiLoadingSpinner, EuiEmptyPrompt } from '@elastic/eui';
-import React, { useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
+import React from 'react';
 import moment from 'moment';
 import { LogStream } from '@kbn/infra-plugin/public';
-import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
+import { useFetcher } from '../../../hooks/use_fetcher';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { APIReturnType } from '../../../services/rest/create_call_apm_api';
 
@@ -32,7 +29,7 @@ export function ServiceLogs() {
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
-  const { data, status } = useFetcher(
+  const { data } = useFetcher(
     (callApmApi) => {
       if (start && end) {
         return callApmApi(
@@ -53,32 +50,6 @@ export function ServiceLogs() {
     },
     [environment, kuery, serviceName, start, end]
   );
-
-  const noInfrastructureData = useMemo(() => {
-    return isEmpty(data?.containerIds) && isEmpty(data?.hostNames);
-  }, [data]);
-
-  if (status === FETCH_STATUS.LOADING) {
-    return (
-      <div style={{ textAlign: 'center' }}>
-        <EuiLoadingSpinner size="m" />
-      </div>
-    );
-  }
-
-  if (status === FETCH_STATUS.SUCCESS && noInfrastructureData) {
-    return (
-      <EuiEmptyPrompt
-        title={
-          <h2>
-            {i18n.translate('xpack.apm.serviceLogs.noInfrastructureMessage', {
-              defaultMessage: 'There are no log messages to display.',
-            })}
-          </h2>
-        }
-      />
-    );
-  }
 
   return (
     <LogStream

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -7568,7 +7568,6 @@
     "xpack.apm.serviceIcons.serviceDetails.service.frameworkLabel": "Nom du framework",
     "xpack.apm.serviceIcons.serviceDetails.service.runtimeLabel": "Nom et version de l'exécution",
     "xpack.apm.serviceIcons.serviceDetails.service.versionLabel": "Version du service",
-    "xpack.apm.serviceLogs.noInfrastructureMessage": "Il n'y a aucun message de log à afficher.",
     "xpack.apm.serviceMap.anomalyDetectionPopoverDisabled": "Affichez les indicateurs d'intégrité du service en activant la détection des anomalies dans les paramètres APM.",
     "xpack.apm.serviceMap.anomalyDetectionPopoverLink": "Afficher les anomalies",
     "xpack.apm.serviceMap.anomalyDetectionPopoverNoData": "Nous n'avons pas trouvé de score d'anomalie dans la plage temporelle sélectionnée. Consultez les détails dans l'explorateur d'anomalies.",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7555,7 +7555,6 @@
     "xpack.apm.serviceIcons.serviceDetails.service.frameworkLabel": "フレームワーク名",
     "xpack.apm.serviceIcons.serviceDetails.service.runtimeLabel": "ランタイム名・バージョン",
     "xpack.apm.serviceIcons.serviceDetails.service.versionLabel": "サービスバージョン",
-    "xpack.apm.serviceLogs.noInfrastructureMessage": "表示するログメッセージがありません。",
     "xpack.apm.serviceMap.anomalyDetectionPopoverDisabled": "APM 設定で異常検知を有効にすると、サービス正常性インジケーターが表示されます。",
     "xpack.apm.serviceMap.anomalyDetectionPopoverLink": "異常を表示",
     "xpack.apm.serviceMap.anomalyDetectionPopoverNoData": "選択した時間範囲で、異常スコアを検出できませんでした。異常エクスプローラーで詳細を確認してください。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7572,7 +7572,6 @@
     "xpack.apm.serviceIcons.serviceDetails.service.frameworkLabel": "框架名称",
     "xpack.apm.serviceIcons.serviceDetails.service.runtimeLabel": "运行时名称和版本",
     "xpack.apm.serviceIcons.serviceDetails.service.versionLabel": "服务版本",
-    "xpack.apm.serviceLogs.noInfrastructureMessage": "没有可显示的日志消息。",
     "xpack.apm.serviceMap.anomalyDetectionPopoverDisabled": "通过在 APM 设置中启用异常检测来显示服务运行状况指标。",
     "xpack.apm.serviceMap.anomalyDetectionPopoverLink": "查看异常",
     "xpack.apm.serviceMap.anomalyDetectionPopoverNoData": "在选定时间范围内找不到异常分数。请在 Anomaly Explorer 中查看详情。",


### PR DESCRIPTION
Close https://github.com/elastic/kibana/issues/142656

This PR removes the "no-data" check since it was overly restrictive. Now we always try to show the logs component and rely on its own no-data check. Below is an example of how the no-data check has changed slightly.

## Before (APM UI no-data check)

![image](https://user-images.githubusercontent.com/209966/194305909-672b103e-6d16-42a3-bd71-8dde5aca936b.png)


## After (Logs no-data check)

![image](https://user-images.githubusercontent.com/209966/194305926-3095da1d-72b5-42b4-8dda-2d247bb7ac07.png)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->