### PR TITLE
[UnifiedFieldList] Remove kibana-vis-editors codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,6 @@
 /x-pack/test/functional/apps/lens @elastic/kibana-vis-editors
 /x-pack/test/api_integration/apis/lens/ @elastic/kibana-vis-editors
 /test/functional/apps/visualize/ @elastic/kibana-vis-editors
-/src/plugins/unified_field_list/ @elastic/kibana-vis-editors
 /test/api_integration/apis/unified_field_list/ @elastic/kibana-vis-editors
 
 # Application Services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,6 @@
 /x-pack/test/functional/apps/lens @elastic/kibana-vis-editors
 /x-pack/test/api_integration/apis/lens/ @elastic/kibana-vis-editors
 /test/functional/apps/visualize/ @elastic/kibana-vis-editors
-/test/api_integration/apis/unified_field_list/ @elastic/kibana-vis-editors
 
 # Application Services
 /examples/bfetch_explorer/ @elastic/kibana-app-services


### PR DESCRIPTION
## Summary

This PR removes  `kibana-vis-editors ` codeowner ship of `/src/plugins/unified_field_list/` since currently mainly @jughosta of @elastic/kibana-data-discovery is working on it, and it seems, GitHub doesn't allow shared codeownership.

