### PR TITLE
[Lens][Visualize] Hides the unused dimension label from the tooltip

### DIFF
--- a/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
@@ -619,8 +619,8 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
               xScale={xScale}
               ySortPredicate={yAxisColumn ? getSortPredicate(yAxisColumn) : 'dataIndex'}
               xSortPredicate={xAxisColumn ? getSortPredicate(xAxisColumn) : 'dataIndex'}
-              xAxisLabelName={xAxisColumn?.name}
-              yAxisLabelName={yAxisColumn?.name}
+              xAxisLabelName={xAxisColumn?.name || ''}
+              yAxisLabelName={yAxisColumn?.name || ''}
               xAxisTitle={args.gridConfig.isXAxisTitleVisible ? xAxisTitle : undefined}
               yAxisTitle={args.gridConfig.isYAxisTitleVisible ? yAxisTitle : undefined}
               xAxisLabelFormatter={(v) =>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/143626

It hides the unnecessary dimension from the tooltip

Missing X axis
<img width="964" alt="image" src="https://user-images.githubusercontent.com/17003240/196875284-98878d9f-9bf5-4845-b7e5-d3a994af6089.png">

Missing Y axis
<img width="984" alt="image" src="https://user-images.githubusercontent.com/17003240/196875386-97501292-7079-4b24-b7b6-8f062d71e398.png">


I can't find any regression by applying this change but I'd appreciate another pair of 👁️ 