### PR TITLE
Fix Anomalies table bug when ES is empty

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.test.ts
@@ -129,6 +129,22 @@ describe('useNotableAnomaliesSearch', () => {
     });
   });
 
+  it('does not throw error when aggregations is undefined', async () => {
+    await act(async () => {
+      mockNotableAnomaliesSearch.mockResolvedValue({});
+      const { waitForNextUpdate } = renderHook(
+        () => useNotableAnomaliesSearch({ skip: false, from, to }),
+        {
+          wrapper: TestProviders,
+        }
+      );
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      expect(mockAddToastError).not.toBeCalled();
+    });
+  });
+
   it('returns uninstalled jobs', async () => {
     mockuseInstalledSecurityJobs.mockReturnValue({
       loading: false,

--- a/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
@@ -110,7 +110,7 @@ export const useNotableAnomaliesSearch = ({
 
         if (isSubscribed) {
           setLoading(false);
-          const buckets = response.aggregations.number_of_anomalies.buckets;
+          const buckets = response.aggregations?.number_of_anomalies.buckets ?? [];
           setData(formatResultData(buckets, notableAnomaliesJobs));
         }
       } catch (error) {

--- a/x-pack/plugins/security_solution/public/common/components/ml/api/anomalies_search.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/api/anomalies_search.ts
@@ -14,7 +14,7 @@ export interface Body {
 }
 
 export interface AnomaliesSearchResponse {
-  aggregations: {
+  aggregations?: {
     number_of_anomalies: {
       buckets: Array<{
         key: NotableAnomaliesJobId;


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/143617




## Summary

On an empty ES cluster, the anomalies search API response doesn't contain the aggregation. That wasn't expected by the UI which throws errors. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
