### PR TITLE
[Controls] Fix Initialization Race Condition

### DIFF
--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -200,8 +200,7 @@ export class ControlGroupContainer extends Container<
       this.recalculateDataViews();
       this.recalculateFilters();
       this.setupSubscriptions();
-      // set initialized state on next frame to ensure initial filters have been published into output.
-      setTimeout(() => this.initialized$.next(true));
+      this.initialized$.next(true);
     });
   }
 

--- a/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
+++ b/src/plugins/controls/public/control_group/embeddable/control_group_container.tsx
@@ -200,7 +200,8 @@ export class ControlGroupContainer extends Container<
       this.recalculateDataViews();
       this.recalculateFilters();
       this.setupSubscriptions();
-      this.initialized$.next(true);
+      // set initialized state on next frame to ensure initial filters have been published into output.
+      setTimeout(() => this.initialized$.next(true));
     });
   }
 

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -153,7 +153,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       isProjectEnabledInLabs('labs:dashboard:dashboardControls')
     ) {
       this.controlGroup = controlGroup;
-      this.controlGroup.untilReady().then(() => {
+      this.controlGroup.untilInitialized().then(() => {
         if (!this.controlGroup || isErrorEmbeddable(this.controlGroup)) return;
         syncDashboardControlGroup({
           dashboardContainer: this,

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -153,16 +153,13 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       isProjectEnabledInLabs('labs:dashboard:dashboardControls')
     ) {
       this.controlGroup = controlGroup;
-      this.controlGroup.untilInitialized().then(() => {
-        if (!this.controlGroup || isErrorEmbeddable(this.controlGroup)) return;
-        syncDashboardControlGroup({
-          dashboardContainer: this,
-          controlGroup: this.controlGroup,
-        }).then((result) => {
-          if (!result) return;
-          const { onDestroyControlGroup } = result;
-          this.onDestroyControlGroup = onDestroyControlGroup;
-        });
+      syncDashboardControlGroup({
+        dashboardContainer: this,
+        controlGroup: this.controlGroup,
+      }).then((result) => {
+        if (!result) return;
+        const { onDestroyControlGroup } = result;
+        this.onDestroyControlGroup = onDestroyControlGroup;
       });
     }
 

--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
@@ -86,7 +86,9 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
       this.props.controlGroup.render(this.controlsRoot.current);
     }
     if (this.props.controlGroup) {
-      this.props.controlGroup?.untilReady().then(() => this.setState({ controlGroupReady: true }));
+      this.props.controlGroup
+        ?.untilInitialized()
+        .then(() => this.setState({ controlGroupReady: true }));
     }
   }
 

--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
@@ -33,7 +33,6 @@ export interface DashboardViewportProps {
 
 interface State {
   isFullScreenMode: boolean;
-  controlGroupReady: boolean;
   useMargins: boolean;
   title: string;
   description?: string;
@@ -57,7 +56,6 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
     this.controlsRoot = React.createRef();
 
     this.state = {
-      controlGroupReady: !this.props.controlGroup,
       isFullScreenMode,
       panelCount: Object.values(panels).length,
       useMargins,
@@ -84,11 +82,6 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
     });
     if (this.props.controlGroup && this.controlsRoot.current) {
       this.props.controlGroup.render(this.controlsRoot.current);
-    }
-    if (this.props.controlGroup) {
-      this.props.controlGroup
-        ?.untilInitialized()
-        .then(() => this.setState({ controlGroupReady: true }));
     }
   }
 
@@ -166,9 +159,7 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
               <DashboardEmptyScreen isEditMode={isEditMode} />
             </div>
           )}
-          {this.state.controlGroupReady && (
-            <DashboardGrid container={container} onDataLoaded={this.props.onDataLoaded} />
-          )}
+          <DashboardGrid container={container} onDataLoaded={this.props.onDataLoaded} />
         </div>
       </>
     );

--- a/x-pack/test/functional/apps/dashboard/group3/drilldowns/dashboard_to_dashboard_drilldown.ts
+++ b/x-pack/test/functional/apps/dashboard/group3/drilldowns/dashboard_to_dashboard_drilldown.ts
@@ -37,9 +37,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const spaces = getService('spaces');
   const elasticChart = getService('elasticChart');
 
-  // Failing: See https://github.com/elastic/kibana/issues/142913
-  // Failing: See https://github.com/elastic/kibana/issues/142912
-  describe.skip('Dashboard to dashboard drilldown', function () {
+  describe('Dashboard to dashboard drilldown', function () {
     describe('Create & use drilldowns', () => {
       before(async () => {
         log.debug('Dashboard Drilldowns:initTests');


### PR DESCRIPTION
## Summary
Fixes a race condition introduced in https://github.com/elastic/kibana/pull/142868 by forcing the dashboard container to initialize _after_ the control group is finished loading.

Previously, the dashboard viewport and the container would wait until all of the Control children had finished loading before _rendering_, but they would not wait for the control group to finish loading before starting to initialize embeddable children.

This could cause a race condition in cases when the Dashboard's panels loaded too quickly to get the initial filters from the control group.

Fixes https://github.com/elastic/kibana/issues/142912
Fixes https://github.com/elastic/kibana/issues/142913

[Flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1418)



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->