### PR TITLE
[Enterprise Search] Copy and doclink improvements for Index Pipeline settings

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -126,7 +126,6 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       connectorsMongoDB: `${ENTERPRISE_SEARCH_DOCS}connectors-mongodb.html`,
       connectorsMySQL: `${ENTERPRISE_SEARCH_DOCS}connectors-mysql.html`,
       connectorsWorkplaceSearch: `${ENTERPRISE_SEARCH_DOCS}connectors.html#connectors-workplace-search`,
-      contentExtraction: `${ENTERPRISE_SEARCH_DOCS}content-extraction.html`,
       crawlerGettingStarted: `${ENTERPRISE_SEARCH_DOCS}crawler-getting-started.html`,
       crawlerManaging: `${ENTERPRISE_SEARCH_DOCS}crawler-managing.html`,
       crawlerOverview: `${ENTERPRISE_SEARCH_DOCS}crawler.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -111,7 +111,6 @@ export interface DocLinks {
     readonly connectorsMongoDB: string;
     readonly connectorsMySQL: string;
     readonly connectorsWorkplaceSearch: string;
-    readonly contentExtraction: string;
     readonly crawlerGettingStarted: string;
     readonly crawlerManaging: string;
     readonly crawlerOverview: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
@@ -72,6 +72,9 @@ export const Settings: React.FC = () => {
               'Allow all ingestion mechanisms on your Enterprise Search deployment to extract searchable content from binary files, like PDFs and Word documents. This setting applies to all new Elasticsearch indices created by an Enterprise Search ingestion mechanism.',
           }
         )}
+        label={i18n.translate('xpack.enterpriseSearch.content.settings.contactExtraction.label', {
+          defaultMessage: 'Content extraction',
+        })}
         link={
           <EuiLink href={docLinks.contentExtraction} target="_blank">
             {i18n.translate('xpack.enterpriseSearch.content.settings.contactExtraction.link', {
@@ -99,6 +102,9 @@ export const Settings: React.FC = () => {
               'Whitespace reduction will strip your full-text content of whitespace by default.',
           }
         )}
+        label={i18n.translate('xpack.enterpriseSearch.content.settings.whitespaceReduction.label', {
+          defaultMessage: 'Whitespace reduction',
+        })}
         link={
           <EuiLink href="TODO TODO TODO TODO" external>
             {i18n.translate('xpack.enterpriseSearch.content.settings.whitespaceReduction.link', {
@@ -129,6 +135,9 @@ export const Settings: React.FC = () => {
               'ML Inference Pipelines will run as part of your pipelines. You will have to configure processors for each index individually on its pipelines page.',
           }
         )}
+        label={i18n.translate('xpack.enterpriseSearch.content.settings.mlInference.label', {
+          defaultMessage: 'ML Inference',
+        })}
         link={
           <EuiLink href={docLinks.contentExtraction} target="_blank">
             {i18n.translate('xpack.enterpriseSearch.content.settings.mlInference.link', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
@@ -76,7 +76,7 @@ export const Settings: React.FC = () => {
           defaultMessage: 'Content extraction',
         })}
         link={
-          <EuiLink href={docLinks.contentExtraction} target="_blank">
+          <EuiLink href={docLinks.ingestPipelines} target="_blank">
             {i18n.translate('xpack.enterpriseSearch.content.settings.contactExtraction.link', {
               defaultMessage: 'Learn more about content extraction',
             })}
@@ -106,7 +106,7 @@ export const Settings: React.FC = () => {
           defaultMessage: 'Whitespace reduction',
         })}
         link={
-          <EuiLink href="TODO TODO TODO TODO" external>
+          <EuiLink href={docLinks.ingestPipelines} external>
             {i18n.translate('xpack.enterpriseSearch.content.settings.whitespaceReduction.link', {
               defaultMessage: 'Learn more about whitespace reduction',
             })}
@@ -139,7 +139,7 @@ export const Settings: React.FC = () => {
           defaultMessage: 'ML Inference',
         })}
         link={
-          <EuiLink href={docLinks.contentExtraction} target="_blank">
+          <EuiLink href={docLinks.ingestPipelines} target="_blank">
             {i18n.translate('xpack.enterpriseSearch.content.settings.mlInference.link', {
               defaultMessage: 'Learn more about content extraction',
             })}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings_panel.tsx
@@ -20,6 +20,7 @@ import { i18n } from '@kbn/i18n';
 
 interface SettingsPanelProps {
   description: string;
+  label: string;
   link: React.ReactNode;
   onChange: (event: EuiSwitchEvent) => void;
   title: string;
@@ -28,6 +29,7 @@ interface SettingsPanelProps {
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   description,
+  label,
   link,
   onChange,
   title,
@@ -57,13 +59,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     <EuiSplitPanel.Inner grow={false} color="subdued">
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem>
-          <EuiSwitch
-            checked={value}
-            label={i18n.translate('xpack.enterpriseSearch.content.settings.extractBinaryLabel', {
-              defaultMessage: 'Content extraction',
-            })}
-            onChange={onChange}
-          />
+          <EuiSwitch checked={value} label={label} onChange={onChange} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>{link}</EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -61,7 +61,6 @@ class DocLinks {
   public connectorsMongoDB: string;
   public connectorsMySQL: string;
   public connectorsWorkplaceSearch: string;
-  public contentExtraction: string;
   public crawlerGettingStarted: string;
   public crawlerManaging: string;
   public crawlerOverview: string;
@@ -175,7 +174,6 @@ class DocLinks {
     this.connectorsMongoDB = '';
     this.connectorsMySQL = '';
     this.connectorsWorkplaceSearch = '';
-    this.contentExtraction = '';
     this.crawlerGettingStarted = '';
     this.crawlerManaging = '';
     this.crawlerOverview = '';
@@ -291,7 +289,6 @@ class DocLinks {
     this.connectorsMongoDB = docLinks.links.enterpriseSearch.connectorsMongoDB;
     this.connectorsMySQL = docLinks.links.enterpriseSearch.connectorsMySQL;
     this.connectorsWorkplaceSearch = docLinks.links.enterpriseSearch.connectorsWorkplaceSearch;
-    this.contentExtraction = docLinks.links.enterpriseSearch.contentExtraction;
     this.crawlerGettingStarted = docLinks.links.enterpriseSearch.crawlerGettingStarted;
     this.crawlerManaging = docLinks.links.enterpriseSearch.crawlerManaging;
     this.crawlerOverview = docLinks.links.enterpriseSearch.crawlerOverview;


### PR DESCRIPTION
## Summary

- Updates copy for switches on settings panel
- Updates doclinks to use https://www.elastic.co/guide/en/enterprise-search/master/ingest-pipelines.html
- Removes https://www.elastic.co/guide/en/enterprise-search/master/content-extraction.html which was planned for 8.5.0 but is no longer (request by @chriscressman)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->