### PR TITLE
[Synthetics UI] Prefer `custom_heartbeat_id` to `monitor.id` for Uptime detail link when present

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
@@ -118,6 +118,7 @@ export const LastTenTestRuns = () => {
     },
   ];
 
+  const historyIdParam = monitor?.custom_heartbeat_id ?? monitor?.id;
   return (
     <EuiPanel hasShadow={false} hasBorder css={{ minHeight: 200 }}>
       <EuiFlexGroup alignItems="center" gutterSize="s">
@@ -133,7 +134,8 @@ export const LastTenTestRuns = () => {
             iconType="list"
             iconSide="left"
             data-test-subj="monitorSummaryViewLastTestRun"
-            href={`${basePath}/app/uptime/monitor/${btoa(monitor?.id ?? '')}`}
+            disabled={!historyIdParam}
+            href={`${basePath}/app/uptime/monitor/${btoa(historyIdParam ?? '')}`}
           >
             {i18n.translate('xpack.synthetics.monitorDetails.summary.viewHistory', {
               defaultMessage: 'View History',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
@@ -118,7 +118,7 @@ export const LastTenTestRuns = () => {
     },
   ];
 
-  const historyIdParam = monitor?.custom_heartbeat_id ?? monitor?.id;
+  const historyIdParam = monitor?.[ConfigKey.CUSTOM_HEARTBEAT_ID] ?? monitor?.[ConfigKey.ID];
   return (
     <EuiPanel hasShadow={false} hasBorder css={{ minHeight: 200 }}>
       <EuiFlexGroup alignItems="center" gutterSize="s">


### PR DESCRIPTION
## Summary

Resolves #143016.

We link to the Uptime detail link from the Synthetics last 10 runs view. Unfortunately, when there's a custom heartbeat ID, our view is not resilient to this. Uptime UI utilizes the custom ID for its queries, so we need to account for this as long as we are linking to that UI.


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->