### PR TITLE
[ML] Calculate model memory limit for Lens created jobs

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { mergeWith, uniqBy, isEqual } from 'lodash';
+import { firstValueFrom } from 'rxjs';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   Embeddable,
@@ -105,6 +106,32 @@ export class QuickJobCreator {
       datafeedStarted: { success: false },
     };
 
+    // calculate model memory limit
+    try {
+      if (start !== undefined && end !== undefined) {
+        const { modelMemoryLimit } = await firstValueFrom(
+          this.mlApiServices.calculateModelMemoryLimit$({
+            datafeedConfig: datafeed,
+            analysisConfig: job.analysis_config,
+            indexPattern: datafeedConfig.indices[0],
+            query: datafeedConfig.query,
+            timeFieldName: job.data_description.time_field!,
+            earliestMs: start!,
+            latestMs: end!,
+          })
+        );
+        if (job.analysis_limits === undefined) {
+          job.analysis_limits = {};
+        }
+        job.analysis_limits.model_memory_limit = modelMemoryLimit;
+      }
+    } catch (error) {
+      // could not calculate mml, continue with job creation as default value will be used.
+      // eslint-disable-next-line no-console
+      console.error('could not calculate model memory limit', error);
+    }
+
+    // put job
     try {
       await this.mlApiServices.addJob({ jobId: job.job_id, job });
     } catch (error) {
@@ -113,6 +140,7 @@ export class QuickJobCreator {
     }
     result.jobCreated.success = true;
 
+    // put datafeed
     try {
       await this.mlApiServices.addDatafeed({ datafeedId, datafeedConfig: datafeed });
     } catch (error) {
@@ -122,6 +150,7 @@ export class QuickJobCreator {
     result.datafeedCreated.success = true;
 
     if (startJob) {
+      // open job, ignore error if already open
       try {
         await this.mlApiServices.openJob({ jobId });
       } catch (error) {
@@ -133,6 +162,7 @@ export class QuickJobCreator {
       }
       result.jobOpened.success = true;
 
+      // start datafeed
       try {
         await this.mlApiServices.startDatafeed({
           datafeedId,

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
@@ -108,7 +108,7 @@ export class QuickJobCreator {
 
     // calculate model memory limit
     try {
-      if (start !== undefined && end !== undefined) {
+      if (start !== undefined && end !== undefined && datafeedConfig.indices.length > 0) {
         const { modelMemoryLimit } = await firstValueFrom(
           this.mlApiServices.calculateModelMemoryLimit$({
             datafeedConfig: datafeed,

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_lens/quick_create_job.ts
@@ -108,16 +108,21 @@ export class QuickJobCreator {
 
     // calculate model memory limit
     try {
-      if (start !== undefined && end !== undefined && datafeedConfig.indices.length > 0) {
+      if (
+        start !== undefined &&
+        end !== undefined &&
+        job.data_description.time_field !== undefined &&
+        datafeedConfig.indices.length > 0
+      ) {
         const { modelMemoryLimit } = await firstValueFrom(
           this.mlApiServices.calculateModelMemoryLimit$({
             datafeedConfig: datafeed,
             analysisConfig: job.analysis_config,
             indexPattern: datafeedConfig.indices[0],
             query: datafeedConfig.query,
-            timeFieldName: job.data_description.time_field!,
-            earliestMs: start!,
-            latestMs: end!,
+            timeFieldName: job.data_description.time_field,
+            earliestMs: start,
+            latestMs: end,
           })
         );
         if (job.analysis_limits === undefined) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/lens_to_ml.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/lens_to_ml.ts
@@ -86,6 +86,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await ml.testExecution.logTestStep('pre-fills the job selection');
       await ml.jobSelection.assertJobSelection([jobId]);
 
+      await ml.api.assertModelMemoryLimitForJob(jobId, '11mb');
+
       await ml.api.deleteAnomalyDetectionJobES(jobId);
     });
 
@@ -117,6 +119,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await ml.testExecution.logTestStep('pre-fills the job selection');
       await ml.jobSelection.assertJobSelection([jobId]);
+
+      await ml.api.assertModelMemoryLimitForJob(jobId, '12mb');
 
       await ml.api.deleteAnomalyDetectionJobES(jobId);
     });

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1008,6 +1008,19 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug('> Filter deleted.');
     },
 
+    async assertModelMemoryLimitForJob(jobId: string, expectedMml: string) {
+      const {
+        body: {
+          jobs: [job],
+        },
+      } = await this.getAnomalyDetectionJob(jobId);
+      const mml = job.analysis_limits.model_memory_limit;
+      expect(mml).to.eql(
+        expectedMml,
+        `Expected model memory limit to be  ${expectedMml}, got  ${mml}`
+      );
+    },
+
     async waitForFilterToExist(filterId: string, errorMsg?: string) {
       await retry.waitForWithTimeout(`'${filterId}' to exist`, 5 * 1000, async () => {
         if (await this.getFilter(filterId, 200)) {


### PR DESCRIPTION
When creating a job from a Lens visualization, we should use the calculate model memory limit api so the default value of `1024mb` is not used.
The calculation happens when the user presses the create button, before the job is saved.
If for some reason the calculation fails, the error is ignored (logged to the browser's console) and the job creation continues with the default value.

Fixes https://github.com/elastic/kibana/issues/143451


