### PR TITLE
[Dashboard] Fix help documentation link for dashboard 

### DIFF
--- a/src/plugins/dashboard/public/application/lib/help_menu_util.ts
+++ b/src/plugins/dashboard/public/application/lib/help_menu_util.ts
@@ -12,9 +12,8 @@ import { pluginServices } from '../../services/plugin_services';
 export function addHelpMenuToAppChrome() {
   const {
     chrome: { setHelpExtension },
-    documentationLinks: { kibanaGuideDocLink },
+    documentationLinks: { dashboardDocLink },
   } = pluginServices.getServices();
-
   setHelpExtension({
     appName: i18n.translate('dashboard.helpMenu.appName', {
       defaultMessage: 'Dashboards',
@@ -22,7 +21,7 @@ export function addHelpMenuToAppChrome() {
     links: [
       {
         linkType: 'documentation',
-        href: `${kibanaGuideDocLink}`,
+        href: `${dashboardDocLink}`,
       },
     ],
   });

--- a/src/plugins/dashboard/public/services/documentation_links/documentation_links.stub.ts
+++ b/src/plugins/dashboard/public/services/documentation_links/documentation_links.stub.ts
@@ -18,5 +18,6 @@ export const documentationLinksServiceFactory: DocumentationLinksServiceFactory 
   return {
     indexPatternsDocLink: corePluginMock.docLinks.links.indexPatterns.introduction,
     kibanaGuideDocLink: corePluginMock.docLinks.links.kibana.guide,
+    dashboardDocLink: corePluginMock.docLinks.links.dashboard.guide,
   };
 };

--- a/src/plugins/dashboard/public/services/documentation_links/documentation_links_service.ts
+++ b/src/plugins/dashboard/public/services/documentation_links/documentation_links_service.ts
@@ -21,14 +21,16 @@ export const documentationLinksServiceFactory: DocumentationLinksServiceFactory 
   const {
     docLinks: {
       links: {
-        kibana: { guide },
+        kibana,
         indexPatterns: { introduction },
+        dashboard,
       },
     },
   } = coreStart;
 
   return {
     indexPatternsDocLink: introduction,
-    kibanaGuideDocLink: guide,
+    kibanaGuideDocLink: kibana.guide,
+    dashboardDocLink: dashboard.guide,
   };
 };

--- a/src/plugins/dashboard/public/services/documentation_links/types.ts
+++ b/src/plugins/dashboard/public/services/documentation_links/types.ts
@@ -11,4 +11,5 @@ import { CoreStart } from '@kbn/core/public';
 export interface DashboardDocumentationLinksService {
   indexPatternsDocLink: CoreStart['docLinks']['links']['indexPatterns']['introduction'];
   kibanaGuideDocLink: CoreStart['docLinks']['links']['kibana']['guide'];
+  dashboardDocLink: CoreStart['docLinks']['links']['dashboard']['guide'];
 }


### PR DESCRIPTION
## Summary

Seemingly random PR, incoming 🚀 

A bug was introduced in the [Dashboard services abstraction PR](https://github.com/elastic/kibana/pull/139145) where the Dashboard help link no longer sent the user to the correct location - instead, it sent them to the generic Kibana documentation. This PR fixes this by adding the Dashboard documentation link to the `documentationLinks` service and setting the correct help extension in `addHelpMenuToAppChrome`.

**Before**

https://user-images.githubusercontent.com/8698078/197617243-f458ffa8-1d99-4c55-a364-78ef43e16da4.mov

**After**

https://user-images.githubusercontent.com/8698078/197616253-9227e91f-5d67-4a3b-bea0-6d77f17cfc18.mov


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->