### PR TITLE
[8.6] [Kubernetes Security ] Fix Kubernetes  session charts counts

### DIFF
--- a/x-pack/plugins/kubernetes_security/common/constants.ts
+++ b/x-pack/plugins/kubernetes_security/common/constants.ts
@@ -43,6 +43,8 @@ export const COUNT_WIDGET_KEY_PODS = 'CountPodsWidgets';
 export const COUNT_WIDGET_KEY_CONTAINER_IMAGES = 'CountContainerImagesWidgets';
 
 export const DEFAULT_QUERY = '{"bool":{"must":[],"filter":[],"should":[],"must_not":[]}}';
+export const DEFAULT_KUBERNETES_FILTER_QUERY =
+  '{"bool":{"must":[],"filter":[{"bool": {"should": [{"exists": {"field": "orchestrator.cluster.id"}}]}}],"should":[],"must_not":[]}}';
 export const DEFAULT_FILTER_QUERY =
   '{"bool":{"must":[],"filter":[{"bool": {"should": [{"exists": {"field": "process.entry_leader.entity_id"}}]}}],"should":[],"must_not":[]}}';
 export const DEFAULT_FILTER = {

--- a/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/index.tsx
+++ b/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import {
@@ -35,10 +35,11 @@ import {
   COUNT_WIDGET_KEY_NAMESPACE,
   COUNT_WIDGET_KEY_NODES,
   COUNT_WIDGET_KEY_CONTAINER_IMAGES,
+  DEFAULT_KUBERNETES_FILTER_QUERY,
 } from '../../../common/constants';
 import { PercentWidget } from '../percent_widget';
 import { CountWidget } from '../count_widget';
-import { KubernetesSecurityDeps } from '../../types';
+import { GlobalFilter, KubernetesSecurityDeps } from '../../types';
 import { AggregateResult } from '../../../common/types/aggregate';
 import { useLastUpdated } from '../../hooks';
 import { useStyles } from './styles';
@@ -66,6 +67,16 @@ const KubernetesSecurityRoutesComponent = ({
   );
   const styles = useStyles();
   const lastUpdated = useLastUpdated(globalFilter);
+
+  const globalFilterForKubernetes: GlobalFilter = useMemo(() => {
+    return {
+      ...globalFilter,
+      filterQuery: JSON.stringify({
+        ...JSON.parse(globalFilter?.filterQuery ?? ''),
+        ...JSON.parse(DEFAULT_KUBERNETES_FILTER_QUERY),
+      }),
+    };
+  }, [globalFilter]);
 
   const onReduceInteractiveAggs = useCallback(
     (result: AggregateResult): Record<string, number> =>
@@ -125,7 +136,7 @@ const KubernetesSecurityRoutesComponent = ({
                     <CountWidget
                       title={COUNT_WIDGET_CLUSTERS}
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       widgetKey={COUNT_WIDGET_KEY_CLUSTERS}
                       groupedBy={ORCHESTRATOR_CLUSTER_ID}
                     />
@@ -134,7 +145,7 @@ const KubernetesSecurityRoutesComponent = ({
                     <CountWidget
                       title={COUNT_WIDGET_NAMESPACE}
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       widgetKey={COUNT_WIDGET_KEY_NAMESPACE}
                       groupedBy={ORCHESTRATOR_NAMESPACE}
                     />
@@ -143,7 +154,7 @@ const KubernetesSecurityRoutesComponent = ({
                     <CountWidget
                       title={COUNT_WIDGET_NODES}
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       widgetKey={COUNT_WIDGET_KEY_NODES}
                       groupedBy={CLOUD_INSTANCE_NAME}
                     />
@@ -152,7 +163,7 @@ const KubernetesSecurityRoutesComponent = ({
                     <CountWidget
                       title={COUNT_WIDGET_PODS}
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       widgetKey={COUNT_WIDGET_KEY_NODES}
                       groupedBy={ORCHESTRATOR_RESOURCE_ID}
                     />
@@ -161,7 +172,7 @@ const KubernetesSecurityRoutesComponent = ({
                     <CountWidget
                       title={COUNT_WIDGET_CONTAINER_IMAGES}
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       widgetKey={COUNT_WIDGET_KEY_CONTAINER_IMAGES}
                       groupedBy={CONTAINER_IMAGE_NAME}
                     />
@@ -191,7 +202,7 @@ const KubernetesSecurityRoutesComponent = ({
                       }
                       widgetKey="sessionsPercentage"
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       dataValueMap={{
                         true: {
                           name: i18n.translate(
@@ -244,7 +255,7 @@ const KubernetesSecurityRoutesComponent = ({
                       }
                       widgetKey="rootLoginPercentage"
                       indexPattern={indexPattern}
-                      globalFilter={globalFilter}
+                      globalFilter={globalFilterForKubernetes}
                       dataValueMap={{
                         '0': {
                           name: i18n.translate('xpack.kubernetesSecurity.entryUserChart.root', {
@@ -273,7 +284,7 @@ const KubernetesSecurityRoutesComponent = ({
                 <ContainerNameWidget
                   widgetKey="containerNameSessions"
                   indexPattern={indexPattern}
-                  globalFilter={globalFilter}
+                  globalFilter={globalFilterForKubernetes}
                   groupedBy={CONTAINER_IMAGE_NAME}
                   countBy={ENTRY_LEADER_ENTITY_ID}
                 />
@@ -282,7 +293,7 @@ const KubernetesSecurityRoutesComponent = ({
           </>
         )}
         <TreeViewContainer
-          globalFilter={globalFilter}
+          globalFilter={globalFilterForKubernetes}
           renderSessionsView={renderSessionsView}
           indexPattern={indexPattern}
         />


### PR DESCRIPTION
[Kubernetes Dashboard sessions charts data isn't scoping to Kubernetes context](https://github.com/elastic/kibana/issues/142926)
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
This PR adds changes to the default empty `globalFilter.filterQuery` to include the `orchestrator.cluster.id` field which will provide the correct number of sessions and container sessions to the  Kubernetes Security Dashboard.

<img width="1445" alt="image" src="https://user-images.githubusercontent.com/17135495/195231119-4eb6bb16-bd67-4aed-8c70-a57b7347f398.png">



### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
