### PR TITLE
[Security Solution][Investigations] - Return beta tag to process ancestry

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo, useCallback, useEffect, useState } from 'react';
-import { EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiBetaBadge, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 
 import type { DataProvider } from '../../../../../common/types';
 import { TimelineId } from '../../../../../common/types/timeline';
@@ -23,6 +23,7 @@ import {
   PROCESS_ANCESTRY_EMPTY,
   PROCESS_ANCESTRY_ERROR,
 } from './translations';
+import { BETA } from '../../../translations';
 
 interface Props {
   data: TimelineEventsDetailsItem;
@@ -109,6 +110,7 @@ export const RelatedAlertsByProcessAncestry = React.memo<Props>(
         }
         renderContent={renderContent}
         onToggle={onToggle}
+        extraAction={<EuiBetaBadge size="s" label={BETA} color="subdued" />}
       />
     );
   }

--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
@@ -98,6 +98,8 @@ export const RelatedAlertsByProcessAncestry = React.memo<Props>(
       );
     }, [showContent, cache, data, eventId, timelineId, index, originalDocumentId]);
 
+    const betaBadge = useMemo(() => <EuiBetaBadge size="s" label={BETA} color="subdued" />, []);
+
     return (
       <InsightAccordion
         prefix="RelatedAlertsByProcessAncestry"
@@ -110,7 +112,7 @@ export const RelatedAlertsByProcessAncestry = React.memo<Props>(
         }
         renderContent={renderContent}
         onToggle={onToggle}
-        extraAction={<EuiBetaBadge size="s" label={BETA} color="subdued" />}
+        extraAction={betaBadge}
       />
     );
   }


### PR DESCRIPTION
## Summary

This PR re-introduces the beta label tag to the insights by process ancestry accordion. Temporarily addresses https://github.com/elastic/kibana/issues/141949 until a new pattern is implemented in 8.6 for investigating multiple id's within timeline.

<img width="711" alt="image" src="https://user-images.githubusercontent.com/17211684/195107609-b1cfb6c0-8284-404c-8df8-6036607d9d8f.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->