### PR TITLE
Fix unenroll outputs shape

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -96,10 +96,13 @@ export interface Agent extends AgentBase {
   access_api_key?: string;
   // @deprecated
   default_api_key_history?: FleetServerAgent['default_api_key_history'];
-  outputs?: Record<string, {
-    api_key_id: string;
-    to_retire_api_key_ids?: FleetServerAgent['default_api_key_history'];
-  }>;
+  outputs?: Record<
+    string,
+    {
+      api_key_id: string;
+      to_retire_api_key_ids?: FleetServerAgent['default_api_key_history'];
+    }
+  >;
   status?: AgentStatus;
   packages: string[];
   sort?: Array<number | string | null>;

--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -96,7 +96,7 @@ export interface Agent extends AgentBase {
   access_api_key?: string;
   // @deprecated
   default_api_key_history?: FleetServerAgent['default_api_key_history'];
-  outputs?: Array<{
+  outputs?: Record<string, {
     api_key_id: string;
     to_retire_api_key_ids?: FleetServerAgent['default_api_key_history'];
   }>;

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -331,15 +331,25 @@ describe('invalidateAPIKeysForAgents', () => {
             id: 'defaultApiKeyHistory2',
           },
         ],
-        outputs: [
-          {
+        outputs: {
+          output1: {
             api_key_id: 'outputApiKey1',
-            to_retire_api_key_ids: [{ id: 'outputApiKeyRetire1' }, { id: 'outputApiKeyRetire2' }],
+            to_retire_api_key_ids: [
+              { id: 'outputApiKeyRetire1' },
+              { id: 'outputApiKeyRetire2' },
+            ]
           },
-          {
+          output2: {
             api_key_id: 'outputApiKey2',
           },
-        ],
+          output3: {
+            api_key_id: 'outputApiKey3',
+            to_retire_api_key_ids: [
+              // Somes Fleet Server agents don't have an id here (probably a bug)
+              { retired_at: 'foo' }
+            ]
+          },
+        }
       } as any,
     ]);
 
@@ -353,6 +363,7 @@ describe('invalidateAPIKeysForAgents', () => {
       'outputApiKeyRetire1',
       'outputApiKeyRetire2',
       'outputApiKey2',
+      'outputApiKey3'
     ]);
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -334,10 +334,7 @@ describe('invalidateAPIKeysForAgents', () => {
         outputs: {
           output1: {
             api_key_id: 'outputApiKey1',
-            to_retire_api_key_ids: [
-              { id: 'outputApiKeyRetire1' },
-              { id: 'outputApiKeyRetire2' },
-            ]
+            to_retire_api_key_ids: [{ id: 'outputApiKeyRetire1' }, { id: 'outputApiKeyRetire2' }],
           },
           output2: {
             api_key_id: 'outputApiKey2',
@@ -346,10 +343,10 @@ describe('invalidateAPIKeysForAgents', () => {
             api_key_id: 'outputApiKey3',
             to_retire_api_key_ids: [
               // Somes Fleet Server agents don't have an id here (probably a bug)
-              { retired_at: 'foo' }
-            ]
+              { retired_at: 'foo' },
+            ],
           },
-        }
+        },
       } as any,
     ]);
 
@@ -363,7 +360,7 @@ describe('invalidateAPIKeysForAgents', () => {
       'outputApiKeyRetire1',
       'outputApiKeyRetire2',
       'outputApiKey2',
-      'outputApiKey3'
+      'outputApiKey3',
     ]);
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
@@ -223,7 +223,7 @@ export async function invalidateAPIKeysForAgents(agents: Agent[]) {
         if (output.to_retire_api_key_ids) {
           Object.values(output.to_retire_api_key_ids).forEach((apiKey) => {
             if (apiKey?.id) {
-              keys.push(apiKey.id)
+              keys.push(apiKey.id);
             }
           });
         }

--- a/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll_action_runner.ts
@@ -216,12 +216,16 @@ export async function invalidateAPIKeysForAgents(agents: Agent[]) {
       agent.default_api_key_history.forEach((apiKey) => keys.push(apiKey.id));
     }
     if (agent.outputs) {
-      agent.outputs.forEach((output) => {
+      Object.values(agent.outputs).forEach((output) => {
         if (output.api_key_id) {
           keys.push(output.api_key_id);
         }
         if (output.to_retire_api_key_ids) {
-          output.to_retire_api_key_ids.forEach((apiKey) => keys.push(apiKey.id));
+          Object.values(output.to_retire_api_key_ids).forEach((apiKey) => {
+            if (apiKey?.id) {
+              keys.push(apiKey.id)
+            }
+          });
         }
       });
     }


### PR DESCRIPTION
## Summary

Fix regression from https://github.com/elastic/kibana/pull/142579

Tested with regular agent and agent running Fleet Server, bulk and single unenroll.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->