### PR TITLE
[Synthetics] Rely on refresh context to update status panel

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_status.tsx
@@ -9,8 +9,13 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiStat, EuiTitle } fro
 import { i18n } from '@kbn/i18n';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { clearOverviewStatusErrorAction, selectOverviewStatus } from '../../../../state';
+import {
+  clearOverviewStatusErrorAction,
+  fetchOverviewStatusAction,
+  selectOverviewStatus,
+} from '../../../../state';
 import { kibanaService } from '../../../../../../utils/kibana_service';
+import { useSyntheticsRefreshContext } from '../../../../contexts';
 
 function title(t?: number) {
   return t ?? '-';
@@ -19,6 +24,12 @@ function title(t?: number) {
 export function OverviewStatus() {
   const { status, statusError } = useSelector(selectOverviewStatus);
   const dispatch = useDispatch();
+
+  const { lastRefresh } = useSyntheticsRefreshContext();
+
+  useEffect(() => {
+    dispatch(fetchOverviewStatusAction.get());
+  }, [dispatch, lastRefresh]);
 
   useEffect(() => {
     if (statusError) {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -14,7 +14,6 @@ import { useEnablement } from '../../../hooks';
 import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 import {
   fetchMonitorOverviewAction,
-  fetchOverviewStatusAction,
   selectOverviewState,
   selectServiceLocationsState,
 } from '../../../state';
@@ -53,7 +52,6 @@ export const OverviewPage: React.FC = () => {
 
   useEffect(() => {
     dispatch(fetchMonitorOverviewAction.get(pageState));
-    dispatch(fetchOverviewStatusAction.get());
   }, [dispatch, pageState]);
 
   const {


### PR DESCRIPTION
## Summary

We previously intended for the overview status panel on the Synthetics Overview page to refresh at the same time as the cards in the monitor list update. The functionality of how the cards fresh is not as simple to access as I anticipated, so we are moving a dedicated dispatch for data back into the component itself, and referencing the refresh context to trigger updates to the count.

## Testing this PR

I am going to trigger a cloud deployment for this PR. You should be able to log in and add/edit monitors for multiple locations. Disable them, make some monitors that are down, and ensure the totals expressed in the status panel are aligned with your expectations.