### PR TITLE
[Console] Fix bug in which loading from a remote url fails when View in Console button is clicked in Elastic docs

### DIFF
--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -115,7 +115,9 @@ function EditorUI({ initialTextValue, setEditorInstance }: EditorProps) {
 
     const loadBufferFromRemote = (url: string) => {
       const coreEditor = editor.getCoreEditor();
-      if (/^https?:\/\//.test(url)) {
+      // Normalize and encode the URL to avoid issues with spaces and other special characters.
+      const encodedUrl = new URL(url).toString();
+      if (/^https?:\/\//.test(encodedUrl)) {
         const loadFrom: Record<string, any> = {
           url,
           // Having dataType here is required as it doesn't allow jQuery to `eval` content


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/143951

This PR fixes the issue with loading data from a remote url when `View in Console` button is clicked in Elastic [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html). The issue was that the url for the console editor in elastic docs has a different format than the one in local dev. For instance, in local dev the url is `http://localhost:5601/app/dev_tools#/console` while in elastic docs the url is `http://localhost:5601/app/kibana#/dev_tools/console`. Changing the url in elastic docs to the one in local dev fixes the issue. However, this PR also fixes the issue when the url in elastic docs is not changed.

To test this PR:

1. Start Kibana with `yarn start --run-examples`. This will start Kibana without a base path to get those local links to work
2. Go to https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
3.  Click the "View in Console" button.
4.  The console editor should open with the request from the docs.