### PR TITLE
[Files] Fix image intersection observer behavior

### DIFF
--- a/x-pack/examples/files_example/public/components/app.tsx
+++ b/x-pack/examples/files_example/public/components/app.tsx
@@ -36,8 +36,10 @@ interface FilesExampleAppDeps {
 type ListResponse = FilesClientResponses<MyImageMetadata>['list'];
 
 export const FilesExampleApp = ({ files, notifications }: FilesExampleAppDeps) => {
-  const { data, isLoading, error, refetch } = useQuery<ListResponse>(['files'], () =>
-    files.example.list()
+  const { data, isLoading, error, refetch } = useQuery<ListResponse>(
+    ['files'],
+    () => files.example.list(),
+    { refetchOnWindowFocus: false }
   );
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showFilePickerModal, setShowFilePickerModal] = useState(false);

--- a/x-pack/examples/files_example/public/components/file_picker.tsx
+++ b/x-pack/examples/files_example/public/components/file_picker.tsx
@@ -18,5 +18,5 @@ interface Props {
 }
 
 export const MyFilePicker: FunctionComponent<Props> = ({ onClose, onDone }) => {
-  return <FilePicker kind={exampleFileKind.id} onClose={onClose} onDone={onDone} />;
+  return <FilePicker kind={exampleFileKind.id} onClose={onClose} onDone={onDone} pageSize={50} />;
 };

--- a/x-pack/plugins/files/public/components/file_picker/components/file_card.tsx
+++ b/x-pack/plugins/files/public/components/file_picker/components/file_card.tsx
@@ -58,11 +58,6 @@ export const FileCard: FunctionComponent<Props> = ({ file }) => {
               `}
               meta={file.meta as FileImageMetadata}
               src={client.getDownloadHref({ id: file.id, fileKind: kind })}
-              // There is an issue where the intersection observer does not fire reliably.
-              // I'm not sure if this is becuause of the image being in a modal
-              // The result is that the image does not always get loaded.
-              // TODO: Investigate this behaviour further
-              lazy={false}
             />
           ) : (
             <div

--- a/x-pack/plugins/files/public/components/image/components/img.tsx
+++ b/x-pack/plugins/files/public/components/image/components/img.tsx
@@ -25,7 +25,8 @@ export const Img = React.forwardRef<HTMLImageElement, Props>(
       `,
       !src
         ? css`
-            position: absolute;
+            position: absolute; // ensure that the image is visible at the top
+            top: 0;
             visibility: hidden;
           `
         : undefined,

--- a/x-pack/plugins/files/public/components/image/components/img.tsx
+++ b/x-pack/plugins/files/public/components/image/components/img.tsx
@@ -12,20 +12,20 @@ import { css } from '@emotion/react';
 import { sizes } from '../styles';
 
 export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
-  hidden: boolean;
   size?: EuiImageSize;
   observerRef: (el: null | HTMLImageElement) => void;
 }
 
 export const Img = React.forwardRef<HTMLImageElement, Props>(
-  ({ observerRef, src, hidden, size, ...rest }, ref) => {
+  ({ observerRef, src, size, ...rest }, ref) => {
     const { euiTheme } = useEuiTheme();
     const styles = [
       css`
         transition: opacity ${euiTheme.animation.extraFast};
       `,
-      hidden
+      !src
         ? css`
+            position: absolute;
             visibility: hidden;
           `
         : undefined,

--- a/x-pack/plugins/files/public/components/image/components/img.tsx
+++ b/x-pack/plugins/files/public/components/image/components/img.tsx
@@ -25,9 +25,12 @@ export const Img = React.forwardRef<HTMLImageElement, Props>(
       `,
       !src
         ? css`
-            position: absolute; // ensure that the image is visible at the top
-            top: 0;
             visibility: hidden;
+            position: absolute; // ensure that empty img tag occupies full container
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
           `
         : undefined,
       size ? sizes[size] : undefined,

--- a/x-pack/plugins/files/public/components/image/image.tsx
+++ b/x-pack/plugins/files/public/components/image/image.tsx
@@ -32,15 +32,6 @@ export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
    * Emits when the image first becomes visible
    */
   onFirstVisible?: () => void;
-
-  /**
-   * As an optimisation images are only loaded when they are visible.
-   * This setting overrides this behavior and loads an image as soon as the
-   * component mounts.
-   *
-   * @default true
-   */
-  lazy?: boolean;
 }
 
 /**
@@ -55,25 +46,12 @@ export interface Props extends ImgHTMLAttributes<HTMLImageElement> {
  */
 export const Image = React.forwardRef<HTMLImageElement, Props>(
   (
-    {
-      src,
-      alt,
-      onFirstVisible,
-      onLoad,
-      onError,
-      meta,
-      wrapperProps,
-      size = 'original',
-      lazy = true,
-      ...rest
-    },
+    { src, alt, onFirstVisible, onLoad, onError, meta, wrapperProps, size = 'original', ...rest },
     ref
   ) => {
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
     const [blurDelayExpired, setBlurDelayExpired] = useState(false);
     const { isVisible, ref: observerRef } = useViewportObserver({ onFirstVisible });
-
-    const loadImage = lazy ? isVisible : true;
 
     useEffect(() => {
       let unmounted = false;
@@ -112,8 +90,7 @@ export const Image = React.forwardRef<HTMLImageElement, Props>(
           observerRef={observerRef}
           ref={ref}
           size={size}
-          hidden={!loadImage}
-          src={loadImage ? src : undefined}
+          src={isVisible ? src : undefined}
           alt={alt}
           onLoad={(ev) => {
             setIsLoaded(true);

--- a/x-pack/plugins/files/public/components/image/image.tsx
+++ b/x-pack/plugins/files/public/components/image/image.tsx
@@ -54,12 +54,10 @@ export const Image = React.forwardRef<HTMLImageElement, Props>(
     const { isVisible, ref: observerRef } = useViewportObserver({ onFirstVisible });
 
     useEffect(() => {
-      let unmounted = false;
       const id = window.setTimeout(() => {
-        if (!unmounted) setBlurDelayExpired(true);
+        setBlurDelayExpired(true);
       }, 200);
       return () => {
-        unmounted = true;
         window.clearTimeout(id);
       };
     }, []);


### PR DESCRIPTION
## Summary

Occasionally the observer does not fire with a "visible" event for the image tag. This happened because the img tag was placed below the blurhash and could be pushed out of view in a component with overflow hidden (as is the case in the file picker https://github.com/elastic/kibana/pull/143111). The result (see screenshot) is that the image can get "stuck" on the blurhash.

This PR makes the image tag appear "on top" of the blurhash so that when the container is scrolled into view it will render correctly.

Original context: https://github.com/elastic/kibana/pull/143111/files#r999145694

Also removes the "lazy" option from the `Image` component since it should, preferably, always load lazily.

## How to reproduce the issue
On main

1. Launch Kibana with `--run-examples`
2. Go to the developer examples section in the side nav and open the file picker app
3. Ensure that you have a bunch of files uploaded
4. Click on the "Select a file" button to open the file picker
5. Flip back and forth between pages, scrolling down.

## The issue

<img width="1212" alt="Screenshot 2022-10-24 at 12 25 21" src="https://user-images.githubusercontent.com/8155004/197507308-1dcf6ea8-19a3-474c-9882-3b21dd184a84.png">

