### PR TITLE
[Guided onboarding] Add API integration tests

### DIFF
--- a/x-pack/test/api_integration/apis/guided_onboarding/get_state.ts
+++ b/x-pack/test/api_integration/apis/guided_onboarding/get_state.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import {
+  searchAddDataActiveState,
+  securityAddDataInProgressState,
+} from '@kbn/guided-onboarding-plugin/public/services/api.mocks';
+import { guidedSetupSavedObjectsType } from '@kbn/guided-onboarding-plugin/server/saved_objects/guided_setup';
+import type { GuideState } from '@kbn/guided-onboarding';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function testGetState({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const kibanaServer = getService('kibanaServer');
+
+  describe('GET /api/guided_onboarding/state', () => {
+    afterEach(async () => {
+      // Clean up saved objects
+      await kibanaServer.savedObjects.clean({ types: [guidedSetupSavedObjectsType] });
+    });
+
+    const createGuides = async (guides: GuideState[]) => {
+      for (const guide of guides) {
+        await kibanaServer.savedObjects.create({
+          type: guidedSetupSavedObjectsType,
+          id: guide.guideId,
+          overwrite: true,
+          attributes: guide,
+        });
+      }
+    };
+
+    it('should return the state for all guides', async () => {
+      await createGuides([searchAddDataActiveState, securityAddDataInProgressState]);
+
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      expect(response.body.state.length).to.eql(2);
+      expect(response.body).to.eql({
+        state: [searchAddDataActiveState, securityAddDataInProgressState],
+      });
+    });
+
+    it('should return the state for the active guide with query param `active=true`', async () => {
+      await createGuides([
+        searchAddDataActiveState,
+        { ...securityAddDataInProgressState, isActive: false },
+      ]);
+
+      const response = await supertest
+        .get('/api/guided_onboarding/state')
+        .query({ active: true })
+        .expect(200);
+      expect(response.body).to.eql({ state: [searchAddDataActiveState] });
+    });
+
+    it('should return state from saved object if it exists', async () => {
+      // Add a new state to the saved object
+      await kibanaServer.savedObjects.create({
+        type: guidedSetupSavedObjectsType,
+        id: securityAddDataInProgressState.guideId,
+        overwrite: true,
+        attributes: securityAddDataInProgressState,
+      });
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      expect(response.body).to.eql({
+        state: [securityAddDataInProgressState],
+      });
+    });
+
+    it("should return an empty array if saved object doesn't exist", async () => {
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      expect(response.body).to.eql({ state: [] });
+    });
+  });
+}

--- a/x-pack/test/api_integration/apis/guided_onboarding/index.ts
+++ b/x-pack/test/api_integration/apis/guided_onboarding/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function apiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('guided onboarding', () => {
+    loadTestFile(require.resolve('./get_state'));
+    loadTestFile(require.resolve('./put_state'));
+  });
+}

--- a/x-pack/test/api_integration/apis/guided_onboarding/put_state.ts
+++ b/x-pack/test/api_integration/apis/guided_onboarding/put_state.ts
@@ -11,11 +11,13 @@ import {
   testGuideNotActiveState,
 } from '@kbn/guided-onboarding-plugin/public/services/api.mocks';
 import { guidedSetupSavedObjectsType } from '@kbn/guided-onboarding-plugin/server/saved_objects/guided_setup';
