### PR TITLE
[Maps] style tracks by sort field

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.test.ts
@@ -24,6 +24,10 @@ const esResponse = {
             },
             properties: {
               complete: true,
+              sort_values: [
+                1665381987801,
+                1665385805491,
+              ]
             },
           },
         },
@@ -40,6 +44,10 @@ const esResponse = {
             },
             properties: {
               complete: false,
+              sort_values: [
+                1665360000000,
+                1665375849240,
+              ]
             },
           },
         },
@@ -49,22 +57,22 @@ const esResponse = {
 };
 
 it('Should convert elasticsearch aggregation response into feature collection', () => {
-  const geoJson = convertToGeoJson(esResponse, 'machine.os.keyword');
+  const geoJson = convertToGeoJson(esResponse, 'machine.os.keyword', 'timestamp');
   expect(geoJson.numTrimmedTracks).toBe(1);
-  expect(geoJson.featureCollection.features.length).toBe(2);
+  expect(geoJson.featureCollection.features.length).toBe(4);
   expect(geoJson.featureCollection.features[0]).toEqual({
     geometry: {
       coordinates: [
         [-95.339639, 41.584389],
-        [-95.339639, 41.0],
       ],
       type: 'LineString',
     },
-    id: 'ios',
+    id: 'ios_0',
     properties: {
       complete: true,
       doc_count: 1,
       ['machine.os.keyword']: 'ios',
+      ['timestamp']: 1665381987801,
     },
     type: 'Feature',
   });

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.test.ts
@@ -24,10 +24,7 @@ const esResponse = {
             },
             properties: {
               complete: true,
-              sort_values: [
-                1665381987801,
-                1665385805491,
-              ]
+              sort_values: [1665381987801, 1665385805491],
             },
           },
         },
@@ -44,10 +41,7 @@ const esResponse = {
             },
             properties: {
               complete: false,
-              sort_values: [
-                1665360000000,
-                1665375849240,
-              ]
+              sort_values: [1665360000000, 1665375849240],
             },
           },
         },
@@ -62,9 +56,7 @@ it('Should convert elasticsearch aggregation response into feature collection', 
   expect(geoJson.featureCollection.features.length).toBe(4);
   expect(geoJson.featureCollection.features[0]).toEqual({
     geometry: {
-      coordinates: [
-        [-95.339639, 41.584389],
-      ],
+      coordinates: [[-95.339639, 41.584389]],
       type: 'LineString',
     },
     id: 'ios_0',

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/convert_to_geojson.ts
@@ -11,7 +11,11 @@ import { extractPropertiesFromBucket } from '../../../../common/elasticsearch_ut
 
 const KEYS_TO_IGNORE = ['key', 'path'];
 
-export function convertToGeoJson(esResponse: any, entitySplitFieldName: string, sortFieldName: string) {
+export function convertToGeoJson(
+  esResponse: any,
+  entitySplitFieldName: string,
+  sortFieldName: string
+) {
   const features: Feature[] = [];
   let numTrimmedTracks = 0;
 
@@ -24,7 +28,7 @@ export function convertToGeoJson(esResponse: any, entitySplitFieldName: string, 
     if (!trackFeature.properties!.complete) {
       numTrimmedTracks++;
     }
-    
+
     // Create feature for each segment in track (LineString)
     for (let i = 1; i < trackFeature.geometry.coordinates.length; i++) {
       features.push({
@@ -33,7 +37,7 @@ export function convertToGeoJson(esResponse: any, entitySplitFieldName: string, 
         geometry: {
           type: 'LineString',
           coordinates: [
-            trackFeature.geometry.coordinates[i-1],
+            trackFeature.geometry.coordinates[i - 1],
             trackFeature.geometry.coordinates[i],
           ],
         },

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
@@ -152,11 +152,7 @@ export class ESGeoLineSource extends AbstractESAggSource {
   }
 
   async getFields(): Promise<IField[]> {
-    return [
-      ...this.getMetricFields(),
-      this._createSplitField(),
-      this._createSortField(),
-    ];
+    return [...this.getMetricFields(), this._createSplitField(), this._createSortField()];
   }
 
   getFieldByName(name: string): IField | null {
@@ -318,7 +314,7 @@ export class ESGeoLineSource extends AbstractESAggSource {
     const { featureCollection, numTrimmedTracks } = convertToGeoJson(
       tracksResp,
       this._descriptor.splitField,
-      this._descriptor.sortField,
+      this._descriptor.sortField
     );
     console.log(featureCollection);
 


### PR DESCRIPTION
POC to see how [geo-line include_sort](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geo-line.html) parameter can be used to style tracks by sort time.

The screen shots below show airline tracks for the last 15 minutes. Green indicates older times while red indicates newer times

<img width="600" alt="Screen Shot 2022-10-10 at 2 27 59 PM" src="https://user-images.githubusercontent.com/373691/194947829-86a6c6de-5922-41ec-9998-55ad05d419ca.png">

<img width="400" alt="Screen Shot 2022-10-10 at 2 28 37 PM" src="https://user-images.githubusercontent.com/373691/194947874-cab3146f-98ff-4c3f-b551-75a6b36b6927.png">
