### PR TITLE
Disables SecuritySolution Timelines unit test config

### DIFF
--- a/.buildkite/disabled_jest_configs.json
+++ b/.buildkite/disabled_jest_configs.json
@@ -1,3 +1,4 @@
 [
-  "x-pack/plugins/watcher/jest.config.js"
+  "x-pack/plugins/watcher/jest.config.js",
+  "x-pack/plugins/security_solution/public/timelines/jest.config.js"
 ]

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
@@ -129,8 +129,7 @@ jest.mock('../../fields_browser/create_field_button', () => ({
   useCreateFieldButton: () => <></>,
 }));
 
-// SKIP: https://github.com/elastic/kibana/issues/143718
-describe.skip('Body', () => {
+describe('Body', () => {
   const mount = useMountAppended();
   const mockRefetch = jest.fn();
   let appToastsMock: jest.Mocked<ReturnType<typeof useAppToastsMock.create>>;


### PR DESCRIPTION
Per https://github.com/elastic/kibana/issues/143718#issue-1415733623, if disabling the single suite doesn't resolve the flakiness we will need to disable the entire config. 