### PR TITLE
[Plugins Service] Potential startup perf improvement

### DIFF
--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -479,7 +479,7 @@ test('`stop` calls `stop` defined by the plugin instance', async () => {
 });
 
 describe('#getConfigSchema()', () => {
-  it('reads config schema from plugin', () => {
+  it('reads config schema from plugin', async () => {
     const pluginSchema = schema.any();
     const configDescriptor = {
       schema: pluginSchema,
@@ -506,10 +506,10 @@ describe('#getConfigSchema()', () => {
       }),
     });
 
-    expect(plugin.getConfigDescriptor()).toBe(configDescriptor);
+    expect(await plugin.getConfigDescriptor()).toBe(configDescriptor);
   });
 
-  it('returns null if config definition not specified', () => {
+  it('returns null if config definition not specified', async () => {
     jest.doMock(join('plugin-with-no-definition', 'server'), () => ({}), { virtual: true });
     const manifest = createPluginManifest();
     const opaqueId = Symbol();
@@ -525,10 +525,10 @@ describe('#getConfigSchema()', () => {
         nodeInfo,
       }),
     });
-    expect(plugin.getConfigDescriptor()).toBe(null);
+    expect(await plugin.getConfigDescriptor()).toBe(null);
   });
 
-  it('returns null for plugins without a server part', () => {
+  it('returns null for plugins without a server part', async () => {
     const manifest = createPluginManifest({ server: false });
     const opaqueId = Symbol();
     const plugin = new PluginWrapper({
@@ -543,10 +543,10 @@ describe('#getConfigSchema()', () => {
         nodeInfo,
       }),
     });
-    expect(plugin.getConfigDescriptor()).toBe(null);
+    expect(await plugin.getConfigDescriptor()).toBe(null);
   });
 
-  it('throws if plugin contains invalid schema', () => {
+  it('throws if plugin contains invalid schema', async () => {
     jest.doMock(
       join('plugin-invalid-schema', 'server'),
       () => ({
@@ -572,7 +572,7 @@ describe('#getConfigSchema()', () => {
         nodeInfo,
       }),
     });
-    expect(() => plugin.getConfigDescriptor()).toThrowErrorMatchingInlineSnapshot(
+    await expect(() => plugin.getConfigDescriptor()).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Configuration schema expected to be an instance of Type"`
     );
   });

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -149,13 +149,12 @@ export class PluginWrapper<
     this.instance = undefined;
   }
 
-  public getConfigDescriptor(): PluginConfigDescriptor | null {
+  public async getConfigDescriptor(): Promise<PluginConfigDescriptor | null> {
     if (!this.manifest.server) {
       return null;
     }
     const pluginPathServer = join(this.path, 'server');
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const pluginDefinition = require(pluginPathServer);
+    const pluginDefinition = await import(pluginPathServer);
 
     if (!('config' in pluginDefinition)) {
       this.log.debug(`"${pluginPathServer}" does not export "config".`);


### PR DESCRIPTION
## Summary

Testing out if loading the server-side plugins in memory provides any startup improvements.

Looking at CI, it usually takes about 13s to process the `getConfigDescriptor()` part. It internally synchronously `require` the server-side plugin code base to read the exposed `config` variable.

Hopefully, using `await import` and parallelizing the execution for all plugins might cut down the startup time a bit.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
