### PR TITLE
Curations settings: use analytics_enabled flag instead of fetching log settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings.tsx
@@ -30,7 +30,8 @@ import { Loading } from '../../../../../shared/loading';
 import { EuiButtonTo } from '../../../../../shared/react_router_helpers';
 import { SETTINGS_PATH } from '../../../../routes';
 import { DataPanel } from '../../../data_panel';
-import { LogRetentionLogic, LogRetentionOptions } from '../../../log_retention';
+
+import { EngineLogic } from '../../../engine';
 
 import { AutomatedIcon } from '../../components/automated_icon';
 
@@ -50,26 +51,17 @@ export const CurationsSettings: React.FC = () => {
     toggleCurationsMode,
   } = useActions(CurationsSettingsLogic);
 
-  const { isLogRetentionUpdating, logRetention } = useValues(LogRetentionLogic);
-  const { fetchLogRetention } = useActions(LogRetentionLogic);
-
-  const analyticsDisabled = !logRetention?.[LogRetentionOptions.Analytics].enabled;
-
-  useEffect(() => {
-    if (hasPlatinumLicense) {
-      fetchLogRetention();
-    }
-  }, [hasPlatinumLicense]);
+  const {
+    engine: { analytics_enabled: analyticsEnabled },
+  } = useValues(EngineLogic);
 
   useEffect(() => {
-    if (logRetention) {
-      if (!analyticsDisabled) {
-        loadCurationsSettings();
-      } else {
-        onSkipLoadingCurationsSettings();
-      }
+    if (analyticsEnabled && dataLoading) {
+      loadCurationsSettings();
+    } else {
+      onSkipLoadingCurationsSettings();
     }
-  }, [logRetention]);
+  });
 
   if (!hasPlatinumLicense)
     return (
@@ -117,7 +109,7 @@ export const CurationsSettings: React.FC = () => {
         </EuiButtonEmpty>
       </DataPanel>
     );
-  if (dataLoading || isLogRetentionUpdating) return <Loading />;
+  if (dataLoading) return <Loading />;
 
   return (
     <>
@@ -139,7 +131,7 @@ export const CurationsSettings: React.FC = () => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />
-      {analyticsDisabled && (
+      {!analyticsEnabled && (
         <>
           <EuiCallOut
             iconType="iInCircle"
@@ -189,7 +181,7 @@ export const CurationsSettings: React.FC = () => {
               }
             )}
             checked={enabled}
-            disabled={analyticsDisabled}
+            disabled={!analyticsEnabled}
             onChange={toggleCurationsEnabled}
           />
         </EuiFlexItem>
@@ -202,7 +194,7 @@ export const CurationsSettings: React.FC = () => {
               }
             )}
             checked={mode === 'automatic'}
-            disabled={analyticsDisabled}
+            disabled={!analyticsEnabled}
             onChange={toggleCurationsMode}
           />
         </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings.tsx
@@ -61,7 +61,7 @@ export const CurationsSettings: React.FC = () => {
     } else {
       onSkipLoadingCurationsSettings();
     }
-  });
+  }, [analyticsEnabled, dataLoading]);
 
   if (!hasPlatinumLicense)
     return (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -63,7 +63,7 @@ export interface EngineDetails extends Engine {
   includedEngines?: EngineDetails[];
   adaptive_relevance_suggestions?: SearchRelevanceSuggestionDetails;
   adaptive_relevance_suggestions_active: boolean;
-  analytics_enabled: boolean;
+  analytics_enabled?: boolean;
 }
 
 interface ResultField {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -63,6 +63,7 @@ export interface EngineDetails extends Engine {
   includedEngines?: EngineDetails[];
   adaptive_relevance_suggestions?: SearchRelevanceSuggestionDetails;
   adaptive_relevance_suggestions_active: boolean;
+  analytics_enabled: boolean;
 }
 
 interface ResultField {


### PR DESCRIPTION
## Summary

Fixes curations settings not being rendered for admin roles.
The root of the issue has to do with the UI fetching the log settings, which can only be accessed by owner roles.
For users that have other types of roles, the API call will return a 403 status and the curations settings will not be correctly displayed.
Instead of fetching the log settings, which are used to determine whether analytics logs are available, we will instead use the `analytics_enabled` flag from the engine details.

