### PR TITLE
[Enterprise Search] introduce rich select for ml models

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -160,15 +160,15 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => 
                     </EuiToolTip>
                   </EuiFlexItem>
                 )}
-                {(modelType.length > 0 ? [modelType] : modelTypes).map((type) => (
-                  <EuiFlexItem grow={false} key={type}>
-                    <EuiFlexGroup gutterSize="xs">
-                      <EuiFlexItem>
-                        <EuiBadge color="hollow">{type}</EuiBadge>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
-                ))}
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup gutterSize="xs">
+                    <EuiFlexItem>
+                      <span>
+                        <EuiBadge color="hollow">{modelType}</EuiBadge>
+                      </span>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/custom_pipeline_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/custom_pipeline_item.tsx
@@ -56,15 +56,17 @@ export const CustomPipelineItem: React.FC<{
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiBadge color="hollow">
-              {i18n.translate(
-                'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.processorsDescription',
-                {
-                  defaultMessage: '{processorsCount} Processors',
-                  values: { processorsCount },
-                }
-              )}
-            </EuiBadge>
+            <span>
+              <EuiBadge color="hollow">
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.processorsDescription',
+                  {
+                    defaultMessage: '{processorsCount} Processors',
+                    values: { processorsCount },
+                  }
+                )}
+              </EuiBadge>
+            </span>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/default_pipeline_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/default_pipeline_item.tsx
@@ -75,12 +75,14 @@ export const DefaultPipelineItem: React.FC<{
             </EuiFlexItem>
           )}
           <EuiFlexItem grow={false}>
