### PR TITLE
[Discover] Fix flaky Discover URL state functional test

### DIFF
--- a/test/functional/apps/discover/group1/_discover.ts
+++ b/test/functional/apps/discover/group1/_discover.ts
@@ -26,8 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     defaultIndex: 'logstash-*',
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/142222
-  describe.skip('discover test', function describeIndexTests() {
+  describe('discover test', function describeIndexTests() {
     before(async function () {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
@@ -364,21 +363,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // One of these should fail
     describe('URL state', () => {
       it('should show a warning and fall back to the default data view when navigating to a URL with an invalid data view ID', async () => {
         await PageObjects.common.navigateToApp('discover');
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await PageObjects.header.waitUntilLoadingHasFinished();
         const dataViewId = await PageObjects.discover.getCurrentDataViewId();
-
         const originalUrl = await browser.getCurrentUrl();
         const newUrl = originalUrl.replace(dataViewId, 'invalid-data-view-id');
         await browser.get(newUrl);
-
         await PageObjects.header.waitUntilLoadingHasFinished();
-        expect(await browser.getCurrentUrl()).to.be(originalUrl);
-        expect(await testSubjects.exists('dscDataViewNotFoundShowDefaultWarning')).to.be(true);
+        await retry.try(async () => {
+          expect(await browser.getCurrentUrl()).to.be(originalUrl);
+          expect(await testSubjects.exists('dscDataViewNotFoundShowDefaultWarning')).to.be(true);
+        });
       });
 
       it('should show a warning and fall back to the current data view if the URL is updated to an invalid data view ID', async () => {
@@ -386,14 +384,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         const originalHash = await browser.execute<[], string>('return window.location.hash');
         const dataViewId = await PageObjects.discover.getCurrentDataViewId();
-
         const newHash = originalHash.replace(dataViewId, 'invalid-data-view-id');
         await browser.execute(`window.location.hash = "${newHash}"`);
         await PageObjects.header.waitUntilLoadingHasFinished();
-
-        const currentHash = await browser.execute<[], string>('return window.location.hash');
-        expect(currentHash).to.be(originalHash);
-        expect(await testSubjects.exists('dscDataViewNotFoundShowSavedWarning')).to.be(true);
+        await retry.try(async () => {
+          const currentHash = await browser.execute<[], string>('return window.location.hash');
+          expect(currentHash).to.be(originalHash);
+          expect(await testSubjects.exists('dscDataViewNotFoundShowSavedWarning')).to.be(true);
+        });
       });
     });
   });

--- a/test/functional/apps/discover/group1/_discover.ts
+++ b/test/functional/apps/discover/group1/_discover.ts
@@ -364,6 +364,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    // One of these should fail
     describe('URL state', () => {
       it('should show a warning and fall back to the default data view when navigating to a URL with an invalid data view ID', async () => {
         await PageObjects.common.navigateToApp('discover');


### PR DESCRIPTION
## Summary

This PR fixes flaky Discover URL state functional tests.

Flaky test runs:
- ✅ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1400
- ❌ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1455
- ✅ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1460

Fixes #142222.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)