### PR TITLE
[Enterprise Search] Adds inference pipeline errors to index pipelines tab

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/pipelines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/pipelines.ts
@@ -34,3 +34,9 @@ export interface MlInferenceHistoryItem {
 export interface MlInferenceHistoryResponse {
   history: MlInferenceHistoryItem[];
 }
+
+export interface MlInferenceError {
+  message: string;
+  doc_count: number;
+  timestamp: string | undefined; // Date string
+}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_ml_inference_pipeline_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_ml_inference_pipeline_errors.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MlInferenceError } from '../../../../../common/types/pipelines';
+import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface FetchMlInferenceErrorsApiLogicArgs {
+  indexName: string;
+}
+export interface FetchMlInferenceErrorsApiLogicResponse {
+  errors: MlInferenceError[];
+}
+
+export const fetchMlInferenceErrors = async ({ indexName }: FetchMlInferenceErrorsApiLogicArgs) => {
+  const route = `/internal/enterprise_search/indices/${indexName}/ml_inference/errors`;
+
+  return await HttpLogic.values.http.get<FetchMlInferenceErrorsApiLogicResponse>(route);
+};
+
+export const FetchMlInferenceErrorsApiLogic = createApiLogic(
+  ['fetch_ml_inference_errors_api_logic'],
+  fetchMlInferenceErrors
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiBasicTable, EuiLoadingSpinner } from '@elastic/eui';
+
+import { InferenceErrors } from './inference_errors';
+
+describe('InferenceErrors', () => {
+  const indexName = 'unit-test-index';
+  const defaultValues = {
+    indexName,
+    isLoading: true,
+  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues(defaultValues);
+  });
+  it('renders spinner when loading data', () => {
+    const wrapper = shallow(<InferenceErrors />);
+    expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(1);
+    expect(wrapper.find(EuiBasicTable)).toHaveLength(0);
+  });
+  it('renders expected table columns', () => {
+    setMockValues({
+      ...defaultValues,
+      inferenceErrors: [],
+      isLoading: false,
+    });
+    const wrapper = shallow(<InferenceErrors />);
+    expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(0);
+    expect(wrapper.find(EuiBasicTable)).toHaveLength(1);
+    const table = wrapper.find(EuiBasicTable);
+    expect(table.prop('columns')).toEqual([
+      {
+        dataType: 'date',
+        field: 'timestamp',
+        name: expect.any(String),
+      },
+      {
+        dataType: 'string',
+        field: 'message',
+        name: expect.any(String),
+        textOnly: true,
+        width: '70%',
+      },
+      {
+        dataType: 'number',
+        field: 'doc_count',
+        name: expect.any(String),
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.test.tsx
@@ -40,6 +40,7 @@ describe('InferenceErrors', () => {
     expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(0);
     expect(wrapper.find(EuiBasicTable)).toHaveLength(1);
     const table = wrapper.find(EuiBasicTable);
+    expect(table.prop('tableLayout')).toEqual('auto');
     expect(table.prop('columns')).toEqual([
       {
         dataType: 'date',
@@ -51,7 +52,6 @@ describe('InferenceErrors', () => {
         field: 'message',
         name: expect.any(String),
         textOnly: true,
-        width: '70%',
       },
       {
         dataType: 'number',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
@@ -43,7 +43,6 @@ export const InferenceErrors: React.FC = () => {
         { defaultMessage: 'Inference error' }
       ),
       textOnly: true,
-      width: '70%',
     },
     {
       dataType: 'number',
@@ -77,7 +76,12 @@ export const InferenceErrors: React.FC = () => {
         {isLoading ? (
           <EuiLoadingSpinner />
         ) : (
-          <EuiBasicTable columns={errorsColumns} items={inferenceErrors} rowHeader="message" />
+          <EuiBasicTable
+            tableLayout="auto"
+            columns={errorsColumns}
+            items={inferenceErrors}
+            rowHeader="message"
+          />
         )}
       </DataPanel>
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiBasicTable, EuiBasicTableColumn, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { MlInferenceError } from '../../../../../../common/types/pipelines';
+import { DataPanel } from '../../../../shared/data_panel/data_panel';
+
+import { InferenceErrorsLogic } from './inference_errors_logic';
+
+export const InferenceErrors: React.FC = () => {
+  const { indexName, isLoading, inferenceErrors } = useValues(InferenceErrorsLogic);
+  const { fetchIndexInferenceErrorLogs } = useActions(InferenceErrorsLogic);
+
+  useEffect(() => {
+    fetchIndexInferenceErrorLogs({ indexName });
+  }, [indexName]);
+
+  const errorsColumns: Array<EuiBasicTableColumn<MlInferenceError>> = [
+    {
+      dataType: 'date',
+      field: 'timestamp',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineLogs.tableColumn.timestamp',
+        { defaultMessage: 'Timestamp' }
+      ),
+    },
+    {
+      dataType: 'string',
+      field: 'message',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineLogs.tableColumn.message',
+        { defaultMessage: 'Inference error' }
+      ),
+      textOnly: true,
+      width: '70%',
+    },
+    {
+      dataType: 'number',
+      field: 'doc_count',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineLogs.tableColumn.docCount',
+        { defaultMessage: 'Approx. document count' }
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiSpacer />
+      <DataPanel
+        hasBorder
+        iconType="documents"
+        title={
+          <h2>
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineLogs.title',
+              { defaultMessage: 'Ingestion logs' }
+            )}
+          </h2>
+        }
+        subtitle={i18n.translate(
+          'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineLogs.subtitle',
+          { defaultMessage: 'Errors and dropped data failures' }
+        )}
+      >
+        {isLoading ? (
+          <EuiLoadingSpinner />
+        ) : (
+          <EuiBasicTable columns={errorsColumns} items={inferenceErrors} rowHeader="message" />
+        )}
+      </DataPanel>
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors_logic.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { LogicMounter, mockFlashMessageHelpers } from '../../../../__mocks__/kea_logic';
+
+import { Status } from '../../../../../../common/types/api';
+import { FetchMlInferenceErrorsApiLogic } from '../../../api/pipelines/fetch_ml_inference_pipeline_errors';
+
+import { InferenceErrorsLogic } from './inference_errors_logic';
+
+const DEFAULT_VALUES = {
+  fetchIndexInferenceHistoryStatus: Status.IDLE,
+  indexName: '',
+  inferenceErrors: [],
+  inferenceErrorsData: undefined,
+  isLoading: true,
+};
+
+describe('InferenceErrorsLogic', () => {
+  const { mount } = new LogicMounter(InferenceErrorsLogic);
+  const { mount: mountFetchInferenceErrorsApiLogic } = new LogicMounter(
+    FetchMlInferenceErrorsApiLogic
+  );
+  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mountFetchInferenceErrorsApiLogic();
+    mount();
+  });
+
+  it('has expected default values', () => {
+    expect(InferenceErrorsLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    it('should clear flash errors when fetching data', () => {
+      FetchMlInferenceErrorsApiLogic.actions.makeRequest({ indexName: 'test' });
+      expect(clearFlashMessages).toHaveBeenCalledTimes(1);
+    });
+    it('should flash errors fetching errors', () => {
+      FetchMlInferenceErrorsApiLogic.actions.apiError('error' as any);
+      expect(flashAPIErrors).toHaveBeenCalledWith('error');
+    });
+    it('should load fetched errors', () => {
+      const inferenceErrorsData = {
+        errors: [
+          {
+            doc_count: 10,
+            message: 'I am a stick!',
+            timestamp: '1999-12-31T23:59:59.999Z',
+          },
+        ],
+      };
+      FetchMlInferenceErrorsApiLogic.actions.apiSuccess(inferenceErrorsData);
+      expect(InferenceErrorsLogic.values).toEqual({
+        ...DEFAULT_VALUES,
+        fetchIndexInferenceHistoryStatus: Status.SUCCESS,
+        inferenceErrors: inferenceErrorsData.errors,
+        inferenceErrorsData,
+        isLoading: false,
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors_logic.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { Status } from '../../../../../../common/types/api';
+import { MlInferenceError } from '../../../../../../common/types/pipelines';
+import { Actions } from '../../../../shared/api_logic/create_api_logic';
+import { clearFlashMessages, flashAPIErrors } from '../../../../shared/flash_messages';
+import {
+  FetchMlInferenceErrorsApiLogicArgs,
+  FetchMlInferenceErrorsApiLogicResponse,
+  FetchMlInferenceErrorsApiLogic,
+} from '../../../api/pipelines/fetch_ml_inference_pipeline_errors';
+import { IndexNameLogic } from '../index_name_logic';
+
+interface InferenceErrorsActions {
+  fetchIndexInferenceErrorLogs: Actions<
+    FetchMlInferenceErrorsApiLogicArgs,
+    FetchMlInferenceErrorsApiLogicResponse
+  >['makeRequest'];
+  fetchIndexInferenceErrorLogsError: Actions<
+    FetchMlInferenceErrorsApiLogicArgs,
+    FetchMlInferenceErrorsApiLogicResponse
+  >['apiError'];
+}
+
+interface InferenceErrorsValues {
+  fetchIndexInferenceHistoryStatus: Status;
+  indexName: string;
+  inferenceErrors: MlInferenceError[];
+  inferenceErrorsData: FetchMlInferenceErrorsApiLogicResponse | undefined;
+  isLoading: boolean;
+}
+
+export const InferenceErrorsLogic = kea<
+  MakeLogicType<InferenceErrorsValues, InferenceErrorsActions>
+>({
+  connect: {
+    actions: [
+      FetchMlInferenceErrorsApiLogic,
+      [
+        'makeRequest as fetchIndexInferenceErrorLogs',
+        'apiError as fetchIndexInferenceErrorLogsError',
+      ],
+    ],
+    values: [
+      IndexNameLogic,
+      ['indexName'],
+      FetchMlInferenceErrorsApiLogic,
+      ['data as inferenceErrorsData', 'status as fetchIndexInferenceHistoryStatus'],
+    ],
+  },
+  listeners: () => ({
+    fetchIndexInferenceErrorLogs: () => clearFlashMessages(),
+    fetchIndexInferenceErrorLogsError: (error) => flashAPIErrors(error),
+  }),
+  path: ['enterprise_search', 'content', 'pipelines_inference_errors'],
+  selectors: ({ selectors }) => ({
+    inferenceErrors: [
+      () => [selectors.inferenceErrorsData],
+      (inferenceErrorsData: FetchMlInferenceErrorsApiLogicResponse | undefined) =>
+        inferenceErrorsData?.errors ?? [],
+    ],
+    isLoading: [
+      () => [selectors.fetchIndexInferenceHistoryStatus],
+      (fetchIndexInferenceHistoryStatus: Status) =>
+        fetchIndexInferenceHistoryStatus !== Status.SUCCESS &&
+        fetchIndexInferenceHistoryStatus !== Status.ERROR,
+    ],
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -25,6 +25,7 @@ import { DataPanel } from '../../../../shared/data_panel/data_panel';
 import { docLinks } from '../../../../shared/doc_links';
 import { isApiIndex } from '../../../utils/indices';
 
+import { InferenceErrors } from './inference_errors';
 import { InferenceHistory } from './inference_history';
 import { IngestPipelinesCard } from './ingest_pipelines_card';
 import { AddMLInferencePipelineButton } from './ml_inference/add_ml_inference_button';
@@ -172,6 +173,7 @@ export const SearchIndexPipelines: React.FC = () => {
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
+      <InferenceErrors />
       {showAddMlInferencePipelineModal && (
         <AddMLInferencePipelineModal onClose={closeAddMlInferencePipelineModal} />
       )}

--- a/x-pack/plugins/enterprise_search/server/lib/ml_inference_pipeline/get_inference_errors.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml_inference_pipeline/get_inference_errors.ts
@@ -12,11 +12,7 @@ import {
 
 import { ElasticsearchClient } from '@kbn/core/server';
 
-export interface MlInferenceError {
-  message: string;
-  doc_count: number;
-  timestamp: string | undefined; // Date string
-}
+import { MlInferenceError } from '../../../common/types/pipelines';
 
 export interface ErrorAggregationBucket extends AggregationsStringRareTermsBucketKeys {
   max_error_timestamp: {


### PR DESCRIPTION
## Summary

Added the Ingestion logs panel to the pipelines tab for a search index. This will show up to 20 unique ingestion errors from inference pipelines stored on documents in the index.

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/1972968/195121662-e2600bec-67b7-473a-ae2f-cc2dbd7d2d61.png">
No errors:
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/1972968/195123062-00fe8f8a-a029-4d91-8f24-ee08fcbf3666.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)