### PR TITLE
[APM] Performance fix for 'cardinality' telemetry task

### DIFF
--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -17,7 +17,11 @@ type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
 
 type TelemetryTaskExecutor = (params: {
   indices: ApmIndicesConfig;
-  search<TSearchRequest extends ESSearchRequest>(
+  search<
+    TSearchRequest extends ESSearchRequest & { index: string | string[] } & {
+      body: { timeout: string };
+    }
+  >(
     params: TSearchRequest
   ): Promise<ESSearchResponse<unknown, TSearchRequest>>;
   indicesStats(

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -434,7 +434,7 @@ describe('data telemetry collection tasks', () => {
         }
       });
 
-      expect(await task?.executor({ search } as any)).toEqual({
+      expect(await task?.executor({ search, indices } as any)).toEqual({
         cardinality: {
           client: { geo: { country_iso_code: { rum: { '1d': 5 } } } },
           transaction: { name: { all_agents: { '1d': 3 }, rum: { '1d': 1 } } },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1032,8 +1032,9 @@ export const tasks: TelemetryTask[] = [
   },
   {
     name: 'cardinality',
-    executor: async ({ search }) => {
+    executor: async ({ indices, search }) => {
       const allAgentsCardinalityResponse = await search({
+        index: [indices.transaction],
         body: {
           size: 0,
           timeout,
@@ -1058,6 +1059,7 @@ export const tasks: TelemetryTask[] = [
       });
 
       const rumAgentCardinalityResponse = await search({
+        index: [indices.transaction],
         body: {
           size: 0,
           timeout,

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -148,6 +148,7 @@ export const tasks: TelemetryTask[] = [
         await search({
           index: indices.transaction,
           body: {
+            timeout,
             query: {
               bool: {
                 filter: [
@@ -355,6 +356,7 @@ export const tasks: TelemetryTask[] = [
       const response = await search({
         index: [indices.transaction],
         body: {
+          timeout,
           query: {
             bool: {
               filter: [{ range: { '@timestamp': { gte: 'now-1d' } } }],


### PR DESCRIPTION
## Summary

Someone found an [instance where this telemetry task took 29 hours.](https://github.com/elastic/telemetry/issues/504#issuecomment-1285281256) We should figure out why the `timeout` argument didn't stop that earlier in that instance, but I also noticed that we're not narrowing the indices at all on these queries. We now only search the traces indices which should (hopefully) improve the performance on this dramatically.

/cc @felixbarny @dgieselaar 

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

Closes https://github.com/elastic/kibana/issues/143819.


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->