-import type { GuideId } from '@kbn/guided-onboarding';
+import type { GuideState } from '@kbn/guided-onboarding';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
-const testGuideA = testGuideStep1ActiveState;
-const testGuideB = { ...testGuideNotActiveState, guideId: 'testGuideB' as GuideId }; // different guideId
+const mockSearchGuideNotActiveState: GuideState = {
+  ...testGuideNotActiveState,
+  guideId: 'search',
+};
 
 export default function testPutState({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
@@ -31,9 +33,9 @@ export default function testPutState({ getService }: FtrProviderContext) {
       // Create a saved object for the guide
       await kibanaServer.savedObjects.create({
         type: guidedSetupSavedObjectsType,
-        id: testGuideA.guideId,
+        id: testGuideStep1ActiveState.guideId,
         overwrite: true,
-        attributes: testGuideA,
+        attributes: testGuideStep1ActiveState,
       });
 
       // Update the state of the guide
@@ -41,7 +43,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
         .put(`/api/guided_onboarding/state`)
         .set('kbn-xsrf', 'true')
         .send({
-          ...testGuideA,
+          ...testGuideStep1ActiveState,
           status: 'complete',
         })
         .expect(200);
@@ -57,7 +59,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
         .put(`/api/guided_onboarding/state`)
         .set('kbn-xsrf', 'true')
         .send({
-          ...testGuideA,
+          ...testGuideStep1ActiveState,
           status: 'ready_to_complete',
         })
         .expect(200);
@@ -74,7 +76,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
         .put(`/api/guided_onboarding/state`)
         .set('kbn-xsrf', 'true')
         .send({
-          ...testGuideA,
+          ...testGuideStep1ActiveState,
           isActive: true,
         })
         .expect(200);
@@ -84,7 +86,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
         .put(`/api/guided_onboarding/state`)
         .set('kbn-xsrf', 'true')
         .send({
-          ...testGuideB,
+          ...mockSearchGuideNotActiveState,
           isActive: false,
         })
         .expect(200);
@@ -94,7 +96,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
         .put(`/api/guided_onboarding/state`)
         .set('kbn-xsrf', 'true')
         .send({
-          guideId: 'testGuideC',
+          guideId: 'observability',
           isActive: true,
           status: 'in_progress',
           steps: [
@@ -120,7 +122,7 @@ export default function testPutState({ getService }: FtrProviderContext) {
       expect(guides.length).to.eql(3);
       const activeGuides = guides.filter((guide: { isActive: boolean }) => guide.isActive);
       expect(activeGuides.length).to.eql(1);
-      expect(activeGuides[0].guideId).to.eql('testGuideC');
+      expect(activeGuides[0].guideId).to.eql('observability');
     });
   });
 }

--- a/x-pack/test/api_integration/apis/guided_onboarding/put_state.ts
+++ b/x-pack/test/api_integration/apis/guided_onboarding/put_state.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import {
+  securityAddDataInProgressState,
+  searchAddDataActiveState,
+} from '@kbn/guided-onboarding-plugin/public/services/api.mocks';
+import { guidedSetupSavedObjectsType } from '@kbn/guided-onboarding-plugin/server/saved_objects/guided_setup';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function testPutState({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const kibanaServer = getService('kibanaServer');
+
+  describe('PUT /api/guided_onboarding/state', () => {
+    afterEach(async () => {
+      // Clean up saved objects
+      await kibanaServer.savedObjects.clean({ types: [guidedSetupSavedObjectsType] });
+    });
+
+    it('should update a guide that has an existing saved object', async () => {
+      // Create a saved object for the guide
+      await kibanaServer.savedObjects.create({
+        type: guidedSetupSavedObjectsType,
+        id: securityAddDataInProgressState.guideId,
+        overwrite: true,
+        attributes: securityAddDataInProgressState,
+      });
+
+      // Update the state of the guide
+      await supertest
+        .put(`/api/guided_onboarding/state`)
+        .set('kbn-xsrf', 'true')
+        .send({
+          ...securityAddDataInProgressState,
+          status: 'complete',
+        })
+        .expect(200);
+
+      // Check that the guide was updated
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      const [updatedGuide] = response.body.state;
+      expect(updatedGuide.status).to.eql('complete');
+    });
+
+    it('should update a guide that does not have a saved object', async () => {
+      await supertest
+        .put(`/api/guided_onboarding/state`)
+        .set('kbn-xsrf', 'true')
+        .send({
+          ...securityAddDataInProgressState,
+          status: 'ready_to_complete',
+        })
+        .expect(200);
+
+      // Check that the guide was updated
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      const [updatedGuide] = response.body.state;
+      expect(updatedGuide.status).to.eql('ready_to_complete');
+    });
+
+    it('should update any existing active guides to inactive', async () => {
+      // Create an active guide
+      await supertest
+        .put(`/api/guided_onboarding/state`)
+        .set('kbn-xsrf', 'true')
+        .send({
+          ...securityAddDataInProgressState,
+          isActive: true,
+        })
+        .expect(200);
+
+      // Create an inactive guide
+      await supertest
+        .put(`/api/guided_onboarding/state`)
+        .set('kbn-xsrf', 'true')
+        .send({
+          ...searchAddDataActiveState,
+          isActive: false,
+        })
+        .expect(200);
+
+      // Create a new guide with isActive: true
+      await supertest
+        .put(`/api/guided_onboarding/state`)
+        .set('kbn-xsrf', 'true')
+        .send({
+          guideId: 'observability',
+          isActive: true,
+          status: 'in_progress',
+          steps: [
+            {
+              id: 'add_data',
+              status: 'inactive',
+            },
+            {
+              id: 'view_dashboard',
+              status: 'inactive',
+            },
+            {
+              id: 'tour_observability',
+              status: 'inactive',
+            },
+          ],
+        })
+        .expect(200);
+
+      // Check that the active guide was updated
+      const response = await supertest.get('/api/guided_onboarding/state').expect(200);
+      const guides = response.body.state;
+      expect(guides.length).to.eql(3);
+      const activeGuides = guides.filter((guide: { isActive: boolean }) => guide.isActive);
+      expect(activeGuides.length).to.eql(1);
+      expect(activeGuides[0].guideId).to.eql('observability');
+    });
+  });
+}

--- a/x-pack/test/api_integration/apis/index.ts
+++ b/x-pack/test/api_integration/apis/index.ts
@@ -39,5 +39,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./cases'));
     loadTestFile(require.resolve('./monitoring_collection'));
     loadTestFile(require.resolve('./cloud_security_posture'));
+    loadTestFile(require.resolve('./guided_onboarding'));
   });
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/142261

### Summary

This PR adds the following API integration tests for the guided onboarding plugin:

 #### GET /state
- [x]  Returns the state for all guides (?active=false)
- [x]  Returns state for the active guide (?active=true)
- [x]  Returns an empty array if saved object doesn't exist

#### PUT /state

- [x] Updates a guide that has an existing saved object
- [x] Updates a guide that does not have a saved object
- [x] Updates any existing active guides to inactive