### PR TITLE
[TIP] Cleanup structure and imports for the entire timeline module

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
@@ -10,7 +10,7 @@ import { EuiButtonIcon, EuiContextMenuPanel, EuiPopover, EuiToolTip } from '@ela
 import { i18n } from '@kbn/i18n';
 import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 import { FilterInContextMenu, FilterOutContextMenu } from '../../../../query_bar';
-import { AddToTimelineContextMenu } from '../../../../timeline/components/add_to_timeline';
+import { AddToTimelineContextMenu } from '../../../../timeline';
 
 export const POPOVER_BUTTON_TEST_ID = 'tiBarchartPopoverButton';
 export const TIMELINE_BUTTON_TEST_ID = 'tiBarchartTimelineButton';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.tsx
@@ -21,7 +21,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { InvestigateInTimelineButton } from '../../../timeline/components/investigate_in_timeline';
+import { InvestigateInTimelineButton } from '../../../timeline';
 import { DateFormatter } from '../../../../components/date_formatter/date_formatter';
 import { Indicator, RawIndicatorFieldId } from '../../../../../common/types/indicator';
 import { IndicatorsFlyoutJson } from './json_tab';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
@@ -16,7 +16,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { FilterInButtonIcon, FilterOutButtonIcon } from '../../../../query_bar';
-import { AddToTimelineContextMenu } from '../../../../timeline/components/add_to_timeline';
+import { AddToTimelineContextMenu } from '../../../../timeline';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils';
 import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/actions_row_cell.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/actions_row_cell.tsx
@@ -7,7 +7,7 @@
 
 import React, { useContext, VFC } from 'react';
 import { EuiFlexGroup } from '@elastic/eui';
-import { InvestigateInTimelineButtonIcon } from '../../../../timeline/components/investigate_in_timeline';
+import { InvestigateInTimelineButtonIcon } from '../../../../timeline';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { OpenIndicatorFlyoutButton } from './open_flyout_button';
 import { IndicatorsTableContext } from '../contexts';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_actions.tsx
@@ -8,7 +8,7 @@
 import React, { VFC } from 'react';
 import { EuiDataGridColumnCellActionProps } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import { Indicator } from '../../../../../../common/types/indicator';
-import { AddToTimelineCellAction } from '../../../../timeline/components/add_to_timeline';
+import { AddToTimelineCellAction } from '../../../../timeline';
 import { FilterInCellAction, FilterOutCellAction } from '../../../../query_bar';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils';
 import type { Pagination } from '../../../services';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_popover_renderer.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_popover_renderer.tsx
