### PR TITLE
[Enterprise Search]Allow snake_case variables in server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1415,21 +1415,8 @@ module.exports = {
         '@typescript-eslint/naming-convention': [
           'error',
           {
-            selector: 'default',
-            format: ['camelCase'],
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-          {
-            selector: 'default',
+            selector: 'variable',
             modifiers: ['destructured'],
-            format: ['camelCase', 'snake_case'],
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-          {
-            selector: 'default',
-            modifiers: ['requiresQuotes'],
             format: null,
             leadingUnderscore: 'allow',
             trailingUnderscore: 'allow',
@@ -1439,11 +1426,6 @@ module.exports = {
             format: ['camelCase', 'UPPER_CASE'],
             leadingUnderscore: 'allow',
             trailingUnderscore: 'allow',
-          },
-
-          {
-            selector: 'typeLike',
-            format: ['PascalCase'],
           },
         ],
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1406,6 +1406,48 @@ module.exports = {
         ],
       },
     },
+    /**
+     * Allows snake_case variables in the server, because that's how we return API properties
+     */
+    {
+      files: ['x-pack/plugins/enterprise_search/server/**/*.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'default',
+            format: ['camelCase'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+          {
+            selector: 'default',
+            modifiers: ['destructured'],
+            format: ['camelCase', 'snake_case'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+          {
+            selector: 'default',
+            modifiers: ['requiresQuotes'],
+            format: null,
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+          {
+            selector: 'variable',
+            format: ['camelCase', 'UPPER_CASE'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+
+          {
+            selector: 'typeLike',
+            format: ['PascalCase'],
+          },
+        ],
+      },
+    },
     {
       // Source files only - allow `any` in test/mock files
       files: ['x-pack/plugins/enterprise_search/**/*.{ts,tsx}'],
@@ -1684,37 +1726,6 @@ module.exports = {
       files: ['x-pack/plugins/enterprise_search/**/*.{ts,tsx}'],
       rules: {
         quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
-      },
-    },
-
-    /**
-     * Enterprise Search case override
-     * Allows snake_case variables in the server, because that's how we return API properties
-     */
-    {
-      files: ['x-pack/plugins/enterprise_search/server/**/*.{ts,tsx}'],
-      rules: {
-        '@typescript-eslint/naming-convention': [
-          'error',
-          {
-            selector: 'default',
-            format: ['camelCase', 'snake_case'],
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-
-          {
-            selector: 'variable',
-            format: ['camelCase', 'UPPER_CASE', 'snake_case'],
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-
-          {
-            selector: 'typeLike',
-            format: ['PascalCase'],
-          },
-        ],
       },
     },
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1688,6 +1688,37 @@ module.exports = {
     },
 
     /**
+     * Enterprise Search case override
+     * Allows snake_case variables in the server, because that's how we return API properties
+     */
+    {
+      files: ['x-pack/plugins/enterprise_search/server/**/*.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'default',
+            format: ['camelCase', 'snake_case'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+
+          {
+            selector: 'variable',
+            format: ['camelCase', 'UPPER_CASE', 'snake_case'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+
+          {
+            selector: 'typeLike',
+            format: ['PascalCase'],
+          },
+        ],
+      },
+    },
+
+    /**
      * Code inside .buildkite runs separately from everything else in CI, before bootstrap, with ts-node. It needs a few tweaks because of this.
      */
     {

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -48,7 +48,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         meta: { page: { total_results: 1 } },
       };
 
-      EnterpriseSearchAPI.mockReturn(responseBody);
+      enterpriseSearchAPI.mockReturn(responseBody);
 
       const requestHandler = enterpriseSearchRequestHandler.createRequest({
         path: '/as/credentials/collection',
@@ -61,7 +61,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         },
       });
 
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+      enterpriseSearchAPI.shouldHaveBeenCalledWith(
         'http://localhost:3002/as/credentials/collection?type=indexed&pageIndex=1',
         { method: 'GET' }
       );
@@ -80,12 +80,12 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
 
         await makeAPICall(requestHandler, { route: { method: 'POST' } });
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
           method: 'POST',
         });
 
         await makeAPICall(requestHandler, { route: { method: 'DELETE' } });
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
           method: 'DELETE',
         });
       });
@@ -96,7 +96,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler, { body: { bodacious: true } });
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
           body: '{"bodacious":true}',
         });
       });
@@ -107,7 +107,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler, { body: Buffer.from('{"bodacious":true}') });
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example', {
           body: '{"bodacious":true}',
         });
       });
@@ -118,7 +118,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler, { query: { someQuery: false } });
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+        enterpriseSearchAPI.shouldHaveBeenCalledWith(
           'http://localhost:3002/api/example?someQuery=false'
         );
       });
