### PR TITLE
[Discover] Fix issue where histogram does not fill its container when time interval is not auto

### DIFF
--- a/src/plugins/discover/public/application/main/components/chart/histogram.tsx
+++ b/src/plugins/discover/public/application/main/components/chart/histogram.tsx
@@ -41,6 +41,7 @@ import {
   renderEndzoneTooltip,
 } from '@kbn/charts-plugin/public';
 import { LEGACY_TIME_AXIS, MULTILAYER_TIME_AXIS_STYLE } from '@kbn/charts-plugin/common';
+import { css } from '@emotion/react';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { DataCharts$, DataChartsMessage } from '../../hooks/use_saved_search';
 import { FetchStatus } from '../../../types';
@@ -252,12 +253,16 @@ export function DiscoverHistogram({
     </EuiText>
   );
   if (bucketInterval?.scaled) {
+    const timeRangeWrapperCss = css`
+      flex-grow: 0;
+    `;
     timeRange = (
       <EuiFlexGroup
         alignItems="baseline"
         justifyContent="center"
         gutterSize="none"
         responsive={false}
+        css={timeRangeWrapperCss}
       >
         <EuiFlexItem grow={false}>{timeRange}</EuiFlexItem>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

This PR fixes an issue where the histogram does not fill its container when time interval is not `auto`:
<img width="1365" alt="Screen Shot 2022-10-10 at 2 03 12 PM" src="https://user-images.githubusercontent.com/25592674/194918908-e6b4a6b0-c996-429a-a66f-6f66dc48598b.png">

Resolves #142998.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->