### PR TITLE
[Enterprise Search] Move connector config callout to fourth config step

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -18,7 +18,6 @@ import {
   EuiSpacer,
   EuiSteps,
   EuiCodeBlock,
-  EuiHorizontalRule,
   EuiCallOut,
   EuiButton,
 } from '@elastic/eui';
@@ -179,7 +178,24 @@ export const ConnectorConfiguration: React.FC = () => {
                           }
                         )}
                       </EuiText>
-                      <EuiHorizontalRule />
+                    </>
+                  ),
+                  status:
+                    !indexData.connector.status ||
+                    indexData.connector.status === ConnectorStatus.CREATED
+                      ? 'incomplete'
+                      : 'complete',
+                  title: i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.steps.deployConnector.title',
+                    {
+                      defaultMessage: 'Deploy a connector',
+                    }
+                  ),
+                  titleSize: 'xs',
+                },
+                {
+                  children: (
+                    <ConnectorConfigurationConfig>
                       {!indexData.connector.status ||
                       indexData.connector.status === ConnectorStatus.CREATED ? (
                         <EuiCallOut
@@ -226,23 +242,8 @@ export const ConnectorConfiguration: React.FC = () => {
                           )}
                         />
                       )}
-                    </>
+                    </ConnectorConfigurationConfig>
                   ),
-                  status:
-                    !indexData.connector.status ||
-                    indexData.connector.status === ConnectorStatus.CREATED
-                      ? 'incomplete'
-                      : 'complete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.steps.deployConnector.title',
-                    {
-                      defaultMessage: 'Deploy a connector',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: <ConnectorConfigurationConfig />,
                   status:
                     indexData.connector.status === ConnectorStatus.CONNECTED
                       ? 'complete'


### PR DESCRIPTION
## Summary

This moves the connector configuration callout to the fourth step of the build-a-connector configuration, so that we don't have an empty fourth step.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/94373878/195073283-7d4e669e-27f0-40c3-8002-9731bcd19be7.png">
