### PR TITLE
feat(slo): Handle timeslices budgeting method

### DIFF
--- a/x-pack/plugins/observability/server/domain/services/date_range.test.ts
+++ b/x-pack/plugins/observability/server/domain/services/date_range.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { TimeWindow } from '../../types/models/time_window';
-import { Duration, DurationUnit } from '../../types/schema';
+import { Duration, DurationUnit } from '../../types/models';
 import { toDateRange } from './date_range';
 
 const THIRTY_DAYS = new Duration(30, DurationUnit.d);

--- a/x-pack/plugins/observability/server/domain/services/date_range.ts
+++ b/x-pack/plugins/observability/server/domain/services/date_range.ts
@@ -7,6 +7,7 @@
 
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
+import { toMomentUnitOfTime } from '../../types/models';
 
 import type { TimeWindow } from '../../types/models/time_window';
 import {
@@ -48,21 +49,4 @@ export const toDateRange = (timeWindow: TimeWindow, currentDate: Date = new Date
   }
 
   assertNever(timeWindow);
-};
-
-const toMomentUnitOfTime = (unit: DurationUnit): moment.unitOfTime.Diff => {
-  switch (unit) {
-    case DurationUnit.d:
-      return 'days';
-    case DurationUnit.w:
-      return 'weeks';
-    case DurationUnit.M:
-      return 'months';
-    case DurationUnit.Q:
-      return 'quarters';
-    case DurationUnit.Y:
-      return 'years';
-    default:
-      assertNever(unit);
-  }
 };

--- a/x-pack/plugins/observability/server/domain/services/date_range.ts
+++ b/x-pack/plugins/observability/server/domain/services/date_range.ts
@@ -10,11 +10,7 @@ import moment from 'moment';
 import { toMomentUnitOfTime } from '../../types/models';
 
 import type { TimeWindow } from '../../types/models/time_window';
-import {
-  calendarAlignedTimeWindowSchema,
-  DurationUnit,
-  rollingTimeWindowSchema,
-} from '../../types/schema';
+import { calendarAlignedTimeWindowSchema, rollingTimeWindowSchema } from '../../types/schema';
 
 export interface DateRange {
   from: Date;

--- a/x-pack/plugins/observability/server/domain/services/index.ts
+++ b/x-pack/plugins/observability/server/domain/services/index.ts
@@ -8,3 +8,4 @@
 export * from './compute_error_budget';
 export * from './compute_sli';
 export * from './date_range';
+export * from './validate_slo';

--- a/x-pack/plugins/observability/server/domain/services/validate_slo.test.ts
+++ b/x-pack/plugins/observability/server/domain/services/validate_slo.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSLO } from '.';
+import { createSLO } from '../../services/slo/fixtures/slo';
+import { Duration, DurationUnit } from '../../types/models/duration';
+
+describe('validateSLO', () => {
+  describe('any slo', () => {
+    it("throws when 'objective.target' is lte 0", () => {
+      const slo = createSLO({ objective: { target: 0 } });
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.target');
+    });
+
+    it("throws when 'objective.target' is gt 1", () => {
+      const slo = createSLO({ objective: { target: 1.0001 } });
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.target');
+    });
+
+    it("throws when time window duration unit is 'm'", () => {
+      const slo = createSLO({
+        time_window: { duration: new Duration(1, DurationUnit.m), is_rolling: true },
+      });
+      expect(() => validateSLO(slo)).toThrowError('Invalid time_window.duration');
+    });
+
+    it("throws when time window duration unit is 'h'", () => {
+      const slo = createSLO({
+        time_window: { duration: new Duration(1, DurationUnit.h), is_rolling: true },
+      });
+      expect(() => validateSLO(slo)).toThrowError('Invalid time_window.duration');
+    });
+  });
+
+  describe('slo with timeslices budgeting method', () => {
+    it("throws when 'objective.timeslice_target' is not present", () => {
+      const slo = createSLO({
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_window: new Duration(1, DurationUnit.m),
+        },
+      });
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.timeslice_target');
+    });
+
+    it("throws when 'objective.timeslice_target' is lte 0", () => {
+      const slo = createSLO({
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_target: 0,
+          timeslice_window: new Duration(1, DurationUnit.m),
+        },
+      });
+
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.timeslice_target');
+    });
+
+    it("throws when 'objective.timeslice_target' is gt 1", () => {
+      const slo = createSLO({
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_target: 1.001,
+          timeslice_window: new Duration(1, DurationUnit.m),
+        },
+      });
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.timeslice_target');
+    });
+
+    it("throws when 'objective.timeslice_window' is not present", () => {
+      const slo = createSLO({
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_target: 0.95,
+        },
+      });
+
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.timeslice_window');
+    });
+
+    it("throws when 'objective.timeslice_window' is not in minutes or hours", () => {
+      const slo = createSLO({
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_target: 0.95,
+        },
+      });
+
+      expect(() =>
+        validateSLO({
+          ...slo,
+          objective: { ...slo.objective, timeslice_window: new Duration(1, DurationUnit.d) },
+        })
+      ).toThrowError('Invalid objective.timeslice_window');
+
+      expect(() =>
+        validateSLO({
+          ...slo,
+          objective: { ...slo.objective, timeslice_window: new Duration(1, DurationUnit.w) },
+        })
+      ).toThrowError('Invalid objective.timeslice_window');
+
+      expect(() =>
+        validateSLO({
+          ...slo,
+          objective: { ...slo.objective, timeslice_window: new Duration(1, DurationUnit.M) },
+        })
+      ).toThrowError('Invalid objective.timeslice_window');
+
+      expect(() =>
+        validateSLO({
+          ...slo,
+          objective: { ...slo.objective, timeslice_window: new Duration(1, DurationUnit.Q) },
+        })
+      ).toThrowError('Invalid objective.timeslice_window');
+
+      expect(() =>
+        validateSLO({
+          ...slo,
+          objective: { ...slo.objective, timeslice_window: new Duration(1, DurationUnit.Y) },
+        })
+      ).toThrowError('Invalid objective.timeslice_window');
+    });
+
+    it("throws when 'objective.timeslice_window' is longer than 'slo.time_window'", () => {
+      const slo = createSLO({
+        time_window: { duration: new Duration(1, DurationUnit.w), is_rolling: true },
+        budgeting_method: 'timeslices',
+        objective: {
+          target: 0.95,
+          timeslice_target: 0.95,
+          timeslice_window: new Duration(169, DurationUnit.h), // 1 week + 1 hours = 169 hours
+        },
+      });
+
+      expect(() => validateSLO(slo)).toThrowError('Invalid objective.timeslice_window');
+    });
+  });
+});

