### PR TITLE
[ML] Disable notifications polling for the basic license

### DIFF
--- a/x-pack/plugins/ml/public/application/components/ml_page/side_nav.tsx
+++ b/x-pack/plugins/ml/public/application/components/ml_page/side_nav.tsx
@@ -84,7 +84,13 @@ export function useSideNavItems(activeRoute: MlRoute | undefined) {
           {
             id: 'notifications',
             pathId: ML_PAGES.NOTIFICATIONS,
-            name: <NotificationsIndicator />,
+            name: disableLinks ? (
+              i18n.translate('xpack.ml.navMenu.notificationsTabLinkText', {
+                defaultMessage: 'Notifications',
+              })
+            ) : (
+              <NotificationsIndicator />
+            ),
             disabled: disableLinks,
             testSubj: 'mlMainTab notifications',
           },


### PR DESCRIPTION
Disables notifications polling for the basic license.

FYI this is a quick fix that is only suitable for `8.5.0`.  For the latest `main` some other changes are required because of the  [MlNotificationsContextProvider](https://github.com/elastic/kibana/blob/1d08141e27bd6f3ff834c4239b0f9efa2d04f184/x-pack/plugins/ml/public/application/contexts/ml/ml_notifications_context.tsx#L37) introduced in https://github.com/elastic/kibana/pull/142245. 

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->