### PR TITLE
[Enterprise Search]Add more tests for ml_inference_logic

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/mappings/mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/mappings/mappings_logic.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndicesGetMappingIndexMappingRecord } from '@elastic/elasticsearch/lib/api/types';
+import type { IndicesGetMappingIndexMappingRecord } from '@elastic/elasticsearch/lib/api/types';
 
 import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
 import { HttpLogic } from '../../../shared/http';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -163,4 +163,60 @@ describe('MlInferenceLogic', () => {
       });
     });
   });
+
+  describe('listeners', () => {
+    describe('createPipeline', () => {
+      const mockModelConfiguration = {
+        ...DEFAULT_VALUES.addInferencePipelineModal,
+        configuration: {
+          destinationField: '',
+          modelID: 'mock-model-id',
+          pipelineName: 'mock-pipeline-name',
+          sourceField: 'mock_text_field',
+        },
+        indexName: 'my-index-123',
+      };
+      it('calls makeCreatePipelineRequest when no destinationField is passed', () => {
+        mount({
+          ...DEFAULT_VALUES,
+          addInferencePipelineModal: {
+            ...mockModelConfiguration,
+          },
+        });
+        jest.spyOn(MLInferenceLogic.actions, 'makeCreatePipelineRequest');
+        MLInferenceLogic.actions.createPipeline();
+
+        expect(MLInferenceLogic.actions.makeCreatePipelineRequest).toHaveBeenCalledWith({
+          destinationField: undefined,
+          indexName: mockModelConfiguration.indexName,
+          modelId: mockModelConfiguration.configuration.modelID,
+          pipelineName: mockModelConfiguration.configuration.pipelineName,
+          sourceField: mockModelConfiguration.configuration.sourceField,
+        });
+      });
+
+      it('calls makeCreatePipelineRequest with passed destinationField', () => {
+        mount({
+          ...DEFAULT_VALUES,
+          addInferencePipelineModal: {
+            ...mockModelConfiguration,
+            configuration: {
+              ...mockModelConfiguration.configuration,
+              destinationField: 'mockDestinationField',
+            },
+          },
+        });
+        jest.spyOn(MLInferenceLogic.actions, 'makeCreatePipelineRequest');
+        MLInferenceLogic.actions.createPipeline();
+
+        expect(MLInferenceLogic.actions.makeCreatePipelineRequest).toHaveBeenCalledWith({
+          destinationField: 'mockDestinationField',
+          indexName: mockModelConfiguration.indexName,
+          modelId: mockModelConfiguration.configuration.modelID,
+          pipelineName: mockModelConfiguration.configuration.pipelineName,
+          sourceField: mockModelConfiguration.configuration.sourceField,
+        });
+      });
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -94,7 +94,6 @@ interface MLInferenceProcessorsActions {
   setAddInferencePipelineStep: (step: AddInferencePipelineSteps) => {
     step: AddInferencePipelineSteps;
   };
-  setCreateErrors(errors: string[]): { errors: string[] };
   setIndexName: (indexName: string) => { indexName: string };
   setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => {
     configuration: InferencePipelineConfiguration;
@@ -148,7 +147,6 @@ export const MLInferenceLogic = kea<
     clearFormErrors: true,
     createPipeline: true,
     setAddInferencePipelineStep: (step: AddInferencePipelineSteps) => ({ step }),
-    setCreateErrors: (errors: string[]) => ({ errors }),
     setFormErrors: (inputErrors: AddInferencePipelineFormErrors) => ({ inputErrors }),
     setIndexName: (indexName: string) => ({ indexName }),
     setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => ({
@@ -208,7 +206,6 @@ export const MLInferenceLogic = kea<
         sourceField: configuration.sourceField,
       });
     },
-    makeCreatePipelineRequest: () => actions.setCreateErrors([]),
     setIndexName: ({ indexName }) => {
       actions.makeMLModelsRequest(undefined);
       actions.makeMappingRequest({ indexName });
@@ -268,7 +265,7 @@ export const MLInferenceLogic = kea<
       [],
       {
         createApiError: (_, error) => getErrorsFromHttpResponse(error),
-        setCreateErrors: (_, { errors }) => errors,
+        makeCreatePipelineRequest: () => [],
       },
     ],
     simulatePipelineErrors: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
@@ -7,7 +7,7 @@
 import { LogicMounter, mockFlashMessageHelpers } from '../../../../__mocks__/kea_logic';
 import { apiIndex, connectorIndex } from '../../../__mocks__/view_index.mock';
 
-import { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
+import type { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 
 import { UpdatePipelineApiLogic } from '../../../api/connector/update_pipeline_api_logic';
 import { FetchCustomPipelineApiLogic } from '../../../api/index/fetch_custom_pipeline_api_logic';
@@ -223,15 +223,15 @@ describe('PipelinesLogic', () => {
 
         expect(PipelinesLogic.values).toEqual({
           ...DEFAULT_VALUES,
+          canSetPipeline: false,
+          canUseMlInferencePipeline: true,
           customPipelineData: indexPipelines,
+          hasIndexIngestionPipeline: true,
           index: {
             ...apiIndex,
           },
           indexName,
           pipelineName: indexName,
-          canSetPipeline: false,
-          hasIndexIngestionPipeline: true,
-          canUseMlInferencePipeline: true,
         });
       });
     });


### PR DESCRIPTION
## Summary
Adds more tests to cover create listeners on ML Inference Logic.
Also removed an action that was not used anywhere and not necessary 

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
