### PR TITLE
[Lens] Add automatic = insertion on equal comparison typing when in Formula

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
@@ -41,6 +41,8 @@ import {
   getTokenInfo,
   offsetToRowColumn,
   monacoPositionToOffset,
+  createEditOperation,
+  MARKER,
 } from './math_completion';
 import { LANGUAGE_ID } from './math_tokenization';
 import { MemoizedFormulaHelp } from './formula_help';
@@ -84,6 +86,8 @@ export const WrappedFormulaEditor = ({
 };
 
 const MemoizedFormulaEditor = React.memo(FormulaEditor);
+
+const namedArgumentsTypes = new Set(['kql', 'lucene', 'shift', 'reducedTimeRange']);
 
 export function FormulaEditor({
   layer,
@@ -533,47 +537,44 @@ export function FormulaEditor({
           const isSingleQuoteCase = /'LENS_MATH_MARKER/;
           // Make sure that we are only adding kql='' or lucene='', and also
           // check that the = sign isn't inside the KQL expression like kql='='
-          if (
-            !tokenInfo ||
-            typeof tokenInfo.ast === 'number' ||
-            tokenInfo.ast.type !== 'namedArgument' ||
-            (tokenInfo.ast.name !== 'kql' &&
-              tokenInfo.ast.name !== 'lucene' &&
-              tokenInfo.ast.name !== 'shift' &&
-              tokenInfo.ast.name !== 'reducedTimeRange') ||
-            (tokenInfo.ast.value !== 'LENS_MATH_MARKER' &&
-              !isSingleQuoteCase.test(tokenInfo.ast.value))
-          ) {
-            return;
+          if (tokenInfo) {
+            if (
+              typeof tokenInfo.ast === 'number' ||
+              tokenInfo.ast.type !== 'namedArgument' ||
+              !namedArgumentsTypes.has(tokenInfo.ast.name) ||
+              (tokenInfo.ast.value !== MARKER && !isSingleQuoteCase.test(tokenInfo.ast.value))
+            ) {
+              return;
+            }
           }
 
           let editOperation: monaco.editor.IIdentifiedSingleEditOperation | null = null;
+
           const cursorOffset = 2;
           if (char === '=') {
-            editOperation = {
-              range: {
-                ...currentPosition,
-                // Insert after the current char
-                startColumn: currentPosition.startColumn + 1,
-                endColumn: currentPosition.startColumn + 1,
-              },
-              text: `''`,
-            };
+            // check also the previous char whether it was already a =
+            // to avoid infinite loops
+            if (!tokenInfo && currentText.charAt(offset - 1) !== '=') {
+              editOperation = createEditOperation('=', currentPosition, 1);
+            }
+            if (tokenInfo) {
+              editOperation = createEditOperation(`''`, currentPosition, 1);
+            }
           }
+
+          if (!tokenInfo && !editOperation) {
+            return;
+          }
+
           if (
             char === "'" &&
+            tokenInfo?.ast &&
+            typeof tokenInfo.ast !== 'number' &&
+            'name' in tokenInfo.ast &&
             tokenInfo.ast.name !== 'shift' &&
             tokenInfo.ast.name !== 'reducedTimeRange'
           ) {
-            editOperation = {
-              range: {
-                ...currentPosition,
-                // Insert after the current char
-                startColumn: currentPosition.startColumn,
-                endColumn: currentPosition.startColumn + 1,
-              },
-              text: `\\'`,
-            };
+            editOperation = createEditOperation(`\\'`, currentPosition);
           }
 
           if (editOperation) {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.ts
@@ -61,7 +61,7 @@ function inLocation(cursorPosition: number, location: TinymathLocation) {
   return cursorPosition >= location.min && cursorPosition < location.max;
 }
 
-const MARKER = 'LENS_MATH_MARKER';
+export const MARKER = 'LENS_MATH_MARKER';
 
 export function getInfoAtZeroIndexedPosition(
   ast: TinymathAST,
@@ -91,6 +91,23 @@ export function getInfoAtZeroIndexedPosition(
   return {
     ast,
     parent,
+  };
+}
+
+export function createEditOperation(
+  textToInject: string,
+  currentPosition: monaco.IRange,
+  startOffset: number = 0,
+  endOffset: number = 1
+) {
+  return {
+    range: {
+      ...currentPosition,
+      // Insert after the current char
+      startColumn: currentPosition.startColumn + startOffset,
+      endColumn: currentPosition.startColumn + endOffset,
+    },
+    text: textToInject,
   };
 }
 


### PR DESCRIPTION
## Summary

Follow up from #142325

This PR adds the automatic insertion of a second `=` when the user types within a comparison block:

![eq_autocomplete](https://user-images.githubusercontent.com/924948/195618401-483e0589-291e-4732-91c5-a959c15f6317.gif)

As shown in the gif there's no conflict with other named arguments/parameters and it won't work for fields (as they are not valid in that context).

Because the injected char is now equal to the trigger one, there's the potential of an infinite loop, which is prevented by looking at the previous char (try to remove the previous char part from the code to see the issue):

![eq_autocomplete_edge](https://user-images.githubusercontent.com/924948/195618577-693f0ed2-118e-4100-8de7-d17ac940da22.gif)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
