### PR TITLE
[TSVB] Do not debounce pointer events

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_types/timeseries/public/application/visualizations/views/timeseries/index.js
@@ -180,6 +180,7 @@ export const TimeSeries = ({
         onElementClick={(args) => handleElementClick(args)}
         animateData={false}
         onPointerUpdate={handleCursorUpdate}
+        pointerUpdateDebounce={0}
         theme={[
           {
             crosshair: {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/14799

I tested around a bit and removing the debounce from the tsvb chart stops the lagging cursor position.

I noticed a related problem with 100+ series breaking the tooltip completely, but the new tooltip implementation should take care of that.