### PR TITLE
[APM] checks if is serverless first in order to show java lambda metrics

### DIFF
--- a/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
@@ -41,15 +41,17 @@ export async function getMetricsChartDataByAgent({
     start,
     end,
   };
-  if (isServerlessAgent(serviceRuntimeName)) {
-    return getServerlessAgentMetricCharts(options);
-  }
+  const serverlessAgent = isServerlessAgent(serviceRuntimeName);
 
-  if (isJavaAgentName(agentName)) {
+  if (isJavaAgentName(agentName) && !serverlessAgent) {
     return getJavaMetricsCharts({
       ...options,
       serviceNodeName,
     });
+  }
+
+  if (serverlessAgent) {
+    return getServerlessAgentMetricCharts(options);
   }
 
   return getDefaultMetricsCharts(options);

--- a/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
@@ -41,15 +41,15 @@ export async function getMetricsChartDataByAgent({
     start,
     end,
   };
+  if (isServerlessAgent(serviceRuntimeName)) {
+    return getServerlessAgentMetricCharts(options);
+  }
+
   if (isJavaAgentName(agentName)) {
     return getJavaMetricsCharts({
       ...options,
       serviceNodeName,
     });
-  }
-
-  if (isServerlessAgent(serviceRuntimeName)) {
-    return getServerlessAgentMetricCharts(options);
   }
 
   return getDefaultMetricsCharts(options);


### PR DESCRIPTION
<img width="1684" alt="Screen Shot 2022-10-06 at 9 11 17 AM" src="https://user-images.githubusercontent.com/55978943/194321829-79c1332e-9e53-4cc0-bc12-ec3568413cbc.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->