### PR TITLE
[Security Solution] - Fix boolean check for threat intel summary view

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -179,10 +179,11 @@ const EventDetailsComponent: React.FC<Props> = ({
     [detailsEcsData]
   );
 
-  const showThreatSummary = useMemo(
-    () => enrichmentCount > 0 || (isLicenseValid && (hostRisk || userRisk)),
-    [enrichmentCount, hostRisk, isLicenseValid, userRisk]
-  );
+  const showThreatSummary = useMemo(() => {
+    const hasEnrichments = enrichmentCount > 0;
+    const hasRiskInfoWithLicense = isLicenseValid && (hostRisk || userRisk);
+    return hasEnrichments || hasRiskInfoWithLicense;
+  }, [enrichmentCount, hostRisk, isLicenseValid, userRisk]);
 
   const summaryTab: EventViewTab | undefined = useMemo(
     () =>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -179,6 +179,11 @@ const EventDetailsComponent: React.FC<Props> = ({
     [detailsEcsData]
   );
 
+  const showThreatSummary = useMemo(
+    () => enrichmentCount > 0 || (isLicenseValid && (hostRisk || userRisk)),
+    [enrichmentCount, hostRisk, isLicenseValid, userRisk]
+  );
+
   const summaryTab: EventViewTab | undefined = useMemo(
     () =>
       isAlert
@@ -237,20 +242,19 @@ const EventDetailsComponent: React.FC<Props> = ({
                   isReadOnly={isReadOnly}
                 />
 
-                {enrichmentCount > 0 ||
-                  (isLicenseValid && (hostRisk || userRisk) && (
-                    <ThreatSummaryView
-                      isDraggable={isDraggable}
-                      hostRisk={hostRisk}
-                      userRisk={userRisk}
-                      browserFields={browserFields}
-                      data={data}
-                      eventId={id}
-                      timelineId={timelineId}
-                      enrichments={allEnrichments}
-                      isReadOnly={isReadOnly}
-                    />
-                  ))}
+                {showThreatSummary && (
+                  <ThreatSummaryView
+                    isDraggable={isDraggable}
+                    hostRisk={hostRisk}
+                    userRisk={userRisk}
+                    browserFields={browserFields}
+                    data={data}
+                    eventId={id}
+                    timelineId={timelineId}
+                    enrichments={allEnrichments}
+                    isReadOnly={isReadOnly}
+                  />
+                )}
 
                 {isEnrichmentsLoading && (
                   <>
@@ -268,7 +272,6 @@ const EventDetailsComponent: React.FC<Props> = ({
       browserFields,
       data,
       detailsEcsData,
-      enrichmentCount,
       goToTableTab,
       handleOnEventClosed,
       hostRisk,
@@ -277,7 +280,7 @@ const EventDetailsComponent: React.FC<Props> = ({
       isAlert,
       isDraggable,
       isEnrichmentsLoading,
-      isLicenseValid,
+      showThreatSummary,
       isReadOnly,
       renderer,
       timelineId,


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/elastic/kibana/issues/143509 .

The boolean check to show threat intel was written in a way in which it will only show when there user/host risk information is enabled. When playing with the structure of the boolean checks to fix it in place, prettier unfortunately "fixed" the checks to the current format that causes this issue. I pulled the boolean checks out of the render to allow it to be properly structured.

In the long run, these components probably shouldn't be mixed and we should pull out user and host risk into a separate summary component with it's own checks.


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->