### PR TITLE
[Security Solution] split endpoint rbac feature flags

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
@@ -115,6 +115,10 @@ describe('Endpoint Authz service', () => {
     });
 
     describe('and endpoint rbac is enabled', () => {
+      beforeEach(() => {
+        userRoles = [];
+      });
+
       it.each<[EndpointAuthzKeyList[number], string]>([
         ['canWriteEndpointList', 'writeEndpointList'],
         ['canReadEndpointList', 'readEndpointList'],

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
@@ -25,9 +25,18 @@ function hasPermission(
   hasEndpointManagementAccess: boolean,
   privilege: typeof ENDPOINT_PRIVILEGES[number]
 ): boolean {
-  return isEndpointRbacEnabled
-    ? fleetAuthz.packagePrivileges?.endpoint?.actions[privilege].executePackageAction ?? false
-    : hasEndpointManagementAccess;
+  // user is superuser, always return true
+  if (hasEndpointManagementAccess) {
+    return true;
+  }
+
+  // not superuser and FF not enabled, no access
+  if (!isEndpointRbacEnabled) {
+    return false;
+  }
+
+  // FF enabled, access based on privileges
+  return fleetAuthz.packagePrivileges?.endpoint?.actions[privilege].executePackageAction ?? false;
 }
 
 /**

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -66,6 +66,12 @@ export const allowedExperimentalValues = Object.freeze({
   endpointRbacEnabled: false,
 
   /**
+   * Enables endpoint package level rbac for response actions only.
+   * if endpointRbacEnabled is enabled, it will take precedence.
+   */
+  endpointRbacV1Enabled: false,
+
+  /**
    * Enables the Guided Onboarding tour in security
    */
   guidedOnboarding: false,

--- a/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
+++ b/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
@@ -44,6 +44,7 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
 
   const fleetServices = fleetServicesFromUseKibana ?? fleetServicesFromPluginStart;
   const isEndpointRbacEnabled = useIsExperimentalFeatureEnabled('endpointRbacEnabled');
+  const isEndpointRbacV1Enabled = useIsExperimentalFeatureEnabled('endpointRbacV1Enabled');
 
   const endpointPermissions = calculatePermissionsFromCapabilities(
     useKibana().services.application.capabilities
@@ -57,7 +58,7 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
             licenseService,
             fleetAuthz,
             userRoles,
-            isEndpointRbacEnabled,
+            isEndpointRbacEnabled || isEndpointRbacV1Enabled,
             endpointPermissions
           )
         : getEndpointAuthzInitialState()),
@@ -72,6 +73,7 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
     licenseService,
     userRoles,
     isEndpointRbacEnabled,
+    isEndpointRbacV1Enabled,
     endpointPermissions,
   ]);
 

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -244,7 +244,7 @@ export const getManagementFilteredLinks = async (
   plugins: StartPlugins
 ): Promise<LinkItem> => {
   const fleetAuthz = plugins.fleet?.authz;
-  const isEndpointRbacEnabled = ExperimentalFeaturesService.get().endpointRbacEnabled;
+  const { endpointRbacEnabled, endpointRbacV1Enabled } = ExperimentalFeaturesService.get();
   const endpointPermissions = calculatePermissionsFromCapabilities(core.application.capabilities);
   const linksToExclude: SecurityPageName[] = [];
 
@@ -255,7 +255,7 @@ export const getManagementFilteredLinks = async (
           licenseService,
           fleetAuthz,
           currentUserResponse.roles,
-          isEndpointRbacEnabled,
+          endpointRbacEnabled || endpointRbacV1Enabled,
           endpointPermissions
         )
       : getEndpointAuthzInitialState();

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -167,7 +167,7 @@ export class EndpointAppContextService {
   public async getEndpointAuthz(request: KibanaRequest): Promise<EndpointAuthz> {
     const fleetAuthz = await this.getFleetAuthzService().fromRequest(request);
     const userRoles = this.security?.authc.getCurrentUser(request)?.roles ?? [];
-    const isEndpointRbacEnabled = this.experimentalFeatures.endpointRbacEnabled;
+    const { endpointRbacEnabled, endpointRbacV1Enabled } = this.experimentalFeatures;
 
     let endpointPermissions = defaultEndpointPermissions();
     if (this.security) {
@@ -185,7 +185,7 @@ export class EndpointAppContextService {
       this.getLicenseService(),
       fleetAuthz,
       userRoles,
-      isEndpointRbacEnabled,
+      endpointRbacEnabled || endpointRbacV1Enabled,
       endpointPermissions
     );
   }

--- a/x-pack/plugins/security_solution/server/features.ts
+++ b/x-pack/plugins/security_solution/server/features.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 
-import type { KibanaFeatureConfig } from '@kbn/features-plugin/common';
+import type { KibanaFeatureConfig, SubFeatureConfig } from '@kbn/features-plugin/common';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
 import { createUICapabilities } from '@kbn/cases-plugin/common';
@@ -101,6 +101,411 @@ const CLOUD_POSTURE_APP_ID = 'csp';
 // Same as the saved-object type for rules defined by Cloud Security Posture
 const CLOUD_POSTURE_SAVED_OBJECT_RULE_TYPE = 'csp_rule';
 
+const responseActionSubFeatures: SubFeatureConfig[] = [
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.actionsLogManagement.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Actions Log Management access.',
+      }
+    ),
+    name: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.actionsLogManagement',
+      {
+        defaultMessage: 'Actions Log Management',
+      }
+    ),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeActionsLogManagement`, `${APP_ID}-readActionsLogManagement`],
+            id: 'actions_log_management_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeActionsLogManagement', 'readActionsLogManagement'],
+          },
+          {
+            api: [`${APP_ID}-readActionsLogManagement`],
+            id: 'actions_log_management_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readActionsLogManagement'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.hostIsolation.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Host Isolation access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.hostIsolation', {
+      defaultMessage: 'Host Isolation',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeHostIsolation`],
+            id: 'host_isolation_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeHostIsolation'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.processOperations.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Process Operations access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.processOperations', {
+      defaultMessage: 'Process Operations',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeProcessOperations`],
+            id: 'process_operations_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeProcessOperations'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.fileOperations.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for File Operations access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistr.subFeatures.fileOperations', {
+      defaultMessage: 'File Operations',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeFileOperations`],
+            id: 'file_operations_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeFileOperations'],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const subFeatures: SubFeatureConfig[] = [
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.endpointList.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Endpoint List access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.endpointList', {
+      defaultMessage: 'Endpoint List',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeEndpointList`, `${APP_ID}-readEndpointList`],
+            id: 'endpoint_list_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeEndpointList', 'readEndpointList'],
+          },
+          {
+            api: [`${APP_ID}-readEndpointList`],
+            id: 'endpoint_list_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readEndpointList'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.trustedApplications.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Trusted Applications access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.trustedApplications', {
+      defaultMessage: 'Trusted Applications',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeTrustedApplications`, `${APP_ID}-readTrustedApplications`],
+            id: 'trusted_applications_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeTrustedApplications', 'readTrustedApplications'],
+          },
+          {
+            api: [`${APP_ID}-readTrustedApplications`],
+            id: 'trusted_applications_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readTrustedApplications'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.hostIsolationExceptions.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Host Isolation Exceptions access.',
+      }
+    ),
+    name: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.hostIsolationExceptions',
+      {
+        defaultMessage: 'Host Isolation Exceptions',
+      }
+    ),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [
+              `${APP_ID}-writeHostIsolationExceptions`,
+              `${APP_ID}-readHostIsolationExceptions`,
+            ],
+            id: 'host_isolation_exceptions_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeHostIsolationExceptions', 'readHostIsolationExceptions'],
+          },
+          {
+            api: [`${APP_ID}-readHostIsolationExceptions`],
+            id: 'host_isolation_exceptions_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readHostIsolationExceptions'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.blockList.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Blocklist access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.blockList', {
+      defaultMessage: 'Blocklist',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeBlocklist`, `${APP_ID}-readBlocklist`],
+            id: 'blocklist_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeBlocklist', 'readBlocklist'],
+          },
+          {
+            api: [`${APP_ID}-readBlocklist`],
+            id: 'blocklist_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readBlocklist'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.eventFilters.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Event Filters access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.eventFilters', {
+      defaultMessage: 'Event Filters',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writeEventFilters`, `${APP_ID}-readEventFilters`],
+            id: 'event_filters_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writeEventFilters', 'readEventFilters'],
+          },
+          {
+            api: [`${APP_ID}-readEventFilters`],
+            id: 'event_filters_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readEventFilters'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    requireAllSpaces: true,
+    privilegesTooltip: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.policyManagement.privilegesTooltip',
+      {
+        defaultMessage: 'All Spaces is required for Policy Management access.',
+      }
+    ),
+    name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.policyManagement', {
+      defaultMessage: 'Policy Management',
+    }),
+    privilegeGroups: [
+      {
+        groupType: 'mutually_exclusive',
+        privileges: [
+          {
+            api: [`${APP_ID}-writePolicyManagement`, `${APP_ID}-readPolicyManagement`],
+            id: 'policy_management_all',
+            includeIn: 'none',
+            name: 'All',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['writePolicyManagement', 'readPolicyManagement'],
+          },
+          {
+            api: [`${APP_ID}-readPolicyManagement`],
+            id: 'policy_management_read',
+            includeIn: 'none',
+            name: 'Read',
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['readPolicyManagement'],
+          },
+        ],
+      },
+    ],
+  },
+  ...responseActionSubFeatures,
+];
+
+function getSubFeatures(experimentalFeatures: ConfigType['experimentalFeatures']) {
+  if (experimentalFeatures.endpointRbacEnabled) {
+    return subFeatures;
+  }
+
+  if (experimentalFeatures.endpointRbacV1Enabled) {
+    return responseActionSubFeatures;
+  }
+
+  return [];
+}
+
 export const getKibanaPrivilegesFeaturePrivileges = (
   ruleTypes: string[],
   experimentalFeatures: ConfigType['experimentalFeatures']
@@ -182,406 +587,5 @@ export const getKibanaPrivilegesFeaturePrivileges = (
       ui: ['show'],
     },
   },
