### PR TITLE
[Guided onboarding]  Support paragraph description for steps

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
@@ -249,6 +249,62 @@ describe('Guided setup', () => {
 
         expect(find('activeStepButtonLabel').text()).toEqual('Mark done');
       });
+
+      test('should render the step description as a paragraph if it is only one sentence', async () => {
+        const { component, find } = testBed;
+
+        const mockSingleSentenceStepDescriptionGuideState: GuideState = {
+          guideId: 'observability',
+          isActive: true,
+          status: 'in_progress',
+          steps: [
+            {
+              id: 'add_data',
+              status: 'complete',
+            },
+            {
+              id: 'view_dashboard',
+              status: 'complete',
+            },
+            {
+              id: 'tour_observability',
+              status: 'in_progress',
+            },
+          ],
+        };
+
+        await updateComponentWithState(
+          component,
+          mockSingleSentenceStepDescriptionGuideState,
+          true
+        );
+
+        expect(
+          find('guidePanelStepDescription')
+            .last()
+            .containsMatchingElement(
+              <p>{guidesConfig.observability.steps[2].descriptionList[0]}</p>
+            )
+        ).toBe(true);
+      });
+
+      test('should render the step description as an unordered list if it is more than one sentence', async () => {
+        const { component, find } = testBed;
+
+        await updateComponentWithState(component, mockActiveSearchGuideState, true);
+
+        expect(
+          find('guidePanelStepDescription')
+            .first()
+            .containsMatchingElement(
+              <ul>
+                {guidesConfig.search.steps[0].descriptionList.map((description, i) => (
+                  <li key={i}>{description}</li>
+                ))}
+              </ul>
+            )
+        ).toBe(true);
+      });
     });
 
     describe('Quit guide modal', () => {

--- a/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
@@ -95,11 +95,15 @@ export const GuideStep = ({
             <EuiSpacer size="s" />
 
             <EuiText size="s">
-              <ul>
-                {stepConfig.descriptionList.map((description, index) => {
-                  return <li key={`description-${index}`}>{description}</li>;
-                })}
-              </ul>
+              {stepConfig.descriptionList.length === 1 ? (
+                <p>{stepConfig.descriptionList[0]}</p> // If there is only one description, render it as a paragraph
+              ) : (
+                <ul>
+                  {stepConfig.descriptionList.map((description, index) => {
+                    return <li key={`description-${index}`}>{description}</li>;
+                  })}
+                </ul>
+              )}
             </EuiText>
 
             <EuiSpacer />

--- a/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
@@ -93,8 +93,7 @@ export const GuideStep = ({
         >
           <>
             <EuiSpacer size="s" />
-
-            <EuiText size="s">
+            <EuiText size="s" data-test-subj="guidePanelStepDescription">
               {stepConfig.descriptionList.length === 1 ? (
                 <p>{stepConfig.descriptionList[0]}</p> // If there is only one description, render it as a paragraph
               ) : (


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/143606

### Summary

This PR addresses showing the step description as a paragraph instead of a list item when there is only one sentence in the description list. It also adds tests to ensure that the description is rendered as expected.

<details>
 <summary>Screenshot</summary>
<img width="471" alt="Screen Shot 2022-10-24 at 11 10 42" src="https://user-images.githubusercontent.com/53621505/197477877-14db5cb4-fa99-4814-8517-6f2c00c2bf84.png">
</details>