### PR TITLE
[ResponseOps][Alerting] Adding back unknown outcome filter

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/get_filter.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/get_filter.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFilter } from './get_filter';
+
+describe('getFilter', () => {
+  test('should return message filter', () => {
+    expect(getFilter({ message: 'test message' })).toEqual([
+      'message: "test message" OR error.message: "test message"',
+    ]);
+  });
+
+  test('should return outcome filter', () => {
+    expect(getFilter({ outcomeFilter: ['failure', 'warning', 'success', 'unknown'] })).toEqual([
+      'event.outcome: failure OR kibana.alerting.outcome: warning OR kibana.alerting.outcome:success OR (event.outcome: success AND NOT kibana.alerting.outcome:*) OR event.outcome: unknown',
+    ]);
+  });
+
+  test('should return runId filter', () => {
+    expect(getFilter({ runId: 'test' })).toEqual(['kibana.alert.rule.execution.uuid: test']);
+  });
+});

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/get_filter.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/rule_api/get_filter.ts
@@ -39,6 +39,7 @@ function getOutcomeFilter(outcomeFilter: string[]) {
     warning: 'kibana.alerting.outcome: warning',
     success:
       'kibana.alerting.outcome:success OR (event.outcome: success AND NOT kibana.alerting.outcome:*)',
+    unknown: 'event.outcome: unknown',
   };
   return `${outcomeFilter.map((f) => filterMapping[f]).join(' OR ')}`;
 }


### PR DESCRIPTION
## Summary

In this [PR](https://github.com/elastic/kibana/pull/142645), I accidentally removed the unknown filter. This PR adds it back

### To verify

- Create a rule and let it run
- Try to filter on the unknown status on the rule run history table and verify that it sends a filter back in http request
