### PR TITLE
[APM] Show recommended minimum size when reducing rule interval below 5 minutes

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.stories.tsx
@@ -9,6 +9,7 @@ import { Meta, Story } from '@storybook/react';
 import React, { useState } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
+import { TIME_UNITS } from '@kbn/triggers-actions-ui-plugin/public';
 import { RuleParams, ErrorCountRuleType } from '.';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
@@ -129,7 +130,7 @@ EditingInStackManagement.args = {
     serviceName: 'testServiceName',
     threshold: 25,
     windowSize: 1,
-    windowUnit: 'm',
+    windowUnit: TIME_UNITS.MINUTE,
   },
   metadata: undefined,
 };

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -10,7 +10,10 @@ import { defaults, omit } from 'lodash';
 import React, { useEffect } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ForLastExpression } from '@kbn/triggers-actions-ui-plugin/public';
+import {
+  ForLastExpression,
+  TIME_UNITS,
+} from '@kbn/triggers-actions-ui-plugin/public';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { asInteger } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
@@ -21,16 +24,12 @@ import {
   IsAboveField,
   ServiceField,
 } from '../../utils/fields';
-import {
-  AlertMetadata,
-  getIntervalAndTimeRange,
-  TimeUnit,
-} from '../../utils/helper';
+import { AlertMetadata, getIntervalAndTimeRange } from '../../utils/helper';
 import { ApmRuleParamsContainer } from '../../ui_components/apm_rule_params_container';
 
 export interface RuleParams {
   windowSize?: number;
-  windowUnit?: TimeUnit;
+  windowUnit?: TIME_UNITS;
   threshold?: number;
   serviceName?: string;
   environment?: string;
@@ -55,8 +54,8 @@ export function ErrorCountRuleType(props: Props) {
     { ...omit(metadata, ['start', 'end']), ...ruleParams },
     {
       threshold: 25,
-      windowSize: 1,
-      windowUnit: 'm',
+      windowSize: 5,
+      windowUnit: TIME_UNITS.MINUTE,
       environment: ENVIRONMENT_ALL.value,
     }
   );
@@ -65,7 +64,7 @@ export function ErrorCountRuleType(props: Props) {
     (callApmApi) => {
       const { interval, start, end } = getIntervalAndTimeRange({
         windowSize: params.windowSize,
-        windowUnit: params.windowUnit as TimeUnit,
+        windowUnit: params.windowUnit,
       });
       if (interval && start && end) {
         return callApmApi(
@@ -135,7 +134,8 @@ export function ErrorCountRuleType(props: Props) {
 
   return (
     <ApmRuleParamsContainer
-      defaults={params}
+      minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
+      defaultParams={params}
       fields={fields}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_anomaly_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_anomaly_rule_type/index.tsx
@@ -10,6 +10,7 @@ import { defaults, omit } from 'lodash';
 import React, { useEffect } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { TIME_UNITS } from '@kbn/triggers-actions-ui-plugin/public';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { ANOMALY_SEVERITY } from '../../../../../common/ml_constants';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
@@ -61,7 +62,7 @@ export function TransactionDurationAnomalyRuleType(props: Props) {
     },
     {
       windowSize: 30,
-      windowUnit: 'm',
+      windowUnit: TIME_UNITS.MINUTE,
       anomalySeverityType: ANOMALY_SEVERITY.CRITICAL,
       environment: ENVIRONMENT_ALL.value,
     }
@@ -101,7 +102,7 @@ export function TransactionDurationAnomalyRuleType(props: Props) {
   return (
     <ApmRuleParamsContainer
       fields={fields}
-      defaults={params}
+      defaultParams={params}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
     />

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -11,7 +11,10 @@ import { defaults, map, omit } from 'lodash';
 import React, { useEffect } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ForLastExpression } from '@kbn/triggers-actions-ui-plugin/public';
+import {
+  ForLastExpression,
+  TIME_UNITS,
+} from '@kbn/triggers-actions-ui-plugin/public';
 import { AggregationType } from '../../../../../common/rules/apm_rule_types';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { getDurationFormatter } from '../../../../../common/utils/formatters';
@@ -28,11 +31,7 @@ import {
   ServiceField,
   TransactionTypeField,
 } from '../../utils/fields';
-import {
-  AlertMetadata,
-  getIntervalAndTimeRange,
-  TimeUnit,
-} from '../../utils/helper';
+import { AlertMetadata, getIntervalAndTimeRange } from '../../utils/helper';
 import { ApmRuleParamsContainer } from '../../ui_components/apm_rule_params_container';
 import { PopoverExpression } from '../../ui_components/popover_expression';
 
@@ -85,7 +84,7 @@ export function TransactionDurationRuleType(props: Props) {
       aggregationType: AggregationType.Avg,
       threshold: 1500,
       windowSize: 5,
-      windowUnit: 'm',
+      windowUnit: TIME_UNITS.MINUTE,
       environment: ENVIRONMENT_ALL.value,
     }
   );
@@ -94,7 +93,7 @@ export function TransactionDurationRuleType(props: Props) {
     (callApmApi) => {
       const { interval, start, end } = getIntervalAndTimeRange({
         windowSize: params.windowSize,
-        windowUnit: params.windowUnit as TimeUnit,
+        windowUnit: params.windowUnit,
       });
       if (interval && start && end) {
         return callApmApi(
@@ -200,8 +199,9 @@ export function TransactionDurationRuleType(props: Props) {
 
   return (
     <ApmRuleParamsContainer
+      minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
       chartPreview={chartPreview}
-      defaults={params}
+      defaultParams={params}
       fields={fields}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -9,7 +9,10 @@ import { defaults, omit } from 'lodash';
 import React, { useEffect } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ForLastExpression } from '@kbn/triggers-actions-ui-plugin/public';
+import {
+  ForLastExpression,
+  TIME_UNITS,
+} from '@kbn/triggers-actions-ui-plugin/public';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { asPercent } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
@@ -21,11 +24,7 @@ import {
   ServiceField,
   TransactionTypeField,
 } from '../../utils/fields';
-import {
-  AlertMetadata,
-  getIntervalAndTimeRange,
-  TimeUnit,
-} from '../../utils/helper';
+import { AlertMetadata, getIntervalAndTimeRange } from '../../utils/helper';
 import { ApmRuleParamsContainer } from '../../ui_components/apm_rule_params_container';
 
 interface RuleParams {
@@ -57,7 +56,7 @@ export function TransactionErrorRateRuleType(props: Props) {
     {
       threshold: 30,
       windowSize: 5,
-      windowUnit: 'm',
+      windowUnit: TIME_UNITS.MINUTE,
       environment: ENVIRONMENT_ALL.value,
     }
   );
@@ -68,7 +67,7 @@ export function TransactionErrorRateRuleType(props: Props) {
     (callApmApi) => {
       const { interval, start, end } = getIntervalAndTimeRange({
         windowSize: params.windowSize,
-        windowUnit: params.windowUnit as TimeUnit,
+        windowUnit: params.windowUnit,
       });
       if (interval && start && end) {
         return callApmApi(
@@ -142,8 +141,9 @@ export function TransactionErrorRateRuleType(props: Props) {
 
   return (
     <ApmRuleParamsContainer
+      minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
       fields={fields}
-      defaults={params}
+      defaultParams={params}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
       chartPreview={chartPreview}

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.test.tsx
@@ -19,7 +19,7 @@ describe('ApmRuleParamsContainer', () => {
     expect(() =>
       render(
         <ApmRuleParamsContainer
-          defaults={{}}
+          defaultParams={{}}
           fields={[null]}
           setRuleParams={() => {}}
           setRuleProperty={() => {}}

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
@@ -5,23 +5,46 @@
  * 2.0.
  */
 
-import { EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import React, { useEffect } from 'react';
+import { EuiCallOut, EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import moment from 'moment';
+import {
+  getTimeUnitLabel,
+  TIME_UNITS,
+} from '@kbn/triggers-actions-ui-plugin/public';
+
+interface MinimumWindowSize {
+  value: number;
+  unit: TIME_UNITS;
+}
 
 interface Props {
   setRuleParams: (key: string, value: any) => void;
   setRuleProperty: (key: string, value: any) => void;
-  defaults: Record<string, any>;
+  defaultParams: Record<string, any>;
   fields: React.ReactNode[];
   chartPreview?: React.ReactNode;
+  minimumWindowSize?: MinimumWindowSize;
 }
 
 export function ApmRuleParamsContainer(props: Props) {
-  const { fields, setRuleParams, defaults, chartPreview } = props;
+  const {
+    fields,
+    setRuleParams,
+    defaultParams,
+    chartPreview,
+    minimumWindowSize,
+  } = props;
 
   const params: Record<string, any> = {
-    ...defaults,
+    ...defaultParams,
   };
+
+  const showMinimumWindowSizeWarning = useShowMinimumWindowSize({
+    windowSize: params.windowSize,
+    windowUnit: params.windowUnit,
+    minimumWindowSize,
+  });
 
   useEffect(() => {
     // we only want to run this on mount to set default values
@@ -33,6 +56,10 @@ export function ApmRuleParamsContainer(props: Props) {
   }, []);
   return (
     <>
+      {showMinimumWindowSizeWarning && minimumWindowSize && (
+        <MinimumWindowSizeWarning minimumWindowSize={minimumWindowSize} />
+      )}
+
       <EuiSpacer size="l" />
       <EuiFlexGrid gutterSize="l" direction="row" columns={2}>
         {fields.map((field, index) => (
@@ -41,8 +68,63 @@ export function ApmRuleParamsContainer(props: Props) {
           </EuiFlexItem>
         ))}
       </EuiFlexGrid>
+
       {chartPreview}
       <EuiSpacer size="m" />
     </>
   );
+}
+
+function MinimumWindowSizeWarning({
+  minimumWindowSize,
+}: {
+  minimumWindowSize: MinimumWindowSize;
+}) {
+  return (
+    <EuiCallOut
+      title={`Please increase "For the last" to at least ${
+        minimumWindowSize.value
+      } ${getTimeUnitLabel(minimumWindowSize.unit)}`}
+      color="warning"
+      iconType="alert"
+    >
+      <p>
+        The recommended minimum value is {minimumWindowSize.value}{' '}
+        {getTimeUnitLabel(minimumWindowSize.unit)}. This is to ensure that the
+        alert has enough data to evaluate. If you choose a value that is too
+        low, the alert may not fire as expected.
+      </p>
+    </EuiCallOut>
+  );
+}
+
+function useShowMinimumWindowSize({
+  windowSize,
+  windowUnit,
+  minimumWindowSize,
+}: {
+  windowSize?: number;
+  windowUnit?: TIME_UNITS;
+  minimumWindowSize?: MinimumWindowSize;
+}) {
+  const [showMinimumWindowSizeWarning, setShowMinimumWindowSizeWarning] =
+    useState(false);
+
+  useEffect(() => {
+    if (windowSize === undefined || minimumWindowSize === undefined) {
+      return;
+    }
+
+    const currentWindowSize = moment
+      .duration(windowSize, windowUnit)
+      .asMilliseconds();
+    const minimumWindowSizeAsMillis = moment
+      .duration(minimumWindowSize.value, minimumWindowSize.unit)
+      .asMilliseconds();
+
+    const shouldShow = currentWindowSize < minimumWindowSizeAsMillis;
+    setShowMinimumWindowSizeWarning(shouldShow);
+  }, [windowSize, windowUnit, minimumWindowSize]);
+
+  return showMinimumWindowSizeWarning;
 }

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
@@ -7,6 +7,7 @@
 
 import { EuiCallOut, EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import {
   getTimeUnitLabel,
@@ -80,6 +81,18 @@ function MinimumWindowSizeWarning({
 }: {
   minimumWindowSize: MinimumWindowSize;
 }) {
+  const description = i18n.translate(
+    'xpack.apm.alertTypes.minimumWindowSize.description',
+    {
+      defaultMessage:
+        'The recommended minimum value is {sizeValue} {sizeUnit}. This is to ensure that the alert has enough data to evaluate. If you choose a value that is too low, the alert may not fire as expected.',
+      values: {
+        sizeValue: minimumWindowSize.value,
+        sizeUnit: getTimeUnitLabel(minimumWindowSize.unit),
+      },
+    }
+  );
+
   return (
     <EuiCallOut
       title={`Please increase "For the last" to at least ${
@@ -88,12 +101,7 @@ function MinimumWindowSizeWarning({
       color="warning"
       iconType="alert"
     >
-      <p>
-        The recommended minimum value is {minimumWindowSize.value}{' '}
-        {getTimeUnitLabel(minimumWindowSize.unit)}. This is to ensure that the
-        alert has enough data to evaluate. If you choose a value that is too
-        low, the alert may not fire as expected.
-      </p>
+      <p>{description}</p>
     </EuiCallOut>
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/utils/helper.ts
+++ b/x-pack/plugins/apm/public/components/alerting/utils/helper.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import { TIME_UNITS } from '@kbn/triggers-actions-ui-plugin/public';
 import moment from 'moment';
 
 export interface AlertMetadata {
@@ -14,8 +16,6 @@ export interface AlertMetadata {
   end?: string;
 }
 
-export type TimeUnit = 's' | 'm' | 'h' | 'd';
-
 const BUCKET_SIZE = 20;
 
 export function getIntervalAndTimeRange({
@@ -23,7 +23,7 @@ export function getIntervalAndTimeRange({
   windowUnit,
 }: {
   windowSize: number;
-  windowUnit: TimeUnit;
+  windowUnit: TIME_UNITS;
 }) {
   const end = Date.now();
   const start =

--- a/x-pack/plugins/triggers_actions_ui/public/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/index.ts
@@ -142,7 +142,7 @@ export { loadRule } from './application/lib/rule_api/get_rule';
 export { loadAllActions } from './application/lib/action_connector_api';
 export { suspendedComponentWithProps } from './application/lib/suspended_component_with_props';
 export { loadActionTypes } from './application/lib/action_connector_api/connector_types';
-export type { TIME_UNITS } from './application/constants';
+export { TIME_UNITS } from './application/constants';
 export { getTimeUnitLabel } from './common/lib/get_time_unit_label';
 export type { TriggersAndActionsUiServices } from './application/app';
 


### PR DESCRIPTION
[We've seen](https://discuss.elastic.co/t/how-come-apm-alert-for-failed-transaction-rate-threshold-shows-ok-instead-of-active/317640) that users create rules where the ingest delay is larger than the look back window. This means that alerts will not fire as expected because there's no data available when evaluating the rule. 

This PR increases the default window size to 5 minutes, and adds a warning if the window size is lowered below this level.

<img src="https://user-images.githubusercontent.com/209966/198646614-a2371b90-1a09-485a-85bf-d5d9384107a4.png" width="500"/>
