### PR TITLE
[Cloud Posture] improved getHealthyAgents logic

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
@@ -184,7 +184,8 @@ describe('CspSetupStatus route', () => {
     ] as unknown as AgentPolicy[]);
 
     mockAgentClient.getAgentStatusForAgentPolicy.mockResolvedValue({
-      total: 1,
+      online: 1,
+      updating: 0,
     } as unknown as GetAgentStatusResponse['results']);
 
     // Act
@@ -269,7 +270,8 @@ describe('CspSetupStatus route', () => {
     ] as unknown as AgentPolicy[]);
 
     mockAgentClient.getAgentStatusForAgentPolicy.mockResolvedValue({
-      total: 0,
+      online: 0,
+      updating: 0,
     } as unknown as GetAgentStatusResponse['results']);
 
     // Act
@@ -323,7 +325,8 @@ describe('CspSetupStatus route', () => {
     ] as unknown as AgentPolicy[]);
 
     mockAgentClient.getAgentStatusForAgentPolicy.mockResolvedValue({
-      total: 1,
+      online: 1,
+      updating: 0,
     } as unknown as GetAgentStatusResponse['results']);
 
     // Act
@@ -379,7 +382,8 @@ describe('CspSetupStatus route', () => {
     ] as unknown as AgentPolicy[]);
 
     mockAgentClient.getAgentStatusForAgentPolicy.mockResolvedValue({
-      total: 1,
+      online: 1,
+      updating: 0,
     } as unknown as GetAgentStatusResponse['results']);
 
     // Act

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
@@ -44,8 +44,10 @@ const getHealthyAgents = async (
     agentPolicies
   );
 
-  // TODO: should be fixed - currently returns all agents instead of healthy agents only
-  return Object.values(agentStatusesByAgentPolicyId).reduce((sum, status) => sum + status.total, 0);
+  return Object.values(agentStatusesByAgentPolicyId).reduce(
+    (sum, status) => sum + status.online + status.updating,
+    0
+  );
 };
 
 const calculateCspStatusCode = (


### PR DESCRIPTION
## Summary
 
Resolves #136532

`getHealthyAgents` function now checks for `online` and `updating` statuses instead of `total`