### PR TITLE
[Lens] Restore old baseline for performance test

### DIFF
--- a/packages/kbn-journeys/journey/journey.ts
+++ b/packages/kbn-journeys/journey/journey.ts
@@ -12,7 +12,7 @@ import { Page } from 'playwright';
 import callsites from 'callsites';
 import { ToolingLog } from '@kbn/tooling-log';
 import { FtrConfigProvider } from '@kbn/test';
-import { FtrProviderContext } from '@kbn/ftr-common-functional-services';
+import { FtrProviderContext, KibanaServer } from '@kbn/ftr-common-functional-services';
 
 import { Auth } from '../services/auth';
 import { InputDelays } from '../services/input_delays';
@@ -27,6 +27,7 @@ export interface BaseStepCtx {
   log: ToolingLog;
   inputDelays: InputDelays;
   kbnUrl: KibanaUrl;
+  kibanaServer: KibanaServer;
 }
 
 export type AnyStep = Step<{}>;

--- a/packages/kbn-journeys/journey/journey_ftr_harness.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_harness.ts
@@ -358,6 +358,7 @@ export class JourneyFtrHarness {
           })
         )
       ),
+      kibanaServer: this.kibanaServer,
     });
 
     return this.#_ctx;

--- a/x-pack/performance/journeys/data_stress_test_lens.ts
+++ b/x-pack/performance/journeys/data_stress_test_lens.ts
@@ -11,7 +11,8 @@ import { waitForVisualizations } from '../utils';
 export const journey = new Journey({
   kbnArchives: ['test/functional/fixtures/kbn_archiver/stress_test'],
   esArchives: ['test/functional/fixtures/es_archiver/stress_test'],
-}).step('Go to dashboard', async ({ page, kbnUrl }) => {
+}).step('Go to dashboard', async ({ page, kbnUrl, kibanaServer }) => {
+  await kibanaServer.uiSettings.update({ 'histogram:maxBars': 100 });
   await page.goto(kbnUrl.get(`/app/dashboards#/view/92b143a0-2e9c-11ed-b1b6-a504560b392c`));
 
   await waitForVisualizations(page, 1);


### PR DESCRIPTION
We recently changed an advanced setting default (https://github.com/elastic/kibana/pull/143081) which disturbed the baseline for the existing performance test. This PR restores it so values stay comparable.

<img width="838" alt="Screenshot 2022-10-18 at 12 49 10" src="https://user-images.githubusercontent.com/1508364/196410027-db550207-1a82-46b8-b988-e989d0e54440.png">

