### PR TITLE
[ci/longFtrGroup] reduce annotation to warning, tell people not to worry

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -59,11 +59,15 @@ function getRunGroups(bk: BuildkiteClient, allTypes: RunGroup[], typeName: strin
   if (tooLongs.length > 0) {
     bk.setAnnotation(
       `test-group-too-long:${typeName}`,
-      'error',
+      'warning',
       [
         tooLongs.length === 1
-          ? `The following "${typeName}" config has a duration that exceeds the maximum amount of time desired for a single CI job. Please split it up.`
-          : `The following "${typeName}" configs have durations that exceed the maximum amount of time desired for a single CI job. Please split them up.`,
+          ? `The following "${typeName}" config has a duration that exceeds the maximum amount of time desired for a single CI job. ` +
+            `This is not an error, and if you don't own this config then you can ignore this warning. ` +
+            `If you own this config please split it up ASAP and ask Operations if you have questions about how to do that.`
+          : `The following "${typeName}" configs have durations that exceed the maximum amount of time desired for a single CI job. ` +
+            `This is not an error, and if you don't own any of these configs then you can ignore this warning.` +
+            `If you own any of these configs please split them up ASAP and ask Operations if you have questions about how to do that.`,
         '',
         ...tooLongs.map(({ config, durationMin }) => ` - ${config}: ${durationMin} minutes`),
       ].join('\n')


### PR DESCRIPTION
The "ftr configs are too slow" warning listed on PRs is confusing contributors when their PRs fail:

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/1329312/196739901-84ea3fab-d779-456b-943e-831c6a83d31c.png">

People are assuming that since these annotation are red (which we used to indicate their seriousness) that they are the reason their PRs fail, which isn't true. This PR reduce the level to `warning` to disambiguate them from errors, and includes additional text to hopefully reduce the confusion a little bit.