### PR TITLE
feat(slo): Support custom KQL indicator type

### DIFF
--- a/x-pack/plugins/observability/server/errors/errors.ts
+++ b/x-pack/plugins/observability/server/errors/errors.ts
@@ -18,3 +18,4 @@ export class SLONotFound extends ObservabilityError {}
 export class InternalQueryError extends ObservabilityError {}
 export class NotSupportedError extends ObservabilityError {}
 export class IllegalArgumentError extends ObservabilityError {}
+export class InvalidTransformError extends ObservabilityError {}

--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -18,6 +18,7 @@ import {
 import {
   ApmTransactionDurationTransformGenerator,
   ApmTransactionErrorRateTransformGenerator,
+  KQLCustomTransformGenerator,
   TransformGenerator,
 } from '../../services/slo/transform_generators';
 import { IndicatorTypes } from '../../types/models';
@@ -32,6 +33,7 @@ import { createObservabilityServerRoute } from '../create_observability_server_r
 const transformGenerators: Record<IndicatorTypes, TransformGenerator> = {
   'slo.apm.transaction_duration': new ApmTransactionDurationTransformGenerator(),
   'slo.apm.transaction_error_rate': new ApmTransactionErrorRateTransformGenerator(),
+  'slo.kql.custom': new KQLCustomTransformGenerator(),
 };
 
 const createSLORoute = createObservabilityServerRoute({

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -13,6 +13,7 @@ import {
   APMTransactionDurationIndicator,
   APMTransactionErrorRateIndicator,
   Indicator,
+  KQLCustomIndicator,
   SLO,
 } from '../../../types/models';
 import { CreateSLOParams } from '../../../types/rest_specs';
@@ -41,6 +42,19 @@ export const createAPMTransactionDurationIndicator = (
     transaction_name: 'irrelevant',
     transaction_type: 'irrelevant',
     'threshold.us': 500000,
+    ...params,
+  },
+});
+
+export const createKQLCustomIndicator = (
+  params: Partial<KQLCustomIndicator['params']> = {}
+): Indicator => ({
+  type: 'slo.kql.custom',
+  params: {
+    index: 'my-index*',
+    query_filter: 'labels.groupId: group-3',
+    numerator: 'latency < 300',
+    denominator: '',
     ...params,
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KQL Custom Transform Generator aggregates using the denominator kql 1`] = `
+Object {
+  "filter": Object {
+    "bool": Object {
+      "minimum_should_match": 1,
+      "should": Array [
+        Object {
+          "exists": Object {
+            "field": "http.status_code",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`KQL Custom Transform Generator aggregates using the numerator kql 1`] = `
+Object {
+  "filter": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "range": Object {
+                  "latency": Object {
+                    "lt": "400",
+                  },
+                },
+              },
+            ],
+          },
+        },
+        Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "bool": Object {
+                  "minimum_should_match": 1,
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "http.status_code": "2xx",
+                      },
+                    },
+                  ],
+                },
+              },
+              Object {
+                "bool": Object {
+                  "minimum_should_match": 1,
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "http.status_code": "3xx",
+                      },
+                    },
+                  ],
+                },
+              },
+              Object {
+                "bool": Object {
+                  "minimum_should_match": 1,
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "http.status_code": "4xx",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`KQL Custom Transform Generator filters the source using the kql query 1`] = `
+Object {
+  "bool": Object {
+    "minimum_should_match": 1,
+    "should": Array [
+      Object {
+        "match": Object {
+          "labels.groupId": "group-4",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`KQL Custom Transform Generator returns the correct transform params with every specified indicator params 1`] = `
+Object {
+  "_meta": Object {
+    "version": 1,
+  },
+  "dest": Object {
+    "index": "slo-observability.sli-v1",
+    "pipeline": "slo-observability.sli.monthly",
+  },
+  "frequency": "1m",
+  "pivot": Object {
+    "aggregations": Object {
+      "slo.denominator": Object {
+        "filter": Object {
+          "match_all": Object {},
+        },
+      },
+      "slo.numerator": Object {
+        "filter": Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "range": Object {
+                  "latency": Object {
+                    "lt": "300",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    "group_by": Object {
+      "@timestamp": Object {
+        "date_histogram": Object {
+          "calendar_interval": "1m",
+          "field": "@timestamp",
+        },
+      },
+      "slo.id": Object {
+        "terms": Object {
+          "field": "slo.id",
+        },
+      },
+      "slo.revision": Object {
+        "terms": Object {
+          "field": "slo.revision",
+        },
+      },
+    },
+  },
+  "settings": Object {
+    "deduce_mappings": false,
+  },
+  "source": Object {
+    "index": "my-index*",
+    "query": Object {
+      "bool": Object {
+        "minimum_should_match": 1,
+        "should": Array [
+          Object {
+            "match": Object {
+              "labels.groupId": "group-3",
+            },
+          },
+        ],
+      },
+    },
+    "runtime_mappings": Object {
+      "slo.id": Object {
+        "script": Object {
+          "source": Any<String>,
+        },
+        "type": "keyword",
+      },
+      "slo.revision": Object {
+        "script": Object {
+          "source": "emit(1)",
+        },
+        "type": "long",
+      },
+    },
+  },
+  "sync": Object {
+    "time": Object {
+      "delay": "60s",
+      "field": "@timestamp",
+    },
+  },
+  "transform_id": Any<String>,
+}
+`;

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -10,6 +10,7 @@ import {
   MappingRuntimeFieldType,
   TransformPutTransformRequest,
 } from '@elastic/elasticsearch/lib/api/types';
+import { InvalidTransformError } from '../../../errors';
 import { ALL_VALUE, apmTransactionDurationIndicatorSchema } from '../../../types/schema';
 import {
   SLO_DESTINATION_INDEX_NAME,
@@ -25,7 +26,7 @@ const APM_SOURCE_INDEX = 'metrics-apm*';
 export class ApmTransactionDurationTransformGenerator implements TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
     if (!apmTransactionDurationIndicatorSchema.is(slo.indicator)) {
-      throw new Error(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
+      throw new InvalidTransformError(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
     }
 
     return getSLOTransformTemplate(

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -10,6 +10,7 @@ import {
   MappingRuntimeFieldType,
   TransformPutTransformRequest,
 } from '@elastic/elasticsearch/lib/api/types';
+import { InvalidTransformError } from '../../../errors';
 import { ALL_VALUE, apmTransactionErrorRateIndicatorSchema } from '../../../types/schema';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
 import { TransformGenerator } from '.';
@@ -27,7 +28,7 @@ const DEFAULT_GOOD_STATUS_CODES = ['2xx', '3xx', '4xx'];
 export class ApmTransactionErrorRateTransformGenerator implements TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
     if (!apmTransactionErrorRateIndicatorSchema.is(slo.indicator)) {
-      throw new Error(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
+      throw new InvalidTransformError(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
     }
 
     return getSLOTransformTemplate(

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/index.ts
@@ -8,3 +8,4 @@
 export * from './transform_generator';
 export * from './apm_transaction_error_rate';
 export * from './apm_transaction_duration';
+export * from './kql_custom';

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createKQLCustomIndicator, createSLO } from '../fixtures/slo';
+import { KQLCustomTransformGenerator } from './kql_custom';
+
+const generator = new KQLCustomTransformGenerator();
+
+describe('KQL Custom Transform Generator', () => {
+  it('returns the correct transform params with every specified indicator params', async () => {
+    const anSLO = createSLO({ indicator: createKQLCustomIndicator() });
+    const transform = generator.getTransformParams(anSLO);
+
+    expect(transform).toMatchSnapshot({
+      transform_id: expect.any(String),
+      source: { runtime_mappings: { 'slo.id': { script: { source: expect.any(String) } } } },
+    });
+    expect(transform.transform_id).toEqual(`slo-${anSLO.id}-${anSLO.revision}`);
+    expect(transform.source.runtime_mappings!['slo.id']).toMatchObject({
+      script: { source: `emit('${anSLO.id}')` },
+    });
+    expect(transform.source.runtime_mappings!['slo.revision']).toMatchObject({
+      script: { source: `emit(${anSLO.revision})` },
+    });
+  });
+
+  it('filters the source using the kql query', async () => {
+    const anSLO = createSLO({
+      indicator: createKQLCustomIndicator({ query_filter: 'labels.groupId: group-4' }),
+    });
+    const transform = generator.getTransformParams(anSLO);
+
+    expect(transform.source.query).toMatchSnapshot();
+  });
+
+  it('uses the provided index', async () => {
+    const anSLO = createSLO({
+      indicator: createKQLCustomIndicator({ index: 'my-own-index*' }),
+    });
+    const transform = generator.getTransformParams(anSLO);
+
+    expect(transform.source.index).toBe('my-own-index*');
+  });
+
+  it('aggregates using the numerator kql', async () => {
+    const anSLO = createSLO({
+      indicator: createKQLCustomIndicator({
+        numerator:
+          'latency < 400 and (http.status_code: 2xx or http.status_code: 3xx or http.status_code: 4xx)',
+      }),
+    });
+    const transform = generator.getTransformParams(anSLO);
+
+    expect(transform.pivot!.aggregations!['slo.numerator']).toMatchSnapshot();
+  });
+
+  it('aggregates using the denominator kql', async () => {
+    const anSLO = createSLO({
+      indicator: createKQLCustomIndicator({
+        denominator: 'http.status_code: *',
+      }),
+    });
+    const transform = generator.getTransformParams(anSLO);
+
+    expect(transform.pivot!.aggregations!['slo.denominator']).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
@@ -11,6 +11,27 @@ import { KQLCustomTransformGenerator } from './kql_custom';
 const generator = new KQLCustomTransformGenerator();
 
 describe('KQL Custom Transform Generator', () => {
+  describe('validation', () => {
+    it('throws when the KQL numerator is invalid', () => {
+      const anSLO = createSLO({
+        indicator: createKQLCustomIndicator({ numerator: '{ kql.query: invalid' }),
+      });
+      expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
+    });
+    it('throws when the KQL denominator is invalid', () => {
+      const anSLO = createSLO({
+        indicator: createKQLCustomIndicator({ denominator: '{ kql.query: invalid' }),
+      });
+      expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
+    });
+    it('throws when the KQL query_filter is invalid', () => {
+      const anSLO = createSLO({
+        indicator: createKQLCustomIndicator({ query_filter: '{ kql.query: invalid' }),
+      });
+      expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
+    });
+  });
+
   it('returns the correct transform params with every specified indicator params', async () => {
     const anSLO = createSLO({ indicator: createKQLCustomIndicator() });
     const transform = generator.getTransformParams(anSLO);

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AggregationsCalendarInterval,
+  MappingRuntimeFieldType,
+  TransformPutTransformRequest,
+} from '@elastic/elasticsearch/lib/api/types';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+
+import { kqlCustomIndicatorSchema } from '../../../types/schema';
+import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
+import { TransformGenerator } from '.';
+import {
+  SLO_DESTINATION_INDEX_NAME,
+  SLO_INGEST_PIPELINE_NAME,
+  getSLOTransformId,
+} from '../../../assets/constants';
+import { KQLCustomIndicator, SLO } from '../../../types/models';
+
+export class KQLCustomTransformGenerator implements TransformGenerator {
+  public getTransformParams(slo: SLO): TransformPutTransformRequest {
+    if (!kqlCustomIndicatorSchema.is(slo.indicator)) {
+      throw new Error(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
+    }
+
+    return getSLOTransformTemplate(
+      this.buildTransformId(slo),
+      this.buildSource(slo, slo.indicator),
+      this.buildDestination(),
+      this.buildGroupBy(),
+      this.buildAggregations(slo, slo.indicator)
+    );
+  }
+
+  private buildTransformId(slo: SLO): string {
+    return getSLOTransformId(slo.id, slo.revision);
+  }
+
+  private buildSource(slo: SLO, indicator: KQLCustomIndicator) {
+    const filter = toElasticsearchQuery(fromKueryExpression(indicator.params.query_filter));
+    return {
+      index: indicator.params.index,
+      runtime_mappings: {
+        'slo.id': {
+          type: 'keyword' as MappingRuntimeFieldType,
+          script: {
+            source: `emit('${slo.id}')`,
+          },
+        },
+        'slo.revision': {
+          type: 'long' as MappingRuntimeFieldType,
+          script: {
+            source: `emit(${slo.revision})`,
+          },
+        },
+      },
+      query: filter,
+    };
+  }
+
+  private buildDestination() {
+    return {
+      pipeline: SLO_INGEST_PIPELINE_NAME,
+      index: SLO_DESTINATION_INDEX_NAME,
+    };
+  }
+
+  private buildGroupBy() {
+    return {
+      'slo.id': {
+        terms: {
+          field: 'slo.id',
+        },
+      },
+      'slo.revision': {
+        terms: {
+          field: 'slo.revision',
+        },
+      },
+      '@timestamp': {
+        date_histogram: {
+          field: '@timestamp',
+          calendar_interval: '1m' as AggregationsCalendarInterval,
+        },
+      },
+    };
+  }
+
+  private buildAggregations(slo: SLO, indicator: KQLCustomIndicator) {
+    const numerator = toElasticsearchQuery(fromKueryExpression(indicator.params.numerator));
+    const denominator = toElasticsearchQuery(fromKueryExpression(indicator.params.denominator));
+    return {
+      'slo.numerator': {
+        filter: numerator,
+      },
+      'slo.denominator': {
+        filter: denominator,
+      },
+    };
+  }
+}

--- a/x-pack/plugins/observability/server/types/models/indicators.ts
+++ b/x-pack/plugins/observability/server/types/models/indicators.ts
@@ -12,10 +12,12 @@ import {
   indicatorDataSchema,
   indicatorSchema,
   indicatorTypesSchema,
+  kqlCustomIndicatorSchema,
 } from '../schema';
 
 type APMTransactionErrorRateIndicator = t.TypeOf<typeof apmTransactionErrorRateIndicatorSchema>;
 type APMTransactionDurationIndicator = t.TypeOf<typeof apmTransactionDurationIndicatorSchema>;
+type KQLCustomIndicator = t.TypeOf<typeof kqlCustomIndicatorSchema>;
 type Indicator = t.TypeOf<typeof indicatorSchema>;
 type IndicatorTypes = t.TypeOf<typeof indicatorTypesSchema>;
 type IndicatorData = t.TypeOf<typeof indicatorDataSchema>;
@@ -25,5 +27,6 @@ export type {
   IndicatorTypes,
   APMTransactionErrorRateIndicator,
   APMTransactionDurationIndicator,
+  KQLCustomIndicator,
   IndicatorData,
 };

--- a/x-pack/plugins/observability/server/types/schema/indicators.ts
+++ b/x-pack/plugins/observability/server/types/schema/indicators.ts
@@ -8,8 +8,7 @@
 import * as t from 'io-ts';
 import { allOrAnyString } from './common';
 
-const apmTransactionDurationIndicatorTypeSchema = t.literal<string>('slo.apm.transaction_duration');
-
+const apmTransactionDurationIndicatorTypeSchema = t.literal('slo.apm.transaction_duration');
 const apmTransactionDurationIndicatorSchema = t.type({
   type: apmTransactionDurationIndicatorTypeSchema,
   params: t.type({
@@ -21,10 +20,7 @@ const apmTransactionDurationIndicatorSchema = t.type({
   }),
 });
 
-const apmTransactionErrorRateIndicatorTypeSchema = t.literal<string>(
-  'slo.apm.transaction_error_rate'
-);
-
+const apmTransactionErrorRateIndicatorTypeSchema = t.literal('slo.apm.transaction_error_rate');
 const apmTransactionErrorRateIndicatorSchema = t.type({
   type: apmTransactionErrorRateIndicatorTypeSchema,
   params: t.intersection([
@@ -42,16 +38,29 @@ const apmTransactionErrorRateIndicatorSchema = t.type({
   ]),
 });
 
+const kqlCustomIndicatorTypeSchema = t.literal('slo.kql.custom');
+const kqlCustomIndicatorSchema = t.type({
+  type: kqlCustomIndicatorTypeSchema,
+  params: t.type({
+    index: t.string,
+    query_filter: t.string,
+    numerator: t.string,
+    denominator: t.string,
+  }),
+});
+
 const indicatorDataSchema = t.type({ good: t.number, total: t.number });
 
 const indicatorTypesSchema = t.union([
   apmTransactionDurationIndicatorTypeSchema,
   apmTransactionErrorRateIndicatorTypeSchema,
+  kqlCustomIndicatorTypeSchema,
 ]);
 
 const indicatorSchema = t.union([
   apmTransactionDurationIndicatorSchema,
   apmTransactionErrorRateIndicatorSchema,
+  kqlCustomIndicatorSchema,
 ]);
 
 export {
@@ -59,6 +68,8 @@ export {
   apmTransactionDurationIndicatorTypeSchema,
   apmTransactionErrorRateIndicatorSchema,
   apmTransactionErrorRateIndicatorTypeSchema,
+  kqlCustomIndicatorSchema,
+  kqlCustomIndicatorTypeSchema,
   indicatorSchema,
   indicatorTypesSchema,
   indicatorDataSchema,


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/143784

This PR introduces support for custom KQL indicator. The parameters must be valid KQL or an empty string.

## ✅  Manual testing

1. Run Kibana locally
2. Follow the readme from https://github.com/elastic/high-cardinality-cluster to generate logs data
3. Create the following SLO

<details>
<summary>Create SLO with custom KQL indicator</summary>

```
curl --request POST \
  --url http://localhost:5601/cyp/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "SLO latency service log",
	"description": "latency from logs",
	"indicator": {
		"type": "slo.kql.custom",
		"params": {
			"index": "high-cardinality-data-fake_logs*",
			"numerator": "latency < 300",
			"denominator": "",
			"query_filter": "labels.groupId: group-0"
		}
	},
	"time_window": {
		"duration": "7d",
		"is_rolling": true
	},
	"budgeting_method": "occurrences",
	"objective": {
		"target": 0.98
	}
}'
```
</details