### PR TITLE
[Synthetics] Replace custom formatting code with Kibana `uiSettings` value

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_list.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_list.tsx
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import React, { MouseEvent, useMemo, useState } from 'react';
 import { EuiBasicTable, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 import { useHistory } from 'react-router-dom';
+import { useKibanaDateFormat } from '../../../../../hooks/use_kibana_date_format';
 import { Ping } from '../../../../../../common/runtime_types';
 import { useErrorFailedStep } from '../hooks/use_error_failed_step';
 import {
@@ -42,6 +43,8 @@ export const ErrorsList = () => {
 
   const history = useHistory();
 
+  const format = useKibanaDateFormat();
+
   const columns = [
     {
       field: '@timestamp',
@@ -50,7 +53,7 @@ export const ErrorsList = () => {
       render: (value: string, item: Ping) => {
         return (
           <EuiLink href={`${basePath}/app/synthetics/error-details/${item.state?.id}`}>
-            {formatTestRunAt(item.state!.started_at)}
+            {formatTestRunAt(item.state!.started_at, format)}
           </EuiLink>
         );
       },

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
@@ -36,6 +36,7 @@ import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/
 import { isStepEnd } from '../../common/monitor_test_result/browser_steps_list';
 import { JourneyStepScreenshotContainer } from '../../common/monitor_test_result/journey_step_screenshot_container';
 
+import { useKibanaDateFormat } from '../../../../../hooks/use_kibana_date_format';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { useJourneySteps } from '../hooks/use_journey_steps';
 
@@ -207,9 +208,10 @@ const TestDetailsLink = ({
   const { euiTheme } = useEuiTheme();
   const { basePath } = useSyntheticsSettingsContext();
 
+  const format = useKibanaDateFormat();
   const timestampText = (
     <EuiText size="s" css={{ fontWeight: euiTheme.font.weight.medium }}>
-      {formatTestRunAt(timestamp)}
+      {formatTestRunAt(timestamp, format)}
     </EuiText>
   );
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -36,6 +36,7 @@ import { BrowserStepsList } from '../../common/monitor_test_result/browser_steps
 import { SinglePingResult } from '../../common/monitor_test_result/single_ping_result';
 import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/status_badge';
 
+import { useKibanaDateFormat } from '../../../../../hooks/use_kibana_date_format';
 import { useJourneySteps } from '../hooks/use_journey_steps';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 
@@ -103,9 +104,11 @@ const PanelHeader = ({
 
   const { basePath } = useSyntheticsSettingsContext();
 
+  const format = useKibanaDateFormat();
+
   const lastRunTimestamp = useMemo(
-    () => (latestPing?.timestamp ? formatTestRunAt(latestPing?.timestamp) : ''),
-    [latestPing?.timestamp]
+    () => (latestPing?.timestamp ? formatTestRunAt(latestPing?.timestamp, format) : ''),
+    [latestPing?.timestamp, format]
   );
 
   const isBrowserMonitor = monitor?.[ConfigKey.MONITOR_TYPE] === DataStream.BROWSER;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/monitor_test_result/test_time_formats.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/monitor_test_result/test_time_formats.ts
@@ -6,7 +6,6 @@
  */
 
 import moment from 'moment';
-import { i18n } from '@kbn/i18n';
 
 /**
  * Formats the microseconds (µ) into either milliseconds (ms) or seconds (s) based on the duration value
@@ -31,27 +30,7 @@ export const formatTestDuration = (duration = 0, isMilli = false) => {
   return `${(duration / 1000).toFixed(0)} ms`;
 };
 
-export function formatTestRunAt(timestamp: string) {
+export function formatTestRunAt(timestamp: string, format: string) {
   const stampedMoment = moment(timestamp);
-  const startOfToday = moment().startOf('day');
-  const startOfYesterday = moment().add(-1, 'day');
-
-  const dateStr =
-    stampedMoment > startOfToday
-      ? `${TODAY_LABEL}`
-      : stampedMoment > startOfYesterday
-      ? `${YESTERDAY_LABEL}`
-      : `${stampedMoment.format('ll')} `;
-
-  const timeStr = stampedMoment.format('HH:mm:ss');
-
-  return `${dateStr} @ ${timeStr}`;
+  return stampedMoment.format(format);
 }
-
-const TODAY_LABEL = i18n.translate('xpack.synthetics.monitorDetails.summary.today', {
-  defaultMessage: 'Today',
-});
-
-const YESTERDAY_LABEL = i18n.translate('xpack.synthetics.monitorDetails.summary.yesterday', {
-  defaultMessage: 'Yesterday',
-});

--- a/x-pack/plugins/synthetics/public/hooks/use_kibana_date_format.ts
+++ b/x-pack/plugins/synthetics/public/hooks/use_kibana_date_format.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kibanaService } from '../utils/kibana_service';
+
+const DEFAULT_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
+
+export function useKibanaDateFormat() {
+  return kibanaService.core.uiSettings.get('dateFormat', DEFAULT_FORMAT);
+}


### PR DESCRIPTION
## Summary

Resolves #143402.

We previously had implemented some custom date formatting logic based on the designs. The actual intention was that we use the UI Settings value from Kibana core.

I've added a hook to reference the value provided by core, and overwritten the previous logic.