-  subFeatures: experimentalFeatures.endpointRbacEnabled
-    ? [
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.endpointList.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Endpoint List access.',
-            }
-          ),
-          name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.endpointList', {
-            defaultMessage: 'Endpoint List',
-          }),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeEndpointList`, `${APP_ID}-readEndpointList`],
-                  id: 'endpoint_list_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeEndpointList', 'readEndpointList'],
-                },
-                {
-                  api: [`${APP_ID}-readEndpointList`],
-                  id: 'endpoint_list_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readEndpointList'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.trustedApplications.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Trusted Applications access.',
-            }
-          ),
-          name: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.trustedApplications',
-            {
-              defaultMessage: 'Trusted Applications',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeTrustedApplications`, `${APP_ID}-readTrustedApplications`],
-                  id: 'trusted_applications_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeTrustedApplications', 'readTrustedApplications'],
-                },
-                {
-                  api: [`${APP_ID}-readTrustedApplications`],
-                  id: 'trusted_applications_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readTrustedApplications'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.hostIsolationExceptions.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Host Isolation Exceptions access.',
-            }
-          ),
-          name: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.hostIsolationExceptions',
-            {
-              defaultMessage: 'Host Isolation Exceptions',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [
-                    `${APP_ID}-writeHostIsolationExceptions`,
-                    `${APP_ID}-readHostIsolationExceptions`,
-                  ],
-                  id: 'host_isolation_exceptions_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeHostIsolationExceptions', 'readHostIsolationExceptions'],
-                },
-                {
-                  api: [`${APP_ID}-readHostIsolationExceptions`],
-                  id: 'host_isolation_exceptions_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readHostIsolationExceptions'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.blockList.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Blocklist access.',
-            }
-          ),
-          name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.blockList', {
-            defaultMessage: 'Blocklist',
-          }),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeBlocklist`, `${APP_ID}-readBlocklist`],
-                  id: 'blocklist_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeBlocklist', 'readBlocklist'],
-                },
-                {
-                  api: [`${APP_ID}-readBlocklist`],
-                  id: 'blocklist_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readBlocklist'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.eventFilters.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Event Filters access.',
-            }
-          ),
-          name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.eventFilters', {
-            defaultMessage: 'Event Filters',
-          }),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeEventFilters`, `${APP_ID}-readEventFilters`],
-                  id: 'event_filters_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeEventFilters', 'readEventFilters'],
-                },
-                {
-                  api: [`${APP_ID}-readEventFilters`],
-                  id: 'event_filters_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readEventFilters'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.policyManagement.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Policy Management access.',
-            }
-          ),
-          name: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.policyManagement',
-            {
-              defaultMessage: 'Policy Management',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writePolicyManagement`, `${APP_ID}-readPolicyManagement`],
-                  id: 'policy_management_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writePolicyManagement', 'readPolicyManagement'],
-                },
-                {
-                  api: [`${APP_ID}-readPolicyManagement`],
-                  id: 'policy_management_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readPolicyManagement'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.actionsLogManagement.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Actions Log Management access.',
-            }
-          ),
-          name: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.actionsLogManagement',
-            {
-              defaultMessage: 'Actions Log Management',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [
-                    `${APP_ID}-writeActionsLogManagement`,
-                    `${APP_ID}-readActionsLogManagement`,
-                  ],
-                  id: 'actions_log_management_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeActionsLogManagement', 'readActionsLogManagement'],
-                },
-                {
-                  api: [`${APP_ID}-readActionsLogManagement`],
-                  id: 'actions_log_management_read',
-                  includeIn: 'none',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['readActionsLogManagement'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.hostIsolation.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Host Isolation access.',
-            }
-          ),
-          name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.hostIsolation', {
-            defaultMessage: 'Host Isolation',
-          }),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeHostIsolation`],
-                  id: 'host_isolation_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeHostIsolation'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.processOperations.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for Process Operations access.',
-            }
-          ),
-          name: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.processOperations',
-            {
-              defaultMessage: 'Process Operations',
-            }
-          ),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeProcessOperations`],
-                  id: 'process_operations_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeProcessOperations'],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          requireAllSpaces: true,
-          privilegesTooltip: i18n.translate(
-            'xpack.securitySolution.featureRegistry.subFeatures.fileOperations.privilegesTooltip',
-            {
-              defaultMessage: 'All Spaces is required for File Operations access.',
-            }
-          ),
-          name: i18n.translate('xpack.securitySolution.featureRegistr.subFeatures.fileOperations', {
-            defaultMessage: 'File Operations',
-          }),
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  api: [`${APP_ID}-writeFileOperations`],
-                  id: 'file_operations_all',
-                  includeIn: 'none',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  ui: ['writeFileOperations'],
-                },
-              ],
-            },
-          ],
-        },
-      ]
-    : [],
+  subFeatures: getSubFeatures(experimentalFeatures),
 });

--- a/x-pack/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/plugins/security_solution/server/request_context_factory.ts
@@ -106,14 +106,14 @@ export class RequestContextFactory implements IRequestContextFactory {
           if (!startPlugins.fleet) {
             endpointAuthz = getEndpointAuthzInitialState();
           } else {
-            const isEndpointRbacEnabled =
-              endpointAppContextService.experimentalFeatures.endpointRbacEnabled;
+            const { endpointRbacEnabled, endpointRbacV1Enabled } =
+              endpointAppContextService.experimentalFeatures;
             const userRoles = security?.authc.getCurrentUser(request)?.roles ?? [];
             endpointAuthz = calculateEndpointAuthz(
               licenseService,
               fleetAuthz,
               userRoles,
-              isEndpointRbacEnabled,
+              endpointRbacEnabled || endpointRbacV1Enabled,
               endpointPermissions
             );
           }


### PR DESCRIPTION
## Summary

Add `endpointRbacV1Enabled` feature flag that only enables RBAC for response actions.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
