### PR TITLE
[Lens] Improve error messages for incompatible axis data type

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.test.ts
@@ -2458,7 +2458,7 @@ describe('xy_visualization', () => {
         {
           shortMessage: 'Wrong data type for Horizontal axis.',
           longMessage:
-            'Data type mismatch for the Horizontal axis. Cannot mix date and number interval types.',
+            'The Horizontal axis data in layer 1 is incompatible with the data in layer 2. Select a new function for the Horizontal axis.',
         },
       ]);
     });
@@ -2513,7 +2513,8 @@ describe('xy_visualization', () => {
       ).toEqual([
         {
           shortMessage: 'Wrong data type for Horizontal axis.',
-          longMessage: 'Data type mismatch for the Horizontal axis, use a different function.',
+          longMessage:
+            'The Horizontal axis data in layer 1 is incompatible with the data in layer 2. Select a new function for the Horizontal axis.',
         },
       ]);
     });

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -17342,8 +17342,6 @@
     "xpack.lens.xyVisualization.dataFailureSplitShort": "{axis} manquant.",
     "xpack.lens.xyVisualization.dataFailureYLong": "{layers, plural, one {Le calque} other {Les calques}} {layersList} {layers, plural, one {requiert} other {requièrent}} un champ pour {axis}.",
     "xpack.lens.xyVisualization.dataFailureYShort": "{axis} manquant.",
-    "xpack.lens.xyVisualization.dataTypeFailureXLong": "Non-correspondance des types de données pour {axis}. Impossible de mélanger les types d'intervalle date et nombre.",
-    "xpack.lens.xyVisualization.dataTypeFailureXOrdinalLong": "Non-correspondance de type de données pour {axis}, utilisez une autre fonction.",
     "xpack.lens.xyVisualization.dataTypeFailureXShort": "Type de données incorrect pour {axis}.",
     "xpack.lens.xyVisualization.dataTypeFailureYLong": "La dimension {label} fournie pour {axis} possède un type de données incorrect. Nombre attendu mais possède {dataType}",
     "xpack.lens.xyVisualization.dataTypeFailureYShort": "Type de données incorrect pour {axis}.",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -17324,8 +17324,6 @@
     "xpack.lens.xyVisualization.dataFailureSplitShort": "{axis} がありません。",
     "xpack.lens.xyVisualization.dataFailureYLong": "{layers, plural, other  {レイヤー}} {layersList} には {axis} のフィールドが{layers, plural, other  {必要です}}。",
     "xpack.lens.xyVisualization.dataFailureYShort": "{axis} がありません。",
-    "xpack.lens.xyVisualization.dataTypeFailureXLong": "{axis}のデータ型が一致しません。日付と数値間隔型を混合することはできません。",
-    "xpack.lens.xyVisualization.dataTypeFailureXOrdinalLong": "{axis}のデータ型が一致しません。別の関数を使用してください。",
     "xpack.lens.xyVisualization.dataTypeFailureXShort": "{axis}のデータ型が正しくありません。",
     "xpack.lens.xyVisualization.dataTypeFailureYLong": "{axis}のディメンション{label}のデータ型が正しくありません。数値が想定されていますが、{dataType}です",
     "xpack.lens.xyVisualization.dataTypeFailureYShort": "{axis}のデータ型が正しくありません。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -17349,8 +17349,6 @@
     "xpack.lens.xyVisualization.dataFailureSplitShort": "缺少 {axis}。",
     "xpack.lens.xyVisualization.dataFailureYLong": "{layers, plural, other {图层}} {layersList} {layers, plural, other {需要}}一个针对{axis}的字段。",
     "xpack.lens.xyVisualization.dataFailureYShort": "缺少 {axis}。",
-    "xpack.lens.xyVisualization.dataTypeFailureXLong": "{axis} 的数据类型不匹配无法混合日期和数字间隔类型。",
-    "xpack.lens.xyVisualization.dataTypeFailureXOrdinalLong": "{axis} 的数据类型不匹配，请使用其他函数。",
     "xpack.lens.xyVisualization.dataTypeFailureXShort": "{axis} 的数据类型错误。",
     "xpack.lens.xyVisualization.dataTypeFailureYLong": "为 {axis} 提供的维度 {label} 具有错误的数据类型。应为数字，但却为 {dataType}",
     "xpack.lens.xyVisualization.dataTypeFailureYShort": "{axis} 的数据类型错误。",


### PR DESCRIPTION
## Summary

Fix #138120

This PR improves the error messages for incompatible axis data types. Messages have been unified between incompatible combinations of data types into a single message, pointing the user to where the error happens and how to get out of it.

<img width="1155" alt="Screenshot 2022-10-10 at 11 17 41" src="https://user-images.githubusercontent.com/924948/194835540-893096a6-b576-41aa-8824-24dacff41ed2.png">

In case of multiple incompatible axis it still work:

<img width="1157" alt="Screenshot 2022-10-10 at 11 18 15" src="https://user-images.githubusercontent.com/924948/194835655-a2980bc1-0cd7-4b0f-ac1b-a0d181bc44c1.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
