### PR TITLE
[8.5] [Security Solution][Fix]-Reset discarded timeline & Change timeline Save prompt Strategy (#140399)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/timelines/unsaved_timeline.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timelines/unsaved_timeline.cy.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Timeline } from '../../objects/timeline';
+import {
+  MODAL_CONFIRMATION_BTN,
+  MODAL_CONFIRMATION_CANCEL_BTN,
+} from '../../screens/alerts_detection_rules';
+import {
+  ALERTS_PAGE,
+  APP_LEAVE_CONFIRM_MODAL,
+  CASES_PAGE,
+  MANAGE_PAGE,
+  OBSERVABILITY_ALERTS_PAGE,
+} from '../../screens/kibana_navigation';
+import { TIMELINE_SAVE_MODAL } from '../../screens/timeline';
+import { cleanKibana } from '../../tasks/common';
+import {
+  navigateFromKibanaCollapsibleTo,
+  openKibanaNavigation,
+} from '../../tasks/kibana_navigation';
+import { login, visit } from '../../tasks/login';
+import { closeTimelineUsingToggle } from '../../tasks/security_main';
+import {
+  addNameAndDescriptionToTimeline,
+  createNewTimeline,
+  populateTimeline,
+  waitForTimelineChanges,
+} from '../../tasks/timeline';
+import { HOSTS_URL } from '../../urls/navigation';
+
+describe('Save Timeline Prompts', () => {
+  before(() => {
+    cleanKibana();
+    login();
+    /*
+     * When timeline changes are pending, chrome would popup with
+     * a confirm dialog stating that `you can lose unsaved changed.
+     * Below changes will disable that.
+     *
+     * */
+    cy.window().then((win) => {
+      win.onbeforeunload = null;
+    });
+  });
+
+  beforeEach(() => {
+    visit(HOSTS_URL);
+    createNewTimeline();
+  });
+
+  it('unchanged & unsaved timeline should NOT prompt when user navigates away', () => {
+    openKibanaNavigation();
+    navigateFromKibanaCollapsibleTo(OBSERVABILITY_ALERTS_PAGE);
+    cy.url().should('not.contain', HOSTS_URL);
+  });
+
+  it('Changed & unsaved timeline should prompt when user navigates away from security solution', () => {
+    populateTimeline();
+    waitForTimelineChanges();
+    closeTimelineUsingToggle();
+    openKibanaNavigation();
+    navigateFromKibanaCollapsibleTo(OBSERVABILITY_ALERTS_PAGE);
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+  });
+
+  it('Changed & unsaved timeline should NOT prompt when user navigates away within security solution where timelines are enabled', () => {
+    populateTimeline();
+
+    waitForTimelineChanges();
+    closeTimelineUsingToggle();
+    // navigate to any other page in security solution
+    openKibanaNavigation();
+    cy.get(CASES_PAGE).click();
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('not.exist');
+  });
+
+  it('Changed & unsaved timeline should prompt when user navigates away within security solution where timelines are disbaled eg. admin screen', () => {
+    populateTimeline();
+    waitForTimelineChanges();
+    openKibanaNavigation();
+    cy.get(MANAGE_PAGE).click();
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+  });
+
+  it('Changed & saved timeline should NOT prompt when user navigates away out of security solution', () => {
+    populateTimeline();
+    waitForTimelineChanges();
+    closeTimelineUsingToggle();
+    openKibanaNavigation();
+    navigateFromKibanaCollapsibleTo(OBSERVABILITY_ALERTS_PAGE);
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
+    cy.get(MODAL_CONFIRMATION_CANCEL_BTN).click();
+    addNameAndDescriptionToTimeline(
+      {
+        title: 'Some Timeline',
+        description: 'Some Timeline',
+      } as Timeline,
+      true
+    );
+    openKibanaNavigation();
+    navigateFromKibanaCollapsibleTo(OBSERVABILITY_ALERTS_PAGE);
+    cy.url().should('not.contain', HOSTS_URL);
+  });
+
+  it('Changed & saved timeline should NOT prompt when user navigates within security solution where timelines are disabled', () => {
+    populateTimeline();
+    waitForTimelineChanges();
+    closeTimelineUsingToggle();
+    openKibanaNavigation();
+    cy.get(MANAGE_PAGE).click();
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
+    cy.get(MODAL_CONFIRMATION_CANCEL_BTN).click();
+    addNameAndDescriptionToTimeline(
+      {
+        title: 'Some Timeline',
+        description: 'Some Timeline',
+      } as Timeline,
+      true
+    );
+    openKibanaNavigation();
+    cy.get(MANAGE_PAGE).click();
+    cy.url().should('not.contain', HOSTS_URL);
+  });
+
+  it('When user navigates to the page where timeline is present, Time save modal shold not exists.', () => {
+    populateTimeline();
+    waitForTimelineChanges();
+    closeTimelineUsingToggle();
+    openKibanaNavigation();
+    cy.get(MANAGE_PAGE).click();
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
+    cy.get(MODAL_CONFIRMATION_BTN).click();
+
+    // Navigate back to HOSTS_URL and ensure that
+    // timeline save modal is NOT present
+
+    openKibanaNavigation();
+    cy.get(ALERTS_PAGE).click();
+    cy.get(TIMELINE_SAVE_MODAL).should('not.exist');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/kibana_navigation.ts
@@ -30,6 +30,11 @@ export const MANAGE_PAGE =
 
 export const KIBANA_NAVIGATION_TOGGLE = '[data-test-subj="toggleNavButton"]';
 
+export const OBSERVABILITY_ALERTS_PAGE =
+  '[data-test-subj="collapsibleNavGroup-observability"] [title="Alerts"]';
+
 export const SPACES_BUTTON = '[data-test-subj="spacesNavSelector"]';
+
+export const APP_LEAVE_CONFIRM_MODAL = '[data-test-subj="appLeaveConfirmModal"]';
 
 export const getGoToSpaceMenuItem = (space: string) => `[data-test-subj="space-avatar-${space}"]`;

--- a/x-pack/plugins/security_solution/cypress/screens/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/timeline.ts
@@ -237,6 +237,8 @@ export const TOGGLE_TIMELINE_EXPAND_EVENT = '[data-test-subj="expand-event"]';
 
 export const TIMELINE_EDIT_MODAL_OPEN_BUTTON = '[data-test-subj="save-timeline-button-icon"]';
 
+export const TIMELINE_SAVE_MODAL = '[data-test-subj="save-timeline-modal"]';
+
 export const TIMELINE_EDIT_MODAL_SAVE_BUTTON = '[data-test-subj="save-button"]';
 
 export const TIMELINE_EXIT_FULL_SCREEN_BUTTON = '[data-test-subj="exit-full-screen"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -183,9 +183,7 @@ export const loadPrebuiltDetectionRules = () => {
  * load prebuilt rules by clicking button on page header
  */
 export const loadPrebuiltDetectionRulesFromHeaderBtn = () => {
-  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN)
-    .pipe(($el) => $el.trigger('click'))
-    .should('not.exist');
+  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN).click().should('not.exist');
 };
 
 export const openIntegrationsPopover = () => {

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -87,24 +87,36 @@ import { closeFieldsBrowser, filterFieldsBrowser } from './fields_browser';
 
 export const hostExistsQuery = 'host.name: *';
 
-export const addDescriptionToTimeline = (description: string) => {
-  cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+export const addDescriptionToTimeline = (
+  description: string,
+  modalAlreadyOpen: boolean = false
+) => {
+  if (!modalAlreadyOpen) {
+    cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+  }
   cy.get(TIMELINE_DESCRIPTION_INPUT).type(description);
   cy.get(TIMELINE_DESCRIPTION_INPUT).invoke('val').should('equal', description);
   cy.get(TIMELINE_EDIT_MODAL_SAVE_BUTTON).click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.exist');
 };
 
-export const addNameToTimeline = (name: string) => {
-  cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+export const addNameToTimeline = (name: string, modalAlreadyOpen: boolean = false) => {
+  if (!modalAlreadyOpen) {
+    cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+  }
   cy.get(TIMELINE_TITLE_INPUT).type(`${name}{enter}`);
   cy.get(TIMELINE_TITLE_INPUT).should('have.attr', 'value', name);
   cy.get(TIMELINE_EDIT_MODAL_SAVE_BUTTON).click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.exist');
 };
 
-export const addNameAndDescriptionToTimeline = (timeline: Timeline) => {
-  cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+export const addNameAndDescriptionToTimeline = (
+  timeline: Timeline,
+  modalAlreadyOpen: boolean = false
+) => {
+  if (!modalAlreadyOpen) {
+    cy.get(TIMELINE_EDIT_MODAL_OPEN_BUTTON).first().click();
+  }
   cy.get(TIMELINE_TITLE_INPUT).type(`${timeline.title}{enter}`);
   cy.get(TIMELINE_TITLE_INPUT).should('have.attr', 'value', timeline.title);
   cy.get(TIMELINE_DESCRIPTION_INPUT).type(timeline.description);

--- a/x-pack/plugins/security_solution/public/cases/links.ts
+++ b/x-pack/plugins/security_solution/public/cases/links.ts
@@ -26,12 +26,10 @@ export const getCasesLinkItems = (): LinkItem => {
         capabilities: [`${CASES_FEATURE_ID}.${UPDATE_CASES_CAPABILITY}`],
         licenseType: 'gold',
         sideNavDisabled: true,
-        hideTimeline: true,
       },
       [SecurityPageName.caseCreate]: {
         capabilities: [`${CASES_FEATURE_ID}.${CREATE_CASES_CAPABILITY}`],
         sideNavDisabled: true,
-        hideTimeline: true,
       },
     },
   });

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_timeline_save_prompt.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_timeline_save_prompt.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import type { AppLeaveHandler } from '@kbn/core-application-browser';
+import { useHistory } from 'react-router-dom';
+import { useShowTimelineForGivenPath } from '../../utils/timeline/use_show_timeline_for_path';
+import type { TimelineId } from '../../../../common/types';
+import { TimelineStatus, TimelineTabs } from '../../../../common/types';
+import { useKibana } from '../../lib/kibana';
+import { useDeepEqualSelector } from '../use_selector';
+import { APP_ID, APP_PATH } from '../../../../common/constants';
+import { getTimelineShowStatusByIdSelector } from '../../../timelines/components/flyout/selectors';
+import { timelineActions } from '../../../timelines/store/timeline';
+import {
+  UNSAVED_TIMELINE_SAVE_PROMPT,
+  UNSAVED_TIMELINE_SAVE_PROMPT_TITLE,
+} from '../../translations';
+
+// Issue with history.block
+// https://github.com/elastic/kibana/issues/132597
+
+export const useTimelineSavePrompt = (
+  timelineId: TimelineId,
+  onAppLeave: (handler: AppLeaveHandler) => void
+) => {
+  const dispatch = useDispatch();
+  const { overlays, application } = useKibana().services;
+  const getIsTimelineVisible = useShowTimelineForGivenPath();
+  const history = useHistory();
+
+  const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
+  const { status: timelineStatus, updated } = useDeepEqualSelector((state) =>
+    getTimelineShowStatus(state, timelineId)
+  );
+
+  const showSaveTimelineModal = useCallback(() => {
+    dispatch(timelineActions.showTimeline({ id: timelineId, show: true }));
+    dispatch(
+      timelineActions.setActiveTabTimeline({
+        id: timelineId,
+        activeTab: TimelineTabs.query,
+      })
+    );
+    dispatch(
+      timelineActions.toggleModalSaveTimeline({
+        id: timelineId,
+        showModalSaveTimeline: true,
+      })
+    );
+  }, [dispatch, timelineId]);
+
+  useEffect(() => {
+    const unblock = history.block((location) => {
+      const relativePath = location.pathname.replace(APP_PATH, '');
+      async function confirmSaveTimeline() {
+        const confirmRes = await overlays?.openConfirm(UNSAVED_TIMELINE_SAVE_PROMPT, {
+          title: UNSAVED_TIMELINE_SAVE_PROMPT_TITLE,
+          'data-test-subj': 'appLeaveConfirmModal',
+        });
+
+        if (confirmRes) {
+          unblock();
+
+          application.navigateToUrl(location.pathname + location.hash + location.search, {
+            state: location.state,
+          });
+        } else {
+          showSaveTimelineModal();
+        }
+      }
+
+      if (
+        !getIsTimelineVisible(relativePath) &&
+        timelineStatus === TimelineStatus.draft &&
+        updated != null
+      ) {
+        confirmSaveTimeline();
+      } else {
+        return;
+      }
+      return false;
+    });
+
+    return () => {
+      unblock();
+    };
+  }, [
+    history,
+    application,
+    overlays,
+    showSaveTimelineModal,
+    getIsTimelineVisible,
+    timelineStatus,
+    updated,
+  ]);
+
+  useEffect(() => {
+    onAppLeave((actions, nextAppId) => {
+      // Confirm when the user has made any changes to a timeline
+      if (
+        !(nextAppId ?? '').includes(APP_ID) &&
+        timelineStatus === TimelineStatus.draft &&
+        updated != null
+      ) {
+        return actions.confirm(
+          UNSAVED_TIMELINE_SAVE_PROMPT,
+          UNSAVED_TIMELINE_SAVE_PROMPT_TITLE,
+          showSaveTimelineModal
+        );
+      } else {
+        return actions.default();
+      }
+    });
+  });
+};

--- a/x-pack/plugins/security_solution/public/common/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/translations.ts
@@ -36,3 +36,17 @@ export const UPGRADE_ENDPOINT_FOR_RESPONDER = i18n.translate(
       'The current version of the Agent does not support this feature. Upgrade your Agent through Fleet to use this feature and new response actions such as killing and suspending processes.',
   }
 );
+
+export const UNSAVED_TIMELINE_SAVE_PROMPT = i18n.translate(
+  'xpack.securitySolution.timeline.unsavedWorkMessage',
+  {
+    defaultMessage: 'Leave Timeline with unsaved work?',
+  }
+);
+
+export const UNSAVED_TIMELINE_SAVE_PROMPT_TITLE = i18n.translate(
+  'xpack.securitySolution.timeline.unsavedWorkTitle',
+  {
+    defaultMessage: 'Unsaved changes',
+  }
+);

--- a/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline.tsx
@@ -6,55 +6,16 @@
  */
 
 import { useMemo } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
-
-import { getLinksWithHiddenTimeline } from '../../links';
-import { useIsGroupedNavigationEnabled } from '../../components/navigation/helpers';
-import { SourcererScopeName } from '../../store/sourcerer/model';
-import { useSourcererDataView } from '../../containers/sourcerer';
-import { useKibana } from '../../lib/kibana';
-
-const DEPRECATED_HIDDEN_TIMELINE_ROUTES: readonly string[] = [
-  `/cases/configure`,
-  '/administration',
-  '/rules/create',
-  '/get_started',
-  '/explore',
-  '/dashboards',
-  '/manage',
-  '/cloud_security_posture*',
-];
-
-const isTimelinePathVisible = (
-  currentPath: string,
-  isGroupedNavigationEnabled: boolean
-): boolean => {
-  const groupLinksWithHiddenTimelinePaths = getLinksWithHiddenTimeline().map((l) => l.path);
-
-  const hiddenTimelineRoutes = isGroupedNavigationEnabled
-    ? groupLinksWithHiddenTimelinePaths
-    : DEPRECATED_HIDDEN_TIMELINE_ROUTES;
-
-  return !hiddenTimelineRoutes.find((route) => matchPath(currentPath, route));
-};
+import { useLocation } from 'react-router-dom';
+import { useShowTimelineForGivenPath } from './use_show_timeline_for_path';
 
 export const useShowTimeline = () => {
-  const isGroupedNavigationEnabled = useIsGroupedNavigationEnabled();
   const { pathname } = useLocation();
-  const { indicesExist, dataViewId } = useSourcererDataView(SourcererScopeName.timeline);
-  const userHasSecuritySolutionVisible = useKibana().services.application.capabilities.siem.show;
+  const getIsTimelineVisible = useShowTimelineForGivenPath();
 
-  const isTimelineAllowed = useMemo(
-    () => userHasSecuritySolutionVisible && (indicesExist || dataViewId === null),
-    [indicesExist, dataViewId, userHasSecuritySolutionVisible]
+  const showTimeline = useMemo(
+    () => getIsTimelineVisible(pathname),
+    [pathname, getIsTimelineVisible]
   );
-
-  const showTimeline = useMemo(() => {
-    if (!isTimelineAllowed) {
-      return false;
-    }
-    return isTimelinePathVisible(pathname, isGroupedNavigationEnabled);
-  }, [isTimelineAllowed, pathname, isGroupedNavigationEnabled]);
-
   return [showTimeline];
 };

--- a/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { matchPath } from 'react-router-dom';
+
+import { getLinksWithHiddenTimeline } from '../../links';
+import { useIsGroupedNavigationEnabled } from '../../components/navigation/helpers';
+import { SourcererScopeName } from '../../store/sourcerer/model';
+import { useSourcererDataView } from '../../containers/sourcerer';
+import { useKibana } from '../../lib/kibana';
+
+const DEPRECATED_HIDDEN_TIMELINE_ROUTES: readonly string[] = [
+  `/cases/configure`,
+  '/administration',
+  '/rules/create',
+  '/get_started',
+  '/explore',
+  '/dashboards',
+  '/manage',
+  '/cloud_security_posture*',
+];
+
+const isTimelinePathVisible = (
+  currentPath: string,
+  isGroupedNavigationEnabled: boolean
+): boolean => {
+  const groupLinksWithHiddenTimelinePaths = getLinksWithHiddenTimeline().map((l) => l.path);
+
+  const hiddenTimelineRoutes = isGroupedNavigationEnabled
+    ? groupLinksWithHiddenTimelinePaths
+    : DEPRECATED_HIDDEN_TIMELINE_ROUTES;
+
+  return !hiddenTimelineRoutes.find((route) => matchPath(currentPath, route));
+};
+
+export const useShowTimelineForGivenPath = () => {
+  const isGroupedNavigationEnabled = useIsGroupedNavigationEnabled();
+
+  const { indicesExist, dataViewId } = useSourcererDataView(SourcererScopeName.timeline);
+  const userHasSecuritySolutionVisible = useKibana().services.application.capabilities.siem.show;
+
+  const isTimelineAllowed = useMemo(
+    () => userHasSecuritySolutionVisible && (indicesExist || dataViewId === null),
+    [indicesExist, dataViewId, userHasSecuritySolutionVisible]
+  );
+
+  const getIsTimelineVisible = useCallback(
+    (pathname: string) => {
+      if (!isTimelineAllowed) {
+        return false;
+      }
+      return isTimelinePathVisible(pathname, isGroupedNavigationEnabled);
+    },
+    [isTimelineAllowed, isGroupedNavigationEnabled]
+  );
+
+  return getIsTimelineVisible;
+};

--- a/x-pack/plugins/security_solution/public/landing_pages/links.ts
+++ b/x-pack/plugins/security_solution/public/landing_pages/links.ts
@@ -40,7 +40,6 @@ export const dashboardsLandingLinks: LinkItem = {
     entityAnalyticsLinks,
   ],
   skipUrlState: true,
-  hideTimeline: true,
 };
 
 export const threatHuntingLandingLinks: LinkItem = {
@@ -56,5 +55,4 @@ export const threatHuntingLandingLinks: LinkItem = {
   ],
   links: [hostsLinks, networkLinks, usersLinks],
   skipUrlState: true,
-  hideTimeline: true,
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/index.test.tsx
@@ -30,6 +30,8 @@ jest.mock('../timeline', () => ({
   StatefulTimeline: () => <div />,
 }));
 
+jest.mock('../../../common/hooks/timeline/use_timeline_save_prompt');
+
 describe('Flyout', () => {
   const props = {
     onAppLeave: jest.fn(),

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/index.tsx
@@ -5,18 +5,16 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
 import { EuiFocusTrap, EuiOutsideClickDetector } from '@elastic/eui';
 import React, { useEffect, useMemo, useCallback, useState, useRef } from 'react';
-import { useDispatch } from 'react-redux';
 
 import type { AppLeaveHandler } from '@kbn/core/public';
-import { TimelineId, TimelineStatus, TimelineTabs } from '../../../../common/types/timeline';
+import type { TimelineId } from '../../../../common/types/timeline';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { timelineActions } from '../../store/timeline';
 import { FlyoutBottomBar } from './bottom_bar';
 import { Pane } from './pane';
 import { getTimelineShowStatusByIdSelector } from './selectors';
+import { useTimelineSavePrompt } from '../../../common/hooks/timeline/use_timeline_save_prompt';
 
 interface OwnProps {
   timelineId: TimelineId;
@@ -26,13 +24,8 @@ interface OwnProps {
 type VoidFunc = () => void;
 
 const FlyoutComponent: React.FC<OwnProps> = ({ timelineId, onAppLeave }) => {
-  const dispatch = useDispatch();
   const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
-  const {
-    show,
-    status: timelineStatus,
-    updated,
-  } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
+  const { show } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
 
   const [focusOwnership, setFocusOwnership] = useState(true);
   const [triggerOnBlur, setTriggerOnBlur] = useState(true);
@@ -58,6 +51,8 @@ const FlyoutComponent: React.FC<OwnProps> = ({ timelineId, onAppLeave }) => {
     }
   }, []);
 
+  useTimelineSavePrompt(timelineId, onAppLeave);
+
   useEffect(() => {
     if (searchRef.current != null) {
       if (callbackRef.current !== null) {
@@ -72,48 +67,6 @@ const FlyoutComponent: React.FC<OwnProps> = ({ timelineId, onAppLeave }) => {
       }
     };
   }, [handleSearch, triggerOnBlur]);
-
-  useEffect(() => {
-    onAppLeave((actions, nextAppId) => {
-      if (show) {
-        dispatch(timelineActions.showTimeline({ id: TimelineId.active, show: false }));
-      }
-      // Confirm when the user has made any changes to a timeline
-      if (
-        !(nextAppId ?? '').includes('securitySolution') &&
-        timelineStatus === TimelineStatus.draft &&
-        updated != null
-      ) {
-        const showSaveTimelineModal = () => {
-          dispatch(timelineActions.showTimeline({ id: TimelineId.active, show: true }));
-          dispatch(
-            timelineActions.setActiveTabTimeline({
-              id: TimelineId.active,
-              activeTab: TimelineTabs.query,
-            })
-          );
-          dispatch(
-            timelineActions.toggleModalSaveTimeline({
-              id: TimelineId.active,
-              showModalSaveTimeline: true,
-            })
-          );
-        };
-
-        return actions.confirm(
-          i18n.translate('xpack.securitySolution.timeline.unsavedWorkMessage', {
-            defaultMessage: 'Leave Timeline with unsaved work?',
-          }),
-          i18n.translate('xpack.securitySolution.timeline.unsavedWorkTitle', {
-            defaultMessage: 'Unsaved changes',
-          }),
-          showSaveTimelineModal
-        );
-      } else {
-        return actions.default();
-      }
-    });
-  }, [dispatch, onAppLeave, show, timelineStatus, updated]);
 
   return (
     <EuiOutsideClickDetector onOutsideClick={onOutsideClick}>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_create_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_create_timeline.test.tsx
@@ -128,23 +128,30 @@ describe('useCreateTimelineButton', () => {
 
         wrapper.find('[data-test-subj="timeline-new"]').first().simulate('click');
 
+        expect(mockDispatch.mock.calls.length).toBe(6);
+
         expect(mockDispatch.mock.calls[0][0].type).toEqual(
           'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW'
         );
         expect(mockDispatch.mock.calls[1][0].type).toEqual(
           'x-pack/security_solution/local/timeline/CREATE_TIMELINE'
         );
+
         expect(mockDispatch.mock.calls[2][0].type).toEqual(
+          'x-pack/security_solution/local/timeline/SET_TIMELINE_UPDATED_AT'
+        );
+
+        expect(mockDispatch.mock.calls[3][0].type).toEqual(
           'x-pack/security_solution/local/inputs/ADD_LINK_TO'
         );
-        expect(mockDispatch.mock.calls[2][0].payload).toEqual([
+        expect(mockDispatch.mock.calls[3][0].payload).toEqual([
           InputsModelId.global,
           InputsModelId.timeline,
         ]);
-        expect(mockDispatch.mock.calls[3][0].type).toEqual(
+        expect(mockDispatch.mock.calls[4][0].type).toEqual(
           'x-pack/security_solution/local/app/ADD_NOTE'
         );
-        expect(mockDispatch.mock.calls[4][0].type).toEqual(
+        expect(mockDispatch.mock.calls[5][0].type).toEqual(
           'x-pack/security_solution/local/inputs/SET_RELATIVE_RANGE_DATE_PICKER'
         );
       });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_create_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_create_timeline.tsx
@@ -57,6 +57,13 @@ export const useCreateTimeline = ({ timelineId, timelineType, closeGearMenu }: P
           timelineType,
         })
       );
+
+      dispatch(
+        timelineActions.setTimelineUpdatedAt({
+          id: TimelineId.active,
+          updated: undefined,
+        })
+      );
       dispatch(inputsActions.addLinkTo([InputsModelId.global, InputsModelId.timeline]));
       dispatch(appActions.addNotes({ notes: [] }));
       if (globalTimeRange.kind === 'absolute') {

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
@@ -70,7 +70,7 @@ export const createTimeline = actionCreator<TimelinePersistInput>('CREATE_TIMELI
 
 export const pinEvent = actionCreator<{ id: string; eventId: string }>('PIN_EVENT');
 
-export const setTimelineUpdatedAt = actionCreator<{ id: string; updated: number }>(
+export const setTimelineUpdatedAt = actionCreator<{ id: string; updated: number | undefined }>(
   'SET_TIMELINE_UPDATED_AT'
 );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Security Solution][Fix]-Reset discarded timeline & Change timeline Save prompt Strategy (#140399)](https://github.com/elastic/kibana/pull/140399)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2022-10-05T15:45:45Z","message":"[Security Solution][Fix]-Reset discarded timeline & Change timeline Save prompt Strategy (#140399)\n\nPlease go through #140614 to get the context of this PR.\r\n\r\n_tl,dr;_\r\n\r\nTimeline bottom bar has been enabled on below pages.\r\n\r\n- Security / Dashboards\r\n- Security / Explore\r\n- Security / Cases / ....\r\n\r\nWhen user navigates to any other pages within security solution where `timeline bottom bar` is not visible, use will be reminded that they have an unsaved timeline. \r\n\r\nJustification for enabling `timeline bottom bar` on above pages is to prevent users from getting too many timeline save reminders if they navigate within `Security Solution` plugin.","sha":"803189f543c958408500fa885b8bab863a0f8dab","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Threat Hunting:Investigations","backport:prev-minor","v8.4.2"],"number":140399,"url":"https://github.com/elastic/kibana/pull/140399","mergeCommit":{"message":"[Security Solution][Fix]-Reset discarded timeline & Change timeline Save prompt Strategy (#140399)\n\nPlease go through #140614 to get the context of this PR.\r\n\r\n_tl,dr;_\r\n\r\nTimeline bottom bar has been enabled on below pages.\r\n\r\n- Security / Dashboards\r\n- Security / Explore\r\n- Security / Cases / ....\r\n\r\nWhen user navigates to any other pages within security solution where `timeline bottom bar` is not visible, use will be reminded that they have an unsaved timeline. \r\n\r\nJustification for enabling `timeline bottom bar` on above pages is to prevent users from getting too many timeline save reminders if they navigate within `Security Solution` plugin.","sha":"803189f543c958408500fa885b8bab863a0f8dab"}},"sourceBranch":"main","suggestedTargetBranches":["8.4"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->