### PR TITLE
added fleet usage sender that sends hourly usage through EBT

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -19,7 +19,7 @@ import type { PackageUsage } from './package_collectors';
 import { getFleetServerUsage } from './fleet_server_collector';
 import type { FleetServerUsage } from './fleet_server_collector';
 
-interface Usage {
+export interface Usage {
   agents_enabled: boolean;
   agents: AgentUsage;
   packages: PackageUsage[];

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -91,6 +91,7 @@ import type {
   AgentPolicyServiceInterface,
   PackageService,
 } from './services';
+import { FleetUsageSender } from './services';
 import {
   appContextService,
   licenseService,
@@ -100,7 +101,7 @@ import {
   AgentServiceImpl,
   PackageServiceImpl,
 } from './services';
-import { registerFleetUsageCollector } from './collectors/register';
+import { registerFleetUsageCollector, fetchUsage } from './collectors/register';
 import { getAuthzFromRequest, makeRouterWithFleetAuthz } from './routes/security';
 import { FleetArtifactsClient } from './services/artifacts';
 import type { FleetRouter } from './types/request_context';
@@ -217,6 +218,7 @@ export class FleetPlugin
   private readonly telemetryEventsSender: TelemetryEventsSender;
   private readonly fleetStatus$: BehaviorSubject<ServiceStatus>;
   private bulkActionsResolver?: BulkActionsResolver;
+  private fleetUsageSender?: FleetUsageSender;
 
   private agentService?: AgentService;
   private packageService?: PackageService;
@@ -378,6 +380,14 @@ export class FleetPlugin
 
     // Register usage collection
     registerFleetUsageCollector(core, config, deps.usageCollection);
+    const fetch = async () => fetchUsage(core, config);
+    this.fleetUsageSender = new FleetUsageSender(
+      deps.taskManager,
+      core,
+      fetch,
+      this.kibanaVersion,
+      this.isProductionMode
+    );
 
     const router: FleetRouter = core.http.createRouter<FleetRequestHandlerContext>();
     // Allow read-only users access to endpoints necessary for Integrations UI
@@ -444,6 +454,7 @@ export class FleetPlugin
 
     this.telemetryEventsSender.start(plugins.telemetry, core);
     this.bulkActionsResolver?.start(plugins.taskManager);
+    this.fleetUsageSender?.start(plugins.taskManager);
 
     const logger = appContextService.getLogger();
 

--- a/x-pack/plugins/fleet/server/services/fleet_usage_sender.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_usage_sender.ts
@@ -43,9 +43,8 @@ export class FleetUsageSender {
               appContextService.getLogger().info('Running Fleet Usage telemetry send task');
 
               const usageData = await fetchUsage();
+              appContextService.getLogger().debug(JSON.stringify(usageData));
               core.analytics.reportEvent('Fleet Usage', usageData);
-
-              appContextService.getLogger().info('Completed Fleet Usage telemetry send task');
             },
 
             async cancel() {},
@@ -56,7 +55,7 @@ export class FleetUsageSender {
     this.registerTelemetryEventType(core);
 
     core.analytics.registerShipper(FleetShipper, {
-      channelName: 'fleet-usage',
+      channelName: 'fleet-usages',
       version: kibanaVersion,
       sendTo: isProductionMode ? 'production' : 'staging',
     });

--- a/x-pack/plugins/fleet/server/services/fleet_usage_sender.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_usage_sender.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+/* eslint-disable max-classes-per-file */
+import type {
+  ConcreteTaskInstance,
+  TaskManagerStartContract,
+  TaskManagerSetupContract,
+} from '@kbn/task-manager-plugin/server';
+import type { CoreSetup } from '@kbn/core/server';
+
+import { ElasticV3ServerShipper } from '@kbn/analytics-shippers-elastic-v3-server';
+
+import { appContextService } from './app_context';
+
+export class FleetShipper extends ElasticV3ServerShipper {
+  public static shipperName = 'fleet_shipper';
+}
+
+export class FleetUsageSender {
+  private taskManager?: TaskManagerStartContract;
+  private taskId = 'Fleet-Usage-Sender-Task';
+  private taskType = 'Fleet-Usage-Sender';
+
+  constructor(
+    taskManager: TaskManagerSetupContract,
+    core: CoreSetup,
+    fetchUsage: Function,
+    kibanaVersion: string,
+    isProductionMode: boolean
+  ) {
+    taskManager.registerTaskDefinitions({
+      [this.taskType]: {
+        title: 'Fleet Usage Sender',
+        timeout: '1m',
+        maxAttempts: 1,
+        createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
+          return {
+            async run() {
+              appContextService.getLogger().info('Running Fleet Usage telemetry send task');
+
+              const usageData = await fetchUsage();
+              core.analytics.reportEvent('Fleet Usage', usageData);
+
+              appContextService.getLogger().info('Completed Fleet Usage telemetry send task');
+            },
+
+            async cancel() {},
+          };
+        },
+      },
+    });
+    this.registerTelemetryEventType(core);
+
+    core.analytics.registerShipper(FleetShipper, {
+      channelName: 'fleet-usage',
+      version: kibanaVersion,
+      sendTo: isProductionMode ? 'production' : 'staging',
+    });
+  }
+
+  public async start(taskManager: TaskManagerStartContract) {
+    this.taskManager = taskManager;
+
+    appContextService.getLogger().info(`Task ${this.taskId} scheduled with interval 1h`);
+    await this.taskManager?.ensureScheduled({
+      id: this.taskId,
+      taskType: this.taskType,
+      schedule: {
+        interval: '1h',
+      },
+      scope: ['fleet'],
+      state: {},
+      params: {},
+    });
+  }
+
+  /**
+   *  took schema from [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/fleet/server/collectors/register.ts#L53) and adapted to EBT format
+   */
+  private registerTelemetryEventType(core: CoreSetup): void {
+    core.analytics.registerEventType({
+      eventType: 'Fleet Usage',
+      schema: {
+        agents_enabled: { type: 'boolean', _meta: { description: 'agents enabled' } },
+        agents: {
+          properties: {
+            total_enrolled: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled agents, in any state',
+              },
+            },
+            healthy: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled agents in a healthy state',
+              },
+            },
+            unhealthy: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled agents in an unhealthy state',
+              },
+            },
+            updating: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled agents in an updating state',
+              },
+            },
+            offline: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled agents currently offline',
+              },
+            },
+            total_all_statuses: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of agents in any state, both enrolled and inactive',
+              },
+            },
+          },
+        },
+        fleet_server: {
+          properties: {
+            total_enrolled: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled Fleet Server agents, in any state',
+              },
+            },
+            total_all_statuses: {
+              type: 'long',
+              _meta: {
+                description:
+                  'The total number of Fleet Server agents in any state, both enrolled and inactive.',
+              },
+            },
+            healthy: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled Fleet Server agents in a healthy state.',
+              },
+            },
+            unhealthy: {
+              type: 'long',
+              _meta: {
+                description:
+                  'The total number of enrolled Fleet Server agents in an unhealthy state',
+              },
+            },
+            updating: {
+              type: 'long',
+              _meta: {
+                description:
+                  'The total number of enrolled Fleet Server agents in an updating state',
+              },
+            },
+            offline: {
+              type: 'long',
+              _meta: {
+                description: 'The total number of enrolled Fleet Server agents currently offline',
+              },
+            },
+            num_host_urls: {
+              type: 'long',
+              _meta: {
+                description: 'The number of Fleet Server hosts configured in Fleet settings.',
+              },
+            },
+          },
+        },
+        packages: {
+          type: 'array',
+          items: {
+            properties: {
+              name: { type: 'keyword' },
+              version: { type: 'keyword' },
+              enabled: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    });
+  }
+}

--- a/x-pack/plugins/fleet/server/services/index.ts
+++ b/x-pack/plugins/fleet/server/services/index.ts
@@ -62,3 +62,5 @@ export type { PackageService, PackageClient } from './epm';
 
 // Fleet server policy config
 export { migrateSettingsToFleetServerHost } from './fleet_server_host';
+
+export { FleetUsageSender } from './fleet_usage_sender';


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/140909

Added a scheduled task to report Fleet usage telemetry hourly through EBT.
Using a new channel `fleet-usages`.

The published events locally can be visible in Telemetry workbench by querying the last message in this channel.

https://infra.elastic.dev/telemetry/workbench/test/events

https://infra.elastic.dev/api/v1/kpi-engine/fetch-channel-event?channel=fleet-usages

We need a new indexer as well to index the events in telemetry cluster. The format is slightly different than the format sent by kibana telemetry once a day (the fleet usage format is the same).

<img width="839" alt="image" src="https://user-images.githubusercontent.com/90178898/195333885-debe180b-fe66-4a7a-9af8-cdfe7eb4dbf9.png">


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
