### PR TITLE
[Enterprise Search] Remove link to nowhere

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
@@ -45,14 +45,6 @@ export const CrawlRequestsPanel: React.FC = () => {
                 'Requests originating from the crawler can be identified by the following User Agent. This is configured in your enterprise-search.yml file.',
             }
           )}{' '}
-          <EuiLink target="_blank" href={'' /* needs docLink */}>
-            {i18n.translate(
-              'xpack.enterpriseSearch.crawler.crawlRequestsPanel.userAgentDocumentationLink',
-              {
-                defaultMessage: 'Learn more about Elastic crawler user agents',
-              }
-            )}
-          </EuiLink>
         </EuiText>
         <EuiSpacer size="s" />
         <EuiCode>{data ? data.userAgent : ''}</EuiCode>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_panel.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiCode, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiCode, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { DataPanel } from '../../../../../shared/data_panel/data_panel';


### PR DESCRIPTION
## Summary

https://github.com/elastic/enterprise-search-team/issues/3009

Remove link to documentation that doesn't exist yet.

Only a link was removed so no need for tests or documentation updates.