### PR TITLE
[Security Solution] Allow Users to launch Timeline from the Entity Analytics dashboard

### DIFF
--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/risk_score/all/index.ts
@@ -9,10 +9,13 @@ import type { IEsSearchRequest, IEsSearchResponse } from '@kbn/data-plugin/commo
 import type { ESQuery } from '../../../../typed_json';
 
 import type { Inspect, Maybe, SortField, TimerangeInput } from '../../../common';
+import type { RiskScoreEntity } from '../common';
 
 export interface RiskScoreRequestOptions extends IEsSearchRequest {
   defaultIndex: string[];
+  riskScoreEntity: RiskScoreEntity;
   timerange?: TimerangeInput;
+  includeAlertsCount?: boolean;
   onlyLatest?: boolean;
   pagination?: {
     cursorStart: number;
@@ -47,6 +50,7 @@ export interface HostRiskScore {
     name: string;
     risk: RiskStats;
   };
+  alertsCount?: number;
 }
 
 export interface UserRiskScore {
@@ -55,6 +59,7 @@ export interface UserRiskScore {
     name: string;
     risk: RiskStats;
   };
+  alertsCount?: number;
 }
 
 export interface RuleRisk {
@@ -73,6 +78,7 @@ export const enum RiskScoreFields {
   userName = 'user.name',
   userRiskScore = 'user.risk.calculated_score_norm',
   userRisk = 'user.risk.calculated_level',
+  alertsCount = 'alertsCount',
 }
 
 export interface RiskScoreItem {
@@ -85,6 +91,8 @@ export interface RiskScoreItem {
 
   [RiskScoreFields.hostRiskScore]: Maybe<number>;
   [RiskScoreFields.userRiskScore]: Maybe<number>;
+
+  [RiskScoreFields.alertsCount]: Maybe<number>;
 }
 
 export const enum RiskSeverity {

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
@@ -7,19 +7,28 @@
 
 import React from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiLink, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { get } from 'lodash/fp';
 import { UsersTableType } from '../../../../users/store/model';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { HostDetailsLink, UserDetailsLink } from '../../../../common/components/links';
 import { HostsTableType } from '../../../../hosts/store/model';
 import { RiskScore } from '../../../../common/components/severity/common';
-import type { HostRiskScore, RiskSeverity } from '../../../../../common/search_strategy';
+import type {
+  HostRiskScore,
+  RiskSeverity,
+  UserRiskScore,
+} from '../../../../../common/search_strategy';
 import { RiskScoreEntity, RiskScoreFields } from '../../../../../common/search_strategy';
 import * as i18n from './translations';
+import { FormattedCount } from '../../../../common/components/formatted_number';
 
-type HostRiskScoreColumns = Array<EuiBasicTableColumn<HostRiskScore>>;
+type HostRiskScoreColumns = Array<EuiBasicTableColumn<HostRiskScore & UserRiskScore>>;
 
-export const getRiskScoreColumns = (riskEntity: RiskScoreEntity): HostRiskScoreColumns => [
+export const getRiskScoreColumns = (
+  riskEntity: RiskScoreEntity,
+  openEntityInTimeline: (hostName: string) => void
+): HostRiskScoreColumns => [
   {
     field: riskEntity === RiskScoreEntity.host ? 'host.name' : 'user.name',
     name: i18n.ENTITY_NAME(riskEntity),
@@ -74,5 +83,21 @@ export const getRiskScoreColumns = (riskEntity: RiskScoreEntity): HostRiskScoreC
       }
       return getEmptyTagValue();
     },
+  },
+  {
+    field: RiskScoreFields.alertsCount,
+    width: '15%',
+    name: i18n.ALERTS,
+    truncateText: false,
+    mobileOptions: { show: true },
+    render: (alertCount: number, risk) => (
+      <EuiLink
+        data-test-subj="risk-score-alerts"
+        disabled={alertCount === 0}
+        onClick={() => openEntityInTimeline(get('host.name', risk) ?? get('user.name', risk))}
+      >
+        <FormattedCount count={alertCount} />
+      </EuiLink>
+    ),
   },
 ];

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
@@ -27,7 +27,7 @@ type HostRiskScoreColumns = Array<EuiBasicTableColumn<HostRiskScore & UserRiskSc
 
 export const getRiskScoreColumns = (
   riskEntity: RiskScoreEntity,
-  openEntityInTimeline: (hostName: string) => void
+  openEntityInTimeline: (entityName: string) => void
 ): HostRiskScoreColumns => [
   {
     field: riskEntity === RiskScoreEntity.host ? 'host.name' : 'user.name',

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.test.tsx
@@ -9,6 +9,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { EntityAnalyticsRiskScores } from '.';
+import type { UserRiskScore } from '../../../../../common/search_strategy';
 import { RiskScoreEntity, RiskSeverity } from '../../../../../common/search_strategy';
 import type { SeverityCount } from '../../../../common/components/severity/types';
 import { useRiskScore, useRiskScoreKpi } from '../../../../risk_score/containers';
@@ -115,6 +116,39 @@ describe.each([RiskScoreEntity.host, RiskScoreEntity.user])(
       );
 
       expect(queryByTestId('entity_analytics_content')).not.toBeInTheDocument();
+    });
+
+    it('renders alerts count', () => {
+      mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });
+      mockUseRiskScoreKpi.mockReturnValue({
+        severityCount: mockSeverityCount,
+        loading: false,
+      });
+      const alertsCount = 999;
+      const data: UserRiskScore[] = [
+        {
+          '@timestamp': '1234567899',
+          user: {
+            name: 'testUsermame',
+            risk: {
+              rule_risks: [],
+              calculated_level: RiskSeverity.high,
+              calculated_score_norm: 75,
+              multipliers: [],
+            },
+          },
+          alertsCount,
+        },
+      ];
+      mockUseRiskScore.mockReturnValue({ ...defaultProps, data });
+
+      const { queryByTestId } = render(
+        <TestProviders>
+          <EntityAnalyticsRiskScores riskEntity={riskEntity} />
+        </TestProviders>
+      );
+
+      expect(queryByTestId('risk-score-alerts')).toHaveTextContent(alertsCount.toString());
     });
   }
 );

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { useDispatch } from 'react-redux';
@@ -40,6 +40,7 @@ import { Loader } from '../../../../common/components/loader';
 import { Panel } from '../../../../common/components/panel';
 import * as commonI18n from '../common/translations';
 import { usersActions } from '../../../../users/store';
