### PR TITLE
[Security Solution] Removes duplicated code from `tasks/api_calls/timelines.ts` 

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
@@ -13,7 +13,7 @@ import {
 } from '../../objects/timeline';
 
 import { TIMELINE_TEMPLATES_URL } from '../../urls/navigation';
-import { createTimeline } from '../../tasks/api_calls/timelines';
+import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
 import { cleanKibana } from '../../tasks/common';
 
 describe('Export timelines', () => {
@@ -23,7 +23,7 @@ describe('Export timelines', () => {
       method: 'POST',
       path: '/api/timeline/_export?file_name=timelines_export.ndjson',
     }).as('export');
-    createTimeline(getTimelineTemplate(), 'template').then((response) => {
+    createTimelineTemplate(getTimelineTemplate()).then((response) => {
       cy.wrap(response).as('templateResponse');
       cy.wrap(response.body.data.persistTimeline.timeline.savedObjectId).as('templateId');
     });

--- a/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
@@ -13,7 +13,7 @@ import {
 } from '../../objects/timeline';
 
 import { TIMELINE_TEMPLATES_URL } from '../../urls/navigation';
-import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
+import { createTimeline } from '../../tasks/api_calls/timelines';
 import { cleanKibana } from '../../tasks/common';
 
 describe('Export timelines', () => {
@@ -23,7 +23,7 @@ describe('Export timelines', () => {
       method: 'POST',
       path: '/api/timeline/_export?file_name=timelines_export.ndjson',
     }).as('export');
-    createTimelineTemplate(getTimelineTemplate()).then((response) => {
+    createTimeline(getTimelineTemplate(), 'template').then((response) => {
       cy.wrap(response).as('templateResponse');
       cy.wrap(response.body.data.persistTimeline.timeline.savedObjectId).as('templateId');
     });

--- a/x-pack/plugins/security_solution/cypress/e2e/timelines/creation.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timelines/creation.cy.ts
@@ -23,7 +23,7 @@ import {
   EDIT_TIMELINE_BTN,
   EDIT_TIMELINE_TOOLTIP,
 } from '../../screens/timeline';
-import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
+import { createTimeline } from '../../tasks/api_calls/timelines';
 
 import { cleanKibana, deleteTimelines } from '../../tasks/common';
 import { login, visit, visitWithoutDateRange } from '../../tasks/login';
@@ -48,7 +48,7 @@ import { OVERVIEW_URL, TIMELINE_TEMPLATES_URL } from '../../urls/navigation';
 describe('Create a timeline from a template', () => {
   before(() => {
     deleteTimelines();
-    createTimelineTemplate(getTimeline());
+    createTimeline(getTimeline(), 'template');
     visitWithoutDateRange(TIMELINE_TEMPLATES_URL);
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/timelines/creation.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timelines/creation.cy.ts
@@ -23,7 +23,7 @@ import {
   EDIT_TIMELINE_BTN,
   EDIT_TIMELINE_TOOLTIP,
 } from '../../screens/timeline';
-import { createTimeline } from '../../tasks/api_calls/timelines';
+import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
 
 import { cleanKibana, deleteTimelines } from '../../tasks/common';
 import { login, visit, visitWithoutDateRange } from '../../tasks/login';
@@ -48,7 +48,7 @@ import { OVERVIEW_URL, TIMELINE_TEMPLATES_URL } from '../../urls/navigation';
 describe('Create a timeline from a template', () => {
   before(() => {
     deleteTimelines();
-    createTimeline(getTimeline(), 'template');
+    createTimelineTemplate(getTimeline());
     visitWithoutDateRange(TIMELINE_TEMPLATES_URL);
   });
 

--- a/x-pack/plugins/security_solution/cypress/objects/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/timeline.ts
@@ -147,6 +147,8 @@ export const expectedExportedTimeline = (timelineResponse: Cypress.Response<Time
     updated: timelineBody.updated,
     updatedBy: 'elastic',
     timelineType: 'default',
+    templateTimelineId: null,
+    templateTimelineVersion: null,
     sort: [],
     eventNotes: [],
     globalNotes: [],

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
@@ -7,7 +7,10 @@
 
 import type { CompleteTimeline } from '../../objects/timeline';
 
-export const createTimeline = (timeline: CompleteTimeline) =>
+export const createTimeline = (
+  timeline: CompleteTimeline,
+  timelineType: 'default' | 'template' = 'default'
+) =>
   cy.request({
     method: 'POST',
     url: 'api/timeline',
@@ -45,56 +48,11 @@ export const createTimeline = (timeline: CompleteTimeline) =>
         },
         description: timeline.description,
         title: timeline.title,
+        timelineType,
         savedQueryId: null,
         ...(timeline.dataViewId != null && timeline.indexNames != null
           ? { dataViewId: timeline.dataViewId, indexNames: timeline.indexNames }
           : {}),
-      },
-    },
-    headers: { 'kbn-xsrf': 'cypress-creds' },
-  });
-
-export const createTimelineTemplate = (timeline: CompleteTimeline) =>
-  cy.request({
-    method: 'POST',
-    url: 'api/timeline',
-    body: {
-      timeline: {
-        columns: [
-          {
-            id: '@timestamp',
-          },
-          {
-            id: 'user.name',
-          },
-          {
-            id: 'event.category',
-          },
-          {
-            id: 'event.action',
-          },
-          {
-            id: 'host.name',
-          },
-        ],
-        kqlMode: 'filter',
-        kqlQuery: {
-          filterQuery: {
-            kuery: {
-              expression: timeline.query,
-              kind: 'kuery',
-            },
-          },
-        },
-        dateRange: {
-          end: '1577881376000',
-          start: '1514809376000',
-        },
-        description: timeline.description,
-        title: timeline.title,
-        templateTimelineVersion: 1,
-        timelineType: 'template',
-        savedQueryId: null,
       },
     },
     headers: { 'kbn-xsrf': 'cypress-creds' },

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
@@ -7,52 +7,69 @@
 
 import type { CompleteTimeline } from '../../objects/timeline';
 
-export const createTimeline = (
-  timeline: CompleteTimeline,
-  timelineType: 'default' | 'template' = 'default'
-) =>
+const timelineBody = (timeline: CompleteTimeline) => {
+  return {
+    columns: [
+      {
+        id: '@timestamp',
+      },
+      {
+        id: 'user.name',
+      },
+      {
+        id: 'event.category',
+      },
+      {
+        id: 'event.action',
+      },
+      {
+        id: 'host.name',
+      },
+    ],
+    kqlMode: 'filter',
+    kqlQuery: {
+      filterQuery: {
+        kuery: {
+          expression: timeline.query,
+          kind: 'kuery',
+        },
+      },
+    },
+    dateRange: {
+      end: '2022-04-01T12:22:56.000Z',
+      start: '2018-01-01T12:22:56.000Z',
+    },
+    description: timeline.description,
+    title: timeline.title,
+    savedQueryId: null,
+    ...(timeline.dataViewId != null && timeline.indexNames != null
+      ? { dataViewId: timeline.dataViewId, indexNames: timeline.indexNames }
+      : {}),
+  };
+};
+
+export const createTimeline = (timeline: CompleteTimeline) =>
   cy.request({
     method: 'POST',
     url: 'api/timeline',
     body: {
       timeline: {
-        columns: [
-          {
-            id: '@timestamp',
-          },
-          {
-            id: 'user.name',
-          },
-          {
-            id: 'event.category',
-          },
-          {
-            id: 'event.action',
-          },
-          {
-            id: 'host.name',
-          },
-        ],
-        kqlMode: 'filter',
-        kqlQuery: {
-          filterQuery: {
-            kuery: {
-              expression: timeline.query,
-              kind: 'kuery',
-            },
-          },
-        },
-        dateRange: {
-          end: '2022-04-01T12:22:56.000Z',
-          start: '2018-01-01T12:22:56.000Z',
-        },
-        description: timeline.description,
-        title: timeline.title,
-        timelineType,
-        savedQueryId: null,
-        ...(timeline.dataViewId != null && timeline.indexNames != null
-          ? { dataViewId: timeline.dataViewId, indexNames: timeline.indexNames }
-          : {}),
+        ...timelineBody(timeline),
+        timelineType: 'default',
+      },
+    },
+    headers: { 'kbn-xsrf': 'cypress-creds' },
+  });
+
+export const createTimelineTemplate = (timeline: CompleteTimeline) =>
+  cy.request({
+    method: 'POST',
+    url: 'api/timeline',
+    body: {
+      timeline: {
+        ...timelineBody(timeline),
+        timelineType: 'template',
+        templateTimelineVersion: 1,
       },
     },
     headers: { 'kbn-xsrf': 'cypress-creds' },


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
