### PR TITLE
[Data] [Search] postFlightRequest should accept `disableShardFailureWarning` param

### DIFF
--- a/src/plugins/data/common/search/aggs/agg_type.ts
+++ b/src/plugins/data/common/search/aggs/agg_type.ts
@@ -29,7 +29,8 @@ type PostFlightRequestFn<TAggConfig> = (
   searchSource: ISearchSource,
   inspectorRequestAdapter?: RequestAdapter,
   abortSignal?: AbortSignal,
-  searchSessionId?: string
+  searchSessionId?: string,
+  disableShardFailureWarning?: boolean
 ) => Promise<estypes.SearchResponse<any>>;
 
 export interface AggTypeConfig<

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -333,7 +333,8 @@ export const createOtherBucketPostFlightRequest = (
     searchSource,
     inspectorRequestAdapter,
     abortSignal,
-    searchSessionId
+    searchSessionId,
+    disableShardFailureWarning
   ) => {
     if (!resp.aggregations) return resp;
     const nestedSearchSource = searchSource.createChild();
@@ -347,6 +348,7 @@ export const createOtherBucketPostFlightRequest = (
         nestedSearchSource.fetch$({
           abortSignal,
           sessionId: searchSessionId,
+          disableShardFailureWarning,
           inspector: {
             adapter: inspectorRequestAdapter,
             title: i18n.translate('data.search.aggs.buckets.terms.otherBucketTitle', {

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -511,7 +511,8 @@ export class SearchSource {
             this,
             options.inspector?.adapter,
             options.abortSignal,
-            options.sessionId
+            options.sessionId,
+            options.disableShardFailureWarning
           );
         }
       }


### PR DESCRIPTION
## Summary

In order not to annoy the user with a large number of unnecessary notifications, we must pass the `disableShardFailureWarning` search option set in the parent context to the`postFlightRequest` method 

**Before**: 

https://user-images.githubusercontent.com/20072247/195129526-02cfc6a2-631a-4ba4-b85e-2a984fdca631.mov

**After**: 

<img width="981" alt="image" src="https://user-images.githubusercontent.com/20072247/195129057-5ebd2ceb-3cda-4d1a-9c8e-43fdadded22c.png">



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->