-            <EuiBadge color="hollow">
-              {i18n.translate(
-                'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.managedBadge.label',
-                { defaultMessage: 'Managed' }
-              )}
-            </EuiBadge>
+            <span>
+              <EuiBadge color="hollow">
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.indices.pipelines.ingestPipelinesCard.managedBadge.label',
+                  { defaultMessage: 'Managed' }
+                )}
+              </EuiBadge>
+            </span>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -17,6 +17,8 @@ import {
   EuiFormRow,
   EuiLink,
   EuiSelect,
+  EuiSuperSelect,
+  EuiSuperSelectOption,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -29,6 +31,9 @@ import { docLinks } from '../../../../../shared/doc_links';
 import { IndexViewLogic } from '../../index_view_logic';
 
 import { MLInferenceLogic } from './ml_inference_logic';
+import { MlModelSelectOption } from './model_select_option';
+
+const MODEL_SELECT_PLACEHOLDER_VALUE = 'model_placeholder$$';
 
 const NoSourceFieldsError: React.FC = () => (
   <FormattedMessage
@@ -61,6 +66,22 @@ export const ConfigurePipeline: React.FC = () => {
   const models = supportedMLModels ?? [];
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
   const emptySourceFields = (sourceFields?.length ?? 0) === 0;
+
+  const modelOptions: Array<EuiSuperSelectOption<string>> = [
+    {
+      disabled: true,
+      inputDisplay: i18n.translate(
+        'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.model.placeholder',
+        { defaultMessage: 'Select a model' }
+      ),
+      value: MODEL_SELECT_PLACEHOLDER_VALUE,
+    },
+    ...models.map((model) => ({
+      dropdownDisplay: <MlModelSelectOption model={model} />,
+      inputDisplay: model.model_id,
+      value: model.model_id,
+    })),
+  ];
 
   return (
     <>
@@ -134,27 +155,19 @@ export const ConfigurePipeline: React.FC = () => {
           )}
           fullWidth
         >
-          <EuiSelect
+          <EuiSuperSelect
             data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-configureInferencePipeline-selectTrainedModel`}
             fullWidth
-            value={modelID}
-            options={[
-              {
-                disabled: true,
-                text: i18n.translate(
-                  'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.model.placeholder',
-                  { defaultMessage: 'Select a model' }
-                ),
-                value: '',
-              },
-              ...models.map((m) => ({ text: m.model_id, value: m.model_id })),
-            ]}
-            onChange={(e) =>
+            hasDividers
+            itemLayoutAlign="top"
+            onChange={(value) =>
               setInferencePipelineConfiguration({
                 ...configuration,
-                modelID: e.target.value,
+                modelID: value,
               })
             }
+            options={modelOptions}
+            valueOfSelected={modelID === '' ? MODEL_SELECT_PLACEHOLDER_VALUE : modelID}
           />
         </EuiFormRow>
         <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -131,14 +131,14 @@ interface MLInferenceProcessorsValues {
   mappingData: typeof MappingsApiLogic.values.data;
   mappingStatus: Status;
   mlInferencePipeline?: MlInferencePipeline;
-  mlModelsData: typeof MLModelsApiLogic.values.data;
+  mlModelsData: TrainedModelConfigResponse[];
   mlModelsStatus: Status;
   simulatePipelineData: typeof SimulateMlInterfacePipelineApiLogic.values.data;
   simulatePipelineErrors: string[];
   simulatePipelineResult: IngestSimulateResponse;
   simulatePipelineStatus: Status;
   sourceFields: string[] | undefined;
-  supportedMLModels: typeof MLModelsApiLogic.values.data;
+  supportedMLModels: TrainedModelConfigResponse[];
 }
 
 export const MLInferenceLogic = kea<

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -33,12 +33,10 @@ export const MlModelSelectOption: React.FC<MlModelSelectOptionProps> = ({ model 
               <EuiTextColor color="subdued">{model.model_id}</EuiTextColor>
             </EuiFlexItem>
           )}
-          <EuiFlexItem grow={false} key={type}>
-            <EuiFlexGroup gutterSize="xs">
-              <EuiFlexItem>
-                <EuiBadge color="hollow">{type}</EuiBadge>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <span>
+              <EuiBadge color="hollow">{type}</EuiBadge>
+            </span>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiTextColor, EuiTitle } from '@elastic/eui';
+import { TrainedModelConfigResponse } from '@kbn/ml-plugin/common/types/trained_models';
+
+import { getMlModelTypesForModelConfig } from '../../../../../../../common/ml_inference_pipeline';
+import { getMLType, getModelDisplayTitle } from '../../../shared/ml_inference/utils';
+
+export interface MlModelSelectOptionProps {
+  model: TrainedModelConfigResponse;
+}
+export const MlModelSelectOption: React.FC<MlModelSelectOptionProps> = ({ model }) => {
+  const type = getMLType(getMlModelTypesForModelConfig(model));
+  const title = getModelDisplayTitle(type);
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem>
+        <EuiTitle size="xs">
+          <h4>{title ?? model.model_id}</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="flexEnd">
+          {title && (
+            <EuiFlexItem>
+              <EuiTextColor color="subdued">{model.model_id}</EuiTextColor>
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false} key={type}>
+            <EuiFlexGroup gutterSize="xs">
+              <EuiFlexItem>
+                <EuiBadge color="hollow">{type}</EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
## Summary

replaced the plane select for ml models with an `EuiSuperSelect` in the add inference pipeline modal. This is to give the user more context and useful information about the ML model when they are selecting it.

Updated rendering of `EuiBadge`s on the pipelines page to be wrapped in a `span` inside `EuiFlexItem` to prevent them from going full width at small screen sizes.

### Screenshots
Selecting a model.
![image](https://user-images.githubusercontent.com/1972968/196508532-3f55b704-179b-4f22-be9d-81852d42d7e4.png)
Selected
![image](https://user-images.githubusercontent.com/1972968/196508569-ba248177-f01f-4339-af8c-c7445c67c183.png)
Empty state
<img width="789" alt="image" src="https://user-images.githubusercontent.com/1972968/196508632-b35bc212-332b-4405-9a70-0bb22bbff742.png">

Before wrapping badge in span:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/1972968/196509152-6420cd8e-7f1e-406a-a89e-f3ccb711eeaf.png">
<img width="719" alt="image" src="https://user-images.githubusercontent.com/1972968/196693353-639f5795-8b43-4e29-af4a-db56fb294ee7.png">

After wrapping badges in span:
<img width="719" alt="image" src="https://user-images.githubusercontent.com/1972968/196693196-005c0684-90ec-4414-acc7-6f6f499e91d8.png">
<img width="719" alt="image" src="https://user-images.githubusercontent.com/1972968/196693278-ecacde27-8d0f-42ee-adce-5cc98145cd58.png">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))