@@ -130,7 +130,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler, { query: { someQuery: false } });
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+        enterpriseSearchAPI.shouldHaveBeenCalledWith(
           'http://localhost:3002/api/example?someQuery=true'
         );
       });
@@ -141,7 +141,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler, { query: { 'page[current]': 1 } });
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+        enterpriseSearchAPI.shouldHaveBeenCalledWith(
           'http://localhost:3002/api/example?page%5Bcurrent%5D=1'
         );
       });
@@ -153,7 +153,7 @@ describe('EnterpriseSearchRequestHandler', () => {
           });
           await makeAPICall(requestHandler, { params: { example: 'hello', id: 'world' } });
 
-          EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+          enterpriseSearchAPI.shouldHaveBeenCalledWith(
             'http://localhost:3002/api/examples/hello/some/world'
           );
         });
@@ -164,7 +164,7 @@ describe('EnterpriseSearchRequestHandler', () => {
           });
           await makeAPICall(requestHandler, { params: { example: 'hello#@/$%^/&[]{}/";world' } });
 
-          EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+          enterpriseSearchAPI.shouldHaveBeenCalledWith(
             'http://localhost:3002/api/examples/hello%23%40%2F%24%25%5E%2F%26%5B%5D%7B%7D%2F%22%3Bworld'
           );
         });
