### PR TITLE
[Lens][TSVB] Navigate to Lens TSVB Table.

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -106,6 +106,10 @@
         },
         {
           "id": "kibDevDocsEmbeddables"
+        },
+        {
+          "id": "kibCloudExperimentsPlugin",
+          "label": "A/B testing on Elastic Cloud"
         }
       ]
     },

--- a/packages/core/analytics/core-analytics-browser-internal/src/track_viewport_size.test.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/track_viewport_size.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { firstValueFrom, take, type Subscription, toArray } from 'rxjs';
+import { analyticsClientMock } from './analytics_service.test.mocks';
+import { trackViewportSize } from './track_viewport_size';
+
+describe('trackViewportSize', () => {
+  const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+  let subscription: Subscription | undefined;
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    jest.resetAllMocks();
+  });
+
+  test('registers the analytics event type, the context provider, and a listener to the "resize" events', () => {
+    subscription = trackViewportSize(analyticsClientMock);
+
+    expect(analyticsClientMock.registerContextProvider).toHaveBeenCalledTimes(1);
+    expect(analyticsClientMock.registerContextProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'viewport_size',
+      })
+    );
+
+    expect(analyticsClientMock.registerEventType).toHaveBeenCalledTimes(1);
+    expect(analyticsClientMock.registerEventType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'viewport_resize',
+      })
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function), undefined);
+  });
+
+  test('emits a context update before the resize occurs', async () => {
+    subscription = trackViewportSize(analyticsClientMock);
+
+    const { context$ } = analyticsClientMock.registerContextProvider.mock.calls[0][0];
+    await expect(firstValueFrom(context$.pipe(take(1)))).resolves.toStrictEqual({
+      viewport_width: 1024,
+      viewport_height: 768,
+    });
+  });
+
+  test('reports an analytics event when a resize event occurs', async () => {
+    subscription = trackViewportSize(analyticsClientMock);
+
+    const { context$ } = analyticsClientMock.registerContextProvider.mock.calls[0][0];
+
+    // window.resizeTo(100, 100) wouldn't trigger the event in Jest, so we need to call the listener straight away.
+    // eslint-disable-next-line dot-notation
+    window['innerWidth'] = 100;
+    // eslint-disable-next-line dot-notation
+    window['innerHeight'] = 100;
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    (addEventListenerSpy.mock.calls[0][1] as Function)();
+
+    await expect(firstValueFrom(context$.pipe(take(2), toArray()))).resolves.toStrictEqual([
+      { viewport_width: 1024, viewport_height: 768 },
+      { viewport_width: 100, viewport_height: 100 },
+    ]);
+
+    expect(analyticsClientMock.reportEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsClientMock.reportEvent).toHaveBeenCalledWith('viewport_resize', {
+      viewport_width: 100,
+      viewport_height: 100,
+    });
+  });
+});

--- a/packages/core/analytics/core-analytics-browser-internal/src/track_viewport_size.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/track_viewport_size.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { debounceTime, fromEvent, map, merge, of, shareReplay } from 'rxjs';
+import type { AnalyticsClient, RootSchema } from '@kbn/analytics-client';
+
+export interface ViewportSize {
+  viewport_width: number;
+  viewport_height: number;
+}
+
+const schema: RootSchema<ViewportSize> = {
+  viewport_width: {
+    type: 'long',
+    _meta: { description: 'The value seen as the CSS viewport @media (width)' },
+  },
+  viewport_height: {
+    type: 'long',
+    _meta: { description: 'The value seen as the CSS viewport @media (height)' },
+  },
+};
+
+/**
+ * Get the @media (width) and @media (height) in the format of {@link ViewportSize}
+ */
+function getViewportSize(): ViewportSize {
+  // Explanation of the math below: https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions
+  return {
+    viewport_width: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
+    viewport_height: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0),
+  };
+}
+
+/**
+ * Registers the event type "viewport_size" in the analytics client, and the context provider with the same name.
+ * Then it listens to all the "resize" events in the UI and reports their size as {@link ViewportSize}
+ * @param analytics
+ */
+export function trackViewportSize(analytics: AnalyticsClient) {
+  // window or document?
+  // According to MDN, it only emits on `window`: https://developer.mozilla.org/en-US/docs/Web/API/Window/resize_event
+  const resize$ = fromEvent(window, 'resize').pipe(
+    debounceTime(200),
+    map(() => getViewportSize()),
+    shareReplay(1)
+  );
+
+  analytics.registerEventType<ViewportSize>({
+    eventType: 'viewport_resize',
+    schema,
+  });
+
+  analytics.registerContextProvider({
+    name: 'viewport_size',
+    schema,
+    context$: merge(
+      of(getViewportSize()), // Emits an initial value so initial events' context is also populated
+      resize$
+    ),
+  });
+
+  return resize$.subscribe((event) => analytics.reportEvent('viewport_resize', event));
+}

--- a/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
@@ -23,6 +23,7 @@ import type {
   ChromeBadge,
   ChromeBreadcrumb,
   ChromeBreadcrumbsAppendExtension,
+  ChromeGlobalHelpExtensionMenuLink,
   ChromeHelpExtension,
   ChromeUserBanner,
 } from '@kbn/core-chrome-browser';
@@ -103,6 +104,9 @@ export class ChromeService {
   }: StartDeps): Promise<InternalChromeStart> {
     this.initVisibility(application);
 
+    const globalHelpExtensionMenuLinks$ = new BehaviorSubject<ChromeGlobalHelpExtensionMenuLink[]>(
+      []
+    );
     const helpExtension$ = new BehaviorSubject<ChromeHelpExtension | undefined>(undefined);
     const breadcrumbs$ = new BehaviorSubject<ChromeBreadcrumb[]>([]);
     const breadcrumbsAppendExtension$ = new BehaviorSubject<
@@ -213,6 +217,7 @@ export class ChromeService {
           customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
           kibanaDocLink={docLinks.links.kibana.guide}
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
+          globalHelpExtensionMenuLinks$={globalHelpExtensionMenuLinks$}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
           homeHref={http.basePath.prepend('/app/home')}
@@ -251,6 +256,17 @@ export class ChromeService {
         breadcrumbsAppendExtension?: ChromeBreadcrumbsAppendExtension
       ) => {
         breadcrumbsAppendExtension$.next(breadcrumbsAppendExtension);
+      },
+
+      getGlobalHelpExtensionMenuLinks$: () => globalHelpExtensionMenuLinks$.asObservable(),
+
+      registerGlobalHelpExtensionMenuLink: (
+        globalHelpExtensionMenuLink: ChromeGlobalHelpExtensionMenuLink
+      ) => {
+        globalHelpExtensionMenuLinks$.next([
+          ...globalHelpExtensionMenuLinks$.value,
+          globalHelpExtensionMenuLink,
+        ]);
       },
 
       getHelpExtension$: () => helpExtension$.pipe(takeUntil(this.stop$)),

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.test.tsx
@@ -33,6 +33,7 @@ function mockProps() {
     customNavLink$: new BehaviorSubject(undefined),
     recentlyAccessed$: new BehaviorSubject([]),
     forceAppSwitcherNavigation$: new BehaviorSubject(false),
+    globalHelpExtensionMenuLinks$: new BehaviorSubject([]),
     helpExtension$: new BehaviorSubject(undefined),
     helpSupportUrl$: new BehaviorSubject(''),
     navControlsLeft$: new BehaviorSubject([]),

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
@@ -32,6 +32,7 @@ import type {
   ChromeRecentlyAccessedHistoryItem,
   ChromeBreadcrumbsAppendExtension,
   ChromeHelpExtension,
+  ChromeGlobalHelpExtensionMenuLink,
   ChromeUserBanner,
 } from '@kbn/core-chrome-browser';
 import { LoadingIndicator } from '../loading_indicator';
@@ -60,6 +61,7 @@ export interface HeaderProps {
   navLinks$: Observable<ChromeNavLink[]>;
   recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
   forceAppSwitcherNavigation$: Observable<boolean>;
+  globalHelpExtensionMenuLinks$: Observable<ChromeGlobalHelpExtensionMenuLink[]>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
   navControlsLeft$: Observable<readonly ChromeNavControl[]>;
@@ -80,6 +82,7 @@ export function Header({
   onIsLockedUpdate,
   homeHref,
   breadcrumbsAppendExtension$,
+  globalHelpExtensionMenuLinks$,
   ...observables
 }: HeaderProps) {
   const isVisible = useObservable(observables.isVisible$, false);
@@ -145,6 +148,7 @@ export function Header({
                     <HeaderNavControls navControls$={observables.navControlsExtension$} />
                   </EuiHideFor>,
                   <HeaderHelpMenu
+                    globalHelpExtensionMenuLinks$={globalHelpExtensionMenuLinks$}
                     helpExtension$={observables.helpExtension$}
                     helpSupportUrl$={observables.helpSupportUrl$}
                     kibanaDocLink={kibanaDocLink}

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { BehaviorSubject, of } from 'rxjs';
+import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
+import { HeaderHelpMenu } from './header_help_menu';
+
+describe('HeaderHelpMenu', () => {
+  test('it only renders the default content', () => {
+    const application = applicationServiceMock.createInternalStartContract();
+    const helpExtension$ = new BehaviorSubject(undefined);
+    const helpSupportUrl$ = new BehaviorSubject('');
+
+    const component = mountWithIntl(
+      <HeaderHelpMenu
+        navigateToUrl={application.navigateToUrl}
+        globalHelpExtensionMenuLinks$={of([])}
+        helpExtension$={helpExtension$}
+        helpSupportUrl$={helpSupportUrl$}
+        kibanaVersion={'version'}
+        kibanaDocLink={''}
+      />
+    );
+
+    expect(component.find('EuiButtonEmpty').length).toBe(1); // only the toggle view on/off button
+    component.find('EuiButtonEmpty').simulate('click');
+
+    // 4 default links + the toggle button
+    expect(component.find('EuiButtonEmpty').length).toBe(5);
+  });
+
+  test('it renders the global custom content + the default content', () => {
+    const application = applicationServiceMock.createInternalStartContract();
+    const helpExtension$ = new BehaviorSubject(undefined);
+    const helpSupportUrl$ = new BehaviorSubject('');
+
+    const component = mountWithIntl(
+      <HeaderHelpMenu
+        navigateToUrl={application.navigateToUrl}
+        globalHelpExtensionMenuLinks$={of([
+          {
+            linkType: 'custom',
+            href: 'my-link-2',
+            content: 'Some other text for the link',
+            priority: 10,
+          },
+          {
+            linkType: 'custom',
+            href: 'my-link',
+            content: 'Some text for the link',
+            'data-test-subj': 'my-test-custom-link',
+            priority: 100,
+          },
+        ])}
+        helpExtension$={helpExtension$}
+        helpSupportUrl$={helpSupportUrl$}
+        kibanaVersion={'version'}
+        kibanaDocLink={''}
+      />
+    );
+
+    expect(component.find('EuiButtonEmpty').length).toBe(1); // only the toggle view on/off button
+    component.find('EuiButtonEmpty').simulate('click');
+
+    // 2 custom global link + 4 default links + the toggle button
+    expect(component.find('EuiButtonEmpty').length).toBe(7);
+
+    expect(component.find('[data-test-subj="my-test-custom-link"]').exists()).toBeTruthy();
+
+    // The first global component is the second button (first is the toggle button)
+    expect(component.find('EuiButtonEmpty').at(1).prop('data-test-subj')).toBe(
+      'my-test-custom-link'
+    );
+  });
+});

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -25,13 +25,17 @@ import {
 } from '@elastic/eui';
 
 import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
-import type { ChromeHelpExtension } from '@kbn/core-chrome-browser';
+import type {
+  ChromeHelpExtension,
+  ChromeGlobalHelpExtensionMenuLink,
+} from '@kbn/core-chrome-browser';
 import { GITHUB_CREATE_ISSUE_LINK, KIBANA_FEEDBACK_LINK } from '../../constants';
 import { HeaderExtension } from './header_extension';
 import { isModifiedOrPrevented } from './nav_link';
 
 interface Props {
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
+  globalHelpExtensionMenuLinks$: Observable<ChromeGlobalHelpExtensionMenuLink[]>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
   kibanaVersion: string;
@@ -42,6 +46,7 @@ interface State {
   isOpen: boolean;
   helpExtension?: ChromeHelpExtension;
   helpSupportUrl: string;
+  globalHelpExtensionMenuLinks: ChromeGlobalHelpExtensionMenuLink[];
 }
 
 export class HeaderHelpMenu extends Component<Props, State> {
@@ -54,17 +59,20 @@ export class HeaderHelpMenu extends Component<Props, State> {
       isOpen: false,
       helpExtension: undefined,
       helpSupportUrl: '',
+      globalHelpExtensionMenuLinks: [],
     };
   }
 
   public componentDidMount() {
     this.subscription = combineLatest(
       this.props.helpExtension$,
-      this.props.helpSupportUrl$
-    ).subscribe(([helpExtension, helpSupportUrl]) => {
+      this.props.helpSupportUrl$,
+      this.props.globalHelpExtensionMenuLinks$
+    ).subscribe(([helpExtension, helpSupportUrl, globalHelpExtensionMenuLinks]) => {
       this.setState({
         helpExtension,
         helpSupportUrl,
+        globalHelpExtensionMenuLinks,
       });
     });
   }
@@ -80,6 +88,7 @@ export class HeaderHelpMenu extends Component<Props, State> {
     const { kibanaVersion } = this.props;
 
     const defaultContent = this.renderDefaultContent();
+    const globalCustomContent = this.renderGlobalCustomContent();
     const customContent = this.renderCustomContent();
 
     const button = (
@@ -126,8 +135,9 @@ export class HeaderHelpMenu extends Component<Props, State> {
         </EuiPopoverTitle>
 
         <div style={{ maxWidth: 240 }}>
+          {globalCustomContent}
           {defaultContent}
-          {defaultContent && customContent && <EuiHorizontalRule margin="m" />}
+          {(defaultContent || customContent) && <EuiHorizontalRule margin="m" />}
           {customContent}
         </div>
       </EuiPopover>
@@ -181,6 +191,22 @@ export class HeaderHelpMenu extends Component<Props, State> {
         </EuiButtonEmpty>
       </Fragment>
     );
+  }
+
+  private renderGlobalCustomContent() {
+    const { navigateToUrl } = this.props;
+    const { globalHelpExtensionMenuLinks } = this.state;
+
+    return globalHelpExtensionMenuLinks
+      .sort((a, b) => b.priority - a.priority)
+      .map((link, index) => {
+        const { linkType, content: text, href, ...rest } = link;
+        return createCustomLink(index, text, true, {
+          href,
+          onClick: this.createOnClickHandler(href, navigateToUrl),
+          ...rest,
+        });
+      });
   }
 
   private renderCustomContent() {

--- a/packages/core/chrome/core-chrome-browser-mocks/src/chrome_service.mock.ts
+++ b/packages/core/chrome/core-chrome-browser-mocks/src/chrome_service.mock.ts
@@ -50,6 +50,8 @@ const createStartContractMock = () => {
     setBreadcrumbs: jest.fn(),
     getBreadcrumbsAppendExtension$: jest.fn(),
     setBreadcrumbsAppendExtension: jest.fn(),
+    getGlobalHelpExtensionMenuLinks$: jest.fn(),
+    registerGlobalHelpExtensionMenuLink: jest.fn(),
     getHelpExtension$: jest.fn(),
     setHelpExtension: jest.fn(),
     setHelpSupportUrl: jest.fn(),
@@ -66,6 +68,7 @@ const createStartContractMock = () => {
   startContract.getBreadcrumbs$.mockReturnValue(new BehaviorSubject([{} as ChromeBreadcrumb]));
   startContract.getBreadcrumbsAppendExtension$.mockReturnValue(new BehaviorSubject(undefined));
   startContract.getCustomNavLink$.mockReturnValue(new BehaviorSubject(undefined));
+  startContract.getGlobalHelpExtensionMenuLinks$.mockReturnValue(new BehaviorSubject([]));
   startContract.getHelpExtension$.mockReturnValue(new BehaviorSubject(undefined));
   startContract.getIsNavDrawerLocked$.mockReturnValue(new BehaviorSubject(false));
   startContract.getBodyClasses$.mockReturnValue(new BehaviorSubject([]));

--- a/packages/core/chrome/core-chrome-browser/index.ts
+++ b/packages/core/chrome/core-chrome-browser/index.ts
@@ -23,6 +23,7 @@ export type {
   ChromeHelpExtensionMenuDocumentationLink,
   ChromeHelpExtensionMenuDiscussLink,
   ChromeHelpExtensionMenuCustomLink,
+  ChromeGlobalHelpExtensionMenuLink,
   ChromeDocTitle,
   ChromeStart,
   ChromeRecentlyAccessed,

--- a/packages/core/chrome/core-chrome-browser/src/contracts.ts
+++ b/packages/core/chrome/core-chrome-browser/src/contracts.ts
@@ -14,6 +14,7 @@ import type { ChromeNavControls } from './nav_controls';
 import type { ChromeHelpExtension } from './help_extension';
 import type { ChromeBreadcrumb, ChromeBreadcrumbsAppendExtension } from './breadcrumb';
 import type { ChromeBadge, ChromeUserBanner } from './types';
+import { ChromeGlobalHelpExtensionMenuLink } from './help_extension';
 
 /**
  * ChromeStart allows plugins to customize the global chrome header UI and
@@ -106,7 +107,19 @@ export interface ChromeStart {
   setCustomNavLink(newCustomNavLink?: Partial<ChromeNavLink>): void;
 
   /**
-   * Get an observable of the current custom help conttent
+   * Get the list of the registered global help extension menu links
+   */
+  getGlobalHelpExtensionMenuLinks$(): Observable<ChromeGlobalHelpExtensionMenuLink[]>;
+
+  /**
+   * Append a global help extension menu link
+   */
+  registerGlobalHelpExtensionMenuLink(
+    globalHelpExtensionMenuLink: ChromeGlobalHelpExtensionMenuLink
+  ): void;
+
+  /**
+   * Get an observable of the current custom help content
    */
   getHelpExtension$(): Observable<ChromeHelpExtension | undefined>;
 

--- a/packages/core/chrome/core-chrome-browser/src/help_extension.ts
+++ b/packages/core/chrome/core-chrome-browser/src/help_extension.ts
@@ -95,6 +95,14 @@ export interface ChromeHelpExtensionMenuCustomLink extends ChromeHelpExtensionLi
 }
 
 /** @public */
+export interface ChromeGlobalHelpExtensionMenuLink extends ChromeHelpExtensionMenuCustomLink {
+  /**
+   * Highest priority items are listed at the top of the list of links.
+   */
+  priority: number;
+}
+
+/** @public */
 export type ChromeHelpExtensionMenuLink =
   | ChromeHelpExtensionMenuGitHubLink
   | ChromeHelpExtensionMenuDiscussLink

--- a/packages/core/chrome/core-chrome-browser/src/index.ts
+++ b/packages/core/chrome/core-chrome-browser/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ChromeHelpExtensionMenuDiscussLink,
   ChromeHelpExtensionMenuDocumentationLink,
   ChromeHelpExtensionMenuGitHubLink,
+  ChromeGlobalHelpExtensionMenuLink,
 } from './help_extension';
 export type { ChromeNavControls, ChromeNavControl } from './nav_controls';
 export type { ChromeNavLinks, ChromeNavLink } from './nav_links';

--- a/src/plugins/vis_types/timeseries/public/application/components/series_editor.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/series_editor.js
@@ -65,6 +65,10 @@ export class SeriesEditor extends Component {
     }
   };
 
+  handleSeriesChange = (doc) => {
+    handleChange(this.props, doc);
+  };
+
   render() {
     const { limit, model, name, fields, colorPicker } = this.props;
     const list = model[name].filter((val, index) => index < (limit || Infinity));
@@ -89,7 +93,7 @@ export class SeriesEditor extends Component {
                   disableDelete={model[name].length < 2}
                   fields={fields}
                   onAdd={() => handleAdd(this.props, newSeriesFn)}
-                  onChange={(doc) => handleChange(this.props, doc)}
+                  onChange={this.handleSeriesChange}
                   onClone={() => this.handleClone(row)}
                   onDelete={() => handleDelete(this.props, row)}
                   model={row}

--- a/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/config.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/config.js
@@ -35,7 +35,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { getDefaultQueryLanguage } from '../../lib/get_default_query_language';
 import { checkIfNumericMetric } from '../../lib/check_if_numeric_metric';
 import { QueryBarWrapper } from '../../query_bar_wrapper';
-import { DATA_FORMATTERS } from '../../../../../common/enums';
+import { DATA_FORMATTERS, BUCKET_TYPES } from '../../../../../common/enums';
 import { isConfigurationFeatureEnabled } from '../../../../../common/check_ui_restrictions';
 import { filterCannotBeAppliedErrorMessage } from '../../../../../common/errors';
 import { tsvbEditorRowStyles } from '../../../styles/common.styles';

--- a/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/config.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/config.js
@@ -50,13 +50,20 @@ class TableSeriesConfigUi extends Component {
     }
   }
 
+  handleAggregateByChange = (selectedOptions) => {
+    this.props.onChange({
+      aggregate_by: selectedOptions?.[0],
+    });
+  };
+
+  handleSelectChange = createSelectHandler(this.props.onChange);
+  handleTextChange = createTextHandler(this.props.onChange);
+
   changeModelFormatter = (formatter) => this.props.onChange({ formatter });
 
   render() {
     const defaults = { offset_time: '', value_template: '{{value}}' };
     const model = { ...defaults, ...this.props.model };
-    const handleSelectChange = createSelectHandler(this.props.onChange);
-    const handleTextChange = createTextHandler(this.props.onChange);
     const htmlId = htmlIdGenerator();
 
     const functionOptions = [
@@ -160,7 +167,7 @@ class TableSeriesConfigUi extends Component {
               fullWidth
             >
               <EuiFieldText
-                onChange={handleTextChange('value_template')}
+                onChange={this.handleTextChange('value_template')}
                 value={model.value_template}
                 disabled={model.formatter === DATA_FORMATTERS.DEFAULT}
                 fullWidth
@@ -214,7 +221,7 @@ class TableSeriesConfigUi extends Component {
         <EuiHorizontalRule margin="s" />
 
         <EuiFlexGroup responsive={false} wrap={true}>
-          <EuiFlexItem grow={true}>
+          <EuiFlexItem grow={true} data-test-subj="aggregateBy">
             <FieldSelect
               label={
                 <FormattedMessage id="visTypeTimeseries.table.fieldLabel" defaultMessage="Field" />
@@ -222,11 +229,7 @@ class TableSeriesConfigUi extends Component {
               fields={this.props.fields}
               indexPattern={this.props.panel.index_pattern}
               value={model.aggregate_by}
-              onChange={(value) =>
-                this.props.onChange({
-                  aggregate_by: value?.[0],
-                })
-              }
+              onChange={this.handleAggregateByChange}
               fullWidth
               restrict={[
                 KBN_FIELD_TYPES.NUMBER,
@@ -236,7 +239,7 @@ class TableSeriesConfigUi extends Component {
                 KBN_FIELD_TYPES.STRING,
               ]}
               uiRestrictions={this.props.uiRestrictions}
-              type={'terms'}
+              type={BUCKET_TYPES.TERMS}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
@@ -251,9 +254,10 @@ class TableSeriesConfigUi extends Component {
               fullWidth
             >
               <EuiComboBox
+                data-test-subj="aggregateFunction"
                 options={functionOptions}
                 selectedOptions={selectedAggFuncOption ? [selectedAggFuncOption] : []}
-                onChange={handleSelectChange('aggregate_function')}
+                onChange={this.handleSelectChange('aggregate_function')}
                 singleSelection={{ asPlainText: true }}
                 fullWidth
               />

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/gauge/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/gauge/index.ts
@@ -45,7 +45,10 @@ const getMaxFormula = (metric: Metric, column?: Column) => {
   }))`;
 };
 
-export const convertToLens: ConvertTsvbToLensVisualization = async (model, timeRange) => {
+export const convertToLens: ConvertTsvbToLensVisualization = async (
+  { params: model },
+  timeRange
+) => {
   const dataViews = getDataViewsStart();
 
   const series = model.series[0];

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/index.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import type { Panel } from '../../common/types';
 import { convertTSVBtoLensConfiguration } from '.';
 
@@ -42,7 +43,9 @@ describe('convertTSVBtoLensConfiguration', () => {
       ...model,
       type: 'markdown',
     } as Panel;
-    const triggerOptions = await convertTSVBtoLensConfiguration(metricModel);
+    const triggerOptions = await convertTSVBtoLensConfiguration({
+      params: metricModel,
+    } as Vis<Panel>);
     expect(triggerOptions).toBeNull();
   });
 
@@ -51,7 +54,9 @@ describe('convertTSVBtoLensConfiguration', () => {
       ...model,
       use_kibana_indexes: false,
     };
-    const triggerOptions = await convertTSVBtoLensConfiguration(stringIndexPatternModel);
+    const triggerOptions = await convertTSVBtoLensConfiguration({
+      params: stringIndexPatternModel,
+    } as Vis<Panel>);
     expect(triggerOptions).toBeNull();
   });
 });

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/index.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import { TimeRange } from '@kbn/data-plugin/common';
 import type { Panel } from '../../common/types';
 import { PANEL_TYPES } from '../../common/enums';
@@ -29,6 +30,10 @@ const getConvertFnByType = (type: PANEL_TYPES) => {
       const { convertToLens } = await import('./gauge');
       return convertToLens;
     },
+    [PANEL_TYPES.TABLE]: async () => {
+      const { convertToLens } = await import('./table');
+      return convertToLens;
+    },
   };
 
   return convertionFns[type]?.();
@@ -39,17 +44,17 @@ const getConvertFnByType = (type: PANEL_TYPES) => {
  * Returns the Lens model, only if it is supported. If not, it returns null.
  * In case of null, the menu item is disabled and the user can't navigate to Lens.
  */
-export const convertTSVBtoLensConfiguration = async (model: Panel, timeRange?: TimeRange) => {
+export const convertTSVBtoLensConfiguration = async (vis: Vis<Panel>, timeRange?: TimeRange) => {
   // Disables the option for not supported charts, for the string mode and for series with annotations
-  if (!model.use_kibana_indexes) {
+  if (!vis.params.use_kibana_indexes) {
     return null;
   }
   // Disables if model is invalid
-  if (model.isModelInvalid) {
+  if (vis.params.isModelInvalid) {
     return null;
   }
 
-  const convertFn = await getConvertFnByType(model.type);
+  const convertFn = await getConvertFnByType(vis.params.type);
 
-  return (await convertFn?.(model, timeRange)) ?? null;
+  return (await convertFn?.(vis, timeRange)) ?? null;
 };

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.test.ts
@@ -14,7 +14,7 @@ import { getConfigurationForMetric, getConfigurationForGauge } from '.';
 
 const mockGetPalette = jest.fn();
 
-jest.mock('./palette', () => ({
+jest.mock('../palette', () => ({
   getPalette: jest.fn(() => mockGetPalette()),
 }));
 

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.ts
@@ -10,7 +10,7 @@ import color from 'color';
 import { MetricVisConfiguration } from '@kbn/visualizations-plugin/common';
 import { Panel } from '../../../../../common/types';
 import { Column, Layer } from '../../convert';
-import { getPalette } from './palette';
+import { getPalette } from '../palette';
 import { findMetricColumn, getMetricWithCollapseFn } from '../../../utils';
 
 export const getConfigurationForMetric = (

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/palette/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/palette/index.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { getPalette } from './palette';
+import { getPalette } from '.';
 
 describe('getPalette', () => {
   const baseColor = '#fff';

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/palette/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/palette/index.ts
@@ -8,7 +8,7 @@
 import color from 'color';
 import { ColorStop, CustomPaletteParams, PaletteOutput } from '@kbn/coloring';
 import { uniqBy } from 'lodash';
-import { Panel } from '../../../../../common/types';
+import { Panel, Series } from '../../../../../common/types';
 
 const Operators = {
   GTE: 'gte',
@@ -24,9 +24,11 @@ type ColorStopsWithMinMax = Pick<
 
 type MetricColorRules = Exclude<Panel['background_color_rules'], undefined>;
 type GaugeColorRules = Exclude<Panel['gauge_color_rules'], undefined>;
+type SeriesColorRules = Exclude<Series['color_rules'], undefined>;
 
 type MetricColorRule = MetricColorRules[number];
 type GaugeColorRule = GaugeColorRules[number];
+type SeriesColorRule = SeriesColorRules[number];
 
 type ValidMetricColorRule = Omit<MetricColorRule, 'background_color' | 'color'> &
   (
@@ -44,31 +46,47 @@ type ValidGaugeColorRule = Omit<GaugeColorRule, 'gauge'> & {
   gauge: Exclude<GaugeColorRule['gauge'], undefined>;
 };
 
+type ValidSeriesColorRule = Omit<SeriesColorRule, 'text'> & {
+  text: Exclude<SeriesColorRule['text'], undefined>;
+};
+
 const isValidColorRule = (
   rule: MetricColorRule | GaugeColorRule
-): rule is ValidMetricColorRule | ValidGaugeColorRule => {
+): rule is ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule => {
   const { background_color: bColor, color: textColor } = rule as MetricColorRule;
   const { gauge } = rule as GaugeColorRule;
+  const { text } = rule as SeriesColorRule;
 
-  return rule.operator && (bColor ?? textColor ?? gauge) && rule.value !== undefined ? true : false;
+  return rule.operator && (bColor ?? textColor ?? gauge ?? text) && rule.value !== undefined
+    ? true
+    : false;
 };
 
 const isMetricColorRule = (
-  rule: ValidMetricColorRule | ValidGaugeColorRule
+  rule: ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule
 ): rule is ValidMetricColorRule => {
   const metricRule = rule as ValidMetricColorRule;
   return metricRule.background_color ?? metricRule.color ? true : false;
 };
 
-const getColor = (rule: ValidMetricColorRule | ValidGaugeColorRule) => {
+const isGaugeColorRule = (
+  rule: ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule
+): rule is ValidGaugeColorRule => {
+  const metricRule = rule as ValidGaugeColorRule;
+  return metricRule.gauge ? true : false;
+};
+
+const getColor = (rule: ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule) => {
   if (isMetricColorRule(rule)) {
     return rule.background_color ?? rule.color;
+  } else if (isGaugeColorRule(rule)) {
+    return rule.gauge;
   }
-  return rule.gauge;
+  return rule.text;
 };
 
 const getColorStopsWithMinMaxForAllGteOrWithLte = (
-  rules: Array<ValidMetricColorRule | ValidGaugeColorRule>,
+  rules: Array<ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule>,
   tailOperator: string,
   baseColor?: string
 ): ColorStopsWithMinMax => {
@@ -125,7 +143,7 @@ const getColorStopsWithMinMaxForAllGteOrWithLte = (
 };
 
 const getColorStopsWithMinMaxForLtWithLte = (
-  rules: Array<ValidMetricColorRule | ValidGaugeColorRule>
+  rules: Array<ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule>
 ): ColorStopsWithMinMax => {
   const lastRule = rules[rules.length - 1];
   const colorStops = rules.reduce<ColorStop[]>((colors, rule, index, rulesArr) => {
@@ -166,7 +184,7 @@ const getColorStopsWithMinMaxForLtWithLte = (
 };
 
 const getColorStopWithMinMaxForLte = (
-  rule: ValidMetricColorRule | ValidGaugeColorRule
+  rule: ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule
 ): ColorStopsWithMinMax => {
   const colorStop = {
     color: color(getColor(rule)).hex(),
@@ -183,7 +201,7 @@ const getColorStopWithMinMaxForLte = (
 };
 
 const getColorStopWithMinMaxForGte = (
-  rule: ValidMetricColorRule | ValidGaugeColorRule,
+  rule: ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule,
   baseColor?: string
 ): ColorStopsWithMinMax => {
   const colorStop = {
@@ -224,12 +242,14 @@ const getCustomPalette = (
 };
 
 export const getPalette = (
-  rules: MetricColorRules | GaugeColorRules,
+  rules: MetricColorRules | GaugeColorRules | SeriesColorRules,
   baseColor?: string
 ): PaletteOutput<CustomPaletteParams> | null | undefined => {
-  const validRules = (rules as Array<MetricColorRule | GaugeColorRule>).filter<
-    ValidMetricColorRule | ValidGaugeColorRule
-  >((rule): rule is ValidMetricColorRule | ValidGaugeColorRule => isValidColorRule(rule));
+  const validRules = (rules as Array<MetricColorRule | GaugeColorRule | SeriesColorRule>).filter<
+    ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule
+  >((rule): rule is ValidMetricColorRule | ValidGaugeColorRule | ValidSeriesColorRule =>
+    isValidColorRule(rule)
+  );
 
   validRules.sort((rule1, rule2) => {
     return rule1.value! - rule2.value!;

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/table/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/table/index.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createSeries } from '../../__mocks__';
+import { getColumnState } from '.';
+
+const mockGetPalette = jest.fn();
+
+jest.mock('../palette', () => ({
+  getPalette: jest.fn(() => mockGetPalette()),
+}));
+
+describe('getColumnState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPalette.mockReturnValue({ id: 'custom' });
+  });
+
+  test('should return column state without palette if series is not provided', () => {
+    const config = getColumnState('test');
+    expect(config).toEqual({
+      columnId: 'test',
+      alignment: 'left',
+      colorMode: 'none',
+    });
+    expect(mockGetPalette).toBeCalledTimes(0);
+  });
+
+  test('should return column state with palette if series is provided', () => {
+    const config = getColumnState('test', undefined, createSeries());
+    expect(config).toEqual({
+      columnId: 'test',
+      alignment: 'left',
+      colorMode: 'text',
+      palette: { id: 'custom' },
+    });
+    expect(mockGetPalette).toBeCalledTimes(1);
+  });
+
+  test('should return column state with collapseFn if collapseFn is provided', () => {
+    const config = getColumnState('test', 'max', createSeries());
+    expect(config).toEqual({
+      columnId: 'test',
+      alignment: 'left',
+      colorMode: 'text',
+      palette: { id: 'custom' },
+      collapseFn: 'max',
+    });
+    expect(mockGetPalette).toBeCalledTimes(1);
+  });
+});

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/table/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/table/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Series } from '../../../../../common/types';
+import { getPalette } from '../palette';
+
+export const getColumnState = (columnId: string, collapseFn?: string, series?: Series) => {
+  const palette = series ? getPalette(series.color_rules ?? [], series.color) : undefined;
+  return {
+    columnId,
+    alignment: 'left' as const,
+    colorMode: palette ? 'text' : 'none',
+    ...(palette ? { palette } : {}),
+    ...(collapseFn ? { collapseFn } : {}),
+  };
+};

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/column.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/column.ts
@@ -32,7 +32,7 @@ interface ExtraColumnFields {
 
 const isSupportedFormat = (format: string) => ['bytes', 'number', 'percent'].includes(format);
 
-export const getFormat = (series: Series): FormatParams => {
+export const getFormat = (series: Pick<Series, 'formatter' | 'value_template'>): FormatParams => {
   let suffix;
 
   if (!series.formatter || series.formatter === 'default') {

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/date_histogram.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/date_histogram.ts
@@ -9,28 +9,36 @@
 import type { DataView } from '@kbn/data-views-plugin/common';
 import uuid from 'uuid';
 import { DateHistogramParams, DataType } from '@kbn/visualizations-plugin/common/convert_to_lens';
-import { DateHistogramColumn } from './types';
-import type { Panel, Series } from '../../../../common/types';
+import { DateHistogramColumn, DateHistogramSeries } from './types';
+import type { Panel } from '../../../../common/types';
 
 const getInterval = (interval?: string) => {
   return interval && !interval?.includes('=') ? interval : 'auto';
 };
 
-export const convertToDateHistogramParams = (model: Panel, series: Series): DateHistogramParams => {
+export const convertToDateHistogramParams = (
+  model: Panel | undefined,
+  series: DateHistogramSeries,
+  includeEmptyRows: boolean = true
+): DateHistogramParams => {
   return {
-    interval: getInterval(series.override_index_pattern ? series.series_interval : model.interval),
+    interval: getInterval(series.override_index_pattern ? series.series_interval : model?.interval),
     dropPartials: series.override_index_pattern
       ? series.series_drop_last_bucket > 0
-      : model.drop_last_bucket > 0,
-    includeEmptyRows: true,
+      : (model?.drop_last_bucket ?? 0) > 0,
+    includeEmptyRows,
   };
 };
 
 export const convertToDateHistogramColumn = (
-  model: Panel,
-  series: Series,
+  model: Panel | undefined,
+  series: DateHistogramSeries,
   dataView: DataView,
-  { fieldName, isSplit }: { fieldName: string; isSplit: boolean }
+  {
+    fieldName,
+    isSplit,
+    includeEmptyRows = true,
+  }: { fieldName: string; isSplit: boolean; includeEmptyRows?: boolean }
 ): DateHistogramColumn | null => {
   const dateField = dataView.getFieldByName(fieldName);
 
@@ -38,7 +46,7 @@ export const convertToDateHistogramColumn = (
     return null;
   }
 
-  const params = convertToDateHistogramParams(model, series);
+  const params = convertToDateHistogramParams(model, series, includeEmptyRows);
 
   return {
     columnId: uuid(),

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/filters.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/filters.ts
@@ -8,10 +8,9 @@
 
 import uuid from 'uuid';
 import { FiltersParams } from '@kbn/visualizations-plugin/common/convert_to_lens';
-import { FiltersColumn } from './types';
-import type { Series } from '../../../../common/types';
+import { FiltersColumn, FiltersSeries } from './types';
 
-export const convertToFiltersParams = (series: Series): FiltersParams => {
+export const convertToFiltersParams = (series: FiltersSeries): FiltersParams => {
   const splitFilters = [];
   if (series.split_mode === 'filter' && series.filter) {
     splitFilters.push({ filter: series.filter });
@@ -35,7 +34,10 @@ export const convertToFiltersParams = (series: Series): FiltersParams => {
   };
 };
 
-export const convertToFiltersColumn = (series: Series, isSplit: boolean): FiltersColumn | null => {
+export const convertToFiltersColumn = (
+  series: FiltersSeries,
+  isSplit: boolean
+): FiltersColumn | null => {
   const params = convertToFiltersParams(series);
   if (!params.filters.length) {
     return null;

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/terms.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/terms.ts
@@ -9,16 +9,15 @@
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { DataType, TermsParams } from '@kbn/visualizations-plugin/common';
 import uuid from 'uuid';
-import { Series } from '../../../../common/types';
 import { excludeMetaFromColumn, getFormat, isColumnWithMeta } from './column';
-import { Column, TermsColumn } from './types';
+import { Column, TermsColumn, TermsSeries } from './types';
 
 interface OrderByWithAgg {
   orderAgg?: TermsParams['orderAgg'];
   orderBy: TermsParams['orderBy'];
 }
 
-const getOrderByWithAgg = (series: Series, columns: Column[]): OrderByWithAgg | null => {
+const getOrderByWithAgg = (series: TermsSeries, columns: Column[]): OrderByWithAgg | null => {
   if (series.terms_order_by === '_key') {
     return { orderBy: { type: 'alphabetical' } };
   }
@@ -56,7 +55,7 @@ const getOrderByWithAgg = (series: Series, columns: Column[]): OrderByWithAgg | 
 };
 
 export const convertToTermsParams = (
-  series: Series,
+  series: TermsSeries,
   columns: Column[],
   secondaryFields: string[]
 ): TermsParams | null => {
@@ -84,10 +83,11 @@ export const convertToTermsParams = (
 
 export const convertToTermsColumn = (
   termFields: [string, ...string[]],
-  series: Series,
+  series: TermsSeries,
   columns: Column[],
   dataView: DataView,
-  isSplit: boolean = false
+  isSplit: boolean = false,
+  label?: string
 ): TermsColumn | null => {
   const [baseField, ...secondaryFields] = termFields;
   const field = dataView.getFieldByName(baseField);
@@ -108,6 +108,7 @@ export const convertToTermsColumn = (
     sourceField: field.name,
     isBucketed: true,
     isSplit,
+    label,
     params: { ...params, ...getFormat(series) },
   };
 };

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/types.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/convert/types.ts
@@ -117,4 +117,24 @@ export interface CommonColumnConverterArgs {
   dataView: DataView;
 }
 
+export type TermsSeries = Pick<
+  Series,
+  | 'split_mode'
+  | 'terms_direction'
+  | 'terms_order_by'
+  | 'terms_size'
+  | 'terms_include'
+  | 'terms_exclude'
+  | 'terms_field'
+  | 'formatter'
+  | 'value_template'
+>;
+
+export type FiltersSeries = Pick<Series, 'split_mode' | 'filter' | 'split_filters'>;
+
+export type DateHistogramSeries = Pick<
+  Series,
+  'split_mode' | 'override_index_pattern' | 'series_interval' | 'series_drop_last_bucket'
+>;
+
 export { FiltersColumn, TermsColumn, DateHistogramColumn };

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/metrics/supported_metrics.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/metrics/supported_metrics.ts
@@ -68,6 +68,7 @@ const supportedPanelTypes: readonly PANEL_TYPES[] = [
   PANEL_TYPES.TOP_N,
   PANEL_TYPES.METRIC,
   PANEL_TYPES.GAUGE,
+  PANEL_TYPES.TABLE,
 ];
 
 const supportedTimeRangeModes: readonly TIME_RANGE_DATA_MODES[] = [

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/metric/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/metric/index.test.ts
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import { METRIC_TYPES } from '@kbn/data-plugin/public';
 import { stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { convertToLens } from '.';
 import { createPanel, createSeries } from '../lib/__mocks__';
+import { Panel } from '../../../common/types';
 
 const mockGetMetricsColumns = jest.fn();
 const mockGetBucketsColumns = jest.fn();
@@ -53,6 +55,10 @@ describe('convertToLens', () => {
       }),
     ],
   });
+
+  const vis = {
+    params: model,
+  } as Vis<Panel>;
 
   const bucket = {
     isBucketed: true,
@@ -135,27 +141,27 @@ describe('convertToLens', () => {
 
   test('should return null for invalid metrics', async () => {
     mockIsValidMetrics.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockIsValidMetrics).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported metrics', async () => {
     mockGetMetricsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetMetricsColumns).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported buckets', async () => {
     mockGetBucketsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetBucketsColumns).toBeCalledTimes(1);
   });
 
   test('should return state for valid model', async () => {
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsMetric');
     expect(mockGetBucketsColumns).toBeCalledTimes(model.series.length);
@@ -163,16 +169,16 @@ describe('convertToLens', () => {
   });
 
   test('should skip hidden series', async () => {
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
             hidden: true,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsMetric');
     expect(mockIsValidMetrics).toBeCalledTimes(0);
@@ -185,8 +191,8 @@ describe('convertToLens', () => {
       indexPattern: { id: 'test-index-pattern-1' },
     });
 
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
@@ -197,8 +203,8 @@ describe('convertToLens', () => {
             hidden: false,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeNull();
   });
 
@@ -207,8 +213,8 @@ describe('convertToLens', () => {
     mockGetBucketsColumns.mockReturnValueOnce([]);
     mockGetMetricsColumns.mockReturnValueOnce([metric]);
 
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
@@ -219,8 +225,8 @@ describe('convertToLens', () => {
             hidden: false,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeNull();
   });
 
@@ -229,8 +235,8 @@ describe('convertToLens', () => {
     mockGetBucketsColumns.mockReturnValueOnce([bucket2]);
     mockGetMetricsColumns.mockReturnValueOnce([metric]);
 
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
@@ -241,8 +247,8 @@ describe('convertToLens', () => {
             hidden: false,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeNull();
   });
 
@@ -251,8 +257,8 @@ describe('convertToLens', () => {
     mockGetBucketsColumns.mockReturnValueOnce([bucket]);
     mockGetMetricsColumns.mockReturnValueOnce([metric]);
 
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
@@ -263,8 +269,8 @@ describe('convertToLens', () => {
             hidden: false,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsMetric');
     expect(mockGetConfigurationForMetric).toBeCalledTimes(1);

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/metric/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/metric/index.ts
@@ -22,7 +22,10 @@ import { excludeMetaFromLayers, getUniqueBuckets } from '../utils';
 const MAX_SERIES = 2;
 const MAX_BUCKETS = 2;
 
-export const convertToLens: ConvertTsvbToLensVisualization = async (model, timeRange) => {
+export const convertToLens: ConvertTsvbToLensVisualization = async (
+  { params: model },
+  timeRange
+) => {
   const dataViews = getDataViewsStart();
   const seriesNum = model.series.filter((series) => !series.hidden).length;
 

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.test.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { TableVisConfiguration } from '@kbn/visualizations-plugin/common';
+import { Vis } from '@kbn/visualizations-plugin/public';
+import { METRIC_TYPES } from '@kbn/data-plugin/public';
+import { stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
+import { convertToLens } from '.';
+import { createPanel, createSeries } from '../lib/__mocks__';
+import { Panel } from '../../../common/types';
+import { TSVB_METRIC_TYPES } from '../../../common/enums';
+
+const mockConvertToDateHistogramColumn = jest.fn();
+const mockGetMetricsColumns = jest.fn();
+const mockGetBucketsColumns = jest.fn();
+const mockGetConfigurationForTimeseries = jest.fn();
+const mockIsValidMetrics = jest.fn();
+const mockGetDatasourceValue = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve(stubLogstashDataView));
+const mockGetDataSourceInfo = jest.fn();
+const mockGetColumnState = jest.fn();
+
+jest.mock('../../services', () => ({
+  getDataViewsStart: jest.fn(() => mockGetDatasourceValue),
+}));
+
+jest.mock('../lib/convert', () => ({
+  excludeMetaFromColumn: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../lib/series', () => ({
+  getMetricsColumns: jest.fn(() => mockGetMetricsColumns()),
+  getBucketsColumns: jest.fn(() => mockGetBucketsColumns()),
+}));
+
+jest.mock('../lib/configurations/table', () => ({
+  getColumnState: jest.fn(() => mockGetColumnState()),
+}));
+
+jest.mock('../lib/metrics', () => ({
+  isValidMetrics: jest.fn(() => mockIsValidMetrics()),
+  getReducedTimeRange: jest.fn().mockReturnValue('10'),
+}));
+
+jest.mock('../lib/datasource', () => ({
+  getDataSourceInfo: jest.fn(() => mockGetDataSourceInfo()),
+}));
+
+describe('convertToLens', () => {
+  const model = createPanel({
+    series: [
+      createSeries({
+        metrics: [
+          { id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' },
+          { id: 'some-id-1', type: METRIC_TYPES.COUNT },
+        ],
+      }),
+    ],
+  });
+
+  const vis = {
+    params: model,
+    uiState: {
+      get: () => ({}),
+    },
+  } as Vis<Panel>;
+
+  beforeEach(() => {
+    mockIsValidMetrics.mockReturnValue(true);
+    mockGetDataSourceInfo.mockReturnValue({
+      indexPatternId: 'test-index-pattern',
+      timeField: 'timeField',
+      indexPattern: { id: 'test-index-pattern' },
+    });
+    mockConvertToDateHistogramColumn.mockReturnValue({});
+    mockGetMetricsColumns.mockReturnValue([{}]);
+    mockGetBucketsColumns.mockReturnValue([{}]);
+    mockGetConfigurationForTimeseries.mockReturnValue({ layers: [] });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return null for invalid metrics', async () => {
+    mockIsValidMetrics.mockReturnValue(null);
+    const result = await convertToLens(vis);
+    expect(result).toBeNull();
+    expect(mockIsValidMetrics).toBeCalledTimes(1);
+  });
+
+  test('should return null for invalid or unsupported metrics', async () => {
+    mockGetMetricsColumns.mockReturnValue(null);
+    const result = await convertToLens(vis);
+    expect(result).toBeNull();
+    expect(mockGetMetricsColumns).toBeCalledTimes(1);
+  });
+
+  test('should return null if several series have different “Field” + “Aggregate function”', async () => {
+    const result = await convertToLens({
+      params: createPanel({
+        series: [createSeries({ aggregate_by: 'new' }), createSeries({ aggregate_by: 'test' })],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeNull();
+    expect(mockGetBucketsColumns).toBeCalledTimes(1);
+  });
+
+  test('should return null if “Aggregate function” is not supported', async () => {
+    const result = await convertToLens({
+      params: createPanel({
+        series: [createSeries({ aggregate_by: 'new', aggregate_function: 'cumulative_sum' })],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeNull();
+    expect(mockGetBucketsColumns).toBeCalledTimes(1);
+  });
+
+  test('should return null if model have not visible metrics', async () => {
+    const result = await convertToLens({
+      params: createPanel({
+        series: [
+          createSeries({
+            metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
+            hidden: true,
+          }),
+        ],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeNull();
+  });
+
+  test('should return null if only static value is visible metric', async () => {
+    mockGetMetricsColumns.mockReturnValue([
+      { columnId: 'metric-column-1', operationType: 'static_value' },
+    ]);
+    const result = await convertToLens({
+      params: createPanel({
+        series: [
+          createSeries({
+            metrics: [{ id: 'some-id', type: TSVB_METRIC_TYPES.STATIC }],
+            hidden: true,
+          }),
+        ],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeNull();
+  });
+
+  test('should return state for valid model', async () => {
+    const result = await convertToLens(vis);
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('lnsDatatable');
+    expect(mockGetBucketsColumns).toBeCalledTimes(1);
+    // every series + group by
+    expect(mockGetColumnState).toBeCalledTimes(model.series.length + 1);
+  });
+
+  test('should return state for valid model with “Field” + “Aggregate function”', async () => {
+    const result = await convertToLens({
+      params: createPanel({
+        series: [createSeries({ aggregate_by: 'new', aggregate_function: 'sum' })],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('lnsDatatable');
+    expect(mockGetBucketsColumns).toBeCalledTimes(2);
+    // every series + group by + (“Field” + “Aggregate function”)
+    expect(mockGetColumnState).toBeCalledTimes(model.series.length + 2);
+  });
+
+  test('should return correct sorting config', async () => {
+    mockGetMetricsColumns.mockReturnValue([{ columnId: 'metric-column-1' }]);
+    const result = await convertToLens({
+      params: createPanel({
+        series: [createSeries({ id: 'test' })],
+      }),
+      uiState: {
+        get: () => ({ sort: { order: 'decs', column: 'test' } }),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('lnsDatatable');
+    expect((result?.configuration as TableVisConfiguration).sorting).toEqual({
+      direction: 'decs',
+      columnId: 'metric-column-1',
+    });
+    expect(mockGetBucketsColumns).toBeCalledTimes(1);
+    // every series + group by
+    expect(mockGetColumnState).toBeCalledTimes(model.series.length + 1);
+  });
+
+  test('should skip hidden series', async () => {
+    const result = await convertToLens({
+      params: createPanel({
+        series: [
+          createSeries({
+            metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
+            hidden: true,
+          }),
+          createSeries({
+            metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
+          }),
+        ],
+      }),
+      uiState: {
+        get: () => ({}),
+      },
+    } as Vis<Panel>);
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('lnsDatatable');
+    expect(mockIsValidMetrics).toBeCalledTimes(1);
+  });
+});

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import uuid from 'uuid';
+import { parseTimeShift } from '@kbn/data-plugin/common';
+import { getIndexPatternIds, Layer } from '@kbn/visualizations-plugin/common/convert_to_lens';
+import { PANEL_TYPES } from '../../../common/enums';
+import { getDataViewsStart } from '../../services';
+import { getColumnState } from '../lib/configurations/table';
+import { getDataSourceInfo } from '../lib/datasource';
+import { getMetricsColumns, getBucketsColumns } from '../lib/series';
+import { getReducedTimeRange, isValidMetrics } from '../lib/metrics';
+import { ConvertTsvbToLensVisualization } from '../types';
+import { Layer as ExtendedLayer, excludeMetaFromColumn, Column } from '../lib/convert';
+
+const excludeMetaFromLayers = (layers: Record<string, ExtendedLayer>): Record<string, Layer> => {
+  const newLayers: Record<string, Layer> = {};
+  Object.entries(layers).forEach(([layerId, layer]) => {
+    const columns = layer.columns.map(excludeMetaFromColumn);
+    newLayers[layerId] = { ...layer, columns };
+  });
+
+  return newLayers;
+};
+
+export const convertToLens: ConvertTsvbToLensVisualization = async (
+  { params: model, uiState },
+  timeRange
+) => {
+  const columnStates = [];
+  const dataViews = getDataViewsStart();
+  const seriesNum = model.series.filter((series) => !series.hidden).length;
+  const sortConfig = uiState.get('table')?.sort ?? {};
+
+  const datasourceInfo = await getDataSourceInfo(
+    model.index_pattern,
+    model.time_field,
+    false,
+    undefined,
+    undefined,
+    dataViews
+  );
+
+  if (!datasourceInfo) {
+    return null;
+  }
+
+  const { indexPatternId, indexPattern } = datasourceInfo;
+
+  const commonBucketsColumns = getBucketsColumns(
+    undefined,
+    {
+      split_mode: 'terms',
+      terms_field: model.pivot_id,
+      terms_size: model.pivot_rows ? model.pivot_rows.toString() : undefined,
+    },
+    [],
+    indexPattern!,
+    false,
+    model.pivot_label,
+    false
+  );
+
+  if (!commonBucketsColumns) {
+    return null;
+  }
+
+  const sortConfiguration = {
+    columnId: commonBucketsColumns[0].columnId,
+    direction: sortConfig.order,
+  };
+
+  columnStates.push(getColumnState(commonBucketsColumns[0].columnId));
+
+  let bucketsColumns: Column[] | null = [];
+
+  if (
+    !model.series.every(
+      (s) =>
+        ((!s.aggregate_by && !model.series[0].aggregate_by) ||
+          s.aggregate_by === model.series[0].aggregate_by) &&
+        ((!s.aggregate_function && !model.series[0].aggregate_function) ||
+          s.aggregate_function === model.series[0].aggregate_function)
+    )
+  ) {
+    return null;
+  }
+
+  if (model.series[0].aggregate_by) {
+    if (
+      !model.series[0].aggregate_function ||
+      !['sum', 'avg', 'min', 'max'].includes(model.series[0].aggregate_function)
+    ) {
+      return null;
+    }
+    bucketsColumns = getBucketsColumns(
+      undefined,
+      {
+        split_mode: 'terms',
+        terms_field: model.series[0].aggregate_by,
+      },
+      [],
+      indexPattern!,
+      false
+    );
+    if (bucketsColumns === null) {
+      return null;
+    }
+
+    columnStates.push(
+      getColumnState(bucketsColumns[0].columnId, model.series[0].aggregate_function)
+    );
+  }
+
+  const metrics = [];
+
+  // handle multiple layers/series
+  for (const [_, series] of model.series.entries()) {
+    if (series.hidden) {
+      continue;
+    }
+
+    // not valid time shift
+    if (series.offset_time && parseTimeShift(series.offset_time) === 'invalid') {
+      return null;
+    }
+
+    if (!isValidMetrics(series.metrics, PANEL_TYPES.TABLE, series.time_range_mode)) {
+      return null;
+    }
+
+    const reducedTimeRange = getReducedTimeRange(model, series, timeRange);
+
+    // handle multiple metrics
+    const metricsColumns = getMetricsColumns(series, indexPattern!, seriesNum, {
+      reducedTimeRange,
+    });
+    if (!metricsColumns) {
+      return null;
+    }
+
+    columnStates.push(getColumnState(metricsColumns[0].columnId, undefined, series));
+
+    if (sortConfig.column === series.id) {
+      sortConfiguration.columnId = metricsColumns[0].columnId;
+    }
+
+    metrics.push(...metricsColumns);
+  }
+
+  const extendedLayer: ExtendedLayer = {
+    indexPatternId: indexPatternId as string,
+    layerId: uuid(),
+    columns: [...metrics, ...commonBucketsColumns, ...bucketsColumns],
+    columnOrder: [],
+  };
+
+  const layers = Object.values(excludeMetaFromLayers({ 0: extendedLayer }));
+
+  return {
+    type: 'lnsDatatable',
+    layers,
+    configuration: {
+      columns: columnStates,
+      layerId: extendedLayer.layerId,
+      layerType: 'data',
+      sorting: sortConfiguration,
+    },
+    indexPatternIds: getIndexPatternIds(layers),
+  };
+};

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/table/index.ts
@@ -94,7 +94,7 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
   if (model.series[0].aggregate_by) {
     if (
       !model.series[0].aggregate_function ||
-      !['sum', 'avg', 'min', 'max'].includes(model.series[0].aggregate_function)
+      !['sum', 'mean', 'min', 'max'].includes(model.series[0].aggregate_function)
     ) {
       return null;
     }
@@ -113,7 +113,10 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
     }
 
     columnStates.push(
-      getColumnState(bucketsColumns[0].columnId, model.series[0].aggregate_function)
+      getColumnState(
+        bucketsColumns[0].columnId,
+        model.series[0].aggregate_function === 'mean' ? 'avg' : model.series[0].aggregate_function
+      )
     );
   }
 
@@ -151,6 +154,10 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
     }
 
     metrics.push(...metricsColumns);
+  }
+
+  if (!metrics.length || metrics.every((metric) => metric.operationType === 'static_value')) {
+    return null;
   }
 
   const extendedLayer: ExtendedLayer = {

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.test.ts
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import { METRIC_TYPES } from '@kbn/data-plugin/public';
 import { stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { convertToLens } from '.';
 import { createPanel, createSeries } from '../lib/__mocks__';
+import { Panel } from '../../../common/types';
 
 const mockConvertToDateHistogramColumn = jest.fn();
 const mockGetMetricsColumns = jest.fn();
@@ -60,6 +62,10 @@ describe('convertToLens', () => {
     ],
   });
 
+  const vis = {
+    params: model,
+  } as Vis<Panel>;
+
   beforeEach(() => {
     mockIsValidMetrics.mockReturnValue(true);
     mockGetDataSourceInfo.mockReturnValue({
@@ -79,35 +85,35 @@ describe('convertToLens', () => {
 
   test('should return null for invalid metrics', async () => {
     mockIsValidMetrics.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockIsValidMetrics).toBeCalledTimes(1);
   });
 
   test('should return null for empty time field', async () => {
     mockGetDataSourceInfo.mockReturnValue({ timeField: null });
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetDataSourceInfo).toBeCalledTimes(1);
   });
 
   test('should return null for invalid date histogram', async () => {
     mockConvertToDateHistogramColumn.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockConvertToDateHistogramColumn).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported metrics', async () => {
     mockGetMetricsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetMetricsColumns).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported buckets', async () => {
     mockGetBucketsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetBucketsColumns).toBeCalledTimes(1);
   });
@@ -119,14 +125,14 @@ describe('convertToLens', () => {
         operationType: 'static_value',
       },
     ]);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetMetricsColumns).toBeCalledTimes(1);
     expect(mockGetBucketsColumns).toBeCalledTimes(1);
   });
 
   test('should return state for valid model', async () => {
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsXY');
     expect(mockGetBucketsColumns).toBeCalledTimes(model.series.length);
@@ -134,16 +140,16 @@ describe('convertToLens', () => {
   });
 
   test('should skip hidden series', async () => {
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
             hidden: true,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsXY');
     expect(mockIsValidMetrics).toBeCalledTimes(0);

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/timeseries/index.ts
@@ -14,7 +14,6 @@ import {
 } from '@kbn/visualizations-plugin/common/convert_to_lens';
 import uuid from 'uuid';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
-import { Panel } from '../../../common/types';
 import { PANEL_TYPES } from '../../../common/enums';
 import { getDataViewsStart } from '../../services';
 import { getDataSourceInfo } from '../lib/datasource';
@@ -41,7 +40,7 @@ const excludeMetaFromLayers = (layers: Record<string, ExtendedLayer>): Record<st
   return newLayers;
 };
 
-export const convertToLens: ConvertTsvbToLensVisualization = async (model: Panel) => {
+export const convertToLens: ConvertTsvbToLensVisualization = async ({ params: model }) => {
   const dataViews: DataViewsPublicPluginStart = getDataViewsStart();
   const extendedLayers: Record<number, ExtendedLayer> = {};
   const seriesNum = model.series.filter((series) => !series.hidden).length;

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.test.ts
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import { METRIC_TYPES } from '@kbn/data-plugin/public';
 import { stubLogstashDataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { convertToLens } from '.';
 import { createPanel, createSeries } from '../lib/__mocks__';
+import { Panel } from '../../../common/types';
 
 const mockGetMetricsColumns = jest.fn();
 const mockGetBucketsColumns = jest.fn();
@@ -59,6 +61,10 @@ describe('convertToLens', () => {
     ],
   });
 
+  const vis = {
+    params: model,
+  } as Vis<Panel>;
+
   beforeEach(() => {
     mockIsValidMetrics.mockReturnValue(true);
     mockGetDataSourceInfo.mockReturnValue({
@@ -77,27 +83,27 @@ describe('convertToLens', () => {
 
   test('should return null for invalid metrics', async () => {
     mockIsValidMetrics.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockIsValidMetrics).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported metrics', async () => {
     mockGetMetricsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetMetricsColumns).toBeCalledTimes(1);
   });
 
   test('should return null for invalid or unsupported buckets', async () => {
     mockGetBucketsColumns.mockReturnValue(null);
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeNull();
     expect(mockGetBucketsColumns).toBeCalledTimes(1);
   });
 
   test('should return state for valid model', async () => {
-    const result = await convertToLens(model);
+    const result = await convertToLens(vis);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsXY');
     expect(mockGetBucketsColumns).toBeCalledTimes(model.series.length);
@@ -105,16 +111,16 @@ describe('convertToLens', () => {
   });
 
   test('should skip hidden series', async () => {
-    const result = await convertToLens(
-      createPanel({
+    const result = await convertToLens({
+      params: createPanel({
         series: [
           createSeries({
             metrics: [{ id: 'some-id', type: METRIC_TYPES.AVG, field: 'test-field' }],
             hidden: true,
           }),
         ],
-      })
-    );
+      }),
+    } as Vis<Panel>);
     expect(result).toBeDefined();
     expect(result?.type).toBe('lnsXY');
     expect(mockIsValidMetrics).toBeCalledTimes(0);

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
@@ -28,7 +28,10 @@ const excludeMetaFromLayers = (layers: Record<string, ExtendedLayer>): Record<st
   return newLayers;
 };
 
-export const convertToLens: ConvertTsvbToLensVisualization = async (model, timeRange) => {
+export const convertToLens: ConvertTsvbToLensVisualization = async (
+  { params: model },
+  timeRange
+) => {
   const dataViews = getDataViewsStart();
   const extendedLayers: Record<number, ExtendedLayer> = {};
   const seriesNum = model.series.filter((series) => !series.hidden).length;

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/types.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/types.ts
@@ -6,18 +6,22 @@
  * Side Public License, v 1.
  */
 
+import { Vis } from '@kbn/visualizations-plugin/public';
 import {
   MetricVisConfiguration,
   NavigateToLensContext,
   XYConfiguration,
+  TableVisConfiguration,
 } from '@kbn/visualizations-plugin/common';
 import { TimeRange } from '@kbn/data-plugin/common';
 import type { Panel } from '../../common/types';
 
 export type ConvertTsvbToLensVisualization = (
-  model: Panel,
+  vis: Vis<Panel>,
   timeRange?: TimeRange
-) => Promise<NavigateToLensContext<XYConfiguration | MetricVisConfiguration> | null>;
+) => Promise<NavigateToLensContext<
+  XYConfiguration | MetricVisConfiguration | TableVisConfiguration
+> | null>;
 
 export interface Filter {
   kql?: string | { [key: string]: any } | undefined;

--- a/src/plugins/vis_types/timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_types/timeseries/public/metrics_type.ts
@@ -171,15 +171,13 @@ export const metricsVisDefinition: VisTypeDefinition<
     return {
       canNavigateToLens: Boolean(
         vis?.params
-          ? await convertTSVBtoLensConfiguration(vis.params as Panel, timeFilter?.getAbsoluteTime())
+          ? await convertTSVBtoLensConfiguration(vis, timeFilter?.getAbsoluteTime())
           : null
       ),
     };
   },
   navigateToLens: async (vis, timeFilter) =>
-    vis?.params
-      ? await convertTSVBtoLensConfiguration(vis?.params as Panel, timeFilter?.getAbsoluteTime())
-      : null,
+    vis?.params ? await convertTSVBtoLensConfiguration(vis, timeFilter?.getAbsoluteTime()) : null,
 
   inspectorAdapters: () => ({
     requests: new RequestAdapter(),

--- a/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
+++ b/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
@@ -183,6 +183,7 @@ export interface ColumnState {
   summaryRow?: 'none' | 'sum' | 'avg' | 'count' | 'min' | 'max';
   alignment?: 'left' | 'right' | 'center';
   collapseFn?: CollapseFunction;
+  palette?: PaletteOutput<CustomPaletteParams>;
 }
 
 export interface TableVisConfiguration {

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -114,6 +114,7 @@ const TopNav = ({
     vis.type,
     vis.params,
     uiStateJSON?.vis,
+    uiStateJSON?.table,
     vis.data.indexPattern,
   ]);
 

--- a/test/analytics/tests/instrumented_events/from_the_browser/core_context_providers.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/core_context_providers.ts
@@ -91,5 +91,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(event.context).not.to.have.property('cloudId');
       }
     });
+
+    it('should have the properties provided by the "viewport_size" context provider', async () => {
+      expect(event.context).to.have.property('viewport_width');
+      expect(event.context.viewport_width).to.be.a('number');
+      expect(event.context).to.have.property('viewport_height');
+      expect(event.context.viewport_height).to.be.a('number');
+    });
   });
 }

--- a/test/analytics/tests/instrumented_events/from_the_browser/index.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/index.ts
@@ -15,5 +15,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./loaded_kibana'));
     loadTestFile(require.resolve('./loaded_dashboard'));
     loadTestFile(require.resolve('./core_context_providers'));
+    loadTestFile(require.resolve('./viewport_resize'));
   });
 }

--- a/test/analytics/tests/instrumented_events/from_the_browser/viewport_resize.ts
+++ b/test/analytics/tests/instrumented_events/from_the_browser/viewport_resize.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../services';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const ebtUIHelper = getService('kibana_ebt_ui');
+  const browser = getService('browser');
+  const { common } = getPageObjects(['common']);
+
+  describe('Event "viewport_resize"', () => {
+    beforeEach(async () => {
+      // Navigating to `home` with the Welcome prompt because some runs were flaky
+      // as we handle the Welcome screen only if the login prompt pops up.
+      // Otherwise, it stays in the Welcome screen :/
+      await common.navigateToApp('home');
+    });
+
+    it('should emit a "viewport_resize" event when the browser is resized', async () => {
+      const events = await ebtUIHelper.getEvents(1, {
+        eventTypes: ['viewport_resize'],
+        withTimeoutMs: 100,
+      });
+      expect(events.length).to.be(0);
+      // Resize the window
+      await browser.setWindowSize(500, 500);
+      const { height, width } = await browser.getWindowSize();
+      expect(height).to.eql(500);
+      expect(width).to.eql(500);
+
+      const actualInnerHeight = await browser.execute(() => window.innerHeight);
+      expect(actualInnerHeight <= height).to.be(true); // The address bar takes some space when not running on HEADLESS
+
+      const [event] = await ebtUIHelper.getEvents(1, { eventTypes: ['viewport_resize'] });
+      expect(event.event_type).to.eql('viewport_resize');
+      expect(event.properties).to.eql({
+        viewport_width: 500,
+        viewport_height: actualInnerHeight,
+      });
+
+      // Validating that the context is also updated
+      expect(event.context.viewport_width).to.be(500);
+      expect(event.context.viewport_height).to.be(actualInnerHeight);
+    });
+  });
+}

--- a/test/functional/apps/management/_index_pattern_filter.ts
+++ b/test/functional/apps/management/_index_pattern_filter.ts
@@ -15,7 +15,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['settings']);
   const esArchiver = getService('esArchiver');
 
-  describe('index pattern filter', function describeIndexTests() {
+  // Failing: See https://github.com/elastic/kibana/issues/143109
+  describe.skip('index pattern filter', function describeIndexTests() {
     before(async function () {
       await esArchiver.emptyKibanaIndex();
       await kibanaServer.uiSettings.replace({});

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -659,6 +659,18 @@ export class VisualBuilderPageObject extends FtrService {
     await this.comboBox.setElement(fieldEl, field);
   }
 
+  public async setFieldForAggregateBy(field: string): Promise<void> {
+    const aggregateBy = await this.testSubjects.find('aggregateBy');
+
+    await this.comboBox.setElement(aggregateBy, field);
+  }
+
+  public async setFunctionForAggregateFunction(func: string): Promise<void> {
+    const aggregateFunction = await this.testSubjects.find('aggregateFunction');
+
+    await this.comboBox.setElement(aggregateFunction, func);
+  }
+
   public async checkFieldForAggregationValidity(aggNth: number = 0): Promise<boolean> {
     const fieldEl = await this.getFieldForAggregation(aggNth);
 

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -662,13 +662,23 @@ export class VisualBuilderPageObject extends FtrService {
   public async setFieldForAggregateBy(field: string): Promise<void> {
     const aggregateBy = await this.testSubjects.find('aggregateBy');
 
-    await this.comboBox.setElement(aggregateBy, field);
+    await this.retry.try(async () => {
+      await this.comboBox.setElement(aggregateBy, field);
+      if (!(await this.comboBox.isOptionSelected(aggregateBy, field))) {
+        throw new Error('aggregate by field is not selected');
+      }
+    });
   }
 
   public async setFunctionForAggregateFunction(func: string): Promise<void> {
     const aggregateFunction = await this.testSubjects.find('aggregateFunction');
 
-    await this.comboBox.setElement(aggregateFunction, func);
+    await this.retry.try(async () => {
+      await this.comboBox.setElement(aggregateFunction, func);
+      if (!(await this.comboBox.isOptionSelected(aggregateFunction, func))) {
+        throw new Error('aggregate function is not selected');
+      }
+    });
   }
 
   public async checkFieldForAggregationValidity(aggNth: number = 0): Promise<boolean> {

--- a/x-pack/examples/files_example/public/components/app.tsx
+++ b/x-pack/examples/files_example/public/components/app.tsx
@@ -36,8 +36,10 @@ interface FilesExampleAppDeps {
 type ListResponse = FilesClientResponses<MyImageMetadata>['list'];
 
 export const FilesExampleApp = ({ files, notifications }: FilesExampleAppDeps) => {
-  const { data, isLoading, error, refetch } = useQuery<ListResponse>(['files'], () =>
-    files.example.list()
+  const { data, isLoading, error, refetch } = useQuery<ListResponse>(
+    ['files'],
+    () => files.example.list(),
+    { refetchOnWindowFocus: false }
   );
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showFilePickerModal, setShowFilePickerModal] = useState(false);

--- a/x-pack/examples/files_example/public/components/file_picker.tsx
+++ b/x-pack/examples/files_example/public/components/file_picker.tsx
@@ -18,5 +18,5 @@ interface Props {
 }
 
 export const MyFilePicker: FunctionComponent<Props> = ({ onClose, onDone }) => {
-  return <FilePicker kind={exampleFileKind.id} onClose={onClose} onDone={onDone} />;
+  return <FilePicker kind={exampleFileKind.id} onClose={onClose} onDone={onDone} pageSize={50} />;
 };

--- a/x-pack/plugins/apm/common/agent_configuration/runtime_types/trace_continuation_strategy_rt.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/runtime_types/trace_continuation_strategy_rt.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+
+export const traceContinuationStrategyRt = t.union([
+  t.literal('continue'),
+  t.literal('restart'),
+  t.literal('restart_external'),
+]);

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
@@ -48,9 +48,19 @@ Array [
     "validationName": "(\\"off\\" | \\"errors\\" | \\"transactions\\" | \\"all\\")",
   },
   Object {
+    "key": "capture_body_content_types",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
     "key": "capture_headers",
     "type": "boolean",
     "validationName": "(\\"true\\" | \\"false\\")",
+  },
+  Object {
+    "key": "capture_jmx_metrics",
+    "type": "text",
+    "validationName": "string",
   },
   Object {
     "key": "circuit_breaker_enabled",
@@ -58,9 +68,35 @@ Array [
     "validationName": "(\\"true\\" | \\"false\\")",
   },
   Object {
+    "key": "dedot_custom_metrics",
+    "type": "boolean",
+    "validationName": "(\\"true\\" | \\"false\\")",
+  },
+  Object {
     "key": "enable_log_correlation",
     "type": "boolean",
     "validationName": "(\\"true\\" | \\"false\\")",
+  },
+  Object {
+    "key": "exit_span_min_duration",
+    "min": "0ms",
+    "type": "duration",
+    "units": Array [
+      "ms",
+      "s",
+      "m",
+    ],
+    "validationName": "durationRt",
+  },
+  Object {
+    "key": "ignore_exceptions",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
+    "key": "ignore_message_queues",
+    "type": "text",
+    "validationName": "string",
   },
   Object {
     "key": "log_level",
@@ -157,6 +193,33 @@ Array [
     "validationName": "durationRt",
   },
   Object {
+    "key": "span_compression_enabled",
+    "type": "boolean",
+    "validationName": "(\\"true\\" | \\"false\\")",
+  },
+  Object {
+    "key": "span_compression_exact_match_max_duration",
+    "min": "0ms",
+    "type": "duration",
+    "units": Array [
+      "ms",
+      "s",
+      "m",
+    ],
+    "validationName": "durationRt",
+  },
+  Object {
+    "key": "span_compression_same_kind_max_duration",
+    "min": "0ms",
+    "type": "duration",
+    "units": Array [
+      "ms",
+      "s",
+      "m",
+    ],
+    "validationName": "durationRt",
+  },
+  Object {
     "key": "span_frames_min_duration",
     "min": "-1ms",
     "type": "duration",
@@ -206,7 +269,36 @@ Array [
     "validationName": "floatRt",
   },
   Object {
+    "key": "trace_continuation_strategy",
+    "options": Array [
+      Object {
+        "text": "continue",
+        "value": "continue",
+      },
+      Object {
+        "text": "restart",
+        "value": "restart",
+      },
+      Object {
+        "text": "restart_external",
+        "value": "restart_external",
+      },
+    ],
+    "type": "select",
+    "validationName": "(\\"continue\\" | \\"restart\\" | \\"restart_external\\")",
+  },
+  Object {
+    "key": "trace_methods",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
     "key": "transaction_ignore_urls",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
+    "key": "transaction_ignore_user_agents",
     "type": "text",
     "validationName": "string",
   },
@@ -218,9 +310,24 @@ Array [
     "validationName": "integerRt",
   },
   Object {
+    "key": "transaction_name_groups",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
     "key": "transaction_sample_rate",
     "type": "float",
     "validationName": "floatRt",
+  },
+  Object {
+    "key": "unnest_exceptions",
+    "type": "text",
+    "validationName": "string",
+  },
+  Object {
+    "key": "use_path_as_transaction_name",
+    "type": "boolean",
+    "validationName": "(\\"true\\" | \\"false\\")",
   },
 ]
 `;

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { captureBodyRt } from '../runtime_types/capture_body_rt';
 import { logLevelRt } from '../runtime_types/log_level_rt';
+import { traceContinuationStrategyRt } from '../runtime_types/trace_continuation_strategy_rt';
 import { RawSettingDefinition } from './types';
 
 export const generalSettings: RawSettingDefinition[] = [
@@ -72,6 +73,29 @@ export const generalSettings: RawSettingDefinition[] = [
     excludeAgents: ['js-base', 'rum-js', 'php'],
   },
 
+  {
+    key: 'capture_body_content_types',
+    type: 'text',
+    defaultValue:
+      'application/x-www-form-urlencoded*, text/*, application/json*, application/xml*',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.captureBodyContentTypes.label',
+      {
+        defaultMessage: 'Capture Body Content Types',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.captureBodyContentTypes.description',
+      {
+        defaultMessage:
+          'Configures which content types should be recorded.\n' +
+          '\n' +
+          'The defaults end with a wildcard so that content types like `text/plain; charset=utf-8` are captured as well.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
   // Capture headers
   {
     key: 'capture_headers',
@@ -88,6 +112,67 @@ export const generalSettings: RawSettingDefinition[] = [
       }
     ),
     excludeAgents: ['js-base', 'rum-js', 'nodejs', 'php'],
+  },
+
+  {
+    key: 'dedot_custom_metrics',
+    type: 'boolean',
+    defaultValue: 'true',
+    label: i18n.translate('xpack.apm.agentConfig.dedotCustomMetrics.label', {
+      defaultMessage: 'Dedot custom metrics',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.dedotCustomMetrics.description',
+      {
+        defaultMessage:
+          'Replaces dots with underscores in the metric names for custom metrics.\n' +
+          '\n' +
+          'WARNING: Setting this to `false` can lead to mapping conflicts as dots indicate nesting in Elasticsearch.\n' +
+          'An example of when a conflict happens is two metrics with the name `foo` and `foo.bar`.\n' +
+          'The first metric maps `foo` to a number and the second metric maps `foo` as an object.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'exit_span_min_duration',
+    type: 'duration',
+    defaultValue: '0ms',
+    min: '0ms',
+    label: i18n.translate('xpack.apm.agentConfig.exitSpanMinDuration.label', {
+      defaultMessage: 'Exit span min duration',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.exitSpanMinDuration.description',
+      {
+        defaultMessage:
+          'Exit spans are spans that represent a call to an external service, like a database. If such calls are very short, they are usually not relevant and can be ignored.\n' +
+          '\n' +
+          'NOTE: If a span propagates distributed tracing ids, it will not be ignored, even if it is shorter than the configured threshold. This is to ensure that no broken traces are recorded.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'ignore_message_queues',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.ignoreMessageQueues.label', {
+      defaultMessage: 'Ignore message queues',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.ignoreMessageQueues.description',
+      {
+        defaultMessage:
+          'Used to filter out specific messaging queues/topics from being traced. \n' +
+          '\n' +
+          'This property should be set to an array containing one or more strings.\n' +
+          'When set, sends-to and receives-from the specified queues/topic will be ignored.',
+      }
+    ),
+    includeAgents: ['java'],
   },
 
   // LOG_LEVEL
@@ -147,6 +232,68 @@ export const generalSettings: RawSettingDefinition[] = [
     includeAgents: ['java'],
   },
 
+  {
+    key: 'span_compression_enabled',
+    type: 'boolean',
+    defaultValue: 'true',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionEnabled.label',
+      {
+        defaultMessage: 'Span compression enabled',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionEnabled.description',
+      {
+        defaultMessage:
+          'Setting this option to true will enable span compression feature.\n' +
+          'Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information such as DB statements of all the compressed spans will not be collected.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'span_compression_exact_match_max_duration',
+    type: 'duration',
+    defaultValue: '50ms',
+    min: '0ms',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionExactMatchMaxDuration.label',
+      {
+        defaultMessage: 'Span compression exact match max duration',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionExactMatchMaxDuration.description',
+      {
+        defaultMessage:
+          'Consecutive spans that are exact match and that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+  {
+    key: 'span_compression_same_kind_max_duration',
+    type: 'duration',
+    defaultValue: '0ms',
+    min: '0ms',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionSameKindMaxDuration.label',
+      {
+        defaultMessage: 'Span compression same kind max duration',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.spanCompressionSameKindMaxDuration.description',
+      {
+        defaultMessage:
+          'Consecutive spans to the same destination that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
   // SPAN_FRAMES_MIN_DURATION
   {
     key: 'span_frames_min_duration',
@@ -182,6 +329,44 @@ export const generalSettings: RawSettingDefinition[] = [
       }
     ),
     includeAgents: ['java', 'dotnet', 'go'],
+  },
+
+  {
+    key: 'trace_continuation_strategy',
+    validation: traceContinuationStrategyRt,
+    type: 'select',
+    defaultValue: 'continue',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.traceContinuationStrategy.label',
+      {
+        defaultMessage: 'Trace continuation strategy',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.traceContinuationStrategy.description',
+      {
+        defaultMessage:
+          'This option allows some control over how the APM agent handles W3C trace-context headers on incoming requests. By default, the `traceparent` and `tracestate` headers are used per W3C spec for distributed tracing. However, in certain cases it can be helpful to not use the incoming `traceparent` header. Some example use cases:\n' +
+          '\n' +
+          '* An Elastic-monitored service is receiving requests with `traceparent` headers from unmonitored services.\n' +
+          '* An Elastic-monitored service is publicly exposed, and does not want tracing data (trace-ids, sampling decisions) to possibly be spoofed by user requests.\n' +
+          '\n' +
+          'Valid values are:\n' +
+          "* 'continue': The default behavior. An incoming `traceparent` value is used to continue the trace and determine the sampling decision.\n" +
+          "* 'restart': Always ignores the `traceparent` header of incoming requests. A new trace-id will be generated and the sampling decision will be made based on transaction_sample_rate. A span link will be made to the incoming `traceparent`.\n" +
+          "* 'restart_external': If an incoming request includes the `es` vendor flag in `tracestate`, then any `traceparent` will be considered internal and will be handled as described for 'continue' above. Otherwise, any `traceparent` is considered external and will be handled as described for 'restart' above.\n" +
+          '\n' +
+          'Starting with Elastic Observability 8.2, span links are visible in trace views.\n' +
+          '\n' +
+          'This option is case-insensitive.',
+      }
+    ),
+    options: [
+      { text: 'continue', value: 'continue' },
+      { text: 'restart', value: 'restart' },
+      { text: 'restart_external', value: 'restart_external' },
+    ],
+    includeAgents: ['java'],
   },
 
   // Transaction max spans
@@ -256,5 +441,77 @@ export const generalSettings: RawSettingDefinition[] = [
       }
     ),
     includeAgents: ['java', 'nodejs', 'python', 'dotnet', 'ruby', 'go'],
+  },
+
+  {
+    key: 'transaction_ignore_user_agents',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.transactionIgnoreUserAgents.label',
+      {
+        defaultMessage: 'Transaction ignore user agents',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.transactionIgnoreUserAgents.description',
+      {
+        defaultMessage:
+          'Used to restrict requests from certain User-Agents from being instrumented.\n' +
+          '\n' +
+          'When an incoming HTTP request is detected,\n' +
+          'the User-Agent from the request headers will be tested against each element in this list.\n' +
+          'Example: `curl/*`, `*pingdom*`',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'use_path_as_transaction_name',
+    type: 'boolean',
+    defaultValue: 'false',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.usePathAsTransactionName.label',
+      {
+        defaultMessage: 'Use path as transaction name',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.usePathAsTransactionName.description',
+      {
+        defaultMessage:
+          'If set to `true`,\n' +
+          'transaction names of unsupported or partially-supported frameworks will be in the form of `$method $path` instead of just `$method unknown route`.\n' +
+          '\n' +
+          'WARNING: If your URLs contain path parameters like `/user/$userId`,\n' +
+          'you should be very careful when enabling this flag,\n' +
+          'as it can lead to an explosion of transaction groups.\n' +
+          'Take a look at the `transaction_name_groups` option on how to mitigate this problem by grouping URLs together.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'transaction_name_groups',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.transactionNameGroups.label', {
+      defaultMessage: 'Transaction name groups',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.transactionNameGroups.description',
+      {
+        defaultMessage:
+          'With this option,\n' +
+          'you can group transaction names that contain dynamic parts with a wildcard expression.\n' +
+          'For example,\n' +
+          'the pattern `GET /user/*/cart` would consolidate transactions,\n' +
+          'such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`,\n' +
+          'hence reducing the transaction name cardinality.',
+      }
+    ),
+    includeAgents: ['java'],
   },
 ];

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -43,134 +43,150 @@ describe('filterByAgent', () => {
 
   describe('options per agent', () => {
     it('go', () => {
-      expect(getSettingKeysForAgent('go')).toEqual([
-        'capture_body',
-        'capture_headers',
-        'log_level',
-        'recording',
-        'sanitize_field_names',
-        'span_frames_min_duration',
-        'stack_trace_limit',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('go')).toEqual(
+        expect.arrayContaining([
+          'capture_body',
+          'capture_headers',
+          'log_level',
+          'recording',
+          'sanitize_field_names',
+          'span_frames_min_duration',
+          'stack_trace_limit',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('java', () => {
-      expect(getSettingKeysForAgent('java')).toEqual([
-        'api_request_size',
-        'api_request_time',
-        'capture_body',
-        'capture_headers',
-        'circuit_breaker_enabled',
-        'enable_log_correlation',
-        'log_level',
-        'profiling_inferred_spans_enabled',
-        'profiling_inferred_spans_excluded_classes',
-        'profiling_inferred_spans_included_classes',
-        'profiling_inferred_spans_min_duration',
-        'profiling_inferred_spans_sampling_interval',
-        'recording',
-        'sanitize_field_names',
-        'server_timeout',
-        'span_frames_min_duration',
-        'stack_trace_limit',
-        'stress_monitor_cpu_duration_threshold',
-        'stress_monitor_gc_relief_threshold',
-        'stress_monitor_gc_stress_threshold',
-        'stress_monitor_system_cpu_relief_threshold',
-        'stress_monitor_system_cpu_stress_threshold',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('java')).toEqual(
+        expect.arrayContaining([
+          'api_request_size',
+          'api_request_time',
+          'capture_body',
+          'capture_headers',
+          'circuit_breaker_enabled',
+          'enable_log_correlation',
+          'log_level',
+          'profiling_inferred_spans_enabled',
+          'profiling_inferred_spans_excluded_classes',
+          'profiling_inferred_spans_included_classes',
+          'profiling_inferred_spans_min_duration',
+          'profiling_inferred_spans_sampling_interval',
+          'recording',
+          'sanitize_field_names',
+          'server_timeout',
+          'span_frames_min_duration',
+          'stack_trace_limit',
+          'stress_monitor_cpu_duration_threshold',
+          'stress_monitor_gc_relief_threshold',
+          'stress_monitor_gc_stress_threshold',
+          'stress_monitor_system_cpu_relief_threshold',
+          'stress_monitor_system_cpu_stress_threshold',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('js-base', () => {
-      expect(getSettingKeysForAgent('js-base')).toEqual([
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('js-base')).toEqual(
+        expect.arrayContaining(['transaction_sample_rate'])
+      );
     });
 
     it('rum-js', () => {
-      expect(getSettingKeysForAgent('rum-js')).toEqual([
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('rum-js')).toEqual(
+        expect.arrayContaining(['transaction_sample_rate'])
+      );
     });
 
     it('nodejs', () => {
-      expect(getSettingKeysForAgent('nodejs')).toEqual([
-        'capture_body',
-        'log_level',
-        'sanitize_field_names',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('nodejs')).toEqual(
+        expect.arrayContaining([
+          'capture_body',
+          'log_level',
+          'sanitize_field_names',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('python', () => {
-      expect(getSettingKeysForAgent('python')).toEqual([
-        'api_request_size',
-        'api_request_time',
-        'capture_body',
-        'capture_headers',
-        'log_level',
-        'recording',
-        'sanitize_field_names',
-        'span_frames_min_duration',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('python')).toEqual(
+        expect.arrayContaining([
+          'api_request_size',
+          'api_request_time',
+          'capture_body',
+          'capture_headers',
+          'log_level',
+          'recording',
+          'sanitize_field_names',
+          'span_frames_min_duration',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('dotnet', () => {
-      expect(getSettingKeysForAgent('dotnet')).toEqual([
-        'capture_body',
-        'capture_headers',
-        'log_level',
-        'recording',
-        'sanitize_field_names',
-        'span_frames_min_duration',
-        'stack_trace_limit',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('dotnet')).toEqual(
+        expect.arrayContaining([
+          'capture_body',
+          'capture_headers',
+          'log_level',
+          'recording',
+          'sanitize_field_names',
+          'span_frames_min_duration',
+          'stack_trace_limit',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('ruby', () => {
-      expect(getSettingKeysForAgent('ruby')).toEqual([
-        'api_request_size',
-        'api_request_time',
-        'capture_body',
-        'capture_headers',
-        'log_level',
-        'recording',
-        'sanitize_field_names',
-        'span_frames_min_duration',
-        'transaction_ignore_urls',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('ruby')).toEqual(
+        expect.arrayContaining([
+          'api_request_size',
+          'api_request_time',
+          'capture_body',
+          'capture_headers',
+          'log_level',
+          'recording',
+          'sanitize_field_names',
+          'span_frames_min_duration',
+          'transaction_ignore_urls',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('php', () => {
-      expect(getSettingKeysForAgent('php')).toEqual([
-        'log_level',
-        'recording',
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent('php')).toEqual(
+        expect.arrayContaining([
+          'log_level',
+          'recording',
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
 
     it('"All" services (no agent name)', () => {
-      expect(getSettingKeysForAgent(undefined)).toEqual([
-        'transaction_max_spans',
-        'transaction_sample_rate',
-      ]);
+      expect(getSettingKeysForAgent(undefined)).toEqual(
+        expect.arrayContaining([
+          'transaction_max_spans',
+          'transaction_sample_rate',
+        ])
+      );
     });
   });
 });

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/java_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/java_settings.ts
@@ -238,4 +238,95 @@ export const javaSettings: RawSettingDefinition[] = [
     ),
     includeAgents: ['java'],
   },
+
+  {
+    key: 'capture_jmx_metrics',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.captureJmxMetrics.label', {
+      defaultMessage: 'Capture JMX metrics',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.captureJmxMetrics.description',
+      {
+        defaultMessage:
+          'Report metrics from JMX to the APM Server\n' +
+          '\n' +
+          'Can contain multiple comma separated JMX metric definitions:\n' +
+          '\n' +
+          '`object_name[<JMX object name pattern>] attribute[<JMX attribute>:metric_name=<optional metric name>]`\n' +
+          '\n' +
+          'See the Java agent documentation for more details.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'ignore_exceptions',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.ignoreExceptions.label', {
+      defaultMessage: 'Ignore exceptions',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.ignoreExceptions.description',
+      {
+        defaultMessage:
+          'A list of exceptions that should be ignored and not reported as errors.\n' +
+          'This allows to ignore exceptions thrown in regular control flow that are not actual errors.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'trace_methods',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.traceMethods.label', {
+      defaultMessage: 'Trace methods',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.traceMethods.description',
+      {
+        defaultMessage:
+          'A list of methods for which to create a transaction or span.\n' +
+          '\n' +
+          'If you want to monitor a large number of methods,\n' +
+          'use  `profiling_inferred_spans_enabled`.\n' +
+          '\n' +
+          'This works by instrumenting each matching method to include code that creates a span for the method.\n' +
+          'While creating a span is quite cheap in terms of performance,\n' +
+          'instrumenting a whole code base or a method which is executed in a tight loop leads to significant overhead.\n' +
+          '\n' +
+          'NOTE: Only use wildcards if necessary.\n' +
+          'The more methods you match the more overhead will be caused by the agent.\n' +
+          'Also note that there is a maximum amount of spans per transaction `transaction_max_spans`.\n' +
+          '\n' +
+          'See the Java agent documentation for more details.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
+  {
+    key: 'unnest_exceptions',
+    type: 'text',
+    defaultValue: '',
+    label: i18n.translate('xpack.apm.agentConfig.unnestExceptions.label', {
+      defaultMessage: 'Unnest exceptions',
+    }),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.unnestExceptions.description',
+      {
+        defaultMessage:
+          'When reporting exceptions,\n' +
+          'un-nests the exceptions matching the wildcard pattern.\n' +
+          "This can come in handy for Spring's `org.springframework.web.util.NestedServletException`,\n" +
+          'for example.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
 ];

--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
@@ -24,10 +24,10 @@ import {
   SPAN_SUBTYPE,
   SPAN_TYPE,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../helpers/setup_request';
 import { withApmSpan } from '../../../utils/with_apm_span';
 import { Node, NodeType } from '../../../../common/connections';
 import { excludeRumExitSpansQuery } from '../exclude_rum_exit_spans_query';
+import { APMEventClient } from '../../helpers/create_es_client/create_apm_event_client';
 
 type Destination = {
   dependencyName: string;
@@ -48,21 +48,19 @@ type Destination = {
 // - for each span, find the transaction it creates
 // - if there is a transaction, match the dependency name (span.destination.service.resource) to a service
 export const getDestinationMap = ({
-  setup,
+  apmEventClient,
   start,
   end,
   filter,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   filter: QueryDslQueryContainer[];
   offset?: string;
 }) => {
   return withApmSpan('get_destination_map', async () => {
-    const { apmEventClient } = setup;
-
     const { startWithOffset, endWithOffset } = getOffsetInMs({
       start,
       end,

--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
@@ -27,27 +27,25 @@ import {
 } from '../../../../common/elasticsearch_fieldnames';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { EventOutcome } from '../../../../common/event_outcome';
-import { Setup } from '../../helpers/setup_request';
 import { NodeType } from '../../../../common/connections';
 import { excludeRumExitSpansQuery } from '../exclude_rum_exit_spans_query';
+import { APMEventClient } from '../../helpers/create_es_client/create_apm_event_client';
 
 export const getStats = async ({
-  setup,
+  apmEventClient,
   start,
   end,
   filter,
   numBuckets,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   filter: QueryDslQueryContainer[];
   numBuckets: number;
   offset?: string;
 }) => {
-  const { apmEventClient } = setup;
-
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/index.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/index.ts
@@ -9,14 +9,14 @@ import { ValuesType } from 'utility-types';
 import { merge } from 'lodash';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { joinByKey } from '../../../../common/utils/join_by_key';
-import { Setup } from '../../helpers/setup_request';
 import { getStats } from './get_stats';
 import { getDestinationMap } from './get_destination_map';
 import { calculateThroughputWithRange } from '../../helpers/calculate_throughput';
 import { withApmSpan } from '../../../utils/with_apm_span';
+import { APMEventClient } from '../../helpers/create_es_client/create_apm_event_client';
 
 export function getConnectionStats({
-  setup,
+  apmEventClient,
   start,
   end,
   numBuckets,
@@ -24,7 +24,7 @@ export function getConnectionStats({
   collapseBy,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   numBuckets: number;
@@ -35,7 +35,7 @@ export function getConnectionStats({
   return withApmSpan('get_connection_stats_and_map', async () => {
     const [allMetrics, destinationMap] = await Promise.all([
       getStats({
-        setup,
+        apmEventClient,
         start,
         end,
         filter,
@@ -43,7 +43,7 @@ export function getConnectionStats({
         offset,
       }),
       getDestinationMap({
-        setup,
+        apmEventClient,
         start,
         end,
         filter,

--- a/x-pack/plugins/apm/server/lib/helpers/get_apm_event_client.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/get_apm_event_client.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UI_SETTINGS } from '@kbn/data-plugin/common';
+import { APMRouteHandlerResources } from '../../routes/typings';
+import { getApmIndices } from '../../routes/settings/apm_indices/get_apm_indices';
+import { APMEventClient } from './create_es_client/create_apm_event_client';
+import { withApmSpan } from '../../utils/with_apm_span';
+
+export async function getApmEventClient({
+  context,
+  params,
+  config,
+  request,
+}: APMRouteHandlerResources): Promise<APMEventClient> {
+  return withApmSpan('get_apm_event_client', async () => {
+    const coreContext = await context.core;
+    const [indices, includeFrozen] = await Promise.all([
+      getApmIndices({
+        savedObjectsClient: coreContext.savedObjects.client,
+        config,
+      }),
+      withApmSpan('get_ui_settings', () =>
+        coreContext.uiSettings.client.get<boolean>(
+          UI_SETTINGS.SEARCH_INCLUDE_FROZEN
+        )
+      ),
+    ]);
+
+    return new APMEventClient({
+      esClient: coreContext.elasticsearch.client.asCurrentUser,
+      debug: params.query._inspect,
+      request,
+      indices,
+      options: { includeFrozen },
+    });
+  });
+}

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -14,7 +14,6 @@ import {
   ApmIndicesConfig,
   getApmIndices,
 } from '../../routes/settings/apm_indices/get_apm_indices';
-import { APMEventClient } from './create_es_client/create_apm_event_client';
 import {
   APMInternalClient,
   createInternalESClient,
@@ -25,7 +24,6 @@ import { withApmSpan } from '../../utils/with_apm_span';
 // https://github.com/microsoft/TypeScript/issues/34933
 
 export interface Setup {
-  apmEventClient: APMEventClient;
   internalClient: APMInternalClient;
   ml?: ReturnType<typeof getMlSetup>;
   config: APMConfig;
@@ -45,7 +43,7 @@ export async function setupRequest({
     const coreContext = await context.core;
     const licensingContext = await context.licensing;
 
-    const [indices, includeFrozen] = await Promise.all([
+    const [indices] = await Promise.all([
       getApmIndices({
         savedObjectsClient: coreContext.savedObjects.client,
         config,
@@ -59,13 +57,6 @@ export async function setupRequest({
 
     return {
       indices,
-      apmEventClient: new APMEventClient({
-        esClient: coreContext.elasticsearch.client.asCurrentUser,
-        debug: query._inspect,
-        request,
-        indices,
-        options: { includeFrozen },
-      }),
       internalClient: await createInternalESClient({
         context,
         request,

--- a/x-pack/plugins/apm/server/lib/helpers/spans/get_is_using_service_destination_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/spans/get_is_using_service_destination_metrics.ts
@@ -19,7 +19,7 @@ import {
   SPAN_DURATION,
   SPAN_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../setup_request';
+import { APMEventClient } from '../create_es_client/create_apm_event_client';
 
 export function getProcessorEventForServiceDestinationStatistics(
   searchServiceDestinationMetrics: boolean
@@ -54,20 +54,18 @@ export function getDocCountFieldForServiceDestinationStatistics(
 }
 
 export async function getIsUsingServiceDestinationMetrics({
-  setup,
+  apmEventClient,
   useSpanName,
   kuery,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   useSpanName: boolean;
   kuery: string;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   async function getServiceDestinationMetricsCount(
     query?: QueryDslQueryContainer
   ) {

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.test.ts
@@ -63,7 +63,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be false', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         { config }
       );
       expect(mock.response).toBe(false);
@@ -71,7 +76,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should not query for data', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         { config }
       );
       expect(mock.spy).toHaveBeenCalledTimes(0);
@@ -84,7 +94,12 @@ describe('getIsUsingTransactionEvents', () => {
     };
     it('should be false when kuery is empty', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         { config }
       );
       expect(mock.response).toBe(false);
@@ -92,9 +107,10 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be false when kuery is set and metrics data found', async () => {
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getIsUsingTransactionEvents({
-            setup,
+            config: setup.config,
+            apmEventClient,
             kuery: 'proccessor.event: "transaction"',
           }),
         {
@@ -116,9 +132,10 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be true when kuery is set and metrics data are not found', async () => {
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getIsUsingTransactionEvents({
-            setup,
+            config: setup.config,
+            apmEventClient,
             kuery: 'proccessor.event: "transaction"',
           }),
         {
@@ -140,7 +157,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should not query for data when kuery is empty', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         { config }
       );
       expect(mock.spy).toHaveBeenCalledTimes(0);
@@ -148,9 +170,10 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should query for data when kuery is set', async () => {
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getIsUsingTransactionEvents({
-            setup,
+            config: setup.config,
+            apmEventClient,
             kuery: 'proccessor.event: "transaction"',
           }),
         { config }
@@ -167,7 +190,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should query for data once if metrics data found', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         {
           config,
           mockResponse: (request) => {
@@ -187,7 +215,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should query for data twice if metrics data not found', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         {
           config,
           mockResponse: (request) => {
@@ -207,7 +240,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be false if metrics data are found', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         {
           config,
           mockResponse: (request) => {
@@ -226,7 +264,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be true if no metrics data are found', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         {
           config,
           mockResponse: (request) => {
@@ -245,7 +288,12 @@ describe('getIsUsingTransactionEvents', () => {
 
     it('should be false if no metrics or transactions data are found', async () => {
       mock = await inspectSearchParams(
-        (setup) => getIsUsingTransactionEvents({ setup, kuery: '' }),
+        (setup, apmEventClient) =>
+          getIsUsingTransactionEvents({
+            config: setup.config,
+            apmEventClient,
+            kuery: '',
+          }),
         { config, mockResponse: () => mockResponseNoHits }
       );
       expect(mock.response).toBe(false);

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
@@ -8,17 +8,19 @@
 import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { getSearchTransactionsEvents } from '.';
-import { Setup } from '../setup_request';
 import { APMEventClient } from '../create_es_client/create_apm_event_client';
 import { SearchAggregatedTransactionSetting } from '../../../../common/aggregated_transactions';
+import { APMConfig } from '../../..';
 
 export async function getIsUsingTransactionEvents({
-  setup: { config, apmEventClient },
+  config,
+  apmEventClient,
   kuery,
   start,
   end,
 }: {
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   kuery: string;
   start?: number;
   end?: number;

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_coldstart_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_coldstart_rate.ts
@@ -21,13 +21,13 @@ import {
   getProcessorEventForTransactions,
 } from '../helpers/transactions';
 import { getBucketSizeForAggregatedTransactions } from '../helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../helpers/setup_request';
 import {
   calculateTransactionColdstartRate,
   getColdstartAggregation,
   getTransactionColdstartRateTimeSeries,
 } from '../helpers/transaction_coldstart_rate';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../helpers/create_es_client/create_apm_event_client';
 
 export async function getColdstartRate({
   environment,
@@ -35,7 +35,7 @@ export async function getColdstartRate({
   serviceName,
   transactionType,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -46,7 +46,7 @@ export async function getColdstartRate({
   serviceName: string;
   transactionType?: string;
   transactionName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
@@ -55,8 +55,6 @@ export async function getColdstartRate({
   transactionColdstartRate: Coordinate[];
   average: number | null;
 }> {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -131,7 +129,7 @@ export async function getColdstartRatePeriods({
   serviceName,
   transactionType,
   transactionName = '',
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -142,7 +140,7 @@ export async function getColdstartRatePeriods({
   serviceName: string;
   transactionType?: string;
   transactionName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
@@ -154,7 +152,7 @@ export async function getColdstartRatePeriods({
     serviceName,
     transactionType,
     transactionName,
-    setup,
+    apmEventClient,
     searchAggregatedTransactions,
   };
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_failed_transaction_rate.ts
@@ -24,13 +24,13 @@ import {
   getProcessorEventForTransactions,
 } from '../helpers/transactions';
 import { getBucketSizeForAggregatedTransactions } from '../helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../helpers/setup_request';
 import {
   calculateFailedTransactionRate,
   getOutcomeAggregation,
   getFailedTransactionRateTimeSeries,
 } from '../helpers/transaction_error_rate';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../helpers/create_es_client/create_apm_event_client';
 
 export async function getFailedTransactionRate({
   environment,
@@ -38,7 +38,7 @@ export async function getFailedTransactionRate({
   serviceName,
   transactionTypes,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -50,7 +50,7 @@ export async function getFailedTransactionRate({
   serviceName: string;
   transactionTypes: string[];
   transactionName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
@@ -60,8 +60,6 @@ export async function getFailedTransactionRate({
   timeseries: Coordinate[];
   average: number | null;
 }> {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/alerts/route.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/route.ts
@@ -13,6 +13,7 @@ import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { environmentRt, rangeRt } from '../default_api_types';
 import { AggregationType } from '../../../common/rules/apm_rule_types';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const alertParamsRt = t.intersection([
   t.partial({
@@ -40,12 +41,16 @@ const transactionErrorRateChartPreview = createApmServerRoute({
   handler: async (
     resources
   ): Promise<{ errorRateChartPreview: Array<{ x: number; y: number }> }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { _inspect, ...alertParams } = params.query;
 
     const errorRateChartPreview = await getTransactionErrorRateChartPreview({
-      setup,
+      config: setup.config,
+      apmEventClient,
       alertParams,
     });
 
@@ -60,13 +65,13 @@ const transactionErrorCountChartPreview = createApmServerRoute({
   handler: async (
     resources
   ): Promise<{ errorCountChartPreview: Array<{ x: number; y: number }> }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
 
     const { _inspect, ...alertParams } = params.query;
 
     const errorCountChartPreview = await getTransactionErrorCountChartPreview({
-      setup,
+      apmEventClient,
       alertParams,
     });
 
@@ -86,7 +91,10 @@ const transactionDurationChartPreview = createApmServerRoute({
       data: Array<{ x: number; y: number | null }>;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
 
     const { params } = resources;
 
@@ -94,7 +102,8 @@ const transactionDurationChartPreview = createApmServerRoute({
 
     const latencyChartPreview = await getTransactionDurationChartPreview({
       alertParams,
-      setup,
+      config: setup.config,
+      apmEventClient,
     });
 
     return { latencyChartPreview };

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/get_error_count_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/get_error_count_chart_preview.ts
@@ -10,16 +10,15 @@ import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { SERVICE_NAME } from '../../../../../common/elasticsearch_fieldnames';
 import { AlertParams } from '../../route';
 import { environmentQuery } from '../../../../../common/utils/environment_query';
-import { Setup } from '../../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransactionErrorCountChartPreview({
-  setup,
+  apmEventClient,
   alertParams,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   alertParams: AlertParams;
 }) {
-  const { apmEventClient } = setup;
   const { serviceName, environment, interval, start, end } = alertParams;
 
   const query = {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/get_transaction_duration_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/get_transaction_duration_chart_preview.ts
@@ -21,21 +21,23 @@ import {
   getDurationFieldForTransactions,
   getProcessorEventForTransactions,
 } from '../../../../lib/helpers/transactions';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import {
   ENVIRONMENT_NOT_DEFINED,
   getEnvironmentLabel,
 } from '../../../../../common/environment_filter_values';
 import { averageOrPercentileAgg } from '../../average_or_percentile_agg';
+import { APMConfig } from '../../../..';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransactionDurationChartPreview({
   alertParams,
-  setup,
+  config,
+  apmEventClient,
 }: {
   alertParams: AlertParams;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
 }) {
-  const { apmEventClient } = setup;
   const {
     aggregationType = AggregationType.Avg,
     environment,
@@ -46,7 +48,8 @@ export async function getTransactionDurationChartPreview({
     end,
   } = alertParams;
   const searchAggregatedTransactions = await getSearchTransactionsEvents({
-    ...setup,
+    config,
+    apmEventClient,
     kuery: '',
   });
 

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/get_transaction_error_rate_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/get_transaction_error_rate_chart_preview.ts
@@ -17,25 +17,28 @@ import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../../../lib/helpers/transactions';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import {
   calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../../../lib/helpers/transaction_error_rate';
+import { APMConfig } from '../../../..';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransactionErrorRateChartPreview({
-  setup,
+  config,
+  apmEventClient,
   alertParams,
 }: {
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   alertParams: AlertParams;
 }) {
-  const { apmEventClient } = setup;
   const { serviceName, environment, transactionType, interval, start, end } =
     alertParams;
 
   const searchAggregatedTransactions = await getSearchTransactionsEvents({
-    ...setup,
+    config,
+    apmEventClient,
     kuery: '',
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation.ts
@@ -12,12 +12,11 @@ import {
   TRANSACTION_DURATION,
 } from '../../../../common/elasticsearch_fieldnames';
 import type { CommonCorrelationsQueryParams } from '../../../../common/correlations/types';
-
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchDurationCorrelation = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -29,7 +28,7 @@ export const fetchDurationCorrelation = async ({
   fractions,
   totalDocCount,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent;
   expectations: number[];
   ranges: estypes.AggregationsAggregationRange[];
@@ -40,8 +39,6 @@ export const fetchDurationCorrelation = async ({
   correlation: number | null;
   ksTest: number | null;
 }> => {
-  const { apmEventClient } = setup;
-
   const resp = await apmEventClient.search('get_duration_correlation', {
     apm: {
       events: [eventType],

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation_with_histogram.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_correlation_with_histogram.ts
@@ -19,13 +19,13 @@ import {
 } from '../../../../common/correlations/constants';
 
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { fetchDurationCorrelation } from './fetch_duration_correlation';
 import { fetchDurationRanges } from './fetch_duration_ranges';
 import { getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function fetchDurationCorrelationWithHistogram({
-  setup,
+  apmEventClient,
   chartType,
   start,
   end,
@@ -39,7 +39,7 @@ export async function fetchDurationCorrelationWithHistogram({
   totalDocCount,
   fieldValuePair,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   chartType: LatencyDistributionChartType;
   expectations: number[];
   ranges: estypes.AggregationsAggregationRange[];
@@ -60,7 +60,7 @@ export async function fetchDurationCorrelationWithHistogram({
   };
 
   const { correlation, ksTest } = await fetchDurationCorrelation({
-    setup,
+    apmEventClient,
     eventType,
     start,
     end,
@@ -76,7 +76,7 @@ export async function fetchDurationCorrelationWithHistogram({
   if (correlation !== null && ksTest !== null && !isNaN(ksTest)) {
     if (correlation > CORRELATION_THRESHOLD && ksTest < KS_TEST_THRESHOLD) {
       const { durationRanges: histogram } = await fetchDurationRanges({
-        setup,
+        apmEventClient,
         chartType,
         start,
         end,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_field_candidates.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_field_candidates.ts
@@ -16,9 +16,8 @@ import {
   POPULATED_DOC_COUNT_SAMPLE_SIZE,
 } from '../../../../common/correlations/constants';
 import { hasPrefixToInclude } from '../../../../common/correlations/utils';
-
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const SUPPORTED_ES_FIELD_TYPES = [
   ES_FIELD_TYPES.KEYWORD,
@@ -36,7 +35,7 @@ export const shouldBeExcluded = (fieldName: string) => {
 };
 
 export const fetchDurationFieldCandidates = async ({
-  setup,
+  apmEventClient,
   eventType,
   query,
   start,
@@ -45,13 +44,11 @@ export const fetchDurationFieldCandidates = async ({
   kuery,
 }: CommonCorrelationsQueryParams & {
   query: estypes.QueryDslQueryContainer;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent.transaction | ProcessorEvent.span;
 }): Promise<{
   fieldCandidates: string[];
 }> => {
-  const { apmEventClient } = setup;
-
   // Get all supported fields
   const [respMapping, respRandomDoc] = await Promise.all([
     apmEventClient.fieldCaps('get_field_caps', {

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_fractions.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_fractions.ts
@@ -13,14 +13,14 @@ import {
   SPAN_DURATION,
   TRANSACTION_DURATION,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
 
 /**
  * Compute the actual percentile bucket counts and actual fractions
  */
 export const fetchDurationFractions = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -29,11 +29,10 @@ export const fetchDurationFractions = async ({
   query,
   ranges,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent;
   ranges: estypes.AggregationsAggregationRange[];
 }): Promise<{ fractions: number[]; totalDocCount: number }> => {
-  const { apmEventClient } = setup;
   const resp = await apmEventClient.search('get_duration_fractions', {
     apm: {
       events: [eventType],

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
@@ -10,9 +10,9 @@ import { scaleLog } from 'd3-scale';
 import { isFiniteNumber } from '@kbn/observability-plugin/common/utils/is_finite_number';
 import { CommonCorrelationsQueryParams } from '../../../../common/correlations/types';
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
 import { getDurationField, getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
   // A d3 based scale function as a helper to get equally distributed bins on a log scale.
@@ -25,7 +25,7 @@ const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
 
 export const fetchDurationHistogramRangeSteps = async ({
   chartType,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -36,7 +36,7 @@ export const fetchDurationHistogramRangeSteps = async ({
   durationMaxOverride,
 }: CommonCorrelationsQueryParams & {
   chartType: LatencyDistributionChartType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchMetrics: boolean;
   durationMinOverride?: number;
   durationMaxOverride?: number;
@@ -58,8 +58,6 @@ export const fetchDurationHistogramRangeSteps = async ({
       ),
     };
   }
-
-  const { apmEventClient } = setup;
 
   const durationField = getDurationField(chartType, searchMetrics);
 

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_percentiles.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_percentiles.ts
@@ -6,15 +6,15 @@
  */
 
 import { SIGNIFICANT_VALUE_DIGITS } from '../../../../common/correlations/constants';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
 import { CommonCorrelationsQueryParams } from '../../../../common/correlations/types';
 import { getDurationField, getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchDurationPercentiles = async ({
   chartType,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -24,7 +24,7 @@ export const fetchDurationPercentiles = async ({
   searchMetrics,
 }: CommonCorrelationsQueryParams & {
   chartType: LatencyDistributionChartType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   percents?: number[];
   searchMetrics: boolean;
 }): Promise<{
@@ -63,7 +63,7 @@ export const fetchDurationPercentiles = async ({
       },
     },
   };
-  const response = await setup.apmEventClient.search(
+  const response = await apmEventClient.search(
     'get_duration_percentiles',
     params
   );

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_ranges.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_duration_ranges.ts
@@ -8,14 +8,14 @@
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { sumBy } from 'lodash';
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
 import { Environment } from '../../../../common/environment_rt';
 import { getDurationField, getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchDurationRanges = async ({
   rangeSteps,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -25,7 +25,7 @@ export const fetchDurationRanges = async ({
   searchMetrics,
 }: {
   rangeSteps: number[];
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: Environment;
@@ -37,7 +37,6 @@ export const fetchDurationRanges = async ({
   totalDocCount: number;
   durationRanges: Array<{ key: number; doc_count: number }>;
 }> => {
-  const { apmEventClient } = setup;
   const durationField = getDurationField(chartType, searchMetrics);
 
   // when using metrics data, ensure we filter by docs with the appropriate duration field

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_failed_events_correlation_p_values.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_failed_events_correlation_p_values.ts
@@ -13,13 +13,13 @@ import {
 } from '../../../../common/elasticsearch_fieldnames';
 import { EventOutcome } from '../../../../common/event_outcome';
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
 import { fetchDurationRanges } from './fetch_duration_ranges';
 import { getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchFailedEventsCorrelationPValues = async ({
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -28,12 +28,10 @@ export const fetchFailedEventsCorrelationPValues = async ({
   rangeSteps,
   fieldName,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   rangeSteps: number[];
   fieldName: string;
 }) => {
-  const { apmEventClient } = setup;
-
   const chartType = LatencyDistributionChartType.failedTransactionsCorrelations;
   const searchMetrics = false; // failed transactions correlations does not search metrics documents
   const eventType = getEventType(chartType, searchMetrics);
@@ -106,7 +104,7 @@ export const fetchFailedEventsCorrelationPValues = async ({
       0.25 * Math.min(Math.max((bucket.score - 13.816) / 101.314, 0), 1);
 
     const { durationRanges: histogram } = await fetchDurationRanges({
-      setup,
+      apmEventClient,
       chartType,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_field_value_pairs.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_field_value_pairs.ts
@@ -13,11 +13,11 @@ import type {
 import { TERMS_SIZE } from '../../../../common/correlations/constants';
 
 import { splitAllSettledPromises } from '../utils';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from './get_common_correlations_query';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchFieldValuePairs = async ({
-  setup,
+  apmEventClient,
   fieldCandidates,
   eventType,
   start,
@@ -26,12 +26,10 @@ export const fetchFieldValuePairs = async ({
   kuery,
   query,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   fieldCandidates: string[];
   eventType: ProcessorEvent;
 }): Promise<{ fieldValuePairs: FieldValuePair[]; errors: any[] }> => {
-  const { apmEventClient } = setup;
-
   const { fulfilled: responses, rejected: errors } = splitAllSettledPromises(
     await Promise.allSettled(
       fieldCandidates.map(async (fieldName) => {

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_p_values.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_p_values.ts
@@ -10,6 +10,7 @@ import type { FailedTransactionsCorrelation } from '../../../../common/correlati
 
 import { CommonCorrelationsQueryParams } from '../../../../common/correlations/types';
 import { LatencyDistributionChartType } from '../../../../common/latency_distribution_chart_types';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { Setup } from '../../../lib/helpers/setup_request';
 import { splitAllSettledPromises, getEventType } from '../utils';
 import { fetchDurationHistogramRangeSteps } from './fetch_duration_histogram_range_steps';
@@ -17,6 +18,7 @@ import { fetchFailedEventsCorrelationPValues } from './fetch_failed_events_corre
 
 export const fetchPValues = async ({
   setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -27,6 +29,7 @@ export const fetchPValues = async ({
   fieldCandidates,
 }: CommonCorrelationsQueryParams & {
   setup: Setup;
+  apmEventClient: APMEventClient;
   durationMin?: number;
   durationMax?: number;
   fieldCandidates: string[];
@@ -36,7 +39,7 @@ export const fetchPValues = async ({
   const eventType = getEventType(chartType, searchMetrics);
 
   const { rangeSteps } = await fetchDurationHistogramRangeSteps({
-    setup,
+    apmEventClient,
     chartType,
     start,
     end,
@@ -52,7 +55,7 @@ export const fetchPValues = async ({
     await Promise.allSettled(
       fieldCandidates.map((fieldName) =>
         fetchFailedEventsCorrelationPValues({
-          setup,
+          apmEventClient,
           start,
           end,
           environment,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/fetch_significant_correlations.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/fetch_significant_correlations.ts
@@ -26,9 +26,11 @@ import { fetchDurationFractions } from './fetch_duration_fractions';
 import { fetchDurationHistogramRangeSteps } from './fetch_duration_histogram_range_steps';
 import { fetchDurationRanges } from './fetch_duration_ranges';
 import { getEventType } from '../utils';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchSignificantCorrelations = async ({
   setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -39,6 +41,7 @@ export const fetchSignificantCorrelations = async ({
   fieldValuePairs,
 }: CommonCorrelationsQueryParams & {
   setup: Setup;
+  apmEventClient: APMEventClient;
   durationMinOverride?: number;
   durationMaxOverride?: number;
   fieldValuePairs: FieldValuePair[];
@@ -50,7 +53,7 @@ export const fetchSignificantCorrelations = async ({
   const eventType = getEventType(chartType, searchMetrics);
 
   const { percentiles: percentilesRecords } = await fetchDurationPercentiles({
-    setup,
+    apmEventClient,
     chartType,
     start,
     end,
@@ -69,7 +72,7 @@ export const fetchSignificantCorrelations = async ({
   const { expectations, ranges } = computeExpectationsAndRanges(percentiles);
 
   const { fractions, totalDocCount } = await fetchDurationFractions({
-    setup,
+    apmEventClient,
     eventType,
     start,
     end,
@@ -80,7 +83,7 @@ export const fetchSignificantCorrelations = async ({
   });
 
   const { rangeSteps } = await fetchDurationHistogramRangeSteps({
-    setup,
+    apmEventClient,
     chartType,
     start,
     end,
@@ -96,7 +99,7 @@ export const fetchSignificantCorrelations = async ({
     await Promise.allSettled(
       fieldValuePairs.map((fieldValuePair) =>
         fetchDurationCorrelationWithHistogram({
-          setup,
+          apmEventClient,
           chartType,
           start,
           end,
@@ -142,7 +145,7 @@ export const fetchSignificantCorrelations = async ({
   if (latencyCorrelations.length === 0 && fallbackResult) {
     const { fieldName, fieldValue } = fallbackResult;
     const { durationRanges: histogram } = await fetchDurationRanges({
-      setup,
+      apmEventClient,
       chartType,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_boolean_field_stats.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_boolean_field_stats.ts
@@ -11,11 +11,11 @@ import {
   FieldValuePair,
 } from '../../../../../common/correlations/types';
 import { BooleanFieldStats } from '../../../../../common/correlations/field_stats_types';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from '../get_common_correlations_query';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchBooleanFieldStats = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -24,12 +24,10 @@ export const fetchBooleanFieldStats = async ({
   field,
   query,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent;
   field: FieldValuePair;
 }): Promise<BooleanFieldStats> => {
-  const { apmEventClient } = setup;
-
   const { fieldName } = field;
 
   const { aggregations } = await apmEventClient.search(

--- a/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_field_value_field_stats.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_field_value_field_stats.ts
@@ -14,11 +14,11 @@ import {
   FieldValueFieldStats,
   TopValueBucket,
 } from '../../../../../common/correlations/field_stats_types';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from '../get_common_correlations_query';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchFieldValueFieldStats = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -28,11 +28,9 @@ export const fetchFieldValueFieldStats = async ({
   field,
 }: CommonCorrelationsQueryParams & {
   eventType: ProcessorEvent;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   field: FieldValuePair;
 }): Promise<FieldValueFieldStats> => {
-  const { apmEventClient } = setup;
-
   const { aggregations } = await apmEventClient.search(
     'get_field_value_field_stats',
     {

--- a/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_fields_stats.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_fields_stats.ts
@@ -16,10 +16,10 @@ import { FieldStats } from '../../../../../common/correlations/field_stats_types
 import { fetchKeywordFieldStats } from './fetch_keyword_field_stats';
 import { fetchNumericFieldStats } from './fetch_numeric_field_stats';
 import { fetchBooleanFieldStats } from './fetch_boolean_field_stats';
-import { Setup } from '../../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchFieldsStats = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -29,13 +29,12 @@ export const fetchFieldsStats = async ({
   fieldsToSample,
 }: CommonCorrelationsQueryParams & {
   eventType: ProcessorEvent;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   fieldsToSample: string[];
 }): Promise<{
   stats: FieldStats[];
   errors: any[];
 }> => {
-  const { apmEventClient } = setup;
   const stats: FieldStats[] = [];
   const errors: any[] = [];
 
@@ -68,7 +67,7 @@ export const fetchFieldsStats = async ({
           case ES_FIELD_TYPES.KEYWORD:
           case ES_FIELD_TYPES.IP:
             return fetchKeywordFieldStats({
-              setup,
+              apmEventClient,
               eventType,
               start,
               end,
@@ -91,7 +90,7 @@ export const fetchFieldsStats = async ({
           case ES_FIELD_TYPES.UNSIGNED_LONG:
           case ES_FIELD_TYPES.BYTE:
             return fetchNumericFieldStats({
-              setup,
+              apmEventClient,
               eventType,
               start,
               end,
@@ -104,7 +103,7 @@ export const fetchFieldsStats = async ({
             break;
           case ES_FIELD_TYPES.BOOLEAN:
             return fetchBooleanFieldStats({
-              setup,
+              apmEventClient,
               eventType,
               start,
               end,

--- a/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_keyword_field_stats.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_keyword_field_stats.ts
@@ -11,11 +11,11 @@ import {
   FieldValuePair,
 } from '../../../../../common/correlations/types';
 import { KeywordFieldStats } from '../../../../../common/correlations/field_stats_types';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { getCommonCorrelationsQuery } from '../get_common_correlations_query';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const fetchKeywordFieldStats = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -24,12 +24,10 @@ export const fetchKeywordFieldStats = async ({
   query,
   field,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent;
   field: FieldValuePair;
 }): Promise<KeywordFieldStats> => {
-  const { apmEventClient } = setup;
-
   const body = await apmEventClient.search('get_keyword_field_stats', {
     apm: {
       events: [eventType],

--- a/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_numeric_field_stats.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/queries/field_stats/fetch_numeric_field_stats.ts
@@ -15,11 +15,11 @@ import {
   CommonCorrelationsQueryParams,
   FieldValuePair,
 } from '../../../../../common/correlations/types';
-import { Setup } from '../../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getCommonCorrelationsQuery } from '../get_common_correlations_query';
 
 export const fetchNumericFieldStats = async ({
-  setup,
+  apmEventClient,
   eventType,
   start,
   end,
@@ -28,12 +28,10 @@ export const fetchNumericFieldStats = async ({
   query,
   field,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   eventType: ProcessorEvent;
   field: FieldValuePair;
 }): Promise<NumericFieldStats> => {
-  const { apmEventClient } = setup;
-
   const { fieldName } = field;
 
   const { aggregations } = await apmEventClient.search(

--- a/x-pack/plugins/apm/server/routes/correlations/route.ts
+++ b/x-pack/plugins/apm/server/routes/correlations/route.ts
@@ -30,6 +30,7 @@ import { fetchFieldValuePairs } from './queries/fetch_field_value_pairs';
 import { fetchSignificantCorrelations } from './queries/fetch_significant_correlations';
 import { fetchFieldsStats } from './queries/field_stats/fetch_fields_stats';
 import { fetchPValues } from './queries/fetch_p_values';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const INVALID_LICENSE = i18n.translate('xpack.apm.correlations.license.text', {
   defaultMessage:
@@ -58,7 +59,7 @@ const fieldCandidatesTransactionsRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: {
@@ -87,7 +88,7 @@ const fieldCandidatesTransactionsRoute = createApmServerRoute({
           ],
         },
       },
-      setup,
+      apmEventClient,
     });
   },
 });
@@ -124,7 +125,7 @@ const fieldStatsTransactionsRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       body: {
@@ -140,7 +141,7 @@ const fieldStatsTransactionsRoute = createApmServerRoute({
     } = resources.params;
 
     return fetchFieldsStats({
-      setup,
+      apmEventClient,
       eventType: ProcessorEvent.transaction,
       start,
       end,
@@ -190,7 +191,7 @@ const fieldValueStatsTransactionsRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: {
@@ -207,7 +208,7 @@ const fieldValueStatsTransactionsRoute = createApmServerRoute({
     } = resources.params;
 
     return fetchFieldValueFieldStats({
-      setup,
+      apmEventClient,
       eventType: ProcessorEvent.transaction,
       start,
       end,
@@ -262,7 +263,7 @@ const fieldValuePairsTransactionsRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       body: {
@@ -278,7 +279,7 @@ const fieldValuePairsTransactionsRoute = createApmServerRoute({
     } = resources.params;
 
     return fetchFieldValuePairs({
-      setup,
+      apmEventClient,
       eventType: ProcessorEvent.transaction,
       start,
       end,
@@ -334,8 +335,10 @@ const significantCorrelationsTransactionsRoute = createApmServerRoute({
     totalDocCount: number;
     fallbackResult?: import('./../../../common/correlations/latency_correlations/types').LatencyCorrelation;
   }> => {
-    const setup = await setupRequest(resources);
-
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const {
       body: {
         serviceName,
@@ -353,6 +356,7 @@ const significantCorrelationsTransactionsRoute = createApmServerRoute({
 
     return fetchSignificantCorrelations({
       setup,
+      apmEventClient,
       start,
       end,
       environment,
@@ -402,7 +406,10 @@ const pValuesTransactionsRoute = createApmServerRoute({
     ccsWarning: boolean;
     fallbackResult?: import('./../../../common/correlations/failed_transactions_correlations/types').FailedTransactionsCorrelation;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
 
     const {
       body: {
@@ -421,6 +428,7 @@ const pValuesTransactionsRoute = createApmServerRoute({
 
     return fetchPValues({
       setup,
+      apmEventClient,
       start,
       end,
       environment,

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.test.ts
@@ -11,6 +11,7 @@ import * as HistoricalAgentData from '../historical_data/has_historical_agent_da
 import { DataViewsService } from '@kbn/data-views-plugin/common';
 import { APMRouteHandlerResources, APMCore } from '../typings';
 import { APMConfig } from '../..';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 function getMockedDataViewService(existingDataViewTitle: string) {
   return {
@@ -44,11 +45,14 @@ const coreMock = {
   },
 } as unknown as APMCore;
 
+const apmEventClientMock = { search: jest.fn() } as unknown as APMEventClient;
+
 describe('createStaticDataView', () => {
   it(`should not create data view if 'xpack.apm.autocreateApmIndexPattern=false'`, async () => {
     const dataViewService = getMockedDataViewService('apm-*');
     await createStaticDataView({
       setup: setupMock,
+      apmEventClient: apmEventClientMock,
       resources: {
         config: { autoCreateApmDataView: false },
       } as APMRouteHandlerResources,
@@ -67,6 +71,7 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup: setupMock,
+      apmEventClient: apmEventClientMock,
       resources: {
         config: { autoCreateApmDataView: false },
       } as APMRouteHandlerResources,
@@ -85,6 +90,7 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup: setupMock,
+      apmEventClient: apmEventClientMock,
       resources: {
         core: coreMock,
         config: { autoCreateApmDataView: true },
@@ -107,6 +113,7 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup: setupMock,
+      apmEventClient: apmEventClientMock,
       resources: {
         core: coreMock,
         config: { autoCreateApmDataView: true },
@@ -136,6 +143,7 @@ describe('createStaticDataView', () => {
 
     await createStaticDataView({
       setup: setupMock,
+      apmEventClient: apmEventClientMock,
       resources: {
         core: coreMock,
         config: { autoCreateApmDataView: true },

--- a/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/create_static_data_view.ts
@@ -19,6 +19,7 @@ import { getApmDataViewTitle } from './get_apm_data_view_title';
 
 import { APMRouteHandlerResources } from '../typings';
 import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export type CreateDataViewResponse = Promise<
   | { created: boolean; dataView: DataView }
@@ -29,10 +30,12 @@ export async function createStaticDataView({
   dataViewService,
   resources,
   setup,
+  apmEventClient,
 }: {
   dataViewService: DataViewsService;
   resources: APMRouteHandlerResources;
   setup: Setup;
+  apmEventClient: APMEventClient;
 }): CreateDataViewResponse {
   const { config } = resources;
 
@@ -50,7 +53,7 @@ export async function createStaticDataView({
 
     // Discover and other apps will throw errors if an data view exists without having matching indices.
     // The following ensures the data view is only created if APM data is found
-    const hasData = await hasHistoricalAgentData(setup);
+    const hasData = await hasHistoricalAgentData(apmEventClient);
 
     if (!hasData) {
       return {

--- a/x-pack/plugins/apm/server/routes/data_view/route.ts
+++ b/x-pack/plugins/apm/server/routes/data_view/route.ts
@@ -13,13 +13,17 @@ import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getApmDataViewTitle } from './get_apm_data_view_title';
 import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
 import { setupRequest } from '../../lib/helpers/setup_request';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const staticDataViewRoute = createApmServerRoute({
   endpoint: 'POST /internal/apm/data_view/static',
   options: { tags: ['access:apm'] },
   handler: async (resources): CreateDataViewResponse => {
     const { context, plugins, request } = resources;
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const coreContext = await context.core;
 
     const dataViewStart = await plugins.dataViews.start();
@@ -34,6 +38,7 @@ const staticDataViewRoute = createApmServerRoute({
       dataViewService,
       resources,
       setup,
+      apmEventClient,
     });
 
     return res;

--- a/x-pack/plugins/apm/server/routes/dependencies/get_dependency_latency_distribution.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_dependency_latency_distribution.ts
@@ -14,12 +14,12 @@ import {
 import { Environment } from '../../../common/environment_rt';
 import { EventOutcome } from '../../../common/event_outcome';
 import { LatencyDistributionChartType } from '../../../common/latency_distribution_chart_types';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { getOverallLatencyDistribution } from '../latency_distribution/get_overall_latency_distribution';
 import { OverallLatencyDistributionResponse } from '../latency_distribution/types';
 
 export async function getDependencyLatencyDistribution({
-  setup,
+  apmEventClient,
   dependencyName,
   spanName,
   kuery,
@@ -28,7 +28,7 @@ export async function getDependencyLatencyDistribution({
   end,
   percentileThreshold,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   dependencyName: string;
   spanName: string;
   kuery: string;
@@ -40,9 +40,9 @@ export async function getDependencyLatencyDistribution({
   allSpansDistribution: OverallLatencyDistributionResponse;
   failedSpansDistribution: OverallLatencyDistributionResponse;
 }> {
-  const commonProps = {
+  const commonParams = {
     chartType: LatencyDistributionChartType.dependencyLatency,
-    setup,
+    apmEventClient,
     start,
     end,
     environment,
@@ -62,11 +62,11 @@ export async function getDependencyLatencyDistribution({
 
   const [allSpansDistribution, failedSpansDistribution] = await Promise.all([
     getOverallLatencyDistribution({
-      ...commonProps,
+      ...commonParams,
       query: commonQuery,
     }),
     getOverallLatencyDistribution({
-      ...commonProps,
+      ...commonParams,
       query: {
         bool: {
           filter: [

--- a/x-pack/plugins/apm/server/routes/dependencies/get_error_rate_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_error_rate_charts_for_dependency.ts
@@ -17,7 +17,6 @@ import {
   SPAN_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getMetricsDateHistogramParams } from '../../lib/helpers/metrics';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import {
@@ -25,11 +24,12 @@ import {
   getDocumentTypeFilterForServiceDestinationStatistics,
   getProcessorEventForServiceDestinationStatistics,
 } from '../../lib/helpers/spans/get_is_using_service_destination_metrics';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getErrorRateChartsForDependency({
   dependencyName,
   spanName,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -39,7 +39,7 @@ export async function getErrorRateChartsForDependency({
 }: {
   dependencyName: string;
   spanName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: string;
@@ -47,8 +47,6 @@ export async function getErrorRateChartsForDependency({
   searchServiceDestinationMetrics: boolean;
   offset?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_latency_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_latency_charts_for_dependency.ts
@@ -15,7 +15,6 @@ import {
   SPAN_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getMetricsDateHistogramParams } from '../../lib/helpers/metrics';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import {
@@ -24,12 +23,13 @@ import {
   getLatencyFieldForServiceDestinationStatistics,
   getProcessorEventForServiceDestinationStatistics,
 } from '../../lib/helpers/spans/get_is_using_service_destination_metrics';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getLatencyChartsForDependency({
   dependencyName,
   spanName,
   searchServiceDestinationMetrics,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -39,15 +39,13 @@ export async function getLatencyChartsForDependency({
   dependencyName: string;
   spanName: string;
   searchServiceDestinationMetrics: boolean;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: string;
   kuery: string;
   offset?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_metadata_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_metadata_for_dependency.ts
@@ -9,21 +9,19 @@ import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { maybe } from '../../../common/utils/maybe';
 import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getMetadataForDependency({
-  setup,
+  apmEventClient,
   dependencyName,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   dependencyName: string;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const sampleResponse = await apmEventClient.search(
     'get_metadata_for_dependency',
     {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_throughput_charts_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_throughput_charts_for_dependency.ts
@@ -15,7 +15,6 @@ import {
   SPAN_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import { getBucketSize } from '../../lib/helpers/get_bucket_size';
 import {
@@ -23,11 +22,12 @@ import {
   getDocumentTypeFilterForServiceDestinationStatistics,
   getProcessorEventForServiceDestinationStatistics,
 } from '../../lib/helpers/spans/get_is_using_service_destination_metrics';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getThroughputChartsForDependency({
   dependencyName,
   spanName,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -37,7 +37,7 @@ export async function getThroughputChartsForDependency({
 }: {
   dependencyName: string;
   spanName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: string;
@@ -45,8 +45,6 @@ export async function getThroughputChartsForDependency({
   searchServiceDestinationMetrics: boolean;
   offset?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_top_dependencies.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_top_dependencies.ts
@@ -10,10 +10,10 @@ import { NodeType } from '../../../common/connections';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { getConnectionStats } from '../../lib/connections/get_connection_stats';
 import { getConnectionStatsItemsWithRelativeImpact } from '../../lib/connections/get_connection_stats/get_connection_stats_items_with_relative_impact';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTopDependencies({
-  setup,
+  apmEventClient,
   start,
   end,
   numBuckets,
@@ -21,7 +21,7 @@ export async function getTopDependencies({
   offset,
   kuery,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   numBuckets: number;
@@ -30,7 +30,7 @@ export async function getTopDependencies({
   kuery: string;
 }) {
   const statsItems = await getConnectionStats({
-    setup,
+    apmEventClient,
     start,
     end,
     numBuckets,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_operations.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_operations.ts
@@ -24,13 +24,13 @@ import { environmentQuery } from '../../../common/utils/environment_query';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import { calculateThroughputWithRange } from '../../lib/helpers/calculate_throughput';
 import { getBucketSizeForAggregatedTransactions } from '../../lib/helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   getDocumentTypeFilterForServiceDestinationStatistics,
   getLatencyFieldForServiceDestinationStatistics,
   getProcessorEventForServiceDestinationStatistics,
 } from '../../lib/helpers/spans/get_is_using_service_destination_metrics';
 import { calculateImpactBuilder } from '../traces/calculate_impact_builder';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 const MAX_NUM_OPERATIONS = 500;
 
@@ -47,7 +47,7 @@ export interface DependencyOperation {
 }
 
 export async function getTopDependencyOperations({
-  setup,
+  apmEventClient,
   dependencyName,
   start,
   end,
@@ -56,7 +56,7 @@ export async function getTopDependencyOperations({
   kuery,
   searchServiceDestinationMetrics,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   dependencyName: string;
   start: number;
   end: number;
@@ -65,8 +65,6 @@ export async function getTopDependencyOperations({
   kuery: string;
   searchServiceDestinationMetrics: boolean;
 }) {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset, offsetInMs } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_spans.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_top_dependency_spans.ts
@@ -30,7 +30,7 @@ import { Environment } from '../../../common/environment_rt';
 import { EventOutcome } from '../../../common/event_outcome';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { AgentName } from '../../../typings/es_schemas/ui/fields/agent';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 const MAX_NUM_SPANS = 1000;
 
@@ -48,7 +48,7 @@ export interface DependencySpan {
 }
 
 export async function getTopDependencySpans({
-  setup,
+  apmEventClient,
   dependencyName,
   spanName,
   start,
@@ -58,7 +58,7 @@ export async function getTopDependencySpans({
   sampleRangeFrom,
   sampleRangeTo,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   dependencyName: string;
   spanName: string;
   start: number;
@@ -68,8 +68,6 @@ export async function getTopDependencySpans({
   sampleRangeFrom?: number;
   sampleRangeTo?: number;
 }): Promise<DependencySpan[]> {
-  const { apmEventClient } = setup;
-
   const spans = (
     await apmEventClient.search('get_top_dependency_spans', {
       apm: {

--- a/x-pack/plugins/apm/server/routes/dependencies/get_upstream_services_for_dependency.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/get_upstream_services_for_dependency.ts
@@ -10,10 +10,10 @@ import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../common/elasticsearch
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { getConnectionStats } from '../../lib/connections/get_connection_stats';
 import { getConnectionStatsItemsWithRelativeImpact } from '../../lib/connections/get_connection_stats/get_connection_stats_items_with_relative_impact';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getUpstreamServicesForDependency({
-  setup,
+  apmEventClient,
   start,
   end,
   dependencyName,
@@ -22,7 +22,7 @@ export async function getUpstreamServicesForDependency({
   environment,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   dependencyName: string;
@@ -32,7 +32,7 @@ export async function getUpstreamServicesForDependency({
   offset?: string;
 }) {
   const statsItems = await getConnectionStats({
-    setup,
+    apmEventClient,
     start,
     end,
     filter: [

--- a/x-pack/plugins/apm/server/routes/dependencies/route.ts
+++ b/x-pack/plugins/apm/server/routes/dependencies/route.ts
@@ -7,7 +7,6 @@
 
 import * as t from 'io-ts';
 import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
-import { setupRequest } from '../../lib/helpers/setup_request';
 import { environmentRt, kueryRt, rangeRt } from '../default_api_types';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getMetadataForDependency } from './get_metadata_for_dependency';
@@ -28,6 +27,7 @@ import {
   DependencySpan,
   getTopDependencySpans,
 } from './get_top_dependency_spans';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const topDependenciesRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/dependencies/top_dependencies',
@@ -100,11 +100,11 @@ const topDependenciesRoute = createApmServerRoute({
       location: import('./../../../common/connections').Node;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { environment, offset, numBuckets, kuery, start, end } =
       resources.params.query;
 
-    const opts = { setup, start, end, numBuckets, environment, kuery };
+    const opts = { apmEventClient, start, end, numBuckets, environment, kuery };
 
     const [currentDependencies, previousDependencies] = await Promise.all([
       getTopDependencies(opts),
@@ -198,7 +198,7 @@ const upstreamServicesForDependencyRoute = createApmServerRoute({
       location: import('./../../../common/connections').Node;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const {
       query: {
         dependencyName,
@@ -213,7 +213,7 @@ const upstreamServicesForDependencyRoute = createApmServerRoute({
 
     const opts = {
       dependencyName,
-      setup,
+      apmEventClient,
       start,
       end,
       numBuckets,
@@ -264,14 +264,14 @@ const dependencyMetadataRoute = createApmServerRoute({
   ): Promise<{
     metadata: { spanType: string | undefined; spanSubtype: string | undefined };
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
 
     const { dependencyName, start, end } = params.query;
 
     const metadata = await getMetadataForDependency({
       dependencyName,
-      setup,
+      apmEventClient,
       start,
       end,
     });
@@ -304,7 +304,7 @@ const dependencyLatencyChartsRoute = createApmServerRoute({
     currentTimeseries: Array<{ x: number; y: number }>;
     comparisonTimeseries: Array<{ x: number; y: number }> | null;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const {
       dependencyName,
@@ -322,7 +322,7 @@ const dependencyLatencyChartsRoute = createApmServerRoute({
         dependencyName,
         spanName,
         searchServiceDestinationMetrics,
-        setup,
+        apmEventClient,
         start,
         end,
         kuery,
@@ -333,7 +333,7 @@ const dependencyLatencyChartsRoute = createApmServerRoute({
             dependencyName,
             spanName,
             searchServiceDestinationMetrics,
-            setup,
+            apmEventClient,
             start,
             end,
             kuery,
@@ -371,7 +371,7 @@ const dependencyThroughputChartsRoute = createApmServerRoute({
     currentTimeseries: Array<{ x: number; y: number | null }>;
     comparisonTimeseries: Array<{ x: number; y: number | null }> | null;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const {
       dependencyName,
@@ -388,7 +388,7 @@ const dependencyThroughputChartsRoute = createApmServerRoute({
       getThroughputChartsForDependency({
         dependencyName,
         spanName,
-        setup,
+        apmEventClient,
         start,
         end,
         kuery,
@@ -399,7 +399,7 @@ const dependencyThroughputChartsRoute = createApmServerRoute({
         ? getThroughputChartsForDependency({
             dependencyName,
             spanName,
-            setup,
+            apmEventClient,
             start,
             end,
             kuery,
@@ -438,7 +438,7 @@ const dependencyFailedTransactionRateChartsRoute = createApmServerRoute({
     currentTimeseries: Array<{ x: number; y: number }>;
     comparisonTimeseries: Array<{ x: number; y: number }> | null;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const {
       dependencyName,
@@ -455,7 +455,7 @@ const dependencyFailedTransactionRateChartsRoute = createApmServerRoute({
       getErrorRateChartsForDependency({
         dependencyName,
         spanName,
-        setup,
+        apmEventClient,
         start,
         end,
         kuery,
@@ -466,7 +466,7 @@ const dependencyFailedTransactionRateChartsRoute = createApmServerRoute({
         ? getErrorRateChartsForDependency({
             dependencyName,
             spanName,
-            setup,
+            apmEventClient,
             start,
             end,
             kuery,
@@ -501,7 +501,7 @@ const dependencyOperationsRoute = createApmServerRoute({
   handler: async (
     resources
   ): Promise<{ operations: DependencyOperation[] }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: {
@@ -516,7 +516,7 @@ const dependencyOperationsRoute = createApmServerRoute({
     } = resources.params;
 
     const operations = await getTopDependencyOperations({
-      setup,
+      apmEventClient,
       dependencyName,
       start,
       end,
@@ -553,7 +553,7 @@ const dependencyLatencyDistributionChartsRoute = createApmServerRoute({
     allSpansDistribution: OverallLatencyDistributionResponse;
     failedSpansDistribution: OverallLatencyDistributionResponse;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const {
       dependencyName,
@@ -566,7 +566,7 @@ const dependencyLatencyDistributionChartsRoute = createApmServerRoute({
     } = params.query;
 
     return getDependencyLatencyDistribution({
-      setup,
+      apmEventClient,
       dependencyName,
       spanName,
       percentileThreshold,
@@ -593,7 +593,7 @@ const topDependencySpansRoute = createApmServerRoute({
     ]),
   }),
   handler: async (resources): Promise<{ spans: DependencySpan[] }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: {
@@ -609,7 +609,7 @@ const topDependencySpansRoute = createApmServerRoute({
     } = resources.params;
 
     const spans = await getTopDependencySpans({
-      setup,
+      apmEventClient,
       dependencyName,
       spanName,
       start,

--- a/x-pack/plugins/apm/server/routes/environments/get_all_environments.test.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_all_environments.test.ts
@@ -19,11 +19,11 @@ describe('getAllEnvironments', () => {
   });
 
   it('fetches all environments', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getAllEnvironments({
         searchAggregatedTransactions: false,
         serviceName: 'test',
-        setup,
+        apmEventClient,
         size: 50,
       })
     );
@@ -32,12 +32,12 @@ describe('getAllEnvironments', () => {
   });
 
   it('fetches all environments with includeMissing', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getAllEnvironments({
         includeMissing: true,
         searchAggregatedTransactions: false,
         serviceName: 'test',
-        setup,
+        apmEventClient,
         size: 50,
       })
     );

--- a/x-pack/plugins/apm/server/routes/environments/get_all_environments.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_all_environments.ts
@@ -7,13 +7,13 @@
 
 import { termQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   SERVICE_NAME,
   SERVICE_ENVIRONMENT,
 } from '../../../common/elasticsearch_fieldnames';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../common/environment_filter_values';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 /**
  * This is used for getting *all* environments, and does not filter by range.
@@ -23,20 +23,18 @@ export async function getAllEnvironments({
   includeMissing = false,
   searchAggregatedTransactions,
   serviceName,
-  setup,
+  apmEventClient,
   size,
 }: {
   includeMissing?: boolean;
   searchAggregatedTransactions: boolean;
   serviceName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   size: number;
 }) {
   const operationName = serviceName
     ? 'get_all_environments_for_service'
     : 'get_all_environments_for_all_services';
-
-  const { apmEventClient } = setup;
 
   const params = {
     apm: {

--- a/x-pack/plugins/apm/server/routes/environments/get_environments.test.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_environments.test.ts
@@ -19,9 +19,9 @@ describe('getEnvironments', () => {
   });
 
   it('fetches environments', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getEnvironments({
-        setup,
+        apmEventClient,
         serviceName: 'foo',
         searchAggregatedTransactions: false,
         size: 50,
@@ -34,9 +34,9 @@ describe('getEnvironments', () => {
   });
 
   it('fetches environments without a service name', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getEnvironments({
-        setup,
+        apmEventClient,
         searchAggregatedTransactions: false,
         size: 50,
         start: 0,

--- a/x-pack/plugins/apm/server/routes/environments/get_environments.ts
+++ b/x-pack/plugins/apm/server/routes/environments/get_environments.ts
@@ -13,8 +13,8 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../common/environment_filter_values';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
-import { Setup } from '../../lib/helpers/setup_request';
 import { Environment } from '../../../common/environment_rt';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 /**
  * This is used for getting the list of environments for the environments selector,
@@ -23,12 +23,12 @@ import { Environment } from '../../../common/environment_rt';
 export async function getEnvironments({
   searchAggregatedTransactions,
   serviceName,
-  setup,
+  apmEventClient,
   size,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName?: string;
   searchAggregatedTransactions: boolean;
   size: number;
@@ -38,8 +38,6 @@ export async function getEnvironments({
   const operationName = serviceName
     ? 'get_environments_for_service'
     : 'get_environments';
-
-  const { apmEventClient } = setup;
 
   const params = {
     apm: {

--- a/x-pack/plugins/apm/server/routes/environments/route.ts
+++ b/x-pack/plugins/apm/server/routes/environments/route.ts
@@ -12,6 +12,7 @@ import { setupRequest } from '../../lib/helpers/setup_request';
 import { getEnvironments } from './get_environments';
 import { rangeRt } from '../default_api_types';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const environmentsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/environments',
@@ -36,11 +37,14 @@ const environmentsRoute = createApmServerRoute({
         >
     >;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { context, params } = resources;
     const { serviceName, start, end } = params.query;
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -51,7 +55,7 @@ const environmentsRoute = createApmServerRoute({
       maxSuggestions
     );
     const environments = await getEnvironments({
-      setup,
+      apmEventClient,
       serviceName,
       searchAggregatedTransactions,
       size,

--- a/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.test.ts
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { getBuckets } from './get_buckets';
-import { APMConfig } from '../../..';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 
 describe('get buckets', () => {
@@ -29,30 +28,9 @@ describe('get buckets', () => {
       serviceName: 'myServiceName',
       bucketSize: 10,
       kuery: '',
-      setup: {
-        apmEventClient: {
-          search: clientSpy,
-        } as any,
-        internalClient: {
-          search: clientSpy,
-        } as any,
-        config: new Proxy(
-          {},
-          {
-            get: () => 'myIndex',
-          }
-        ) as APMConfig,
-        indices: {
-          sourcemap: 'apm-*',
-          error: 'apm-*',
-          onboarding: 'apm-*',
-          span: 'apm-*',
-          transaction: 'apm-*',
-          metric: 'apm-*',
-          apmAgentConfigurationIndex: '.apm-agent-configuration',
-          apmCustomLinkIndex: '.apm-custom-link',
-        },
-      },
+      apmEventClient: {
+        search: clientSpy,
+      } as any,
       start: 1528113600000,
       end: 1528977600000,
     });

--- a/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.ts
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/get_buckets.ts
@@ -16,7 +16,7 @@ import {
   SERVICE_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getBuckets({
   environment,
@@ -24,7 +24,7 @@ export async function getBuckets({
   serviceName,
   groupId,
   bucketSize,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
@@ -33,12 +33,10 @@ export async function getBuckets({
   serviceName: string;
   groupId?: string;
   bucketSize: number;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [ProcessorEvent.error],

--- a/x-pack/plugins/apm/server/routes/errors/distribution/get_distribution.ts
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/get_distribution.ts
@@ -6,10 +6,10 @@
  */
 
 import { offsetPreviousPeriodCoordinates } from '../../../../common/utils/offset_previous_period_coordinate';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { BUCKET_TARGET_COUNT } from '../../transactions/constants';
 import { getBuckets } from './get_buckets';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 function getBucketSize({ start, end }: { start: number; end: number }) {
   return Math.floor((end - start) / BUCKET_TARGET_COUNT);
@@ -20,7 +20,7 @@ export async function getErrorDistribution({
   kuery,
   serviceName,
   groupId,
-  setup,
+  apmEventClient,
   start,
   end,
   offset,
@@ -29,7 +29,7 @@ export async function getErrorDistribution({
   kuery: string;
   serviceName: string;
   groupId?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   offset?: string;
@@ -50,7 +50,7 @@ export async function getErrorDistribution({
     kuery,
     serviceName,
     groupId,
-    setup,
+    apmEventClient,
     bucketSize,
   };
   const currentPeriodPromise = getBuckets({

--- a/x-pack/plugins/apm/server/routes/errors/distribution/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/errors/distribution/queries.test.ts
@@ -20,10 +20,10 @@ describe('error distribution queries', () => {
   });
 
   it('fetches an error distribution', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getErrorDistribution({
         serviceName: 'serviceName',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -35,11 +35,11 @@ describe('error distribution queries', () => {
   });
 
   it('fetches an error distribution with a group id', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getErrorDistribution({
         serviceName: 'serviceName',
         groupId: 'foo',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,

--- a/x-pack/plugins/apm/server/routes/errors/erroneous_transactions/get_top_erroneous_transactions.ts
+++ b/x-pack/plugins/apm/server/routes/errors/erroneous_transactions/get_top_erroneous_transactions.ts
@@ -26,16 +26,16 @@ import {
   TRANSACTION_TYPE,
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getBucketSize } from '../../../lib/helpers/get_bucket_size';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 async function getTopErroneousTransactions({
   environment,
   kuery,
   serviceName,
   groupId,
-  setup,
+  apmEventClient,
   start,
   end,
   numBuckets,
@@ -45,14 +45,12 @@ async function getTopErroneousTransactions({
   kuery: string;
   serviceName: string;
   groupId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   numBuckets: number;
   offset?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset, offsetInMs } = getOffsetInMs({
     start,
     end,
@@ -132,7 +130,7 @@ async function getTopErroneousTransactions({
 export async function getTopErroneousTransactionsPeriods({
   kuery,
   serviceName,
-  setup,
+  apmEventClient,
   numBuckets,
   groupId,
   environment,
@@ -142,7 +140,7 @@ export async function getTopErroneousTransactionsPeriods({
 }: {
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   numBuckets: number;
   groupId: string;
   environment: string;
@@ -155,7 +153,7 @@ export async function getTopErroneousTransactionsPeriods({
       environment,
       kuery,
       serviceName,
-      setup,
+      apmEventClient,
       numBuckets,
       groupId,
       start,
@@ -166,7 +164,7 @@ export async function getTopErroneousTransactionsPeriods({
           environment,
           kuery,
           serviceName,
-          setup,
+          apmEventClient,
           numBuckets,
           groupId,
           start,

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_detailed_statistics.ts
@@ -20,13 +20,13 @@ import {
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getBucketSize } from '../../../lib/helpers/get_bucket_size';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getErrorGroupDetailedStatistics({
   kuery,
   serviceName,
-  setup,
+  apmEventClient,
   numBuckets,
   groupIds,
   environment,
@@ -36,7 +36,7 @@ export async function getErrorGroupDetailedStatistics({
 }: {
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   numBuckets: number;
   groupIds: string[];
   environment: string;
@@ -44,8 +44,6 @@ export async function getErrorGroupDetailedStatistics({
   end: number;
   offset?: string;
 }): Promise<Array<{ groupId: string; timeseries: Coordinate[] }>> {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -124,7 +122,7 @@ export async function getErrorGroupDetailedStatistics({
 export async function getErrorGroupPeriods({
   kuery,
   serviceName,
-  setup,
+  apmEventClient,
   numBuckets,
   groupIds,
   environment,
@@ -134,7 +132,7 @@ export async function getErrorGroupPeriods({
 }: {
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   numBuckets: number;
   groupIds: string[];
   environment: string;
@@ -146,7 +144,7 @@ export async function getErrorGroupPeriods({
     environment,
     kuery,
     serviceName,
-    setup,
+    apmEventClient,
     numBuckets,
     groupIds,
   };

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -25,12 +25,12 @@ import {
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getErrorName } from '../../../lib/helpers/get_error_name';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getErrorGroupMainStatistics({
   kuery,
   serviceName,
-  setup,
+  apmEventClient,
   environment,
   sortField,
   sortDirection = 'desc',
@@ -42,7 +42,7 @@ export async function getErrorGroupMainStatistics({
 }: {
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   environment: string;
   sortField?: string;
   sortDirection?: 'asc' | 'desc';
@@ -52,8 +52,6 @@ export async function getErrorGroupMainStatistics({
   transactionName?: string;
   transactionType?: string;
 }) {
-  const { apmEventClient } = setup;
-
   // sort buckets by last occurrence of error
   const sortByLatestOccurrence = sortField === 'lastSeen';
 

--- a/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample.ts
+++ b/x-pack/plugins/apm/server/routes/errors/get_error_groups/get_error_group_sample.ts
@@ -15,14 +15,14 @@ import {
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getTransaction } from '../../transactions/get_transaction';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getErrorGroupSample({
   environment,
   kuery,
   serviceName,
   groupId,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
@@ -30,12 +30,10 @@ export async function getErrorGroupSample({
   kuery: string;
   serviceName: string;
   groupId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [ProcessorEvent.error as const],
@@ -72,7 +70,7 @@ export async function getErrorGroupSample({
     transaction = await getTransaction({
       transactionId,
       traceId,
-      setup,
+      apmEventClient,
       start,
       end,
     });

--- a/x-pack/plugins/apm/server/routes/errors/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/errors/queries.test.ts
@@ -21,11 +21,11 @@ describe('error queries', () => {
   });
 
   it('fetches a single error group', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getErrorGroupSample({
         groupId: 'groupId',
         serviceName: 'serviceName',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -37,12 +37,12 @@ describe('error queries', () => {
   });
 
   it('fetches multiple error groups', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getErrorGroupMainStatistics({
         sortDirection: 'asc',
         sortField: 'foo',
         serviceName: 'serviceName',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -54,12 +54,12 @@ describe('error queries', () => {
   });
 
   it('fetches multiple error groups when sortField = lastSeen', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getErrorGroupMainStatistics({
         sortDirection: 'asc',
         sortField: 'lastSeen',
         serviceName: 'serviceName',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,

--- a/x-pack/plugins/apm/server/routes/errors/route.ts
+++ b/x-pack/plugins/apm/server/routes/errors/route.ts
@@ -9,13 +9,13 @@ import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
 import * as t from 'io-ts';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getErrorDistribution } from './distribution/get_distribution';
-import { setupRequest } from '../../lib/helpers/setup_request';
 import { environmentRt, kueryRt, rangeRt } from '../default_api_types';
 import { getErrorGroupMainStatistics } from './get_error_groups/get_error_group_main_statistics';
 import { getErrorGroupPeriods } from './get_error_groups/get_error_group_detailed_statistics';
 import { getErrorGroupSample } from './get_error_groups/get_error_group_sample';
 import { offsetRt } from '../../../common/comparison_rt';
 import { getTopErroneousTransactionsPeriods } from './erroneous_transactions/get_top_erroneous_transactions';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const errorsMainStatisticsRoute = createApmServerRoute({
   endpoint:
@@ -49,7 +49,7 @@ const errorsMainStatisticsRoute = createApmServerRoute({
     }>;
   }> => {
     const { params } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { serviceName } = params.path;
     const { environment, kuery, sortField, sortDirection, start, end } =
       params.query;
@@ -60,7 +60,7 @@ const errorsMainStatisticsRoute = createApmServerRoute({
       serviceName,
       sortField,
       sortDirection,
-      setup,
+      apmEventClient,
       start,
       end,
     });
@@ -102,7 +102,7 @@ const errorsMainStatisticsByTransactionNameRoute = createApmServerRoute({
     }>;
   }> => {
     const { params } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { serviceName } = params.path;
     const {
       environment,
@@ -118,7 +118,7 @@ const errorsMainStatisticsByTransactionNameRoute = createApmServerRoute({
       environment,
       kuery,
       serviceName,
-      setup,
+      apmEventClient,
       start,
       end,
       maxNumberOfErrorGroups,
@@ -164,7 +164,7 @@ const errorsDetailedStatisticsRoute = createApmServerRoute({
       groupId: string;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
 
     const {
@@ -177,7 +177,7 @@ const errorsDetailedStatisticsRoute = createApmServerRoute({
       environment,
       kuery,
       serviceName,
-      setup,
+      apmEventClient,
       numBuckets,
       groupIds,
       start,
@@ -207,7 +207,7 @@ const errorGroupsRoute = createApmServerRoute({
     occurrencesCount: number;
   }> => {
     const { params } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { serviceName, groupId } = params.path;
     const { environment, kuery, start, end } = params.query;
 
@@ -216,7 +216,7 @@ const errorGroupsRoute = createApmServerRoute({
       groupId,
       kuery,
       serviceName,
-      setup,
+      apmEventClient,
       start,
       end,
     });
@@ -250,7 +250,7 @@ const errorDistributionRoute = createApmServerRoute({
     }>;
     bucketSize: number;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { environment, kuery, groupId, start, end, offset } = params.query;
@@ -259,7 +259,7 @@ const errorDistributionRoute = createApmServerRoute({
       kuery,
       serviceName,
       groupId,
-      setup,
+      apmEventClient,
       start,
       end,
       offset,
@@ -298,7 +298,7 @@ const topErroneousTransactionsRoute = createApmServerRoute({
     }>;
   }> => {
     const { params } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       path: { serviceName, groupId },
@@ -310,7 +310,7 @@ const topErroneousTransactionsRoute = createApmServerRoute({
       groupId,
       kuery,
       serviceName,
-      setup,
+      apmEventClient,
       start,
       end,
       numBuckets,

--- a/x-pack/plugins/apm/server/routes/event_metadata/route.ts
+++ b/x-pack/plugins/apm/server/routes/event_metadata/route.ts
@@ -9,7 +9,7 @@ import * as t from 'io-ts';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getEventMetadata } from './get_event_metadata';
 import { processorEventRt } from '../../../common/processor_event';
-import { setupRequest } from '../../lib/helpers/setup_request';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const eventMetadataRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/event_metadata/{processorEvent}/{id}',
@@ -23,14 +23,14 @@ const eventMetadataRoute = createApmServerRoute({
   handler: async (
     resources
   ): Promise<{ metadata: Partial<Record<string, unknown[]>> }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       path: { processorEvent, id },
     } = resources.params;
 
     const metadata = await getEventMetadata({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       processorEvent,
       id,
     });

--- a/x-pack/plugins/apm/server/routes/fallback_to_transactions/route.ts
+++ b/x-pack/plugins/apm/server/routes/fallback_to_transactions/route.ts
@@ -10,6 +10,7 @@ import { getIsUsingTransactionEvents } from '../../lib/helpers/transactions/get_
 import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { kueryRt, rangeRt } from '../default_api_types';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const fallbackToTransactionsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/fallback_to_transactions',
@@ -18,7 +19,10 @@ const fallbackToTransactionsRoute = createApmServerRoute({
   }),
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ fallbackToTransactions: boolean }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const {
       params: {
         query: { kuery, start, end },
@@ -26,7 +30,8 @@ const fallbackToTransactionsRoute = createApmServerRoute({
     } = resources;
     return {
       fallbackToTransactions: await getIsUsingTransactionEvents({
-        setup,
+        config: setup.config,
+        apmEventClient,
         kuery,
         start,
         end,

--- a/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
+++ b/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
@@ -6,12 +6,10 @@
  */
 
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 // Note: this logic is duplicated in tutorials/apm/envs/on_prem
-export async function hasHistoricalAgentData(setup: Setup) {
-  const { apmEventClient } = setup;
-
+export async function hasHistoricalAgentData(apmEventClient: APMEventClient) {
   const params = {
     terminate_after: 1,
     apm: {

--- a/x-pack/plugins/apm/server/routes/historical_data/route.ts
+++ b/x-pack/plugins/apm/server/routes/historical_data/route.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { setupRequest } from '../../lib/helpers/setup_request';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { hasHistoricalAgentData } from './has_historical_agent_data';
 
@@ -13,8 +13,8 @@ const hasDataRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/has_data',
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ hasData: boolean }> => {
-    const setup = await setupRequest(resources);
-    const hasData = await hasHistoricalAgentData(setup);
+    const apmEventClient = await getApmEventClient(resources);
+    const hasData = await hasHistoricalAgentData(apmEventClient);
     return { hasData };
   },
 });

--- a/x-pack/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -7,7 +7,6 @@
 
 import { rangeQuery, kqlQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../lib/helpers/setup_request';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import {
   SERVICE_NAME,
@@ -15,24 +14,23 @@ import {
   HOST_HOSTNAME,
   KUBERNETES_POD_NAME,
 } from '../../../common/elasticsearch_fieldnames';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export const getInfrastructureData = async ({
   kuery,
   serviceName,
   environment,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   kuery: string;
   serviceName: string;
   environment: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) => {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search('get_service_infrastructure', {
     apm: {
       events: [ProcessorEvent.metric],

--- a/x-pack/plugins/apm/server/routes/infrastructure/route.ts
+++ b/x-pack/plugins/apm/server/routes/infrastructure/route.ts
@@ -6,7 +6,7 @@
  */
 import * as t from 'io-ts';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
-import { setupRequest } from '../../lib/helpers/setup_request';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { environmentRt, kueryRt, rangeRt } from '../default_api_types';
 import { getInfrastructureData } from './get_infrastructure_data';
 import { getContainerHostNames } from './get_host_names';
@@ -29,7 +29,7 @@ const infrastructureRoute = createApmServerRoute({
     hostNames: string[];
     podNames: string[];
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const infraMetricsClient = createInfraMetricsClient(resources);
 
     const { params } = resources;
@@ -40,7 +40,7 @@ const infrastructureRoute = createApmServerRoute({
     } = params;
 
     const infrastructureData = await getInfrastructureData({
-      setup,
+      apmEventClient,
       serviceName,
       environment,
       kuery,

--- a/x-pack/plugins/apm/server/routes/latency_distribution/get_overall_latency_distribution.ts
+++ b/x-pack/plugins/apm/server/routes/latency_distribution/get_overall_latency_distribution.ts
@@ -7,21 +7,17 @@
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Environment } from '../../../common/environment_rt';
-
-import { Setup } from '../../lib/helpers/setup_request';
-
 import { withApmSpan } from '../../utils/with_apm_span';
-
 import { fetchDurationRanges } from '../correlations/queries/fetch_duration_ranges';
 import { fetchDurationHistogramRangeSteps } from '../correlations/queries/fetch_duration_histogram_range_steps';
-
 import { getPercentileThresholdValue } from './get_percentile_threshold_value';
 import type { OverallLatencyDistributionResponse } from './types';
 import { LatencyDistributionChartType } from '../../../common/latency_distribution_chart_types';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getOverallLatencyDistribution({
   chartType,
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -33,7 +29,7 @@ export async function getOverallLatencyDistribution({
   searchMetrics,
 }: {
   chartType: LatencyDistributionChartType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: Environment;
@@ -51,7 +47,7 @@ export async function getOverallLatencyDistribution({
     overallLatencyDistribution.percentileThresholdValue =
       await getPercentileThresholdValue({
         chartType,
-        setup,
+        apmEventClient,
         start,
         end,
         environment,
@@ -70,7 +66,7 @@ export async function getOverallLatencyDistribution({
     const { durationMin, durationMax, rangeSteps } =
       await fetchDurationHistogramRangeSteps({
         chartType,
-        setup,
+        apmEventClient,
         start,
         end,
         environment,
@@ -88,7 +84,7 @@ export async function getOverallLatencyDistribution({
     // #3: get histogram chart data
     const { totalDocCount, durationRanges } = await fetchDurationRanges({
       chartType,
-      setup,
+      apmEventClient,
       start,
       end,
       environment,

--- a/x-pack/plugins/apm/server/routes/latency_distribution/get_percentile_threshold_value.ts
+++ b/x-pack/plugins/apm/server/routes/latency_distribution/get_percentile_threshold_value.ts
@@ -7,11 +7,11 @@
 
 import { CommonCorrelationsQueryParams } from '../../../common/correlations/types';
 import { LatencyDistributionChartType } from '../../../common/latency_distribution_chart_types';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { fetchDurationPercentiles } from '../correlations/queries/fetch_duration_percentiles';
 
 export async function getPercentileThresholdValue({
-  setup,
+  apmEventClient,
   chartType,
   start,
   end,
@@ -21,13 +21,13 @@ export async function getPercentileThresholdValue({
   percentileThreshold,
   searchMetrics,
 }: CommonCorrelationsQueryParams & {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   chartType: LatencyDistributionChartType;
   percentileThreshold: number;
   searchMetrics: boolean;
 }) {
   const durationPercentiles = await fetchDurationPercentiles({
-    setup,
+    apmEventClient,
     chartType,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/default.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/default.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMConfig } from '../../..';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getCPUChartData } from './shared/cpu';
 import { getMemoryChartData } from './shared/memory';
 
@@ -13,19 +14,37 @@ export function getDefaultMetricsCharts({
   environment,
   kuery,
   serviceName,
-  setup,
+  config,
+  apmEventClient,
   start,
   end,
 }: {
   environment: string;
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
   return Promise.all([
-    getCPUChartData({ environment, kuery, setup, serviceName, start, end }),
-    getMemoryChartData({ environment, kuery, setup, serviceName, start, end }),
+    getCPUChartData({
+      environment,
+      kuery,
+      config,
+      apmEventClient,
+      serviceName,
+      start,
+      end,
+    }),
+    getMemoryChartData({
+      environment,
+      kuery,
+      config,
+      apmEventClient,
+      serviceName,
+      start,
+      end,
+    }),
   ]);
 }

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.test.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.test.ts
@@ -9,6 +9,7 @@ import {
   METRIC_JAVA_GC_COUNT,
   METRIC_JAVA_GC_TIME,
 } from '../../../../../../common/elasticsearch_fieldnames';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { Setup } from '../../../../../lib/helpers/setup_request';
 import { ChartBase } from '../../../types';
 
@@ -50,9 +51,11 @@ describe('fetchAndTransformGcMetrics', () => {
         },
       };
       const setup = {
-        apmEventClient: { search: () => Promise.resolve(response) },
         config: { 'xpack.gc.metricsInterval': 0 },
       } as unknown as Setup;
+      const apmEventClient = {
+        search: () => Promise.resolve(response),
+      } as unknown as APMEventClient;
       const fieldName = METRIC_JAVA_GC_TIME;
 
       const { series } = await fetchAndTransformGcMetrics({
@@ -61,7 +64,8 @@ describe('fetchAndTransformGcMetrics', () => {
         fieldName,
         kuery: '',
         operationName: 'test operation name',
-        setup,
+        config: setup.config,
+        apmEventClient,
         serviceName: 'test service name',
         start: 1633456140000,
         end: 1633457078105,
@@ -110,9 +114,11 @@ describe('fetchAndTransformGcMetrics', () => {
         },
       };
       const setup = {
-        apmEventClient: { search: () => Promise.resolve(response) },
         config: { 'xpack.gc.metricsInterval': 0 },
       } as unknown as Setup;
+      const apmEventClient = {
+        search: () => Promise.resolve(response),
+      } as unknown as APMEventClient;
       const fieldName = METRIC_JAVA_GC_COUNT;
 
       const { series } = await fetchAndTransformGcMetrics({
@@ -121,7 +127,8 @@ describe('fetchAndTransformGcMetrics', () => {
         fieldName,
         kuery: '',
         operationName: 'test operation name',
-        setup,
+        config: setup.config,
+        apmEventClient,
         serviceName: 'test service name',
         start: 1633456140000,
         end: 1633457078105,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
@@ -10,7 +10,6 @@ import { euiLightVars as theme } from '@kbn/ui-theme';
 import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { isFiniteNumber } from '../../../../../../common/utils/is_finite_number';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { getMetricsDateHistogramParams } from '../../../../../lib/helpers/metrics';
 import { ChartBase } from '../../../types';
 
@@ -28,11 +27,14 @@ import {
   environmentQuery,
   serviceNodeNameQuery,
 } from '../../../../../../common/utils/environment_query';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function fetchAndTransformGcMetrics({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   chartBase,
@@ -43,7 +45,8 @@ export async function fetchAndTransformGcMetrics({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -52,8 +55,6 @@ export async function fetchAndTransformGcMetrics({
   fieldName: typeof METRIC_JAVA_GC_COUNT | typeof METRIC_JAVA_GC_TIME;
   operationName: string;
 }) {
-  const { apmEventClient, config } = setup;
-
   const { bucketSize } = getBucketSize({ start, end });
 
   // GC rate and time are reported by the agents as monotonically

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/get_gc_rate_chart.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/get_gc_rate_chart.ts
@@ -8,9 +8,10 @@
 import { euiLightVars as theme } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
 import { METRIC_JAVA_GC_COUNT } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { fetchAndTransformGcMetrics } from './fetch_and_transform_gc_metrics';
 import { ChartBase } from '../../../types';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   [METRIC_JAVA_GC_COUNT]: {
@@ -34,7 +35,8 @@ const chartBase: ChartBase = {
 function getGcRateChart({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -42,7 +44,8 @@ function getGcRateChart({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -51,7 +54,8 @@ function getGcRateChart({
   return fetchAndTransformGcMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/get_gc_time_chart.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/gc/get_gc_time_chart.ts
@@ -8,9 +8,10 @@
 import { euiLightVars as theme } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
 import { METRIC_JAVA_GC_TIME } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { fetchAndTransformGcMetrics } from './fetch_and_transform_gc_metrics';
 import { ChartBase } from '../../../types';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
+import { APMConfig } from '../../../../..';
 
 const series = {
   [METRIC_JAVA_GC_TIME]: {
@@ -34,7 +35,8 @@ const chartBase: ChartBase = {
 function getGcTimeChart({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -42,7 +44,8 @@ function getGcTimeChart({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -51,7 +54,8 @@ function getGcTimeChart({
   return fetchAndTransformGcMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/heap_memory/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/heap_memory/index.ts
@@ -13,10 +13,11 @@ import {
   METRIC_JAVA_HEAP_MEMORY_USED,
   AGENT_NAME,
 } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { fetchAndTransformMetrics } from '../../../fetch_and_transform_metrics';
 import { ChartBase } from '../../../types';
 import { JAVA_AGENT_NAMES } from '../../../../../../common/agent_name';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   heapMemoryUsed: {
@@ -55,7 +56,8 @@ const chartBase: ChartBase = {
 export function getHeapMemoryChart({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -63,7 +65,8 @@ export function getHeapMemoryChart({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -72,7 +75,8 @@ export function getHeapMemoryChart({
   return fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/index.ts
@@ -7,18 +7,20 @@
 
 import { withApmSpan } from '../../../../utils/with_apm_span';
 import { getHeapMemoryChart } from './heap_memory';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { getNonHeapMemoryChart } from './non_heap_memory';
 import { getThreadCountChart } from './thread_count';
 import { getCPUChartData } from '../shared/cpu';
 import { getMemoryChartData } from '../shared/memory';
 import { getGcRateChart } from './gc/get_gc_rate_chart';
 import { getGcTimeChart } from './gc/get_gc_time_chart';
+import { APMConfig } from '../../../..';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export function getJavaMetricsCharts({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -26,7 +28,8 @@ export function getJavaMetricsCharts({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -36,7 +39,8 @@ export function getJavaMetricsCharts({
     const options = {
       environment,
       kuery,
-      setup,
+      config,
+      apmEventClient,
       serviceName,
       serviceNodeName,
       start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/non_heap_memory/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/non_heap_memory/index.ts
@@ -13,10 +13,11 @@ import {
   METRIC_JAVA_NON_HEAP_MEMORY_USED,
   AGENT_NAME,
 } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { ChartBase } from '../../../types';
 import { fetchAndTransformMetrics } from '../../../fetch_and_transform_metrics';
 import { JAVA_AGENT_NAMES } from '../../../../../../common/agent_name';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   nonHeapMemoryUsed: {
@@ -52,7 +53,8 @@ const chartBase: ChartBase = {
 export async function getNonHeapMemoryChart({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -60,7 +62,8 @@ export async function getNonHeapMemoryChart({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -69,7 +72,8 @@ export async function getNonHeapMemoryChart({
   return fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/java/thread_count/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/java/thread_count/index.ts
@@ -11,10 +11,11 @@ import {
   METRIC_JAVA_THREAD_COUNT,
   AGENT_NAME,
 } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { ChartBase } from '../../../types';
 import { fetchAndTransformMetrics } from '../../../fetch_and_transform_metrics';
 import { JAVA_AGENT_NAMES } from '../../../../../../common/agent_name';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   threadCount: {
@@ -44,7 +45,8 @@ const chartBase: ChartBase = {
 export async function getThreadCountChart({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -52,7 +54,8 @@ export async function getThreadCountChart({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -61,7 +64,8 @@ export async function getThreadCountChart({
   return fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/active_instances.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/active_instances.ts
@@ -8,13 +8,14 @@
 import { i18n } from '@kbn/i18n';
 import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import { euiLightVars as theme } from '@kbn/ui-theme';
+import { APMConfig } from '../../../..';
 import {
   SERVICE_NAME,
   SERVICE_NODE_NAME,
 } from '../../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../../common/utils/environment_query';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getMetricsDateHistogramParams } from '../../../../lib/helpers/metrics';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
@@ -24,7 +25,8 @@ import { GenericMetricsChart } from '../../fetch_and_transform_metrics';
 export async function getActiveInstances({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
@@ -32,14 +34,13 @@ export async function getActiveInstances({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
   searchAggregatedTransactions: boolean;
 }): Promise<GenericMetricsChart> {
-  const { apmEventClient, config } = setup;
-
   const aggs = {
     activeInstances: {
       cardinality: {

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/cold_start_count.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/cold_start_count.ts
@@ -8,11 +8,12 @@
 import { i18n } from '@kbn/i18n';
 import { termQuery } from '@kbn/observability-plugin/server';
 import { euiLightVars as theme } from '@kbn/ui-theme';
+import { APMConfig } from '../../../..';
 import {
   FAAS_COLDSTART,
   METRICSET_NAME,
 } from '../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { fetchAndTransformMetrics } from '../../fetch_and_transform_metrics';
 import { ChartBase } from '../../types';
 
@@ -36,14 +37,16 @@ const chartBase: ChartBase = {
 export function getColdStartCount({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
@@ -51,7 +54,8 @@ export function getColdStartCount({
   return fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/cold_start_duration.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/cold_start_duration.ts
@@ -8,10 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { euiLightVars as theme } from '@kbn/ui-theme';
 import { FAAS_COLDSTART_DURATION } from '../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { fetchAndTransformMetrics } from '../../fetch_and_transform_metrics';
 import { ChartBase } from '../../types';
 import { isFiniteNumber } from '../../../../../common/utils/is_finite_number';
+import { APMConfig } from '../../../..';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const chartBase: ChartBase = {
   title: i18n.translate('xpack.apm.agentMetrics.serverless.coldStartDuration', {
@@ -41,14 +42,16 @@ const chartBase: ChartBase = {
 export async function getColdStartDuration({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
@@ -56,7 +59,8 @@ export async function getColdStartDuration({
   const coldStartDurationMetric = await fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/compute_usage.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/compute_usage.ts
@@ -13,6 +13,7 @@ import {
   termQuery,
 } from '@kbn/observability-plugin/server';
 import { euiLightVars as theme } from '@kbn/ui-theme';
+import { APMConfig } from '../../../..';
 import {
   FAAS_BILLED_DURATION,
   METRICSET_NAME,
@@ -21,8 +22,8 @@ import {
 } from '../../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../../common/utils/environment_query';
 import { isFiniteNumber } from '../../../../../common/utils/is_finite_number';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getMetricsDateHistogramParams } from '../../../../lib/helpers/metrics';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { GenericMetricsChart } from '../../fetch_and_transform_metrics';
 
 /**
@@ -50,20 +51,20 @@ function calculateComputeUsageGBSeconds({
 export async function getComputeUsage({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
 }): Promise<GenericMetricsChart> {
-  const { apmEventClient, config } = setup;
-
   const aggs = {
     avgFaasBilledDuration: { avg: { field: FAAS_BILLED_DURATION } },
     avgTotalMemory: { avg: { field: METRIC_SYSTEM_TOTAL_MEMORY } },

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/index.ts
@@ -6,7 +6,6 @@
  */
 
 import { withApmSpan } from '../../../../utils/with_apm_span';
-import { Setup } from '../../../../lib/helpers/setup_request';
 import { getServerlessFunctionLatency } from './serverless_function_latency';
 import { getColdStartDuration } from './cold_start_duration';
 import { getMemoryChartData } from '../shared/memory';
@@ -14,25 +13,30 @@ import { getComputeUsage } from './compute_usage';
 import { getActiveInstances } from './active_instances';
 import { getColdStartCount } from './cold_start_count';
 import { getSearchTransactionsEvents } from '../../../../lib/helpers/transactions';
+import { APMConfig } from '../../../..';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export function getServerlessAgentMetricCharts({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
 }) {
   return withApmSpan('get_serverless_agent_metric_charts', async () => {
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      ...setup,
+      config,
+      apmEventClient,
       kuery,
       start,
       end,
@@ -41,7 +45,8 @@ export function getServerlessAgentMetricCharts({
     const options = {
       environment,
       kuery,
-      setup,
+      apmEventClient,
+      config,
       serviceName,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/serverless_function_latency.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/serverless/serverless_function_latency.ts
@@ -7,11 +7,12 @@
 
 import { i18n } from '@kbn/i18n';
 import { euiLightVars as theme } from '@kbn/ui-theme';
+import { APMConfig } from '../../../..';
 import { FAAS_BILLED_DURATION } from '../../../../../common/elasticsearch_fieldnames';
 import { LatencyAggregationType } from '../../../../../common/latency_aggregation_types';
 import { isFiniteNumber } from '../../../../../common/utils/is_finite_number';
 import { getVizColorForIndex } from '../../../../../common/viz_colors';
-import { Setup } from '../../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getLatencyTimeseries } from '../../../transactions/get_latency_charts';
 import {
   fetchAndTransformMetrics,
@@ -45,7 +46,7 @@ const chartBase: ChartBase = {
 async function getServerlessLantecySeries({
   environment,
   kuery,
-  setup,
+  apmEventClient,
   serviceName,
   start,
   end,
@@ -53,7 +54,7 @@ async function getServerlessLantecySeries({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
@@ -63,7 +64,7 @@ async function getServerlessLantecySeries({
     environment,
     kuery,
     serviceName,
-    setup,
+    apmEventClient,
     searchAggregatedTransactions,
     latencyAggregationType: LatencyAggregationType.avg,
     start,
@@ -88,7 +89,8 @@ async function getServerlessLantecySeries({
 export async function getServerlessFunctionLatency({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   start,
   end,
@@ -96,7 +98,8 @@ export async function getServerlessFunctionLatency({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
@@ -105,7 +108,8 @@ export async function getServerlessFunctionLatency({
   const options = {
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/shared/cpu/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/shared/cpu/index.ts
@@ -11,9 +11,10 @@ import {
   METRIC_SYSTEM_CPU_PERCENT,
   METRIC_PROCESS_CPU_PERCENT,
 } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { ChartBase } from '../../../types';
 import { fetchAndTransformMetrics } from '../../../fetch_and_transform_metrics';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   systemCPUMax: {
@@ -55,7 +56,8 @@ const chartBase: ChartBase = {
 export function getCPUChartData({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -63,7 +65,8 @@ export function getCPUChartData({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -72,7 +75,8 @@ export function getCPUChartData({
   return fetchAndTransformMetrics({
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     serviceNodeName,
     start,

--- a/x-pack/plugins/apm/server/routes/metrics/by_agent/shared/memory/index.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/by_agent/shared/memory/index.ts
@@ -15,9 +15,10 @@ import {
   METRIC_SYSTEM_FREE_MEMORY,
   METRIC_SYSTEM_TOTAL_MEMORY,
 } from '../../../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../../../lib/helpers/setup_request';
 import { fetchAndTransformMetrics } from '../../../fetch_and_transform_metrics';
 import { ChartBase } from '../../../types';
+import { APMConfig } from '../../../../..';
+import { APMEventClient } from '../../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const series = {
   memoryUsedMax: {
@@ -83,7 +84,8 @@ export const percentCgroupMemoryUsedScript = {
 export async function getMemoryChartData({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   faasId,
@@ -92,7 +94,8 @@ export async function getMemoryChartData({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   faasId?: string;
@@ -103,7 +106,8 @@ export async function getMemoryChartData({
     const cgroupResponse = await fetchAndTransformMetrics({
       environment,
       kuery,
-      setup,
+      config,
+      apmEventClient,
       serviceName,
       serviceNodeName,
       start,
@@ -124,7 +128,8 @@ export async function getMemoryChartData({
       return await fetchAndTransformMetrics({
         environment,
         kuery,
-        setup,
+        config,
+        apmEventClient,
         serviceName,
         serviceNodeName,
         start,

--- a/x-pack/plugins/apm/server/routes/metrics/fetch_and_transform_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/fetch_and_transform_metrics.ts
@@ -12,9 +12,11 @@ import type { AggregationOptionsByType } from '@kbn/es-types';
 import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { getVizColorForIndex } from '../../../common/viz_colors';
-import { APMEventESSearchRequest } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import {
+  APMEventClient,
+  APMEventESSearchRequest,
+} from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { getMetricsDateHistogramParams } from '../../lib/helpers/metrics';
-import { Setup } from '../../lib/helpers/setup_request';
 import { ChartBase } from './types';
 import {
   environmentQuery,
@@ -22,6 +24,7 @@ import {
 } from '../../../common/utils/environment_query';
 import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
 import { ChartType, Coordinate, YUnit } from '../../../typings/timeseries';
+import { APMConfig } from '../..';
 
 type MetricsAggregationMap = Unionize<{
   min: AggregationOptionsByType['min'];
@@ -63,7 +66,8 @@ export interface FetchAndTransformMetrics {
 export async function fetchAndTransformMetrics<T extends MetricAggs>({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   start,
@@ -75,7 +79,8 @@ export async function fetchAndTransformMetrics<T extends MetricAggs>({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   start: number;
@@ -85,8 +90,6 @@ export async function fetchAndTransformMetrics<T extends MetricAggs>({
   additionalFilters?: QueryDslQueryContainer[];
   operationName: string;
 }): Promise<FetchAndTransformMetrics> {
-  const { apmEventClient, config } = setup;
-
   const params: GenericMetricsRequest = {
     apm: {
       events: [ProcessorEvent.metric],

--- a/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/get_metrics_chart_data_by_agent.ts
@@ -5,17 +5,19 @@
  * 2.0.
  */
 
-import { Setup } from '../../lib/helpers/setup_request';
 import { getJavaMetricsCharts } from './by_agent/java';
 import { getDefaultMetricsCharts } from './by_agent/default';
 import { isJavaAgentName, isServerlessAgent } from '../../../common/agent_name';
 import { GenericMetricsChart } from './fetch_and_transform_metrics';
 import { getServerlessAgentMetricCharts } from './by_agent/serverless';
+import { APMConfig } from '../..';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getMetricsChartDataByAgent({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   serviceNodeName,
   agentName,
@@ -25,7 +27,8 @@ export async function getMetricsChartDataByAgent({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   serviceNodeName?: string;
   agentName: string;
@@ -36,7 +39,8 @@ export async function getMetricsChartDataByAgent({
   const options = {
     environment,
     kuery,
-    setup,
+    config,
+    apmEventClient,
     serviceName,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/metrics/get_service_nodes.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/get_service_nodes.ts
@@ -21,25 +21,23 @@ import {
   SERVICE_NODE_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 const getServiceNodes = async ({
   kuery,
-  setup,
+  apmEventClient,
   serviceName,
   environment,
   start,
   end,
 }: {
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   environment: string;
   start: number;
   end: number;
 }) => {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [ProcessorEvent.metric],

--- a/x-pack/plugins/apm/server/routes/metrics/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/queries.test.ts
@@ -22,9 +22,10 @@ describe('metrics queries', () => {
 
   const createTests = (serviceNodeName?: string) => {
     it('fetches cpu chart data', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getCPUChartData({
-          setup,
+          config: setup.config,
+          apmEventClient,
           serviceName: 'foo',
           serviceNodeName,
           environment: ENVIRONMENT_ALL.value,
@@ -38,9 +39,10 @@ describe('metrics queries', () => {
     });
 
     it('fetches memory chart data', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getMemoryChartData({
-          setup,
+          config: setup.config,
+          apmEventClient,
           serviceName: 'foo',
           serviceNodeName,
           environment: ENVIRONMENT_ALL.value,
@@ -54,9 +56,10 @@ describe('metrics queries', () => {
     });
 
     it('fetches heap memory chart data', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getHeapMemoryChart({
-          setup,
+          config: setup.config,
+          apmEventClient,
           serviceName: 'foo',
           serviceNodeName,
           environment: ENVIRONMENT_ALL.value,
@@ -70,9 +73,10 @@ describe('metrics queries', () => {
     });
 
     it('fetches non heap memory chart data', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getNonHeapMemoryChart({
-          setup,
+          config: setup.config,
+          apmEventClient,
           serviceName: 'foo',
           serviceNodeName,
           environment: ENVIRONMENT_ALL.value,
@@ -86,9 +90,10 @@ describe('metrics queries', () => {
     });
 
     it('fetches thread count chart data', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getThreadCountChart({
-          setup,
+          config: setup.config,
+          apmEventClient,
           serviceName: 'foo',
           serviceNodeName,
           environment: ENVIRONMENT_ALL.value,

--- a/x-pack/plugins/apm/server/routes/metrics/route.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/route.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { environmentRt, kueryRt, rangeRt } from '../default_api_types';
@@ -39,7 +40,10 @@ const metricsChartsRoute = createApmServerRoute({
     charts: FetchAndTransformMetrics[];
   }> => {
     const { params } = resources;
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { serviceName } = params.path;
     const {
       agentName,
@@ -54,7 +58,8 @@ const metricsChartsRoute = createApmServerRoute({
     const charts = await getMetricsChartDataByAgent({
       environment,
       kuery,
-      setup,
+      config: setup.config,
+      apmEventClient,
       serviceName,
       agentName,
       serviceNodeName,
@@ -88,14 +93,14 @@ const serviceMetricsJvm = createApmServerRoute({
       threadCount: number | null;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { kuery, environment, start, end } = params.query;
 
     const serviceNodes = await getServiceNodes({
       kuery,
-      setup,
+      apmEventClient,
       serviceName,
       environment,
       start,

--- a/x-pack/plugins/apm/server/routes/observability_overview/get_service_count.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/get_service_count.ts
@@ -8,22 +8,20 @@
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceCount({
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [

--- a/x-pack/plugins/apm/server/routes/observability_overview/get_transactions_per_minute.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/get_transactions_per_minute.ts
@@ -11,30 +11,28 @@ import {
   TRANSACTION_REQUEST,
 } from '../../../common/transaction_types';
 import { TRANSACTION_TYPE } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../lib/helpers/transactions';
 import { calculateThroughputWithRange } from '../../lib/helpers/calculate_throughput';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransactionsPerMinute({
-  setup,
+  apmEventClient,
   bucketSize,
   searchAggregatedTransactions,
   start,
   end,
   intervalString,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   bucketSize: number;
   intervalString: string;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const { aggregations } = await apmEventClient.search(
     'observability_overview_get_transactions_per_minute',
     {

--- a/x-pack/plugins/apm/server/routes/observability_overview/has_data.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/has_data.ts
@@ -6,10 +6,16 @@
  */
 
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { ApmIndicesConfig } from '../settings/apm_indices/get_apm_indices';
 
-export async function getHasData({ setup }: { setup: Setup }) {
-  const { apmEventClient } = setup;
+export async function getHasData({
+  indices,
+  apmEventClient,
+}: {
+  indices: ApmIndicesConfig;
+  apmEventClient: APMEventClient;
+}) {
   try {
     const params = {
       apm: {
@@ -32,12 +38,12 @@ export async function getHasData({ setup }: { setup: Setup }) {
     );
     return {
       hasData: response.hits.total.value > 0,
-      indices: setup.indices,
+      indices,
     };
   } catch (e) {
     return {
       hasData: false,
-      indices: setup.indices,
+      indices,
     };
   }
 }

--- a/x-pack/plugins/apm/server/routes/observability_overview/route.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview/route.ts
@@ -15,6 +15,7 @@ import { rangeRt } from '../default_api_types';
 import { getSearchTransactionsEvents } from '../../lib/helpers/transactions';
 import { withApmSpan } from '../../utils/with_apm_span';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const observabilityOverviewHasDataRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/observability_overview/has_data',
@@ -25,8 +26,11 @@ const observabilityOverviewHasDataRoute = createApmServerRoute({
     hasData: boolean;
     indices: import('./../../../../observability/common/typings').ApmIndicesConfig;
   }> => {
-    const setup = await setupRequest(resources);
-    return await getHasData({ setup });
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
+    return await getHasData({ indices: setup.indices, apmEventClient });
   },
 });
 
@@ -47,11 +51,14 @@ const observabilityOverviewRoute = createApmServerRoute({
       | { value: undefined; timeseries: never[] }
       | { value: number; timeseries: Array<{ x: number; y: number | null }> };
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { bucketSize, intervalString, start, end } = resources.params.query;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -71,13 +78,13 @@ const observabilityOverviewRoute = createApmServerRoute({
       }> => {
         const [serviceCount, transactionPerMinute] = await Promise.all([
           getServiceCount({
-            setup,
+            apmEventClient,
             searchAggregatedTransactions,
             start,
             end,
           }),
           getTransactionsPerMinute({
-            setup,
+            apmEventClient,
             bucketSize,
             searchAggregatedTransactions,
             start,

--- a/x-pack/plugins/apm/server/routes/service_groups/get_services_counts.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/get_services_counts.ts
@@ -8,23 +8,21 @@
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { rangeQuery, kqlQuery } from '@kbn/observability-plugin/server';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { Setup } from '../../lib/helpers/setup_request';
 import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
 import { SavedServiceGroup } from '../../../common/service_groups';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServicesCounts({
-  setup,
+  apmEventClient,
   start,
   end,
   serviceGroups,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   serviceGroups: SavedServiceGroup[];
 }) {
-  const { apmEventClient } = setup;
-
   const serviceGroupsKueryMap: Record<string, QueryDslQueryContainer> =
     serviceGroups.reduce((acc, sg) => {
       return {

--- a/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/lookup_services.ts
@@ -13,23 +13,21 @@ import {
   SERVICE_ENVIRONMENT,
   SERVICE_NAME,
 } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function lookupServices({
-  setup,
+  apmEventClient,
   kuery,
   start,
   end,
   maxNumberOfServices,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   kuery: string;
   start: number;
   end: number;
   maxNumberOfServices: number;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search('lookup_services', {
     apm: {
       events: [

--- a/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
@@ -13,16 +13,14 @@ import {
   ExternalConnectionNode,
   ServiceConnectionNode,
 } from '../../../common/service_map';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function fetchServicePathsFromTraceIds(
-  setup: Setup,
+  apmEventClient: APMEventClient,
   traceIds: string[],
   start: number,
   end: number
 ) {
-  const { apmEventClient } = setup;
-
   // make sure there's a range so ES can skip shards
   const dayInMs = 24 * 60 * 60 * 1000;
   const startRange = start - dayInMs;

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_dependency_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_dependency_node_info.ts
@@ -17,14 +17,14 @@ import { EventOutcome } from '../../../common/event_outcome';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { withApmSpan } from '../../utils/with_apm_span';
 import { calculateThroughputWithRange } from '../../lib/helpers/calculate_throughput';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getBucketSize } from '../../lib/helpers/get_bucket_size';
 import { getFailedTransactionRateTimeSeries } from '../../lib/helpers/transaction_error_rate';
 import { NodeStats } from '../../../common/service_map';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface Options {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   environment: string;
   dependencyName: string;
   start: number;
@@ -35,13 +35,12 @@ interface Options {
 export function getServiceMapDependencyNodeInfo({
   environment,
   dependencyName,
-  setup,
+  apmEventClient,
   start,
   end,
   offset,
 }: Options): Promise<NodeStats> {
   return withApmSpan('get_service_map_dependency_node_stats', async () => {
-    const { apmEventClient } = setup;
     const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
@@ -7,7 +7,7 @@
 
 import { find, uniqBy } from 'lodash';
 import { Connection, ConnectionNode } from '../../../common/service_map';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { fetchServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
 
 export function getConnections({
@@ -40,18 +40,18 @@ export function getConnections({
 }
 
 export async function getServiceMapFromTraceIds({
-  setup,
+  apmEventClient,
   traceIds,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   traceIds: string[];
   start: number;
   end: number;
 }) {
   const serviceMapFromTraceIdsScriptResponse =
-    await fetchServicePathsFromTraceIds(setup, traceIds, start, end);
+    await fetchServicePathsFromTraceIds(apmEventClient, traceIds, start, end);
 
   const serviceMapScriptedAggValue =
     serviceMapFromTraceIdsScriptResponse.aggregations?.service_map.value;

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_service_node_info.ts
@@ -24,7 +24,6 @@ import {
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import { getBucketSizeForAggregatedTransactions } from '../../lib/helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   getDocumentTypeFilterForTransactions,
   getDurationFieldForTransactions,
@@ -36,9 +35,10 @@ import {
   percentCgroupMemoryUsedScript,
   percentSystemMemoryUsedScript,
 } from '../metrics/by_agent/shared/memory';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface Options {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   environment: string;
   serviceName: string;
   searchAggregatedTransactions: boolean;
@@ -53,7 +53,7 @@ interface TaskParameters {
   searchAggregatedTransactions: boolean;
   minutes: number;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   intervalString: string;
@@ -65,7 +65,7 @@ interface TaskParameters {
 export function getServiceMapServiceNodeInfo({
   environment,
   serviceName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -99,7 +99,7 @@ export function getServiceMapServiceNodeInfo({
       searchAggregatedTransactions,
       minutes,
       serviceName,
-      setup,
+      apmEventClient,
       start: startWithOffset,
       end: endWithOffset,
       intervalString,
@@ -125,7 +125,7 @@ export function getServiceMapServiceNodeInfo({
 }
 
 async function getFailedTransactionsRateStats({
-  setup,
+  apmEventClient,
   serviceName,
   environment,
   searchAggregatedTransactions,
@@ -137,7 +137,7 @@ async function getFailedTransactionsRateStats({
   return withApmSpan('get_error_rate_for_service_map_node', async () => {
     const { average, timeseries } = await getFailedTransactionRate({
       environment,
-      setup,
+      apmEventClient,
       serviceName,
       searchAggregatedTransactions,
       start,
@@ -154,7 +154,7 @@ async function getFailedTransactionsRateStats({
 }
 
 async function getTransactionStats({
-  setup,
+  apmEventClient,
   filter,
   minutes,
   searchAggregatedTransactions,
@@ -163,8 +163,6 @@ async function getTransactionStats({
   intervalString,
   offsetInMs,
 }: TaskParameters): Promise<NodeStats['transactionStats']> {
-  const { apmEventClient } = setup;
-
   const durationField = getDurationFieldForTransactions(
     searchAggregatedTransactions
   );
@@ -241,15 +239,13 @@ async function getTransactionStats({
 }
 
 async function getCpuStats({
-  setup,
+  apmEventClient,
   filter,
   intervalString,
   start,
   end,
   offsetInMs,
 }: TaskParameters): Promise<NodeStats['cpuUsage']> {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search(
     'get_avg_cpu_usage_for_service_map_node',
     {
@@ -295,7 +291,7 @@ async function getCpuStats({
 }
 
 function getMemoryStats({
-  setup,
+  apmEventClient,
   filter,
   intervalString,
   start,
@@ -303,8 +299,6 @@ function getMemoryStats({
   offsetInMs,
 }: TaskParameters) {
   return withApmSpan('get_memory_stats_for_service_map_node', async () => {
-    const { apmEventClient } = setup;
-
     const getMemoryUsage = async ({
       additionalFilters,
       script,

--- a/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
@@ -18,29 +18,30 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { SERVICE_MAP_TIMEOUT_ERROR } from '../../../common/service_map';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
 import { serviceGroupQuery } from '../../lib/service_group_query';
 import { ServiceGroup } from '../../../common/service_groups';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { APMConfig } from '../..';
 
 const MAX_TRACES_TO_INSPECT = 1000;
 
 export async function getTraceSampleIds({
   serviceNames,
   environment,
-  setup,
+  config,
+  apmEventClient,
   start,
   end,
   serviceGroup,
 }: {
   serviceNames?: string[];
   environment: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   serviceGroup: ServiceGroup | null;
 }) {
-  const { apmEventClient, config } = setup;
-
   const query = {
     bool: {
       filter: [...rangeQuery(start, end), ...serviceGroupQuery(serviceGroup)],

--- a/x-pack/plugins/apm/server/routes/service_map/route.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/route.ts
@@ -21,6 +21,7 @@ import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { environmentRt, rangeRt } from '../default_api_types';
 import { getServiceGroup } from '../service_groups/get_service_group';
 import { offsetRt } from '../../../common/comparison_rt';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const serviceMapRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/service-map',
@@ -115,21 +116,23 @@ const serviceMapRoute = createApmServerRoute({
       savedObjects: { client: savedObjectsClient },
       uiSettings: { client: uiSettingsClient },
     } = await context.core;
-    const [setup, serviceGroup, maxNumberOfServices] = await Promise.all([
-      setupRequest(resources),
-      serviceGroupId
-        ? getServiceGroup({
-            savedObjectsClient,
-            serviceGroupId,
-          })
-        : Promise.resolve(null),
-      uiSettingsClient.get<number>(apmServiceGroupMaxNumberOfServices),
-    ]);
+    const [setup, apmEventClient, serviceGroup, maxNumberOfServices] =
+      await Promise.all([
+        setupRequest(resources),
+        getApmEventClient(resources),
+        serviceGroupId
+          ? getServiceGroup({
+              savedObjectsClient,
+              serviceGroupId,
+            })
+          : Promise.resolve(null),
+        uiSettingsClient.get<number>(apmServiceGroupMaxNumberOfServices),
+      ]);
 
     const serviceNames = compact([serviceName]);
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -137,6 +140,7 @@ const serviceMapRoute = createApmServerRoute({
     });
     return getServiceMap({
       setup,
+      apmEventClient,
       serviceNames,
       environment,
       searchAggregatedTransactions,
@@ -176,7 +180,10 @@ const serviceMapServiceNodeRoute = createApmServerRoute({
     if (!isActivePlatinumLicense(licensingContext.license)) {
       throw Boom.forbidden(invalidLicenseMessage);
     }
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
 
     const {
       path: { serviceName },
@@ -184,7 +191,7 @@ const serviceMapServiceNodeRoute = createApmServerRoute({
     } = params;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -193,7 +200,7 @@ const serviceMapServiceNodeRoute = createApmServerRoute({
 
     const commonProps = {
       environment,
-      setup,
+      apmEventClient,
       serviceName,
       searchAggregatedTransactions,
       start,
@@ -239,13 +246,19 @@ const serviceMapDependencyNodeRoute = createApmServerRoute({
     if (!isActivePlatinumLicense(licensingContext.license)) {
       throw Boom.forbidden(invalidLicenseMessage);
     }
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: { dependencyName, environment, start, end, offset },
     } = params;
 
-    const commonProps = { environment, setup, dependencyName, start, end };
+    const commonProps = {
+      environment,
+      apmEventClient,
+      dependencyName,
+      start,
+      end,
+    };
 
     const [currentPeriod, previousPeriod] = await Promise.all([
       getServiceMapDependencyNodeInfo(commonProps),

--- a/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.test.ts
+++ b/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.test.ts
@@ -26,9 +26,9 @@ describe('getDerivedServiceAnnotations', () => {
   describe('with 0 versions', () => {
     it('returns no annotations', async () => {
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getDerivedServiceAnnotations({
-            setup,
+            apmEventClient,
             serviceName: 'foo',
             environment: 'bar',
             searchAggregatedTransactions: false,
@@ -54,9 +54,9 @@ describe('getDerivedServiceAnnotations', () => {
   describe('with 1 version', () => {
     it('returns no annotations', async () => {
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getDerivedServiceAnnotations({
-            setup,
+            apmEventClient,
             serviceName: 'foo',
             environment: 'bar',
             searchAggregatedTransactions: false,
@@ -87,9 +87,9 @@ describe('getDerivedServiceAnnotations', () => {
         versionsFirstSeen,
       ];
       mock = await inspectSearchParams(
-        (setup) =>
+        (setup, apmEventClient) =>
           getDerivedServiceAnnotations({
-            setup,
+            apmEventClient,
             serviceName: 'foo',
             environment: 'bar',
             searchAggregatedTransactions: false,

--- a/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
+++ b/x-pack/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
@@ -18,10 +18,10 @@ import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../../lib/helpers/transactions';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getDerivedServiceAnnotations({
-  setup,
+  apmEventClient,
   serviceName,
   environment,
   searchAggregatedTransactions,
@@ -30,13 +30,11 @@ export async function getDerivedServiceAnnotations({
 }: {
   serviceName: string;
   environment: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
     ...getDocumentTypeFilterForTransactions(searchAggregatedTransactions),

--- a/x-pack/plugins/apm/server/routes/services/annotations/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/services/annotations/index.test.ts
@@ -10,11 +10,11 @@ import {
 } from '@kbn/observability-plugin/server';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { getServiceAnnotations } from '.';
-import { Setup } from '../../../lib/helpers/setup_request';
 import * as GetDerivedServiceAnnotations from './get_derived_service_annotations';
 import * as GetStoredAnnotations from './get_stored_annotations';
 import { Annotation, AnnotationType } from '../../../../common/annotations';
 import { errors } from '@elastic/elasticsearch';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 describe('getServiceAnnotations', () => {
   const storedAnnotations = [
@@ -60,7 +60,7 @@ describe('getServiceAnnotations', () => {
       client: {} as ElasticsearchClient,
       logger: {} as Logger,
       annotationsClient: {} as ScopedAnnotationsClient,
-      setup: {} as Setup,
+      apmEventClient: {} as APMEventClient,
     });
     expect(annotations).toEqual({
       annotations: storedAnnotations,
@@ -96,7 +96,7 @@ describe('getServiceAnnotations', () => {
       client: {} as ElasticsearchClient,
       logger: {} as Logger,
       annotationsClient: {} as ScopedAnnotationsClient,
-      setup: {} as Setup,
+      apmEventClient: {} as APMEventClient,
     });
     expect(annotations).toEqual({
       annotations: storedAnnotations,
@@ -133,7 +133,7 @@ describe('getServiceAnnotations', () => {
         client: {} as ElasticsearchClient,
         logger: {} as Logger,
         annotationsClient: {} as ScopedAnnotationsClient,
-        setup: {} as Setup,
+        apmEventClient: {} as APMEventClient,
       })
     ).rejects.toThrow('BOOM');
   });
@@ -171,7 +171,7 @@ describe('getServiceAnnotations', () => {
       client: {} as ElasticsearchClient,
       logger: {} as Logger,
       annotationsClient: {} as ScopedAnnotationsClient,
-      setup: {} as Setup,
+      apmEventClient: {} as APMEventClient,
     });
     expect(annotations).toEqual({ annotations: [] });
   });
@@ -206,7 +206,7 @@ describe('getServiceAnnotations', () => {
         client: {} as ElasticsearchClient,
         logger: {} as Logger,
         annotationsClient: {} as ScopedAnnotationsClient,
-        setup: {} as Setup,
+        apmEventClient: {} as APMEventClient,
       })
     ).rejects.toThrow('BOOM');
   });
@@ -240,7 +240,7 @@ describe('getServiceAnnotations', () => {
       client: {} as ElasticsearchClient,
       logger: {} as Logger,
       annotationsClient: {} as ScopedAnnotationsClient,
-      setup: {} as Setup,
+      apmEventClient: {} as APMEventClient,
     });
     expect(annotations).toEqual({
       annotations: storedAnnotations,

--- a/x-pack/plugins/apm/server/routes/services/annotations/index.ts
+++ b/x-pack/plugins/apm/server/routes/services/annotations/index.ts
@@ -7,12 +7,12 @@
 
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { ScopedAnnotationsClient } from '@kbn/observability-plugin/server';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getDerivedServiceAnnotations } from './get_derived_service_annotations';
 import { getStoredAnnotations } from './get_stored_annotations';
 
 export async function getServiceAnnotations({
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   serviceName,
   environment,
@@ -24,7 +24,7 @@ export async function getServiceAnnotations({
 }: {
   serviceName: string;
   environment: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   annotationsClient?: ScopedAnnotationsClient;
   client: ElasticsearchClient;
@@ -38,7 +38,7 @@ export async function getServiceAnnotations({
   // start fetching derived annotations (based on transactions), but don't wait on it
   // it will likely be significantly slower than the stored annotations
   const derivedAnnotationsPromise = getDerivedServiceAnnotations({
-    setup,
+    apmEventClient,
     serviceName,
     environment,
     searchAggregatedTransactions,

--- a/x-pack/plugins/apm/server/routes/services/get_service_agent.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_agent.ts
@@ -12,7 +12,7 @@ import {
   SERVICE_NAME,
   SERVICE_RUNTIME_NAME,
 } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface ServiceAgent {
   agent?: {
@@ -27,17 +27,15 @@ interface ServiceAgent {
 
 export async function getServiceAgent({
   serviceName,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     terminate_after: 1,
     apm: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_dependencies.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_dependencies.ts
@@ -9,10 +9,10 @@ import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { getConnectionStats } from '../../lib/connections/get_connection_stats';
 import { getConnectionStatsItemsWithRelativeImpact } from '../../lib/connections/get_connection_stats/get_connection_stats_items_with_relative_impact';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceDependencies({
-  setup,
+  apmEventClient,
   start,
   end,
   serviceName,
@@ -20,7 +20,7 @@ export async function getServiceDependencies({
   environment,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   serviceName: string;
@@ -29,7 +29,7 @@ export async function getServiceDependencies({
   offset?: string;
 }) {
   const statsItems = await getConnectionStats({
-    setup,
+    apmEventClient,
     start,
     end,
     numBuckets,

--- a/x-pack/plugins/apm/server/routes/services/get_service_dependencies_breakdown.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_dependencies_breakdown.ts
@@ -9,18 +9,18 @@ import { kqlQuery } from '@kbn/observability-plugin/server';
 import { getNodeName } from '../../../common/connections';
 import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getConnectionStats } from '../../lib/connections/get_connection_stats';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceDependenciesBreakdown({
-  setup,
+  apmEventClient,
   start,
   end,
   serviceName,
   environment,
   kuery,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   serviceName: string;
@@ -28,7 +28,7 @@ export async function getServiceDependenciesBreakdown({
   kuery: string;
 }) {
   const items = await getConnectionStats({
-    setup,
+    apmEventClient,
     start,
     end,
     numBuckets: 100,

--- a/x-pack/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
@@ -12,27 +12,26 @@ import {
   SERVICE_NAME,
   SERVICE_NODE_NAME,
 } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
 import { maybe } from '../../../common/utils/maybe';
 import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../lib/helpers/transactions';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceInstanceMetadataDetails({
   serviceName,
   serviceNodeName,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   serviceName: string;
   serviceNodeName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
   const filter = [
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [SERVICE_NODE_NAME]: serviceNodeName } },

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/detailed_statistics.ts
@@ -11,15 +11,15 @@ import { Coordinate } from '../../../../typings/timeseries';
 import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
 import { joinByKey } from '../../../../common/utils/join_by_key';
 import { withApmSpan } from '../../../utils/with_apm_span';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getServiceInstancesSystemMetricStatistics } from './get_service_instances_system_metric_statistics';
 import { getServiceInstancesTransactionStatistics } from './get_service_instances_transaction_statistics';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface ServiceInstanceDetailedStatisticsParams {
   environment: string;
   kuery: string;
   latencyAggregationType: LatencyAggregationType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   transactionType: string;
   searchAggregatedTransactions: boolean;
@@ -67,7 +67,7 @@ export async function getServiceInstancesDetailedStatisticsPeriods({
   environment,
   kuery,
   latencyAggregationType,
-  setup,
+  apmEventClient,
   serviceName,
   transactionType,
   searchAggregatedTransactions,
@@ -80,7 +80,7 @@ export async function getServiceInstancesDetailedStatisticsPeriods({
   environment: string;
   kuery: string;
   latencyAggregationType: LatencyAggregationType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   transactionType: string;
   searchAggregatedTransactions: boolean;
@@ -97,7 +97,7 @@ export async function getServiceInstancesDetailedStatisticsPeriods({
         environment,
         kuery,
         latencyAggregationType,
-        setup,
+        apmEventClient,
         serviceName,
         transactionType,
         searchAggregatedTransactions,

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_system_metric_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_system_metric_statistics.ts
@@ -20,7 +20,7 @@ import { SERVICE_NODE_NAME_MISSING } from '../../../../common/service_nodes';
 import { Coordinate } from '../../../../typings/timeseries';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getBucketSize } from '../../../lib/helpers/get_bucket_size';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import {
   percentCgroupMemoryUsedScript,
   percentSystemMemoryUsedScript,
@@ -48,7 +48,7 @@ export async function getServiceInstancesSystemMetricStatistics<
 >({
   environment,
   kuery,
-  setup,
+  apmEventClient,
   serviceName,
   size,
   start,
@@ -58,7 +58,7 @@ export async function getServiceInstancesSystemMetricStatistics<
   isComparisonSearch,
   offset,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   start: number;
   end: number;
@@ -70,8 +70,6 @@ export async function getServiceInstancesSystemMetricStatistics<
   isComparisonSearch: T;
   offset?: string;
 }): Promise<Array<ServiceInstanceSystemMetricStatistics<T>>> {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_transaction_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/get_service_instances_transaction_statistics.ts
@@ -27,8 +27,8 @@ import {
   getLatencyAggregation,
   getLatencyValue,
 } from '../../../lib/helpers/latency_aggregation_type';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface ServiceInstanceTransactionPrimaryStatistics {
   serviceNodeName: string;
@@ -54,7 +54,7 @@ export async function getServiceInstancesTransactionStatistics<
   environment,
   kuery,
   latencyAggregationType,
-  setup,
+  apmEventClient,
   transactionType,
   serviceName,
   size,
@@ -67,7 +67,7 @@ export async function getServiceInstancesTransactionStatistics<
   offset,
 }: {
   latencyAggregationType: LatencyAggregationType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   transactionType: string;
   searchAggregatedTransactions: boolean;
@@ -81,8 +81,6 @@ export async function getServiceInstancesTransactionStatistics<
   numBuckets?: number;
   offset?: string;
 }): Promise<Array<ServiceInstanceTransactionStatistics<T>>> {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/services/get_service_instances/main_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_instances/main_statistics.ts
@@ -8,7 +8,7 @@
 import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
 import { joinByKey } from '../../../../common/utils/join_by_key';
 import { withApmSpan } from '../../../utils/with_apm_span';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { getServiceInstancesSystemMetricStatistics } from './get_service_instances_system_metric_statistics';
 import { getServiceInstancesTransactionStatistics } from './get_service_instances_transaction_statistics';
 
@@ -16,7 +16,7 @@ interface ServiceInstanceMainStatisticsParams {
   environment: string;
   kuery: string;
   latencyAggregationType: LatencyAggregationType;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   serviceName: string;
   transactionType: string;
   searchAggregatedTransactions: boolean;

--- a/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
@@ -28,7 +28,7 @@ import {
 import { ContainerType } from '../../../common/service_metadata';
 import { TransactionRaw } from '../../../typings/es_schemas/raw/transaction_raw';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { should } from './get_service_metadata_icons';
 
 type ServiceMetadataDetailsRaw = Pick<
@@ -78,19 +78,17 @@ export interface ServiceMetadataDetails {
 
 export async function getServiceMetadataDetails({
   serviceName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
 }: {
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }): Promise<ServiceMetadataDetails> {
-  const { apmEventClient } = setup;
-
   const filter = [
     { term: { [SERVICE_NAME]: serviceName } },
     ...rangeQuery(start, end),

--- a/x-pack/plugins/apm/server/routes/services/get_service_metadata_icons.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_metadata_icons.ts
@@ -20,7 +20,7 @@ import {
 import { ContainerType } from '../../../common/service_metadata';
 import { TransactionRaw } from '../../../typings/es_schemas/raw/transaction_raw';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 type ServiceMetadataIconsRaw = Pick<
   TransactionRaw,
@@ -44,19 +44,17 @@ export const should = [
 
 export async function getServiceMetadataIcons({
   serviceName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
 }: {
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }): Promise<ServiceMetadataIcons> {
-  const { apmEventClient } = setup;
-
   const filter = [
     { term: { [SERVICE_NAME]: serviceName } },
     ...rangeQuery(start, end),

--- a/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
@@ -7,7 +7,6 @@
 
 import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   HOST_NAME,
   CONTAINER_ID,
@@ -22,24 +21,23 @@ import {
   serviceNodeNameQuery,
 } from '../../../common/utils/environment_query';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceNodeMetadata({
   kuery,
   serviceName,
   serviceNodeName,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   kuery: string;
   serviceName: string;
   serviceNodeName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [ProcessorEvent.metric],

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_group_detailed_statistics.ts
@@ -28,16 +28,16 @@ import {
   getLatencyAggregation,
   getLatencyValue,
 } from '../../lib/helpers/latency_aggregation_type';
-import { Setup } from '../../lib/helpers/setup_request';
 import { calculateFailedTransactionRate } from '../../lib/helpers/transaction_error_rate';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceTransactionGroupDetailedStatistics({
   environment,
   kuery,
   serviceName,
   transactionNames,
-  setup,
+  apmEventClient,
   numBuckets,
   searchAggregatedTransactions,
   transactionType,
@@ -50,7 +50,7 @@ export async function getServiceTransactionGroupDetailedStatistics({
   kuery: string;
   serviceName: string;
   transactionNames: string[];
-  setup: Setup;
+  apmEventClient: APMEventClient;
   numBuckets: number;
   searchAggregatedTransactions: boolean;
   transactionType: string;
@@ -67,8 +67,6 @@ export async function getServiceTransactionGroupDetailedStatistics({
     impact: number;
   }>
 > {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -185,7 +183,7 @@ export async function getServiceTransactionGroupDetailedStatistics({
 export async function getServiceTransactionGroupDetailedStatisticsPeriods({
   serviceName,
   transactionNames,
-  setup,
+  apmEventClient,
   numBuckets,
   searchAggregatedTransactions,
   transactionType,
@@ -198,7 +196,7 @@ export async function getServiceTransactionGroupDetailedStatisticsPeriods({
 }: {
   serviceName: string;
   transactionNames: string[];
-  setup: Setup;
+  apmEventClient: APMEventClient;
   numBuckets: number;
   searchAggregatedTransactions: boolean;
   transactionType: string;
@@ -210,7 +208,7 @@ export async function getServiceTransactionGroupDetailedStatisticsPeriods({
   offset?: string;
 }) {
   const commonProps = {
-    setup,
+    apmEventClient,
     serviceName,
     transactionNames,
     searchAggregatedTransactions,

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_groups.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_groups.ts
@@ -25,8 +25,9 @@ import {
   getLatencyAggregation,
   getLatencyValue,
 } from '../../lib/helpers/latency_aggregation_type';
-import { Setup } from '../../lib/helpers/setup_request';
 import { calculateFailedTransactionRate } from '../../lib/helpers/transaction_error_rate';
+import { APMConfig } from '../..';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export type ServiceOverviewTransactionGroupSortField =
   | 'name'
@@ -39,7 +40,8 @@ export async function getServiceTransactionGroups({
   environment,
   kuery,
   serviceName,
-  setup,
+  config,
+  apmEventClient,
   searchAggregatedTransactions,
   transactionType,
   latencyAggregationType,
@@ -49,14 +51,14 @@ export async function getServiceTransactionGroups({
   environment: string;
   kuery: string;
   serviceName: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   transactionType: string;
   latencyAggregationType: LatencyAggregationType;
   start: number;
   end: number;
 }) {
-  const { apmEventClient, config } = setup;
   const bucketSize = config.ui.transactionGroupBucketSize;
 
   const field = getDurationFieldForTransactions(searchAggregatedTransactions);

--- a/x-pack/plugins/apm/server/routes/services/get_service_transaction_types.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_transaction_types.ts
@@ -10,27 +10,25 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
 } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../lib/helpers/transactions';
 
 export async function getServiceTransactionTypes({
-  setup,
+  apmEventClient,
   serviceName,
   searchAggregatedTransactions,
   start,
   end,
 }: {
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_aggregated_transaction_stats.ts
@@ -24,15 +24,15 @@ import { environmentQuery } from '../../../../common/utils/environment_query';
 import { AgentName } from '../../../../typings/es_schemas/ui/fields/agent';
 import { calculateThroughputWithRange } from '../../../lib/helpers/calculate_throughput';
 import { calculateFailedTransactionRateFromServiceMetrics } from '../../../lib/helpers/transaction_error_rate';
-import { ServicesItemsSetup } from './get_services_items';
 import { serviceGroupQuery } from '../../../lib/service_group_query';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
 import { getDocumentTypeFilterForServiceMetrics } from '../../../lib/helpers/service_metrics';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 interface AggregationParams {
   environment: string;
   kuery: string;
-  setup: ServicesItemsSetup;
+  apmEventClient: APMEventClient;
   maxNumServices: number;
   start: number;
   end: number;
@@ -43,15 +43,13 @@ interface AggregationParams {
 export async function getServiceAggregatedTransactionStats({
   environment,
   kuery,
-  setup,
+  apmEventClient,
   maxNumServices,
   start,
   end,
   serviceGroup,
   randomSampler,
 }: AggregationParams) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search(
     'get_service_aggregated_transaction_stats',
     {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
@@ -28,15 +28,15 @@ import {
   calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../../lib/helpers/transaction_error_rate';
-import { ServicesItemsSetup } from './get_services_items';
 import { serviceGroupQuery } from '../../../lib/service_group_query';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface AggregationParams {
   environment: string;
   kuery: string;
-  setup: ServicesItemsSetup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   maxNumServices: number;
   start: number;
@@ -48,7 +48,7 @@ interface AggregationParams {
 export async function getServiceTransactionStats({
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   maxNumServices,
   start,
@@ -56,8 +56,6 @@ export async function getServiceTransactionStats({
   serviceGroup,
   randomSampler,
 }: AggregationParams) {
-  const { apmEventClient } = setup;
-
   const outcomes = getOutcomeAggregation();
 
   const metrics = {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_services_from_error_and_metric_documents.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_services_from_error_and_metric_documents.ts
@@ -14,14 +14,14 @@ import {
   SERVICE_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { serviceGroupQuery } from '../../../lib/service_group_query';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServicesFromErrorAndMetricDocuments({
   environment,
-  setup,
+  apmEventClient,
   maxNumServices,
   kuery,
   start,
@@ -29,7 +29,7 @@ export async function getServicesFromErrorAndMetricDocuments({
   serviceGroup,
   randomSampler,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   environment: string;
   maxNumServices: number;
   kuery: string;
@@ -38,8 +38,6 @@ export async function getServicesFromErrorAndMetricDocuments({
   serviceGroup: ServiceGroup | null;
   randomSampler: RandomSampler;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search(
     'get_services_from_error_and_metric_documents',
     {

--- a/x-pack/plugins/apm/server/routes/services/get_services/get_sorted_and_filtered_services.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_sorted_and_filtered_services.ts
@@ -15,9 +15,11 @@ import { ServiceGroup } from '../../../../common/service_groups';
 import { Setup } from '../../../lib/helpers/setup_request';
 import { getHealthStatuses } from './get_health_statuses';
 import { lookupServices } from '../../service_groups/lookup_services';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getSortedAndFilteredServices({
   setup,
+  apmEventClient,
   start,
   end,
   environment,
@@ -26,6 +28,7 @@ export async function getSortedAndFilteredServices({
   maxNumberOfServices,
 }: {
   setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: Environment;
@@ -33,8 +36,6 @@ export async function getSortedAndFilteredServices({
   serviceGroup: ServiceGroup | null;
   maxNumberOfServices: number;
 }) {
-  const { apmEventClient } = setup;
-
   async function getServiceNamesFromTermsEnum() {
     if (environment !== ENVIRONMENT_ALL.value) {
       return [];
@@ -72,7 +73,7 @@ export async function getSortedAndFilteredServices({
     }),
     serviceGroup
       ? getServiceNamesFromServiceGroup({
-          setup,
+          apmEventClient,
           start,
           end,
           maxNumberOfServices,
@@ -93,20 +94,20 @@ export async function getSortedAndFilteredServices({
 }
 
 async function getServiceNamesFromServiceGroup({
-  setup,
+  apmEventClient,
   start,
   end,
   maxNumberOfServices,
   serviceGroup: { kuery },
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   maxNumberOfServices: number;
   serviceGroup: ServiceGroup;
 }) {
   const services = await lookupServices({
-    setup,
+    apmEventClient,
     kuery,
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/services/get_services/index.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/index.ts
@@ -11,11 +11,13 @@ import { Setup } from '../../../lib/helpers/setup_request';
 import { getServicesItems } from './get_services_items';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServices({
   environment,
   kuery,
   setup,
+  apmEventClient,
   searchAggregatedTransactions,
   searchAggregatedServiceMetrics,
   logger,
@@ -27,6 +29,7 @@ export async function getServices({
   environment: string;
   kuery: string;
   setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   searchAggregatedServiceMetrics: boolean;
   logger: Logger;
@@ -40,6 +43,7 @@ export async function getServices({
       environment,
       kuery,
       setup,
+      apmEventClient,
       searchAggregatedTransactions,
       searchAggregatedServiceMetrics,
       logger,

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_aggregated_transaction_detailed_statistics.ts
@@ -24,16 +24,16 @@ import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
 import { calculateThroughputWithRange } from '../../../lib/helpers/calculate_throughput';
 import { getBucketSizeForAggregatedTransactions } from '../../../lib/helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { calculateFailedTransactionRateFromServiceMetrics } from '../../../lib/helpers/transaction_error_rate';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
 import { getDocumentTypeFilterForServiceMetrics } from '../../../lib/helpers/service_metrics';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceAggregatedTransactionDetailedStats({
   serviceNames,
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedServiceMetrics,
   offset,
   start,
@@ -43,14 +43,13 @@ export async function getServiceAggregatedTransactionDetailedStats({
   serviceNames: string[];
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedServiceMetrics: boolean;
   offset?: string;
   start: number;
   end: number;
   randomSampler: RandomSampler;
 }) {
-  const { apmEventClient } = setup;
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -185,7 +184,7 @@ export async function getServiceAggregatedDetailedStatsPeriods({
   serviceNames,
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedServiceMetrics,
   offset,
   start,
@@ -195,7 +194,7 @@ export async function getServiceAggregatedDetailedStatsPeriods({
   serviceNames: string[];
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedServiceMetrics: boolean;
   offset?: string;
   start: number;
@@ -207,7 +206,7 @@ export async function getServiceAggregatedDetailedStatsPeriods({
       serviceNames,
       environment,
       kuery,
-      setup,
+      apmEventClient,
       searchAggregatedServiceMetrics,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
@@ -25,18 +25,18 @@ import {
 } from '../../../lib/helpers/transactions';
 import { calculateThroughputWithRange } from '../../../lib/helpers/calculate_throughput';
 import { getBucketSizeForAggregatedTransactions } from '../../../lib/helpers/get_bucket_size_for_aggregated_transactions';
-import { Setup } from '../../../lib/helpers/setup_request';
 import {
   calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../../lib/helpers/transaction_error_rate';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceTransactionDetailedStats({
   serviceNames,
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   offset,
   start,
@@ -46,14 +46,13 @@ export async function getServiceTransactionDetailedStats({
   serviceNames: string[];
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   offset?: string;
   start: number;
   end: number;
   randomSampler: RandomSampler;
 }) {
-  const { apmEventClient } = setup;
   const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -182,7 +181,7 @@ export async function getServiceDetailedStatsPeriods({
   serviceNames,
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   offset,
   start,
@@ -192,7 +191,7 @@ export async function getServiceDetailedStatsPeriods({
   serviceNames: string[];
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   offset?: string;
   start: number;
@@ -204,7 +203,7 @@ export async function getServiceDetailedStatsPeriods({
       serviceNames,
       environment,
       kuery,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/index.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/index.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getServiceDetailedStatsPeriods } from './get_service_transaction_detailed_statistics';
 import { getServiceAggregatedDetailedStatsPeriods } from './get_service_aggregated_transaction_detailed_statistics';
 import { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServicesDetailedStatistics({
   serviceNames,
   environment,
   kuery,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   searchAggregatedServiceMetrics,
   offset,
@@ -25,7 +25,7 @@ export async function getServicesDetailedStatistics({
   serviceNames: string[];
   environment: string;
   kuery: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   searchAggregatedServiceMetrics: boolean;
   offset?: string;
@@ -37,7 +37,7 @@ export async function getServicesDetailedStatistics({
     serviceNames,
     environment,
     kuery,
-    setup,
+    apmEventClient,
     start,
     end,
     randomSampler,

--- a/x-pack/plugins/apm/server/routes/services/get_throughput.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_throughput.ts
@@ -20,16 +20,16 @@ import {
   getDocumentTypeFilterForTransactions,
   getProcessorEventForTransactions,
 } from '../../lib/helpers/transactions';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
 import { getBucketSizeForAggregatedTransactions } from '../../lib/helpers/get_bucket_size_for_aggregated_transactions';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 interface Options {
   environment: string;
   kuery: string;
   searchAggregatedTransactions: boolean;
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   transactionType: string;
   transactionName?: string;
   start: number;
@@ -42,15 +42,13 @@ export async function getThroughput({
   kuery,
   searchAggregatedTransactions,
   serviceName,
-  setup,
+  apmEventClient,
   transactionType,
   transactionName,
   start,
   end,
   offset,
 }: Options) {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/services/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/services/queries.test.ts
@@ -23,10 +23,10 @@ describe('services queries', () => {
   });
 
   it('fetches the service agent name', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getServiceAgent({
         serviceName: 'foo',
-        setup,
+        apmEventClient,
         start: 0,
         end: 50000,
       })
@@ -36,10 +36,10 @@ describe('services queries', () => {
   });
 
   it('fetches the service transaction types', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getServiceTransactionTypes({
         serviceName: 'foo',
-        setup,
+        apmEventClient,
         searchAggregatedTransactions: false,
         start: 0,
         end: 50000,
@@ -50,9 +50,10 @@ describe('services queries', () => {
   });
 
   it('fetches the service items', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getServicesItems({
         setup,
+        apmEventClient,
         searchAggregatedTransactions: false,
         searchAggregatedServiceMetrics: false,
         logger: {} as any,
@@ -74,7 +75,9 @@ describe('services queries', () => {
   });
 
   it('fetches the agent status', async () => {
-    mock = await inspectSearchParams((setup) => hasHistoricalAgentData(setup));
+    mock = await inspectSearchParams((setup, apmEventClient) =>
+      hasHistoricalAgentData(apmEventClient)
+    );
 
     expect(mock.params).toMatchSnapshot();
   });

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -56,6 +56,7 @@ import { getServiceGroup } from '../service_groups/get_service_group';
 import { offsetRt } from '../../../common/comparison_rt';
 import { getRandomSampler } from '../../lib/helpers/get_random_sampler';
 import { createInfraMetricsClient } from '../../lib/helpers/create_es_client/create_infra_metrics_client/create_infra_metrics_client';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const servicesRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services',
@@ -126,15 +127,17 @@ const servicesRoute = createApmServerRoute({
     const savedObjectsClient = (await context.core).savedObjects.client;
     const coreContext = await resources.context.core;
 
-    const [setup, serviceGroup, randomSampler] = await Promise.all([
-      setupRequest(resources),
-      serviceGroupId
-        ? getServiceGroup({ savedObjectsClient, serviceGroupId })
-        : Promise.resolve(null),
-      getRandomSampler({ security, request, probability }),
-    ]);
+    const [setup, apmEventClient, serviceGroup, randomSampler] =
+      await Promise.all([
+        setupRequest(resources),
+        getApmEventClient(resources),
+        serviceGroupId
+          ? getServiceGroup({ savedObjectsClient, serviceGroupId })
+          : Promise.resolve(null),
+        getRandomSampler({ security, request, probability }),
+      ]);
 
-    const { apmEventClient, config } = setup;
+    const { config } = setup;
 
     const serviceMetricsEnabled =
       await coreContext.uiSettings.client.get<boolean>(enableServiceMetrics);
@@ -153,6 +156,7 @@ const servicesRoute = createApmServerRoute({
       environment,
       kuery,
       setup,
+      apmEventClient,
       searchAggregatedTransactions,
       searchAggregatedServiceMetrics,
       logger,
@@ -223,12 +227,13 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
 
     const { serviceNames } = params.body;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
-    const { apmEventClient, config } = setup;
+    const { config } = setup;
 
     const serviceMetricsEnabled =
       await coreContext.uiSettings.client.get<boolean>(enableServiceMetrics);
@@ -250,7 +255,7 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
     return getServicesDetailedStatistics({
       environment,
       kuery,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       searchAggregatedServiceMetrics,
       offset,
@@ -274,14 +279,17 @@ const serviceMetadataDetailsRoute = createApmServerRoute({
   ): Promise<
     import('./get_service_metadata_details').ServiceMetadataDetails
   > => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const infraMetricsClient = createInfraMetricsClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { start, end } = params.query;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -290,7 +298,7 @@ const serviceMetadataDetailsRoute = createApmServerRoute({
 
     const serviceMetadataDetails = await getServiceMetadataDetails({
       serviceName,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       start,
       end,
@@ -321,13 +329,16 @@ const serviceMetadataIconsRoute = createApmServerRoute({
   handler: async (
     resources
   ): Promise<import('./get_service_metadata_icons').ServiceMetadataIcons> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { serviceName } = params.path;
     const { start, end } = params.query;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       start,
       end,
@@ -336,7 +347,7 @@ const serviceMetadataIconsRoute = createApmServerRoute({
 
     return getServiceMetadataIcons({
       serviceName,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       start,
       end,
@@ -359,14 +370,14 @@ const serviceAgentRoute = createApmServerRoute({
     | { agentName?: undefined; runtimeName?: undefined }
     | { agentName: string | undefined; runtimeName: string | undefined }
   > => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { start, end } = params.query;
 
     return getServiceAgent({
       serviceName,
-      setup,
+      apmEventClient,
       start,
       end,
     });
@@ -383,16 +394,19 @@ const serviceTransactionTypesRoute = createApmServerRoute({
   }),
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ transactionTypes: string[] }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { serviceName } = params.path;
     const { start, end } = params.query;
 
     return getServiceTransactionTypes({
       serviceName,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions: await getSearchTransactionsEvents({
-        apmEventClient: setup.apmEventClient,
+        apmEventClient,
         config: setup.config,
         start,
         end,
@@ -418,14 +432,14 @@ const serviceNodeMetadataRoute = createApmServerRoute({
   handler: async (
     resources
   ): Promise<{ host: string | number; containerId: string | number }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName, serviceNodeName } = params.path;
     const { kuery, start, end } = params.query;
 
     return getServiceNodeMetadata({
       kuery,
-      setup,
+      apmEventClient,
       serviceName,
       serviceNodeName,
       start,
@@ -448,7 +462,10 @@ const serviceAnnotationsRoute = createApmServerRoute({
   ): Promise<{
     annotations: Array<import('./../../../common/annotations').Annotation>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params, plugins, context, request, logger } = resources;
     const { serviceName } = params.path;
     const { environment, start, end } = params.query;
@@ -466,7 +483,7 @@ const serviceAnnotationsRoute = createApmServerRoute({
             )
           : undefined,
         getSearchTransactionsEvents({
-          apmEventClient: setup.apmEventClient,
+          apmEventClient,
           config: setup.config,
           start,
           end,
@@ -477,7 +494,7 @@ const serviceAnnotationsRoute = createApmServerRoute({
 
     return getServiceAnnotations({
       environment,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       serviceName,
       annotationsClient,
@@ -586,7 +603,10 @@ const serviceThroughputRoute = createApmServerRoute({
       y: import('./../../../typings/common').Maybe<number>;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { serviceName } = params.path;
     const {
@@ -599,7 +619,8 @@ const serviceThroughputRoute = createApmServerRoute({
       end,
     } = params.query;
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      ...setup,
+      config: setup.config,
+      apmEventClient,
       kuery,
       start,
       end,
@@ -610,7 +631,7 @@ const serviceThroughputRoute = createApmServerRoute({
       kuery,
       searchAggregatedTransactions,
       serviceName,
-      setup,
+      apmEventClient,
       transactionType,
       transactionName,
     };
@@ -680,7 +701,10 @@ const serviceInstancesMainStatisticsRoute = createApmServerRoute({
       memoryUsage?: number | null | undefined;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { serviceName } = params.path;
     const {
@@ -694,7 +718,8 @@ const serviceInstancesMainStatisticsRoute = createApmServerRoute({
     } = params.query;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      ...setup,
+      config: setup.config,
+      apmEventClient,
       kuery,
       start,
       end,
@@ -706,7 +731,7 @@ const serviceInstancesMainStatisticsRoute = createApmServerRoute({
         kuery,
         latencyAggregationType,
         serviceName,
-        setup,
+        apmEventClient,
         transactionType,
         searchAggregatedTransactions,
         start,
@@ -719,7 +744,7 @@ const serviceInstancesMainStatisticsRoute = createApmServerRoute({
               kuery,
               latencyAggregationType,
               serviceName,
-              setup,
+              apmEventClient,
               transactionType,
               searchAggregatedTransactions,
               start,
@@ -800,7 +825,10 @@ const serviceInstancesDetailedStatisticsRoute = createApmServerRoute({
       serviceNodeName: string;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { serviceName } = params.path;
     const {
@@ -816,7 +844,8 @@ const serviceInstancesDetailedStatisticsRoute = createApmServerRoute({
     } = params.query;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      ...setup,
+      apmEventClient,
+      config: setup.config,
       kuery,
       start,
       end,
@@ -827,7 +856,7 @@ const serviceInstancesDetailedStatisticsRoute = createApmServerRoute({
       kuery,
       latencyAggregationType,
       serviceName,
-      setup,
+      apmEventClient,
       transactionType,
       searchAggregatedTransactions,
       numBuckets,
@@ -901,7 +930,7 @@ export const serviceInstancesMetadataDetails = createApmServerRoute({
       | import('./../../../typings/es_schemas/raw/fields/cloud').Cloud
       | undefined;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const infraMetricsClient = createInfraMetricsClient(resources);
     const { params } = resources;
     const { serviceName, serviceNodeName } = params.path;
@@ -909,7 +938,7 @@ export const serviceInstancesMetadataDetails = createApmServerRoute({
 
     const serviceInstanceMetadataDetails =
       await getServiceInstanceMetadataDetails({
-        setup,
+        apmEventClient,
         serviceName,
         serviceNodeName,
         start,
@@ -1002,13 +1031,13 @@ export const serviceDependenciesRoute = createApmServerRoute({
       location: import('./../../../common/connections').Node;
     }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { environment, numBuckets, start, end, offset } = params.query;
 
     const opts = {
-      setup,
+      apmEventClient,
       start,
       end,
       serviceName,
@@ -1061,13 +1090,13 @@ export const serviceDependenciesBreakdownRoute = createApmServerRoute({
   ): Promise<{
     breakdown: Array<{ title: string; data: Array<{ x: number; y: number }> }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
     const { environment, start, end, kuery } = params.query;
 
     const breakdown = await getServiceDependenciesBreakdown({
-      setup,
+      apmEventClient,
       start,
       end,
       serviceName,
@@ -1177,16 +1206,19 @@ const sortedAndFilteredServicesRoute = createApmServerRoute({
       uiSettings: { client: uiSettingsClient },
     } = await resources.context.core;
 
-    const [setup, serviceGroup, maxNumberOfServices] = await Promise.all([
-      setupRequest(resources),
-      serviceGroupId
-        ? getServiceGroup({ savedObjectsClient, serviceGroupId })
-        : Promise.resolve(null),
-      uiSettingsClient.get<number>(apmServiceGroupMaxNumberOfServices),
-    ]);
+    const [setup, apmEventClient, serviceGroup, maxNumberOfServices] =
+      await Promise.all([
+        setupRequest(resources),
+        getApmEventClient(resources),
+        serviceGroupId
+          ? getServiceGroup({ savedObjectsClient, serviceGroupId })
+          : Promise.resolve(null),
+        uiSettingsClient.get<number>(apmServiceGroupMaxNumberOfServices),
+      ]);
     return {
       services: await getSortedAndFilteredServices({
         setup,
+        apmEventClient,
         start,
         end,
         environment,

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_name_by_service.ts
@@ -6,19 +6,17 @@
  */
 
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { SERVICE_NAME } from '../../../../common/elasticsearch_fieldnames';
 import { AGENT_NAME } from '../../../../common/elasticsearch_fieldnames';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getAgentNameByService({
   serviceName,
-  setup,
+  apmEventClient,
 }: {
   serviceName: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
 }) {
-  const { apmEventClient } = setup;
-
   const params = {
     terminate_after: 1,
     apm: {

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_environments/index.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_environments/index.ts
@@ -10,15 +10,18 @@ import { getAllEnvironments } from '../../../environments/get_all_environments';
 import { Setup } from '../../../../lib/helpers/setup_request';
 import { getExistingEnvironmentsForService } from './get_existing_environments_for_service';
 import { ALL_OPTION_VALUE } from '../../../../../common/agent_configuration/all_option';
+import { APMEventClient } from '../../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getEnvironments({
   serviceName,
   setup,
+  apmEventClient,
   searchAggregatedTransactions,
   size,
 }: {
   serviceName: string | undefined;
   setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   size: number;
 }) {
@@ -27,7 +30,7 @@ export async function getEnvironments({
       getAllEnvironments({
         searchAggregatedTransactions,
         serviceName,
-        setup,
+        apmEventClient,
         size,
       }),
       getExistingEnvironmentsForService({ serviceName, setup, size }),

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/queries.test.ts
@@ -24,11 +24,11 @@ describe('agent configuration queries', () => {
 
   describe('getAllEnvironments', () => {
     it('fetches all environments', async () => {
-      mock = await inspectSearchParams((setup) =>
+      mock = await inspectSearchParams((setup, apmEventClient) =>
         getAllEnvironments({
           searchAggregatedTransactions: false,
           serviceName: 'foo',
-          setup,
+          apmEventClient,
           size: 50,
         })
       );

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../../common/agent_configuration/runtime_types/agent_configuration_intake_rt';
 import { getSearchTransactionsEvents } from '../../../lib/helpers/transactions';
 import { syncAgentConfigsToApmPackagePolicies } from '../../fleet/sync_agent_configs_to_apm_package_policies';
+import { getApmEventClient } from '../../../lib/helpers/get_apm_event_client';
 
 // get list of configurations
 const agentConfigurationRoute = createApmServerRoute({
@@ -269,13 +270,16 @@ const listAgentConfigurationEnvironmentsRoute = createApmServerRoute({
   ): Promise<{
     environments: Array<{ name: string; alreadyConfigured: boolean }>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { context, params } = resources;
     const coreContext = await context.core;
 
     const { serviceName, start, end } = params.query;
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery: '',
       start,
@@ -287,6 +291,7 @@ const listAgentConfigurationEnvironmentsRoute = createApmServerRoute({
     const environments = await getEnvironments({
       serviceName,
       setup,
+      apmEventClient,
       searchAggregatedTransactions,
       size,
     });
@@ -303,10 +308,13 @@ const agentConfigurationAgentNameRoute = createApmServerRoute({
   }),
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ agentName: string | undefined }> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.query;
-    const agentName = await getAgentNameByService({ serviceName, setup });
+    const agentName = await getAgentNameByService({
+      serviceName,
+      apmEventClient,
+    });
     return { agentName };
   },
 });

--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection/route.ts
@@ -20,6 +20,7 @@ import { notifyFeatureUsage } from '../../../feature';
 import { updateToV3 } from './update_to_v3';
 import { environmentStringRt } from '../../../../common/environment_rt';
 import { getMlJobsWithAPMGroup } from '../../../lib/anomaly_detection/get_ml_jobs_with_apm_group';
+import { getApmEventClient } from '../../../lib/helpers/get_apm_event_client';
 
 // get ML anomaly detection jobs for each environment
 const anomalyDetectionJobsRoute = createApmServerRoute({
@@ -94,11 +95,14 @@ const anomalyDetectionEnvironmentsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/settings/anomaly-detection/environments',
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ environments: string[] }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const coreContext = await resources.context.core;
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery: '',
     });
@@ -108,7 +112,7 @@ const anomalyDetectionEnvironmentsRoute = createApmServerRoute({
     const environments = await getAllEnvironments({
       includeMissing: true,
       searchAggregatedTransactions,
-      setup,
+      apmEventClient,
       size,
     });
 

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.test.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.test.ts
@@ -10,29 +10,29 @@ import {
   SearchParamsMock,
 } from '../../../utils/test_helpers';
 import { getTransaction } from './get_transaction';
-import { Setup } from '../../../lib/helpers/setup_request';
 import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
   SERVICE_ENVIRONMENT,
   TRANSACTION_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 describe('custom link get transaction', () => {
   let mock: SearchParamsMock;
   it('fetches without filter', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTransaction({
-        setup: setup as unknown as Setup,
+        apmEventClient: apmEventClient as unknown as APMEventClient,
       })
     );
 
     expect(mock.params).toMatchSnapshot();
   });
   it('fetches with all filter', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTransaction({
-        setup: setup as unknown as Setup,
+        apmEventClient: apmEventClient as unknown as APMEventClient,
         filters: {
           [SERVICE_NAME]: 'foo',
           [SERVICE_ENVIRONMENT]: 'bar',

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/get_transaction.ts
@@ -8,19 +8,17 @@
 import * as t from 'io-ts';
 import { compact } from 'lodash';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { filterOptionsRt } from './custom_link_types';
 import { splitFilterValueByComma } from './helper';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransaction({
-  setup,
+  apmEventClient,
   filters = {},
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   filters?: t.TypeOf<typeof filterOptionsRt>;
 }) {
-  const { apmEventClient } = setup;
-
   const esFilters = compact(
     Object.entries(filters)
       // loops through the filters splitting the value by comma and removing white spaces

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/route.ts
@@ -19,6 +19,7 @@ import { deleteCustomLink } from './delete_custom_link';
 import { getTransaction } from './get_transaction';
 import { listCustomLinks } from './list_custom_links';
 import { createApmServerRoute } from '../../apm_routes/create_apm_server_route';
+import { getApmEventClient } from '../../../lib/helpers/get_apm_event_client';
 
 const customLinkTransactionRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/settings/custom_links/transaction',
@@ -31,12 +32,12 @@ const customLinkTransactionRoute = createApmServerRoute({
   ): Promise<
     import('./../../../../typings/es_schemas/ui/transaction').Transaction
   > => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { query } = params;
     // picks only the items listed in FILTER_OPTIONS
     const filters = pick(query, FILTER_OPTIONS);
-    return await getTransaction({ setup, filters });
+    return await getTransaction({ apmEventClient, filters });
   },
 });
 

--- a/x-pack/plugins/apm/server/routes/span_links/get_linked_children.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_linked_children.ts
@@ -18,24 +18,22 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import type { SpanRaw } from '../../../typings/es_schemas/raw/span_raw';
 import type { TransactionRaw } from '../../../typings/es_schemas/raw/transaction_raw';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getBufferedTimerange } from './utils';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 async function fetchLinkedChildrenOfSpan({
   traceId,
-  setup,
+  apmEventClient,
   start,
   end,
   spanId,
 }: {
   traceId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   spanId?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { startWithBuffer, endWithBuffer } = getBufferedTimerange({
     start,
     end,
@@ -83,18 +81,18 @@ function getSpanId(source: TransactionRaw | SpanRaw) {
 
 export async function getLinkedChildrenCountBySpanId({
   traceId,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   traceId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
   const linkedChildren = await fetchLinkedChildrenOfSpan({
     traceId,
-    setup,
+    apmEventClient,
     start,
     end,
   });
@@ -115,20 +113,20 @@ export async function getLinkedChildrenCountBySpanId({
 export async function getLinkedChildrenOfSpan({
   traceId,
   spanId,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   traceId: string;
   spanId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
   const linkedChildren = await fetchLinkedChildrenOfSpan({
     traceId,
     spanId,
-    setup,
+    apmEventClient,
     start,
     end,
   });

--- a/x-pack/plugins/apm/server/routes/span_links/get_linked_parents.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_linked_parents.ts
@@ -15,10 +15,10 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { SpanRaw } from '../../../typings/es_schemas/raw/span_raw';
 import { TransactionRaw } from '../../../typings/es_schemas/raw/transaction_raw';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getLinkedParentsOfSpan({
-  setup,
+  apmEventClient,
   traceId,
   spanId,
   start,
@@ -27,13 +27,11 @@ export async function getLinkedParentsOfSpan({
 }: {
   traceId: string;
   spanId: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   processorEvent: ProcessorEvent;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search('get_linked_parents_of_span', {
     apm: {
       events: [processorEvent],

--- a/x-pack/plugins/apm/server/routes/span_links/get_span_links_details.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/get_span_links_details.ts
@@ -26,24 +26,22 @@ import { SpanLinkDetails } from '../../../common/span_links';
 import { SpanLink } from '../../../typings/es_schemas/raw/fields/span_links';
 import { SpanRaw } from '../../../typings/es_schemas/raw/span_raw';
 import { TransactionRaw } from '../../../typings/es_schemas/raw/transaction_raw';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getBufferedTimerange } from './utils';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 async function fetchSpanLinksDetails({
-  setup,
+  apmEventClient,
   kuery,
   spanLinks,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   kuery: string;
   spanLinks: SpanLink[];
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const { startWithBuffer, endWithBuffer } = getBufferedTimerange({
     start,
     end,
@@ -119,13 +117,13 @@ async function fetchSpanLinksDetails({
 }
 
 export async function getSpanLinksDetails({
-  setup,
+  apmEventClient,
   spanLinks,
   kuery,
   start,
   end,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   spanLinks: SpanLink[];
   kuery: string;
   start: number;
@@ -140,7 +138,7 @@ export async function getSpanLinksDetails({
   const chunkedResponses = await Promise.all(
     spanLinksChunks.map((spanLinksChunk) =>
       fetchSpanLinksDetails({
-        setup,
+        apmEventClient,
         kuery,
         spanLinks: spanLinksChunk,
         start,

--- a/x-pack/plugins/apm/server/routes/span_links/route.ts
+++ b/x-pack/plugins/apm/server/routes/span_links/route.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import * as t from 'io-ts';
-import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getSpanLinksDetails } from './get_span_links_details';
 import { getLinkedChildrenOfSpan } from './get_linked_children';
@@ -13,6 +12,7 @@ import { kueryRt, rangeRt } from '../default_api_types';
 import { SpanLinkDetails } from '../../../common/span_links';
 import { processorEventRt } from '../../../common/processor_event';
 import { getLinkedParentsOfSpan } from './get_linked_parents';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const linkedParentsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/parents',
@@ -36,9 +36,9 @@ const linkedParentsRoute = createApmServerRoute({
     const {
       params: { query, path },
     } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const linkedParents = await getLinkedParentsOfSpan({
-      setup,
+      apmEventClient,
       traceId: path.traceId,
       spanId: path.spanId,
       start: query.start,
@@ -48,7 +48,7 @@ const linkedParentsRoute = createApmServerRoute({
 
     return {
       spanLinksDetails: await getSpanLinksDetails({
-        setup,
+        apmEventClient,
         spanLinks: linkedParents,
         kuery: query.kuery,
         start: query.start,
@@ -76,9 +76,9 @@ const linkedChildrenRoute = createApmServerRoute({
     const {
       params: { query, path },
     } = resources;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     const linkedChildren = await getLinkedChildrenOfSpan({
-      setup,
+      apmEventClient,
       traceId: path.traceId,
       spanId: path.spanId,
       start: query.start,
@@ -87,7 +87,7 @@ const linkedChildrenRoute = createApmServerRoute({
 
     return {
       spanLinksDetails: await getSpanLinksDetails({
-        setup,
+        apmEventClient,
         spanLinks: linkedChildren,
         kuery: query.kuery,
         start: query.start,

--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_service_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_service_statistics.ts
@@ -34,9 +34,11 @@ import {
   getEstimatedSizeForDocumentsInIndex,
 } from './indices_stats_helpers';
 import { RandomSampler } from '../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 async function getMainServiceStatistics({
   setup,
+  apmEventClient,
   context,
   indexLifecyclePhase,
   randomSampler,
@@ -46,6 +48,7 @@ async function getMainServiceStatistics({
   kuery,
 }: {
   setup: Setup;
+  apmEventClient: APMEventClient;
   context: ApmPluginRequestHandlerContext;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   randomSampler: RandomSampler;
@@ -54,8 +57,6 @@ async function getMainServiceStatistics({
   environment: string;
   kuery: string;
 }) {
-  const { apmEventClient } = setup;
-
   const [{ indices: allIndicesStats }, response] = await Promise.all([
     getTotalIndicesStats({ context, setup }),
     apmEventClient.search('get_main_service_statistics', {
@@ -177,6 +178,7 @@ async function getMainServiceStatistics({
 
 export async function getServiceStatistics({
   setup,
+  apmEventClient,
   context,
   indexLifecyclePhase,
   randomSampler,
@@ -187,6 +189,7 @@ export async function getServiceStatistics({
   searchAggregatedTransactions,
 }: {
   setup: Setup;
+  apmEventClient: APMEventClient;
   context: ApmPluginRequestHandlerContext;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   randomSampler: RandomSampler;
@@ -200,6 +203,7 @@ export async function getServiceStatistics({
     await Promise.all([
       getMainServiceStatistics({
         setup,
+        apmEventClient,
         context,
         indexLifecyclePhase,
         randomSampler,
@@ -209,7 +213,7 @@ export async function getServiceStatistics({
         end,
       }),
       getTotalTransactionsPerService({
-        setup,
+        apmEventClient,
         searchAggregatedTransactions,
         indexLifecyclePhase,
         randomSampler,

--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_size_timeseries.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_size_timeseries.ts
@@ -29,11 +29,13 @@ import {
   getTotalIndicesStats,
   getEstimatedSizeForDocumentsInIndex,
 } from './indices_stats_helpers';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getSizeTimeseries({
   environment,
   kuery,
   setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -44,6 +46,7 @@ export async function getSizeTimeseries({
   environment: string;
   kuery: string;
   setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
@@ -51,8 +54,6 @@ export async function getSizeTimeseries({
   randomSampler: RandomSampler;
   context: ApmPluginRequestHandlerContext;
 }) {
-  const { apmEventClient } = setup;
-
   const { intervalString } = getBucketSizeForAggregatedTransactions({
     start,
     end,

--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_storage_details_per_processor_event.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_storage_details_per_processor_event.ts
@@ -30,9 +30,11 @@ import {
   getEstimatedSizeForDocumentsInIndex,
 } from './indices_stats_helpers';
 import { RandomSampler } from '../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getStorageDetailsPerProcessorEvent({
   setup,
+  apmEventClient,
   context,
   indexLifecyclePhase,
   randomSampler,
@@ -43,6 +45,7 @@ export async function getStorageDetailsPerProcessorEvent({
   serviceName,
 }: {
   setup: Setup;
+  apmEventClient: APMEventClient;
   context: ApmPluginRequestHandlerContext;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   randomSampler: RandomSampler;
@@ -52,8 +55,6 @@ export async function getStorageDetailsPerProcessorEvent({
   kuery: string;
   serviceName: string;
 }) {
-  const { apmEventClient } = setup;
-
   const [{ indices: allIndicesStats }, response] = await Promise.all([
     getTotalIndicesStats({ setup, context }),
     apmEventClient.search('get_storage_details_per_processor_event', {

--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_summary_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_summary_statistics.ts
@@ -36,9 +36,10 @@ import {
   isRootTransaction,
 } from '../../lib/helpers/transactions';
 import { calculateThroughputWithRange } from '../../lib/helpers/calculate_throughput';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTracesPerMinute({
-  setup,
+  apmEventClient,
   indexLifecyclePhase,
   start,
   end,
@@ -46,7 +47,7 @@ export async function getTracesPerMinute({
   kuery,
   searchAggregatedTransactions,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   start: number;
   end: number;
@@ -54,8 +55,6 @@ export async function getTracesPerMinute({
   kuery: string;
   searchAggregatedTransactions: boolean;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search('get_traces_per_minute', {
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
@@ -103,6 +102,7 @@ export async function getTracesPerMinute({
 
 export async function getMainSummaryStats({
   setup,
+  apmEventClient,
   context,
   indexLifecyclePhase,
   randomSampler,
@@ -112,6 +112,7 @@ export async function getMainSummaryStats({
   kuery,
 }: {
   setup: Setup;
+  apmEventClient: APMEventClient;
   context: ApmPluginRequestHandlerContext;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   randomSampler: RandomSampler;
@@ -120,8 +121,6 @@ export async function getMainSummaryStats({
   environment: string;
   kuery: string;
 }) {
-  const { apmEventClient } = setup;
-
   const [{ indices: allIndicesStats }, res] = await Promise.all([
     getTotalIndicesStats({ context, setup }),
     apmEventClient.search('get_storage_explorer_main_summary_stats', {

--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_total_transactions_per_service.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_total_transactions_per_service.ts
@@ -10,7 +10,6 @@ import {
   kqlQuery,
   rangeQuery,
 } from '@kbn/observability-plugin/server';
-import { Setup } from '../../lib/helpers/setup_request';
 import {
   getProcessorEventForTransactions,
   getDocumentTypeFilterForTransactions,
@@ -22,9 +21,10 @@ import {
 } from '../../../common/storage_explorer_types';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { RandomSampler } from '../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTotalTransactionsPerService({
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   indexLifecyclePhase,
   randomSampler,
@@ -33,7 +33,7 @@ export async function getTotalTransactionsPerService({
   environment,
   kuery,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   indexLifecyclePhase: IndexLifecyclePhaseSelectOption;
   randomSampler: RandomSampler;
@@ -42,8 +42,6 @@ export async function getTotalTransactionsPerService({
   environment: string;
   kuery: string;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search(
     'get_total_transactions_per_service',
     {

--- a/x-pack/plugins/apm/server/routes/storage_explorer/route.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/route.ts
@@ -29,6 +29,7 @@ import {
   getMainSummaryStats,
   getTracesPerMinute,
 } from './get_summary_statistics';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const storageExplorerRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/storage_explorer',
@@ -71,19 +72,21 @@ const storageExplorerRoute = createApmServerRoute({
       },
     } = params;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery,
     });
 
     const serviceStatistics = await getServiceStatistics({
       setup,
+      apmEventClient,
       context,
       indexLifecyclePhase,
       randomSampler,
@@ -147,13 +150,15 @@ const storageExplorerServiceDetailsRoute = createApmServerRoute({
       },
     } = params;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
     const processorEventStats = await getStorageDetailsPerProcessorEvent({
       setup,
+      apmEventClient,
       context,
       indexLifecyclePhase,
       randomSampler,
@@ -206,13 +211,14 @@ const storageChartRoute = createApmServerRoute({
       },
     } = params;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery,
     });
@@ -226,6 +232,7 @@ const storageChartRoute = createApmServerRoute({
       start,
       end,
       setup,
+      apmEventClient,
       context,
     });
 
@@ -295,13 +302,14 @@ const storageExplorerSummaryStatsRoute = createApmServerRoute({
       },
     } = params;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery,
     });
@@ -309,6 +317,7 @@ const storageExplorerSummaryStatsRoute = createApmServerRoute({
     const [mainSummaryStats, tracesPerMinute] = await Promise.all([
       getMainSummaryStats({
         setup,
+        apmEventClient,
         context,
         indexLifecyclePhase,
         randomSampler,
@@ -318,7 +327,7 @@ const storageExplorerSummaryStatsRoute = createApmServerRoute({
         kuery,
       }),
       getTracesPerMinute({
-        setup,
+        apmEventClient,
         indexLifecyclePhase,
         start,
         end,

--- a/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_aggregation.ts
+++ b/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_aggregation.ts
@@ -8,14 +8,14 @@ import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
 import { SERVICE_NAME } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getSuggestionsWithTermsAggregation({
   fieldName,
   fieldValue,
   searchAggregatedTransactions,
   serviceName,
-  setup,
+  apmEventClient,
   size,
   start,
   end,
@@ -24,13 +24,11 @@ export async function getSuggestionsWithTermsAggregation({
   fieldValue: string;
   searchAggregatedTransactions: boolean;
   serviceName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   size: number;
   start: number;
   end: number;
 }) {
-  const { apmEventClient } = setup;
-
   const response = await apmEventClient.search(
     'get_suggestions_with_terms_aggregation',
     {

--- a/x-pack/plugins/apm/server/routes/suggestions/route.ts
+++ b/x-pack/plugins/apm/server/routes/suggestions/route.ts
@@ -13,6 +13,7 @@ import { getSearchTransactionsEvents } from '../../lib/helpers/transactions';
 import { setupRequest } from '../../lib/helpers/setup_request';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { rangeRt } from '../default_api_types';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const suggestionsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/suggestions',
@@ -28,11 +29,14 @@ const suggestionsRoute = createApmServerRoute({
   }),
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ terms: string[] }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { context, params } = resources;
     const { fieldName, fieldValue, serviceName, start, end } = params.query;
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      apmEventClient: setup.apmEventClient,
+      apmEventClient,
       config: setup.config,
       kuery: '',
     });
@@ -46,7 +50,7 @@ const suggestionsRoute = createApmServerRoute({
         fieldName,
         fieldValue,
         searchAggregatedTransactions,
-        setup,
+        apmEventClient,
         size,
         start,
         end,
@@ -65,7 +69,7 @@ const suggestionsRoute = createApmServerRoute({
       fieldValue,
       searchAggregatedTransactions,
       serviceName,
-      setup,
+      apmEventClient,
       size,
       start,
       end,

--- a/x-pack/plugins/apm/server/routes/time_range_metadata/route.ts
+++ b/x-pack/plugins/apm/server/routes/time_range_metadata/route.ts
@@ -7,7 +7,7 @@
 import { toBooleanRt } from '@kbn/io-ts-utils';
 import * as t from 'io-ts';
 import { TimeRangeMetadata } from '../../../common/time_range_metadata';
-import { setupRequest } from '../../lib/helpers/setup_request';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { getIsUsingServiceDestinationMetrics } from '../../lib/helpers/spans/get_is_using_service_destination_metrics';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { kueryRt, rangeRt } from '../default_api_types';
@@ -25,7 +25,7 @@ export const timeRangeMetadataRoute = createApmServerRoute({
     tags: ['access:apm'],
   },
   handler: async (resources): Promise<TimeRangeMetadata> => {
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     const {
       query: { useSpanName, start, end, kuery },
@@ -33,7 +33,7 @@ export const timeRangeMetadataRoute = createApmServerRoute({
 
     const [isUsingServiceDestinationMetrics] = await Promise.all([
       getIsUsingServiceDestinationMetrics({
-        setup,
+        apmEventClient,
         useSpanName,
         start,
         end,

--- a/x-pack/plugins/apm/server/routes/traces/get_top_traces_primary_stats.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_top_traces_primary_stats.ts
@@ -13,7 +13,6 @@ import {
 } from '@kbn/observability-plugin/server';
 import { AgentName } from '../../../typings/es_schemas/ui/fields/agent';
 import { withApmSpan } from '../../utils/with_apm_span';
-import { Setup } from '../../lib/helpers/setup_request';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { calculateImpactBuilder } from './calculate_impact_builder';
@@ -31,6 +30,7 @@ import {
   TRANSACTION_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { RandomSampler } from '../../lib/helpers/get_random_sampler';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export type BucketKey = Record<
   typeof TRANSACTION_NAME | typeof SERVICE_NAME,
@@ -44,7 +44,7 @@ interface TopTracesParams {
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   randomSampler: RandomSampler;
 }
 export async function getTopTracesPrimaryStats({
@@ -54,11 +54,11 @@ export async function getTopTracesPrimaryStats({
   searchAggregatedTransactions,
   start,
   end,
-  setup,
+  apmEventClient,
   randomSampler,
 }: TopTracesParams) {
   return withApmSpan('get_top_traces_primary_stats', async () => {
-    const response = await setup.apmEventClient.search(
+    const response = await apmEventClient.search(
       'get_transaction_group_stats',
       {
         apm: {

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -18,16 +18,17 @@ import {
   TRACE_ID,
   TRANSACTION_DURATION,
 } from '../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../lib/helpers/setup_request';
 import { getLinkedChildrenCountBySpanId } from '../span_links/get_linked_children';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { APMConfig } from '../..';
 
 export async function getTraceItems(
   traceId: string,
-  setup: Setup,
+  config: APMConfig,
+  apmEventClient: APMEventClient,
   start: number,
   end: number
 ) {
-  const { apmEventClient, config } = setup;
   const maxTraceItems = config.ui.maxTraceItems;
   const excludedLogLevels = ['debug', 'info', 'warning'];
 
@@ -80,7 +81,7 @@ export async function getTraceItems(
     await Promise.all([
       errorResponsePromise,
       traceResponsePromise,
-      getLinkedChildrenCountBySpanId({ traceId, setup, start, end }),
+      getLinkedChildrenCountBySpanId({ traceId, apmEventClient, start, end }),
     ]);
 
   const exceedsMax = traceResponse.hits.total.value > maxTraceItems;

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_samples_by_query.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_samples_by_query.ts
@@ -11,7 +11,6 @@ import {
 } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { Environment } from '../../../common/environment_rt';
-import { Setup } from '../../lib/helpers/setup_request';
 import { TraceSearchType } from '../../../common/trace_explorer';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import {
@@ -22,16 +21,17 @@ import {
   TRANSACTION_SAMPLED,
 } from '../../../common/elasticsearch_fieldnames';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTraceSamplesByQuery({
-  setup,
+  apmEventClient,
   start,
   end,
   environment,
   query,
   type,
 }: {
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
   environment: Environment;
@@ -45,7 +45,7 @@ export async function getTraceSamplesByQuery({
   if (type === TraceSearchType.kql) {
     traceIds =
       (
-        await setup.apmEventClient.search('get_trace_ids_by_kql_query', {
+        await apmEventClient.search('get_trace_ids_by_kql_query', {
           apm: {
             events: [
               ProcessorEvent.transaction,
@@ -81,7 +81,7 @@ export async function getTraceSamplesByQuery({
   } else if (type === TraceSearchType.eql) {
     traceIds =
       (
-        await setup.apmEventClient.eqlSearch('get_trace_ids_by_eql_query', {
+        await apmEventClient.eqlSearch('get_trace_ids_by_eql_query', {
           apm: {
             events: [
               ProcessorEvent.transaction,
@@ -115,7 +115,7 @@ export async function getTraceSamplesByQuery({
     return [];
   }
 
-  const traceSamplesResponse = await setup.apmEventClient.search(
+  const traceSamplesResponse = await apmEventClient.search(
     'get_trace_samples_by_trace_ids',
     {
       apm: {

--- a/x-pack/plugins/apm/server/routes/traces/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/traces/queries.test.ts
@@ -19,8 +19,8 @@ describe('trace queries', () => {
   });
 
   it('fetches a trace', async () => {
-    mock = await inspectSearchParams((setup) =>
-      getTraceItems('foo', setup, 0, 50000)
+    mock = await inspectSearchParams((setup, apmEventClient) =>
+      getTraceItems('foo', setup.config, apmEventClient, 0, 50000)
     );
 
     expect(mock.params).toMatchSnapshot();

--- a/x-pack/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/plugins/apm/server/routes/traces/route.ts
@@ -22,6 +22,7 @@ import { getTopTracesPrimaryStats } from './get_top_traces_primary_stats';
 import { getTraceItems } from './get_trace_items';
 import { getTraceSamplesByQuery } from './get_trace_samples_by_query';
 import { getRandomSampler } from '../../lib/helpers/get_random_sampler';
+import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 
 const tracesRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/traces',
@@ -51,13 +52,15 @@ const tracesRoute = createApmServerRoute({
 
     const { environment, kuery, start, end, probability } = params.query;
 
-    const [setup, randomSampler] = await Promise.all([
+    const [setup, apmEventClient, randomSampler] = await Promise.all([
       setupRequest(resources),
+      getApmEventClient(resources),
       getRandomSampler({ security, request, probability }),
     ]);
 
     const searchAggregatedTransactions = await getSearchTransactionsEvents({
-      ...setup,
+      apmEventClient,
+      config: setup.config,
       kuery,
       start,
       end,
@@ -66,7 +69,7 @@ const tracesRoute = createApmServerRoute({
     return await getTopTracesPrimaryStats({
       environment,
       kuery,
-      setup,
+      apmEventClient,
       searchAggregatedTransactions,
       start,
       end,
@@ -97,12 +100,15 @@ const tracesByIdRoute = createApmServerRoute({
     >;
     linkedChildrenOfSpanCountBySpanId: Record<string, number>;
   }> => {
-    const setup = await setupRequest(resources);
+    const [setup, apmEventClient] = await Promise.all([
+      setupRequest(resources),
+      getApmEventClient(resources),
+    ]);
     const { params } = resources;
     const { traceId } = params.path;
     const { start, end } = params.query;
-
-    return getTraceItems(traceId, setup, start, end);
+    const { config } = setup;
+    return getTraceItems(traceId, config, apmEventClient, start, end);
   },
 });
 
@@ -121,8 +127,8 @@ const rootTransactionByTraceIdRoute = createApmServerRoute({
   }> => {
     const { params } = resources;
     const { traceId } = params.path;
-    const setup = await setupRequest(resources);
-    return getRootTransactionByTraceId(traceId, setup);
+    const apmEventClient = await getApmEventClient(resources);
+    return getRootTransactionByTraceId(traceId, apmEventClient);
   },
 });
 
@@ -141,9 +147,9 @@ const transactionByIdRoute = createApmServerRoute({
   }> => {
     const { params } = resources;
     const { transactionId } = params.path;
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
     return {
-      transaction: await getTransaction({ transactionId, setup }),
+      transaction: await getTransaction({ transactionId, apmEventClient }),
     };
   },
 });
@@ -173,11 +179,11 @@ const findTracesRoute = createApmServerRoute({
   }> => {
     const { start, end, environment, query, type } = resources.params.query;
 
-    const setup = await setupRequest(resources);
+    const apmEventClient = await getApmEventClient(resources);
 
     return {
       traceSamples: await getTraceSamplesByQuery({
-        setup,
+        apmEventClient,
         start,
         end,
         environment,

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.test.ts
@@ -27,7 +27,6 @@ const mockIndices: ApmIndicesConfig = {
 function getMockSetup(esResponse: any) {
   const clientSpy = jest.fn().mockReturnValueOnce(esResponse);
   return {
-    apmEventClient: { search: clientSpy } as any,
     internalClient: { search: clientSpy } as any,
     config: new Proxy(
       {},
@@ -39,87 +38,107 @@ function getMockSetup(esResponse: any) {
   };
 }
 
+function getMockApmEventClient(esResponse: any) {
+  const apmEventClientSpy = jest.fn().mockReturnValueOnce(esResponse);
+  return { apmEventClient: { search: apmEventClientSpy } as any };
+}
+
 describe('getTransactionBreakdown', () => {
-  it('returns an empty array if no data is available', async () => {
-    const response = await getTransactionBreakdown({
-      serviceName: 'myServiceName',
-      transactionType: 'request',
-      setup: getMockSetup(noDataResponse),
-      environment: ENVIRONMENT_ALL.value,
-      kuery: '',
-      start: 0,
-      end: 500000,
-    });
+  describe('when no data is available', () => {
+    const { config } = getMockSetup(noDataResponse);
+    const { apmEventClient } = getMockApmEventClient(noDataResponse);
+    it('returns an empty array if no data is available', async () => {
+      const response = await getTransactionBreakdown({
+        serviceName: 'myServiceName',
+        transactionType: 'request',
+        config,
+        apmEventClient,
+        environment: ENVIRONMENT_ALL.value,
+        kuery: '',
+        start: 0,
+        end: 500000,
+      });
 
-    expect(Object.keys(response.timeseries).length).toBe(0);
+      expect(Object.keys(response.timeseries).length).toBe(0);
+    });
   });
 
-  it('returns a timeseries grouped by type and subtype', async () => {
-    const response = await getTransactionBreakdown({
-      serviceName: 'myServiceName',
-      transactionType: 'request',
-      setup: getMockSetup(dataResponse),
-      environment: ENVIRONMENT_ALL.value,
-      kuery: '',
-      start: 0,
-      end: 500000,
+  describe('when data is returned', () => {
+    it('returns a timeseries grouped by type and subtype', async () => {
+      const { config } = getMockSetup(dataResponse);
+      const { apmEventClient } = getMockApmEventClient(dataResponse);
+      const response = await getTransactionBreakdown({
+        serviceName: 'myServiceName',
+        transactionType: 'request',
+        config,
+        apmEventClient,
+        environment: ENVIRONMENT_ALL.value,
+        kuery: '',
+        start: 0,
+        end: 500000,
+      });
+
+      const { timeseries } = response;
+
+      expect(timeseries.length).toBe(4);
+
+      const appTimeseries = timeseries[0];
+      expect(appTimeseries.title).toBe('app');
+      expect(appTimeseries.type).toBe('areaStacked');
+      expect(appTimeseries.hideLegend).toBe(false);
+
+      // empty buckets should result in null values for visible types
+      expect(appTimeseries.data.length).toBe(276);
+      expect(appTimeseries.data.length).not.toBe(257);
+
+      expect(appTimeseries.data[0].x).toBe(1561102380000);
+
+      expect(appTimeseries.data[0].y).toBeCloseTo(0.8689440187037277);
     });
 
-    const { timeseries } = response;
+    it('should not include more KPIs than MAX_KPIs', async () => {
+      const { config } = getMockSetup(dataResponse);
+      const { apmEventClient } = getMockApmEventClient(dataResponse);
+      // @ts-expect-error
+      constants.MAX_KPIS = 2;
 
-    expect(timeseries.length).toBe(4);
+      const response = await getTransactionBreakdown({
+        serviceName: 'myServiceName',
+        transactionType: 'request',
+        config,
+        apmEventClient,
+        environment: ENVIRONMENT_ALL.value,
+        kuery: '',
+        start: 0,
+        end: 500000,
+      });
+      const { timeseries } = response;
 
-    const appTimeseries = timeseries[0];
-    expect(appTimeseries.title).toBe('app');
-    expect(appTimeseries.type).toBe('areaStacked');
-    expect(appTimeseries.hideLegend).toBe(false);
-
-    // empty buckets should result in null values for visible types
-    expect(appTimeseries.data.length).toBe(276);
-    expect(appTimeseries.data.length).not.toBe(257);
-
-    expect(appTimeseries.data[0].x).toBe(1561102380000);
-
-    expect(appTimeseries.data[0].y).toBeCloseTo(0.8689440187037277);
-  });
-
-  it('should not include more KPIs than MAX_KPIs', async () => {
-    // @ts-expect-error
-    constants.MAX_KPIS = 2;
-
-    const response = await getTransactionBreakdown({
-      serviceName: 'myServiceName',
-      transactionType: 'request',
-      setup: getMockSetup(dataResponse),
-      environment: ENVIRONMENT_ALL.value,
-      kuery: '',
-      start: 0,
-      end: 500000,
+      expect(timeseries.map((serie) => serie.title)).toEqual(['app', 'http']);
     });
 
-    const { timeseries } = response;
+    it('fills in gaps for a given timestamp', async () => {
+      const { config } = getMockSetup(dataResponse);
+      const { apmEventClient } = getMockApmEventClient(dataResponse);
+      const response = await getTransactionBreakdown({
+        serviceName: 'myServiceName',
+        transactionType: 'request',
+        config,
+        apmEventClient,
+        environment: ENVIRONMENT_ALL.value,
+        kuery: '',
+        start: 0,
+        end: 500000,
+      });
 
-    expect(timeseries.map((serie) => serie.title)).toEqual(['app', 'http']);
-  });
+      const { timeseries } = response;
 
-  it('fills in gaps for a given timestamp', async () => {
-    const response = await getTransactionBreakdown({
-      serviceName: 'myServiceName',
-      transactionType: 'request',
-      setup: getMockSetup(dataResponse),
-      environment: ENVIRONMENT_ALL.value,
-      kuery: '',
-      start: 0,
-      end: 500000,
+      const appTimeseries = timeseries.find((series) => series.title === 'app');
+
+      // missing values should be 0 if other span types do have data for that timestamp
+      expect(
+        (appTimeseries as NonNullable<typeof appTimeseries>).data[1].y
+      ).toBe(0);
     });
-
-    const { timeseries } = response;
-
-    const appTimeseries = timeseries.find((series) => series.title === 'app');
-
-    // missing values should be 0 if other span types do have data for that timestamp
-    expect((appTimeseries as NonNullable<typeof appTimeseries>).data[1].y).toBe(
-      0
-    );
   });
 });

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -17,16 +17,18 @@ import {
   TRANSACTION_TYPE,
   TRANSACTION_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getMetricsDateHistogramParams } from '../../../lib/helpers/metrics';
 import { MAX_KPIS } from './constants';
 import { getVizColorForIndex } from '../../../../common/viz_colors';
+import { APMConfig } from '../../..';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransactionBreakdown({
   environment,
   kuery,
-  setup,
+  config,
+  apmEventClient,
   serviceName,
   transactionName,
   transactionType,
@@ -35,15 +37,14 @@ export async function getTransactionBreakdown({
 }: {
   environment: string;
   kuery: string;
-  setup: Setup;
+  config: APMConfig;
+  apmEventClient: APMEventClient;
   serviceName: string;
   transactionName?: string;
   transactionType: string;
   start: number;
   end: number;
 }) {
-  const { apmEventClient, config } = setup;
-
   const subAggs = {
     sum_all_self_times: {
       sum: {

--- a/x-pack/plugins/apm/server/routes/transactions/get_failed_transaction_rate_periods.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_failed_transaction_rate_periods.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Setup } from '../../lib/helpers/setup_request';
 import { getFailedTransactionRate } from '../../lib/transaction_groups/get_failed_transaction_rate';
 import { offsetPreviousPeriodCoordinates } from '../../../common/utils/offset_previous_period_coordinate';
+import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getFailedTransactionRatePeriods({
   environment,
@@ -14,7 +14,7 @@ export async function getFailedTransactionRatePeriods({
   serviceName,
   transactionType,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   start,
   end,
@@ -25,7 +25,7 @@ export async function getFailedTransactionRatePeriods({
   serviceName: string;
   transactionType: string;
   transactionName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   start: number;
   end: number;
@@ -37,7 +37,7 @@ export async function getFailedTransactionRatePeriods({
     serviceName,
     transactionTypes: [transactionType],
     transactionName,
-    setup,
+    apmEventClient,
     searchAggregatedTransactions,
   };
 

--- a/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
@@ -23,13 +23,13 @@ import {
   getDurationFieldForTransactions,
   getProcessorEventForTransactions,
 } from '../../../lib/helpers/transactions';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { getBucketSizeForAggregatedTransactions } from '../../../lib/helpers/get_bucket_size_for_aggregated_transactions';
 import {
   getLatencyAggregation,
   getLatencyValue,
 } from '../../../lib/helpers/latency_aggregation_type';
 import { getOffsetInMs } from '../../../../common/utils/get_offset_in_ms';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export type LatencyChartsSearchResponse = Awaited<
   ReturnType<typeof searchLatency>
@@ -41,7 +41,7 @@ function searchLatency({
   serviceName,
   transactionType,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   latencyAggregationType,
   start,
@@ -53,15 +53,13 @@ function searchLatency({
   serviceName: string;
   transactionType: string | undefined;
   transactionName: string | undefined;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   latencyAggregationType: LatencyAggregationType;
   start: number;
   end: number;
   offset?: string;
 }) {
-  const { apmEventClient } = setup;
-
   const { startWithOffset, endWithOffset } = getOffsetInMs({
     start,
     end,
@@ -127,7 +125,7 @@ export async function getLatencyTimeseries({
   serviceName,
   transactionType,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   latencyAggregationType,
   start,
@@ -139,7 +137,7 @@ export async function getLatencyTimeseries({
   serviceName: string;
   transactionType?: string;
   transactionName?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   latencyAggregationType: LatencyAggregationType;
   start: number;
@@ -152,7 +150,7 @@ export async function getLatencyTimeseries({
     serviceName,
     transactionType,
     transactionName,
-    setup,
+    apmEventClient,
     searchAggregatedTransactions,
     latencyAggregationType,
     start,
@@ -185,7 +183,7 @@ export async function getLatencyPeriods({
   serviceName,
   transactionType,
   transactionName,
-  setup,
+  apmEventClient,
   searchAggregatedTransactions,
   latencyAggregationType,
   kuery,
@@ -197,7 +195,7 @@ export async function getLatencyPeriods({
   serviceName: string;
   transactionType: string | undefined;
   transactionName: string | undefined;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   searchAggregatedTransactions: boolean;
   latencyAggregationType: LatencyAggregationType;
   kuery: string;
@@ -210,7 +208,7 @@ export async function getLatencyPeriods({
     serviceName,
     transactionType,
     transactionName,
-    setup,
+    apmEventClient,
     searchAggregatedTransactions,
     kuery,
     environment,

--- a/x-pack/plugins/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_transaction/index.ts
@@ -11,24 +11,22 @@ import {
   TRACE_ID,
   TRANSACTION_ID,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../lib/helpers/setup_request';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getTransaction({
   transactionId,
   traceId,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
   transactionId: string;
   traceId?: string;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start?: number;
   end?: number;
 }) {
-  const { apmEventClient } = setup;
-
   const resp = await apmEventClient.search('get_transaction', {
     apm: {
       events: [ProcessorEvent.transaction],

--- a/x-pack/plugins/apm/server/routes/transactions/get_transaction_by_trace/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_transaction_by_trace/index.ts
@@ -10,14 +10,12 @@ import {
   TRACE_ID,
   PARENT_ID,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getRootTransactionByTraceId(
   traceId: string,
-  setup: Setup
+  apmEventClient: APMEventClient
 ) {
-  const { apmEventClient } = setup;
-
   const params = {
     apm: {
       events: [ProcessorEvent.transaction as const],

--- a/x-pack/plugins/apm/server/routes/transactions/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/queries.test.ts
@@ -22,11 +22,12 @@ describe('transaction queries', () => {
   });
 
   it('fetches breakdown data for transactions', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTransactionBreakdown({
         serviceName: 'foo',
         transactionType: 'bar',
-        setup,
+        config: setup.config,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -38,12 +39,13 @@ describe('transaction queries', () => {
   });
 
   it('fetches breakdown data for transactions for a transaction name', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTransactionBreakdown({
         serviceName: 'foo',
         transactionType: 'bar',
         transactionName: 'baz',
-        setup,
+        config: setup.config,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -55,14 +57,14 @@ describe('transaction queries', () => {
   });
 
   it('fetches transaction trace samples', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTraceSamples({
         serviceName: 'foo',
         transactionName: 'bar',
         transactionType: 'baz',
         traceId: 'qux',
         transactionId: 'quz',
-        setup,
+        apmEventClient,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
         start: 0,
@@ -74,11 +76,11 @@ describe('transaction queries', () => {
   });
 
   it('fetches a transaction', async () => {
-    mock = await inspectSearchParams((setup) =>
+    mock = await inspectSearchParams((setup, apmEventClient) =>
       getTransaction({
         transactionId: 'foo',
         traceId: 'bar',
-        setup,
+        apmEventClient,
         start: 0,
         end: 50000,
       })

--- a/x-pack/plugins/apm/server/routes/transactions/trace_samples/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/trace_samples/index.ts
@@ -18,7 +18,7 @@ import {
   TRANSACTION_TYPE,
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { Setup } from '../../../lib/helpers/setup_request';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 
 const TRACE_SAMPLES_SIZE = 500;
 
@@ -32,7 +32,7 @@ export async function getTraceSamples({
   traceId,
   sampleRangeFrom,
   sampleRangeTo,
-  setup,
+  apmEventClient,
   start,
   end,
 }: {
@@ -45,13 +45,11 @@ export async function getTraceSamples({
   traceId: string;
   sampleRangeFrom?: number;
   sampleRangeTo?: number;
-  setup: Setup;
+  apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) {
   return withApmSpan('get_trace_samples', async () => {
-    const { apmEventClient } = setup;
-
     const commonFilters = [
       { term: { [SERVICE_NAME]: serviceName } },
       { term: { [TRANSACTION_TYPE]: transactionType } },

--- a/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.test.ts
@@ -31,47 +31,74 @@ describe('Cloud Links Plugin - public', () => {
       plugin.stop();
     });
 
-    test('calls maybeAddCloudLinks when cloud and security are enabled and it is an authenticated page', () => {
-      const coreStart = coreMock.createStart();
-      coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
-      const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
-      const security = securityMock.createStart();
-      plugin.start(coreStart, { cloud, security });
-      expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(1);
+    describe('Onboarding Setup Guide link registration', () => {
+      test('registers the Onboarding Setup Guide link when cloud is enabled and it is an authenticated page', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
+        plugin.start(coreStart, { cloud });
+        expect(coreStart.chrome.registerGlobalHelpExtensionMenuLink).toHaveBeenCalledTimes(1);
+      });
+
+      test('does not register the Onboarding Setup Guide link when cloud is enabled but it is an unauthenticated page', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(true);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
+        plugin.start(coreStart, { cloud });
+        expect(coreStart.chrome.registerGlobalHelpExtensionMenuLink).not.toHaveBeenCalled();
+      });
+
+      test('does not register the Onboarding Setup Guide link when cloud is not enabled', () => {
+        const coreStart = coreMock.createStart();
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: false };
+        plugin.start(coreStart, { cloud });
+        expect(coreStart.chrome.registerGlobalHelpExtensionMenuLink).not.toHaveBeenCalled();
+      });
     });
 
-    test('does not call maybeAddCloudLinks when security is disabled', () => {
-      const coreStart = coreMock.createStart();
-      coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
-      const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
-      plugin.start(coreStart, { cloud });
-      expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
-    });
+    describe('maybeAddCloudLinks', () => {
+      test('calls maybeAddCloudLinks when cloud and security are enabled and it is an authenticated page', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
+        const security = securityMock.createStart();
+        plugin.start(coreStart, { cloud, security });
+        expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(1);
+      });
 
-    test('does not call maybeAddCloudLinks when the page is anonymous', () => {
-      const coreStart = coreMock.createStart();
-      coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(true);
-      const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
-      const security = securityMock.createStart();
-      plugin.start(coreStart, { cloud, security });
-      expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
-    });
+      test('does not call maybeAddCloudLinks when security is disabled', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
+        plugin.start(coreStart, { cloud });
+        expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
+      });
 
-    test('does not call maybeAddCloudLinks when cloud is disabled', () => {
-      const coreStart = coreMock.createStart();
-      coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
-      const security = securityMock.createStart();
-      plugin.start(coreStart, { security });
-      expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
-    });
+      test('does not call maybeAddCloudLinks when the page is anonymous', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(true);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: true };
+        const security = securityMock.createStart();
+        plugin.start(coreStart, { cloud, security });
+        expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
+      });
 
-    test('does not call maybeAddCloudLinks when isCloudEnabled is false', () => {
-      const coreStart = coreMock.createStart();
-      coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
-      const cloud = { ...cloudMock.createStart(), isCloudEnabled: false };
-      const security = securityMock.createStart();
-      plugin.start(coreStart, { cloud, security });
-      expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
+      test('does not call maybeAddCloudLinks when cloud is disabled', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+        const security = securityMock.createStart();
+        plugin.start(coreStart, { security });
+        expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
+      });
+
+      test('does not call maybeAddCloudLinks when isCloudEnabled is false', () => {
+        const coreStart = coreMock.createStart();
+        coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+        const cloud = { ...cloudMock.createStart(), isCloudEnabled: false };
+        const security = securityMock.createStart();
+        plugin.start(coreStart, { cloud, security });
+        expect(maybeAddCloudLinksMock).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { CoreStart, Plugin } from '@kbn/core/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/public';
@@ -26,12 +28,18 @@ export class CloudLinksPlugin
   public setup() {}
 
   public start(core: CoreStart, { cloud, security }: CloudLinksDepsStart) {
-    if (
-      cloud?.isCloudEnabled &&
-      security &&
-      !core.http.anonymousPaths.isAnonymous(window.location.pathname)
-    ) {
-      maybeAddCloudLinks({ security, chrome: core.chrome, cloud });
+    if (cloud?.isCloudEnabled && !core.http.anonymousPaths.isAnonymous(window.location.pathname)) {
+      core.chrome.registerGlobalHelpExtensionMenuLink({
+        linkType: 'custom',
+        href: core.http.basePath.prepend('/app/home#/getting_started'),
+        content: <FormattedMessage id="xpack.cloudLinks.setupGuide" defaultMessage="Setup guide" />,
+        'data-test-subj': 'cloudOnboardingSetupGuideLink',
+        priority: 1000, // We want this link to be at the very top.
+      });
+
+      if (security) {
+        maybeAddCloudLinks({ security, chrome: core.chrome, cloud });
+      }
     }
   }
 

--- a/x-pack/plugins/files/public/components/file_picker/components/file_card.tsx
+++ b/x-pack/plugins/files/public/components/file_picker/components/file_card.tsx
@@ -58,11 +58,6 @@ export const FileCard: FunctionComponent<Props> = ({ file }) => {
               `}
               meta={file.meta as FileImageMetadata}
               src={client.getDownloadHref({ id: file.id, fileKind: kind })}
-              // There is an issue where the intersection observer does not fire reliably.
-              // I'm not sure if this is becuause of the image being in a modal
-              // The result is that the image does not always get loaded.
-              // TODO: Investigate this behaviour further
-              lazy={false}
             />
           ) : (
             <div

--- a/x-pack/plugins/files/public/components/image/components/img.tsx
+++ b/x-pack/plugins/files/public/components/image/components/img.tsx
@@ -12,21 +12,25 @@ import { css } from '@emotion/react';
 import { sizes } from '../styles';
 
 export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
-  hidden: boolean;
   size?: EuiImageSize;
   observerRef: (el: null | HTMLImageElement) => void;
 }
 
 export const Img = React.forwardRef<HTMLImageElement, Props>(
-  ({ observerRef, src, hidden, size, ...rest }, ref) => {
+  ({ observerRef, src, size, ...rest }, ref) => {
     const { euiTheme } = useEuiTheme();
     const styles = [
       css`
         transition: opacity ${euiTheme.animation.extraFast};
       `,
-      hidden
+      !src
         ? css`
             visibility: hidden;
+            position: absolute; // ensure that empty img tag occupies full container
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
           `
         : undefined,
       size ? sizes[size] : undefined,

--- a/x-pack/plugins/files/public/components/image/image.tsx
+++ b/x-pack/plugins/files/public/components/image/image.tsx
@@ -32,15 +32,6 @@ export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
    * Emits when the image first becomes visible
    */
   onFirstVisible?: () => void;
-
-  /**
-   * As an optimisation images are only loaded when they are visible.
-   * This setting overrides this behavior and loads an image as soon as the
-   * component mounts.
-   *
-   * @default true
-   */
-  lazy?: boolean;
 }
 
 /**
@@ -55,33 +46,18 @@ export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
  */
 export const Image = React.forwardRef<HTMLImageElement, Props>(
   (
-    {
-      src,
-      alt,
-      onFirstVisible,
-      onLoad,
-      onError,
-      meta,
-      wrapperProps,
-      size = 'original',
-      lazy = true,
-      ...rest
-    },
+    { src, alt, onFirstVisible, onLoad, onError, meta, wrapperProps, size = 'original', ...rest },
     ref
   ) => {
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
     const [blurDelayExpired, setBlurDelayExpired] = useState(false);
     const { isVisible, ref: observerRef } = useViewportObserver({ onFirstVisible });
 
-    const loadImage = lazy ? isVisible : true;
-
     useEffect(() => {
-      let unmounted = false;
       const id = window.setTimeout(() => {
-        if (!unmounted) setBlurDelayExpired(true);
+        setBlurDelayExpired(true);
       }, 200);
       return () => {
-        unmounted = true;
         window.clearTimeout(id);
       };
     }, []);
@@ -112,8 +88,7 @@ export const Image = React.forwardRef<HTMLImageElement, Props>(
           observerRef={observerRef}
           ref={ref}
           size={size}
-          hidden={!loadImage}
-          src={loadImage ? src : undefined}
+          src={isVisible ? src : undefined}
           alt={alt}
           onLoad={(ev) => {
             setIsLoaded(true);

--- a/x-pack/plugins/fleet/server/services/elastic_agent_manifest.ts
+++ b/x-pack/plugins/fleet/server/services/elastic_agent_manifest.ts
@@ -81,20 +81,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
       volumes:
         - name: datastreams
@@ -113,26 +104,15 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -367,20 +347,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
             - name: etc-mid
               mountPath: /etc/machine-id
@@ -398,26 +369,15 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd
         # Mount /etc/machine-id from the host to determine host ID
         # Needed for Elastic Security integration
         - name: etc-mid

--- a/x-pack/plugins/profiling/public/utils/formatters/as_number.ts
+++ b/x-pack/plugins/profiling/public/utils/formatters/as_number.ts
@@ -11,18 +11,18 @@ export function asNumber(value: number): string {
   }
 
   value = Math.round(value * 100) / 100;
-  if (value < 0.01) {
+  if (Math.abs(value) < 0.01) {
     return '~0.00';
   }
-  if (value < 1e3) {
+  if (Math.abs(value) < 1e3) {
     return value.toString();
   }
 
-  if (value < 1e6) {
+  if (Math.abs(value) < 1e6) {
     return `${asNumber(value / 1e3)}k`;
   }
 
-  if (value < 1e9) {
+  if (Math.abs(value) < 1e9) {
     return `${asNumber(value / 1e6)}m`;
   }
 

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
@@ -9,10 +9,13 @@ import type { IEsSearchRequest, IEsSearchResponse } from '@kbn/data-plugin/commo
 import type { ESQuery } from '../../../../typed_json';
 
 import type { Inspect, Maybe, SortField, TimerangeInput } from '../../../common';
+import type { RiskScoreEntity } from '../common';
 
 export interface RiskScoreRequestOptions extends IEsSearchRequest {
   defaultIndex: string[];
+  riskScoreEntity: RiskScoreEntity;
   timerange?: TimerangeInput;
+  includeAlertsCount?: boolean;
   onlyLatest?: boolean;
   pagination?: {
     cursorStart: number;
@@ -47,6 +50,7 @@ export interface HostRiskScore {
     name: string;
     risk: RiskStats;
   };
+  alertsCount?: number;
 }
 
 export interface UserRiskScore {
@@ -55,6 +59,7 @@ export interface UserRiskScore {
     name: string;
     risk: RiskStats;
   };
+  alertsCount?: number;
 }
 
 export interface RuleRisk {
@@ -73,6 +78,7 @@ export const enum RiskScoreFields {
   userName = 'user.name',
   userRiskScore = 'user.risk.calculated_score_norm',
   userRisk = 'user.risk.calculated_level',
+  alertsCount = 'alertsCount',
 }
 
 export interface RiskScoreItem {
@@ -85,6 +91,8 @@ export interface RiskScoreItem {
 
   [RiskScoreFields.hostRiskScore]: Maybe<number>;
   [RiskScoreFields.userRiskScore]: Maybe<number>;
+
+  [RiskScoreFields.alertsCount]: Maybe<number>;
 }
 
 export const enum RiskSeverity {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/index.tsx
@@ -18,7 +18,6 @@ import {
   isNewTermsRule,
 } from '../../../../../common/detection_engine/utils';
 import type { FieldHook } from '../../../../shared_imports';
-import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { MlCardDescription } from './ml_card_description';
 
@@ -50,9 +49,6 @@ export const SelectRuleType: React.FC<SelectRuleTypeProps> = ({
   const setThreshold = useCallback(() => setType('threshold'), [setType]);
   const setThreatMatch = useCallback(() => setType('threat_match'), [setType]);
   const setNewTerms = useCallback(() => setType('new_terms'), [setType]);
-  const licensingUrl = useKibana().services.application.getUrlForApp('kibana', {
-    path: '#/management/stack/license_management',
-  });
 
   const eqlSelectableConfig = useMemo(
     () => ({
@@ -130,12 +126,7 @@ export const SelectRuleType: React.FC<SelectRuleTypeProps> = ({
               data-test-subj="machineLearningRuleType"
               title={i18n.ML_TYPE_TITLE}
               titleSize="xs"
-              description={
-                <MlCardDescription
-                  subscriptionUrl={licensingUrl}
-                  hasValidLicense={hasValidLicense}
-                />
-              }
+              description={<MlCardDescription hasValidLicense={hasValidLicense} />}
               icon={<EuiIcon size="l" type="machineLearningApp" />}
               isDisabled={mlSelectableConfig.isDisabled && !mlSelectableConfig.isSelected}
               selectable={mlSelectableConfig}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/ml_card_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/ml_card_description.tsx
@@ -13,7 +13,6 @@ import React from 'react';
 import { ML_TYPE_DESCRIPTION } from './translations';
 
 interface MlCardDescriptionProps {
-  subscriptionUrl: string;
   hasValidLicense?: boolean;
 }
 
@@ -22,7 +21,6 @@ const SmallText = styled.span`
 `;
 
 const MlCardDescriptionComponent: React.FC<MlCardDescriptionProps> = ({
-  subscriptionUrl,
   hasValidLicense = false,
 }) => (
   <SmallText>
@@ -34,7 +32,7 @@ const MlCardDescriptionComponent: React.FC<MlCardDescriptionProps> = ({
         defaultMessage="Access to ML requires a {subscriptionsLink}."
         values={{
           subscriptionsLink: (
-            <EuiLink href={subscriptionUrl} target="_blank">
+            <EuiLink href="https://www.elastic.co/subscriptions" target="_blank">
               <FormattedMessage
                 id="xpack.securitySolution.components.stepDefineRule.ruleTypeField.subscriptionsLink"
                 defaultMessage="Platinum subscription"

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
@@ -7,19 +7,28 @@
 
 import React from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiLink, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { get } from 'lodash/fp';
 import { UsersTableType } from '../../../../users/store/model';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { HostDetailsLink, UserDetailsLink } from '../../../../common/components/links';
 import { HostsTableType } from '../../../../hosts/store/model';
 import { RiskScore } from '../../../../common/components/severity/common';
-import type { HostRiskScore, RiskSeverity } from '../../../../../common/search_strategy';
+import type {
+  HostRiskScore,
+  RiskSeverity,
+  UserRiskScore,
+} from '../../../../../common/search_strategy';
 import { RiskScoreEntity, RiskScoreFields } from '../../../../../common/search_strategy';
 import * as i18n from './translations';
+import { FormattedCount } from '../../../../common/components/formatted_number';
 
-type HostRiskScoreColumns = Array<EuiBasicTableColumn<HostRiskScore>>;
+type HostRiskScoreColumns = Array<EuiBasicTableColumn<HostRiskScore & UserRiskScore>>;
 
-export const getRiskScoreColumns = (riskEntity: RiskScoreEntity): HostRiskScoreColumns => [
+export const getRiskScoreColumns = (
+  riskEntity: RiskScoreEntity,
+  openEntityInTimeline: (entityName: string) => void
+): HostRiskScoreColumns => [
   {
     field: riskEntity === RiskScoreEntity.host ? 'host.name' : 'user.name',
     name: i18n.ENTITY_NAME(riskEntity),
@@ -74,5 +83,21 @@ export const getRiskScoreColumns = (riskEntity: RiskScoreEntity): HostRiskScoreC
       }
       return getEmptyTagValue();
     },
+  },
+  {
+    field: RiskScoreFields.alertsCount,
+    width: '15%',
+    name: i18n.ALERTS,
+    truncateText: false,
+    mobileOptions: { show: true },
+    render: (alertCount: number, risk) => (
+      <EuiLink
+        data-test-subj="risk-score-alerts"
+        disabled={alertCount === 0}
+        onClick={() => openEntityInTimeline(get('host.name', risk) ?? get('user.name', risk))}
+      >
+        <FormattedCount count={alertCount} />
+      </EuiLink>
+    ),
   },
 ];

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.test.tsx
@@ -9,6 +9,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { EntityAnalyticsRiskScores } from '.';
+import type { UserRiskScore } from '../../../../../common/search_strategy';
 import { RiskScoreEntity, RiskSeverity } from '../../../../../common/search_strategy';
 import type { SeverityCount } from '../../../../common/components/severity/types';
 import { useRiskScore, useRiskScoreKpi } from '../../../../risk_score/containers';
@@ -115,6 +116,39 @@ describe.each([RiskScoreEntity.host, RiskScoreEntity.user])(
       );
 
       expect(queryByTestId('entity_analytics_content')).not.toBeInTheDocument();
+    });
+
+    it('renders alerts count', () => {
+      mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });
+      mockUseRiskScoreKpi.mockReturnValue({
+        severityCount: mockSeverityCount,
+        loading: false,
+      });
+      const alertsCount = 999;
+      const data: UserRiskScore[] = [
+        {
+          '@timestamp': '1234567899',
+          user: {
+            name: 'testUsermame',
+            risk: {
+              rule_risks: [],
+              calculated_level: RiskSeverity.high,
+              calculated_score_norm: 75,
+              multipliers: [],
+            },
+          },
+          alertsCount,
+        },
+      ];
+      mockUseRiskScore.mockReturnValue({ ...defaultProps, data });
+
+      const { queryByTestId } = render(
+        <TestProviders>
+          <EntityAnalyticsRiskScores riskEntity={riskEntity} />
+        </TestProviders>
+      );
+
+      expect(queryByTestId('risk-score-alerts')).toHaveTextContent(alertsCount.toString());
     });
   }
 );

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { useDispatch } from 'react-redux';
@@ -40,6 +40,7 @@ import { Loader } from '../../../../common/components/loader';
 import { Panel } from '../../../../common/components/panel';
 import * as commonI18n from '../common/translations';
 import { usersActions } from '../../../../users/store';
+import { useNavigateToTimeline } from '../../detection_response/hooks/use_navigate_to_timeline';
 
 const HOST_RISK_TABLE_QUERY_ID = 'hostRiskDashboardTable';
 const HOST_RISK_KPI_QUERY_ID = 'headerHostRiskScoreKpiQuery';
@@ -90,8 +91,24 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
     [dispatch, riskEntity]
   );
 
+  const { openHostInTimeline, openUserInTimeline } = useNavigateToTimeline();
+
+  const openEntityInTimeline = useCallback(
+    (entityName: string) => {
+      if (riskEntity === RiskScoreEntity.host) {
+        openHostInTimeline({ hostName: entityName });
+      } else if (riskEntity === RiskScoreEntity.user) {
+        openUserInTimeline({ userName: entityName });
+      }
+    },
+    [riskEntity, openHostInTimeline, openUserInTimeline]
+  );
+
   const { toggleStatus, setToggleStatus } = useQueryToggle(entity.tableQueryId);
-  const columns = useMemo(() => getRiskScoreColumns(riskEntity), [riskEntity]);
+  const columns = useMemo(
+    () => getRiskScoreColumns(riskEntity, openEntityInTimeline),
+    [riskEntity, openEntityInTimeline]
+  );
   const [selectedSeverity, setSelectedSeverity] = useState<RiskSeverity[]>([]);
   const getSecuritySolutionLinkProps = useGetSecuritySolutionLinkProps();
 
@@ -146,6 +163,7 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
     },
     timerange,
     riskEntity,
+    includeAlertsCount: true,
   });
 
   useQueryInspector({

--- a/x-pack/plugins/security_solution/public/risk_score/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/risk_score/components/translations.ts
@@ -50,3 +50,7 @@ export const getRiskEntityTranslation = (
 
   return riskEntity === RiskScoreEntity.host ? HOST : USER;
 };
+
+export const ALERTS = i18n.translate('xpack.securitySolution.riskScore.overview.alerts', {
+  defaultMessage: 'Alerts',
+});

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.test.tsx
@@ -168,6 +168,8 @@ describe.each([RiskScoreEntity.host, RiskScoreEntity.user])(
       expect(mockSearch).toHaveBeenCalledWith({
         defaultIndex: [`ml_${riskEntity}_risk_score_latest_default`],
         factoryQueryType: `${riskEntity}sRiskScore`,
+        riskScoreEntity: riskEntity,
+        includeAlertsCount: false,
       });
     });
 

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -45,6 +45,7 @@ export interface RiskScoreState<T extends RiskScoreEntity.host | RiskScoreEntity
 export interface UseRiskScoreParams {
   filterQuery?: ESQuery | string;
   onlyLatest?: boolean;
+  includeAlertsCount?: boolean;
   pagination?:
     | {
         cursorStart: number;
@@ -76,6 +77,7 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
   skip = false,
   pagination,
   riskEntity,
+  includeAlertsCount = false,
 }: UseRiskScore<T>): RiskScoreState<T> => {
   const spaceId = useSpaceId();
   const defaultIndex = spaceId
@@ -158,6 +160,8 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
         ? {
             defaultIndex: [defaultIndex],
             factoryQueryType,
+            riskScoreEntity: riskEntity,
+            includeAlertsCount,
             filterQuery: createFilter(filterQuery),
             pagination:
               cursorStart !== undefined && querySize !== undefined
@@ -179,6 +183,8 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
       sort,
       requestTimerange,
       onlyLatest,
+      riskEntity,
+      includeAlertsCount,
     ]
   );
 

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -343,7 +343,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       const securitySolutionSearchStrategy = securitySolutionSearchStrategyProvider(
         depsStart.data,
         endpointContext,
-        depsStart.spaces?.spacesService?.getSpaceId
+        depsStart.spaces?.spacesService?.getSpaceId,
+        ruleDataClient
       );
 
       plugins.data.search.registerSearchStrategy(

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.test.ts
@@ -8,6 +8,7 @@
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../../../common/constants';
 
 import type { HostsRequestOptions } from '../../../../../../common/search_strategy/security_solution';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy/security_solution';
 import * as buildQuery from './query.all_hosts.dsl';
 import * as buildRiskQuery from '../../risk_score/all/query.risk_score.dsl';
 import { allHosts } from '.';
@@ -128,6 +129,7 @@ describe('allHosts search strategy', () => {
       expect(buildHostsRiskQuery).toHaveBeenCalledWith({
         defaultIndex: ['ml_host_risk_score_latest_test-space'],
         filterQuery: { terms: { 'host.name': [hostName] } },
+        riskScoreEntity: RiskScoreEntity.host,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.ts
@@ -19,7 +19,11 @@ import type {
 } from '../../../../../../common/search_strategy/security_solution/hosts';
 
 import type { HostRiskScore } from '../../../../../../common/search_strategy';
-import { getHostRiskIndex, buildHostNamesFilter } from '../../../../../../common/search_strategy';
+import {
+  RiskScoreEntity,
+  getHostRiskIndex,
+  buildHostNamesFilter,
+} from '../../../../../../common/search_strategy';
 
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import type { SecuritySolutionFactory } from '../../types';
@@ -116,6 +120,7 @@ async function getHostRiskData(
       buildRiskScoreQuery({
         defaultIndex: [getHostRiskIndex(spaceId)],
         filterQuery: buildHostNamesFilter(hostNames),
+        riskScoreEntity: RiskScoreEntity.host,
       })
     );
     return hostRiskResponse;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { riskScore } from '.';
+import type { IEsSearchResponse } from '@kbn/data-plugin/public';
+import { allowedExperimentalValues } from '../../../../../../common/experimental_features';
+import type {
+  HostRiskScore,
+  RiskScoreRequestOptions,
+} from '../../../../../../common/search_strategy';
+import { RiskScoreEntity, RiskSeverity } from '../../../../../../common/search_strategy';
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import type { EndpointAppContext } from '../../../../../endpoint/types';
+import * as buildQuery from './query.risk_score.dsl';
+import { get } from 'lodash/fp';
+import { ruleRegistryMocks } from '@kbn/rule-registry-plugin/server/mocks';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+
+export const mockSearchStrategyResponse: IEsSearchResponse<HostRiskScore> = {
+  rawResponse: {
+    took: 1,
+    timed_out: false,
+    _shards: {
+      total: 2,
+      successful: 2,
+      skipped: 1,
+      failed: 0,
+    },
+    hits: {
+      max_score: null,
+      hits: [
+        {
+          _id: '4',
+          _index: 'index',
+          _source: {
+            '@timestamp': '1234567899',
+            host: {
+              name: 'testUsermame',
+              risk: {
+                rule_risks: [],
+                calculated_level: RiskSeverity.high,
+                calculated_score_norm: 75,
+                multipliers: [],
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+  isPartial: false,
+  isRunning: false,
+  total: 2,
+  loaded: 2,
+};
+
+const searchMock = jest.fn();
+
+const mockDeps = {
+  esClient: {} as IScopedClusterClient,
+  ruleDataClient: {
+    ...(ruleRegistryMocks.createRuleDataClient('.alerts-security.alerts') as IRuleDataClient),
+    getReader: jest.fn((_options?: { namespace?: string }) => ({
+      search: searchMock,
+      getDynamicIndexPattern: jest.fn(),
+    })),
+  },
+  savedObjectsClient: {} as SavedObjectsClientContract,
+  endpointContext: {
+    logFactory: {
+      get: jest.fn().mockReturnValue({
+        warn: jest.fn(),
+      }),
+    },
+    config: jest.fn().mockResolvedValue({}),
+    experimentalFeatures: {
+      ...allowedExperimentalValues,
+    },
+    service: {} as EndpointAppContextService,
+  } as EndpointAppContext,
+  request: {} as KibanaRequest,
+};
+
+export const mockOptions: RiskScoreRequestOptions = {
+  defaultIndex: ['logs-*'],
+  riskScoreEntity: RiskScoreEntity.host,
+  includeAlertsCount: true,
+};
+
+describe('buildRiskScoreQuery search strategy', () => {
+  const buildKpiRiskScoreQuery = jest.spyOn(buildQuery, 'buildRiskScoreQuery');
+
+  describe('buildDsl', () => {
+    test('should build dsl query', () => {
+      riskScore.buildDsl(mockOptions);
+      expect(buildKpiRiskScoreQuery).toHaveBeenCalledWith(mockOptions);
+    });
+  });
+
+  test('should not enhance data when includeAlertsCount is false', async () => {
+    const result = await riskScore.parse(
+      { ...mockOptions, includeAlertsCount: false },
+      mockSearchStrategyResponse,
+      mockDeps
+    );
+
+    expect(get('data[0].alertsCount', result)).toBeUndefined();
+  });
+
+  test('should enhance data with alerts count', async () => {
+    const alertsCunt = 9999;
+    searchMock.mockReturnValue({
+      aggregations: {
+        alertsByEntity: {
+          buckets: [
+            {
+              key: 'testUsermame',
+              doc_count: alertsCunt,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await riskScore.parse(mockOptions, mockSearchStrategyResponse, mockDeps);
+
+    expect(get('data[0].alertsCount', result)).toBe(alertsCunt);
+  });
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
@@ -5,12 +5,19 @@
  * 2.0.
  */
 
-import type { IEsSearchResponse } from '@kbn/data-plugin/common';
+import type { IEsSearchResponse, SearchRequest } from '@kbn/data-plugin/common';
+import { get, getOr } from 'lodash/fp';
+
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type { SecuritySolutionFactory } from '../../types';
 import type {
   RiskScoreRequestOptions,
   RiskQueries,
+  BucketItem,
+  HostRiskScore,
+  UserRiskScore,
 } from '../../../../../../common/search_strategy';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy';
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import { buildRiskScoreQuery } from './query.risk_score.dsl';
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../../../common/constants';
@@ -26,7 +33,14 @@ export const riskScore: SecuritySolutionFactory<
 
     return buildRiskScoreQuery(options);
   },
-  parse: async (options: RiskScoreRequestOptions, response: IEsSearchResponse) => {
+  parse: async (
+    options: RiskScoreRequestOptions,
+    response: IEsSearchResponse,
+    deps?: {
+      spaceId?: string;
+      ruleDataClient?: IRuleDataClient | null;
+    }
+  ) => {
     const inspect = {
       dsl: [inspectStringifyObject(buildRiskScoreQuery(options))],
     };
@@ -34,11 +48,65 @@ export const riskScore: SecuritySolutionFactory<
     const totalCount = getTotalCount(response.rawResponse.hits.total);
     const hits = response?.rawResponse?.hits?.hits;
     const data = hits?.map((hit) => hit._source) ?? [];
+    const nameField = options.riskScoreEntity === RiskScoreEntity.host ? 'host.name' : 'user.name';
+    const names = data.map((risk) => get(nameField, risk) ?? '');
+
+    const enhancedData =
+      deps && options.includeAlertsCount
+        ? await enhanceData(data, names, nameField, deps.ruleDataClient, deps.spaceId)
+        : data;
+
     return {
       ...response,
       inspect,
       totalCount,
-      data,
+      data: enhancedData,
     };
   },
 };
+
+async function enhanceData(
+  data: Array<HostRiskScore | UserRiskScore>,
+  names: string[],
+  nameField: string,
+  ruleDataClient?: IRuleDataClient | null,
+  spaceId?: string
+): Promise<Array<HostRiskScore | UserRiskScore>> {
+  const ruleDataReader = ruleDataClient?.getReader({ namespace: spaceId });
+  const query = getAlertsQueryForEntity(names, nameField);
+
+  const response = await ruleDataReader?.search(query);
+  const buckets: BucketItem[] = getOr([], 'aggregations.alertsByEntity.buckets', response);
+
+  const alertsCountByEntityName: Record<string, number> = buckets.reduce(
+    (acc, { key, doc_count: count }) => ({
+      ...acc,
+      [key]: count,
+    }),
+    {}
+  );
+
+  return data.map((risk) => ({
+    ...risk,
+    alertsCount: alertsCountByEntityName[get(nameField, risk)] ?? 0,
+  }));
+}
+
+const getAlertsQueryForEntity = (names: string[], nameField: string): SearchRequest => ({
+  size: 0,
+  query: {
+    bool: {
+      filter: [
+        { term: { 'kibana.alert.workflow_status': 'open' } },
+        { terms: { [nameField]: names } },
+      ],
+    },
+  },
+  aggs: {
+    alertsByEntity: {
+      terms: {
+        field: nameField,
+      },
+    },
+  },
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -11,6 +11,7 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import type { IEsSearchResponse, ISearchRequestParams } from '@kbn/data-plugin/common';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type {
   FactoryQueryTypes,
   StrategyRequestType,
@@ -29,6 +30,7 @@ export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
       endpointContext: EndpointAppContext;
       request: KibanaRequest;
       spaceId?: string;
+      ruleDataClient?: IRuleDataClient | null;
     }
   ) => Promise<StrategyResponseType<T>>;
 }

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.test.ts
@@ -14,6 +14,7 @@ import type { UsersRequestOptions } from '../../../../../../common/search_strate
 import * as buildRiskQuery from '../../risk_score/all/query.risk_score.dsl';
 
 import { get } from 'lodash/fp';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy';
 
 class IndexNotFoundException extends Error {
   meta: { body: { error: { type: string } } };
@@ -115,6 +116,7 @@ describe('allHosts search strategy', () => {
       expect(buildHostsRiskQuery).toHaveBeenCalledWith({
         defaultIndex: ['ml_user_risk_score_latest_test-space'],
         filterQuery: { terms: { 'user.name': userName } },
+        riskScoreEntity: RiskScoreEntity.user,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.ts
@@ -23,7 +23,11 @@ import type {
 import type { AllUsersAggEsItem } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { buildRiskScoreQuery } from '../../risk_score/all/query.risk_score.dsl';
 import type { RiskSeverity, UserRiskScore } from '../../../../../../common/search_strategy';
-import { buildUserNamesFilter, getUserRiskIndex } from '../../../../../../common/search_strategy';
+import {
+  RiskScoreEntity,
+  buildUserNamesFilter,
+  getUserRiskIndex,
+} from '../../../../../../common/search_strategy';
 
 export const allUsers: SecuritySolutionFactory<UsersQueries.users> = {
   buildDsl: (options: UsersRequestOptions) => {
@@ -123,6 +127,7 @@ async function getUserRiskData(
       buildRiskScoreQuery({
         defaultIndex: [getUserRiskIndex(spaceId)],
         filterQuery: buildUserNamesFilter(userNames),
+        riskScoreEntity: RiskScoreEntity.user,
       })
     );
     return userRiskResponse;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -10,6 +10,7 @@ import type { ISearchStrategy, PluginStart } from '@kbn/data-plugin/server';
 import { shimHitsTotal } from '@kbn/data-plugin/server';
 import { ENHANCED_ES_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import type { KibanaRequest } from '@kbn/core/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type {
   FactoryQueryTypes,
   StrategyResponseType,
@@ -33,7 +34,8 @@ function assertValidRequestType<T extends FactoryQueryTypes>(
 export const securitySolutionSearchStrategyProvider = <T extends FactoryQueryTypes>(
   data: PluginStart,
   endpointContext: EndpointAppContext,
-  getSpaceId?: (request: KibanaRequest) => string
+  getSpaceId?: (request: KibanaRequest) => string,
+  ruleDataClient?: IRuleDataClient | null
 ): ISearchStrategy<StrategyRequestType<T>, StrategyResponseType<T>> => {
   const es = data.search.getSearchStrategy(ENHANCED_ES_SEARCH_STRATEGY);
 
@@ -60,6 +62,7 @@ export const securitySolutionSearchStrategyProvider = <T extends FactoryQueryTyp
             endpointContext,
             request: deps.request,
             spaceId: getSpaceId && getSpaceId(deps.request),
+            ruleDataClient,
           })
         )
       );

--- a/x-pack/plugins/synthetics/e2e/journeys/data_view_permissions.ts
+++ b/x-pack/plugins/synthetics/e2e/journeys/data_view_permissions.ts
@@ -48,10 +48,10 @@ journey('DataViewPermissions', async ({ page, params }) => {
   step('Click explore data button', async () => {
     await page.click(byTestId('uptimeExploreDataButton'));
     await waitForLoadingToFinish({ page });
-    await page.waitForSelector(`text=${permissionError}`, TIMEOUT_60_SEC);
-    expect(await page.$(`text=${permissionError}`)).toBeTruthy();
+  });
+
+  step('it renders for viewer user as well', async () => {
+    await page.waitForSelector(`text=browser`, TIMEOUT_60_SEC);
+    expect(await page.$(`text=Monitor duration`)).toBeTruthy();
   });
 });
-
-const permissionError =
-  "Unable to create Data View. You don't have the required permission, please contact your admin.";

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -348,7 +348,7 @@ export default function (providerContext: FtrProviderContext) {
           return 0;
         }
 
-        const policyId = 'package-policy-test-1';
+        const policyId = 'package-policy-test-';
         packagePoliciesToDeleteIds.push(policyId);
         const getPkRes = await supertest
           .get(`/api/fleet/epm/packages/system`)
@@ -436,6 +436,92 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
         expect(await getSystemPackagePolicyCopyVersion(copy3Id)).to.be(3);
+      });
+
+      it('should work with package policy with space in name', async () => {
+        const policyId = 'package-policy-test-1';
+        packagePoliciesToDeleteIds.push(policyId);
+        const getPkRes = await supertest
+          .get(`/api/fleet/epm/packages/system`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+        systemPkgVersion = getPkRes.body.item.version;
+        // we must first force install the system package to override package verification error on policy create
+        const installPromise = supertest
+          .post(`/api/fleet/epm/packages/system-${systemPkgVersion}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ force: true })
+          .expect(200);
+
+        await Promise.all([
+          installPromise,
+          kibanaServer.savedObjects.create({
+            id: policyId,
+            type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            overwrite: true,
+            attributes: {
+              name: `system-1`,
+              package: {
+                name: 'system',
+              },
+            },
+          }),
+        ]);
+
+        const {
+          body: {
+            item: { id: originalPolicyId },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .query({
+            sys_monitoring: false,
+          })
+          .send({
+            name: 'original policy with package policy with space in name',
+            namespace: 'default',
+          })
+          .expect(200);
+
+        await supertest
+          .post(`/api/fleet/package_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Filetest with space in name',
+            description: '',
+            namespace: 'default',
+            policy_id: originalPolicyId,
+            enabled: true,
+            inputs: [],
+            package: {
+              name: 'filetest',
+              title: 'For File Tests',
+              version: '0.1.0',
+            },
+          })
+          .expect(200);
+
+        const {
+          body: {
+            item: { id: copy1Id },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies/${originalPolicyId}/copy`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'copy 123',
+            description: 'Test',
+          })
+          .expect(200);
+
+        const {
+          body: {
+            item: { package_policies: packagePolicies },
+          },
+        } = await supertest.get(`/api/fleet/agent_policies/${copy1Id}`).expect(200);
+
+        expect(packagePolicies[0].name).to.eql('Filetest with space in name (copy)');
       });
 
       it('should return a 404 with invalid source policy', async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/tsvb/index.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/tsvb/index.ts
@@ -14,5 +14,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./timeseries'));
     loadTestFile(require.resolve('./dashboard'));
     loadTestFile(require.resolve('./top_n'));
+    loadTestFile(require.resolve('./table'));
   });
 }

--- a/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { visualize, visualBuilder, lens, header } = getPageObjects([
+    'visualBuilder',
+    'visualize',
+    'header',
+    'lens',
+  ]);
+
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+
+  describe('Table', function describeIndexTests() {
+    before(async () => {
+      await visualize.initTests();
+    });
+
+    beforeEach(async () => {
+      await visualBuilder.resetPage();
+      await visualBuilder.clickTable();
+      await visualBuilder.checkTableTabIsPresent();
+      await visualBuilder.selectGroupByField('machine.os.raw');
+    });
+
+    it('should not allow converting of not valid panel', async () => {
+      await visualBuilder.selectAggType('Max');
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should not allow converting of unsupported aggregations', async () => {
+      await visualBuilder.selectAggType('Sum of Squares');
+      await visualBuilder.setFieldForAggregation('machine.ram');
+
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should not allow converting sibling pipeline aggregations', async () => {
+      await visualBuilder.createNewAgg();
+
+      await visualBuilder.selectAggType('Overall Average', 1);
+      await visualBuilder.setFieldForAggregation('Count', 1);
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should not allow converting parent pipeline aggregations', async () => {
+      await visualBuilder.clickPanelOptions('table');
+      await visualBuilder.setMetricsDataTimerangeMode('Last value');
+      await visualBuilder.clickDataTab('table');
+      await visualBuilder.createNewAgg();
+
+      await visualBuilder.selectAggType('Cumulative Sum', 1);
+      await visualBuilder.setFieldForAggregation('Count', 1);
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should not allow converting not valid aggregation function', async () => {
+      await visualBuilder.clickSeriesOption();
+      await visualBuilder.setFieldForAggregateBy('timestamp');
+      await visualBuilder.setFunctionForAggregateFunction('Cumulative Sum');
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should not allow converting series with different aggregation fucntion or aggregation by', async () => {
+      await visualBuilder.createNewAggSeries();
+      await visualBuilder.selectAggType('Static Value', 1);
+      await visualBuilder.setStaticValue(10);
+      await visualBuilder.clickSeriesOption();
+      await visualBuilder.setFieldForAggregateBy('bytes');
+      await visualBuilder.setFunctionForAggregateFunction('sum');
+      await visualBuilder.clickSeriesOption(1);
+      await visualBuilder.setFieldForAggregateBy('bytes');
+      await visualBuilder.setFunctionForAggregateFunction('min');
+      await header.waitUntilLoadingHasFinished();
+      expect(await visualize.hasNavigateToLensButton()).to.be(false);
+    });
+
+    it('should allow converting a count aggregation', async () => {
+      expect(await visualize.hasNavigateToLensButton()).to.be(true);
+    });
+
+    it('should convert last value mode to reduced time range', async () => {
+      await visualBuilder.clickPanelOptions('table');
+      await visualBuilder.setMetricsDataTimerangeMode('Last value');
+      await visualBuilder.setIntervalValue('1m');
+      await visualBuilder.clickDataTab('table');
+      await header.waitUntilLoadingHasFinished();
+
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('lnsDataTable');
+      await lens.openDimensionEditor('lnsDatatable_metrics > lns-dimensionTrigger');
+      await testSubjects.click('indexPattern-advanced-accordion');
+      const reducedTimeRange = await testSubjects.find('indexPattern-dimension-reducedTimeRange');
+      expect(await reducedTimeRange.getVisibleText()).to.be('1 minute (1m)');
+      await retry.try(async () => {
+        const layerCount = await lens.getLayerCount();
+        expect(layerCount).to.be(1);
+        const metricDimensionText = await lens.getDimensionTriggerText('lnsDatatable_metrics', 0);
+        expect(metricDimensionText).to.be('Count of records last 1m');
+      });
+    });
+
+    it('should convert static value to the metric dimension', async () => {
+      await visualBuilder.createNewAggSeries();
+      await visualBuilder.selectAggType('Static Value', 1);
+      await visualBuilder.setStaticValue(10);
+
+      await header.waitUntilLoadingHasFinished();
+
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('lnsDataTable');
+      await retry.try(async () => {
+        const layerCount = await lens.getLayerCount();
+        expect(layerCount).to.be(1);
+        const metricDimensionText1 = await lens.getDimensionTriggerText('lnsDatatable_metrics', 0);
+        const metricDimensionText2 = await lens.getDimensionTriggerText('lnsDatatable_metrics', 1);
+        expect(metricDimensionText1).to.be('Count of records');
+        expect(metricDimensionText2).to.be('10');
+      });
+    });
+
+    it('should convert aggregate by to split row dimension', async () => {
+      await visualBuilder.clickSeriesOption();
+      await visualBuilder.setFieldForAggregateBy('clientip');
+      await visualBuilder.setFunctionForAggregateFunction('sum');
+      await header.waitUntilLoadingHasFinished();
+
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('lnsDataTable');
+      await retry.try(async () => {
+        const layerCount = await lens.getLayerCount();
+        expect(layerCount).to.be(1);
+        const splitRowsText1 = await lens.getDimensionTriggerText('lnsDatatable_rows', 0);
+        const splitRowsText2 = await lens.getDimensionTriggerText('lnsDatatable_rows', 1);
+        expect(splitRowsText1).to.be('Top 10 values of machine.os.raw');
+        expect(splitRowsText2).to.be('Top 10 values of clientip');
+      });
+
+      await lens.openDimensionEditor('lnsDatatable_rows > lns-dimensionTrigger', 0, 1);
+      const collapseBy = await testSubjects.find('indexPattern-collapse-by');
+      expect(await collapseBy.getAttribute('value')).to.be('sum');
+    });
+
+    it('should convert group by field with custom label', async () => {
+      await visualBuilder.setColumnLabelValue('test');
+      await header.waitUntilLoadingHasFinished();
+
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('lnsDataTable');
+      await retry.try(async () => {
+        const layerCount = await lens.getLayerCount();
+        expect(layerCount).to.be(1);
+        const splitRowsText = await lens.getDimensionTriggerText('lnsDatatable_rows', 0);
+        expect(splitRowsText).to.be('test');
+      });
+    });
+
+    it('should convert color ranges', async () => {
+      await visualBuilder.clickSeriesOption();
+
+      await visualBuilder.setColorRuleOperator('>= greater than or equal');
+      await visualBuilder.setColorRuleValue(10);
+      await visualBuilder.setColorPickerValue('#54B399');
+
+      await visualBuilder.createColorRule(1);
+
+      await visualBuilder.setColorRuleOperator('>= greater than or equal');
+      await visualBuilder.setColorRuleValue(100, 1);
+      await visualBuilder.setColorPickerValue('#54A000', 1);
+
+      await header.waitUntilLoadingHasFinished();
+      await visualize.navigateToLensFromAnotherVisulization();
+
+      await lens.waitForVisualization('lnsDataTable');
+      await retry.try(async () => {
+        const closePalettePanels = await testSubjects.findAll(
+          'lns-indexPattern-PalettePanelContainerBack'
+        );
+        if (closePalettePanels.length) {
+          await lens.closePalettePanel();
+          await lens.closeDimensionEditor();
+        }
+
+        await lens.openDimensionEditor('lnsDatatable_metrics > lns-dimensionTrigger');
+
+        await lens.openPalettePanel('lnsDatatable');
+        const colorStops = await lens.getPaletteColorStops();
+
+        expect(colorStops).to.eql([
+          { stop: '', color: 'rgba(104, 188, 0, 1)' },
+          { stop: '10', color: 'rgba(84, 179, 153, 1)' },
+          { stop: '100', color: 'rgba(84, 160, 0, 1)' },
+          { stop: '', color: undefined },
+        ]);
+      });
+    });
+  });
+}

--- a/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
@@ -34,6 +34,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     beforeEach(async () => {
       await visualBuilder.resetPage();
       await visualBuilder.clickTable();
+      await header.waitUntilLoadingHasFinished();
       await visualBuilder.checkTableTabIsPresent();
       await visualBuilder.selectGroupByField('machine.os.raw');
     });

--- a/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/tsvb/table.ts
@@ -88,10 +88,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visualBuilder.setStaticValue(10);
       await visualBuilder.clickSeriesOption();
       await visualBuilder.setFieldForAggregateBy('bytes');
-      await visualBuilder.setFunctionForAggregateFunction('sum');
+      await visualBuilder.setFunctionForAggregateFunction('Sum');
       await visualBuilder.clickSeriesOption(1);
       await visualBuilder.setFieldForAggregateBy('bytes');
-      await visualBuilder.setFunctionForAggregateFunction('min');
+      await visualBuilder.setFunctionForAggregateFunction('Min');
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.be(false);
     });
@@ -143,7 +143,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it('should convert aggregate by to split row dimension', async () => {
       await visualBuilder.clickSeriesOption();
       await visualBuilder.setFieldForAggregateBy('clientip');
-      await visualBuilder.setFunctionForAggregateFunction('sum');
+      await visualBuilder.setFunctionForAggregateFunction('Sum');
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisulization();


### PR DESCRIPTION
Completes part of https://github.com/elastic/kibana/issues/138236

## Summary

As part of phasing out TSVB and Visualize all Legacy agg based visulizations should support "open in lens" functionality.
In that PR converter for TSVB Table was added.

---
**Some conversion remarks:**

- “Group by field” becomes row split by top values
- Ignore trend arrows
- Convert sorting config on the table into client side sorting of Lens table
- Convert “Field” + “Aggregate function” into a second row split dimension  by top values which is collapsed by the aggregate function

---
**Some block cases:**

- Several series have different “Field” + “Aggregate function”
- “Aggregate function” is not `max`, `min`, `avg`, `sum`
- Several fields in “Group by field” where one of them is date field
- Only static value metics are visible
