### PR TITLE
[Lens]Adds selected field accordion to the fields list

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.test.tsx
@@ -690,6 +690,31 @@ describe('FormBased Data Panel', () => {
         }),
       };
     });
+
+    it('should list all selected fields if exist', async () => {
+      const newProps = {
+        ...props,
+        layerFields: ['bytes'],
+      };
+      const wrapper = mountWithIntl(<InnerFormBasedDataPanel {...newProps} />);
+      expect(
+        wrapper
+          .find('[data-test-subj="lnsIndexPatternSelectedFields"]')
+          .find(FieldItem)
+          .map((fieldItem) => fieldItem.prop('field').name)
+      ).toEqual(['bytes']);
+    });
+
+    it('should not list the selected fields accordion if no fields given', async () => {
+      const wrapper = mountWithIntl(<InnerFormBasedDataPanel {...props} />);
+      expect(
+        wrapper
+          .find('[data-test-subj="lnsIndexPatternSelectedFields"]')
+          .find(FieldItem)
+          .map((fieldItem) => fieldItem.prop('field').name)
+      ).toEqual([]);
+    });
+
     it('should list all supported fields in the pattern sorted alphabetically in groups', async () => {
       const wrapper = mountWithIntl(<InnerFormBasedDataPanel {...props} />);
       expect(wrapper.find(FieldItem).first().prop('field').displayName).toEqual('Records');

--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
@@ -62,6 +62,7 @@ export type Props = Omit<
   frame: FramePublicAPI;
   indexPatternService: IndexPatternServiceAPI;
   onIndexPatternRefresh: () => void;
+  layerFields?: string[];
 };
 
 function sortFields(fieldA: IndexPatternField, fieldB: IndexPatternField) {
@@ -144,6 +145,7 @@ export function FormBasedDataPanel({
   frame,
   onIndexPatternRefresh,
   usedIndexPatterns,
+  layerFields,
 }: Props) {
   const { indexPatterns, indexPatternRefs, existingFields, isFirstExistenceFetch } =
     frame.dataViews;
@@ -234,6 +236,7 @@ export function FormBasedDataPanel({
           indexPatternService={indexPatternService}
           onIndexPatternRefresh={onIndexPatternRefresh}
           frame={frame}
+          layerFields={layerFields}
         />
       )}
     </>
@@ -282,6 +285,7 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
   indexPatternService,
   frame,
   onIndexPatternRefresh,
+  layerFields,
 }: Omit<
   DatasourceDataPanelProps,
   'state' | 'setState' | 'showNoDataPopover' | 'core' | 'onChangeIndexPattern' | 'usedIndexPatterns'
@@ -296,6 +300,7 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
   frame: FramePublicAPI;
   indexPatternFieldEditor: IndexPatternFieldEditorStart;
   onIndexPatternRefresh: () => void;
+  layerFields?: string[];
 }) {
   const [localState, setLocalState] = useState<DataPanelState>({
     nameFilter: '',
@@ -345,6 +350,7 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
     const allSupportedTypesFields = allFields.filter((field) =>
       supportedFieldTypes.has(field.type)
     );
+    const usedByLayersFields = allFields.filter((field) => layerFields?.includes(field.name));
     const sorted = allSupportedTypesFields.sort(sortFields);
     const groupedFields = {
       ...defaultFieldGroups,
@@ -371,6 +377,19 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
         showInAccordion: false,
         title: '',
         hideDetails: true,
+      },
+      SelectedFields: {
+        fields: usedByLayersFields,
+        fieldCount: usedByLayersFields.length,
+        isInitiallyOpen: true,
+        showInAccordion: true,
+        title: i18n.translate('xpack.lens.indexPattern.selectedFieldsLabel', {
+          defaultMessage: 'Selected fields',
+        }),
+        isAffectedByGlobalFilter: !!filters.length,
+        isAffectedByTimeFilter: true,
+        hideDetails: false,
+        hideIfEmpty: true,
       },
       AvailableFields: {
         fields: groupedFields.availableFields,
@@ -451,6 +470,7 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
     existenceFetchTimeout,
     currentIndexPattern,
     existingFieldsForIndexPattern,
+    layerFields,
   ]);
 
   const fieldGroups: FieldGroups = useMemo(() => {

--- a/x-pack/plugins/lens/public/datasources/form_based/field_list.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/field_list.tsx
@@ -29,6 +29,7 @@ export type FieldGroups = Record<
     isAffectedByTimeFilter: boolean;
     hideDetails?: boolean;
     defaultNoFieldsMessage?: string;
+    hideIfEmpty?: boolean;
   }
 >;
 
@@ -161,55 +162,58 @@ export const FieldList = React.memo(function FieldList({
           )}
         </ul>
         <EuiSpacer size="s" />
-        {fieldGroupsToShow.map(([key, fieldGroup], index) => (
-          <Fragment key={key}>
-            <FieldsAccordion
-              dropOntoWorkspace={dropOntoWorkspace}
-              hasSuggestionForField={hasSuggestionForField}
-              initialIsOpen={Boolean(accordionState[key])}
-              key={key}
-              id={`lnsIndexPattern${key}`}
-              label={fieldGroup.title}
-              helpTooltip={fieldGroup.helpText}
-              exists={exists}
-              editField={editField}
-              removeField={removeField}
-              hideDetails={fieldGroup.hideDetails}
-              hasLoaded={!!hasSyncedExistingFields}
-              fieldsCount={fieldGroup.fields.length}
-              isFiltered={fieldGroup.fieldCount !== fieldGroup.fields.length}
-              paginatedFields={paginatedFields[key]}
-              fieldProps={fieldProps}
-              groupIndex={index + 1}
-              onToggle={(open) => {
-                setAccordionState((s) => ({
-                  ...s,
-                  [key]: open,
-                }));
-                const displayedFieldLength = getDisplayedFieldsLength(fieldGroups, {
-                  ...accordionState,
-                  [key]: open,
-                });
-                setPageSize(
-                  Math.max(PAGINATION_SIZE, Math.min(pageSize * 1.5, displayedFieldLength))
-                );
-              }}
-              showExistenceFetchError={existenceFetchFailed}
-              showExistenceFetchTimeout={existenceFetchTimeout}
-              renderCallout={
-                <NoFieldsCallout
-                  isAffectedByGlobalFilter={fieldGroup.isAffectedByGlobalFilter}
-                  isAffectedByTimerange={fieldGroup.isAffectedByTimeFilter}
-                  isAffectedByFieldFilter={fieldGroup.fieldCount !== fieldGroup.fields.length}
-                  existFieldsInIndex={!!existFieldsInIndex}
-                  defaultNoFieldsMessage={fieldGroup.defaultNoFieldsMessage}
-                />
-              }
-              uiActions={uiActions}
-            />
-            <EuiSpacer size="m" />
-          </Fragment>
-        ))}
+        {fieldGroupsToShow.map(([key, fieldGroup], index) => {
+          if (Boolean(fieldGroup.hideIfEmpty) && !fieldGroup.fields.length) return null;
+          return (
+            <Fragment key={key}>
+              <FieldsAccordion
+                dropOntoWorkspace={dropOntoWorkspace}
+                hasSuggestionForField={hasSuggestionForField}
+                initialIsOpen={Boolean(accordionState[key])}
+                key={key}
+                id={`lnsIndexPattern${key}`}
+                label={fieldGroup.title}
+                helpTooltip={fieldGroup.helpText}
+                exists={exists}
+                editField={editField}
+                removeField={removeField}
+                hideDetails={fieldGroup.hideDetails}
+                hasLoaded={!!hasSyncedExistingFields}
+                fieldsCount={fieldGroup.fields.length}
+                isFiltered={fieldGroup.fieldCount !== fieldGroup.fields.length}
+                paginatedFields={paginatedFields[key]}
+                fieldProps={fieldProps}
+                groupIndex={index + 1}
+                onToggle={(open) => {
+                  setAccordionState((s) => ({
+                    ...s,
+                    [key]: open,
+                  }));
+                  const displayedFieldLength = getDisplayedFieldsLength(fieldGroups, {
+                    ...accordionState,
+                    [key]: open,
+                  });
+                  setPageSize(
+                    Math.max(PAGINATION_SIZE, Math.min(pageSize * 1.5, displayedFieldLength))
+                  );
+                }}
+                showExistenceFetchError={existenceFetchFailed}
+                showExistenceFetchTimeout={existenceFetchTimeout}
+                renderCallout={
+                  <NoFieldsCallout
+                    isAffectedByGlobalFilter={fieldGroup.isAffectedByGlobalFilter}
+                    isAffectedByTimerange={fieldGroup.isAffectedByTimeFilter}
+                    isAffectedByFieldFilter={fieldGroup.fieldCount !== fieldGroup.fields.length}
+                    existFieldsInIndex={!!existFieldsInIndex}
+                    defaultNoFieldsMessage={fieldGroup.defaultNoFieldsMessage}
+                  />
+                }
+                uiActions={uiActions}
+              />
+              <EuiSpacer size="m" />
+            </Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based.test.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based.test.ts
@@ -298,6 +298,20 @@ describe('IndexPattern Data Source', () => {
     });
   });
 
+  describe('#getSelectedFields', () => {
+    it('should return the fields used per layer', async () => {
+      expect(FormBasedDatasource?.getSelectedFields?.(baseState)).toEqual(['op']);
+    });
+
+    it('should return empty array for empty layers', async () => {
+      const state = {
+        ...baseState,
+        layers: {},
+      };
+      expect(FormBasedDatasource?.getSelectedFields?.(state)).toEqual([]);
+    });
+  });
+
   describe('#toExpression', () => {
     it('should generate an empty expression when no columns are selected', async () => {
       const state = FormBasedDatasource.initialize();

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
@@ -263,11 +263,26 @@ export function getFormBasedDatasource({
       });
     },
 
+    getUsedFields(state) {
+      const fields: string[] = [];
+      Object.values(state?.layers)?.forEach((l) => {
+        const { columns } = l;
+        Object.values(columns).forEach((c) => {
+          if ('sourceField' in c) {
+            fields.push(c.sourceField);
+          }
+        });
+      });
+      return fields;
+    },
+
     toExpression: (state, layerId, indexPatterns) =>
       toExpression(state, layerId, indexPatterns, uiSettings),
 
     renderDataPanel(domElement: Element, props: DatasourceDataPanelProps<FormBasedPrivateState>) {
       const { onChangeIndexPattern, ...otherProps } = props;
+      const layerFields = formBasedDatasource?.getUsedFields?.(props.state);
+
       render(
         <KibanaThemeProvider theme$={core.theme.theme$}>
           <I18nProvider>
@@ -292,6 +307,7 @@ export function getFormBasedDatasource({
                 core={core}
                 uiActions={uiActions}
                 onIndexPatternRefresh={onRefreshIndexPattern}
+                layerFields={layerFields}
               />
             </KibanaContextProvider>
           </I18nProvider>

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
@@ -263,7 +263,7 @@ export function getFormBasedDatasource({
       });
     },
 
-    getUsedFields(state) {
+    getSelectedFields(state) {
       const fields: string[] = [];
       Object.values(state?.layers)?.forEach((l) => {
         const { columns } = l;
@@ -281,7 +281,7 @@ export function getFormBasedDatasource({
 
     renderDataPanel(domElement: Element, props: DatasourceDataPanelProps<FormBasedPrivateState>) {
       const { onChangeIndexPattern, ...otherProps } = props;
-      const layerFields = formBasedDatasource?.getUsedFields?.(props.state);
+      const layerFields = formBasedDatasource?.getSelectedFields?.(props.state);
 
       render(
         <KibanaThemeProvider theme$={core.theme.theme$}>

--- a/x-pack/plugins/lens/public/datasources/text_based/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/datapanel.test.tsx
@@ -216,6 +216,20 @@ describe('TextBased Query Languages Data Panel', () => {
     ).toEqual(['timestamp', 'bytes', 'memory']);
   });
 
+  it('should not display the selected fields accordion if there are no fields displayed', async () => {
+    const wrapper = mountWithIntl(<TextBasedDataPanel {...defaultProps} />);
+    expect(wrapper.find('[data-test-subj="lnsSelectedFieldsTextBased"]').length).toEqual(0);
+  });
+
+  it('should display the selected fields accordion if there are fields displayed', async () => {
+    const props = {
+      ...defaultProps,
+      layerFields: ['memory'],
+    };
+    const wrapper = mountWithIntl(<TextBasedDataPanel {...props} />);
+    expect(wrapper.find('[data-test-subj="lnsSelectedFieldsTextBased"]').length).not.toEqual(0);
+  });
+
   it('should list all supported fields in the pattern that match the search input', async () => {
     const wrapper = mountWithIntl(<TextBasedDataPanel {...defaultProps} />);
     const searchBox = wrapper.find('[data-test-subj="lnsTextBasedLangugesFieldSearch"]');

--- a/x-pack/plugins/lens/public/datasources/text_based/fields_accordion.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/fields_accordion.tsx
@@ -65,6 +65,7 @@ export const FieldsAccordion = memo(function InnerFieldsAccordion({
         id={id}
         buttonContent={renderButton}
         extraAction={extraAction}
+        data-test-subj={id}
       >
         <ul
           className="lnsInnerIndexPatternDataPanel__fieldItems"

--- a/x-pack/plugins/lens/public/datasources/text_based/fields_accordion.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/fields_accordion.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import type { DatatableColumn } from '@kbn/expressions-plugin/public';
+
+import {
+  EuiText,
+  EuiNotificationBadge,
+  EuiAccordion,
+  EuiLoadingSpinner,
+  EuiSpacer,
+} from '@elastic/eui';
+import { FieldButton } from '@kbn/react-field';
+import { DragDrop } from '../../drag_drop';
+import { LensFieldIcon } from '../../shared_components';
+import type { DataType } from '../../types';
+
+export interface FieldsAccordionProps {
+  initialIsOpen: boolean;
+  hasLoaded: boolean;
+  isFiltered: boolean;
+  // forceState: 'open' | 'closed';
+  id: string;
+  label: string;
+  fields: DatatableColumn[];
+}
+
+export const FieldsAccordion = memo(function InnerFieldsAccordion({
+  initialIsOpen,
+  hasLoaded,
+  isFiltered,
+  id,
+  label,
+  fields,
+}: FieldsAccordionProps) {
+  const renderButton = useMemo(() => {
+    return (
+      <EuiText size="xs">
+        <strong>{label}</strong>
+      </EuiText>
+    );
+  }, [label]);
+
+  const extraAction = useMemo(() => {
+    if (hasLoaded) {
+      return (
+        <EuiNotificationBadge size="m" color={isFiltered ? 'accent' : 'subdued'}>
+          {fields.length}
+        </EuiNotificationBadge>
+      );
+    }
+
+    return <EuiLoadingSpinner size="m" />;
+  }, [fields.length, hasLoaded, isFiltered]);
+
+  return (
+    <>
+      <EuiAccordion
+        initialIsOpen={initialIsOpen}
+        id={id}
+        buttonContent={renderButton}
+        extraAction={extraAction}
+      >
+        <ul
+          className="lnsInnerIndexPatternDataPanel__fieldItems"
+          data-test-subj="lnsTextBasedLanguagesPanelFields"
+        >
+          {fields.length > 0 &&
+            fields.map((field, index) => (
+              <li key={field?.name}>
+                <DragDrop
+                  draggable
+                  order={[index]}
+                  value={{
+                    field: field?.name,
+                    id: field.id,
+                    humanData: { label: field?.name },
+                  }}
+                  dataTestSubj={`lnsFieldListPanelField-${field.name}`}
+                >
+                  <FieldButton
+                    className={`lnsFieldItem lnsFieldItem--${field?.meta?.type}`}
+                    isActive={false}
+                    onClick={() => {}}
+                    fieldIcon={<LensFieldIcon type={field?.meta.type as DataType} />}
+                    fieldName={field?.name}
+                  />
+                </DragDrop>
+              </li>
+            ))}
+        </ul>
+      </EuiAccordion>
+      <EuiSpacer size="m" />
+    </>
+  );
+});

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -175,6 +175,20 @@ describe('IndexPattern Data Source', () => {
     });
   });
 
+  describe('#getSelectedFields', () => {
+    it('should return the fields used per layer', async () => {
+      expect(TextBasedDatasource?.getSelectedFields?.(baseState)).toEqual(['Test 1']);
+    });
+
+    it('should return empty array for empty layers', async () => {
+      const state = {
+        ...baseState,
+        layers: {},
+      };
+      expect(TextBasedDatasource?.getSelectedFields?.(state)).toEqual([]);
+    });
+  });
+
   describe('#insertLayer', () => {
     it('should insert an empty layer into the previous state', () => {
       expect(TextBasedDatasource.insertLayer(baseState, 'newLayer')).toEqual({

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -327,14 +327,28 @@ export function getTextBasedDatasource({
     toExpression: (state, layerId, indexPatterns) => {
       return toExpression(state, layerId);
     },
+    getUsedFields(state) {
+      const fields: string[] = [];
+      Object.values(state?.layers)?.forEach((l) => {
+        const { columns } = l;
+        Object.values(columns).forEach((c) => {
+          if ('fieldName' in c) {
+            fields.push(c.fieldName);
+          }
+        });
+      });
+      return fields;
+    },
 
     renderDataPanel(domElement: Element, props: DatasourceDataPanelProps<TextBasedPrivateState>) {
+      const layerFields = TextBasedDatasource?.getUsedFields?.(props.state);
       render(
         <I18nProvider>
           <TextBasedDataPanel
             data={data}
             dataViews={dataViews}
             expressions={expressions}
+            layerFields={layerFields}
             {...props}
           />
         </I18nProvider>,

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -327,7 +327,7 @@ export function getTextBasedDatasource({
     toExpression: (state, layerId, indexPatterns) => {
       return toExpression(state, layerId);
     },
-    getUsedFields(state) {
+    getSelectedFields(state) {
       const fields: string[] = [];
       Object.values(state?.layers)?.forEach((l) => {
         const { columns } = l;
@@ -341,7 +341,7 @@ export function getTextBasedDatasource({
     },
 
     renderDataPanel(domElement: Element, props: DatasourceDataPanelProps<TextBasedPrivateState>) {
-      const layerFields = TextBasedDatasource?.getUsedFields?.(props.state);
+      const layerFields = TextBasedDatasource?.getSelectedFields?.(props.state);
       render(
         <I18nProvider>
           <TextBasedDataPanel

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -282,7 +282,7 @@ export interface Datasource<T = unknown, P = unknown> {
     }
   ) => T;
 
-  getUsedFields?: (state: T) => string[];
+  getSelectedFields?: (state: T) => string[];
 
   renderDataPanel: (
     domElement: Element,

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -282,6 +282,8 @@ export interface Datasource<T = unknown, P = unknown> {
     }
   ) => T;
 
+  getUsedFields?: (state: T) => string[];
+
   renderDataPanel: (
     domElement: Element,
     props: DatasourceDataPanelProps<T>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/141916

Displays a new section "Selected fields" on the fields list for both the formBased and textBased datasources.


### TextBased
- I created 2 accordion groups (available and selected)
- Selected is displayed when there are used fields on the layers
- I added a badge with the fields count on each group (to be aligned with the formBased datasource)
<img width="1907" alt="image" src="https://user-images.githubusercontent.com/17003240/195325328-34779651-d05c-4f9d-9a60-b9c22e659dac.png">

### FormBased
- I added one accordion group "Selected fields"
- Selected is displayed when there are used fields on the layers

<img width="1715" alt="image" src="https://user-images.githubusercontent.com/17003240/195325681-24b0f5df-246c-4f7b-9820-8df5a5eb9164.png">



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)