### PR TITLE
Fix typo in API preview UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
@@ -54,7 +54,7 @@ export function useDevToolsRequest({
           'xpack.fleet.createPackagePolicy.devtoolsRequestWithAgentPolicyDescription',
           {
             defaultMessage:
-              'These Kibana requests creates a new agent policy and a new package policy.',
+              'These Kibana requests create a new agent policy and a new package policy.',
           }
         ),
       ];


### PR DESCRIPTION
## Summary

Fixes a typo in the API preview page (beta) in Kibana.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->