### PR TITLE
[Synthetics UI] Tweak the panels in the monitor summary page

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_ten_test_runs.tsx
@@ -119,7 +119,7 @@ export const LastTenTestRuns = () => {
   ];
 
   return (
-    <EuiPanel css={{ minHeight: 200 }}>
+    <EuiPanel hasShadow={false} hasBorder css={{ minHeight: 200 }}>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -52,7 +52,7 @@ export const LastTestRun = () => {
   const loading = stepsLoading || pingsLoading;
 
   return (
-    <EuiPanel css={{ minHeight: 356 }}>
+    <EuiPanel hasShadow={false} hasBorder css={{ minHeight: 356 }}>
       <PanelHeader monitor={monitor} latestPing={latestPing} loading={loading} />
       {!loading && latestPing?.error ? (
         <EuiCallOut

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -35,7 +35,7 @@ export const MonitorSummary = () => {
     <>
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>
-          <EuiPanel>
+          <EuiPanel hasShadow={false} hasBorder>
             <EuiTitle size="xs">
               <h3>{MONITOR_DETAILS_LABEL}</h3>
             </EuiTitle>
@@ -43,7 +43,7 @@ export const MonitorSummary = () => {
           </EuiPanel>
         </EuiFlexItem>
         <EuiFlexItem grow={2}>
-          <EuiPanel css={{ padding: euiTheme.size.s, height: 158 }}>
+          <EuiPanel hasShadow={false} hasBorder paddingSize="s" css={{ height: 158 }}>
             <EuiTitle size="xs">
               <h3 css={{ margin: euiTheme.size.s, marginBottom: 0 }}>{LAST_30DAYS_LABEL}</h3>
             </EuiTitle>
@@ -69,7 +69,7 @@ export const MonitorSummary = () => {
           <EuiSpacer size="l" />
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiPanel>
+              <EuiPanel hasShadow={false} hasBorder>
                 <EuiFlexGroup alignItems="center">
                   <EuiFlexItem grow={false}>
                     <EuiTitle size="xs">

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -33,7 +33,7 @@ export const MonitorSummary = () => {
 
   return (
     <>
-      <EuiFlexGroup>
+      <EuiFlexGroup gutterSize="m">
         <EuiFlexItem grow={1}>
           <EuiPanel hasShadow={false} hasBorder>
             <EuiTitle size="xs">
@@ -66,8 +66,8 @@ export const MonitorSummary = () => {
               <EuiFlexItem>{/* TODO: Add error sparkline*/}</EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>
-          <EuiSpacer size="l" />
-          <EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup gutterSize="m">
             <EuiFlexItem>
               <EuiPanel hasShadow={false} hasBorder>
                 <EuiFlexGroup alignItems="center">
@@ -88,10 +88,10 @@ export const MonitorSummary = () => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="l" />
-      {/* <EuiPanel style={{ height: 100 }}>/!* TODO: Add status panel*!/</EuiPanel> */}
       {/* <EuiSpacer size="l" /> */}
-      <EuiFlexGroup>
+      {/* <EuiPanel style={{ height: 100 }}>/!* TODO: Add status panel*!/</EuiPanel> */}
+      <EuiSpacer size="m" />
+      <EuiFlexGroup gutterSize="m">
         <EuiFlexItem>
           <LastTestRun />
         </EuiFlexItem>
@@ -99,7 +99,7 @@ export const MonitorSummary = () => {
           <StepDurationPanel />
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <LastTenTestRuns />
     </>
   );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
@@ -26,7 +26,7 @@ export const StepDurationPanel = () => {
   const isBrowser = monitor?.type === 'browser';
 
   return (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} hasBorder>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">


### PR DESCRIPTION
Closes #143515.

Adjusts the panels in the summary page to match the intended design.

<img width="1012" alt="Screenshot 2022-10-18 at 14 38 02" src="https://user-images.githubusercontent.com/57448/196431444-52a7c782-56d4-4778-8bf2-74361e8f674b.png">
