### PR TITLE
[8.5] Re-enable APM API tests

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -123,6 +123,9 @@ enabled:
   - x-pack/test/api_integration/config_security_basic.ts
   - x-pack/test/api_integration/config_security_trial.ts
   - x-pack/test/api_integration/config.ts
+  - x-pack/test/apm_api_integration/basic/config.ts
+  - x-pack/test/apm_api_integration/rules/config.ts
+  - x-pack/test/apm_api_integration/trial/config.ts  
   - x-pack/test/banners_functional/config.ts
   - x-pack/test/cases_api_integration/security_and_spaces/config_basic.ts
   - x-pack/test/cases_api_integration/security_and_spaces/config_trial.ts


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/141482

APM api tests were disabled in 8.5 branch in https://github.com/elastic/kibana/pull/141340

This re-enables them