+import { useNavigateToTimeline } from '../../detection_response/hooks/use_navigate_to_timeline';
 
 const HOST_RISK_TABLE_QUERY_ID = 'hostRiskDashboardTable';
 const HOST_RISK_KPI_QUERY_ID = 'headerHostRiskScoreKpiQuery';
@@ -90,8 +91,24 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
     [dispatch, riskEntity]
   );
 
+  const { openHostInTimeline, openUserInTimeline } = useNavigateToTimeline();
+
+  const openEntityInTimeline = useCallback(
+    (entityName: string) => {
+      if (riskEntity === RiskScoreEntity.host) {
+        openHostInTimeline({ hostName: entityName });
+      } else if (riskEntity === RiskScoreEntity.user) {
+        openUserInTimeline({ userName: entityName });
+      }
+    },
+    [riskEntity, openHostInTimeline, openUserInTimeline]
+  );
+
   const { toggleStatus, setToggleStatus } = useQueryToggle(entity.tableQueryId);
-  const columns = useMemo(() => getRiskScoreColumns(riskEntity), [riskEntity]);
+  const columns = useMemo(
+    () => getRiskScoreColumns(riskEntity, openEntityInTimeline),
+    [riskEntity, openEntityInTimeline]
+  );
   const [selectedSeverity, setSelectedSeverity] = useState<RiskSeverity[]>([]);
   const getSecuritySolutionLinkProps = useGetSecuritySolutionLinkProps();
 
@@ -146,6 +163,7 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
     },
     timerange,
     riskEntity,
