### PR TITLE
[Security Solution] Fix rule details enable/disable toggle isDisabled state

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -30,11 +30,10 @@ import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import type { Dispatch } from 'redux';
 import { isTab } from '@kbn/timelines-plugin/public';
 import type { DataViewListItem } from '@kbn/data-views-plugin/common';
-import { tableDefaults } from '../../../../../common/store/data_table/defaults';
-import { dataTableActions, dataTableSelectors } from '../../../../../common/store/data_table';
-import { isMlRule } from '../../../../../../common/machine_learning/helpers';
-import { SecuritySolutionTabNavigation } from '../../../../../common/components/navigation';
-import { InputsModelId } from '../../../../../common/store/inputs/constants';
+
+import { isMlRule } from '../../../../../common/machine_learning/helpers';
+import { SecuritySolutionTabNavigation } from '../../../../common/components/navigation';
+import { InputsModelId } from '../../../../common/store/inputs/constants';
 import {
   useDeepEqualSelector,
   useShallowEqualSelector,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -693,7 +693,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                             !isExistingRule ||
                             !canEditRuleWithActions(rule, hasActionsPrivileges) ||
                             !hasUserCRUDPermission(canUserCRUD) ||
-                            (isMlRule(rule?.type) && !hasMlPermissions && !rule?.enabled)
+                            (isMlRule(rule?.type) && !hasMlPermissions)
                           }
                           enabled={isExistingRule && (rule?.enabled ?? false)}
                           onChange={handleOnChangeEnabledRule}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -30,10 +30,11 @@ import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import type { Dispatch } from 'redux';
 import { isTab } from '@kbn/timelines-plugin/public';
 import type { DataViewListItem } from '@kbn/data-views-plugin/common';
-
-import { isMlRule } from '../../../../../common/machine_learning/helpers';
-import { SecuritySolutionTabNavigation } from '../../../../common/components/navigation';
-import { InputsModelId } from '../../../../common/store/inputs/constants';
+import { tableDefaults } from '../../../../../common/store/data_table/defaults';
+import { dataTableActions, dataTableSelectors } from '../../../../../common/store/data_table';
+import { isMlRule } from '../../../../../../common/machine_learning/helpers';
+import { SecuritySolutionTabNavigation } from '../../../../../common/components/navigation';
+import { InputsModelId } from '../../../../../common/store/inputs/constants';
 import {
   useDeepEqualSelector,
   useShallowEqualSelector,
@@ -693,7 +694,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                             !isExistingRule ||
                             !canEditRuleWithActions(rule, hasActionsPrivileges) ||
                             !hasUserCRUDPermission(canUserCRUD) ||
-                            (!hasMlPermissions && !rule?.enabled)
+                            (isMlRule(rule?.type) && !hasMlPermissions && !rule?.enabled)
                           }
                           enabled={isExistingRule && (rule?.enabled ?? false)}
                           onChange={handleOnChangeEnabledRule}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -80,7 +80,7 @@ const useEnabledColumn = ({ hasCRUDPermissions }: ColumnsProps): TableColumn => 
             isDisabled={
               !canEditRuleWithActions(rule, hasActionsPrivileges) ||
               !hasCRUDPermissions ||
-              (isMlRule(rule.type) && !hasMlPermissions && !rule.enabled)
+              (isMlRule(rule.type) && !hasMlPermissions)
             }
             isLoading={loadingIds.includes(rule.id)}
           />


### PR DESCRIPTION
**Resolves:** [#137149](https://github.com/elastic/kibana/issues/137149)

## Summary

Disables rule details enable/disable toggle for ML rules only under basic license.

Before:

https://user-images.githubusercontent.com/3775283/195514871-f0ccb25e-177d-4b4e-83bc-9c26da1718f0.mov

After:

https://user-images.githubusercontent.com/3775283/195513340-95944c6d-da6d-4ab3-9917-4e03f5791d3a.mov


### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

