### PR TITLE
changed cardinality agg logic in action_status

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/action_status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/action_status.ts
@@ -12,6 +12,8 @@ import type { FleetServerAgentAction, ActionStatus, ListWithKuery } from '../../
 import { AGENT_ACTIONS_INDEX, AGENT_ACTIONS_RESULTS_INDEX } from '../../../common';
 import { appContextService } from '..';
 
+const PRECISION_THRESHOLD = 40000;
+
 /**
  * Return current bulk actions
  */
@@ -42,7 +44,7 @@ export async function getActionStatuses(
             agent_count: {
               cardinality: {
                 field: 'agent_id',
-                precision_threshold: 40000, // max value
+                precision_threshold: PRECISION_THRESHOLD, // max value
               },
             },
           },
@@ -65,9 +67,12 @@ export async function getActionStatuses(
       (bucket: any) => bucket.key === action.actionId
     );
     const nbAgentsActioned = action.nbAgentsActioned || action.nbAgentsActionCreated;
+    const cardinalityCount = (matchingBucket?.agent_count as any)?.value ?? 0;
+    const docCount = matchingBucket?.doc_count ?? 0;
     const nbAgentsAck = Math.min(
-      matchingBucket?.doc_count ?? 0,
-      (matchingBucket?.agent_count as any)?.value ?? 0,
+      docCount,
+      // only using cardinality count when count lower than precision threshold
+      docCount > PRECISION_THRESHOLD ? docCount : cardinalityCount,
       nbAgentsActioned
     );
     const completionTime = (matchingBucket?.max_timestamp as any)?.value_as_string;


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/144161

Changed logic in `action_status` API calculation of agent action acks, to only use cardinality agg if the doc count is less than the precision threshold (40k, this is the max value).

Observed an issue locally that after successful add/remove tags, the ack count didn't reach 50k in `action_status` response, in this case `doc_count` was correct, 50k. 
So it looks like the cardinality agg can be lower or higher than the actual count.

```
 {
        "key": "d3b1ef6c-2ed4-4746-ab88-504bf0c4b4c8",
        "doc_count": 50000,
        "max_timestamp": {
          "value": 1666956506014,
          "value_as_string": "2022-10-28T11:28:26.014Z"
        },
        "agent_count": {
          "value": 49874
        }
      }
```

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->