### PR TITLE
[APM] Fix tooltip text

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -140,7 +140,7 @@ export function ServiceOverviewDependenciesTable({
             'xpack.apm.serviceOverview.dependenciesTableTitleTip',
             {
               defaultMessage:
-                'Uninstrumented downstream services or external connections derived from the exit spans of instrumented services.',
+                'Downstream services and external connections to uninstrumented services',
             }
           )}
         >


### PR DESCRIPTION
The tooltip text for Dependencies section is currently incorrect.

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/209966/195457375-9a776d09-2195-4fe5-bc61-7bae50f1b295.png">
