### PR TITLE
Bugfix: Refresh search results when clearing category filter

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_local_search.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_local_search.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Search as LocalSearch, PrefixIndexStrategy } from 'js-search';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import type { IntegrationCardItem } from '../../../../common/types/models';
 
@@ -16,13 +16,11 @@ export const fieldsToSearch = ['name', 'title'];
 export function useLocalSearch(packageList: IntegrationCardItem[]) {
   const localSearchRef = useRef<LocalSearch>(new LocalSearch(searchIdField));
 
-  useEffect(() => {
-    const localSearch = new LocalSearch(searchIdField);
-    localSearch.indexStrategy = new PrefixIndexStrategy();
-    fieldsToSearch.forEach((field) => localSearch.addIndex(field));
-    localSearch.addDocuments(packageList);
-    localSearchRef.current = localSearch;
-  }, [packageList]);
+  const localSearch = new LocalSearch(searchIdField);
+  localSearch.indexStrategy = new PrefixIndexStrategy();
+  fieldsToSearch.forEach((field) => localSearch.addIndex(field));
+  localSearch.addDocuments(packageList);
+  localSearchRef.current = localSearch;
 
   return localSearchRef;
 }


### PR DESCRIPTION
## Summary

When clearing a category filter, results were not being refreshed. Here, after clearing the communications category, the aws results should be shown again:


https://user-images.githubusercontent.com/3315046/194328995-8fdf0f2d-ef6d-4c24-92d3-dd9aba98ccde.mov



Removing the useEffect fixes this:

https://user-images.githubusercontent.com/3315046/194329020-ab9e6d23-1dfb-4469-ba10-d4ef3146c567.mov




<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->