### PR TITLE
[Unified search] Change the button label when the query has changed

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -436,6 +436,7 @@ export const QueryBarTopRow = React.memo(
             size={shouldShowDatePickerAsBadge() ? 's' : 'm'}
             color={props.isDirty ? 'success' : 'primary'}
             fill={props.isDirty}
+            needsUpdate={props.isDirty}
             data-test-subj="querySubmitButton"
             // @ts-expect-error Need to fix expecting `children` in EUI
             toolTipProps={{


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/143976

Updates the button label when the query is updated.

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/17003240/197891307-c9d130af-612a-426c-9870-7396f50d541b.png">
