### PR TITLE
Fix failing test: printablePdfV2 allows width and height to have decimal, and others

### DIFF
--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -64,13 +64,14 @@ export default function ({ getService }: FtrProviderContext) {
       await runMigrate(); // ensure that the ILM policy exists for the first test
     });
 
-    after(async () => {
-      await reportingAPI.teardownLogs();
-    });
-
     afterEach(async () => {
       await reportingAPI.deleteAllReports();
       await runMigrate(); // ensure that the ILM policy exists
+    });
+
+    after(async () => {
+      await reportingAPI.teardownLogs();
+      await reportingAPI.makeAllReportingIndicesUnmanaged(); // ensure that a delete phase does not remove the index while future tests are running
     });
 
     it('detects when no migration is needed', async () => {

--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -19,13 +19,13 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await reportingAPI.createTestReportingUser();
     });
 
-    // loadTestFile(require.resolve('./bwc_existing_indexes'));
+    loadTestFile(require.resolve('./bwc_existing_indexes'));
     loadTestFile(require.resolve('./security_roles_privileges'));
-    // loadTestFile(require.resolve('./download_csv_dashboard'));
-    // loadTestFile(require.resolve('./generate_csv_discover'));
-    // loadTestFile(require.resolve('./network_policy'));
-    // loadTestFile(require.resolve('./spaces'));
-    // loadTestFile(require.resolve('./usage'));
+    loadTestFile(require.resolve('./download_csv_dashboard'));
+    loadTestFile(require.resolve('./generate_csv_discover'));
+    loadTestFile(require.resolve('./network_policy'));
+    loadTestFile(require.resolve('./spaces'));
+    loadTestFile(require.resolve('./usage'));
     loadTestFile(require.resolve('./error_codes'));
     loadTestFile(require.resolve('./validation'));
     // loadTestFile(require.resolve('./ilm_migration_apis')); // FIXME is this the cause of flaky?

--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -19,16 +19,16 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await reportingAPI.createTestReportingUser();
     });
 
-    loadTestFile(require.resolve('./bwc_existing_indexes'));
+    // loadTestFile(require.resolve('./bwc_existing_indexes'));
     loadTestFile(require.resolve('./security_roles_privileges'));
-    loadTestFile(require.resolve('./download_csv_dashboard'));
-    loadTestFile(require.resolve('./generate_csv_discover'));
-    loadTestFile(require.resolve('./network_policy'));
-    loadTestFile(require.resolve('./spaces'));
-    loadTestFile(require.resolve('./usage'));
-    loadTestFile(require.resolve('./ilm_migration_apis'));
+    // loadTestFile(require.resolve('./download_csv_dashboard'));
+    // loadTestFile(require.resolve('./generate_csv_discover'));
+    // loadTestFile(require.resolve('./network_policy'));
+    // loadTestFile(require.resolve('./spaces'));
+    // loadTestFile(require.resolve('./usage'));
     loadTestFile(require.resolve('./error_codes'));
     loadTestFile(require.resolve('./validation'));
+    // loadTestFile(require.resolve('./ilm_migration_apis')); // FIXME is this the cause of flaky?
   });
 }
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -26,9 +26,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./network_policy'));
     loadTestFile(require.resolve('./spaces'));
     loadTestFile(require.resolve('./usage'));
+    loadTestFile(require.resolve('./ilm_migration_apis'));
     loadTestFile(require.resolve('./error_codes'));
     loadTestFile(require.resolve('./validation'));
-    // loadTestFile(require.resolve('./ilm_migration_apis')); // FIXME is this the cause of flaky?
   });
 }
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/validation.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/validation.ts
@@ -27,8 +27,7 @@ export default function ({ getService }: FtrProviderContext) {
     }
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/143717
-  describe.skip('Job parameter validation', () => {
+  describe('Job parameter validation', () => {
     before(async () => {
       await reportingAPI.initEcommerce();
     });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/143717
Closes https://github.com/elastic/kibana/issues/143738
Closes https://github.com/elastic/kibana/issues/143904

After looking into the issue, it seemed tests were failing, possibly due to improper cleanup from the [API tests on Reporting's ILM policy](https://github.com/elastic/kibana/blob/6c2f1c415b072d72c93e05d49ef9290352ee9793/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts): reports would be deleted in the background before they could be downloaded by the test:
```
[00:09:24]           │ info [o.e.x.i.IndexLifecycleTransition] [ftr] moving index [.reporting-2022-10-23] from [{"phase":"delete","action":"delete","name":"wait-for-shard-history-leases"}] to [{"phase":"delete","action":"delete","name":"cleanup-snapshot"}] in policy [kibana-reporting]
[00:09:24]           │ info [o.e.x.i.IndexLifecycleTransition] [ftr] moving index [.reporting-2022-10-23] from [{"phase":"delete","action":"delete","name":"cleanup-snapshot"}] to [{"phase":"delete","action":"delete","name":"delete"}] in policy [kibana-reporting]
[00:09:24]           │ info [o.e.c.m.MetadataDeleteIndexService] [ftr] [.reporting-2022-10-23/yK_tEOhHQhqxf3L6gZqu1A] deleting index
[00:09:25]           │ proc [kibana] [2022-10-24T18:14:30.360+00:00][WARN ][plugins.reporting] No hits resulted in search
[00:09:25]           │ debg Report at path /api/reporting/jobs/download/l9n3lr6c026u85f10d2yr4by returned code 404
[00:09:25]           │ debg --- retry.tryForTime error: expected 404 to equal 200
```

Tests are no longer flaky:  https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1510