### PR TITLE
[7.17] refactor getHitCount, use Last_1 year (#143912)

### DIFF
--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -221,6 +221,10 @@ export class DiscoverPageObject extends FtrService {
     return await this.testSubjects.getVisibleText('discoverQueryHits');
   }
 
+  public async getHitCountInt() {
+    return parseInt(await this.getHitCount(), 10);
+  }
+
   public async getDocHeader() {
     const table = await this.getDocTable();
     const docHeader = await table.getHeaders();

--- a/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
@@ -18,7 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('filebeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_30 days');
       await retry.try(async () => {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('metricbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
@@ -32,7 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('packetbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.ts
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('winlogbeat-*');
       await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
-        const hitCount = parseInt(await PageObjects.discover.getHitCount(), 10);
+        const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);
       });
     });

--- a/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
@@ -34,41 +34,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             await PageObjects.discover.selectIndexPattern(name);
             await PageObjects.discover.waitUntilSearchingHasFinished();
             if (timefield) {
-              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+              await PageObjects.timePicker.setCommonlyUsedTime('Last_24 hours');
               await PageObjects.discover.waitUntilSearchingHasFinished();
             }
           });
           it('shows hit count greater than zero', async () => {
-            const hitCount = await PageObjects.discover.getHitCountInt();
-            if (hits === '') {
-              expect(hitCount).to.be.greaterThan(0);
-            } else {
-              expect(hitCount).to.be.equal(hits);
-            }
-          });
-          it('shows table rows not empty', async () => {
-            const tableRows = await PageObjects.discover.getDocTableRows();
-            expect(tableRows.length).to.be.greaterThan(0);
-          });
-        });
-      });
-
-      discoverTests.forEach(({ name, timefield, hits }) => {
-        describe('space: ' + space + ', name: ' + name, () => {
-          before(async () => {
-            await PageObjects.common.navigateToActualUrl('home', '/tutorial_directory/sampleData', {
-              basePath,
-            });
-            await PageObjects.header.waitUntilLoadingHasFinished();
-            await PageObjects.home.launchSampleDiscover(name);
-            await PageObjects.header.waitUntilLoadingHasFinished();
-            if (timefield) {
-              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
-              await PageObjects.discover.waitUntilSearchingHasFinished();
-            }
-          });
-          it('shows hit count greater than zero', async () => {
-            const hitCount = await PageObjects.discover.getHitCountInt();
+            const hitCount = await PageObjects.discover.getHitCount();
             if (hits === '') {
               expect(hitCount).to.be.greaterThan(0);
             } else {

--- a/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/discover/discover_smoke_tests.ts
@@ -34,12 +34,41 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             await PageObjects.discover.selectIndexPattern(name);
             await PageObjects.discover.waitUntilSearchingHasFinished();
             if (timefield) {
-              await PageObjects.timePicker.setCommonlyUsedTime('Last_24 hours');
+              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
               await PageObjects.discover.waitUntilSearchingHasFinished();
             }
           });
           it('shows hit count greater than zero', async () => {
-            const hitCount = await PageObjects.discover.getHitCount();
+            const hitCount = await PageObjects.discover.getHitCountInt();
+            if (hits === '') {
+              expect(hitCount).to.be.greaterThan(0);
+            } else {
+              expect(hitCount).to.be.equal(hits);
+            }
+          });
+          it('shows table rows not empty', async () => {
+            const tableRows = await PageObjects.discover.getDocTableRows();
+            expect(tableRows.length).to.be.greaterThan(0);
+          });
+        });
+      });
+
+      discoverTests.forEach(({ name, timefield, hits }) => {
+        describe('space: ' + space + ', name: ' + name, () => {
+          before(async () => {
+            await PageObjects.common.navigateToActualUrl('home', '/tutorial_directory/sampleData', {
+              basePath,
+            });
+            await PageObjects.header.waitUntilLoadingHasFinished();
+            await PageObjects.home.launchSampleDiscover(name);
+            await PageObjects.header.waitUntilLoadingHasFinished();
+            if (timefield) {
+              await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+              await PageObjects.discover.waitUntilSearchingHasFinished();
+            }
+          });
+          it('shows hit count greater than zero', async () => {
+            const hitCount = await PageObjects.discover.getHitCountInt();
             if (hits === '') {
               expect(hitCount).to.be.greaterThan(0);
             } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [refactor getHitCount, use Last_1 year (#143912)](https://github.com/elastic/kibana/pull/143912)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lee Drengenberg","email":"lee.drengenberg@elastic.co"},"sourceCommit":{"committedDate":"2022-10-25T14:37:06Z","message":"refactor getHitCount, use Last_1 year (#143912)\n\n* refactor getHitCount, use Last_1 year\r\n\r\n* revert change to heartbeat test","sha":"1cd4c4892d26feda9f9459485f8ff98a44d0c8e6","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:QA","release_note:skip","backport:all-open","v8.5.0","v8.6.0"],"number":143912,"url":"https://github.com/elastic/kibana/pull/143912","mergeCommit":{"message":"refactor getHitCount, use Last_1 year (#143912)\n\n* refactor getHitCount, use Last_1 year\r\n\r\n* revert change to heartbeat test","sha":"1cd4c4892d26feda9f9459485f8ff98a44d0c8e6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/143954","number":143954,"state":"MERGED","mergeCommit":{"sha":"75595ce8e3fad4dad28f7f2dab5e0e57b5cd8826","message":"refactor getHitCount, use Last_1 year (#143912) (#143954)\n\n* refactor getHitCount, use Last_1 year\n\n* revert change to heartbeat test\n\n(cherry picked from commit 1cd4c4892d26feda9f9459485f8ff98a44d0c8e6)\n\nCo-authored-by: Lee Drengenberg <lee.drengenberg@elastic.co>"}},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/143912","number":143912,"mergeCommit":{"message":"refactor getHitCount, use Last_1 year (#143912)\n\n* refactor getHitCount, use Last_1 year\r\n\r\n* revert change to heartbeat test","sha":"1cd4c4892d26feda9f9459485f8ff98a44d0c8e6"}}]}] BACKPORT-->