### PR TITLE
[Fleet] Fix error in agent policy duplication

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -348,7 +348,7 @@ export default function (providerContext: FtrProviderContext) {
           return 0;
         }
 
-        const policyId = 'package-policy-test-1';
+        const policyId = 'package-policy-test-';
         packagePoliciesToDeleteIds.push(policyId);
         const getPkRes = await supertest
           .get(`/api/fleet/epm/packages/system`)
@@ -436,6 +436,92 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
         expect(await getSystemPackagePolicyCopyVersion(copy3Id)).to.be(3);
+      });
+
+      it('should work with package policy with space in name', async () => {
+        const policyId = 'package-policy-test-1';
+        packagePoliciesToDeleteIds.push(policyId);
+        const getPkRes = await supertest
+          .get(`/api/fleet/epm/packages/system`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+        systemPkgVersion = getPkRes.body.item.version;
+        // we must first force install the system package to override package verification error on policy create
+        const installPromise = supertest
+          .post(`/api/fleet/epm/packages/system-${systemPkgVersion}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ force: true })
+          .expect(200);
+
+        await Promise.all([
+          installPromise,
+          kibanaServer.savedObjects.create({
+            id: policyId,
+            type: PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            overwrite: true,
+            attributes: {
+              name: `system-1`,
+              package: {
+                name: 'system',
+              },
+            },
+          }),
+        ]);
+
+        const {
+          body: {
+            item: { id: originalPolicyId },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .query({
+            sys_monitoring: false,
+          })
+          .send({
+            name: 'original policy with package policy with space in name',
+            namespace: 'default',
+          })
+          .expect(200);
+
+        await supertest
+          .post(`/api/fleet/package_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Filetest with space in name',
+            description: '',
+            namespace: 'default',
+            policy_id: originalPolicyId,
+            enabled: true,
+            inputs: [],
+            package: {
+              name: 'filetest',
+              title: 'For File Tests',
+              version: '0.1.0',
+            },
+          })
+          .expect(200);
+
+        const {
+          body: {
+            item: { id: copy1Id },
+          },
+        } = await supertest
+          .post(`/api/fleet/agent_policies/${originalPolicyId}/copy`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'copy 123',
+            description: 'Test',
+          })
+          .expect(200);
+
+        const {
+          body: {
+            item: { package_policies: packagePolicies },
+          },
+        } = await supertest.get(`/api/fleet/agent_policies/${copy1Id}`).expect(200);
+
+        expect(packagePolicies[0].name).to.eql('Filetest with space in name (copy)');
       });
 
       it('should return a 404 with invalid source policy', async () => {


### PR DESCRIPTION
## Summary

Resolve #142932

That PR fix a bug when trying to duplicate an agent policy containing a package policy with a name with space.

KQL do not allow to do a search with space and wildcard, that PR fix that by searching all package policy with the name starting with the first word, than match in javascript the names.



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->