### PR TITLE
[8.5] [XY] Fixes the detailed tooltip wrap problem (#142818)

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
+++ b/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
@@ -6,12 +6,14 @@
   padding: $euiSizeS;
 
   table {
+    table-layout: fixed;
+    width: 100%;
+
     td,
     th {
       text-align: left;
       padding: $euiSizeXS;
       overflow-wrap: break-word;
-      word-wrap: break-word;
     }
   }
 }
@@ -22,10 +24,13 @@
   }
 }
 
+.detailedTooltip__labelContainer {
+  max-width: $euiSizeXL * 5;
+}
+
 .detailedTooltip__labelContainer,
 .detailedTooltip__valueContainer {
   overflow-wrap: break-word;
-  word-wrap: break-word;
 }
 
 .detailedTooltip__label {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[XY] Fixes the detailed tooltip wrap problem (#142818)](https://github.com/elastic/kibana/pull/142818)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2022-10-10T07:27:29Z","message":"[XY] Fixes the detailed tooltip wrap problem (#142818)\n\n* [XY] Fixes the detailed tooltip wrap problem\r\n\r\n* Add max width to the label container\r\n\r\n* Apply PR comments","sha":"d7924aa7507bdc4ca3b514bfedd470f333512931","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:XYAxis","Team:VisEditors","backport:skip","v8.6.0"],"number":142818,"url":"https://github.com/elastic/kibana/pull/142818","mergeCommit":{"message":"[XY] Fixes the detailed tooltip wrap problem (#142818)\n\n* [XY] Fixes the detailed tooltip wrap problem\r\n\r\n* Add max width to the label container\r\n\r\n* Apply PR comments","sha":"d7924aa7507bdc4ca3b514bfedd470f333512931"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/142818","number":142818,"mergeCommit":{"message":"[XY] Fixes the detailed tooltip wrap problem (#142818)\n\n* [XY] Fixes the detailed tooltip wrap problem\r\n\r\n* Add max width to the label container\r\n\r\n* Apply PR comments","sha":"d7924aa7507bdc4ca3b514bfedd470f333512931"}}]}] BACKPORT-->