### PR TITLE
[APM] Make `track_total_hits` and `size` required in apm alerting client

### DIFF
--- a/x-pack/plugins/apm/server/routes/alerts/alerting_es_client.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/alerting_es_client.ts
@@ -8,7 +8,13 @@
 import type { ESSearchRequest, ESSearchResponse } from '@kbn/es-types';
 import { RuleExecutorServices } from '@kbn/alerting-plugin/server';
 
-export async function alertingEsClient<TParams extends ESSearchRequest>({
+export type APMEventESSearchRequestParams = ESSearchRequest & {
+  body: { size: number; track_total_hits: boolean | number };
+};
+
+export async function alertingEsClient<
+  TParams extends APMEventESSearchRequestParams
+>({
   scopedClusterClient,
   params,
 }: {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/anomaly/register_anomaly_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/anomaly/register_anomaly_rule_type.ts
@@ -61,7 +61,7 @@ const paramsSchema = schema.object({
   ]),
 });
 
-const alertTypeConfig = RULE_TYPES_CONFIG[ApmRuleType.Anomaly];
+const ruleTypeConfig = RULE_TYPES_CONFIG[ApmRuleType.Anomaly];
 
 export function registerAnomalyRuleType({
   logger,
@@ -78,9 +78,9 @@ export function registerAnomalyRuleType({
   alerting.registerType(
     createLifecycleRuleType({
       id: ApmRuleType.Anomaly,
-      name: alertTypeConfig.name,
-      actionGroups: alertTypeConfig.actionGroups,
-      defaultActionGroupId: alertTypeConfig.defaultActionGroupId,
+      name: ruleTypeConfig.name,
+      actionGroups: ruleTypeConfig.actionGroups,
+      defaultActionGroupId: ruleTypeConfig.defaultActionGroupId,
       validate: {
         params: paramsSchema,
       },
@@ -272,7 +272,7 @@ export function registerAnomalyRuleType({
                 [ALERT_REASON]: reasonMessage,
               },
             })
-            .scheduleActions(alertTypeConfig.defaultActionGroupId, {
+            .scheduleActions(ruleTypeConfig.defaultActionGroupId, {
               serviceName,
               transactionType,
               environment: getEnvironmentLabel(environment),

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/anomaly/register_anomaly_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/anomaly/register_anomaly_rule_type.ts
@@ -61,7 +61,7 @@ const paramsSchema = schema.object({
   ]),
 });
 
-const ruleTypeConfig = RULE_TYPES_CONFIG[ApmRuleType.Anomaly];
+const alertTypeConfig = RULE_TYPES_CONFIG[ApmRuleType.Anomaly];
 
 export function registerAnomalyRuleType({
   logger,
@@ -78,9 +78,9 @@ export function registerAnomalyRuleType({
   alerting.registerType(
     createLifecycleRuleType({
       id: ApmRuleType.Anomaly,
-      name: ruleTypeConfig.name,
-      actionGroups: ruleTypeConfig.actionGroups,
-      defaultActionGroupId: ruleTypeConfig.defaultActionGroupId,
+      name: alertTypeConfig.name,
+      actionGroups: alertTypeConfig.actionGroups,
+      defaultActionGroupId: alertTypeConfig.defaultActionGroupId,
       validate: {
         params: paramsSchema,
       },
@@ -145,6 +145,7 @@ export function registerAnomalyRuleType({
         const jobIds = mlJobs.map((job) => job.jobId);
         const anomalySearchParams = {
           body: {
+            track_total_hits: false,
             size: 0,
             query: {
               bool: {
@@ -271,7 +272,7 @@ export function registerAnomalyRuleType({
                 [ALERT_REASON]: reasonMessage,
               },
             })
-            .scheduleActions(ruleTypeConfig.defaultActionGroupId, {
+            .scheduleActions(alertTypeConfig.defaultActionGroupId, {
               serviceName,
               transactionType,
               environment: getEnvironmentLabel(environment),

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
@@ -83,18 +83,19 @@ export function registerErrorCountRuleType({
       producer: APM_SERVER_FEATURE_ID,
       minimumLicenseRequired: 'basic',
       isExportable: true,
-      executor: async ({ services, params }) => {
+      executor: async ({ services, params: ruleParams }) => {
         const config = await firstValueFrom(config$);
-        const ruleParams = params;
 
         const indices = await getApmIndices({
           config,
           savedObjectsClient: services.savedObjectsClient,
         });
+
         const searchParams = {
           index: indices.error,
-          size: 0,
           body: {
+            track_total_hits: false,
+            size: 0,
             query: {
               bool: {
                 filter: [

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -125,6 +125,7 @@ export function registerTransactionDurationRuleType({
       const searchParams = {
         index,
         body: {
+          track_total_hits: false,
           size: 0,
           query: {
             bool: {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
@@ -112,8 +112,9 @@ export function registerTransactionErrorRateRuleType({
 
         const searchParams = {
           index,
-          size: 0,
           body: {
+            track_total_hits: false,
+            size: 0,
             query: {
               bool: {
                 filter: [


### PR DESCRIPTION
`track_total_hits` and `size` are required params in our other es clients (`apmEventClient` and `infraMetricsClient`). This brings the alerting client on par with the others.