### PR TITLE
[Maps] Fail to load Maps if hardware acceleration is disabled

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -13,6 +13,7 @@ import { Action, ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { maplibregl } from '@kbn/mapbox-gl';
 import type { Map as MapboxMap, MapOptions, MapMouseEvent } from '@kbn/mapbox-gl';
 import { ResizeChecker } from '@kbn/kibana-utils-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { DrawFilterControl } from './draw_control/draw_filter_control';
 import { ScaleControl } from './scale_control';
 import { TooltipControl } from './tooltip_control';
@@ -149,7 +150,16 @@ export class MbMap extends Component<Props, State> {
   }
 
   async _createMbMapInstance(initialView: MapCenterAndZoom | null): Promise<MapboxMap> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      if (!maplibregl.supported({ failIfMajorPerformanceCaveat: true }))
+        reject(
+          new Error(
+            i18n.translate('xpack.maps.webGlError', {
+              defaultMessage: `Your browser or device does not support WebGL or hardware acceleration is not available.`,
+            })
+          )
+        );
+
       const mbStyle = {
         version: 8 as 8,
         sources: {},


### PR DESCRIPTION
## Summary

Return an error if hardware acceleration is disabled or otherwise not available in the user's browser.

When hardware acceleration is not available in the browser, WebGL rendering falls back to software rendering. This usually incurs a noticeable, but not necessarily prohibitive, performance impact when panning or zooming in Maps. 

I'm opening this PR to show that it is possible to deny Maps from loading if performance will suffer. But I'm concerned that in doing so, **we may be disabling Maps completely for existing or new users** who are unfazed by performance. We should consider carefully if we wish to implement it. 

To test this PR:

In Chrome, open chrome://settings/ in the address bar and search for "hardware". Disable the feature called "Use hardware acceleration when available" and restart Chrome.

In Firefox, disable hardware acceleration using [these instructions](https://support.mozilla.org/en-US/kb/performance-settings).

