### PR TITLE
[Stack Functional Integration] Dismiss to the uptime tour pop-up

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
@@ -15,6 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('check heartbeat overview page', function () {
     it('Uptime app should show 1 UP monitor', async function () {
       await PageObjects.common.navigateToApp('uptime', { insertTimestamp: false });
+      await PageObjects.uptime.dismissTour();
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
 
       await retry.try(async function () {


### PR DESCRIPTION
## Summary

We need to dismiss the uptime tour pop-up in the test because it interferes with the timepicker selection during our tests. 





<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->