### PR TITLE
[XY] Fixes the colors and tooltips sync

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/layered_xy_vis.test.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/layered_xy_vis.test.ts
@@ -24,7 +24,11 @@ describe('layeredXyVis', () => {
     expect(result).toEqual({
       type: 'render',
       as: XY_VIS,
-      value: { args: { ...rest, layers: [sampleExtendedLayer] } },
+      value: {
+        args: { ...rest, layers: [sampleExtendedLayer] },
+        syncColors: false,
+        syncTooltips: false,
+      },
     });
   });
 

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/layered_xy_vis_fn.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/layered_xy_vis_fn.ts
@@ -61,6 +61,8 @@ export const layeredXyVisFn: LayeredXyVisFn['fn'] = async (data, args, handlers)
           (handlers.variables?.embeddableTitle as string) ??
           handlers.getExecutionContext?.()?.description,
       },
+      syncColors: handlers?.isSyncColorsEnabled?.() ?? false,
+      syncTooltips: handlers?.isSyncTooltipsEnabled?.() ?? false,
     },
   };
 };

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/xy_vis.test.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/xy_vis.test.ts
@@ -38,6 +38,8 @@ describe('xyVis', () => {
             },
           ],
         },
+        syncColors: false,
+        syncTooltips: false,
       },
     });
   });
@@ -344,6 +346,8 @@ describe('xyVis', () => {
             },
           ],
         },
+        syncColors: false,
+        syncTooltips: false,
       },
     });
   });

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/xy_vis_fn.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/xy_vis_fn.ts
@@ -136,6 +136,8 @@ export const xyVisFn: XyVisFn['fn'] = async (data, args, handlers) => {
           (handlers.variables?.embeddableTitle as string) ??
           handlers.getExecutionContext?.()?.description,
       },
+      syncColors: handlers?.isSyncColorsEnabled?.() ?? false,
+      syncTooltips: handlers?.isSyncTooltipsEnabled?.() ?? false,
     },
   };
 };

--- a/src/plugins/chart_expressions/expression_xy/common/types/expression_renderers.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/types/expression_renderers.ts
@@ -16,6 +16,8 @@ import { XYProps } from './expression_functions';
 
 export interface XYChartProps {
   args: XYProps;
+  syncTooltips: boolean;
+  syncColors: boolean;
 }
 
 export interface XYRender {

--- a/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -226,8 +226,8 @@ export const getXyChartRenderer = ({
               onClickValue={onClickValue}
               onSelectRange={onSelectRange}
               renderMode={handlers.getRenderMode()}
-              syncColors={handlers.isSyncColorsEnabled()}
-              syncTooltips={handlers.isSyncTooltipsEnabled()}
+              syncColors={config.syncColors}
+              syncTooltips={config.syncTooltips}
               uiState={handlers.uiState as PersistedState}
               renderComplete={renderComplete}
             />

--- a/src/plugins/chart_expressions/expression_xy/public/helpers/interval.test.ts
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/interval.test.ts
@@ -18,7 +18,7 @@ describe('calculateMinInterval', () => {
   beforeEach(() => {
     const { layers, ...restArgs } = sampleArgs().args;
 
-    xyProps = { args: { ...restArgs, layers } };
+    xyProps = { args: { ...restArgs, layers }, syncColors: false, syncTooltips: false };
     layer = xyProps.args.layers[0] as DataLayerConfig;
     layer.xScaleType = 'time';
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/142954

This PR fixes the bug on the XY agg based visualizations that the colors and tooltips were not synced when the switches were on, on the dashboard level.

![lens](https://user-images.githubusercontent.com/17003240/194816307-4c49201a-b95e-429e-aa2f-148e84770f2c.gif)