--- a/x-pack/plugins/observability/server/domain/services/validate_slo.ts
+++ b/x-pack/plugins/observability/server/domain/services/validate_slo.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IllegalArgumentError } from '../../errors';
+import { SLO } from '../../types/models';
+import { Duration, DurationUnit } from '../../types/models/duration';
+import { timeslicesBudgetingMethodSchema } from '../../types/schema';
+
+/**
+ * Asserts the SLO is valid from a business invariants point of view.
+ * e.g. a 'target' objective requires a number between ]0, 1]
+ * e.g. a 'timeslices' budgeting method requires an objective's timeslice_target to be defined.
+ *
+ * @param slo {SLO}
+ */
+export function validateSLO(slo: SLO) {
+  if (!isValidTargetNumber(slo.objective.target)) {
+    throw new IllegalArgumentError('Invalid objective.target');
+  }
+
+  if (!isValidTimeWindowDuration(slo.time_window.duration)) {
+    throw new IllegalArgumentError('Invalid time_window.duration');
+  }
+
+  if (timeslicesBudgetingMethodSchema.is(slo.budgeting_method)) {
+    if (
+      slo.objective.timeslice_target === undefined ||
+      !isValidTargetNumber(slo.objective.timeslice_target)
+    ) {
+      throw new IllegalArgumentError('Invalid objective.timeslice_target');
+    }
+
+    if (
+      slo.objective.timeslice_window === undefined ||
+      !isValidTimesliceWindowDuration(slo.objective.timeslice_window, slo.time_window.duration)
+    ) {
+      throw new IllegalArgumentError('Invalid objective.timeslice_window');
+    }
+  }
+}
+
+function isValidTargetNumber(value: number): boolean {
+  return value > 0 && value <= 1;
+}
+
+function isValidTimeWindowDuration(duration: Duration): boolean {
+  return [DurationUnit.d, DurationUnit.w, DurationUnit.M, DurationUnit.Q, DurationUnit.Y].includes(
+    duration.unit
+  );
+}
+
+function isValidTimesliceWindowDuration(timesliceWindow: Duration, timeWindow: Duration): boolean {
+  return (
+    [DurationUnit.m, DurationUnit.h].includes(timesliceWindow.unit) &&
+    timesliceWindow.isShorterThan(timeWindow)
+  );
+}