@@ -173,14 +173,14 @@ describe('EnterpriseSearchRequestHandler', () => {
 
     describe('response passing', () => {
       it('returns the response status code from Enterprise Search', async () => {
-        EnterpriseSearchAPI.mockReturn({}, { status: 201 });
+        enterpriseSearchAPI.mockReturn({}, { status: 201 });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({
           path: '/api/example',
         });
         await makeAPICall(requestHandler);
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example');
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/example');
         expect(responseMock.custom).toHaveBeenCalledWith({
           body: {},
           statusCode: 201,
@@ -196,7 +196,7 @@ describe('EnterpriseSearchRequestHandler', () => {
           regular: 'data',
         };
 
-        EnterpriseSearchAPI.mockReturn(jsonWithSessionData, { headers: JSON_HEADER });
+        enterpriseSearchAPI.mockReturn(jsonWithSessionData, { headers: JSON_HEADER });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/prep' });
         await makeAPICall(requestHandler);
@@ -212,7 +212,7 @@ describe('EnterpriseSearchRequestHandler', () => {
 
       it('passes back the response body as-is if hasJsonResponse is false', async () => {
         const mockFile = new File(['mockFile'], 'mockFile.json');
-        EnterpriseSearchAPI.mockReturn(mockFile);
+        enterpriseSearchAPI.mockReturn(mockFile);
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({
           path: '/api/file',
@@ -220,7 +220,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler);
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/file');
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/file');
         expect(responseMock.custom).toHaveBeenCalledWith({
           body: expect.any(Buffer), // Unfortunately Response() buffers the body so we can't actually inspect/equality assert on it
           statusCode: 200,
@@ -233,13 +233,13 @@ describe('EnterpriseSearchRequestHandler', () => {
   describe('error responses', () => {
     describe('handleClientError()', () => {
       afterEach(() => {
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/4xx');
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/4xx');
         expect(mockLogger.error).not.toHaveBeenCalled();
       });
 
       it('passes back json.error', async () => {
         const error = 'some error message';
-        EnterpriseSearchAPI.mockReturn({ error }, { status: 404, headers: JSON_HEADER });
+        enterpriseSearchAPI.mockReturn({ error }, { status: 404, headers: JSON_HEADER });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/4xx' });
         await makeAPICall(requestHandler);
@@ -256,7 +256,7 @@ describe('EnterpriseSearchRequestHandler', () => {
 
       it('passes back json.errors', async () => {
         const errors = ['one', 'two', 'three'];
-        EnterpriseSearchAPI.mockReturn({ errors }, { status: 400, headers: JSON_HEADER });
+        enterpriseSearchAPI.mockReturn({ errors }, { status: 400, headers: JSON_HEADER });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/4xx' });
         await makeAPICall(requestHandler);
@@ -272,7 +272,7 @@ describe('EnterpriseSearchRequestHandler', () => {
       });
 
       it('handles empty json', async () => {
-        EnterpriseSearchAPI.mockReturn({}, { status: 400, headers: JSON_HEADER });
+        enterpriseSearchAPI.mockReturn({}, { status: 400, headers: JSON_HEADER });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/4xx' });
         await makeAPICall(requestHandler);
@@ -288,7 +288,7 @@ describe('EnterpriseSearchRequestHandler', () => {
       });
 
       it('handles invalid json', async () => {
-        EnterpriseSearchAPI.mockReturn('invalid' as any, { status: 400, headers: JSON_HEADER });
+        enterpriseSearchAPI.mockReturn('invalid' as any, { status: 400, headers: JSON_HEADER });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/4xx' });
         await makeAPICall(requestHandler);
@@ -304,7 +304,7 @@ describe('EnterpriseSearchRequestHandler', () => {
       });
 
       it('handles blank bodies', async () => {
-        EnterpriseSearchAPI.mockReturn(undefined as any, { status: 404 });
+        enterpriseSearchAPI.mockReturn(undefined as any, { status: 404 });
 
         const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/4xx' });
         await makeAPICall(requestHandler);
@@ -321,11 +321,11 @@ describe('EnterpriseSearchRequestHandler', () => {
     });
 
     it('handleServerError()', async () => {
-      EnterpriseSearchAPI.mockReturn('something crashed!' as any, { status: 500 });
+      enterpriseSearchAPI.mockReturn('something crashed!' as any, { status: 500 });
       const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/5xx' });
 
       await makeAPICall(requestHandler);
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/5xx');
+      enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/5xx');
 
       expect(responseMock.customError).toHaveBeenCalledWith({
         statusCode: 502,
@@ -338,14 +338,14 @@ describe('EnterpriseSearchRequestHandler', () => {
     });
 
     it('handleReadOnlyModeError()', async () => {
-      EnterpriseSearchAPI.mockReturn(
+      enterpriseSearchAPI.mockReturn(
         { errors: ['Read only mode'] },
         { status: 503, headers: { ...JSON_HEADER, [READ_ONLY_MODE_HEADER]: 'true' } }
       );
       const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/503' });
 
       await makeAPICall(requestHandler);
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/503');
+      enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/503');
 
       expect(responseMock.customError).toHaveBeenCalledWith({
         statusCode: 503,
@@ -358,14 +358,14 @@ describe('EnterpriseSearchRequestHandler', () => {
     });
 
     it('handleInvalidDataError()', async () => {
-      EnterpriseSearchAPI.mockReturn({ results: false });
+      enterpriseSearchAPI.mockReturn({ results: false });
       const requestHandler = enterpriseSearchRequestHandler.createRequest({
         path: '/api/invalid',
         hasValidData: (body?: any) => Array.isArray(body?.results),
       });
 
       await makeAPICall(requestHandler);
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/invalid');
+      enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/invalid');
 
       expect(responseMock.customError).toHaveBeenCalledWith({
         statusCode: 502,
@@ -378,11 +378,11 @@ describe('EnterpriseSearchRequestHandler', () => {
     });
 
     it('handleConnectionError()', async () => {
-      EnterpriseSearchAPI.mockReturnError();
+      enterpriseSearchAPI.mockReturnError();
       const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/failed' });
 
       await makeAPICall(requestHandler);
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/failed');
+      enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/failed');
 
       expect(responseMock.customError).toHaveBeenCalledWith({
         statusCode: 502,
@@ -399,7 +399,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
         await makeAPICall(requestHandler);
 
-        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/unauthenticated');
+        enterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/unauthenticated');
         expect(responseMock.customError).toHaveBeenCalledWith({
           statusCode: 502,
           body: 'Cannot authenticate Enterprise Search user',
@@ -409,21 +409,21 @@ describe('EnterpriseSearchRequestHandler', () => {
       });
 
       it('errors when receiving a 401 response', async () => {
-        EnterpriseSearchAPI.mockReturn({}, { status: 401 });
+        enterpriseSearchAPI.mockReturn({}, { status: 401 });
       });
 
       it('errors when redirected to /login', async () => {
-        EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/login' });
+        enterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/login' });
       });
 
       it('errors when redirected to /ent/select', async () => {
-        EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/ent/select' });
+        enterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/ent/select' });
       });
     });
   });
 
   it('setResponseHeaders', async () => {
-    EnterpriseSearchAPI.mockReturn('anything' as any, {
+    enterpriseSearchAPI.mockReturn('anything' as any, {
       headers: { [READ_ONLY_MODE_HEADER]: 'true' },
     });
     const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/' });
@@ -449,7 +449,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         regular: 'data',
       };
 
-      EnterpriseSearchAPI.mockReturn(sessionDataBody, { headers: JSON_HEADER });
+      enterpriseSearchAPI.mockReturn(sessionDataBody, { headers: JSON_HEADER });
 
       const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/' });
       await makeAPICall(requestHandler);
@@ -477,7 +477,7 @@ const makeAPICall = (handler: Function, params = {}) => {
   return handler(null, request, responseMock);
 };
 
-const EnterpriseSearchAPI = {
+const enterpriseSearchAPI = {
   shouldHaveBeenCalledWith(expectedUrl: string, expectedParams = {}) {
     expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
       headers: { Authorization: 'Basic 123', ...JSON_HEADER },


### PR DESCRIPTION
## Summary

This allows snake_case formatted variables in the Enterprise Search server code, because that's what most of our APIs use.