### PR TITLE
chore(slo): Add missing properties in saved object definition

### DIFF
--- a/x-pack/plugins/observability/server/saved_objects/slo.ts
+++ b/x-pack/plugins/observability/server/saved_objects/slo.ts
@@ -42,8 +42,11 @@ export const slo: SavedObjectsType = {
       objective: {
         properties: {
           target: { type: 'float' },
+          timeslice_target: { type: 'float' },
+          timeslice_window: { type: 'keyword' },
         },
       },
+      revision: { type: 'short' },
       created_at: { type: 'date' },
       updated_at: { type: 'date' },
     },


### PR DESCRIPTION
## 📝 Summary

While working on another PR, I noticed the saved object definition was not up to date. This PR adds the missing properties in the SavedObject definition.
