### PR TITLE
[APM] Normalize time range for apm-per-service telemetry

### DIFF
--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -1170,7 +1170,7 @@ export const tasks: TelemetryTask[] = [
           query: {
             bool: {
               filter: [
-                { range: { '@timestamp': { gte: 'now-1h' } } },
+                range1d,
                 { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
               ],
             },


### PR DESCRIPTION
## Summary

After discussions on https://github.com/elastic/kibana/pull/144061 I think we should probably normalize `apm-per-service` to also use the `range1d` filter instead of `now-1h`.

Edit: At @graphaelli's recommendation I'm going to have it do 1d, check the timeout, and if it timed out do the 1h version. I'll re-request review at that point.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
