### PR TITLE
[Security Solution] relax metadata + policy response API permissions

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -67,10 +67,10 @@ export function registerEndpointRoutes(
     {
       path: HOST_METADATA_GET_ROUTE,
       validate: GetMetadataRequestSchema,
-      options: { authRequired: true, tags: ['access:securitySolution'] },
+      options: { authRequired: true },
     },
     withEndpointAuthz(
-      { all: ['canReadSecuritySolution'] },
+      { any: ['canReadSecuritySolution', 'canAccessFleet'] },
       logger,
       getMetadataRequestHandler(endpointAppContext, logger)
     )

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -674,7 +674,6 @@ describe('test endpoint routes', () => {
       expect(esSearchMock).toHaveBeenCalledTimes(1);
       expect(routeConfig.options).toEqual({
         authRequired: true,
-        tags: ['access:securitySolution'],
       });
       expect(mockResponse.notFound).toBeCalled();
       const message = mockResponse.notFound.mock.calls[0][0]?.body;
@@ -706,7 +705,6 @@ describe('test endpoint routes', () => {
       expect(esSearchMock).toHaveBeenCalledTimes(1);
       expect(routeConfig.options).toEqual({
         authRequired: true,
-        tags: ['access:securitySolution'],
       });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
@@ -741,7 +739,6 @@ describe('test endpoint routes', () => {
       expect(esSearchMock).toHaveBeenCalledTimes(1);
       expect(routeConfig.options).toEqual({
         authRequired: true,
-        tags: ['access:securitySolution'],
       });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
@@ -778,7 +775,6 @@ describe('test endpoint routes', () => {
       expect(esSearchMock).toHaveBeenCalledTimes(1);
       expect(routeConfig.options).toEqual({
         authRequired: true,
-        tags: ['access:securitySolution'],
       });
       expect(mockResponse.ok).toBeCalled();
       const result = mockResponse.ok.mock.calls[0][0]?.body as HostInfo;
@@ -814,7 +810,37 @@ describe('test endpoint routes', () => {
       expect(mockResponse.badRequest).toBeCalled();
     });
 
-    it('should get forbidden if no security solution access', async () => {
+    it('should work if no security solution access but has fleet access', async () => {
+      const response = legacyMetadataSearchResponseMock(
+        new EndpointDocGenerator().generateHostMetadata()
+      );
+      const mockRequest = httpServerMock.createKibanaRequest({
+        params: { id: response.hits.hits[0]._id },
+      });
+      const esSearchMock = mockScopedClient.asInternalUser.search;
+
+      mockAgentClient.getAgent.mockResolvedValue(agentGenerator.generate({ status: 'online' }));
+      esSearchMock.mockResponseOnce(response);
+
+      [routeConfig, routeHandler] = routerMock.get.mock.calls.find(([{ path }]) =>
+        path.startsWith(HOST_METADATA_GET_ROUTE)
+      )!;
+
+      const contextOverrides = {
+        endpointAuthz: getEndpointAuthzInitialStateMock({
+          canReadSecuritySolution: false,
+        }),
+      };
+      await routeHandler(
+        createRouteHandlerContext(mockScopedClient, mockSavedObjectClient, contextOverrides),
+        mockRequest,
+        mockResponse
+      );
+
+      expect(mockResponse.ok).toBeCalled();
+    });
+
+    it('should get forbidden if no security solution or fleet access', async () => {
       const mockRequest = httpServerMock.createKibanaRequest();
 
       [routeConfig, routeHandler] = routerMock.get.mock.calls.find(([{ path }]) =>
@@ -822,7 +848,10 @@ describe('test endpoint routes', () => {
       )!;
 
       const contextOverrides = {
-        endpointAuthz: getEndpointAuthzInitialStateMock({ canReadSecuritySolution: false }),
+        endpointAuthz: getEndpointAuthzInitialStateMock({
+          canAccessFleet: false,
+          canReadSecuritySolution: false,
+        }),
       };
       await routeHandler(
         createRouteHandlerContext(mockScopedClient, mockSavedObjectClient, contextOverrides),

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
@@ -55,7 +55,7 @@ describe('test policy response handler', () => {
       const response = createSearchResponse(new EndpointDocGenerator().generatePolicyResponse());
       const hostPolicyResponseHandler = getHostPolicyResponseHandler();
 
-      mockScopedClient.asCurrentUser.search.mockResponseOnce(response);
+      mockScopedClient.asInternalUser.search.mockResponseOnce(response);
       const mockRequest = httpServerMock.createKibanaRequest({
         params: { agentId: 'id' },
       });
@@ -78,7 +78,7 @@ describe('test policy response handler', () => {
     it('should return not found when there is no response policy for host', async () => {
       const hostPolicyResponseHandler = getHostPolicyResponseHandler();
 
-      mockScopedClient.asCurrentUser.search.mockResponseOnce(createSearchResponse());
+      mockScopedClient.asInternalUser.search.mockResponseOnce(createSearchResponse());
 
       const mockRequest = httpServerMock.createKibanaRequest({
         params: { agentId: 'id' },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/index.ts
@@ -30,7 +30,7 @@ export function registerPolicyRoutes(router: IRouter, endpointAppContext: Endpoi
       options: { authRequired: true },
     },
     withEndpointAuthz(
-      { all: ['canAccessEndpointManagement'] },
+      { any: ['canReadSecuritySolution', 'canAccessFleet'] },
       logger,
       getHostPolicyResponseHandler()
     )

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/service.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/service.ts
@@ -51,7 +51,7 @@ export async function getPolicyResponseByAgentId(
   dataClient: IScopedClusterClient
 ): Promise<GetHostPolicyResponse | undefined> {
   const query = getESQueryPolicyResponseByAgentID(agentID, index);
-  const response = await dataClient.asCurrentUser.search<HostPolicyResponse>(query);
+  const response = await dataClient.asInternalUser.search<HostPolicyResponse>(query);
 
   if (response.hits.hits.length > 0 && response.hits.hits[0]._source != null) {
     return {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -8,7 +8,6 @@
 import { wrapErrorAndRejectPromise } from '@kbn/security-solution-plugin/common/endpoint/data_loaders/utils';
 import {
   AGENT_POLICY_SUMMARY_ROUTE,
-  BASE_POLICY_RESPONSE_ROUTE,
   GET_PROCESSES_ROUTE,
   ISOLATE_HOST_ROUTE,
   ISOLATE_HOST_ROUTE_V2,
@@ -47,11 +46,6 @@ export default function ({ getService }: FtrProviderContext) {
       {
         method: 'get',
         path: '/api/endpoint/action_log/one?start_date=2021-12-01&end_date=2021-12-04',
-        body: undefined,
-      },
-      {
-        method: 'get',
-        path: `${BASE_POLICY_RESPONSE_ROUTE}?agentId=1`,
         body: undefined,
       },
       {


### PR DESCRIPTION
## Summary

Relax metadata + policy response APIs to allow access with fleet permissions.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
