### PR TITLE
[APM] Fix bug that causes alert expression to not close

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/popover_expression/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/popover_expression/index.tsx
@@ -28,7 +28,7 @@ export function PopoverExpression(props: Props) {
           description={title}
           value={value}
           isActive={popoverOpen}
-          onClick={() => setPopoverOpen(true)}
+          onClick={() => setPopoverOpen((state) => !state)}
         />
       }
       repositionOnScroll


### PR DESCRIPTION
This fixes an issue where the popover was unclosable if the expression element is clicked twice

**Reproduction of bug**
https://codesandbox.io/s/popoverexpression-wont-close-8jpbsz?file=/demo.js

**Before:**
https://user-images.githubusercontent.com/209966/196442335-1c712bd2-deb4-483b-ae80-c1df993943d9.mp4

**After:**
https://user-images.githubusercontent.com/209966/196443056-5f4fb28d-ecd2-44e5-8b69-68efc627ca13.mp4

