### PR TITLE
[TIP] Add TLP Badges support

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/__snapshots__/field.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/__snapshots__/field.test.tsx.snap
@@ -1,196 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<IndicatorField /> should render tlp marking badge 1`] = `
+<DocumentFragment>
+  <span
+    class="euiBadge euiBadge--iconLeft"
+    style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+    title="Red"
+  >
+    <span
+      class="euiBadge__content"
+    >
+      <span
+        class="euiBadge__text"
+      >
+        Red
+      </span>
+    </span>
+  </span>
+</DocumentFragment>
+`;
+
 exports[`<IndicatorField /> should return - 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      -
-    </div>
-  </body>,
-  "container": <div>
-    -
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+<DocumentFragment>
+  -
+</DocumentFragment>
 `;
 
 exports[`<IndicatorField /> should return date-formatted value 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      Dec 31, 2021 @ 20:01:01.000
-    </div>
-  </body>,
-  "container": <div>
-    Dec 31, 2021 @ 20:01:01.000
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+<DocumentFragment>
+  Dec 31, 2021 @ 20:01:01.000
+</DocumentFragment>
 `;
 
 exports[`<IndicatorField /> should return non formatted value 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      0.0.0.0
-    </div>
-  </body>,
-  "container": <div>
-    0.0.0.0
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+<DocumentFragment>
+  0.0.0.0
+</DocumentFragment>
 `;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field.test.tsx
@@ -8,8 +8,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { IndicatorFieldValue } from '.';
-import { generateMockIndicator } from '../../types';
-import { EMPTY_VALUE } from '../../../../common/constants';
+import {
+  generateMockIndicator,
+  generateMockIndicatorWithTlp,
+} from '../../../../../common/types';
+import { EMPTY_VALUE } from '../../../../../common/constants';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 
 const mockIndicator = generateMockIndicator();
@@ -19,23 +22,37 @@ describe('<IndicatorField />', () => {
 
   it('should return non formatted value', () => {
     const mockField = 'threat.indicator.ip';
-    const component = render(<IndicatorFieldValue indicator={mockIndicator} field={mockField} />);
-    expect(component).toMatchSnapshot();
+    const { asFragment } = render(
+      <IndicatorFieldValue indicator={mockIndicator} field={mockField} />
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it(`should return ${EMPTY_VALUE}`, () => {
     const mockField = 'abc';
-    const component = render(<IndicatorFieldValue indicator={mockIndicator} field={mockField} />);
-    expect(component).toMatchSnapshot();
+    const { asFragment } = render(
+      <IndicatorFieldValue indicator={mockIndicator} field={mockField} />
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should return date-formatted value', () => {
     const mockField = 'threat.indicator.first_seen';
-    const component = render(
+    const { asFragment } = render(
       <TestProvidersComponent>
         <IndicatorFieldValue indicator={mockIndicator} field={mockField} />
       </TestProvidersComponent>
     );
-    expect(component).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render tlp marking badge', () => {
+    const mockField = 'threat.indicator.marking.tlp';
+    const { asFragment } = render(
+      <TestProvidersComponent>
+        <IndicatorFieldValue indicator={generateMockIndicatorWithTlp()} field={mockField} />
+      </TestProvidersComponent>
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field.test.tsx
@@ -8,11 +8,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { IndicatorFieldValue } from '.';
-import {
-  generateMockIndicator,
-  generateMockIndicatorWithTlp,
-} from '../../../../../common/types';
-import { EMPTY_VALUE } from '../../../../../common/constants';
+import { generateMockIndicator, generateMockIndicatorWithTlp } from '../../types';
+import { EMPTY_VALUE } from '../../../../common/constants';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 
 const mockIndicator = generateMockIndicator();

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field_value.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_value/field_value.tsx
@@ -11,6 +11,7 @@ import { EMPTY_VALUE } from '../../../../common/constants';
 import { Indicator, RawIndicatorFieldId } from '../../types';
 import { DateFormatter } from '../../../../components/date_formatter';
 import { unwrapValue } from '../../utils';
+import { TLPBadge } from '../tlp_badge';
 
 export interface IndicatorFieldValueProps {
   /**
@@ -29,8 +30,12 @@ export interface IndicatorFieldValueProps {
  */
 export const IndicatorFieldValue: VFC<IndicatorFieldValueProps> = ({ indicator, field }) => {
   const fieldType = useFieldTypes()[field];
-
   const value = unwrapValue(indicator, field as RawIndicatorFieldId);
+
+  if (field === RawIndicatorFieldId.MarkingTLP) {
+    return <TLPBadge value={value} />;
+  }
+
   return fieldType === 'date' ? (
     <DateFormatter date={value as string} />
   ) : value ? (

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { StoryProvidersComponent } from '../../../../common/mocks/story_providers';
-import { generateMockIndicator, Indicator } from '../../../../../common/types';
+import { generateMockIndicator, Indicator } from '../../types';
 import { IndicatorsFlyout } from '.';
 
 export default {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.stories.tsx
@@ -7,50 +7,35 @@
 
 import React from 'react';
 import { Story } from '@storybook/react';
-import { CoreStart } from '@kbn/core/public';
-import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
-import { mockIndicatorsFiltersContext } from '../../../../common/mocks/mock_indicators_filters_context';
-import { mockUiSettingsService } from '../../../../common/mocks/mock_kibana_ui_settings_service';
-import { mockKibanaTimelinesService } from '../../../../common/mocks/mock_kibana_timelines_service';
-import { generateMockIndicator, Indicator } from '../../types';
+import { StoryProvidersComponent } from '../../../../common/mocks/story_providers';
+import { generateMockIndicator, Indicator } from '../../../../../common/types';
 import { IndicatorsFlyout } from '.';
-import { IndicatorsFiltersContext } from '../../containers/filters';
 
 export default {
   component: IndicatorsFlyout,
   title: 'IndicatorsFlyout',
 };
 
-const coreMock = {
-  uiSettings: mockUiSettingsService(),
-  timelines: mockKibanaTimelinesService,
-} as unknown as CoreStart;
-const KibanaReactContext = createKibanaReactContext(coreMock);
-
 export const Default: Story<void> = () => {
   const mockIndicator: Indicator = generateMockIndicator();
 
   return (
-    <KibanaReactContext.Provider>
-      <IndicatorsFiltersContext.Provider value={mockIndicatorsFiltersContext}>
-        <IndicatorsFlyout
-          indicator={mockIndicator}
-          closeFlyout={() => window.alert('Closing flyout')}
-        />
-      </IndicatorsFiltersContext.Provider>
-    </KibanaReactContext.Provider>
+    <StoryProvidersComponent>
+      <IndicatorsFlyout
+        indicator={mockIndicator}
+        closeFlyout={() => window.alert('Closing flyout')}
+      />
+    </StoryProvidersComponent>
   );
 };
 
 export const EmptyIndicator: Story<void> = () => {
   return (
-    <KibanaReactContext.Provider>
-      <IndicatorsFiltersContext.Provider value={mockIndicatorsFiltersContext}>
-        <IndicatorsFlyout
-          indicator={{ fields: {} } as Indicator}
-          closeFlyout={() => window.alert('Closing flyout')}
-        />
-      </IndicatorsFiltersContext.Provider>
-    </KibanaReactContext.Provider>
+    <StoryProvidersComponent>
+      <IndicatorsFlyout
+        indicator={{ fields: {} } as Indicator}
+        closeFlyout={() => window.alert('Closing flyout')}
+      />
+    </StoryProvidersComponent>
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/__snapshots__/tlp_badge.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/__snapshots__/tlp_badge.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TLPBadge should handle proper value 1`] = `
+<DocumentFragment>
+  <span
+    class="euiBadge euiBadge--iconLeft"
+    style="background-color: rgb(109, 204, 177); color: rgb(0, 0, 0);"
+    title="Green"
+  >
+    <span
+      class="euiBadge__content"
+    >
+      <span
+        class="euiBadge__text"
+      >
+        Green
+      </span>
+    </span>
+  </span>
+</DocumentFragment>
+`;
+
+exports[`TLPBadge should handle value in various casing with extra spaces 1`] = `
+<DocumentFragment>
+  <span
+    class="euiBadge euiBadge--iconLeft"
+    style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+    title="Red"
+  >
+    <span
+      class="euiBadge__content"
+    >
+      <span
+        class="euiBadge__text"
+      >
+        Red
+      </span>
+    </span>
+  </span>
+</DocumentFragment>
+`;
+
+exports[`TLPBadge should return - if color doesn't exist 1`] = `
+<DocumentFragment>
+  -
+</DocumentFragment>
+`;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/index.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './tlp_badge';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.stories.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import { TLPBadge, TLPBadgeProps } from './tlp_badge';
+
+export default {
+  component: TLPBadge,
+  title: 'TLPBadge',
+};
+
+const Template: ComponentStory<typeof TLPBadge> = (args: TLPBadgeProps) => <TLPBadge {...args} />;
+
+export const Red = Template.bind({});
+Red.args = {
+  value: 'RED',
+};
+
+export const Amber = Template.bind({});
+Amber.args = {
+  value: 'AMBER',
+};
+
+export const AmberStrict = Template.bind({});
+AmberStrict.args = {
+  value: 'AMBER+STRICT',
+};
+
+export const Green = Template.bind({});
+Green.args = {
+  value: 'GREEN',
+};
+
+export const White = Template.bind({});
+White.args = {
+  value: 'WHITE',
+};
+
+export const Clear = Template.bind({});
+Clear.args = {
+  value: 'CLEAR',
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  value: undefined,
+};
+
+export const Other = Template.bind({});
+Other.args = {
+  value: 'other',
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EMPTY_VALUE } from '../../../../common/constants';
+import { TLPBadge } from './tlp_badge';
+
+describe('TLPBadge', () => {
+  it(`should return ${EMPTY_VALUE} if color doesn't exist`, () => {
+    const invalidValue = 'abc';
+    const { asFragment } = render(<TLPBadge value={invalidValue} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should handle value in various casing with extra spaces', () => {
+    const value = ' RED ';
+    const { asFragment } = render(<TLPBadge value={value} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should handle proper value', () => {
+    const value = 'green';
+    const { asFragment } = render(<TLPBadge value={value} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiBadge } from '@elastic/eui';
+import capitalize from 'lodash/capitalize';
+import React, { useMemo, VFC } from 'react';
+import { EMPTY_VALUE } from '../../../../../common/constants';
+
+export interface TLPBadgeProps {
+  value: string | undefined | null;
+}
+
+const LEVEL_TO_COLOR: Record<string, string> = {
+  red: 'danger',
+  amber: 'warning',
+  'amber+strict': 'warning',
+  green: 'success',
+  white: 'hollow',
+  clear: 'hollow',
+} as const;
+
+export const TLPBadge: VFC<TLPBadgeProps> = ({ value }) => {
+  const normalizedValue = value?.toLowerCase().trim();
+  const color = LEVEL_TO_COLOR[normalizedValue || ''];
+
+  const displayValue = useMemo(
+    () => normalizedValue?.replaceAll(/\W/g, ' ').split(' ').map(capitalize).join(' '),
+    [normalizedValue]
+  );
+
+  if (!color) {
+    return <>{EMPTY_VALUE}</>;
+  }
+
+  return <EuiBadge color={color}>{displayValue}</EuiBadge>;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/tlp_badge/tlp_badge.tsx
@@ -8,7 +8,7 @@
 import { EuiBadge } from '@elastic/eui';
 import capitalize from 'lodash/capitalize';
 import React, { useMemo, VFC } from 'react';
-import { EMPTY_VALUE } from '../../../../../common/constants';
+import { EMPTY_VALUE } from '../../../../common/constants';
 
 export interface TLPBadgeProps {
   value: string | undefined | null;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/types/indicator.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/types/indicator.ts
@@ -101,6 +101,20 @@ export const generateMockIndicator = (): Indicator => {
 };
 
 /**
+ * Used to create an Indicator with tlp marking
+ */
+export const generateMockIndicatorWithTlp = (): Indicator => {
+  const indicator = generateMockBaseIndicator();
+
+  indicator.fields['threat.indicator.type'] = ['type'];
+  indicator.fields['threat.indicator.ip'] = ['0.0.0.0'];
+  indicator.fields['threat.indicator.name'] = ['0.0.0.0'];
+  indicator.fields['threat.indicator.marking.tlp'] = ['RED'];
+
+  return indicator;
+};
+
+/**
  * Used to create a Url Indicator.
  */
 export const generateMockUrlIndicator = (): Indicator => {


### PR DESCRIPTION
## Summary

This PR adds the missing TLP Marking badges inside the flyout and data grids.

Also, flyout story is now fixed as well.

![image](https://user-images.githubusercontent.com/11671118/196153830-b4943a8e-ee19-4c6f-a378-2e3153b0b1df.png)

Note: I will create an issue for handling the excess margin inside the data grid; I've tried fixing this but it won't be easy it seems...

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/security-team/issues/5181
https://github.com/elastic/security-team/issues/5182
