### PR TITLE
refactor getHitCount, use Last_1 year

### DIFF
--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -243,6 +243,10 @@ export class DiscoverPageObject extends FtrService {
     return await this.testSubjects.getVisibleText('unifiedHistogramQueryHits');
   }
 
+  public async getHitCountInt() {
+    return parseInt(await this.getHitCount(), 10);
+  }
+
   public async getDocHeader() {
     const table = await this.getDocTable();
     const docHeader = await table.getHeaders();

--- a/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
@@ -18,7 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('filebeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async () => {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
 
       await retry.try(async function () {
-        const upCount = parseInt((await PageObjects.uptime.getSnapshotCount()).up, 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(upCount).to.eql(1);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/heartbeat/_heartbeat.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
 
       await retry.try(async function () {
-        const hitCount = await PageObjects.discover.getHitCountInt();
+        const upCount = parseInt((await PageObjects.uptime.getSnapshotCount()).up, 10);
         expect(upCount).to.eql(1);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('metricbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
@@ -32,7 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('packetbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.ts
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('winlogbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
@@ -40,12 +40,12 @@ export default function ({ getPageObjects }: FtrProviderContext) {
             await PageObjects.discover.selectIndexPattern(String(index));
             await PageObjects.discover.waitUntilSearchingHasFinished();
             if (timefield) {
-              await PageObjects.timePicker.setCommonlyUsedTime('Last_24 hours');
+              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
               await PageObjects.discover.waitUntilSearchingHasFinished();
             }
           });
           it('shows hit count greater than zero', async () => {
-            const hitCount = await PageObjects.discover.getHitCount();
+            const hitCount = await PageObjects.discover.getHitCountInt();
             if (hits === '') {
               expect(hitCount).to.be.greaterThan(0);
             } else {
@@ -69,12 +69,12 @@ export default function ({ getPageObjects }: FtrProviderContext) {
             await PageObjects.home.launchSampleDiscover(name);
             await PageObjects.header.waitUntilLoadingHasFinished();
             if (timefield) {
-              await PageObjects.timePicker.setCommonlyUsedTime('Last_24 hours');
+              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
               await PageObjects.discover.waitUntilSearchingHasFinished();
             }
           });
           it('shows hit count greater than zero', async () => {
-            const hitCount = await PageObjects.discover.getHitCount();
+            const hitCount = await PageObjects.discover.getHitCountInt();
             if (hits === '') {
               expect(hitCount).to.be.greaterThan(0);
             } else {


### PR DESCRIPTION
## Summary

NOTE: The tests in this PR don't run as a part of the regular Kibana CI.

In `x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts` I hit a failure after changing the time span of the test to `Last_1 year` because the hit count was a string including the comma-separator like `"9,340"` and that didn't compare greater than the int 0.  There were several other tests where we had fixed that with parseInt so I refactored that to create a new getHitCountInt() method.  There are a lot of other tests that are comparing exact hit count strings so I left those as-is.  



<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->