### PR TITLE
[Synthetics] Added monitor duration sparkline

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_sparklines.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_sparklines.tsx
@@ -11,7 +11,7 @@ import { ReportTypes, useTheme } from '@kbn/observability-plugin/public';
 import { useParams } from 'react-router-dom';
 import { ClientPluginsStart } from '../../../../../plugin';
 
-export const AvailabilitySparklines = () => {
+export const DurationSparklines = () => {
   const {
     services: {
       observability: { ExploratoryViewEmbeddable },
@@ -32,10 +32,10 @@ export const AvailabilitySparklines = () => {
           {
             seriesType: 'area',
             time: { from: 'now-30d/d', to: 'now' },
-            name: 'Monitor availability',
+            name: 'Monitor duration',
             dataType: 'synthetics',
-            selectedMetricField: 'monitor_availability',
-            reportDefinitions: { 'monitor.id': [monitorId] },
+            selectedMetricField: 'monitor.duration.us',
+            reportDefinitions: { config_id: [monitorId] },
             color: theme.eui.euiColorVis1,
           },
         ]}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+import { DurationSparklines } from './duration_sparklines';
 import { MonitorDurationTrend } from './duration_trend';
 import { StepDurationPanel } from './step_duration_panel';
 import { AvailabilityPanel } from './availability_panel';
@@ -56,7 +57,9 @@ export const MonitorSummary = () => {
               <EuiFlexItem>
                 <DurationPanel />
               </EuiFlexItem>
-              <EuiFlexItem>{/* TODO: Add duration metric sparkline*/}</EuiFlexItem>
+              <EuiFlexItem>
+                <DurationSparklines />
+              </EuiFlexItem>
               <EuiFlexItem>
                 <MonitorErrorsCount />
               </EuiFlexItem>


### PR DESCRIPTION
## Summary

Added monitor duration sparkline

part of https://github.com/elastic/kibana/issues/134204


<img width="1559" alt="image" src="https://user-images.githubusercontent.com/3505601/195571533-7bd8b088-5f82-4b0e-a0d0-4d445c0a66ea.png">
