### PR TITLE
[Security/EBT] Skip `user_id` registration on anonymous pages

### DIFF
--- a/x-pack/plugins/security/public/analytics/analytics_service.test.ts
+++ b/x-pack/plugins/security/public/analytics/analytics_service.test.ts
@@ -34,9 +34,12 @@ describe('AnalyticsService', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 
+    const { analytics, http } = coreMock.createSetup();
+
     analyticsService.setup({
       authc,
-      analytics: coreMock.createSetup().analytics,
+      analytics,
+      http,
       securityLicense: licenseMock.create({ allowLogin: true }),
     });
     analyticsService.start({ http: mockCore.http });
@@ -63,9 +66,12 @@ describe('AnalyticsService', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 
+    const { analytics, http } = coreMock.createSetup();
+
     analyticsService.setup({
       authc,
-      analytics: coreMock.createSetup().analytics,
+      analytics,
+      http,
       securityLicense: licenseMock.create(licenseFeatures$.asObservable()),
     });
     analyticsService.start({ http: mockCore.http });
@@ -116,9 +122,12 @@ describe('AnalyticsService', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 
+    const { analytics, http } = coreMock.createSetup();
+
     analyticsService.setup({
       authc,
-      analytics: coreMock.createSetup().analytics,
+      analytics,
+      http,
       securityLicense: licenseMock.create({ allowLogin: true }),
     });
     analyticsService.start({ http: mockCore.http });
@@ -141,9 +150,12 @@ describe('AnalyticsService', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 
+    const { analytics, http } = coreMock.createSetup();
+
     analyticsService.setup({
       authc,
-      analytics: coreMock.createSetup().analytics,
+      analytics,
+      http,
       securityLicense: licenseMock.create({ allowLogin: false }),
     });
     analyticsService.start({ http: mockCore.http });
@@ -167,9 +179,12 @@ describe('AnalyticsService', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 
+    const { analytics, http } = coreMock.createSetup();
+
     analyticsService.setup({
       authc,
-      analytics: coreMock.createSetup().analytics,
+      analytics,
+      http,
       securityLicense: licenseMock.create({ allowLogin: true }),
     });
     analyticsService.start({ http: mockCore.http });
@@ -183,6 +198,44 @@ describe('AnalyticsService', () => {
     );
     expect(localStorage.getItem(AnalyticsService.AuthTypeInfoStorageKey)).toBe(
       mockCurrentAuthTypeInfo
+    );
+  });
+
+  it('does not register the analytics context provider if the page is anonymous', () => {
+    const authc = authenticationMock.createSetup();
+    const { analytics, http } = coreMock.createSetup();
+
+    http.anonymousPaths.isAnonymous.mockReturnValue(true);
+
+    analyticsService.setup({
+      authc,
+      analytics,
+      http,
+      securityLicense: licenseMock.create({ allowLogin: false }),
+    });
+
+    expect(analytics.registerContextProvider).not.toHaveBeenCalled();
+  });
+
+  it('registers the user_id analytics context provider if the page is anonymous', () => {
+    const authc = authenticationMock.createSetup();
+    authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
+
+    const { analytics, http } = coreMock.createSetup();
+
+    http.anonymousPaths.isAnonymous.mockReturnValue(false);
+
+    analyticsService.setup({
+      authc,
+      analytics,
+      http,
+      securityLicense: licenseMock.create({ allowLogin: false }),
+    });
+
+    expect(analytics.registerContextProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user_id',
+      })
     );
   });
 });

--- a/x-pack/plugins/security/public/analytics/analytics_service.test.ts
+++ b/x-pack/plugins/security/public/analytics/analytics_service.test.ts
@@ -217,7 +217,7 @@ describe('AnalyticsService', () => {
     expect(analytics.registerContextProvider).not.toHaveBeenCalled();
   });
 
-  it('registers the user_id analytics context provider if the page is anonymous', () => {
+  it('registers the user_id analytics context provider if the page is not anonymous', () => {
     const authc = authenticationMock.createSetup();
     authc.getCurrentUser.mockResolvedValue(securityMock.createMockAuthenticatedUser());
 

--- a/x-pack/plugins/security/public/analytics/analytics_service.ts
+++ b/x-pack/plugins/security/public/analytics/analytics_service.ts
@@ -11,6 +11,7 @@ import { throttleTime } from 'rxjs/operators';
 
 import type {
   AnalyticsServiceSetup as CoreAnalyticsServiceSetup,
+  HttpSetup,
   HttpStart,
 } from '@kbn/core/public';
 
@@ -22,6 +23,7 @@ interface AnalyticsServiceSetupParams {
   securityLicense: SecurityLicense;
   analytics: CoreAnalyticsServiceSetup;
   authc: AuthenticationServiceSetup;
+  http: HttpSetup;
   cloudId?: string;
 }
 
@@ -43,9 +45,11 @@ export class AnalyticsService {
   private securityLicense!: SecurityLicense;
   private securityFeaturesSubscription?: Subscription;
 
-  public setup({ analytics, authc, cloudId, securityLicense }: AnalyticsServiceSetupParams) {
+  public setup({ analytics, authc, cloudId, http, securityLicense }: AnalyticsServiceSetupParams) {
     this.securityLicense = securityLicense;
-    registerUserContext(analytics, authc, cloudId);
+    if (http.anonymousPaths.isAnonymous(window.location.pathname) === false) {
+      registerUserContext(analytics, authc, cloudId);
+    }
   }
 
   public start({ http }: AnalyticsServiceStartParams) {

--- a/x-pack/plugins/security/public/plugin.tsx
+++ b/x-pack/plugins/security/public/plugin.tsx
@@ -113,6 +113,7 @@ export class SecurityPlugin
       analytics: core.analytics,
       authc: this.authc,
       cloudId: cloud?.cloudId,
+      http: core.http,
       securityLicense: license,
     });
 


### PR DESCRIPTION
## Summary

We want to avoid registering the context provider `user_id` on anonymous pages because we anticipate they will be undefined.

It's more relevant for our analysis to check when it's `undefined` for non-anonymous pages.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