@@ -14,7 +14,7 @@ import {
 import React from 'react';
 import { CopyToClipboardButtonEmpty } from '../../copy_to_clipboard/copy_to_clipboard';
 import { FilterInButtonEmpty, FilterOutButtonEmpty } from '../../../../query_bar';
-import { AddToTimelineButtonEmpty } from '../../../../timeline/components/add_to_timeline';
+import { AddToTimelineButtonEmpty } from '../../../../timeline';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils/field_value';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { Pagination } from '../../../services/fetch_indicators';

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.stories.tsx
@@ -12,7 +12,7 @@ import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
 import { EuiContextMenuPanel } from '@elastic/eui';
 import { mockKibanaTimelinesService } from '../../../../common/mocks/mock_kibana_timelines_service';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
-import { AddToTimelineButtonIcon, AddToTimelineContextMenu } from './add_to_timeline';
+import { AddToTimelineButtonIcon, AddToTimelineContextMenu } from '.';
 
 export default {
   title: 'AddToTimeline',

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { EMPTY_VALUE } from '../../../../../common/constants';
-import { AddToTimelineButtonIcon } from './add_to_timeline';
+import { AddToTimelineButtonIcon } from '.';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 
 describe('<AddToTimeline />', () => {

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
@@ -16,12 +16,12 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { generateDataProvider } from '../../utils/data_provider';
+import { generateDataProvider } from '../../utils';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../indicators';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { Indicator } from '../../../../../common/types/indicator';
 import { useStyles } from './styles';
-import { useAddToTimeline } from '../../hooks/use_add_to_timeline';
+import { useAddToTimeline } from '../../hooks';
 
 const ICON_TYPE = 'timeline';
 const TITLE = i18n.translate('xpack.threatIntelligence.timeline.addToTimeline', {

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/investigate_in_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/investigate_in_timeline.tsx
@@ -9,7 +9,7 @@ import React, { VFC } from 'react';
 import { EuiButton, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { useInvestigateInTimeline } from '../../hooks/use_investigate_in_timeline';
+import { useInvestigateInTimeline } from '../../hooks';
 import { Indicator } from '../../../../../common/types/indicator';
 
 const BUTTON_ICON_LABEL: string = i18n.translate(

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.test.tsx
@@ -6,14 +6,14 @@
  */
 
 import { EMPTY_VALUE } from '../../../../common/constants';
-import { renderHook, RenderHookResult, Renderer } from '@testing-library/react-hooks';
+import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
 import {
   generateMockIndicator,
   generateMockUrlIndicator,
   Indicator,
 } from '../../../../common/types/indicator';
 import { TestProvidersComponent } from '../../../common/mocks/test_providers';
-import { useAddToTimeline, UseAddToTimelineValue } from './use_add_to_timeline';
+import { useAddToTimeline, UseAddToTimelineValue } from '.';
 
 describe('useInvestigateInTimeline()', () => {
   let hookResult: RenderHookResult<{}, UseAddToTimelineValue, Renderer<unknown>>;

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.ts
@@ -7,7 +7,7 @@
 
 import { DataProvider } from '@kbn/timelines-plugin/common';
 import { AddToTimelineButtonProps } from '@kbn/timelines-plugin/public';
-import { generateDataProvider } from '../utils/data_provider';
+import { generateDataProvider } from '../utils';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../indicators';
 import { Indicator } from '../../../../common/types/indicator';
 

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.test.tsx
@@ -5,11 +5,8 @@
  * 2.0.
  */
 
-import { renderHook, RenderHookResult, Renderer } from '@testing-library/react-hooks';
-import {
-  useInvestigateInTimeline,
-  UseInvestigateInTimelineValue,
-} from './use_investigate_in_timeline';
+import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { useInvestigateInTimeline, UseInvestigateInTimelineValue } from '.';
 import {
   generateMockIndicator,
   generateMockUrlIndicator,

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.ts
@@ -8,7 +8,7 @@
 import { useContext } from 'react';
 import moment from 'moment';
 import { DataProvider } from '@kbn/timelines-plugin/common';
-import { generateDataProvider } from '../utils/data_provider';
+import { generateDataProvider } from '../utils';
 import { SecuritySolutionContext } from '../../../containers/security_solution_context';
 import { fieldAndValueValid, getIndicatorFieldAndValue, unwrapValue } from '../../indicators';
 import {

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './components/add_to_timeline';
+export * from './components/investigate_in_timeline';

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/utils/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/utils/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './data_provider';


### PR DESCRIPTION
## Summary

This PR continues the Threat Intelligence plugin code cleanup (see https://github.com/elastic/security-team/issues/4983) by focusing on the indicators module folder.

Code changes:
- add `index.ts` at root of module and update imports in other modules accordingly

No UI changes.

Here's the folder structure for the entire timeline module folder:
```
.
├── components
│   ├── add_to_timeline
│   │   ├── __snapshots__
│   │   │   └── add_to_timeline.test.tsx.snap
│   │   ├── add_to_timeline.stories.tsx
│   │   ├── add_to_timeline.test.tsx
│   │   ├── add_to_timeline.tsx
│   │   ├── index.ts
│   │   └── styles.ts
│   └── investigate_in_timeline
│       ├── __snapshots__
│       │   └── investigate_in_timeline.test.tsx.snap
│       ├── index.ts
│       ├── investigate_in_timeline.stories.tsx
│       ├── investigate_in_timeline.test.tsx
│       └── investigate_in_timeline.tsx
├── hooks
│   ├── index.ts
│   ├── use_add_to_timeline.test.tsx
│   ├── use_add_to_timeline.ts
│   ├── use_investigate_in_timeline.test.tsx
│   └── use_investigate_in_timeline.ts
├── index.ts
└── utils
    ├── data_provider.test.ts
    ├── data_provider.ts
    └── index.ts
```