### PR TITLE
[Lens] Avoid additional chunk load during dashboard load time

### DIFF
--- a/x-pack/plugins/lens/public/async_services.ts
+++ b/x-pack/plugins/lens/public/async_services.ts
@@ -43,3 +43,5 @@ export * from './embeddable';
 export * from './app_plugin/mounter';
 export * from './lens_attribute_service';
 export * from './app_plugin/save_modal_container';
+
+export * from './trigger_actions/open_in_discover_helpers';

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_action.ts
@@ -17,7 +17,7 @@ interface Context {
   embeddable: IEmbeddable;
 }
 
-export const getDiscoverHelpersAsync = async () => await import('./open_in_discover_helpers');
+export const getDiscoverHelpersAsync = async () => await import('../async_services');
 
 export const createOpenInDiscoverAction = (
   discover: Pick<DiscoverStart, 'locator'>,

--- a/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_in_discover_drilldown.tsx
@@ -30,7 +30,7 @@ interface EmbeddableQueryInput extends EmbeddableInput {
   timeRange?: TimeRange;
 }
 
-export const getDiscoverHelpersAsync = async () => await import('./open_in_discover_helpers');
+export const getDiscoverHelpersAsync = async () => await import('../async_services');
 
 /** @internal */
 export type EmbeddableWithQueryInput = IEmbeddable<EmbeddableQueryInput>;


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/142938, to optimize the page load bundle size a new async chunk was introduced. However, this chunk was loaded separately as part of dashboard loading which slowed down the time to a finished rendered chart a bit.

This PR avoid the additional chunk by moving the exports into the central `async_services` module so it's loaded together with the bulk of the Lens functionality once on startup, while preserving the page load size gains