### PR TITLE
fixed typo in openapi spec

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1187,7 +1187,7 @@
             "schema": {
               "type": "array"
             },
-            "name": "agentsId",
+            "name": "agentsIds",
             "in": "query",
             "required": true
           }
@@ -3710,7 +3710,7 @@
     "/fleet_server_hosts": {
       "get": {
         "summary": "Fleet Server Hosts - List",
-        "description": "Return a list of Fleet server host",
+        "description": "Return a list of Fleet server hosts",
         "tags": [],
         "responses": {
           "200": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -735,7 +735,7 @@ paths:
       parameters:
         - schema:
             type: array
-          name: agentsId
+          name: agentsIds
           in: query
           required: true
   /agents:
@@ -2292,7 +2292,7 @@ paths:
   /fleet_server_hosts:
     get:
       summary: Fleet Server Hosts - List
-      description: Return a list of Fleet server host
+      description: Return a list of Fleet server hosts
       tags: []
       responses:
         '200':

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_status@data.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_status@data.yaml
@@ -22,6 +22,6 @@ get:
   parameters:
     - schema:
         type: array
-      name: agentsId
+      name: agentsIds
       in: query
       required: true


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/143225

Fixed typo in [/agent_status/data](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.json#/default/get-agent-data) openapi spec to match the code that has `agentsIds` parameter.
