### PR TITLE
[Terminal Output] per process 'output' btn wasn't always present.

### DIFF
--- a/x-pack/plugins/session_view/server/routes/io_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/io_events_route.ts
@@ -79,7 +79,7 @@ export const searchProcessWithIOEvents = async (
     ? [
         {
           range: {
-            '@timestamp': {
+            [TIMESTAMP]: {
               gte: range[0],
               lte: range[1],
             },
@@ -105,13 +105,7 @@ export const searchProcessWithIOEvents = async (
         custom_agg: {
           terms: {
             field: PROCESS_ENTITY_ID_PROPERTY,
-          },
-          aggs: {
-            bucket_sort: {
-              bucket_sort: {
-                size: PROCESS_EVENTS_PER_PAGE,
-              },
-            },
+            size: PROCESS_EVENTS_PER_PAGE,
           },
         },
       },
@@ -126,6 +120,7 @@ export const searchProcessWithIOEvents = async (
       event: {
         kind: EventKind.event,
         action: EventAction.text_output,
+        id: bucket.key,
       },
       process: {
         entity_id: bucket.key,

--- a/x-pack/plugins/session_view/server/routes/process_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.ts
@@ -133,7 +133,7 @@ export const fetchEventsAndScopedAlerts = async (
 
     const processesWithIOEvents = await searchProcessWithIOEvents(client, sessionEntityId, range);
 
-    events = [...alertsBody.events, ...processesWithIOEvents, ...events]; // we place process events at the end, as they have proper cursor info. (putting the 'faked' io event indicators at end breaks pagination, since they lack a timestamp).
+    events = [...events, ...alertsBody.events, ...processesWithIOEvents];
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes io_events aggregate query. bucket_sort options incorrect. was maxing out at 10 results, when there could be many more for a single page of process events. This would cause some processes in session view to not have an [output] button when they actually have some output.


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->