### PR TITLE
Restore link to spatial relation operator in ES docs

### DIFF
--- a/docs/maps/search.asciidoc
+++ b/docs/maps/search.asciidoc
@@ -107,7 +107,7 @@ You can create spatial filters in two ways:
 Spatial filters have the following properties:
 
 * *Geometry label* enables you to provide a meaningful name for your spatial filter.
-* *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html[spatial relation operator] to use at search time.
+* *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html#geo-shape-spatial-relations[spatial relation operator] to use at search time.
 * *Action* specifies whether to apply the filter to the current view or to a drilldown action. Only available when the map is a panel in a {kibana-ref}/dashboard.html[dashboard] with {kibana-ref}/drilldowns.html[drilldowns].
 
 [role="screenshot"]


### PR DESCRIPTION
Restores the link to the spatial relation operator Elasticsearch docs, that was temporarily removed in https://github.com/elastic/kibana/pull/143965 so we could merge https://github.com/elastic/elasticsearch/pull/90913 .