### PR TITLE
[8.5] Fix Failing test: Jest Tests.x-pack/plugins/lens/common/expressions/time_scale - time_scale should work with relative time range (#142837)

### DIFF
--- a/x-pack/plugins/lens/common/expressions/time_scale/time_scale.test.ts
+++ b/x-pack/plugins/lens/common/expressions/time_scale/time_scale.test.ts
@@ -22,7 +22,11 @@ describe('time_scale', () => {
     context?: ExecutionContext
   ) => Promise<Datatable>;
 
-  const timeScale = getTimeScale(createDatatableUtilitiesMock, () => 'UTC');
+  const timeScale = getTimeScale(
+    createDatatableUtilitiesMock,
+    () => 'UTC',
+    () => new Date('2010-01-04T06:30:30')
+  );
 
   const emptyTable: Datatable = {
     type: 'datatable',
@@ -390,7 +394,6 @@ describe('time_scale', () => {
         ...emptyTable,
         rows: [
           {
-            date: moment('2010-01-01T00:00:00.000Z').valueOf(),
             metric: 300,
           },
         ],
@@ -419,7 +422,6 @@ describe('time_scale', () => {
         ...emptyTable,
         rows: [
           {
-            date: moment().subtract('1d').valueOf(),
             metric: 300,
           },
         ],
@@ -432,14 +434,14 @@ describe('time_scale', () => {
       {
         getSearchContext: () => ({
           timeRange: {
-            from: 'now-10d',
+            from: 'now-2d',
             to: 'now',
           },
         }),
       } as unknown as ExecutionContext
     );
 
-    expect(result.rows.map(({ scaledMetric }) => scaledMetric)).toEqual([30]);
+    expect(result.rows.map(({ scaledMetric }) => scaledMetric)).toEqual([150]);
   });
 
   it('should apply fn for non-histogram fields (with Reduced time range)', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Fix Failing test: Jest Tests.x-pack/plugins/lens/common/expressions/time_scale - time_scale should work with relative time range (#142837)](https://github.com/elastic/kibana/pull/142837)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2022-10-06T14:23:53Z","message":"Fix Failing test: Jest Tests.x-pack/plugins/lens/common/expressions/time_scale - time_scale should work with relative time range (#142837)\n\nCloses: #142820","sha":"42f0868a0451b3ae34539d030ae975278914dbf9","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:VisEditors","failed-test","release_note:skip","backport:skip","v8.6.0"],"number":142837,"url":"https://github.com/elastic/kibana/pull/142837","mergeCommit":{"message":"Fix Failing test: Jest Tests.x-pack/plugins/lens/common/expressions/time_scale - time_scale should work with relative time range (#142837)\n\nCloses: #142820","sha":"42f0868a0451b3ae34539d030ae975278914dbf9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/142837","number":142837,"mergeCommit":{"message":"Fix Failing test: Jest Tests.x-pack/plugins/lens/common/expressions/time_scale - time_scale should work with relative time range (#142837)\n\nCloses: #142820","sha":"42f0868a0451b3ae34539d030ae975278914dbf9"}}]}] BACKPORT-->