### PR TITLE
[Files] Refactor `list` and `find` and improve support for pagination

### DIFF
--- a/x-pack/plugins/files/public/files_client/files_client.ts
+++ b/x-pack/plugins/files/public/files_client/files_client.ts
@@ -102,9 +102,11 @@ export function createFilesClient({
     getById: ({ kind, ...args }) => {
       return http.get(apiRoutes.getByIdRoute(scopedFileKind ?? kind, args.id));
     },
-    list({ kind, page, perPage } = { kind: '' }) {
-      return http.get(apiRoutes.getListRoute(scopedFileKind ?? kind), {
+    list: ({ kind, page, perPage, ...body } = { kind: '' }) => {
+      return http.post(apiRoutes.getListRoute(scopedFileKind ?? kind), {
+        headers: commonBodyHeaders,
         query: { page, perPage },
+        body: JSON.stringify(body),
       });
     },
     update: ({ kind, id, ...body }) => {

--- a/x-pack/plugins/files/server/file_client/file_client.ts
+++ b/x-pack/plugins/files/server/file_client/file_client.ts
@@ -154,12 +154,16 @@ export class FileClientImpl implements FileClient {
     await this.internalUpdate(id, payload);
   }
 
-  public async find<M = unknown>(arg: P1<FileMetadataClient['find']>): Promise<Array<File<M>>> {
-    return this.metadataClient
-      .find(arg)
-      .then((r) =>
-        r.map(({ id, metadata }) => this.instantiateFile(id, metadata as FileMetadata<M>))
-      );
+  public async find<M = unknown>(
+    arg: P1<FileMetadataClient['find']>
+  ): Promise<{ files: File[]; total: number }> {
+    const result = await this.metadataClient.find(arg);
+    return {
+      total: result.total,
+      files: result.files.map(({ id, metadata }) =>
+        this.instantiateFile(id, metadata as FileMetadata<M>)
+      ),
+    };
   }
 
   public async delete({ id, hasContent = true }: DeleteArgs) {
@@ -191,16 +195,6 @@ export class FileClientImpl implements FileClient {
   public deleteContent: BlobStorageClient['delete'] = (arg) => {
     return this.blobStorageClient.delete(arg);
   };
-
-  public async list(
-    arg?: P1<FileMetadataClient['list']>
-  ): Promise<{ files: File[]; total: number }> {
-    const result = await this.metadataClient.list(arg);
-    return {
-      total: result.total,
-      files: result.files.map(({ id, metadata }) => this.instantiateFile(id, metadata)),
-    };
-  }
 
   /**
    * Upload a blob

--- a/x-pack/plugins/files/server/file_client/file_client.ts
+++ b/x-pack/plugins/files/server/file_client/file_client.ts
@@ -192,10 +192,14 @@ export class FileClientImpl implements FileClient {
     return this.blobStorageClient.delete(arg);
   };
 
-  public async list(arg?: P1<FileMetadataClient['list']>): Promise<File[]> {
-    return this.metadataClient
-      .list(arg)
-      .then((r) => r.map(({ id, metadata }) => this.instantiateFile(id, metadata)));
+  public async list(
+    arg?: P1<FileMetadataClient['list']>
+  ): Promise<{ files: File[]; total: number }> {
+    const result = await this.metadataClient.list(arg);
+    return {
+      total: result.total,
+      files: result.files.map(({ id, metadata }) => this.instantiateFile(id, metadata)),
+    };
   }
 
   /**

--- a/x-pack/plugins/files/server/file_client/file_metadata_client/file_metadata_client.ts
+++ b/x-pack/plugins/files/server/file_client/file_metadata_client/file_metadata_client.ts
@@ -72,21 +72,6 @@ export interface DeleteArg {
   id: string;
 }
 
-export interface ListArg extends Pagination {
-  /**
-   * The file kind to scope this query to
-   */
-  fileKind?: string;
-
-  /**
-   * An string to filter against searchable values
-   */
-  filter?: {
-    name?: string;
-    status?: string;
-  };
-}
-
 export interface FindArg extends Pagination {
   /**
    * The file kind to scope this query to
@@ -125,17 +110,11 @@ export interface FileMetadataClient {
    */
   delete(arg: DeleteArg): Promise<void>;
   /**
-   * List all instances of metadata for a file kind.
-   *
-   * @param arg - Arguments to list file metadata
-   */
-  list(arg?: ListArg): Promise<{ total: number; files: FileDescriptor[] }>;
-  /**
    * Search for a set of file kind instances that match the filters.
    *
    * @param arg - Filters and other settings to match against
    */
-  find(arg: FindFileArgs): Promise<FileDescriptor[]>;
+  find(arg?: FindFileArgs): Promise<{ total: number; files: FileDescriptor[] }>;
   /**
    * Prepare a set of metrics based on the file metadata.
    *

--- a/x-pack/plugins/files/server/file_client/file_metadata_client/file_metadata_client.ts
+++ b/x-pack/plugins/files/server/file_client/file_metadata_client/file_metadata_client.ts
@@ -77,6 +77,14 @@ export interface ListArg extends Pagination {
    * The file kind to scope this query to
    */
   fileKind?: string;
+
+  /**
+   * An string to filter against searchable values
+   */
+  filter?: {
+    name?: string;
+    status?: string;
+  };
 }
 
 export interface FindArg extends Pagination {
@@ -121,7 +129,7 @@ export interface FileMetadataClient {
    *
    * @param arg - Arguments to list file metadata
    */
-  list(arg?: ListArg): Promise<FileDescriptor[]>;
+  list(arg?: ListArg): Promise<{ total: number; files: FileDescriptor[] }>;
   /**
    * Search for a set of file kind instances that match the filters.
    *

--- a/x-pack/plugins/files/server/file_client/file_metadata_client/index.ts
+++ b/x-pack/plugins/files/server/file_client/file_metadata_client/index.ts
@@ -12,7 +12,6 @@ export type {
   FindArg as FindMetadataArg,
   GetArg as GetMetadataArg,
   GetUsageMetricsArgs,
-  ListArg as ListMetadataArg,
   UpdateArgs as UpdateMetadataArg,
 } from './file_metadata_client';
 export { SavedObjectsFileMetadataClient, EsIndexFilesMetadataClient } from './adapters';

--- a/x-pack/plugins/files/server/file_client/index.ts
+++ b/x-pack/plugins/files/server/file_client/index.ts
@@ -13,7 +13,6 @@ export type {
   FindMetadataArg,
   GetMetadataArg,
   GetUsageMetricsArgs,
-  ListMetadataArg,
   UpdateMetadataArg,
 } from './file_metadata_client';
 export { FileClientImpl } from './file_client';

--- a/x-pack/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
+++ b/x-pack/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
@@ -106,7 +106,7 @@ describe('ES-index-backed file client', () => {
     await file3.uploadContent(Readable.from(['test']));
 
     {
-      const results = await fileClient.find({
+      const { files: results } = await fileClient.find({
         status: ['READY'],
         meta: { test: '3' },
       });
@@ -121,7 +121,7 @@ describe('ES-index-backed file client', () => {
     }
 
     {
-      const results = await fileClient.find({
+      const { files: results } = await fileClient.find({
         status: ['READY', 'AWAITING_UPLOAD'],
       });
 
@@ -178,7 +178,7 @@ describe('ES-index-backed file client', () => {
       },
     });
 
-    const { files } = await fileClient.list();
+    const { files } = await fileClient.find();
 
     expect(files).toHaveLength(1);
     expect(files[0].toJSON()).toEqual(

--- a/x-pack/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
+++ b/x-pack/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
@@ -178,10 +178,10 @@ describe('ES-index-backed file client', () => {
       },
     });
 
-    const list = await fileClient.list();
+    const { files } = await fileClient.list();
 
-    expect(list).toHaveLength(1);
-    expect(list[0].toJSON()).toEqual(
+    expect(files).toHaveLength(1);
+    expect(files[0].toJSON()).toEqual(
       expect.objectContaining({
         id: '123',
         fileKind: 'none',

--- a/x-pack/plugins/files/server/file_client/types.ts
+++ b/x-pack/plugins/files/server/file_client/types.ts
@@ -94,18 +94,11 @@ export interface FileClient {
   delete(arg: DeleteArgs): Promise<void>;
 
   /**
-   * See {@link FileMetadataClient.list}
-   *
-   * @param arg - Argument to list files
-   */
-  list(arg?: P1<FileMetadataClient['list']>): Promise<{ files: File[]; total: number }>;
-
-  /**
    * See {@link FileMetadataClient.find}.
    *
    * @param arg - Argument to find files
    */
-  find: (arg: P1<FileMetadataClient['find']>) => Promise<File[]>;
+  find: (arg?: P1<FileMetadataClient['find']>) => Promise<{ files: File[]; total: number }>;
 
   /**
    * Create a file share instance for this file.

--- a/x-pack/plugins/files/server/file_client/types.ts
+++ b/x-pack/plugins/files/server/file_client/types.ts
@@ -98,7 +98,7 @@ export interface FileClient {
    *
    * @param arg - Argument to list files
    */
-  list(arg?: P1<FileMetadataClient['list']>): Promise<File[]>;
+  list(arg?: P1<FileMetadataClient['list']>): Promise<{ files: File[]; total: number }>;
 
   /**
    * See {@link FileMetadataClient.find}.

--- a/x-pack/plugins/files/server/file_service/file_action_types.ts
+++ b/x-pack/plugins/files/server/file_service/file_action_types.ts
@@ -73,6 +73,20 @@ export interface ListFilesArgs extends Pagination {
    * File kind, must correspond to a registered {@link FileKind}.
    */
   fileKind: string;
+
+  /**
+   * Optional filter
+   */
+  filter?: {
+    /**
+     * Filter for names matching
+     */
+    name?: string;
+    /**
+     * Filter for file statuses
+     */
+    status?: string;
+  };
 }
 
 /**

--- a/x-pack/plugins/files/server/file_service/file_action_types.ts
+++ b/x-pack/plugins/files/server/file_service/file_action_types.ts
@@ -66,30 +66,6 @@ export interface DeleteFileArgs {
 }
 
 /**
- * Arguments list files.
- */
-export interface ListFilesArgs extends Pagination {
-  /**
-   * File kind, must correspond to a registered {@link FileKind}.
-   */
-  fileKind: string;
-
-  /**
-   * Optional filter
-   */
-  filter?: {
-    /**
-     * Filter for names matching
-     */
-    name?: string;
-    /**
-     * Filter for file statuses
-     */
-    status?: string;
-  };
-}
-
-/**
  * Arguments to get a file by ID.
  */
 export interface GetByIdArgs {

--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -62,7 +62,7 @@ export interface FileServiceStart {
    *
    * @param args - list files args
    */
-  list<M>(args: ListFilesArgs): Promise<Array<File<M>>>;
+  list<M>(args: ListFilesArgs): Promise<{ files: Array<File<M>>; total: number }>;
 
   /**
    * Get an instance of a share object

--- a/x-pack/plugins/files/server/file_service/file_service.ts
+++ b/x-pack/plugins/files/server/file_service/file_service.ts
@@ -5,14 +5,13 @@
  * 2.0.
  */
 
-import type { FileJSON, FilesMetrics, File } from '../../common';
+import type { FilesMetrics, File, FileJSON } from '../../common';
 import type { FileShareServiceStart } from '../file_share_service/types';
 import type {
   CreateFileArgs,
   UpdateFileArgs,
   DeleteFileArgs,
   GetByIdArgs,
-  ListFilesArgs,
   FindFileArgs,
 } from './file_action_types';
 
@@ -55,14 +54,7 @@ export interface FileServiceStart {
    *
    * @param args - find files args
    */
-  find<M>(args: FindFileArgs): Promise<Array<FileJSON<M>>>;
-
-  /**
-   * List all files of specific file kind.
-   *
-   * @param args - list files args
-   */
-  list<M>(args: ListFilesArgs): Promise<{ files: Array<File<M>>; total: number }>;
+  find<M>(args: FindFileArgs): Promise<{ files: Array<FileJSON<M>>; total: number }>;
 
   /**
    * Get an instance of a share object

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -19,13 +19,7 @@ import { fileObjectType, fileShareObjectType, hiddenTypes } from '../saved_objec
 import { BlobStorageService } from '../blob_storage_service';
 import { FileClientImpl } from '../file_client/file_client';
 import { InternalFileShareService } from '../file_share_service';
-import {
-  CreateFileArgs,
-  FindFileArgs,
-  GetByIdArgs,
-  ListFilesArgs,
-  UpdateFileArgs,
-} from './file_action_types';
+import { CreateFileArgs, FindFileArgs, GetByIdArgs, UpdateFileArgs } from './file_action_types';
 import { InternalFileService } from './internal_file_service';
 import { FileServiceStart } from './file_service';
 import { FileKindsRegistry } from '../../common/file_kinds_registry';
@@ -105,10 +99,10 @@ export class FileServiceFactoryImpl implements FileServiceFactory {
         return internalFileService.getById(args) as Promise<File<M>>;
       },
       async find<M>(args: FindFileArgs) {
-        return internalFileService.findFilesJSON(args) as Promise<Array<FileJSON<M>>>;
-      },
-      async list<M>(args: ListFilesArgs) {
-        return internalFileService.list(args) as Promise<{ files: Array<File<M>>; total: number }>;
+        return internalFileService.findFilesJSON(args) as Promise<{
+          files: Array<FileJSON<M>>;
+          total: number;
+        }>;
       },
       async getUsageMetrics() {
         return internalFileService.getUsageMetrics();

--- a/x-pack/plugins/files/server/file_service/file_service_factory.ts
+++ b/x-pack/plugins/files/server/file_service/file_service_factory.ts
@@ -108,7 +108,7 @@ export class FileServiceFactoryImpl implements FileServiceFactory {
         return internalFileService.findFilesJSON(args) as Promise<Array<FileJSON<M>>>;
       },
       async list<M>(args: ListFilesArgs) {
-        return internalFileService.list(args) as Promise<Array<File<M>>>;
+        return internalFileService.list(args) as Promise<{ files: Array<File<M>>; total: number }>;
       },
       async getUsageMetrics() {
         return internalFileService.getUsageMetrics();

--- a/x-pack/plugins/files/server/file_service/index.ts
+++ b/x-pack/plugins/files/server/file_service/index.ts
@@ -11,7 +11,6 @@ export type {
   DeleteFileArgs,
   FindFileArgs,
   GetByIdArgs,
-  ListFilesArgs,
   UpdateFileArgs,
 } from './file_action_types';
 export type { FileServiceStart } from './file_service';

--- a/x-pack/plugins/files/server/file_service/internal_file_service.ts
+++ b/x-pack/plugins/files/server/file_service/internal_file_service.ts
@@ -92,15 +92,22 @@ export class InternalFileService {
     fileKind: fileKindId,
     page = 1,
     perPage = 100,
-  }: ListFilesArgs): Promise<IFile[]> {
+    filter,
+  }: ListFilesArgs): Promise<{ files: IFile[]; total: number }> {
     const fileKind = this.getFileKind(fileKindId);
     const result = await this.metadataClient.list({
       fileKind: fileKind.id,
       page,
       perPage,
+      filter,
     });
     const fileClient = this.createFileClient(fileKind.id);
-    return result.map((file) => this.toFile(file.id, file.metadata, fileKind.id, fileClient));
+    return {
+      files: result.files.map((file) =>
+        this.toFile(file.id, file.metadata, fileKind.id, fileClient)
+      ),
+      total: result.total,
+    };
   }
 
   public getFileKind(id: string): FileKind {

--- a/x-pack/plugins/files/server/index.ts
+++ b/x-pack/plugins/files/server/index.ts
@@ -13,7 +13,6 @@ export type {
   FileDescriptor,
   GetMetadataArg,
   FindMetadataArg,
-  ListMetadataArg,
   UpdateMetadataArg,
   DeleteMetedataArg,
   FileMetadataClient,
@@ -35,7 +34,6 @@ export type {
 export type {
   GetByIdArgs,
   FindFileArgs,
-  ListFilesArgs,
   CreateFileArgs,
   DeleteFileArgs,
   UpdateFileArgs,

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -99,7 +99,7 @@ describe('FileService', () => {
   }
   afterEach(async () => {
     await Promise.all(disposables.map((file) => file.delete()));
-    const { files } = await fileService.list({ fileKind });
+    const { files } = await fileService.find({ kind: [fileKind] });
     expect(files.length).toBe(0);
     disposables = [];
   });
@@ -146,7 +146,7 @@ describe('FileService', () => {
       createDisposableFile({ fileKind, name: 'test-3' }),
       createDisposableFile({ fileKind, name: 'test-3' /* Also test file with same name */ }),
     ]);
-    const result = await fileService.list({ fileKind });
+    const result = await fileService.find({ kind: [fileKind] });
     expect(result.files.length).toBe(4);
   });
 
@@ -158,9 +158,9 @@ describe('FileService', () => {
       createDisposableFile({ fileKind, name: 'test-3' }),
     ]);
     {
-      const { files, total } = await fileService.list({
-        fileKind,
-        filter: { name: 'foo*' },
+      const { files, total } = await fileService.find({
+        kind: [fileKind],
+        name: ['foo*'],
         perPage: 2,
         page: 1,
       });
@@ -169,9 +169,9 @@ describe('FileService', () => {
     }
 
     {
-      const { files, total } = await fileService.list({
-        fileKind,
-        filter: { name: 'foo*' },
+      const { files, total } = await fileService.find({
+        kind: [fileKind],
+        name: ['foo*'],
         perPage: 2,
         page: 2,
       });
@@ -182,10 +182,10 @@ describe('FileService', () => {
 
   it('deletes files', async () => {
     const file = await fileService.create({ fileKind, name: 'test' });
-    const result = await fileService.list({ fileKind });
+    const result = await fileService.find({ kind: [fileKind] });
     expect(result.files.length).toBe(1);
     await file.delete();
-    expect(await fileService.list({ fileKind })).toEqual({ files: [], total: 0 });
+    expect(await fileService.find({ kind: [fileKind] })).toEqual({ files: [], total: 0 });
   });
 
   interface CustomMeta {

--- a/x-pack/plugins/files/server/integration_tests/file_service.test.ts
+++ b/x-pack/plugins/files/server/integration_tests/file_service.test.ts
@@ -99,8 +99,8 @@ describe('FileService', () => {
   }
   afterEach(async () => {
     await Promise.all(disposables.map((file) => file.delete()));
-    const results = await fileService.list({ fileKind });
-    expect(results.length).toBe(0);
+    const { files } = await fileService.list({ fileKind });
+    expect(files.length).toBe(0);
     disposables = [];
   });
 
@@ -147,15 +147,45 @@ describe('FileService', () => {
       createDisposableFile({ fileKind, name: 'test-3' /* Also test file with same name */ }),
     ]);
     const result = await fileService.list({ fileKind });
-    expect(result.length).toBe(4);
+    expect(result.files.length).toBe(4);
+  });
+
+  it('lists files and filters', async () => {
+    await Promise.all([
+      createDisposableFile({ fileKind, name: 'foo-1' }),
+      createDisposableFile({ fileKind, name: 'foo-2' }),
+      createDisposableFile({ fileKind, name: 'foo-3' }),
+      createDisposableFile({ fileKind, name: 'test-3' }),
+    ]);
+    {
+      const { files, total } = await fileService.list({
+        fileKind,
+        filter: { name: 'foo*' },
+        perPage: 2,
+        page: 1,
+      });
+      expect(files.length).toBe(2);
+      expect(total).toBe(3);
+    }
+
+    {
+      const { files, total } = await fileService.list({
+        fileKind,
+        filter: { name: 'foo*' },
+        perPage: 2,
+        page: 2,
+      });
+      expect(files.length).toBe(1);
+      expect(total).toBe(3);
+    }
   });
 
   it('deletes files', async () => {
     const file = await fileService.create({ fileKind, name: 'test' });
-    const files = await fileService.list({ fileKind });
-    expect(files.length).toBe(1);
+    const result = await fileService.list({ fileKind });
+    expect(result.files.length).toBe(1);
     await file.delete();
-    expect(await fileService.list({ fileKind })).toEqual([]);
+    expect(await fileService.list({ fileKind })).toEqual({ files: [], total: 0 });
   });
 
   interface CustomMeta {

--- a/x-pack/plugins/files/server/mocks.ts
+++ b/x-pack/plugins/files/server/mocks.ts
@@ -17,7 +17,6 @@ export const createFileServiceMock = (): DeeplyMockedKeys<FileServiceStart> => (
   getByToken: jest.fn(),
   getShareObject: jest.fn(),
   getUsageMetrics: jest.fn(),
-  list: jest.fn(),
   listShareObjects: jest.fn(),
   update: jest.fn(),
   updateShareObject: jest.fn(),

--- a/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
@@ -110,14 +110,17 @@ describe('File kind HTTP API', () => {
 
     const {
       body: { files },
-    } = await request.post(root, `/api/files/files/${fileKind}/list`).expect(200);
+    } = await request.post(root, `/api/files/files/${fileKind}/list`).send({}).expect(200);
 
     expect(files).toHaveLength(nrOfFiles);
     expect(files[0]).toEqual(expect.objectContaining({ name: 'test' }));
 
     const {
       body: { files: files2 },
-    } = await request.post(root, `/api/files/files/${fileKind}/list?page=1&perPage=5`).expect(200);
+    } = await request
+      .post(root, `/api/files/files/${fileKind}/list?page=1&perPage=5`)
+      .send({})
+      .expect(200);
     expect(files2).toHaveLength(5);
   });
 

--- a/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/integration_tests/file_kind_http.test.ts
@@ -110,14 +110,14 @@ describe('File kind HTTP API', () => {
 
     const {
       body: { files },
-    } = await request.get(root, `/api/files/files/${fileKind}/list`).expect(200);
+    } = await request.post(root, `/api/files/files/${fileKind}/list`).expect(200);
 
     expect(files).toHaveLength(nrOfFiles);
     expect(files[0]).toEqual(expect.objectContaining({ name: 'test' }));
 
     const {
       body: { files: files2 },
-    } = await request.get(root, `/api/files/files/${fileKind}/list?page=1&perPage=5`).expect(200);
+    } = await request.post(root, `/api/files/files/${fileKind}/list?page=1&perPage=5`).expect(200);
     expect(files2).toHaveLength(5);
   });
 

--- a/x-pack/plugins/files/server/routes/file_kind/list.ts
+++ b/x-pack/plugins/files/server/routes/file_kind/list.ts
@@ -8,15 +8,24 @@ import { schema } from '@kbn/config-schema';
 import type { FileJSON, FileKind } from '../../../common/types';
 import { CreateRouteDefinition, FILES_API_ROUTES } from '../api_routes';
 import type { CreateHandler, FileKindRouter } from './types';
+import {
+  stringOrArrayOfStrings,
+  nameStringOrArrayOfNameStrings,
+  toArrayOrUndefined,
+} from '../find';
 
-export const method = 'get' as const;
+export const method = 'post' as const;
 
 const rt = {
+  body: schema.object({
+    status: schema.maybe(stringOrArrayOfStrings),
+    extension: schema.maybe(stringOrArrayOfStrings),
+    name: schema.maybe(nameStringOrArrayOfNameStrings),
+    meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+  }),
   query: schema.object({
-    page: schema.maybe(schema.number({ defaultValue: 1 })),
+    page: schema.maybe(schema.number()),
     perPage: schema.maybe(schema.number({ defaultValue: 100 })),
-    status: schema.maybe(schema.string()),
-    name: schema.maybe(schema.string()),
   }),
 };
 
@@ -27,16 +36,19 @@ export type Endpoint<M = unknown> = CreateRouteDefinition<
 
 export const handler: CreateHandler<Endpoint> = async ({ files, fileKind }, req, res) => {
   const {
-    query: { page, perPage, status, name },
+    body: { name, status, extension, meta },
+    query: { page, perPage },
   } = req;
   const { fileService } = await files;
-  const response = await fileService
-    .asCurrentUser()
-    .list({ fileKind, page, perPage, filter: { status, name } });
-  const body: Endpoint['output'] = {
-    total: response.total,
-    files: response.files.map((result) => result.toJSON()),
-  };
+  const body: Endpoint['output'] = await fileService.asCurrentUser().find({
+    kind: [fileKind],
+    name: toArrayOrUndefined(name),
+    status: toArrayOrUndefined(status),
+    extension: toArrayOrUndefined(extension),
+    page,
+    perPage,
+    meta,
+  });
   return res.ok({ body });
 };
 


### PR DESCRIPTION
## Summary

When using UI components, like the file picker, it would be best to paginate and filter on the server side. The initial implementation of the list endpoint was not providing adequate functionality for this:

* Need a way to filter out files based on status
* Need a way to filter out files based on name
* Need to report the number of total hits, without necessarily returning everything (used for pagination)

This PR also removes the "list" method from the `FileServiceStart` interface because it is functionality identical to the "find" method.

## What changed

Used to return:

```
{ files: FileJSON[] }
```

Now we return

```
{ files: FileJSON[], total: number }
```

And take as arguments (this is the same as `find`):

`status` - the file status to filter for
`name` - a wildcard-able version of a name to filter by
`meta` - an object that will be used to look up values against consumer provided metadata
`extension` - filter against file extensions

The difference between `list` and `find` as endpoints is that `list` will always be scoped to a file kind and a specific app, whereas `find` will be a management API that is global (related https://github.com/elastic/kibana/pull/143274). Both endpoints use the same code under the hood now, so a bunch of code was deleted.

## Checks

- [x] Functional tests were added/updated


Blocks: https://github.com/elastic/kibana/pull/143111