### PR TITLE
[Lens][Agg based visualizations] Add support convert to lens for visualizations based on saved searches

### DIFF
--- a/src/plugins/visualizations/public/visualize_app/components/visualize_byvalue_editor.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_byvalue_editor.tsx
@@ -110,6 +110,7 @@ export const VisualizeByValueEditor = ({ onAppLeave }: VisualizeAppProps) => {
       visEditorRef={visEditorRef}
       embeddableId={embeddableId}
       onAppLeave={onAppLeave}
+      eventEmitter={eventEmitter}
     />
   );
 };

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_editor.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_editor.tsx
@@ -110,6 +110,7 @@ export const VisualizeEditor = ({ onAppLeave }: VisualizeAppProps) => {
       visEditorRef={visEditorRef}
       onAppLeave={onAppLeave}
       embeddableId={embeddableIdValue}
+      eventEmitter={eventEmitter}
     />
   );
 };

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_editor_common.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_editor_common.tsx
@@ -7,6 +7,7 @@
  */
 
 import './visualize_editor.scss';
+import { EventEmitter } from 'events';
 import React, { RefObject, useCallback, useEffect } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -48,6 +49,7 @@ interface VisualizeEditorCommonProps {
   originatingPath?: string;
   visualizationIdFromUrl?: string;
   embeddableId?: string;
+  eventEmitter?: EventEmitter;
 }
 
 export const VisualizeEditorCommon = ({
@@ -66,6 +68,7 @@ export const VisualizeEditorCommon = ({
   visualizationIdFromUrl,
   embeddableId,
   visEditorRef,
+  eventEmitter,
 }: VisualizeEditorCommonProps) => {
   const { services } = useKibana<VisualizeServices>();
 
@@ -148,6 +151,7 @@ export const VisualizeEditorCommon = ({
           visualizationIdFromUrl={visualizationIdFromUrl}
           embeddableId={embeddableId}
           onAppLeave={onAppLeave}
+          eventEmitter={eventEmitter}
         />
       )}
       {visInstance?.vis?.type?.stage === 'experimental' &&

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useState, useEffect } from 'react';
-
+import { EventEmitter } from 'events';
 import { AppMountParameters, OverlayRef } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
@@ -40,6 +40,7 @@ interface VisualizeTopNavProps {
   visualizationIdFromUrl?: string;
   embeddableId?: string;
   onAppLeave: AppMountParameters['onAppLeave'];
+  eventEmitter?: EventEmitter;
 }
 
 const TopNav = ({
@@ -57,6 +58,7 @@ const TopNav = ({
   visualizationIdFromUrl,
   embeddableId,
   onAppLeave,
+  eventEmitter,
 }: VisualizeTopNavProps) => {
   const { services } = useKibana<VisualizeServices>();
   const { TopNavMenu } = services.navigation.ui;
@@ -116,6 +118,7 @@ const TopNav = ({
     uiStateJSON?.vis,
     uiStateJSON?.table,
     vis.data.indexPattern,
+    eventEmitter,
   ]);
 
   const displayEditInLensItem = Boolean(vis.type.navigateToLens && editInLensConfig);
@@ -140,6 +143,7 @@ const TopNav = ({
           hideLensBadge,
           setNavigateToLens,
           showBadge: !hideTryInLensBadge && displayEditInLensItem,
+          eventEmitter,
         },
         services
       );
@@ -162,6 +166,7 @@ const TopNav = ({
     displayEditInLensItem,
     hideLensBadge,
     hideTryInLensBadge,
+    eventEmitter,
   ]);
   const [indexPatterns, setIndexPatterns] = useState<DataView[]>([]);
   const showDatePicker = () => {

--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import moment from 'moment';
+import EventEmitter from 'events';
 import { i18n } from '@kbn/i18n';
 import { EuiBetaBadgeProps } from '@elastic/eui';
 import { parse } from 'query-string';
@@ -71,6 +72,7 @@ export interface TopNavConfigParams {
   hideLensBadge: () => void;
   setNavigateToLens: (flag: boolean) => void;
   showBadge: boolean;
+  eventEmitter?: EventEmitter;
 }
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
@@ -102,6 +104,7 @@ export const getTopNavConfig = (
     hideLensBadge,
     setNavigateToLens,
     showBadge,
+    eventEmitter,
   }: TopNavConfigParams,
   {
     data,
@@ -301,6 +304,10 @@ export const getTopNavConfig = (
               },
             }),
             run: async () => {
+              // lens doesn't support saved searches, should unlink before transition
+              if (eventEmitter && visInstance.vis.data.savedSearchId) {
+                eventEmitter.emit('unlinkFromSavedSearch', false);
+              }
               const updatedWithMeta = {
                 ...editInLensConfig,
                 savedObjectId: visInstance.vis.id,

--- a/src/plugins/visualizations/public/visualize_app/utils/use/use_linked_search_updates.ts
+++ b/src/plugins/visualizations/public/visualize_app/utils/use/use_linked_search_updates.ts
@@ -29,7 +29,7 @@ export const useLinkedSearchUpdates = (
       // SearchSource is a promise-based stream of search results that can inherit from other search sources.
       const { searchSource } = visInstance.vis.data;
 
-      const unlinkFromSavedSearch = () => {
+      const unlinkFromSavedSearch = (showToast: boolean = true) => {
         const searchSourceParent = savedSearch.searchSource;
         const searchSourceGrandparent = searchSourceParent?.getParent();
         const currentIndex = searchSourceParent?.getField('index');
@@ -44,14 +44,16 @@ export const useLinkedSearchUpdates = (
           parentFilters: (searchSourceParent?.getOwnField('filter') as Filter[]) || [],
         });
 
-        services.toastNotifications.addSuccess(
-          i18n.translate('visualizations.linkedToSearch.unlinkSuccessNotificationText', {
-            defaultMessage: `Unlinked from saved search '{searchTitle}'`,
-            values: {
-              searchTitle: savedSearch.title,
-            },
-          })
-        );
+        if (showToast) {
+          services.toastNotifications.addSuccess(
+            i18n.translate('visualizations.linkedToSearch.unlinkSuccessNotificationText', {
+              defaultMessage: `Unlinked from saved search '{searchTitle}'`,
+              values: {
+                searchTitle: savedSearch.title,
+              },
+            })
+          );
+        }
       };
 
       eventEmitter.on('unlinkFromSavedSearch', unlinkFromSavedSearch);


### PR DESCRIPTION
## Summary

Closes: #144084

Agg based visualizations can be created based on saved searches. To convert these visualizations we should allow the transition by unlinking the saved search and go to lens with the applied filters/query.

[Visualize Library - Elastic.webm](https://user-images.githubusercontent.com/16915480/198284065-1cdf38af-1ca6-4230-b036-c24260aa2c9a.webm)
