### PR TITLE
[Security Solution][Endpoint] Correctly show Host Isolation page for Platinum+ users

### DIFF
--- a/x-pack/plugins/security_solution/public/management/links.test.ts
+++ b/x-pack/plugins/security_solution/public/management/links.test.ts
@@ -44,7 +44,7 @@ describe('links', () => {
       } as unknown as StartPlugins);
   });
 
-  it('it returns all links without filtering when having isolate permissions', async () => {
+  it('it returns all links without filtering when having isolate permission', async () => {
     (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(true);
     fakeHttpServices.get.mockResolvedValue({ total: 0 });
     const filteredLinks = await getManagementFilteredLinks(
@@ -54,7 +54,7 @@ describe('links', () => {
     expect(filteredLinks).toEqual(links);
   });
 
-  it('it returns all but response actions history link when not having isolation permissions but has at least one host isolation exceptions entry', async () => {
+  it('it returns all but response actions history link when NO isolation permission but HAS at least one host isolation exceptions entry', async () => {
     (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
     fakeHttpServices.get.mockResolvedValue({ total: 1 });
     const filteredLinks = await getManagementFilteredLinks(
@@ -67,7 +67,7 @@ describe('links', () => {
     });
   });
 
-  it('it returns all but response actions history when no access privilege to either response actions history or HIE but have at least one HIE entry', async () => {
+  it('it returns all but response actions history when NO access to either response actions history or HIE but HAS at least one HIE entry', async () => {
     fakeHttpServices.get.mockResolvedValue({ total: 1 });
     (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
     const filteredLinks = await getManagementFilteredLinks(
@@ -81,8 +81,10 @@ describe('links', () => {
     });
   });
 
-  it('it returns all but response actions history when no enterprise license', async () => {
+  it('it returns all but response actions history when NO enterprise license and can not isolate but HAS an HIE entry', async () => {
     (licenseService.isEnterprise as jest.Mock).mockReturnValue(false);
+    (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
+    fakeHttpServices.get.mockResolvedValue({ total: 1 });
     const filteredLinks = await getManagementFilteredLinks(
       coreMockStarted,
       getPlugins(['superuser'])
@@ -94,7 +96,25 @@ describe('links', () => {
     });
   });
 
-  it('it returns filtered links when not having isolation permissions and no host isolation exceptions entry', async () => {
+  it('it returns all but response actions history and HIE links when NO enterprise license and no HIE entry', async () => {
+    (licenseService.isEnterprise as jest.Mock).mockReturnValue(false);
+    fakeHttpServices.get.mockResolvedValue({ total: 0 });
+    const filteredLinks = await getManagementFilteredLinks(
+      coreMockStarted,
+      getPlugins(['superuser'])
+    );
+
+    expect(filteredLinks).toEqual({
+      ...links,
+      links: links.links?.filter(
+        (link) =>
+          link.id !== SecurityPageName.hostIsolationExceptions &&
+          link.id !== SecurityPageName.responseActionsHistory
+      ),
+    });
+  });
+
+  it('it returns filtered links when having NO isolation permission and NO host isolation exceptions entry', async () => {
     fakeHttpServices.get.mockResolvedValue({ total: 0 });
     (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
     const filteredLinks = await getManagementFilteredLinks(coreMockStarted, getPlugins([]));

--- a/x-pack/plugins/security_solution/public/management/links.test.ts
+++ b/x-pack/plugins/security_solution/public/management/links.test.ts
@@ -54,23 +54,40 @@ describe('links', () => {
     expect(filteredLinks).toEqual(links);
   });
 
-  it('it returns all links without filtering when not having isolation permissions but has at least one host isolation exceptions entry', async () => {
+  it('it returns all but response actions history link when not having isolation permissions but has at least one host isolation exceptions entry', async () => {
+    (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
     fakeHttpServices.get.mockResolvedValue({ total: 1 });
     const filteredLinks = await getManagementFilteredLinks(
       coreMockStarted,
       getPlugins(['superuser'])
     );
-    (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
-    expect(filteredLinks).toEqual(links);
+    expect(filteredLinks).toEqual({
+      ...links,
+      links: links.links?.filter((link) => link.id !== SecurityPageName.responseActionsHistory),
+    });
   });
 
   it('it returns all but response actions history when no access privilege to either response actions history or HIE but have at least one HIE entry', async () => {
     fakeHttpServices.get.mockResolvedValue({ total: 1 });
+    (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
     const filteredLinks = await getManagementFilteredLinks(
       coreMockStarted,
       getPlugins(['superuser'])
     );
-    (licenseService.isPlatinumPlus as jest.Mock).mockReturnValue(false);
+
+    expect(filteredLinks).toEqual({
+      ...links,
+      links: links.links?.filter((link) => link.id !== SecurityPageName.responseActionsHistory),
+    });
+  });
+
+  it('it returns all but response actions history when no enterprise license', async () => {
+    (licenseService.isEnterprise as jest.Mock).mockReturnValue(false);
+    const filteredLinks = await getManagementFilteredLinks(
+      coreMockStarted,
+      getPlugins(['superuser'])
+    );
+
     expect(filteredLinks).toEqual({
       ...links,
       links: links.links?.filter((link) => link.id !== SecurityPageName.responseActionsHistory),


### PR DESCRIPTION
## Summary

Show Host Isolation page/tab when has platinum license.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

