### PR TITLE
[Security Solution] Update kpi user authentication area configs

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
@@ -7,17 +7,17 @@ Object {
     Object {
       "id": "security-solution-my-test",
       "name": "indexpattern-datasource-current-indexpattern",
-      "type": "{dataViewId}",
+      "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
       "name": "indexpattern-datasource-layer-31213ae3-905b-4e88-b987-0cccb1f3209f",
-      "type": "{dataViewId}",
+      "type": "index-pattern",
     },
     Object {
       "id": "security-solution-my-test",
       "name": "indexpattern-datasource-layer-4590dafb-4ac7-45aa-8641-47a3ff0b817c",
-      "type": "{dataViewId}",
+      "type": "index-pattern",
     },
   ],
   "state": Object {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_user_authentications_area.ts
@@ -183,18 +183,18 @@ export const kpiUserAuthenticationsAreaLensAttributes: LensAttributes = {
   },
   references: [
     {
-      type: '{dataViewId}',
-      id: 'security-solution-default',
+      type: 'index-pattern',
+      id: '{dataViewId}',
       name: 'indexpattern-datasource-current-indexpattern',
     },
     {
-      type: '{dataViewId}',
-      id: 'security-solution-default',
+      type: 'index-pattern',
+      id: '{dataViewId}',
       name: 'indexpattern-datasource-layer-31213ae3-905b-4e88-b987-0cccb1f3209f',
     },
     {
-      type: '{dataViewId}',
-      id: 'security-solution-default',
+      type: 'index-pattern',
+      id: '{dataViewId}',
       name: 'indexpattern-datasource-layer-4590dafb-4ac7-45aa-8641-47a3ff0b817c',
     },
   ],


### PR DESCRIPTION
## Summary

User authentication area chart is unable to be viewed in Lens:

https://user-images.githubusercontent.com/6295984/197994112-c41d23e5-36ca-4af8-914e-0028861e9653.mov

Steps to reproduce:
1. Visit `/app/security/users/allUsers`
2. Click the ... of the authentication area chart, and select `Open in Lens`

Observation:
An error toast appears on the bottom right corner.

Expected:
Display the same visualisation as showed on users page without error.

### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->