### PR TITLE
[APM] POC: Add support for additional dimensions in apm rules

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
@@ -18,7 +18,7 @@ import { createCallApmApi } from '../../../services/rest/create_call_apm_api';
 import { ChartPreview } from '../chart_preview';
 import { EnvironmentField, IsAboveField, ServiceField } from '../fields';
 import { AlertMetadata, getIntervalAndTimeRange, TimeUnit } from '../helper';
-import { ServiceAlertTrigger } from '../service_alert_trigger';
+import { APMFields } from '../service_alert_trigger';
 
 export interface RuleParams {
   windowSize?: number;
@@ -32,12 +32,11 @@ interface Props {
   ruleParams: RuleParams;
   metadata?: AlertMetadata;
   setRuleParams: (key: string, value: any) => void;
-  setRuleProperty: (key: string, value: any) => void;
 }
 
 export function ErrorCountAlertTrigger(props: Props) {
   const { services } = useKibana();
-  const { ruleParams, metadata, setRuleParams, setRuleProperty } = props;
+  const { ruleParams, metadata, setRuleParams } = props;
 
   useEffect(() => {
     createCallApmApi(services as CoreStart);
@@ -126,11 +125,10 @@ export function ErrorCountAlertTrigger(props: Props) {
   );
 
   return (
-    <ServiceAlertTrigger
+    <APMFields
       defaults={params}
       fields={fields}
       setRuleParams={setRuleParams}
-      setRuleProperty={setRuleProperty}
       chartPreview={chartPreview}
     />
   );

--- a/x-pack/plugins/apm/public/components/alerting/fields.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/fields.tsx
@@ -22,11 +22,9 @@ import { SuggestionsSelect } from '../shared/suggestions_select';
 import { PopoverExpression } from './service_alert_trigger/popover_expression';
 
 export function ServiceField({
-  allowAll = true,
   currentValue,
   onChange,
 }: {
-  allowAll?: boolean;
   currentValue?: string;
   onChange: (value?: string) => void;
 }) {
@@ -38,7 +36,7 @@ export function ServiceField({
       })}
     >
       <SuggestionsSelect
-        customOptions={allowAll ? [ENVIRONMENT_ALL] : undefined}
+        customOptions={[ENVIRONMENT_ALL]}
         customOptionText={i18n.translate(
           'xpack.apm.serviceNamesSelectCustomOptionText',
           {
@@ -122,6 +120,38 @@ export function TransactionTypeField({
             defaultMessage: 'Select transaction type',
           }
         )}
+        start={moment().subtract(24, 'h').toISOString()}
+        end={moment().toISOString()}
+      />
+    </PopoverExpression>
+  );
+}
+
+export function CustomFilterField({
+  serviceName,
+  title,
+  fieldName,
+  currentValue,
+  onChange,
+}: {
+  serviceName?: string;
+  title: string;
+  fieldName: string;
+  currentValue?: string;
+  onChange: (value?: string) => void;
+}) {
+  console.log({ serviceName });
+  return (
+    <PopoverExpression value={currentValue || allOptionText} title={title}>
+      <SuggestionsSelect
+        serviceName={serviceName}
+        customOptions={[{ label: 'All', value: '_all_' }]}
+        defaultValue={currentValue}
+        fieldName={fieldName}
+        onChange={onChange}
+        placeholder={i18n.translate('xpack.apm.customFilter', {
+          defaultMessage: `Select ${title}`,
+        })}
         start={moment().subtract(24, 'h').toISOString()}
         end={moment().toISOString()}
       />

--- a/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/index.tsx
@@ -10,13 +10,12 @@ import React, { useEffect } from 'react';
 
 interface Props {
   setRuleParams: (key: string, value: any) => void;
-  setRuleProperty: (key: string, value: any) => void;
   defaults: Record<string, any>;
   fields: React.ReactNode[];
   chartPreview?: React.ReactNode;
 }
 
-export function ServiceAlertTrigger(props: Props) {
+export function APMFields(props: Props) {
   const { fields, setRuleParams, defaults, chartPreview } = props;
 
   const params: Record<string, any> = {

--- a/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/service_alert_trigger.test.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/service_alert_trigger.test.tsx
@@ -8,7 +8,7 @@
 import { render } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { ServiceAlertTrigger } from '.';
+import { APMFields } from '.';
 
 function Wrapper({ children }: { children?: ReactNode }) {
   return <MemoryRouter>{children}</MemoryRouter>;
@@ -18,7 +18,7 @@ describe('ServiceAlertTrigger', () => {
   it('renders', () => {
     expect(() =>
       render(
-        <ServiceAlertTrigger
+        <APMFields
           defaults={{}}
           fields={[null]}
           setRuleParams={() => {}}

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_anomaly_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_anomaly_alert_trigger/index.tsx
@@ -19,7 +19,7 @@ import {
   TransactionTypeField,
 } from '../fields';
 import { AlertMetadata } from '../helper';
-import { ServiceAlertTrigger } from '../service_alert_trigger';
+import { APMFields } from '../service_alert_trigger';
 import { PopoverExpression } from '../service_alert_trigger/popover_expression';
 import {
   AnomalySeverity,
@@ -43,12 +43,11 @@ interface Props {
   ruleParams: AlertParams;
   metadata?: AlertMetadata;
   setRuleParams: (key: string, value: any) => void;
-  setRuleProperty: (key: string, value: any) => void;
 }
 
 export function TransactionDurationAnomalyAlertTrigger(props: Props) {
   const { services } = useKibana();
-  const { ruleParams, metadata, setRuleParams, setRuleProperty } = props;
+  const { ruleParams, metadata, setRuleParams } = props;
 
   useEffect(() => {
     createCallApmApi(services as CoreStart);
@@ -99,11 +98,10 @@ export function TransactionDurationAnomalyAlertTrigger(props: Props) {
   ];
 
   return (
-    <ServiceAlertTrigger
+    <APMFields
       fields={fields}
       defaults={params}
       setRuleParams={setRuleParams}
-      setRuleProperty={setRuleProperty}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
@@ -22,7 +22,7 @@ import {
   TransactionTypeField,
 } from '../fields';
 import { AlertMetadata, getIntervalAndTimeRange, TimeUnit } from '../helper';
-import { ServiceAlertTrigger } from '../service_alert_trigger';
+import { APMFields } from '../service_alert_trigger';
 
 interface RuleParams {
   windowSize?: number;
@@ -37,12 +37,11 @@ interface Props {
   ruleParams: RuleParams;
   metadata?: AlertMetadata;
   setRuleParams: (key: string, value: any) => void;
-  setRuleProperty: (key: string, value: any) => void;
 }
 
 export function TransactionErrorRateAlertTrigger(props: Props) {
   const { services } = useKibana();
-  const { ruleParams, metadata, setRuleParams, setRuleProperty } = props;
+  const { ruleParams, metadata, setRuleParams } = props;
 
   useEffect(() => {
     createCallApmApi(services as CoreStart);
@@ -137,11 +136,10 @@ export function TransactionErrorRateAlertTrigger(props: Props) {
   );
 
   return (
-    <ServiceAlertTrigger
+    <APMFields
       fields={fields}
       defaults={params}
       setRuleParams={setRuleParams}
-      setRuleProperty={setRuleProperty}
       chartPreview={chartPreview}
     />
   );

--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/service_page/form_row_suggestions_select.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/service_page/form_row_suggestions_select.tsx
@@ -20,7 +20,7 @@ interface Props {
   description: string;
   fieldLabel: string;
   value?: string;
-  allowAll?: boolean;
+
   onChange: (value?: string) => void;
   dataTestSubj?: string;
 }
@@ -31,7 +31,6 @@ export function FormRowSuggestionsSelect({
   description,
   fieldLabel,
   value,
-  allowAll = true,
   onChange,
   dataTestSubj,
 }: Props) {
@@ -43,7 +42,7 @@ export function FormRowSuggestionsSelect({
     >
       <EuiFormRow label={fieldLabel}>
         <SuggestionsSelect
-          customOptions={allowAll ? [ALL_OPTION] : undefined}
+          customOptions={[ALL_OPTION]}
           defaultValue={value ? getOptionLabel(value) : undefined}
           fieldName={fieldName}
           onChange={onChange}

--- a/x-pack/plugins/apm/public/components/shared/suggestions_select/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/suggestions_select/index.tsx
@@ -15,6 +15,7 @@ interface SuggestionsSelectProps {
   customOptionText?: string;
   defaultValue?: string;
   fieldName: string;
+  serviceName?: string;
   start: string;
   end: string;
   onChange: (value?: string) => void;
@@ -30,6 +31,7 @@ export function SuggestionsSelect({
   customOptionText,
   defaultValue,
   fieldName,
+  serviceName,
   start,
   end,
   onChange,
@@ -55,6 +57,7 @@ export function SuggestionsSelect({
       return callApmApi('GET /internal/apm/suggestions', {
         params: {
           query: {
+            serviceName,
             fieldName,
             fieldValue: searchValue,
             start,
@@ -63,7 +66,7 @@ export function SuggestionsSelect({
         },
       });
     },
-    [fieldName, searchValue, start, end],
+    [fieldName, serviceName, searchValue, start, end],
     { preservePreviousData: false }
   );
 

--- a/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_enum.ts
+++ b/x-pack/plugins/apm/server/routes/suggestions/get_suggestions_with_terms_enum.ts
@@ -8,7 +8,7 @@ import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { getProcessorEventForTransactions } from '../../lib/helpers/transactions';
 import { Setup } from '../../lib/helpers/setup_request';
 
-export async function getSuggestions({
+export async function getSuggestionsWithTermsEnum({
   fieldName,
   fieldValue,
   searchAggregatedTransactions,
@@ -27,30 +27,33 @@ export async function getSuggestions({
 }) {
   const { apmEventClient } = setup;
 
-  const response = await apmEventClient.termsEnum('get_suggestions', {
-    apm: {
-      events: [
-        getProcessorEventForTransactions(searchAggregatedTransactions),
-        ProcessorEvent.error,
-        ProcessorEvent.metric,
-      ],
-    },
-    body: {
-      case_insensitive: true,
-      field: fieldName,
-      size,
-      string: fieldValue,
-      index_filter: {
-        range: {
-          ['@timestamp']: {
-            gte: start,
-            lte: end,
-            format: 'epoch_millis',
+  const response = await apmEventClient.termsEnum(
+    'get_suggestions_with_terms_enum',
+    {
+      apm: {
+        events: [
+          getProcessorEventForTransactions(searchAggregatedTransactions),
+          ProcessorEvent.error,
+          ProcessorEvent.metric,
+        ],
+      },
+      body: {
+        case_insensitive: true,
+        field: fieldName,
+        size,
+        string: fieldValue,
+        index_filter: {
+          range: {
+            ['@timestamp']: {
+              gte: start,
+              lte: end,
+              format: 'epoch_millis',
+            },
           },
         },
       },
-    },
-  });
+    }
+  );
 
   return { terms: response.terms };
 }


### PR DESCRIPTION
_This is a POC and currently only for demo purposes. Review not needed_

Early POC (frontend only) for adding additional dimensions to APM rules. This aims to solve usecase 1 and three in the [APM Alerting use cases](https://github.com/elastic/kibana/issues/103785).

By adding a new dimension (eg. `transaction.type`) the dimension will be added as a key to the multi_terms agg. 
In the case of `transaction.type`, it will be possible to select "All", and be notified when any transaction group has a latency higher than the threshold. It will also be possible to create rules that only monitor a specific transaction group.

Note: needs design
<img width="500" src="https://user-images.githubusercontent.com/209966/197642079-a2842896-6133-4945-aa2c-223097ea395e.gif"/>


We have three rule types in APM that will benefit from this, with the given dimensions:

 - Transaction Latency
   - Dimensions: `transaction.name`, `container.id`, `kubernetes.pod.name`, `service.version`
 - Failed transaction rate
   - Dimensions: `transaction.name`, `container.id`, `kubernetes.pod.name`, `service.version`
 - Error count
   - Dimensions: `error.grouping_key`, `transaction.name`, `container.id`, `kubernetes.pod.name`, `service.version`