### PR TITLE
[Synthetics] Fix failing Synthetics Integration test

### DIFF
--- a/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
+++ b/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
@@ -149,9 +149,6 @@ export default function (providerContext: FtrProviderContext) {
   });
 
   // FAILING: https://github.com/elastic/kibana/issues/144139
-  // FAILING: https://github.com/elastic/kibana/issues/144140
-  // FAILING: https://github.com/elastic/kibana/issues/144141
-  // FAILING: https://github.com/elastic/kibana/issues/144142
   describe('When on the Synthetics Integration Policy Create Page', function () {
     skipIfNoDockerRegistry(providerContext);
     const basicConfig = {

--- a/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
+++ b/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
@@ -148,7 +148,6 @@ export default function (providerContext: FtrProviderContext) {
     use_output: 'default',
   });
 
-  // FAILING: https://github.com/elastic/kibana/issues/144139
   describe('When on the Synthetics Integration Policy Create Page', function () {
     skipIfNoDockerRegistry(providerContext);
     const basicConfig = {

--- a/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
+++ b/x-pack/test/functional_synthetics/apps/uptime/synthetics_integration.ts
@@ -51,6 +51,11 @@ export default function (providerContext: FtrProviderContext) {
       {
         data_stream: {
           dataset: monitorType,
+          elasticsearch: {
+            privileges: {
+              indices: ['auto_configure', 'create_doc', 'read'],
+            },
+          },
           type: 'synthetics',
         },
         id: `${getSyntheticsPolicy(agentFullPolicy)?.streams?.[0]?.id}`,
@@ -81,6 +86,11 @@ export default function (providerContext: FtrProviderContext) {
             {
               data_stream: {
                 dataset: 'browser.network',
+                elasticsearch: {
+                  privileges: {
+                    indices: ['auto_configure', 'create_doc', 'read'],
+                  },
+                },
                 type: 'synthetics',
               },
               id: `${getSyntheticsPolicy(agentFullPolicy)?.streams?.[1]?.id}`,
@@ -105,6 +115,11 @@ export default function (providerContext: FtrProviderContext) {
             {
               data_stream: {
                 dataset: 'browser.screenshot',
+                elasticsearch: {
+                  privileges: {
+                    indices: ['auto_configure', 'create_doc', 'read'],
+                  },
+                },
                 type: 'synthetics',
               },
               id: `${getSyntheticsPolicy(agentFullPolicy)?.streams?.[2]?.id}`,
@@ -137,7 +152,7 @@ export default function (providerContext: FtrProviderContext) {
   // FAILING: https://github.com/elastic/kibana/issues/144140
   // FAILING: https://github.com/elastic/kibana/issues/144141
   // FAILING: https://github.com/elastic/kibana/issues/144142
-  describe.skip('When on the Synthetics Integration Policy Create Page', function () {
+  describe('When on the Synthetics Integration Policy Create Page', function () {
     skipIfNoDockerRegistry(providerContext);
     const basicConfig = {
       name: monitorName,


### PR DESCRIPTION
## Summary
Resolves https://github.com/elastic/kibana/issues/144139
Resolves https://github.com/elastic/kibana/issues/144140
Resolves https://github.com/elastic/kibana/issues/144141
Resolves https://github.com/elastic/kibana/issues/144142

Fixes a failing Synthetics Integration test by updating the test to include the ES permissions clause.