### PR TITLE
[ML] Fix notifications `count` endpoint when no ML entity is present

### DIFF
--- a/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
+++ b/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
@@ -184,7 +184,7 @@ export class NotificationsService {
 
     const res = await Promise.all(
       entityIdsPerType.map(async (v) => {
-        const responseBody = await this.scopedClusterClient.asInternalUser.search<unknown, any>({
+        const responseBody = await this.scopedClusterClient.asInternalUser.search({
           size: 0,
           index: ML_NOTIFICATION_INDEX_PATTERN,
           body: {

--- a/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
+++ b/x-pack/plugins/ml/server/models/notifications_service/notifications_service_provider.ts
@@ -28,6 +28,14 @@ export class NotificationsService {
     private readonly mlSavedObjectService: MLSavedObjectService
   ) {}
 
+  private getDefaultCountResponse() {
+    return {
+      error: 0,
+      warning: 0,
+      info: 0,
+    } as NotificationsCountResponse;
+  }
+
   /**
    * Provides entity IDs per type for the current space.
    * @private
@@ -176,7 +184,7 @@ export class NotificationsService {
 
     const res = await Promise.all(
       entityIdsPerType.map(async (v) => {
-        const responseBody = await this.scopedClusterClient.asInternalUser.search({
+        const responseBody = await this.scopedClusterClient.asInternalUser.search<unknown, any>({
           size: 0,
           index: ML_NOTIFICATION_INDEX_PATTERN,
           body: {
@@ -217,7 +225,11 @@ export class NotificationsService {
           },
         });
 
-        const byLevel = responseBody.aggregations!
+        if (!responseBody.aggregations) {
+          return this.getDefaultCountResponse();
+        }
+
+        const byLevel = responseBody.aggregations
           .by_level as estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringTermsBucketKeys>;
 
         return Array.isArray(byLevel.buckets)
@@ -229,17 +241,14 @@ export class NotificationsService {
       })
     );
 
-    return res.reduce(
-      (acc, curr) => {
-        for (const levelKey in curr) {
-          if (curr.hasOwnProperty(levelKey)) {
-            acc[levelKey as MlNotificationMessageLevel] +=
-              curr[levelKey as MlNotificationMessageLevel];
-          }
+    return res.reduce((acc, curr) => {
+      for (const levelKey in curr) {
+        if (curr.hasOwnProperty(levelKey)) {
+          acc[levelKey as MlNotificationMessageLevel] +=
+            curr[levelKey as MlNotificationMessageLevel];
         }
-        return acc;
-      },
-      { error: 0, warning: 0, info: 0 } as NotificationsCountResponse
-    );
+      }
+      return acc;
+    }, this.getDefaultCountResponse());
   }
 }


### PR DESCRIPTION
## Summary

Fixes the notifications `count` endpoint when no ML entity is present.

![image](https://user-images.githubusercontent.com/5236598/195841405-21860aaa-01b9-4b95-9e52-4061b17cd8aa.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->