### PR TITLE
[LaunchDarkly] Promote Cloud Experiments documentation in the Dev Docs

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -106,6 +106,10 @@
         },
         {
           "id": "kibDevDocsEmbeddables"
+        },
+        {
+          "id": "kibCloudExperimentsPlugin",
+          "label": "A/B testing on Elastic Cloud"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Resolves #140059

Building the docs.elastic.co repo locally and pointing to this branch shows this new link:
<img width="2107" alt="image" src="https://user-images.githubusercontent.com/5469006/197723231-bb1e0df5-4924-4bf4-8bbd-b9fef503b1d6.png">

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
