### PR TITLE
Temporarily remove broken link

### DIFF
--- a/docs/maps/search.asciidoc
+++ b/docs/maps/search.asciidoc
@@ -107,7 +107,7 @@ You can create spatial filters in two ways:
 Spatial filters have the following properties:
 
 * *Geometry label* enables you to provide a meaningful name for your spatial filter.
-* *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html#_spatial_relations[spatial relation operator] to use at search time.
+* *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html[spatial relation operator] to use at search time.
 * *Action* specifies whether to apply the filter to the current view or to a drilldown action. Only available when the map is a panel in a {kibana-ref}/dashboard.html[dashboard] with {kibana-ref}/drilldowns.html[drilldowns].
 
 [role="screenshot"]


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/90913 adds a proper ID to a section in the Elasticsearch docs. The "Create filters from a map" page in the Kibana docs currently directly links to the header of this section. That link will break because of https://github.com/elastic/elasticsearch/pull/90913. 

This PR temporarily removes that direct link, so the change in the Elasticsearch docs can be made without build errors. Once https://github.com/elastic/elasticsearch/pull/90913 has merged, I will revisit this page in the Kibana docs and update the link so it points to the new ID.