### PR TITLE
[APM] Fix ml permissions by removing usage of `canAccessML` 

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.ts
+++ b/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.ts
@@ -17,17 +17,10 @@ export const getAlertingCapabilities = (
   const isAlertingPluginEnabled = !!plugins.alerting;
   const isAlertingAvailable =
     isAlertingPluginEnabled && (canReadAlerts || canSaveAlerts);
-  const isMlPluginEnabled = 'ml' in plugins;
-  const canReadAnomalies = !!(
-    isMlPluginEnabled &&
-    capabilities.ml.canAccessML &&
-    capabilities.ml.canGetJobs
-  );
 
   return {
     isAlertingAvailable,
     canReadAlerts,
     canSaveAlerts,
-    canReadAnomalies,
   };
 };

--- a/x-pack/plugins/apm/public/components/routing/templates/settings_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/settings_template.tsx
@@ -60,7 +60,7 @@ function getTabs({
   selectedTab: Tab['key'];
   router: ApmRouter;
 }) {
-  const canAccessML = !!core.application.capabilities.ml?.canAccessML;
+  const canReadMlJobs = !!core.application.capabilities.ml?.canGetJobs;
 
   const tabs: Tab[] = [
     {
@@ -90,7 +90,7 @@ function getTabs({
         defaultMessage: 'Anomaly detection',
       }),
       href: router.link('/settings/anomaly-detection'),
-      hidden: !canAccessML,
+      hidden: !canReadMlJobs,
     },
     {
       key: 'custom-links',

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/alerting_popover_flyout.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/alerting_popover_flyout.tsx
@@ -47,7 +47,7 @@ interface Props {
   basePath: IBasePath;
   canReadAlerts: boolean;
   canSaveAlerts: boolean;
-  canReadAnomalies: boolean;
+  canReadMlJobs: boolean;
   includeTransactionDuration: boolean;
 }
 
@@ -55,7 +55,7 @@ export function AlertingPopoverAndFlyout({
   basePath,
   canSaveAlerts,
   canReadAlerts,
-  canReadAnomalies,
+  canReadMlJobs,
   includeTransactionDuration,
 }: Props) {
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -87,7 +87,7 @@ export function AlertingPopoverAndFlyout({
                 panel: CREATE_THRESHOLD_PANEL_ID,
                 'data-test-subj': 'apmAlertsMenuItemCreateThreshold',
               },
-              ...(canReadAnomalies
+              ...(canReadMlJobs
                 ? [
                     {
                       name: createAnomalyAlertAlertLabel,

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/index.tsx
@@ -30,13 +30,10 @@ export function ApmHeaderActionMenu() {
   const { application, http } = core;
   const { basePath } = http;
   const { capabilities } = application;
-  const canAccessML = !!capabilities.ml?.canAccessML;
-  const {
-    isAlertingAvailable,
-    canReadAlerts,
-    canSaveAlerts,
-    canReadAnomalies,
-  } = getAlertingCapabilities(plugins, capabilities);
+  const canReadMlJobs = !!capabilities.ml?.canGetJobs;
+  const canCreateMlJobs = !!capabilities.ml?.canCreateJob;
+  const { isAlertingAvailable, canReadAlerts, canSaveAlerts } =
+    getAlertingCapabilities(plugins, capabilities);
   const canSaveApmAlerts = capabilities.apm.save && canSaveAlerts;
 
   function apmHref(path: string) {
@@ -68,13 +65,13 @@ export function ApmHeaderActionMenu() {
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiHeaderLink>
-      {canAccessML && <AnomalyDetectionSetupLink />}
+      {canCreateMlJobs && <AnomalyDetectionSetupLink />}
       {isAlertingAvailable && (
         <AlertingPopoverAndFlyout
           basePath={basePath}
           canReadAlerts={canReadAlerts}
           canSaveAlerts={canSaveApmAlerts}
-          canReadAnomalies={canReadAnomalies}
+          canReadMlJobs={canReadMlJobs}
           includeTransactionDuration={serviceName !== undefined}
         />
       )}

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -45,6 +45,7 @@ export interface TelemetryTask {
 }
 
 export type CollectTelemetryParams = Parameters<TelemetryTaskExecutor>[0] & {
+  isProd: boolean;
   logger: Logger;
 };
 
@@ -55,6 +56,7 @@ export function collectDataTelemetry({
   indicesStats,
   transportRequest,
   savedObjectsClient,
+  isProd,
 }: CollectTelemetryParams) {
   return tasks.reduce((prev, task) => {
     return prev.then(async (data) => {
@@ -80,8 +82,10 @@ export function collectDataTelemetry({
           },
         });
       } catch (err) {
-        logger.warn(`Failed executing APM telemetry task ${task.name}`);
-        logger.warn(err);
+        // catch error and log as debug in production env and warn in dev env
+        const logLevel = isProd ? logger.debug : logger.warn;
+        logLevel(`Failed executing the APM telemetry task: "${task.name}"`);
+        logLevel(err);
         return data;
       }
     });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
@@ -35,6 +35,7 @@ export async function createApmTelemetry({
   taskManager,
   logger,
   kibanaVersion,
+  isProd,
 }: {
   core: CoreSetup;
   config$: Observable<APMConfig>;
@@ -42,6 +43,7 @@ export async function createApmTelemetry({
   taskManager: TaskManagerSetupContract;
   logger: Logger;
   kibanaVersion: string;
+  isProd: boolean;
 }) {
   taskManager.registerTaskDefinitions({
     [APM_TELEMETRY_TASK_NAME]: {
@@ -93,6 +95,7 @@ export async function createApmTelemetry({
       indicesStats,
       transportRequest,
       savedObjectsClient,
+      isProd,
     });
 
     await savedObjectsClient.create(

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -97,6 +97,7 @@ export class APMPlugin
         taskManager: plugins.taskManager,
         logger: this.logger,
         kibanaVersion: this.initContext.env.packageInfo.version,
+        isProd: this.initContext.env.mode.prod,
       });
     }
 


### PR DESCRIPTION
Closes #143228
Closes #139895

Fixes permission issues with ML and reduces the overall log level of apm telemetry errors to `debug` in production.