+    includeAlertsCount: true,
   });
 
   useQueryInspector({

--- a/x-pack/plugins/security_solution/public/risk_score/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/risk_score/components/translations.ts
@@ -50,3 +50,7 @@ export const getRiskEntityTranslation = (
 
   return riskEntity === RiskScoreEntity.host ? HOST : USER;
 };
+
+export const ALERTS = i18n.translate('xpack.securitySolution.riskScore.overview.alerts', {
+  defaultMessage: 'Alerts',
+});

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.test.tsx
@@ -168,6 +168,8 @@ describe.each([RiskScoreEntity.host, RiskScoreEntity.user])(
       expect(mockSearch).toHaveBeenCalledWith({
         defaultIndex: [`ml_${riskEntity}_risk_score_latest_default`],
         factoryQueryType: `${riskEntity}sRiskScore`,
+        riskScoreEntity: riskEntity,
+        includeAlertsCount: false,
       });
     });
 

--- a/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/risk_score/containers/all/index.tsx
@@ -45,6 +45,7 @@ export interface RiskScoreState<T extends RiskScoreEntity.host | RiskScoreEntity
 export interface UseRiskScoreParams {
   filterQuery?: ESQuery | string;
   onlyLatest?: boolean;
+  includeAlertsCount?: boolean;
   pagination?:
     | {
         cursorStart: number;
@@ -76,6 +77,7 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
   skip = false,
   pagination,
   riskEntity,
+  includeAlertsCount = false,
 }: UseRiskScore<T>): RiskScoreState<T> => {
   const spaceId = useSpaceId();
   const defaultIndex = spaceId
@@ -158,6 +160,8 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
         ? {
             defaultIndex: [defaultIndex],
             factoryQueryType,
+            riskScoreEntity: riskEntity,
+            includeAlertsCount,
             filterQuery: createFilter(filterQuery),
             pagination:
               cursorStart !== undefined && querySize !== undefined
@@ -179,6 +183,8 @@ export const useRiskScore = <T extends RiskScoreEntity.host | RiskScoreEntity.us
       sort,
       requestTimerange,
       onlyLatest,
+      riskEntity,
+      includeAlertsCount,
     ]
   );
 

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -343,7 +343,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       const securitySolutionSearchStrategy = securitySolutionSearchStrategyProvider(
         depsStart.data,
         endpointContext,
-        depsStart.spaces?.spacesService?.getSpaceId
+        depsStart.spaces?.spacesService?.getSpaceId,
+        ruleDataClient
       );
 
       plugins.data.search.registerSearchStrategy(

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.test.ts
@@ -8,6 +8,7 @@
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../../../common/constants';
 
 import type { HostsRequestOptions } from '../../../../../../common/search_strategy/security_solution';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy/security_solution';
 import * as buildQuery from './query.all_hosts.dsl';
 import * as buildRiskQuery from '../../risk_score/all/query.risk_score.dsl';
 import { allHosts } from '.';
@@ -128,6 +129,7 @@ describe('allHosts search strategy', () => {
       expect(buildHostsRiskQuery).toHaveBeenCalledWith({
         defaultIndex: ['ml_host_risk_score_latest_test-space'],
         filterQuery: { terms: { 'host.name': [hostName] } },
+        riskScoreEntity: RiskScoreEntity.host,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/index.ts
@@ -19,7 +19,11 @@ import type {
 } from '../../../../../../common/search_strategy/security_solution/hosts';
 
 import type { HostRiskScore } from '../../../../../../common/search_strategy';
-import { getHostRiskIndex, buildHostNamesFilter } from '../../../../../../common/search_strategy';
+import {
+  RiskScoreEntity,
+  getHostRiskIndex,
+  buildHostNamesFilter,
+} from '../../../../../../common/search_strategy';
 
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import type { SecuritySolutionFactory } from '../../types';
@@ -116,6 +120,7 @@ async function getHostRiskData(
       buildRiskScoreQuery({
         defaultIndex: [getHostRiskIndex(spaceId)],
         filterQuery: buildHostNamesFilter(hostNames),
+        riskScoreEntity: RiskScoreEntity.host,
       })
     );
     return hostRiskResponse;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { riskScore } from '.';
+import type { IEsSearchResponse } from '@kbn/data-plugin/public';
+import { allowedExperimentalValues } from '../../../../../../common/experimental_features';
+import type {
+  HostRiskScore,
+  RiskScoreRequestOptions,
+} from '../../../../../../common/search_strategy';
+import { RiskScoreEntity, RiskSeverity } from '../../../../../../common/search_strategy';
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import type { EndpointAppContext } from '../../../../../endpoint/types';
+import * as buildQuery from './query.risk_score.dsl';
+import { get } from 'lodash/fp';
+import { ruleRegistryMocks } from '@kbn/rule-registry-plugin/server/mocks';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+
+export const mockSearchStrategyResponse: IEsSearchResponse<HostRiskScore> = {
+  rawResponse: {
+    took: 1,
+    timed_out: false,
+    _shards: {
+      total: 2,
+      successful: 2,
+      skipped: 1,
+      failed: 0,
+    },
+    hits: {
+      max_score: null,
+      hits: [
+        {
+          _id: '4',
+          _index: 'index',
+          _source: {
+            '@timestamp': '1234567899',
+            host: {
+              name: 'testUsermame',
+              risk: {
+                rule_risks: [],
+                calculated_level: RiskSeverity.high,
+                calculated_score_norm: 75,
+                multipliers: [],
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+  isPartial: false,
+  isRunning: false,
+  total: 2,
+  loaded: 2,
+};
+
+const searchMock = jest.fn();
+
+const mockDeps = {
+  esClient: {} as IScopedClusterClient,
+  ruleDataClient: {
+    ...(ruleRegistryMocks.createRuleDataClient('.alerts-security.alerts') as IRuleDataClient),
+    getReader: jest.fn((_options?: { namespace?: string }) => ({
+      search: searchMock,
+      getDynamicIndexPattern: jest.fn(),
+    })),
+  },
+  savedObjectsClient: {} as SavedObjectsClientContract,
+  endpointContext: {
+    logFactory: {
+      get: jest.fn().mockReturnValue({
+        warn: jest.fn(),
+      }),
+    },
+    config: jest.fn().mockResolvedValue({}),
+    experimentalFeatures: {
+      ...allowedExperimentalValues,
+    },
+    service: {} as EndpointAppContextService,
+  } as EndpointAppContext,
+  request: {} as KibanaRequest,
+};
+
+export const mockOptions: RiskScoreRequestOptions = {
+  defaultIndex: ['logs-*'],
+  riskScoreEntity: RiskScoreEntity.host,
+  includeAlertsCount: true,
+};
+
+describe('buildRiskScoreQuery search strategy', () => {
+  const buildKpiRiskScoreQuery = jest.spyOn(buildQuery, 'buildRiskScoreQuery');
+
+  describe('buildDsl', () => {
+    test('should build dsl query', () => {
+      riskScore.buildDsl(mockOptions);
+      expect(buildKpiRiskScoreQuery).toHaveBeenCalledWith(mockOptions);
+    });
+  });
+
+  test('should not enhance data when includeAlertsCount is false', async () => {
+    const result = await riskScore.parse(
+      { ...mockOptions, includeAlertsCount: false },
+      mockSearchStrategyResponse,
+      mockDeps
+    );
+
+    expect(get('data[0].alertsCount', result)).toBeUndefined();
+  });
+
+  test('should enhance data with alerts count', async () => {
+    const alertsCunt = 9999;
+    searchMock.mockReturnValue({
+      aggregations: {
+        alertsByEntity: {
+          buckets: [
+            {
+              key: 'testUsermame',
+              doc_count: alertsCunt,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await riskScore.parse(mockOptions, mockSearchStrategyResponse, mockDeps);
+
+    expect(get('data[0].alertsCount', result)).toBe(alertsCunt);
+  });
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
@@ -5,12 +5,19 @@
  * 2.0.
  */
 
-import type { IEsSearchResponse } from '@kbn/data-plugin/common';
+import type { IEsSearchResponse, SearchRequest } from '@kbn/data-plugin/common';
+import { get, getOr } from 'lodash/fp';
+
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type { SecuritySolutionFactory } from '../../types';
 import type {
   RiskScoreRequestOptions,
   RiskQueries,
+  BucketItem,
+  HostRiskScore,
+  UserRiskScore,
 } from '../../../../../../common/search_strategy';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy';
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import { buildRiskScoreQuery } from './query.risk_score.dsl';
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../../../common/constants';
@@ -26,7 +33,14 @@ export const riskScore: SecuritySolutionFactory<
 
     return buildRiskScoreQuery(options);
   },
-  parse: async (options: RiskScoreRequestOptions, response: IEsSearchResponse) => {
+  parse: async (
+    options: RiskScoreRequestOptions,
+    response: IEsSearchResponse,
+    deps?: {
+      spaceId?: string;
+      ruleDataClient?: IRuleDataClient;
+    }
+  ) => {
     const inspect = {
       dsl: [inspectStringifyObject(buildRiskScoreQuery(options))],
     };
@@ -34,11 +48,67 @@ export const riskScore: SecuritySolutionFactory<
     const totalCount = getTotalCount(response.rawResponse.hits.total);
     const hits = response?.rawResponse?.hits?.hits;
     const data = hits?.map((hit) => hit._source) ?? [];
+    const nameField = options.riskScoreEntity === RiskScoreEntity.host ? 'host.name' : 'user.name';
+    const names = data.map((risk) => get(nameField, risk) ?? '');
+
+    const enhancedData =
+      deps && options.includeAlertsCount
+        ? await enhanceData(data, names, nameField, deps.ruleDataClient, deps.spaceId)
+        : data;
+
     return {
       ...response,
       inspect,
       totalCount,
-      data,
+      data: enhancedData,
     };
   },
 };
+
+async function enhanceData(
+  data: Array<HostRiskScore | UserRiskScore>,
+  names: string[],
+  nameField: string,
+  ruleDataClient?: IRuleDataClient,
+  spaceId?: string
+): Promise<Array<HostRiskScore | UserRiskScore>> {
+  const ruleDataReader = ruleDataClient?.getReader({ namespace: spaceId });
+  const query = getAlertsQueryForEntity(names, nameField);
+
+  const response = await ruleDataReader?.search(query);
+  const buckets: BucketItem[] = getOr([], 'aggregations.alertsByEntity.buckets', response);
+
+  const alertsCountByEntityName: Record<string, number> | undefined = buckets.reduce(
+    (acc, { key, doc_count: count }) => ({
+      ...acc,
+      [key]: count,
+    }),
+    {}
+  );
+
+  return alertsCountByEntityName
+    ? data.map((risk) => ({
+        ...risk,
+        alertsCount: alertsCountByEntityName[get(nameField, risk)] ?? 0,
+      }))
+    : data;
+}
+
+const getAlertsQueryForEntity = (names: string[], nameField: string): SearchRequest => ({
+  size: 0,
+  query: {
+    bool: {
+      filter: [
+        { term: { 'kibana.alert.workflow_status': 'open' } },
+        { terms: { [nameField]: names } },
+      ],
+    },
+  },
+  aggs: {
+    alertsByEntity: {
+      terms: {
+        field: nameField,
+      },
+    },
+  },
+});

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
@@ -38,7 +38,7 @@ export const riskScore: SecuritySolutionFactory<
     response: IEsSearchResponse,
     deps?: {
       spaceId?: string;
-      ruleDataClient?: IRuleDataClient;
+      ruleDataClient?: IRuleDataClient | null;
     }
   ) => {
     const inspect = {
@@ -69,7 +69,7 @@ async function enhanceData(
   data: Array<HostRiskScore | UserRiskScore>,
   names: string[],
   nameField: string,
-  ruleDataClient?: IRuleDataClient,
+  ruleDataClient?: IRuleDataClient | null,
   spaceId?: string
 ): Promise<Array<HostRiskScore | UserRiskScore>> {
   const ruleDataReader = ruleDataClient?.getReader({ namespace: spaceId });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/risk_score/all/index.ts
@@ -78,7 +78,7 @@ async function enhanceData(
   const response = await ruleDataReader?.search(query);
   const buckets: BucketItem[] = getOr([], 'aggregations.alertsByEntity.buckets', response);
 
-  const alertsCountByEntityName: Record<string, number> | undefined = buckets.reduce(
+  const alertsCountByEntityName: Record<string, number> = buckets.reduce(
     (acc, { key, doc_count: count }) => ({
       ...acc,
       [key]: count,
@@ -86,12 +86,10 @@ async function enhanceData(
     {}
   );
 
-  return alertsCountByEntityName
-    ? data.map((risk) => ({
-        ...risk,
-        alertsCount: alertsCountByEntityName[get(nameField, risk)] ?? 0,
-      }))
-    : data;
+  return data.map((risk) => ({
+    ...risk,
+    alertsCount: alertsCountByEntityName[get(nameField, risk)] ?? 0,
+  }));
 }
 
 const getAlertsQueryForEntity = (names: string[], nameField: string): SearchRequest => ({

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -11,6 +11,7 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import type { IEsSearchResponse, ISearchRequestParams } from '@kbn/data-plugin/common';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type {
   FactoryQueryTypes,
   StrategyRequestType,
@@ -29,6 +30,7 @@ export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
       endpointContext: EndpointAppContext;
       request: KibanaRequest;
       spaceId?: string;
+      ruleDataClient?: IRuleDataClient;
     }
   ) => Promise<StrategyResponseType<T>>;
 }

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -30,7 +30,7 @@ export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
       endpointContext: EndpointAppContext;
       request: KibanaRequest;
       spaceId?: string;
-      ruleDataClient?: IRuleDataClient;
+      ruleDataClient?: IRuleDataClient | null;
     }
   ) => Promise<StrategyResponseType<T>>;
 }

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.test.ts
@@ -14,6 +14,7 @@ import type { UsersRequestOptions } from '../../../../../../common/search_strate
 import * as buildRiskQuery from '../../risk_score/all/query.risk_score.dsl';
 
 import { get } from 'lodash/fp';
+import { RiskScoreEntity } from '../../../../../../common/search_strategy';
 
 class IndexNotFoundException extends Error {
   meta: { body: { error: { type: string } } };
@@ -115,6 +116,7 @@ describe('allHosts search strategy', () => {
       expect(buildHostsRiskQuery).toHaveBeenCalledWith({
         defaultIndex: ['ml_user_risk_score_latest_test-space'],
         filterQuery: { terms: { 'user.name': userName } },
+        riskScoreEntity: RiskScoreEntity.user,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users/all/index.ts
@@ -23,7 +23,11 @@ import type {
 import type { AllUsersAggEsItem } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { buildRiskScoreQuery } from '../../risk_score/all/query.risk_score.dsl';
 import type { RiskSeverity, UserRiskScore } from '../../../../../../common/search_strategy';
-import { buildUserNamesFilter, getUserRiskIndex } from '../../../../../../common/search_strategy';
+import {
+  RiskScoreEntity,
+  buildUserNamesFilter,
+  getUserRiskIndex,
+} from '../../../../../../common/search_strategy';
 
 export const allUsers: SecuritySolutionFactory<UsersQueries.users> = {
   buildDsl: (options: UsersRequestOptions) => {
@@ -123,6 +127,7 @@ async function getUserRiskData(
       buildRiskScoreQuery({
         defaultIndex: [getUserRiskIndex(spaceId)],
         filterQuery: buildUserNamesFilter(userNames),
+        riskScoreEntity: RiskScoreEntity.user,
       })
     );
     return userRiskResponse;

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -10,6 +10,7 @@ import type { ISearchStrategy, PluginStart } from '@kbn/data-plugin/server';
 import { shimHitsTotal } from '@kbn/data-plugin/server';
 import { ENHANCED_ES_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import type { KibanaRequest } from '@kbn/core/server';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type {
   FactoryQueryTypes,
   StrategyResponseType,
@@ -33,7 +34,8 @@ function assertValidRequestType<T extends FactoryQueryTypes>(
 export const securitySolutionSearchStrategyProvider = <T extends FactoryQueryTypes>(
   data: PluginStart,
   endpointContext: EndpointAppContext,
-  getSpaceId?: (request: KibanaRequest) => string
+  getSpaceId?: (request: KibanaRequest) => string,
+  ruleDataClient: IRuleDataClient | null
 ): ISearchStrategy<StrategyRequestType<T>, StrategyResponseType<T>> => {
   const es = data.search.getSearchStrategy(ENHANCED_ES_SEARCH_STRATEGY);
 
@@ -60,6 +62,7 @@ export const securitySolutionSearchStrategyProvider = <T extends FactoryQueryTyp
             endpointContext,
             request: deps.request,
             spaceId: getSpaceId && getSpaceId(deps.request),
+            ruleDataClient,
           })
         )
       );

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -35,7 +35,7 @@ export const securitySolutionSearchStrategyProvider = <T extends FactoryQueryTyp
   data: PluginStart,
   endpointContext: EndpointAppContext,
   getSpaceId?: (request: KibanaRequest) => string,
-  ruleDataClient: IRuleDataClient | null
+  ruleDataClient?: IRuleDataClient | null
 ): ISearchStrategy<StrategyRequestType<T>, StrategyResponseType<T>> => {
   const es = data.search.getSearchStrategy(ENHANCED_ES_SEARCH_STRATEGY);
 


### PR DESCRIPTION
issue: https://github.com/elastic/security-team/issues/4938

## Summary

Allow Users to launch Timeline from the Entity Analytics dashboard 
![Oct-24-2022 14-47-25](https://user-images.githubusercontent.com/1490444/197531028-b23180de-10d3-497a-82bc-05d443f550be.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser]
