### PR TITLE
Remove #CC from codeowners and fix some paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -348,12 +348,12 @@ x-pack/examples/files_example @elastic/kibana-app-services
 /x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/response-ops
 /docs/user/alerting/ @elastic/response-ops @elastic/mlr-docs
 /docs/management/connectors/ @elastic/response-ops @elastic/mlr-docs
-#CC# /x-pack/plugins/stack_alerts/ @elastic/response-ops
+/x-pack/plugins/stack_alerts/ @elastic/response-ops
 /x-pack/plugins/cases/ @elastic/response-ops
 /x-pack/test/cases_api_integration/ @elastic/response-ops
 /x-pack/test/functional/services/cases/ @elastic/response-ops
 /x-pack/test/functional_with_es_ssl/apps/cases/ @elastic/response-ops
-/x-pack/test/api_integration/apis/cases @elastic/response-ops
+/x-pack/test/api_integration/apis/cases/ @elastic/response-ops
 
 # Enterprise Search
 /x-pack/plugins/enterprise_search @elastic/enterprise-search-frontend


### PR DESCRIPTION
- Removes `#CC#` from the response-ops related paths in CODEOWERS as it currently isn't pinging the team for those folders. Example: https://github.com/elastic/kibana/pull/140885
- Fix `/x-pack/test/api_integration/apis/cases` to have a trailing `/`

I believe CC is there to indicate Kibana QA tools to run code coverage tests (kibana-qa team), so once I confirm this PR fixes it, I will notify them of the broken behaviour.