### PR TITLE
fix: use correct name for CGroup memory limit metric

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
+++ b/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
@@ -597,7 +597,7 @@ Object {
     "derivativeNormalizedUnits": true,
     "description": "Memory limit of the container",
     "docType": undefined,
-    "field": "beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes",
+    "field": "beats_stats.metrics.beat.cgroup.mem.limit.bytes",
     "fieldSource": undefined,
     "format": "0,0.0 b",
     "getDateHistogramSubAggs": undefined,

--- a/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.ts
+++ b/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.ts
@@ -633,7 +633,7 @@ export const metrics = {
   }),
 
   apm_cgroup_memory_limit: new ApmMetric({
-    field: 'beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes',
+    field: 'beats_stats.metrics.beat.cgroup.mem.limit.bytes',
     label: i18n.translate('xpack.monitoring.metrics.apmInstance.memory.memoryLimitLabel', {
       defaultMessage: 'Memory Limit',
     }),

--- a/x-pack/test/api_integration/apis/monitoring/apm/fixtures/cluster.json
+++ b/x-pack/test/api_integration/apis/monitoring/apm/fixtures/cluster.json
@@ -1108,7 +1108,7 @@
         "metric": {
           "app": "apm",
           "description": "Memory limit of the container",
-          "field": "beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes",
+          "field": "beats_stats.metrics.beat.cgroup.mem.limit.bytes",
           "format": "0,0.0 b",
           "hasCalculation": false,
           "isDerivative": false,

--- a/x-pack/test/api_integration/apis/monitoring/apm/fixtures/instance.json
+++ b/x-pack/test/api_integration/apis/monitoring/apm/fixtures/instance.json
@@ -938,7 +938,7 @@
         "metric": {
           "app": "apm",
           "description": "Memory limit of the container",
-          "field": "beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes",
+          "field": "beats_stats.metrics.beat.cgroup.mem.limit.bytes",
           "format": "0,0.0 b",
           "hasCalculation": false,
           "isDerivative": false,


### PR DESCRIPTION
## Summary

It seems memory limit metrics is affected by the same issue of memory usage.
The metric seems to plot `beats_stats.metrics.beat.cgroup.memory.mem.limit.bytes` but as per metricbeat documents the correct field should be either `beats_stats.metrics.beat.cgroup.mem.limit.bytes` or `beat.stats.cgroup.memory.mem.limit.bytes`.

Update field name and tests accordingly.

Related to https://github.com/elastic/apm-server/issues/8596




### Checklist

Delete any items that are not applicable to this PR.




### Risk Matrix

Delete this section if it is not applicable to this PR.




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
