### PR TITLE
Fixes saved objects bulk create functional tests

### DIFF
--- a/x-pack/test/common/lib/test_data_loader.ts
+++ b/x-pack/test/common/lib/test_data_loader.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import { LegacyUrlAlias } from '@kbn/core-saved-objects-base-server-internal';
+import Fs from 'fs/promises';
+import { FtrProviderContext } from '../ftr_provider_context';
+
 export const SPACE_1 = {
   id: 'space_1',
   name: 'Space 1',
@@ -18,6 +22,13 @@ export const SPACE_2 = {
   description: 'This is the second test space',
   disabledFeatures: [],
 };
+
+async function parseLegacyUrlAliases(path: string): Promise<LegacyUrlAlias[]> {
+  return (await Fs.readFile(path, 'utf-8'))
+    .split(/\r?\n\r?\n/)
+    .filter((line) => !!line)
+    .map((line) => JSON.parse(line));
+}
 
 // Objects can only be imported in one space at a time. To have test saved objects
 // that are shared in multiple spaces we should import all objects in the "original"
@@ -62,8 +73,7 @@ const OBJECTS_TO_SHARE: Array<{
   },
 ];
 
-// @ts-ignore
-export function getTestDataLoader({ getService }) {
+export function getTestDataLoader({ getService }: Pick<FtrProviderContext, 'getService'>) {
   const spacesService = getService('spaces');
   const kbnServer = getService('kibanaServer');
   const supertest = getService('supertest');
@@ -112,6 +122,40 @@ export function getTestDataLoader({ getService }) {
       }
     },
 
+    createLegacyUrlAliases: async (
+      spaceData: Array<{ spaceName: string | null; dataUrl: string; disabled?: boolean }>
+    ) => {
+      await Promise.all(
+        spaceData.map(async (data) => {
+          const spaceString = data.spaceName ?? 'default';
+
+          const aliases = await parseLegacyUrlAliases(data.dataUrl);
+          log.info('creating', aliases.length, 'legacy URL aliases', {
+            space: spaceString,
+          });
+
+          await Promise.all(
+            aliases.map(async (alias) => {
+              await es.create({
+                id: `legacy-url-alias:${spaceString}:${alias.targetType}:${alias.sourceId}`,
+                index: '.kibana',
+                refresh: 'wait_for',
+                document: {
+                  type: 'legacy-url-alias',
+                  updated_at: '2017-09-21T18:51:23.794Z',
+                  'legacy-url-alias': {
+                    ...alias,
+                    targetNamespace: spaceString,
+                    ...(data.disabled && { disabled: data.disabled }),
+                  },
+                },
+              });
+            })
+          );
+        })
+      );
+    },
+
     deleteFtrSavedObjectsData: async () => {
       const allSpacesIds = [
         ...(await spacesService.getAll()).map((space: { id: string }) => space.id),
@@ -131,6 +175,7 @@ export function getTestDataLoader({ getService }) {
         index: '.kibana',
         wait_for_completion: true,
         body: {
+          // @ts-expect-error
           conflicts: 'proceed',
           query: {
             bool: {

--- a/x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json
+++ b/x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json
@@ -1,0 +1,6 @@
+{
+  "sourceId": "alias-match",
+  "targetNamespace": "default",
+  "targetType": "resolvetype",
+  "targetId": "alias-match-newid"
+}

--- a/x-pack/test/saved_object_api_integration/common/suites/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/common/suites/bulk_create.ts
@@ -89,6 +89,7 @@ const createRequest = ({ type, id, initialNamespaces }: BulkCreateTestCase) => (
 export function bulkCreateTestSuiteFactory(context: FtrProviderContext) {
   const testDataLoader = getTestDataLoader(context);
   const supertest = context.getService('supertestWithoutAuth');
+  const log = context.getService('log');
 
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_create');
   const expectResponseBody =
@@ -113,6 +114,9 @@ export function bulkCreateTestSuiteFactory(context: FtrProviderContext) {
             const { type, id } = testCase;
             expect(object.type).to.eql(type);
             expect(object.id).to.eql(id);
+            log.info(
+              `object type: ${object.type}, id: ${object.id}, namespaces: ${object.namespaces}`
+            );
             let expectedMetadata;
             if (testCase.fail409Param === 'unresolvableConflict') {
               expectedMetadata = { isNotOverwritable: true };
@@ -214,6 +218,29 @@ export function bulkCreateTestSuiteFactory(context: FtrProviderContext) {
               spaceName: SPACE_2.id,
               dataUrl:
                 'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
             },
           ]);
         });

--- a/x-pack/test/saved_object_api_integration/security_and_spaces/apis/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/security_and_spaces/apis/bulk_create.ts
@@ -164,7 +164,7 @@ export default function (context: FtrProviderContext) {
   };
 
   // Failing: See https://github.com/elastic/kibana/issues/122827
-  describe.skip('_bulk_create', () => {
+  describe('_bulk_create', () => {
     getTestScenarios([false, true]).securityAndSpaces.forEach(
       ({ spaceId, users, modifier: overwrite }) => {
         const suffix = ` within the ${spaceId} space${overwrite ? ' with overwrite enabled' : ''}`;

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/bulk_create.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/bulk_create.ts
@@ -114,7 +114,7 @@ export default function (context: FtrProviderContext) {
   };
 
   // Failing: See https://github.com/elastic/kibana/issues/141782
-  describe.skip('_bulk_create', () => {
+  describe('_bulk_create', () => {
     getTestScenarios([false, true]).spaces.forEach(({ spaceId, modifier: overwrite }) => {
       const suffix = overwrite ? ' with overwrite enabled' : '';
       const tests = createTests(overwrite!, spaceId);


### PR DESCRIPTION
## Summary
- Adds legacy URL alias function to test data loader.
- Fixes test setup for SO bulk create (additional spaces for resovletype objects).

The bulk create tests require legacy URL aliases to catch specific conflict cases. The test data loader has been replacing esArchiver usage, and did not yet contain a way to create legacy URL aliases.

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->