--- a/x-pack/plugins/observability/server/errors/errors.ts
+++ b/x-pack/plugins/observability/server/errors/errors.ts
@@ -17,3 +17,4 @@ export class ObservabilityError extends Error {
 export class SLONotFound extends ObservabilityError {}
 export class InternalQueryError extends ObservabilityError {}
 export class NotSupportedError extends ObservabilityError {}
+export class IllegalArgumentError extends ObservabilityError {}

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -12,6 +12,7 @@ import { ResourceInstaller } from './resource_installer';
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
 import { CreateSLOParams, CreateSLOResponse } from '../../types/rest_specs';
+import { validateSLO } from '../../domain/services';
 
 export class CreateSLO {
   constructor(
@@ -22,6 +23,7 @@ export class CreateSLO {
 
   public async execute(params: CreateSLOParams): Promise<CreateSLOResponse> {
     const slo = this.toSLO(params);
+    validateSLO(slo);
 
     await this.resourceInstaller.ensureCommonResourcesInstalled();
     await this.repository.save(slo);

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -6,8 +6,8 @@
  */
 
 import uuid from 'uuid';
+import { Duration, DurationUnit } from '../../../types/models/duration';
 
-import { Duration, DurationUnit } from '../../../types/schema';
 import {
   APMTransactionDurationIndicator,
   APMTransactionErrorRateIndicator,

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { cloneDeep } from 'lodash';
 import uuid from 'uuid';
 import { Duration, DurationUnit } from '../../../types/models/duration';
 
@@ -65,14 +66,14 @@ export const createSLOParams = (params: Partial<CreateSLOParams> = {}): CreateSL
 
 export const createSLO = (params: Partial<SLO> = {}): SLO => {
   const now = new Date();
-  return {
+  return cloneDeep({
     ...defaultSLO,
     id: uuid.v1(),
     revision: 1,
     created_at: now,
     updated_at: now,
     ...params,
-  };
+  });
 };
 
 export const createSLOWithCalendarTimeWindow = (params: Partial<SLO> = {}): SLO => {

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -9,8 +9,8 @@ import { ElasticsearchClientMock, elasticsearchServiceMock } from '@kbn/core/ser
 import { SLO_DESTINATION_INDEX_NAME } from '../../assets/constants';
 import { toDateRange } from '../../domain/services/date_range';
 import { InternalQueryError } from '../../errors';
-import { Duration, DurationUnit } from '../../types/schema';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
+import { Duration, DurationUnit } from '../../types/models';
 import { DefaultSLIClient } from './sli_client';
 
 describe('SLIClient', () => {

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -7,10 +7,10 @@
 
 import { ElasticsearchClientMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { SLO_DESTINATION_INDEX_NAME } from '../../assets/constants';
-import { toDateRange } from '../../domain/services/date_range';
+import { toDateRange } from '../../domain/services';
 import { InternalQueryError } from '../../errors';
-import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 import { Duration, DurationUnit } from '../../types/models';
+import { createSLO } from './fixtures/slo';
 import { DefaultSLIClient } from './sli_client';
 
 describe('SLIClient', () => {
@@ -21,31 +21,8 @@ describe('SLIClient', () => {
   });
 
   describe('fetchCurrentSLIData', () => {
-    it('throws when aggregations failed', async () => {
-      const slo = createSLO({ indicator: createAPMTransactionErrorRateIndicator() });
-      esClientMock.search.mockResolvedValueOnce({
-        took: 100,
-        timed_out: false,
-        _shards: {
-          total: 0,
-          successful: 0,
-          skipped: 0,
-          failed: 0,
-        },
-        hits: {
-          hits: [],
-        },
-        aggregations: {},
-      });
-      const sliClient = new DefaultSLIClient(esClientMock);
-
-      await expect(sliClient.fetchCurrentSLIData(slo)).rejects.toThrowError(
-        new InternalQueryError('SLI aggregation query')
-      );
-    });
-
-    describe('For a rolling time window SLO type', () => {
-      it('returns the aggregated good and total values', async () => {
+    describe('for SLO defined with occurrences budgeting method', () => {
+      it('throws when aggregations failed', async () => {
         const slo = createSLO({
           time_window: {
             duration: new Duration(7, DurationUnit.d),
@@ -64,53 +41,144 @@ describe('SLIClient', () => {
           hits: {
             hits: [],
           },
-          aggregations: {
-            full_window: { buckets: [{ good: { value: 90 }, total: { value: 100 } }] },
-          },
+          aggregations: {},
         });
         const sliClient = new DefaultSLIClient(esClientMock);
 
-        const result = await sliClient.fetchCurrentSLIData(slo);
-
-        expect(result).toEqual({ good: 90, total: 100 });
-        expect(esClientMock.search).toHaveBeenCalledWith(
-          expect.objectContaining({
-            index: `${SLO_DESTINATION_INDEX_NAME}*`,
-            query: {
-              bool: {
-                filter: [
-                  { term: { 'slo.id': slo.id } },
-                  { term: { 'slo.revision': slo.revision } },
-                ],
-              },
-            },
-            aggs: {
-              full_window: {
-                date_range: {
-                  field: '@timestamp',
-                  ranges: [{ from: 'now-7d/m', to: 'now/m' }],
-                },
-                aggs: {
-                  good: { sum: { field: 'slo.numerator' } },
-                  total: { sum: { field: 'slo.denominator' } },
-                },
-              },
-            },
-          })
+        await expect(sliClient.fetchCurrentSLIData(slo)).rejects.toThrowError(
+          new InternalQueryError('SLI aggregation query')
         );
+      });
+
+      describe('for a rolling time window SLO type', () => {
+        it('returns the aggregated good and total values', async () => {
+          const slo = createSLO({
+            time_window: {
+              duration: new Duration(7, DurationUnit.d),
+              is_rolling: true,
+            },
+          });
+          esClientMock.search.mockResolvedValueOnce({
+            took: 100,
+            timed_out: false,
+            _shards: {
+              total: 0,
+              successful: 0,
+              skipped: 0,
+              failed: 0,
+            },
+            hits: {
+              hits: [],
+            },
+            aggregations: {
+              good: { value: 90 },
+              total: { value: 100 },
+            },
+          });
+          const sliClient = new DefaultSLIClient(esClientMock);
+
+          const result = await sliClient.fetchCurrentSLIData(slo);
+
+          expect(result).toEqual({ good: 90, total: 100 });
+          expect(esClientMock.search).toHaveBeenCalledWith(
+            expect.objectContaining({
+              index: `${SLO_DESTINATION_INDEX_NAME}*`,
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'slo.id': slo.id } },
+                    { term: { 'slo.revision': slo.revision } },
+                    {
+                      range: {
+                        '@timestamp': { gte: 'now-7d/m', lt: 'now/m' },
+                      },
+                    },
+                  ],
+                },
+              },
+              aggs: {
+                good: { sum: { field: 'slo.numerator' } },
+                total: { sum: { field: 'slo.denominator' } },
+              },
+            })
+          );
+        });
+      });
+
+      describe('for a calendar aligned time window SLO type', () => {
+        it('returns the aggregated good and total values', async () => {
+          const slo = createSLO({
+            time_window: {
+              duration: new Duration(1, DurationUnit.M),
+              calendar: {
+                start_time: new Date('2022-09-01T00:00:00.000Z'),
+              },
+            },
+          });
+          esClientMock.search.mockResolvedValueOnce({
+            took: 100,
+            timed_out: false,
+            _shards: {
+              total: 0,
+              successful: 0,
+              skipped: 0,
+              failed: 0,
+            },
+            hits: {
+              hits: [],
+            },
+            aggregations: {
+              good: { value: 90 },
+              total: { value: 100 },
+            },
+          });
+          const sliClient = new DefaultSLIClient(esClientMock);
+
+          const result = await sliClient.fetchCurrentSLIData(slo);
+
+          const expectedDateRange = toDateRange(slo.time_window);
+
+          expect(result).toEqual({ good: 90, total: 100 });
+          expect(esClientMock.search).toHaveBeenCalledWith(
+            expect.objectContaining({
+              index: `${SLO_DESTINATION_INDEX_NAME}*`,
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'slo.id': slo.id } },
+                    { term: { 'slo.revision': slo.revision } },
+                    {
+                      range: {
+                        '@timestamp': {
+                          gte: expectedDateRange.from.toISOString(),
+                          lt: expectedDateRange.to.toISOString(),
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              aggs: {
+                good: { sum: { field: 'slo.numerator' } },
+                total: { sum: { field: 'slo.denominator' } },
+              },
+            })
+          );
+        });
       });
     });
 
-    describe('For a calendar aligned time window SLO type', () => {
-      it('returns the aggregated good and total values', async () => {
+    describe('for SLO defined with timeslices budgeting method', () => {
+      it('throws when aggregations failed', async () => {
         const slo = createSLO({
-          time_window: {
-            duration: new Duration(1, DurationUnit.M),
-            calendar: {
-              start_time: new Date('2022-09-01T00:00:00.000Z'),
-            },
+          budgeting_method: 'timeslices',
+          objective: {
+            target: 0.95,
+            timeslice_target: 0.95,
+            timeslice_window: new Duration(10, DurationUnit.m),
           },
         });
+
         esClientMock.search.mockResolvedValueOnce({
           took: 100,
           timed_out: false,
@@ -123,47 +191,228 @@ describe('SLIClient', () => {
           hits: {
             hits: [],
           },
-          aggregations: {
-            full_window: { buckets: [{ good: { value: 90 }, total: { value: 100 } }] },
-          },
+          aggregations: {},
         });
         const sliClient = new DefaultSLIClient(esClientMock);
 
-        const result = await sliClient.fetchCurrentSLIData(slo);
+        await expect(sliClient.fetchCurrentSLIData(slo)).rejects.toThrowError(
+          new InternalQueryError('SLI aggregation query')
+        );
+      });
 
-        const expectedDateRange = toDateRange(slo.time_window);
-
-        expect(result).toEqual({ good: 90, total: 100 });
-        expect(esClientMock.search).toHaveBeenCalledWith(
-          expect.objectContaining({
-            index: `${SLO_DESTINATION_INDEX_NAME}*`,
-            query: {
-              bool: {
-                filter: [
-                  { term: { 'slo.id': slo.id } },
-                  { term: { 'slo.revision': slo.revision } },
-                ],
+      describe('for a calendar aligned time window SLO type', () => {
+        it('returns the aggregated good and total values', async () => {
+          const slo = createSLO({
+            budgeting_method: 'timeslices',
+            objective: {
+              target: 0.95,
+              timeslice_target: 0.9,
+              timeslice_window: new Duration(10, DurationUnit.m),
+            },
+            time_window: {
+              duration: new Duration(1, DurationUnit.M),
+              calendar: {
+                start_time: new Date('2022-09-01T00:00:00.000Z'),
               },
             },
-            aggs: {
-              full_window: {
-                date_range: {
-                  field: '@timestamp',
-                  ranges: [
+          });
+          esClientMock.search.mockResolvedValueOnce({
+            took: 100,
+            timed_out: false,
+            _shards: {
+              total: 0,
+              successful: 0,
+              skipped: 0,
+              failed: 0,
+            },
+            hits: {
+              hits: [],
+            },
+            aggregations: {
+              slices: { buckets: [] },
+              good: { value: 90 },
+              total: { value: 100 },
+            },
+          });
+          const sliClient = new DefaultSLIClient(esClientMock);
+
+          const result = await sliClient.fetchCurrentSLIData(slo);
+
+          const expectedDateRange = toDateRange(slo.time_window);
+
+          expect(result).toEqual({ good: 90, total: 100 });
+          expect(esClientMock.search).toHaveBeenCalledWith(
+            expect.objectContaining({
+              index: `${SLO_DESTINATION_INDEX_NAME}*`,
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'slo.id': slo.id } },
+                    { term: { 'slo.revision': slo.revision } },
                     {
-                      from: expectedDateRange.from.toISOString(),
-                      to: expectedDateRange.to.toISOString(),
+                      range: {
+                        '@timestamp': {
+                          gte: expectedDateRange.from.toISOString(),
+                          lt: expectedDateRange.to.toISOString(),
+                        },
+                      },
                     },
                   ],
                 },
-                aggs: {
-                  good: { sum: { field: 'slo.numerator' } },
-                  total: { sum: { field: 'slo.denominator' } },
+              },
+              aggs: {
+                slices: {
+                  date_histogram: {
+                    field: '@timestamp',
+                    fixed_interval: '10m',
+                  },
+                  aggs: {
+                    good: {
+                      sum: {
+                        field: 'slo.numerator',
+                      },
+                    },
+                    total: {
+                      sum: {
+                        field: 'slo.denominator',
+                      },
+                    },
+                    good_slice: {
+                      bucket_script: {
+                        buckets_path: {
+                          good: 'good',
+                          total: 'total',
+                        },
+                        script: `params.good / params.total >= ${slo.objective.timeslice_target} ? 1 : 0`,
+                      },
+                    },
+                    count_slice: {
+                      bucket_script: {
+                        buckets_path: {},
+                        script: '1',
+                      },
+                    },
+                  },
+                },
+                good: {
+                  sum_bucket: {
+                    buckets_path: 'slices>good_slice.value',
+                  },
+                },
+                total: {
+                  sum_bucket: {
+                    buckets_path: 'slices>count_slice.value',
+                  },
                 },
               },
+            })
+          );
+        });
+      });
+
+      describe('for a rolling time window SLO type', () => {
+        it('returns the aggregated good and total values', async () => {
+          const slo = createSLO({
+            budgeting_method: 'timeslices',
+            objective: {
+              target: 0.95,
+              timeslice_target: 0.9,
+              timeslice_window: new Duration(10, DurationUnit.m),
             },
-          })
-        );
+            time_window: {
+              duration: new Duration(1, DurationUnit.M),
+              is_rolling: true,
+            },
+          });
+          esClientMock.search.mockResolvedValueOnce({
+            took: 100,
+            timed_out: false,
+            _shards: {
+              total: 0,
+              successful: 0,
+              skipped: 0,
+              failed: 0,
+            },
+            hits: {
+              hits: [],
+            },
+            aggregations: {
+              good: { value: 90 },
+              total: { value: 100 },
+            },
+          });
+          const sliClient = new DefaultSLIClient(esClientMock);
+
+          const result = await sliClient.fetchCurrentSLIData(slo);
+
+          expect(result).toEqual({ good: 90, total: 100 });
+          expect(esClientMock.search).toHaveBeenCalledWith(
+            expect.objectContaining({
+              index: `${SLO_DESTINATION_INDEX_NAME}*`,
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'slo.id': slo.id } },
+                    { term: { 'slo.revision': slo.revision } },
+                    {
+                      range: {
+                        '@timestamp': {
+                          gte: 'now-1M/m',
+                          lt: 'now/m',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              aggs: {
+                slices: {
+                  date_histogram: {
+                    field: '@timestamp',
+                    fixed_interval: '10m',
+                  },
+                  aggs: {
+                    good: {
+                      sum: {
+                        field: 'slo.numerator',
+                      },
+                    },
+                    total: {
+                      sum: {
+                        field: 'slo.denominator',
+                      },
+                    },
+                    good_slice: {
+                      bucket_script: {
+                        buckets_path: {
+                          good: 'good',
+                          total: 'total',
+                        },
+                        script: `params.good / params.total >= ${slo.objective.timeslice_target} ? 1 : 0`,
+                      },
+                    },
+                    count_slice: {
+                      bucket_script: {
+                        buckets_path: {},
+                        script: '1',
+                      },
+                    },
+                  },
+                },
+                good: {
+                  sum_bucket: {
+                    buckets_path: 'slices>good_slice.value',
+                  },
+                },
+                total: {
+                  sum_bucket: {
+                    buckets_path: 'slices>count_slice.value',
+                  },
+                },
+              },
+            })
+          );
+        });
       });
     });
   });

--- a/x-pack/plugins/observability/server/services/slo/sli_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.ts
@@ -5,77 +5,143 @@
  * 2.0.
  */
 
+import { AggregationsSumAggregate } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { assertNever } from '@kbn/std';
 import { SLO_DESTINATION_INDEX_NAME } from '../../assets/constants';
 import { toDateRange } from '../../domain/services/date_range';
-import { InternalQueryError, NotSupportedError } from '../../errors';
-import { IndicatorData, SLO } from '../../types/models';
+import { InternalQueryError } from '../../errors';
+import { Duration, IndicatorData, SLO } from '../../types/models';
 import { calendarAlignedTimeWindowSchema, rollingTimeWindowSchema } from '../../types/schema';
+import {
+  occurencesBudgetingMethodSchema,
+  timeslicesBudgetingMethodSchema,
+} from '../../types/schema';
 
 export interface SLIClient {
   fetchCurrentSLIData(slo: SLO): Promise<IndicatorData>;
 }
 
+type AggKey = 'good' | 'total';
+
 export class DefaultSLIClient implements SLIClient {
   constructor(private esClient: ElasticsearchClient) {}
 
   async fetchCurrentSLIData(slo: SLO): Promise<IndicatorData> {
-    if (slo.budgeting_method !== 'occurrences') {
-      throw new NotSupportedError(`Budgeting method: ${slo.budgeting_method}`);
+    if (occurencesBudgetingMethodSchema.is(slo.budgeting_method)) {
+      const result = await this.esClient.search<unknown, Record<AggKey, AggregationsSumAggregate>>({
+        ...commonQuery(slo),
+        aggs: {
+          good: { sum: { field: 'slo.numerator' } },
+          total: { sum: { field: 'slo.denominator' } },
+        },
+      });
+
+      return handleResult(result.aggregations);
     }
 
-    const result = await this.esClient.search({
-      size: 0,
-      index: `${SLO_DESTINATION_INDEX_NAME}*`,
-      query: {
-        bool: {
-          filter: [{ term: { 'slo.id': slo.id } }, { term: { 'slo.revision': slo.revision } }],
-        },
-      },
-      aggs: {
-        full_window: {
-          date_range: {
-            field: '@timestamp',
-            ranges: [fromSLOTimeWindowToEsRange(slo)],
+    if (timeslicesBudgetingMethodSchema.is(slo.budgeting_method)) {
+      const result = await this.esClient.search<unknown, Record<AggKey, AggregationsSumAggregate>>({
+        ...commonQuery(slo),
+        aggs: {
+          slices: {
+            date_histogram: {
+              field: '@timestamp',
+              fixed_interval: toInterval(slo.objective.timeslice_window),
+            },
+            aggs: {
+              good: { sum: { field: 'slo.numerator' } },
+              total: { sum: { field: 'slo.denominator' } },
+              good_slice: {
+                bucket_script: {
+                  buckets_path: {
+                    good: 'good',
+                    total: 'total',
+                  },
+                  script: `params.good / params.total >= ${slo.objective.timeslice_target} ? 1 : 0`,
+                },
+              },
+              count_slice: {
+                bucket_script: {
+                  buckets_path: {},
+                  script: '1',
+                },
+              },
+            },
           },
-          aggs: {
-            good: { sum: { field: 'slo.numerator' } },
-            total: { sum: { field: 'slo.denominator' } },
+          good: {
+            sum_bucket: {
+              buckets_path: 'slices>good_slice.value',
+            },
+          },
+          total: {
+            sum_bucket: {
+              buckets_path: 'slices>count_slice.value',
+            },
           },
         },
-      },
-    });
+      });
 
-    // @ts-ignore buckets is not recognized
-    const aggs = result.aggregations?.full_window?.buckets[0];
-    if (aggs === undefined) {
-      throw new InternalQueryError('SLI aggregation query');
+      return handleResult(result.aggregations);
     }
 
-    return {
-      good: aggs.good.value,
-      total: aggs.total.value,
-    };
+    assertNever(slo.budgeting_method);
   }
 }
 
-function fromSLOTimeWindowToEsRange(slo: SLO): { from: string; to: string } {
+function fromSLOTimeWindowToEsRange(slo: SLO): { gte: string; lt: string } {
   if (calendarAlignedTimeWindowSchema.is(slo.time_window)) {
     const dateRange = toDateRange(slo.time_window);
 
     return {
-      from: `${dateRange.from.toISOString()}`,
-      to: `${dateRange.to.toISOString()}`,
+      gte: `${dateRange.from.toISOString()}`,
+      lt: `${dateRange.to.toISOString()}`,
     };
   }
 
   if (rollingTimeWindowSchema.is(slo.time_window)) {
     return {
-      from: `now-${slo.time_window.duration.value}${slo.time_window.duration.unit}/m`,
-      to: `now/m`,
+      gte: `now-${slo.time_window.duration.value}${slo.time_window.duration.unit}/m`,
+      lt: `now/m`,
     };
   }
 
   assertNever(slo.time_window);
+}
+
+function commonQuery(slo: SLO) {
+  return {
+    size: 0,
+    index: `${SLO_DESTINATION_INDEX_NAME}*`,
+    query: {
+      bool: {
+        filter: [
+          { term: { 'slo.id': slo.id } },
+          { term: { 'slo.revision': slo.revision } },
+          { range: { '@timestamp': fromSLOTimeWindowToEsRange(slo) } },
+        ],
+      },
+    },
+  };
+}
+
+function handleResult(
+  aggregations: Record<AggKey, AggregationsSumAggregate> | undefined
+): IndicatorData {
+  const good = aggregations?.good;
+  const total = aggregations?.total;
+  if (good === undefined || good.value === null || total === undefined || total.value === null) {
+    throw new InternalQueryError('SLI aggregation query');
+  }
+
+  return {
+    good: good.value,
+    total: total.value,
+  };
+}
+
+function toInterval(duration: Duration | undefined): string {
+  if (duration === undefined) return '1m';
+
+  return `${duration.value}${duration.unit}`;
 }

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -17,6 +17,7 @@ import {
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
 import { SLO } from '../../types/models';
+import { validateSLO } from '../../domain/services';
 
 export class UpdateSLO {
   constructor(
@@ -45,6 +46,7 @@ export class UpdateSLO {
   private updateSLO(originalSlo: SLO, params: UpdateSLOParams) {
     let hasBreakingChange = false;
     const updatedSlo: SLO = Object.assign({}, originalSlo, params, { updated_at: new Date() });
+    validateSLO(updatedSlo);
 
     if (!deepEqual(originalSlo.indicator, updatedSlo.indicator)) {
       hasBreakingChange = true;

--- a/x-pack/plugins/observability/server/types/models/duration.test.ts
+++ b/x-pack/plugins/observability/server/types/models/duration.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Duration, DurationUnit } from './duration';
+
+describe('Duration', () => {
+  it('throws when value is negative', () => {
+    expect(() => new Duration(-1, DurationUnit.d)).toThrow('invalid duration value');
+  });
+
+  it('throws when value is zero', () => {
+    expect(() => new Duration(0, DurationUnit.d)).toThrow('invalid duration value');
+  });
+
+  it('throws when unit is not valid', () => {
+    expect(() => new Duration(1, 'z' as DurationUnit)).toThrow('invalid duration unit');
+  });
+
+  describe('isShorterThan', () => {
+    it('returns true when the current duration is shorter than the other duration', () => {
+      const short = new Duration(1, DurationUnit.m);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.h))).toBe(true);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.d))).toBe(true);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.w))).toBe(true);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.M))).toBe(true);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.Q))).toBe(true);
+      expect(short.isShorterThan(new Duration(1, DurationUnit.Y))).toBe(true);
+    });
+
+    it('returns false when the current duration is longer (or equal) than the other duration', () => {
+      const long = new Duration(1, DurationUnit.Y);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.m))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.h))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.d))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.w))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.M))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.Q))).toBe(false);
+      expect(long.isShorterThan(new Duration(1, DurationUnit.Y))).toBe(false);
+    });
+  });
+});

--- a/x-pack/plugins/observability/server/types/models/duration.ts
+++ b/x-pack/plugins/observability/server/types/models/duration.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { assertNever } from '@kbn/std';
+import * as moment from 'moment';
+
+enum DurationUnit {
+  'm' = 'm',
+  'h' = 'h',
+  'd' = 'd',
+  'w' = 'w',
+  'M' = 'M',
+  'Q' = 'Q',
+  'Y' = 'Y',
+}
+
+class Duration {
+  constructor(public readonly value: number, public readonly unit: DurationUnit) {
+    if (isNaN(value) || value <= 0) {
+      throw new Error('invalid duration value');
+    }
+    if (!Object.values(DurationUnit).includes(unit as unknown as DurationUnit)) {
+      throw new Error('invalid duration unit');
+    }
+  }
+}
+
+const toMomentUnitOfTime = (unit: DurationUnit): moment.unitOfTime.Diff => {
+  switch (unit) {
+    case DurationUnit.m:
+      return 'minutes';
+    case DurationUnit.h:
+      return 'hours';
+    case DurationUnit.d:
+      return 'days';
+    case DurationUnit.w:
+      return 'weeks';
+    case DurationUnit.M:
+      return 'months';
+    case DurationUnit.Q:
+      return 'quarters';
+    case DurationUnit.Y:
+      return 'years';
+    default:
+      assertNever(unit);
+  }
+};
+
+export { Duration, DurationUnit, toMomentUnitOfTime };

--- a/x-pack/plugins/observability/server/types/models/duration.ts
+++ b/x-pack/plugins/observability/server/types/models/duration.ts
@@ -27,6 +27,12 @@ class Duration {
       throw new Error('invalid duration unit');
     }
   }
+
+  isShorterThan(other: Duration): boolean {
+    const otherDurationMoment = moment.duration(other.value, toMomentUnitOfTime(other.unit));
+    const currentDurationMoment = moment.duration(this.value, toMomentUnitOfTime(this.unit));
+    return currentDurationMoment.asSeconds() < otherDurationMoment.asSeconds();
+  }
 }
 
 const toMomentUnitOfTime = (unit: DurationUnit): moment.unitOfTime.Diff => {

--- a/x-pack/plugins/observability/server/types/models/index.ts
+++ b/x-pack/plugins/observability/server/types/models/index.ts
@@ -8,3 +8,4 @@
 export * from './slo';
 export * from './indicators';
 export * from './error_budget';
+export * from './duration';

--- a/x-pack/plugins/observability/server/types/schema/duration.ts
+++ b/x-pack/plugins/observability/server/types/schema/duration.ts
@@ -7,25 +7,7 @@
 
 import { either } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
-
-enum DurationUnit {
-  'd' = 'd',
-  'w' = 'w',
-  'M' = 'M',
-  'Q' = 'Q',
-  'Y' = 'Y',
-}
-
-class Duration {
-  constructor(public readonly value: number, public readonly unit: DurationUnit) {
-    if (isNaN(value) || value <= 0) {
-      throw new Error('invalid duration value');
-    }
-    if (!Object.values(DurationUnit).includes(unit as unknown as DurationUnit)) {
-      throw new Error('invalid duration unit');
-    }
-  }
-}
+import { Duration, DurationUnit } from '../models/duration';
 
 const durationType = new t.Type<Duration, string, unknown>(
   'Duration',
@@ -45,4 +27,4 @@ const durationType = new t.Type<Duration, string, unknown>(
   (duration: Duration): string => `${duration.value}${duration.unit}`
 );
 
-export { Duration, DurationUnit, durationType };
+export { durationType };

--- a/x-pack/plugins/observability/server/types/schema/schema.test.ts
+++ b/x-pack/plugins/observability/server/types/schema/schema.test.ts
@@ -10,7 +10,6 @@ import { fold } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { dateType } from './common';
-import { Duration, DurationUnit } from './duration';
 
 describe('Schema', () => {
   describe('DateType', () => {
@@ -40,20 +39,6 @@ describe('Schema', () => {
           }, t.identity)
         )
       ).toThrow(new Error('decode'));
-    });
-  });
-
-  describe('Duration', () => {
-    it('throws when value is negative', () => {
-      expect(() => new Duration(-1, DurationUnit.d)).toThrow('invalid duration value');
-    });
-
-    it('throws when value is zero', () => {
-      expect(() => new Duration(0, DurationUnit.d)).toThrow('invalid duration value');
-    });
-
-    it('throws when unit is not valid', () => {
-      expect(() => new Duration(1, 'z' as DurationUnit)).toThrow('invalid duration unit');
     });
   });
 });

--- a/x-pack/plugins/observability/server/types/schema/slo.ts
+++ b/x-pack/plugins/observability/server/types/schema/slo.ts
@@ -6,11 +6,24 @@
  */
 
 import * as t from 'io-ts';
+import { durationType } from './duration';
 
-const budgetingMethodSchema = t.literal('occurrences');
+const occurencesBudgetingMethodSchema = t.literal<string>('occurrences');
+const timeslicesBudgetingMethodSchema = t.literal<string>('timeslices');
 
-const objectiveSchema = t.type({
-  target: t.number,
-});
+const budgetingMethodSchema = t.union([
+  occurencesBudgetingMethodSchema,
+  timeslicesBudgetingMethodSchema,
+]);
 
-export { budgetingMethodSchema, objectiveSchema };
+const objectiveSchema = t.intersection([
+  t.type({ target: t.number }),
+  t.partial({ timeslice_target: t.number, timeslice_window: durationType }),
+]);
+
+export {
+  budgetingMethodSchema,
+  occurencesBudgetingMethodSchema,
+  timeslicesBudgetingMethodSchema,
+  objectiveSchema,
+};


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/142786

📣 Suggest to review commit per commit

This PR introduces the **timeslices** budgeting method. The objective requires two new fields, the **timeslice_target** as well as the **timeslice_window**. 

The **validateSLO** domain service has been introduced to ensure that the SLO is valid from a business invariants perspective. For example, a target must be a number between 0 and 1, or when **timeslices** budgeting method is used, we require **timeslice_window** and **timeslice_target**. And the **timeslice_window** must be shorter than the overall slo time window duration.

When fetching the SLI values for an SLO defined with a **timeslices** budgeting method, we split the time window in slices of **timeslice_window**, and by comparing the sum of good events vs total events with the **timeslice_target** we can define the slice as good or not. Finally, we count the number of good slices over the total number of slices. 
These values are then used to compute the error budget consumption as well as the current SLI value, as it is done for the **occurrences** budgeting method.


## ✅ Manual Tests


<details>
<summary>Create an SLO with timeslices budgeting method</summary>

```
curl --request POST \
  --url http://localhost:5601/rbj/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "My SLO Availability - rolling 30d",
	"description": "99% o11y-app all services availablility",
	"indicator": {
		"type": "slo.apm.transaction_error_rate",
		"params": {
			"environment": "development",
			"service": "o11y-app",
			"transaction_type": "request",
			"transaction_name": "GET /flaky",
			"good_status_codes": ["2xx", "3xx", "4xx"]
		}
	},
	"time_window": {
		"duration": "30d",
		"is_rolling": true
	},
	"budgeting_method": "timeslices",
	"objective": {
		"target": 0.99,
		"timeslice_target": 0.95,
		"timeslice_window": "5m"
	}
}'
```
</details>



<details>
<summary>Get the created SLO</summary>

```
curl --request GET \
  --url http://localhost:5601/rbj/api/observability/slos/c944bc40-4bf1-11ed-a403-81b178d94d4d \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'kbn-xsrf: oui'
```
</details>

