### PR TITLE
[Fleet] Only show fleet managed data streams on data streams list page

### DIFF
--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -59,8 +59,16 @@ export const getListHandler: RequestHandler = async (context, request, response)
       getPackageSavedObjects(savedObjects.client),
     ]);
 
-    const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(dataStreamsInfo, 'name');
-    const dataStreamsStatsByName = keyBy(dataStreamStats, 'data_stream');
+    const filteredDataStreamsInfo = dataStreamsInfo.filter(
+      (ds) => ds?._meta?.managed_by === 'fleet'
+    );
+
+    const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');
+
+    const filteredDataStreamsStats = dataStreamStats.filter(
+      (dss) => !!dataStreamsInfoByName[dss.data_stream]
+    );
+    const dataStreamsStatsByName = keyBy(filteredDataStreamsStats, 'data_stream');
 
     // Combine data stream info
     const dataStreams = merge(dataStreamsInfoByName, dataStreamsStatsByName);


### PR DESCRIPTION
## Summary

Closes #123569

Only return data stream info for fleet managed data streams. 

I have updated the test data for the integration tests to cover this behaviour. 

Manual test steps:

- create a data stream doc which follows the data stream naming scheme and is not managed by fleet:

```
      POST /metrics-not_fleet.somedata-default/_doc
      {
          "@timestamp": "2022-01-01",
          "data_stream": {
            "dataset": "not_fleet.somedata",
            "namespace": "default",
            "type": "metrics"
          }
        }
 ```

- view the data streams tab `/app/fleet/data-streams`, this stream should not be visible. Whereas previously we had something like:

<img width="1281" alt="Screenshot 2022-10-13 at 17 09 27" src="https://user-images.githubusercontent.com/3315046/195649237-9f4d3eaf-4df8-4e13-a062-b7b0f0d500c4.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios