### PR TITLE
[Telemetry] Smarter next attempt timer to avoid skipping days

### DIFF
--- a/src/plugins/telemetry/common/constants.ts
+++ b/src/plugins/telemetry/common/constants.ts
@@ -13,6 +13,12 @@
 export const REPORT_INTERVAL_MS = 86400000;
 
 /**
+ * The buffer time, in milliseconds, to consider the {@link REPORT_INTERVAL_MS} as expired.
+ * Currently, 2 minutes.
+ */
+export const REPORT_INTERVAL_BUFFER_MS = 120000;
+
+/**
  * How often we poll for the opt-in status.
  * Currently, 10 seconds.
  */

--- a/src/plugins/telemetry/common/is_report_interval_expired.test.ts
+++ b/src/plugins/telemetry/common/is_report_interval_expired.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { REPORT_INTERVAL_MS } from './constants';
+import { REPORT_INTERVAL_BUFFER_MS, REPORT_INTERVAL_MS } from './constants';
 import { isReportIntervalExpired } from './is_report_interval_expired';
 
 describe('isReportIntervalExpired', () => {
@@ -54,7 +54,9 @@ describe('isReportIntervalExpired', () => {
   });
 
   test('false when close but not yet', () => {
-    expect(isReportIntervalExpired(Date.now() - REPORT_INTERVAL_MS + 1000)).toBe(false);
+    expect(
+      isReportIntervalExpired(Date.now() - REPORT_INTERVAL_MS + REPORT_INTERVAL_BUFFER_MS + 1000)
+    ).toBe(false);
   });
 
   test('false when date in the future', () => {

--- a/src/plugins/telemetry/common/is_report_interval_expired.ts
+++ b/src/plugins/telemetry/common/is_report_interval_expired.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { REPORT_INTERVAL_MS } from './constants';
+import { REPORT_INTERVAL_BUFFER_MS, REPORT_INTERVAL_MS } from './constants';
 
 /**
  * The report is considered expired if:
@@ -15,5 +15,9 @@ import { REPORT_INTERVAL_MS } from './constants';
  * @returns `true` if the report interval is considered expired
  */
 export function isReportIntervalExpired(lastReportAt: number | undefined) {
-  return !lastReportAt || isNaN(lastReportAt) || Date.now() - lastReportAt > REPORT_INTERVAL_MS;
+  return (
+    !lastReportAt ||
+    isNaN(lastReportAt) ||
+    Date.now() - lastReportAt > REPORT_INTERVAL_MS - REPORT_INTERVAL_BUFFER_MS
+  );
 }

--- a/src/plugins/telemetry/server/fetcher.test.mock.ts
+++ b/src/plugins/telemetry/server/fetcher.test.mock.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const fetchMock = jest.fn();
+
+jest.doMock('node-fetch', () => fetchMock);
+
+export const getNextAttemptDateMock = jest.fn();
+
+jest.doMock('./get_next_attempt_date', () => ({ getNextAttemptDate: getNextAttemptDateMock }));

--- a/src/plugins/telemetry/server/fetcher.test.ts
+++ b/src/plugins/telemetry/server/fetcher.test.ts
@@ -7,14 +7,29 @@
  */
 
 /* eslint-disable dot-notation */
-import { FetcherTask } from './fetcher';
+import { fakeSchedulers } from 'rxjs-marbles/jest';
 import { coreMock } from '@kbn/core/server/mocks';
 import {
   telemetryCollectionManagerPluginMock,
   Setup,
 } from '@kbn/telemetry-collection-manager-plugin/server/mocks';
 
+jest.mock('rxjs', () => {
+  const RxJs = jest.requireActual('rxjs');
+  return {
+    ...RxJs,
+    // Redefining timer as a merge of timer and interval because `fakeSchedulers` fails to advance on the intervals
+    timer: (dueTime: number, interval: number) =>
+      RxJs.merge(RxJs.timer(dueTime), RxJs.interval(interval)),
+  };
+});
+
+import { fetchMock, getNextAttemptDateMock } from './fetcher.test.mock';
+import { FetcherTask } from './fetcher';
+
 describe('FetcherTask', () => {
+  beforeEach(() => jest.useFakeTimers('legacy'));
+
   describe('sendIfDue', () => {
     let getCurrentConfigs: jest.Mock;
     let shouldSendReport: jest.Mock;
@@ -94,5 +109,200 @@ describe('FetcherTask', () => {
       expect(sendTelemetry).toHaveBeenNthCalledWith(1, mockTelemetryUrl, mockClusters);
       expect(updateReportFailure).toBeCalledTimes(0);
     });
+  });
+
+  describe('Validate connectivity', () => {
+    let fetcherTask: FetcherTask;
+    let getCurrentConfigs: jest.Mock;
+    let updateReportFailure: jest.Mock;
+
+    beforeEach(() => {
+      getCurrentConfigs = jest.fn();
+      updateReportFailure = jest.fn();
+      fetcherTask = new FetcherTask(coreMock.createPluginInitializerContext({}));
+      Object.assign(fetcherTask, { getCurrentConfigs, updateReportFailure });
+    });
+
+    afterEach(() => {
+      fetchMock.mockReset();
+    });
+
+    test(
+      'Validates connectivity and sets as online when the OPTIONS request succeeds',
+      fakeSchedulers(async (advance) => {
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+        getCurrentConfigs.mockResolvedValue({
+          telemetryOptIn: true,
+          telemetrySendUsageFrom: 'server',
+          failureCount: 0,
+          telemetryUrl: 'test-url',
+        });
+        fetchMock.mockResolvedValue({});
+        const subscription = fetcherTask['validateConnectivity']();
+        advance(5 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('test-url', { method: 'options' });
+        expect(fetcherTask['isOnline$'].value).toBe(true);
+        subscription.unsubscribe();
+      })
+    );
+
+    test(
+      'Skips validation when already set as online',
+      fakeSchedulers(async (advance) => {
+        fetcherTask['isOnline$'].next(true);
+        const subscription = fetcherTask['validateConnectivity']();
+        advance(5 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(0);
+        expect(fetchMock).toHaveBeenCalledTimes(0);
+        expect(fetcherTask['isOnline$'].value).toBe(true);
+        subscription.unsubscribe();
+      })
+    );
+
+    test(
+      'Retries on errors',
+      fakeSchedulers(async (advance) => {
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+        getCurrentConfigs.mockResolvedValue({
+          telemetryOptIn: true,
+          telemetrySendUsageFrom: 'server',
+          failureCount: 0,
+          telemetryUrl: 'test-url',
+        });
+        fetchMock.mockRejectedValue(new Error('Something went terribly wrong'));
+        const subscription = fetcherTask['validateConnectivity']();
+        advance(5 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(updateReportFailure).toHaveBeenCalledTimes(1);
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+
+        // Try again after 12 hours
+        fetchMock.mockResolvedValue({});
+        advance(12 * 60 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(updateReportFailure).toHaveBeenCalledTimes(1);
+        expect(fetcherTask['isOnline$'].value).toBe(true);
+
+        subscription.unsubscribe();
+      })
+    );
+
+    test(
+      'Should not retry if it hit the max number of failures for this version',
+      fakeSchedulers(async (advance) => {
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+        getCurrentConfigs.mockResolvedValue({
+          telemetryOptIn: true,
+          telemetrySendUsageFrom: 'server',
+          failureCount: 3,
+          failureVersion: 'version',
+          currentVersion: 'version',
+          telemetryUrl: 'test-url',
+        });
+        const subscription = fetcherTask['validateConnectivity']();
+        advance(5 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(0);
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+
+        subscription.unsubscribe();
+      })
+    );
+
+    test(
+      'Should retry if it hit the max number of failures for a different version',
+      fakeSchedulers(async (advance) => {
+        expect(fetcherTask['isOnline$'].value).toBe(false);
+        getCurrentConfigs.mockResolvedValue({
+          telemetryOptIn: true,
+          telemetrySendUsageFrom: 'server',
+          failureCount: 3,
+          failureVersion: 'version',
+          currentVersion: 'another_version',
+          telemetryUrl: 'test-url',
+        });
+        const subscription = fetcherTask['validateConnectivity']();
+        advance(5 * 60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve)); // Wait for the promise to fulfill
+        expect(getCurrentConfigs).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetcherTask['isOnline$'].value).toBe(true);
+
+        subscription.unsubscribe();
+      })
+    );
+  });
+
+  describe('startSendIfDueSubscription', () => {
+    let fetcherTask: FetcherTask;
+    let sendIfDue: jest.Mock;
+
+    beforeEach(() => {
+      sendIfDue = jest.fn().mockResolvedValue({});
+      fetcherTask = new FetcherTask(coreMock.createPluginInitializerContext({}));
+      Object.assign(fetcherTask, { sendIfDue });
+    });
+
+    afterEach(() => {
+      getNextAttemptDateMock.mockReset();
+    });
+
+    test('Tries to send telemetry when it is online', () => {
+      const subscription = fetcherTask['startSendIfDueSubscription']();
+      fetcherTask['isOnline$'].next(true);
+      expect(sendIfDue).toHaveBeenCalledTimes(1);
+      subscription.unsubscribe();
+    });
+
+    test('Does not send telemetry when it is offline', () => {
+      const subscription = fetcherTask['startSendIfDueSubscription']();
+      fetcherTask['isOnline$'].next(false);
+      expect(sendIfDue).toHaveBeenCalledTimes(0);
+      subscription.unsubscribe();
+    });
+
+    test(
+      'Sends telemetry when the next attempt date kicks in',
+      fakeSchedulers((advance) => {
+        fetcherTask['isOnline$'].next(true);
+        const subscription = fetcherTask['startSendIfDueSubscription']();
+        const lastReported = Date.now();
+        getNextAttemptDateMock.mockReturnValue(new Date(lastReported + 1000));
+        fetcherTask['lastReported$'].next(lastReported);
+        advance(1000);
+        expect(sendIfDue).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      })
+    );
+
+    test(
+      'Keeps retrying every 1 minute after the next attempt date until a new emission of lastReported occurs',
+      fakeSchedulers(async (advance) => {
+        fetcherTask['isOnline$'].next(true);
+        const subscription = fetcherTask['startSendIfDueSubscription']();
+        const lastReported = Date.now();
+        getNextAttemptDateMock.mockReturnValue(new Date(lastReported + 1000));
+        fetcherTask['lastReported$'].next(lastReported);
+        advance(1000);
+        await new Promise((resolve) => process.nextTick(resolve));
+        expect(sendIfDue).toHaveBeenCalledTimes(1);
+        advance(60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve));
+        expect(sendIfDue).toHaveBeenCalledTimes(2);
+        advance(60 * 1000);
+        await new Promise((resolve) => process.nextTick(resolve));
+        expect(sendIfDue).toHaveBeenCalledTimes(3);
+        subscription.unsubscribe();
+      })
+    );
   });
 });

--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -14,6 +14,7 @@ import {
   merge,
   mergeMap,
   Observable,
+  skip,
   Subscription,
   takeUntil,
   timer,
@@ -135,7 +136,7 @@ export class FetcherTask {
           // Emitting again every 1 minute after the next attempt date in case we reach a deadlock in further checks (like Kibana is not healthy at the moment of sending).
           timer(getNextAttemptDate(lastReported), MINUTE).pipe(
             // Cancel this observable if lastReported$ emits again
-            takeUntil(this.lastReported$)
+            takeUntil(this.lastReported$.pipe(skip(1)))
           )
         )
       )

--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -6,7 +6,18 @@
  * Side Public License, v 1.
  */
 
-import { firstValueFrom, Observable, Subscription, timer } from 'rxjs';
+import {
+  BehaviorSubject,
+  exhaustMap,
+  filter,
+  firstValueFrom,
+  merge,
+  mergeMap,
+  Observable,
+  Subscription,
+  takeUntil,
+  timer,
+} from 'rxjs';
 import fetch from 'node-fetch';
 import type { TelemetryCollectionManagerPluginStart } from '@kbn/telemetry-collection-manager-plugin/server';
 import {
@@ -16,6 +27,7 @@ import {
   SavedObjectsClient,
   CoreStart,
 } from '@kbn/core/server';
+import { getNextAttemptDate } from './get_next_attempt_date';
 import {
   getTelemetryChannelEndpoint,
   getTelemetryOptIn,
@@ -42,15 +54,19 @@ interface TelemetryConfig {
   lastReported: number | undefined;
 }
 
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
 export class FetcherTask {
-  private readonly initialCheckDelayMs = 60 * 1000 * 5;
-  private readonly checkIntervalMs = 60 * 1000 * 60 * 12;
+  private readonly initialCheckDelayMs = 5 * MINUTE;
+  private readonly connectivityCheckIntervalMs = 12 * HOUR;
   private readonly config$: Observable<TelemetryConfigType>;
   private readonly currentKibanaVersion: string;
   private readonly logger: Logger;
-  private intervalId?: Subscription;
-  private lastReported?: number;
-  private isSending = false;
+  private readonly subscriptions = new Subscription();
+  private readonly isOnline$ = new BehaviorSubject<boolean>(false); // Let's initially assume we are not online
+  private readonly lastReported$ = new BehaviorSubject<number>(0);
   private internalRepository?: SavedObjectsClientContract;
   private telemetryCollectionManager?: TelemetryCollectionManagerPluginStart;
 
@@ -64,22 +80,74 @@ export class FetcherTask {
     this.internalRepository = new SavedObjectsClient(savedObjects.createInternalRepository());
     this.telemetryCollectionManager = telemetryCollectionManager;
 
-    this.intervalId = timer(this.initialCheckDelayMs, this.checkIntervalMs).subscribe(() =>
-      this.sendIfDue()
-    );
+    this.subscriptions.add(this.validateConnectivity());
+    this.subscriptions.add(this.startSendIfDueSubscription());
   }
 
   public stop() {
-    if (this.intervalId) {
-      this.intervalId.unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
+  }
+
+  /**
+   * Periodically validates the connectivity from the server to our remote telemetry URL.
+   * OPTIONS is less intrusive as it does not contain any payload and is used here to check if the endpoint is reachable.
+   */
+  private validateConnectivity(): Subscription {
+    return timer(this.initialCheckDelayMs, this.connectivityCheckIntervalMs)
+      .pipe(
+        // Skip any further processing if already online
+        filter(() => !this.isOnline$.value),
+        // Fetch current state and configs
+        exhaustMap(async () => await this.getCurrentConfigs()),
+        // Skip if opted-out, or should only send from the browser
+        filter(
+          ({ telemetryOptIn, telemetrySendUsageFrom }) =>
+            telemetryOptIn === true && telemetrySendUsageFrom === 'server'
+        ),
+        // Skip if already failed three times for this version
+        filter(
+          ({ failureCount, failureVersion, currentVersion }) =>
+            !(failureCount > 2 && failureVersion === currentVersion)
+        ),
+        exhaustMap(async ({ telemetryUrl, failureCount }) => {
+          try {
+            await fetch(telemetryUrl, { method: 'options' });
+            this.isOnline$.next(true);
+          } catch (err) {
+            this.logger.error(`Cannot reach the remote telemetry endpoint ${telemetryUrl}`);
+            await this.updateReportFailure({ failureCount });
+          }
+        })
+      )
+      .subscribe();
+  }
+
+  private startSendIfDueSubscription() {
+    return merge(
+      // Attempt to send telemetry...
+      // ... whenever connectivity changes
+      this.isOnline$,
+      // ... when lastReported$ has a new value...
+      this.lastReported$.pipe(
+        filter(Boolean),
+        mergeMap((lastReported) =>
+          // ... set a timer of 24h from there (+ a random seed to avoid concurrent emissions from multiple Kibana instances).
+          // Emitting again every 1 minute after the next attempt date in case we reach a deadlock in further checks (like Kibana is not healthy at the moment of sending).
+          timer(getNextAttemptDate(lastReported), MINUTE).pipe(
+            // Cancel this observable if lastReported$ emits again
+            takeUntil(this.lastReported$)
+          )
+        )
+      )
+    )
+      .pipe(
+        filter(() => this.isOnline$.value),
+        exhaustMap(() => this.sendIfDue())
+      )
+      .subscribe();
   }
 
   private async sendIfDue() {
-    if (this.isSending) {
-      return;
-    }
-
     // Skip this run if Kibana is not in a healthy state to fetch telemetry.
     if (!(await this.telemetryCollectionManager?.shouldGetTelemetry())) {
       return;
@@ -99,13 +167,11 @@ export class FetcherTask {
     }
 
     let clusters: EncryptedTelemetryPayload = [];
-    this.isSending = true;
 
     try {
       clusters = await this.fetchTelemetry();
     } catch (err) {
       this.logger.warn(`Error fetching usage. (${err})`);
-      this.isSending = false;
       return;
     }
 
@@ -119,7 +185,6 @@ export class FetcherTask {
 
       this.logger.warn(`Error sending telemetry usage data. (${err})`);
     }
-    this.isSending = false;
   }
 
   private async getCurrentConfigs(): Promise<TelemetryConfig> {
@@ -137,6 +202,13 @@ export class FetcherTask {
       telemetrySavedObject,
     });
 
+    const lastReported = telemetrySavedObject ? telemetrySavedObject.lastReported : void 0;
+
+    // If the lastReported value in the SO is more recent than the in-memory one, refresh the memory (another instance or the browser may have reported it)
+    if (lastReported && lastReported > this.lastReported$.value) {
+      this.lastReported$.next(lastReported);
+    }
+
     return {
       telemetryOptIn: getTelemetryOptIn({
         currentKibanaVersion,
@@ -152,15 +224,15 @@ export class FetcherTask {
       failureCount,
       failureVersion,
       currentVersion: currentKibanaVersion,
-      lastReported: telemetrySavedObject ? telemetrySavedObject.lastReported : void 0,
+      lastReported,
     };
   }
 
   private async updateLastReported() {
-    this.lastReported = Date.now();
+    this.lastReported$.next(Date.now());
     updateTelemetrySavedObject(this.internalRepository!, {
       reportFailureCount: 0,
-      lastReported: this.lastReported,
+      lastReported: this.lastReported$.value,
     }).catch((err) => {
       err.message = `Failed to update the telemetry saved object: ${err.message}`;
       this.logger.debug(err);
@@ -168,6 +240,7 @@ export class FetcherTask {
   }
 
   private async updateReportFailure({ failureCount }: { failureCount: number }) {
+    this.isOnline$.next(false);
     updateTelemetrySavedObject(this.internalRepository!, {
       reportFailureCount: failureCount + 1,
       reportFailureVersion: this.currentKibanaVersion,
@@ -180,19 +253,15 @@ export class FetcherTask {
   private shouldSendReport({
     telemetryOptIn,
     telemetrySendUsageFrom,
-    failureCount,
-    failureVersion,
-    currentVersion,
     lastReported,
   }: TelemetryConfig) {
-    if (failureCount > 2 && failureVersion === currentVersion) {
-      return false;
-    }
-
     if (telemetryOptIn && telemetrySendUsageFrom === 'server') {
       // Check both: in-memory and SO-driven value.
       // This will avoid the server retrying over and over when it has issues with storing the state in the SO.
-      if (isReportIntervalExpired(this.lastReported) && isReportIntervalExpired(lastReported)) {
+      if (
+        isReportIntervalExpired(this.lastReported$.value) &&
+        isReportIntervalExpired(lastReported)
+      ) {
         return true;
       }
     }
@@ -210,13 +279,6 @@ export class FetcherTask {
     payload: EncryptedTelemetryPayload
   ): Promise<void> {
     this.logger.debug(`Sending usage stats.`);
-    /**
-     * send OPTIONS before sending usage data.
-     * OPTIONS is less intrusive as it does not contain any payload and is used here to check if the endpoint is reachable.
-     */
-    await fetch(telemetryUrl, {
-      method: 'options',
-    });
 
     await Promise.all(
       payload.map(async ({ clusterUuid, stats }) => {

--- a/src/plugins/telemetry/server/get_next_attempt_date.test.ts
+++ b/src/plugins/telemetry/server/get_next_attempt_date.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import crypto from 'crypto';
+import { getNextAttemptDate } from './get_next_attempt_date';
+
+describe('getNextAttemptDate', () => {
+  // The casting is needed because `randomInt` has multiple call signatures and typescript is taking the callback one.
+  const randomIntSpy = jest.spyOn(crypto, 'randomInt') as unknown as jest.SpyInstance<
+    number,
+    [min: number, max: number]
+  >;
+
+  afterEach(() => {
+    randomIntSpy.mockReset();
+  });
+
+  test('returns the date + 24h + random seed (2 minutes)', () => {
+    randomIntSpy.mockReturnValue(120);
+
+    expect(getNextAttemptDate(new Date('2022-10-27T12:00:00Z').getTime())).toStrictEqual(
+      new Date('2022-10-28T12:02:00Z')
+    );
+  });
+
+  test('returns the start of the next day if the random addition stays in the same day', () => {
+    randomIntSpy.mockReturnValue(120);
+    randomIntSpy.mockReturnValueOnce(-120);
+    expect(getNextAttemptDate(new Date('2022-10-27T00:01:00Z').getTime())).toStrictEqual(
+      new Date('2022-10-28T00:03:00Z')
+    );
+    expect(randomIntSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns the end of the next day minus 1 minute if the random addition goes to the following day', () => {
+    randomIntSpy.mockReturnValue(-120);
+    randomIntSpy.mockReturnValueOnce(120);
+    expect(getNextAttemptDate(new Date('2022-10-27T23:58:30Z').getTime())).toStrictEqual(
+      new Date('2022-10-28T23:56:30Z')
+    );
+    expect(randomIntSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/plugins/telemetry/server/get_next_attempt_date.ts
+++ b/src/plugins/telemetry/server/get_next_attempt_date.ts
@@ -8,7 +8,7 @@
 
 import { randomInt } from 'crypto';
 import moment from 'moment';
-import { REPORT_INTERVAL_BUFFER_MS } from '../common/constants';
+import { REPORT_INTERVAL_BUFFER_MS, REPORT_INTERVAL_MS } from '../common/constants';
 
 const REPORT_INTERVAL_BUFFER_S = REPORT_INTERVAL_BUFFER_MS / 1000;
 
@@ -19,9 +19,9 @@ const REPORT_INTERVAL_BUFFER_S = REPORT_INTERVAL_BUFFER_MS / 1000;
 export function getNextAttemptDate(fromMs: number): Date {
   const lastAttempt = moment(fromMs).utcOffset(0);
   const endOfLastAttemptDay = lastAttempt.clone().endOf('day');
-  const dayPlus24hours = lastAttempt.clone().add(24, 'hours');
-  const endOfNextDay = dayPlus24hours.clone().endOf('day');
-  const nextAttemptDate = dayPlus24hours
+  const dayPlusReportInterval = lastAttempt.clone().add(REPORT_INTERVAL_MS, 'milliseconds');
+  const endOfNextDay = dayPlusReportInterval.clone().endOf('day');
+  const nextAttemptDate = dayPlusReportInterval
     .clone()
     .add(randomInt(-REPORT_INTERVAL_BUFFER_S, REPORT_INTERVAL_BUFFER_S), 'seconds');
 

--- a/src/plugins/telemetry/server/get_next_attempt_date.ts
+++ b/src/plugins/telemetry/server/get_next_attempt_date.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { randomInt } from 'crypto';
+import moment from 'moment';
+import { REPORT_INTERVAL_BUFFER_MS } from '../common/constants';
+
+const REPORT_INTERVAL_BUFFER_S = REPORT_INTERVAL_BUFFER_MS / 1000;
+
+/**
+ * Returns the next attempt to send telemetry
+ * @param fromMs The last attempt in ms from epoch
+ */
+export function getNextAttemptDate(fromMs: number): Date {
+  const lastAttempt = moment(fromMs).utcOffset(0);
+  const endOfLastAttemptDay = lastAttempt.clone().endOf('day');
+  const dayPlus24hours = lastAttempt.clone().add(24, 'hours');
+  const endOfNextDay = dayPlus24hours.clone().endOf('day');
+  const nextAttemptDate = dayPlus24hours
+    .clone()
+    .add(randomInt(-REPORT_INTERVAL_BUFFER_S, REPORT_INTERVAL_BUFFER_S), 'seconds');
+
+  // Edge case: If the random seed makes the next attempt to be in the same day of the last attempt, generate it again
+  if (nextAttemptDate.isBefore(endOfLastAttemptDay)) {
+    return getNextAttemptDate(fromMs);
+  }
+
+  // Edge case: If the random seed goes to the following day, generate it again
+  if (nextAttemptDate.isAfter(endOfNextDay)) {
+    return getNextAttemptDate(fromMs);
+  }
+
+  return nextAttemptDate.toDate();
+}


### PR DESCRIPTION
## Summary

This PR changes the current _check if I should send telemetry every 12h_ into _I'll check again if I should send telemetry in lastReportAt + 24h +- some random seconds_.

This cuts in half the number of attempts + is able to adapt to external factors changing `lastReportAt` (like other Kibana instances reporting telemetry or a browser doing so).

Since the timer is now set to a fixed date, `lastReportAt + 24h`, there's the risk that multiple instances may attempt to send telemetry at the same time. For that reason, we add/substract a random amount of seconds to the next attempt (making sure we don't delay ourselves to the next day).

Resolves #142058.

The 12h interval was initially set because that's the rate at which we want to validate if we have connectivity when Kibana is sitting behind a firewall. To make it more explicit, I moved the connectivity check away from the actual sending. This also saves us from generating the telemetry report if there is no connectivity.

### Backporting strategy

It is considered a bug, and in the original issue, it's been explicitly requested to backport it to the previous minor.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->