### PR TITLE
[Guided onboarding] Revised layout for panel footer

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -40,7 +40,7 @@ export const getGuidePanelStyles = (euiTheme: EuiThemeComputed) => ({
     `,
     flyoutFooter: css`
       border-radius: 0 0 6px 6px;
-      background: ${euiTheme.colors.ghost};
+      background: transparent;
       padding: 24px 30px;
     `,
     flyoutFooterLink: css`

--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -43,5 +43,15 @@ export const getGuidePanelStyles = (euiTheme: EuiThemeComputed) => ({
       background: ${euiTheme.colors.ghost};
       padding: 24px 30px;
     `,
+    flyoutFooterLink: css`
+      color: ${euiTheme.colors.darkShade};
+      font-weight: 400;
+
+      svg[data-icon-type='questionInCircle'] {
+        width: 21px;
+        height: 21px;
+        margin-left: -2px;
+      }
+    `,
   },
 });

--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -46,12 +46,6 @@ export const getGuidePanelStyles = (euiTheme: EuiThemeComputed) => ({
     flyoutFooterLink: css`
       color: ${euiTheme.colors.darkShade};
       font-weight: 400;
-
-      svg[data-icon-type='questionInCircle'] {
-        width: 21px;
-        height: 21px;
-        margin-left: -2px;
-      }
     `,
   },
 });

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -296,6 +296,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
                   href="https://cloud.elastic.co/support "
                   target="_blank"
                   css={styles.flyoutOverrides.flyoutFooterLink}
+                  iconSize="m"
                 >
                   {i18n.translate('guidedOnboarding.dropdownPanel.footer.support', {
                     defaultMessage: 'Need help?',
@@ -314,6 +315,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
                   href="https://www.elastic.co/kibana/feedback"
                   target="_blank"
                   css={styles.flyoutOverrides.flyoutFooterLink}
+                  iconSize="s"
                 >
                   {i18n.translate('guidedOnboarding.dropdownPanel.footer.feedback', {
                     defaultMessage: 'Give feedback',
@@ -332,6 +334,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
                   onClick={openQuitGuideModal}
                   data-test-subj="quitGuideButton"
                   css={styles.flyoutOverrides.flyoutFooterLink}
+                  iconSize="s"
                 >
                   {i18n.translate('guidedOnboarding.dropdownPanel.footer.exitGuideButtonLabel', {
                     defaultMessage: 'Quit guide',

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -289,56 +289,55 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
           </EuiFlyoutBody>
 
           <EuiFlyoutFooter css={styles.flyoutOverrides.flyoutFooter}>
-            <EuiFlexGroup direction="column" alignItems="center" gutterSize="xs">
-              <EuiFlexItem>
-                <EuiButtonEmpty onClick={openQuitGuideModal} data-test-subj="quitGuideButton">
-                  {i18n.translate('guidedOnboarding.dropdownPanel.footer.exitGuideButtonLabel', {
-                    defaultMessage: 'Quit setup guide',
+            <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="xs">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="questionInCircle"
+                  iconSide="right"
+                  href="https://cloud.elastic.co/support "
+                  target="_blank"
+                  css={styles.flyoutOverrides.flyoutFooterLink}
+                >
+                  {i18n.translate('guidedOnboarding.dropdownPanel.footer.support', {
+                    defaultMessage: 'Need help?',
                   })}
                 </EuiButtonEmpty>
               </EuiFlexItem>
-
-              <EuiFlexItem>
-                <EuiText color="subdued" textAlign="center">
-                  <FormattedMessage
-                    id="guidedOnboarding.dropdownPanel.footer.feedbackDescription"
-                    defaultMessage="How's onboarding? We’d love your {feedbackLink}"
-                    values={{
-                      feedbackLink: (
-                        <EuiLink
-                          href="https://www.elastic.co/kibana/feedback"
-                          target="_blank"
-                          external
-                        >
-                          {i18n.translate('guidedOnboarding.dropdownPanel.footer.feedbackLabel', {
-                            defaultMessage: 'feedback',
-                          })}
-                        </EuiLink>
-                      ),
-                    }}
-                  />
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" style={{ color: euiTheme.colors.disabled }}>
+                  |
                 </EuiText>
               </EuiFlexItem>
-
-              <EuiFlexItem>
-                <EuiText color="subdued" textAlign="center">
-                  <FormattedMessage
-                    id="guidedOnboarding.dropdownPanel.footer.supportDescription"
-                    defaultMessage="Other questions? We're {helpLink}"
-                    values={{
-                      helpLink: (
-                        <EuiLink href="https://cloud.elastic.co/support " target="_blank" external>
-                          {i18n.translate(
-                            'guidedOnboarding.dropdownPanel.footer.helpTextDescription',
-                            {
-                              defaultMessage: 'here to help',
-                            }
-                          )}
-                        </EuiLink>
-                      ),
-                    }}
-                  />
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="faceHappy"
+                  iconSide="right"
+                  href="https://www.elastic.co/kibana/feedback"
+                  target="_blank"
+                  css={styles.flyoutOverrides.flyoutFooterLink}
+                >
+                  {i18n.translate('guidedOnboarding.dropdownPanel.footer.feedback', {
+                    defaultMessage: 'Give feedback',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" style={{ color: euiTheme.colors.disabled }}>
+                  |
                 </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="exit"
+                  iconSide="right"
+                  onClick={openQuitGuideModal}
+                  data-test-subj="quitGuideButton"
+                  css={styles.flyoutOverrides.flyoutFooterLink}
+                >
+                  {i18n.translate('guidedOnboarding.dropdownPanel.footer.exitGuideButtonLabel', {
+                    defaultMessage: 'Quit guide',
+                  })}
+                </EuiButtonEmpty>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlyoutFooter>

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -304,7 +304,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiText size="xs" style={{ color: euiTheme.colors.disabled }}>
+                <EuiText size="xs" color={euiTheme.colors.disabled}>
                   |
                 </EuiText>
               </EuiFlexItem>
@@ -323,7 +323,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiText size="xs" style={{ color: euiTheme.colors.disabled }}>
+                <EuiText size="xs" color={euiTheme.colors.disabled}>
                   |
                 </EuiText>
               </EuiFlexItem>

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -27,7 +27,6 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 
 import { ApplicationStart } from '@kbn/core/public';
 import type { GuideState, GuideStep as GuideStepStatus } from '@kbn/guided-onboarding';


### PR DESCRIPTION
## Summary

Modifying the layout of the panel footer to be all on one line. There is a custom style class that was added to style the links and the "Need help" icon as by default the icons appear mismatched.  Let me know if you think there is a better way to organize this.

**Screenshots**:
![image](https://user-images.githubusercontent.com/11224465/197520211-a1fd8866-4616-447b-8880-03cf983ab76e.png)

