### PR TITLE
[Dashboard] [Controls] Skip First Reload

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -153,13 +153,17 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       isProjectEnabledInLabs('labs:dashboard:dashboardControls')
     ) {
       this.controlGroup = controlGroup;
-      syncDashboardControlGroup({ dashboardContainer: this, controlGroup: this.controlGroup }).then(
-        (result) => {
+      this.controlGroup.untilReady().then(() => {
+        if (!this.controlGroup || isErrorEmbeddable(this.controlGroup)) return;
+        syncDashboardControlGroup({
+          dashboardContainer: this,
+          controlGroup: this.controlGroup,
+        }).then((result) => {
           if (!result) return;
           const { onDestroyControlGroup } = result;
           this.onDestroyControlGroup = onDestroyControlGroup;
-        }
-      );
+        });
+      });
     }
 
     this.subscriptions.add(

--- a/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
+++ b/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import { Subscription } from 'rxjs';
 import deepEqual from 'fast-deep-equal';
 import { compareFilters, COMPARE_ALL_OPTIONS, type Filter } from '@kbn/es-query';
-import { debounceTime, distinctUntilChanged, distinctUntilKeyChanged } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, distinctUntilKeyChanged, skip } from 'rxjs/operators';
 
 import {
   ControlGroupInput,
@@ -140,10 +140,13 @@ export const syncDashboardControlGroup = async ({
       .pipe(
         distinctUntilChanged(({ filters: filtersA }, { filters: filtersB }) =>
           compareAllFilters(filtersA, filtersB)
-        )
+        ),
+        skip(1) // skip first filter output because it will have been applied in initialize
       )
-      .subscribe(() => {
-        dashboardContainer.updateInput({ lastReloadRequestTime: Date.now() });
+      .subscribe(({ filters }) => {
+        if (filters && filters.length > 0) {
+          dashboardContainer.updateInput({ lastReloadRequestTime: Date.now() });
+        }
       })
   );
 

--- a/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
+++ b/src/plugins/dashboard/public/application/lib/dashboard_control_group.ts
@@ -143,11 +143,7 @@ export const syncDashboardControlGroup = async ({
         ),
         skip(1) // skip first filter output because it will have been applied in initialize
       )
-      .subscribe(({ filters }) => {
-        if (filters && filters.length > 0) {
-          dashboardContainer.updateInput({ lastReloadRequestTime: Date.now() });
-        }
-      })
+      .subscribe(() => dashboardContainer.updateInput({ lastReloadRequestTime: Date.now() }))
   );
 
   subscriptions.add(


### PR DESCRIPTION
## Summary
Fixes an issue where Discover Saved Searches sometimes were `aborted` on the first load of a dashboard.

This was caused by the control group forcing a `lastReloadRequestTime` updated on dashboards on their first load, even though the control group selections which were saved into the dashboard had already been applied.

This PR fixes this by postponing the dashboard control group sync code until after the control group is finished loading and outputting its initial filters, and by skipping the first, blank filter update that the control group outputs.

### How to test
Because the discover issue is difficult to reproduce with the demo data, and locally, the best way to test this would be to place a console log in 
`src/plugins/dashboard/public/application/lib/dashboard_control_group.ts` line 146. and ensure that the dashboard container's `lastReloadRequestTime` is only updated when expected. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->