### PR TITLE
[Enterprise Search] Use target=_blank for links in validation steps

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/validation_step_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/validation_step_panel.tsx
@@ -10,10 +10,12 @@ import React from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiMarkdownFormat,
   EuiPanel,
   EuiSpacer,
   EuiTitle,
+  getDefaultEuiMarkdownProcessingPlugins,
 } from '@elastic/eui';
 
 import { CrawlerDomainValidationStep } from '../../../../../api/crawler/types';
@@ -26,6 +28,9 @@ interface ValidationStepPanelProps {
   label: string;
   step: CrawlerDomainValidationStep;
 }
+
+const processingPlugins = getDefaultEuiMarkdownProcessingPlugins();
+processingPlugins[1][1].components.a = (props) => <EuiLink {...props} target="_blank" />;
 
 export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
   step,
@@ -49,7 +54,11 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
       {showErrorMessage && (
         <>
           <EuiSpacer size="xs" />
-          <EuiMarkdownFormat textSize="s" data-test-subj="errorMessage">
+          <EuiMarkdownFormat
+            textSize="s"
+            data-test-subj="errorMessage"
+            processingPluginList={processingPlugins}
+          >
             {step.message || ''}
           </EuiMarkdownFormat>
           {action && (


### PR DESCRIPTION
## Summary

This minimizes disruptions to the validation process when user encounters a warning or error.  Accomplished by modifying the processing plugins for the EuiMarkdownFormat component we utilize, as illustrated in this sandbox provided by the EUI team: https://codesandbox.io/s/relaxed-yalow-hy69r4?file=/demo.js:482-645

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

