### PR TITLE
[APM] Suppress error toast when data view cannot be created

### DIFF
--- a/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
@@ -25,7 +25,21 @@ export function useApmDataView() {
   useEffect(() => {
     async function fetchDataView() {
       const title = await getApmDataViewTitle();
-      return services.dataViews.create({ title });
+      try {
+        const displayError = false;
+        return await services.dataViews.create(
+          { title },
+          undefined,
+          displayError
+        );
+      } catch (e) {
+        const noDataScreen = e.message.includes('No matching indices found');
+        if (noDataScreen) {
+          return;
+        }
+
+        throw e;
+      }
     }
 
     fetchDataView().then(setDataView);

--- a/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts
@@ -6,6 +6,7 @@
  */
 
 import { DataView } from '@kbn/data-views-plugin/common';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useEffect, useState } from 'react';
 import { ApmPluginStartDeps } from '../plugin';
@@ -19,7 +20,7 @@ async function getApmDataViewTitle() {
 }
 
 export function useApmDataView() {
-  const { services } = useKibana<ApmPluginStartDeps>();
+  const { services, notifications } = useKibana<ApmPluginStartDeps>();
   const [dataView, setDataView] = useState<DataView | undefined>();
 
   useEffect(() => {
@@ -38,12 +39,19 @@ export function useApmDataView() {
           return;
         }
 
+        notifications.toasts.danger({
+          title: i18n.translate('xpack.apm.data_view.creation_failed', {
+            defaultMessage: 'An error occurred while creating the data view',
+          }),
+          body: e.message,
+        });
+
         throw e;
       }
     }
 
     fetchDataView().then(setDataView);
-  }, [services.dataViews]);
+  }, [notifications.toasts, services.dataViews]);
 
   return { dataView };
 }


### PR DESCRIPTION
Related to: https://github.com/elastic/kibana/pull/143336

**Problem**
APM UI will attempt to create a data view on initial page load:

https://github.com/elastic/kibana/blob/c31c400174e6b6539beff27007abfeed7ae1c090/x-pack/plugins/apm/public/hooks/use_apm_data_view.ts#L25-L32

If the APM integration hasn't been installed, and no data has been ingested, it is not possible to create a data view and an error toast will be displayed

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/209966/196680748-f6d4d68a-853a-48f1-a026-02057e1c788d.png">


We don't want users to see this toast because they didn't initiate the action to create the data view

**Solution**

Suppress the toast
