### PR TITLE
[TSVB] In the case of 2 or more panels on the dashboard, TSVB renderComplete fires 2 times

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -27,7 +27,7 @@ pageLoadAssetSize:
   dataViewEditor: 12000
   dataViewFieldEditor: 27000
   dataViewManagement: 5000
-  dataViews: 46532
+  dataViews: 46600
   dataVisualizer: 27530
   devTools: 38637
   discover: 99999

--- a/src/plugins/data_views/common/data_views/data_views.test.ts
+++ b/src/plugins/data_views/common/data_views/data_views.test.ts
@@ -155,6 +155,9 @@ describe('IndexPatterns', () => {
     const gettedDataView = await indexPatterns.get(id);
 
     expect(dataView).toBe(gettedDataView);
+
+    const dataView2 = await indexPatterns.create({ id });
+    expect(dataView2).toBe(gettedDataView);
   });
 
   test('allowNoIndex flag preserves existing fields when index is missing', async () => {

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -913,7 +913,7 @@ export class DataViewsService {
       ...restOfSpec,
     };
 
-    const indexPattern = new DataView({
+    const dataView = new DataView({
       spec,
       fieldFormats: this.fieldFormats,
       shortDotsEnable,
@@ -921,12 +921,10 @@ export class DataViewsService {
     });
 
     if (!skipFetchFields) {
-      await this.refreshFields(indexPattern, displayErrors);
+      await this.refreshFields(dataView, displayErrors);
     }
 
-    this.dataViewCache.set(indexPattern.id!, Promise.resolve(indexPattern));
-
-    return indexPattern;
+    return dataView;
   }
 
   /**
@@ -949,7 +947,13 @@ export class DataViewsService {
       }
     }
 
-    return await this.createFromSpec(spec, skipFetchFields, displayErrors);
+    const dataView = await this.createFromSpec(spec, skipFetchFields, displayErrors);
+
+    if (dataView.id) {
+      return this.dataViewCache.set(dataView.id, Promise.resolve(dataView));
+    }
+
+    return dataView;
   }
 
   /**

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -939,10 +939,9 @@ export class DataViewsService {
   async create(
     spec: DataViewSpec,
     skipFetchFields = false,
-    displayErrors = true,
-    recreateDataView = false
+    displayErrors = true
   ): Promise<DataView> {
-    if (spec.id && !recreateDataView) {
+    if (spec.id) {
       const cachedDataView = spec.id ? await this.dataViewCache.get(spec.id) : undefined;
 
       if (cachedDataView) {


### PR DESCRIPTION
Closes: #143556, Closes: #144253

### Root cause

`TSVB` uses `useEfect` to change the `DataView`. The problem is that `esaggs.ts` calls `indexPatterns.create` which updates the link to the cached `DataView` each time 

I don't know why it was implemented that way, but it looks like we can try to get a value from the cache before creating a new one.


### Screens

With that changes TSVB works fine

https://user-images.githubusercontent.com/20072247/198004089-66f18637-5a21-4908-911f-a11368b9c63b.mov


