### PR TITLE
[ci] remove github-checks-reporter

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -63,12 +63,6 @@ if is_pr; then
     export ELASTIC_APM_CONTEXT_PROPAGATION_ONLY=true
   fi
 
-  if [[ "${GITHUB_STEP_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
-    export CHECKS_REPORTER_ACTIVE=true
-  else
-    export CHECKS_REPORTER_ACTIVE=false
-  fi
-
   # These can be removed once we're not supporting Jenkins and Buildkite at the same time
   # These are primarily used by github checks reporter and can be configured via /github_checks_api.json
   export ghprbGhRepository="elastic/kibana"
@@ -83,7 +77,6 @@ if is_pr; then
 else
   export ELASTIC_APM_ACTIVE=true
   export ELASTIC_APM_CONTEXT_PROPAGATION_ONLY=false
-  export CHECKS_REPORTER_ACTIVE=false
 fi
 
 # These are for backwards-compatibility

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-checks-reporter-with-killswitch() {
-  if [ "$CHECKS_REPORTER_ACTIVE" == "true" ] ; then
-    yarn run github-checks-reporter "$@"
-  else
-    arguments=("$@");
-    "${arguments[@]:1}";
-  fi
-}
-
 is_pr() {
   [[ "${GITHUB_PR_NUMBER-}" ]] && return
   false

--- a/.buildkite/scripts/saved_object_field_metrics.sh
+++ b/.buildkite/scripts/saved_object_field_metrics.sh
@@ -5,8 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo '--- Default Saved Object Field Metrics'
-checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \
-  node scripts/functional_tests \
-      --debug --bail \
-      --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-      --config x-pack/test/saved_objects_field_count/config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config x-pack/test/saved_objects_field_count/config.ts

--- a/.buildkite/scripts/steps/check_types.sh
+++ b/.buildkite/scripts/steps/check_types.sh
@@ -7,5 +7,4 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-checks-reporter-with-killswitch "Check Types" \
-  node scripts/type_check
+node scripts/type_check

--- a/.buildkite/scripts/steps/checks/bundle_limits.sh
+++ b/.buildkite/scripts/steps/checks/bundle_limits.sh
@@ -6,5 +6,4 @@ source .buildkite/scripts/common/util.sh
 
 echo --- Check Bundle Limits
 
-checks-reporter-with-killswitch "Check Bundle Limits" \
-  node scripts/build_kibana_platform_plugins --validate-limits
+node scripts/build_kibana_platform_plugins --validate-limits

--- a/.buildkite/scripts/steps/checks/file_casing.sh
+++ b/.buildkite/scripts/steps/checks/file_casing.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check File Casing
-checks-reporter-with-killswitch "Check File Casing" \
-  node scripts/check_file_casing --quiet
+node scripts/check_file_casing --quiet

--- a/.buildkite/scripts/steps/checks/ftr_configs.sh
+++ b/.buildkite/scripts/steps/checks/ftr_configs.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check FTR Configs
-checks-reporter-with-killswitch "Check FTR Configs" \
-  node scripts/check_ftr_configs
+node scripts/check_ftr_configs

--- a/.buildkite/scripts/steps/checks/i18n.sh
+++ b/.buildkite/scripts/steps/checks/i18n.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check i18n
-checks-reporter-with-killswitch "Check i18n" \
-  node scripts/i18n_check --ignore-missing
+node scripts/i18n_check --ignore-missing

--- a/.buildkite/scripts/steps/checks/jest_configs.sh
+++ b/.buildkite/scripts/steps/checks/jest_configs.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Jest Configs
-checks-reporter-with-killswitch "Check Jest Configs" \
-  node scripts/check_jest_configs
+node scripts/check_jest_configs

--- a/.buildkite/scripts/steps/checks/licenses.sh
+++ b/.buildkite/scripts/steps/checks/licenses.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Licenses
-checks-reporter-with-killswitch "Check Licenses" \
-  node scripts/check_licenses --dev
+node scripts/check_licenses --dev

--- a/.buildkite/scripts/steps/checks/plugins_with_circular_deps.sh
+++ b/.buildkite/scripts/steps/checks/plugins_with_circular_deps.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Plugins With Circular Dependencies
-checks-reporter-with-killswitch "Check Plugins With Circular Dependencies" \
-  node scripts/find_plugins_with_circular_deps
+node scripts/find_plugins_with_circular_deps

--- a/.buildkite/scripts/steps/checks/telemetry.sh
+++ b/.buildkite/scripts/steps/checks/telemetry.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Telemetry Schema
-checks-reporter-with-killswitch "Check Telemetry Schema" \
-  node scripts/telemetry_check
+node scripts/telemetry_check

--- a/.buildkite/scripts/steps/checks/test_hardening.sh
+++ b/.buildkite/scripts/steps/checks/test_hardening.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Test Hardening
-checks-reporter-with-killswitch "Test Hardening" \
-  node scripts/test_hardening
+node scripts/test_hardening

--- a/.buildkite/scripts/steps/checks/test_projects.sh
+++ b/.buildkite/scripts/steps/checks/test_projects.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Test Projects
-checks-reporter-with-killswitch "Test Projects" \
-  yarn kbn run-in-packages test
+yarn kbn run-in-packages test

--- a/.buildkite/scripts/steps/checks/ts_projects.sh
+++ b/.buildkite/scripts/steps/checks/ts_projects.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check TypeScript Projects
-checks-reporter-with-killswitch "Check TypeScript Projects" \
-  node scripts/check_ts_projects
+node scripts/check_ts_projects

--- a/.buildkite/scripts/steps/checks/verify_notice.sh
+++ b/.buildkite/scripts/steps/checks/verify_notice.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Verify NOTICE
-checks-reporter-with-killswitch "Verify NOTICE" \
-  node scripts/notice --validate
+node scripts/notice --validate

--- a/.buildkite/scripts/steps/fleet/install_all_packages.sh
+++ b/.buildkite/scripts/steps/fleet/install_all_packages.sh
@@ -6,7 +6,6 @@ source .buildkite/scripts/steps/functional/common.sh
 
 echo '--- Installing all packages'
 
-checks-reporter-with-killswitch "Fleet packages Tests" \
- node scripts/functional_tests \
-   --debug --bail \
-   --config x-pack/test/fleet_packages/config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --config x-pack/test/fleet_packages/config.ts

--- a/.buildkite/scripts/steps/functional/apm_cypress.sh
+++ b/.buildkite/scripts/steps/functional/apm_cypress.sh
@@ -15,8 +15,7 @@ echo "--- APM Cypress Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "APM Cypress Tests" \
-  node plugins/apm/scripts/test/e2e.js \
+node plugins/apm/scripts/test/e2e.js \
   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
   --record \
   --key "$APM_CYPRESS_RECORD_KEY"

--- a/.buildkite/scripts/steps/functional/fleet_cypress.sh
+++ b/.buildkite/scripts/steps/functional/fleet_cypress.sh
@@ -8,8 +8,7 @@ export JOB=kibana-fleet-cypress
 
 echo "--- Fleet Cypress tests"
 
-checks-reporter-with-killswitch "Fleet Cypress Tests" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-   --config x-pack/test/fleet_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config x-pack/test/fleet_cypress/cli_config.ts

--- a/.buildkite/scripts/steps/functional/observability_plugin.sh
+++ b/.buildkite/scripts/steps/functional/observability_plugin.sh
@@ -13,5 +13,4 @@ echo "--- Observability plugin @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Observability plugin @elastic/synthetics Tests" \
-  node plugins/observability/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}
+node plugins/observability/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}

--- a/.buildkite/scripts/steps/functional/osquery_cypress.sh
+++ b/.buildkite/scripts/steps/functional/osquery_cypress.sh
@@ -11,8 +11,7 @@ export JOB=kibana-osquery-cypress
 
 echo "--- Osquery Cypress tests"
 
-checks-reporter-with-killswitch "Osquery Cypress Tests" \
- node scripts/functional_tests \
-   --debug --bail \
-   --config x-pack/test/osquery_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --config x-pack/test/osquery_cypress/cli_config.ts
 

--- a/.buildkite/scripts/steps/functional/response_ops.sh
+++ b/.buildkite/scripts/steps/functional/response_ops.sh
@@ -8,8 +8,7 @@ export JOB=kibana-security-solution-chrome
 
 echo "--- Response Ops Cypress Tests on Security Solution"
 
-checks-reporter-with-killswitch "Response Ops Cypress Tests on Security Solution" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-   --config x-pack/test/security_solution_cypress/response_ops_cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config x-pack/test/security_solution_cypress/response_ops_cli_config.ts

--- a/.buildkite/scripts/steps/functional/response_ops_cases.sh
+++ b/.buildkite/scripts/steps/functional/response_ops_cases.sh
@@ -8,8 +8,7 @@ export JOB=kibana-security-solution-chrome
 
 echo "--- Response Ops Cases Cypress Tests on Security Solution"
 
-checks-reporter-with-killswitch "Response Ops Cases Cypress Tests on Security Solution" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-   --config x-pack/test/security_solution_cypress/cases_cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config x-pack/test/security_solution_cypress/cases_cli_config.ts

--- a/.buildkite/scripts/steps/functional/security_solution.sh
+++ b/.buildkite/scripts/steps/functional/security_solution.sh
@@ -10,8 +10,7 @@ export CLI_COUNT=${CLI_COUNT:-$BUILDKITE_PARALLEL_JOB_COUNT}
 
 echo "--- Security Solution tests (Chrome)"
 
-checks-reporter-with-killswitch "Security Solution Cypress Tests (Chrome) $CLI_NUMBER" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
-   --config x-pack/test/security_solution_cypress/cli_config_parallel.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+  --config x-pack/test/security_solution_cypress/cli_config_parallel.ts

--- a/.buildkite/scripts/steps/functional/synthetics.sh
+++ b/.buildkite/scripts/steps/functional/synthetics.sh
@@ -13,5 +13,4 @@ echo "--- synthetics @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "synthetics @elastic/synthetics Tests" \
-  node plugins/synthetics/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --grep "MonitorManagement-monitor*"
+node plugins/synthetics/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --grep "MonitorManagement-monitor*"

--- a/.buildkite/scripts/steps/functional/synthetics_plugin.sh
+++ b/.buildkite/scripts/steps/functional/synthetics_plugin.sh
@@ -13,5 +13,4 @@ echo "--- Synthetics plugin @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Synthetics plugin @elastic/synthetics Tests" \
-  node plugins/synthetics/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}
+node plugins/synthetics/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}

--- a/.buildkite/scripts/steps/functional/ux_synthetics_e2e.sh
+++ b/.buildkite/scripts/steps/functional/ux_synthetics_e2e.sh
@@ -13,5 +13,4 @@ echo "--- User Experience @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "User Experience plugin @elastic/synthetics Tests" \
-  node plugins/ux/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}
+node plugins/ux/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}

--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -7,8 +7,7 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Lint: stylelint'
-checks-reporter-with-killswitch "Lint: stylelint" \
-  node scripts/stylelint
+node scripts/stylelint
 echo "stylelint ✅"
 
 echo '--- Lint: eslint'

--- a/.buildkite/scripts/steps/lint_with_types.sh
+++ b/.buildkite/scripts/steps/lint_with_types.sh
@@ -7,5 +7,4 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo '--- Lint: eslint (with types)'
-checks-reporter-with-killswitch "Lint: eslint (with types)" \
-  node scripts/eslint_with_types
+node scripts/eslint_with_types

--- a/.buildkite/scripts/steps/test/jest.sh
+++ b/.buildkite/scripts/steps/test/jest.sh
@@ -8,8 +8,5 @@ is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
 
-JOB=${BUILDKITE_PARALLEL_JOB:-0}
-
 echo '--- Jest'
-checks-reporter-with-killswitch "Jest Unit Tests $((JOB+1))" \
-  .buildkite/scripts/steps/test/jest_parallel.sh jest.config.js
+.buildkite/scripts/steps/test/jest_parallel.sh jest.config.js

--- a/.buildkite/scripts/steps/test/jest_integration.sh
+++ b/.buildkite/scripts/steps/test/jest_integration.sh
@@ -8,8 +8,5 @@ is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
 
-JOB=${BUILDKITE_PARALLEL_JOB:-0}
-
 echo '--- Jest Integration Tests'
-checks-reporter-with-killswitch "Jest Integration Tests $((JOB+1))" \
-  .buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js
+.buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js

--- a/package.json
+++ b/package.json
@@ -703,7 +703,6 @@
     "@cypress/snapshot": "^2.1.7",
     "@cypress/webpack-preprocessor": "^5.12.2",
     "@elastic/eslint-plugin-eui": "0.0.2",
-    "@elastic/github-checks-reporter": "0.0.20b3",
     "@elastic/makelogs": "^6.0.0",
     "@elastic/synthetics": "^1.0.0-beta.22",
     "@emotion/babel-preset-css-prop": "^11.10.0",

--- a/src/dev/ci_setup/setup_env.sh
+++ b/src/dev/ci_setup/setup_env.sh
@@ -148,20 +148,6 @@ if [[ "$ghprbPullId" && "$ghprbGhRepository" == 'elastic/kibana' ]] ; then
   export CHECKS_REPORTER_ACTIVE=true
 fi
 
-###
-### Implements github-checks-reporter kill switch when scripts are called from the command line
-### $@ - all arguments
-###
-function checks-reporter-with-killswitch() {
-  if [ "$CHECKS_REPORTER_ACTIVE" == "true" ] ; then
-    yarn run github-checks-reporter "$@"
-  else
-    arguments=("$@");
-    "${arguments[@]:1}";
-  fi
-}
-
-export -f checks-reporter-with-killswitch
 
 source "$KIBANA_DIR/src/dev/ci_setup/load_env_keys.sh"
 

--- a/test/scripts/checks/bundle_limits.sh
+++ b/test/scripts/checks/bundle_limits.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Bundle Limits" \
-  node scripts/build_kibana_platform_plugins --validate-limits
+node scripts/build_kibana_platform_plugins --validate-limits

--- a/test/scripts/checks/commit/commit.sh
+++ b/test/scripts/checks/commit/commit.sh
@@ -7,5 +7,4 @@ source src/dev/ci_setup/setup_env.sh
 # the pre-commit hook installation by default.
 # If files are more than 200 we will skip it and just use
 # the further ci steps that already check linting and file casing for the entire repo.
-checks-reporter-with-killswitch "Quick commit checks" \
-  "$(dirname "${0}")/commit_check_runner.sh"
+"$(dirname "${0}")/commit_check_runner.sh"

--- a/test/scripts/checks/file_casing.sh
+++ b/test/scripts/checks/file_casing.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check File Casing" \
-  node scripts/check_file_casing --quiet
+node scripts/check_file_casing --quiet

--- a/test/scripts/checks/i18n.sh
+++ b/test/scripts/checks/i18n.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check i18n" \
-  node scripts/i18n_check --ignore-missing
+node scripts/i18n_check --ignore-missing

--- a/test/scripts/checks/jest_configs.sh
+++ b/test/scripts/checks/jest_configs.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Jest Configs" \
-  node scripts/check_jest_configs
+node scripts/check_jest_configs

--- a/test/scripts/checks/licenses.sh
+++ b/test/scripts/checks/licenses.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Licenses" \
-  node scripts/check_licenses --dev
+node scripts/check_licenses --dev

--- a/test/scripts/checks/plugins_with_circular_deps.sh
+++ b/test/scripts/checks/plugins_with_circular_deps.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Plugins With Circular Dependencies" \
-  node scripts/find_plugins_with_circular_deps
+node scripts/find_plugins_with_circular_deps

--- a/test/scripts/checks/telemetry.sh
+++ b/test/scripts/checks/telemetry.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check Telemetry Schema" \
-  node scripts/telemetry_check
+node scripts/telemetry_check

--- a/test/scripts/checks/test_hardening.sh
+++ b/test/scripts/checks/test_hardening.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Test Hardening" \
-  node scripts/test_hardening
+node scripts/test_hardening

--- a/test/scripts/checks/test_projects.sh
+++ b/test/scripts/checks/test_projects.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Test Projects" \
-  yarn kbn run-in-packages test
+yarn kbn run-in-packages test

--- a/test/scripts/checks/ts_projects.sh
+++ b/test/scripts/checks/ts_projects.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Check TypeScript Projects" \
-  node scripts/check_ts_projects
+node scripts/check_ts_projects

--- a/test/scripts/checks/type_check_plugin_public_api_docs.sh
+++ b/test/scripts/checks/type_check_plugin_public_api_docs.sh
@@ -2,14 +2,12 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Build TS Refs" \
-  node scripts/build_ts_refs \
-    --clean \
-    --no-cache \
-    --force
+node scripts/build_ts_refs \
+  --clean \
+  --no-cache \
+  --force
 
-checks-reporter-with-killswitch "Check Types" \
-  node scripts/type_check
+node scripts/type_check
 
 echo " -- building api docs"
 node --max-old-space-size=12000 scripts/build_api_docs

--- a/test/scripts/checks/verify_notice.sh
+++ b/test/scripts/checks/verify_notice.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Verify NOTICE" \
-  node scripts/notice --validate
+node scripts/notice --validate

--- a/test/scripts/jenkins_accessibility.sh
+++ b/test/scripts/jenkins_accessibility.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Kibana accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/accessibility/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/accessibility/config.ts;

--- a/test/scripts/jenkins_apm_cypress.sh
+++ b/test/scripts/jenkins_apm_cypress.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running APM cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "APM Cypress Tests" \
- node plugins/apm/scripts/test/e2e.js
+node plugins/apm/scripts/test/e2e.js
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_build_kbn_sample_panel_action.sh
+++ b/test/scripts/jenkins_build_kbn_sample_panel_action.sh
@@ -4,6 +4,6 @@ source src/dev/ci_setup/setup_env.sh
 
 cd test/plugin_functional/plugins/kbn_sample_panel_action;
 if [[ ! -d "target" ]]; then
-  checks-reporter-with-killswitch "Build kbn_sample_panel_action" yarn build;
+  yarn build;
 fi
 cd -;

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_oss.sh
 if [[ -z "$CODE_COVERAGE" ]]; then
   echo " -> Running functional and api tests"
 
-  checks-reporter-with-killswitch "Functional tests / Group ${CI_GROUP}" \
-    node scripts/functional_tests \
-      --debug --bail \
-      --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-      --include-tag "ciGroup$CI_GROUP"
+  node scripts/functional_tests \
+    --debug --bail \
+    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+    --include-tag "ciGroup$CI_GROUP"
 
   if [[ ! "$TASK_QUEUE_PROCESS_ID" && "$CI_GROUP" == "1" ]]; then
     source test/scripts/jenkins_build_kbn_sample_panel_action.sh

--- a/test/scripts/jenkins_firefox_smoke.sh
+++ b/test/scripts/jenkins_firefox_smoke.sh
@@ -2,9 +2,8 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Firefox smoke test" \
-  node scripts/functional_tests \
-    --bail --debug \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js;
+node scripts/functional_tests \
+  --bail --debug \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js;

--- a/test/scripts/jenkins_fleet_cypress.sh
+++ b/test/scripts/jenkins_fleet_cypress.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running fleet cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Fleet Cypress Tests" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/fleet_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/fleet_cypress/cli_config.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_osquery_cypress.sh
+++ b/test/scripts/jenkins_osquery_cypress.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running osquery cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Osquery Cypress Tests" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/osquery_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/osquery_cypress/cli_config.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_security_solution_cypress_chrome.sh
+++ b/test/scripts/jenkins_security_solution_cypress_chrome.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Security Solution Cypress Tests (Chrome)" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/security_solution_cypress/cli_config.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/security_solution_cypress/cli_config.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_security_solution_cypress_firefox.sh
+++ b/test/scripts/jenkins_security_solution_cypress_firefox.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "Security Solution Cypress Tests (Firefox)" \
- node scripts/functional_tests \
-   --debug --bail \
-   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-   --config test/security_solution_cypress/config.firefox.ts
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/security_solution_cypress/config.firefox.ts
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_uptime_playwright.sh
+++ b/test/scripts/jenkins_uptime_playwright.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running synthetics @elastic/synthetics tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "synthetics @elastic/synthetics Tests" \
- node plugins/synthetics/scripts/e2e.js
+node plugins/synthetics/scripts/e2e.js
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_ux_synthetics.sh
+++ b/test/scripts/jenkins_ux_synthetics.sh
@@ -5,8 +5,7 @@ source test/scripts/jenkins_test_setup_xpack.sh
 echo " -> Running User Experience plugin @elastic/synthetics tests"
 cd "$XPACK_DIR"
 
-checks-reporter-with-killswitch "User Experience plugin @elastic/synthetics Tests" \
- node plugins/ux/scripts/e2e.js
+node plugins/ux/scripts/e2e.js
 
 echo ""
 echo ""

--- a/test/scripts/jenkins_xpack_accessibility.sh
+++ b/test/scripts/jenkins_xpack_accessibility.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "X-Pack accessibility tests" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/accessibility/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/accessibility/config.ts;

--- a/test/scripts/jenkins_xpack_ci_group.sh
+++ b/test/scripts/jenkins_xpack_ci_group.sh
@@ -5,11 +5,10 @@ source test/scripts/jenkins_test_setup_xpack.sh
 if [[ -z "$CODE_COVERAGE" ]]; then
   echo " -> Running functional and api tests"
 
-  checks-reporter-with-killswitch "X-Pack Chrome Functional tests / Group ${CI_GROUP}" \
-    node scripts/functional_tests \
-      --debug --bail \
-      --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-      --include-tag "ciGroup$CI_GROUP"
+  node scripts/functional_tests \
+    --debug --bail \
+    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+    --include-tag "ciGroup$CI_GROUP"
 
   echo ""
   echo ""

--- a/test/scripts/jenkins_xpack_firefox_smoke.sh
+++ b/test/scripts/jenkins_xpack_firefox_smoke.sh
@@ -2,10 +2,9 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "X-Pack firefox smoke test" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --include-tag "includeFirefox" \
-    --config test/functional/config.firefox.js \
-    --config test/functional_embedded/config.firefox.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --include-tag "includeFirefox" \
+  --config test/functional/config.firefox.js \
+  --config test/functional_embedded/config.firefox.ts;

--- a/test/scripts/jenkins_xpack_saved_objects_field_metrics.sh
+++ b/test/scripts/jenkins_xpack_saved_objects_field_metrics.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_xpack.sh
 
-checks-reporter-with-killswitch "Capture Kibana Saved Objects field count metrics" \
-  node scripts/functional_tests \
-    --debug --bail \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/saved_objects_field_count/config.ts;
+node scripts/functional_tests \
+  --debug --bail \
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/saved_objects_field_count/config.ts;

--- a/test/scripts/lint/eslint.sh
+++ b/test/scripts/lint/eslint.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Lint: eslint" \
-  node scripts/eslint --no-cache
+node scripts/eslint --no-cache

--- a/test/scripts/lint/stylelint.sh
+++ b/test/scripts/lint/stylelint.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Lint: stylelint" \
-  node scripts/stylelint
+node scripts/stylelint

--- a/test/scripts/test/api_integration.sh
+++ b/test/scripts/test/api_integration.sh
@@ -2,8 +2,7 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "API Integration Tests" \
-  node scripts/functional_tests \
-    --config test/api_integration/config.js \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/api_integration/config.js \
+  --bail \
+  --debug

--- a/test/scripts/test/interpreter_functional.sh
+++ b/test/scripts/test/interpreter_functional.sh
@@ -2,9 +2,8 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Interpreter Functional Tests" \
-  node scripts/functional_tests \
-    --config test/interpreter_functional/config.ts \
-    --bail \
-    --debug \
-    --kibana-install-dir $KIBANA_INSTALL_DIR
+node scripts/functional_tests \
+  --config test/interpreter_functional/config.ts \
+  --bail \
+  --debug \
+  --kibana-install-dir $KIBANA_INSTALL_DIR

--- a/test/scripts/test/jest_integration.sh
+++ b/test/scripts/test/jest_integration.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Jest Integration Tests" \
-  node --max-old-space-size=5120 scripts/jest_integration --ci
+node --max-old-space-size=5120 scripts/jest_integration --ci

--- a/test/scripts/test/jest_unit.sh
+++ b/test/scripts/test/jest_unit.sh
@@ -2,5 +2,4 @@
 
 source src/dev/ci_setup/setup_env.sh
 
-checks-reporter-with-killswitch "Jest Unit Tests" \
-  node scripts/jest --ci --maxWorkers=6
+node scripts/jest --ci --maxWorkers=6

--- a/test/scripts/test/plugin_functional.sh
+++ b/test/scripts/test/plugin_functional.sh
@@ -2,8 +2,7 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Plugin Functional Tests" \
-  node scripts/functional_tests \
-    --config test/plugin_functional/config.ts \
-    --bail \
-    --debug
+node scripts/functional_tests \
+  --config test/plugin_functional/config.ts \
+  --bail \
+  --debug

--- a/test/scripts/test/server_integration.sh
+++ b/test/scripts/test/server_integration.sh
@@ -2,20 +2,18 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Server Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/ssl/config.js \
-    --config test/server_integration/http/ssl_redirect/config.js \
-    --config test/server_integration/http/platform/config.ts \
-    --config test/server_integration/http/ssl_with_p12/config.js \
-    --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
-    --bail \
-    --debug \
-    --kibana-install-dir $KIBANA_INSTALL_DIR
+node scripts/functional_tests \
+  --config test/server_integration/http/ssl/config.js \
+  --config test/server_integration/http/ssl_redirect/config.js \
+  --config test/server_integration/http/platform/config.ts \
+  --config test/server_integration/http/ssl_with_p12/config.js \
+  --config test/server_integration/http/ssl_with_p12_intermediate/config.js \
+  --bail \
+  --debug \
+  --kibana-install-dir $KIBANA_INSTALL_DIR
 
 # Tests that must be run against source in order to build test plugins
-checks-reporter-with-killswitch "Status Integration Tests" \
-  node scripts/functional_tests \
-    --config test/server_integration/http/platform/config.status.ts \
-    --bail \
-    --debug \
+node scripts/functional_tests \
+  --config test/server_integration/http/platform/config.status.ts \
+  --bail \
+  --debug

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,18 +1585,6 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/github-checks-reporter@0.0.20b3":
-  version "0.0.20-b3"
-  resolved "https://registry.yarnpkg.com/@elastic/github-checks-reporter/-/github-checks-reporter-0.0.20-b3.tgz#025ac0e152cda03d947faec190c244fbbe59bdfc"
-  integrity sha512-OmhbddqNkFZMYVQxMqpqLj7NJhqphN+wQb68IeiewxvWXq8NEPaBpaZ9f+nUbixmMY2Q/XA0JgtuE4EhMGIljg==
-  dependencies:
-    "@octokit/app" "^2.2.2"
-    "@octokit/plugin-retry" "^2.2.0"
-    "@octokit/request" "^2.4.2"
-    "@octokit/rest" "^16.23.2"
-    async-retry "^1.2.3"
-    strip-ansi "^5.2.0"
-
 "@elastic/makelogs@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@elastic/makelogs/-/makelogs-6.0.0.tgz#d6d74d5d0f020123c54160370d49ca5e0aab1fe1"
@@ -4360,16 +4348,6 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@octokit/app@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-2.2.2.tgz#a1b8248f64159eeccbe4000d888fdae4163c4ad8"
-  integrity sha512-nUwS8jW107ROGuI0Tq4Ga+Zno6CovwaS+Oen6BOKJmoFMLqqB3oXeGZ6InkidtdmUNiYhMtNq2lydb0WVLT8Zg==
-  dependencies:
-    "@octokit/request" "^2.1.2"
-    "@types/lru-cache" "^5.1.0"
-    jsonwebtoken "^8.3.0"
-    lru-cache "^5.1.1"
-
 "@octokit/auth-token@^2.4.0":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.4.tgz#ee31c69b01d0378c12fd3ffe406030f3d94d3b56"
@@ -4396,16 +4374,6 @@
     "@octokit/types" "^6.0.3"
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
-
-"@octokit/endpoint@^3.2.0":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-3.2.3.tgz#bd9aea60cd94ce336656b57a5c9cb7f10be8f4f3"
-  integrity sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==
-  dependencies:
-    deepmerge "3.2.0"
-    is-plain-object "^2.0.4"
-    universal-user-agent "^2.0.1"
-    url-template "^2.0.8"
 
 "@octokit/endpoint@^6.0.1":
   version "6.0.6"
@@ -4479,13 +4447,6 @@
     "@octokit/types" "6.40.0"
     deprecation "^2.3.1"
 
-"@octokit/plugin-retry@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-2.2.0.tgz#11f3957a46ccdb7b7f33caabf8c17e57b25b80b2"
-  integrity sha512-x5Kd8Lke+a4hTDCe5akZxpGmVwu1eeVt2FJX0jeo3CxHGbfHbXb4zhN5quKfGL9oBLV/EdHQIJ6zwIMjuzxOlw==
-  dependencies:
-    bottleneck "^2.15.3"
-
 "@octokit/request-error@^1.0.2":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.2.1.tgz#ede0714c773f32347576c25649dc013ae6b31801"
@@ -4513,18 +4474,6 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^2.1.2", "@octokit/request@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-2.4.2.tgz#87c36e820dd1e43b1629f4f35c95b00cd456320b"
-  integrity sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==
-  dependencies:
-    "@octokit/endpoint" "^3.2.0"
-    deprecation "^1.0.1"
-    is-plain-object "^2.0.4"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.1"
-
 "@octokit/request@^5.2.0":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.2.tgz#1aa74d5da7b9e04ac60ef232edd9a7438dcf32d8"
@@ -4549,7 +4498,7 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^16.23.2", "@octokit/rest@^16.35.0":
+"@octokit/rest@^16.35.0":
   version "16.43.2"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.43.2.tgz#c53426f1e1d1044dee967023e3279c50993dd91b"
   integrity sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==
@@ -9020,13 +8969,6 @@ async-foreach@^0.1.3:
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
   integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
 
-async-retry@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
-  integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
-  dependencies:
-    retry "0.12.0"
-
 async-value-promise@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/async-value-promise/-/async-value-promise-1.1.1.tgz#68957819e3eace804f3b4b69477e2bd276c15378"
@@ -9608,11 +9550,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
-bottleneck@^2.15.3:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.18.0.tgz#41fa63ae185b65435d789d1700334bc48222dacf"
-  integrity sha512-U1xiBRaokw4yEguzikOl0VrnZp6uekjpmfrh6rKtr1D+/jFjYCL6J83ZXlGtlBDwVdTmJJ+4Lg5FpB3xmLSiyA==
 
 bowser@^1.7.3:
   version "1.9.4"
@@ -12092,7 +12029,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@3.2.0, deepmerge@^2.1.1, deepmerge@^4.2.2:
+deepmerge@^2.1.1, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -12248,11 +12185,6 @@ dependency-check@^4.1.0:
     pkg-up "^3.1.0"
     read-package-json "^2.0.10"
     resolve "^1.1.7"
-
-deprecation@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
-  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
 
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
@@ -19814,7 +19746,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@2.6.7, node-fetch@^1.0.1, node-fetch@^2.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^1.0.1, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -20491,7 +20423,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-name@^3.0.0, os-name@^3.1.0:
+os-name@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
   integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
@@ -23562,7 +23494,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@0.12.0, retry@^0.12.0:
+retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
@@ -26399,13 +26331,6 @@ unist-util-visit@^1.3.0:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-universal-user-agent@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
-  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
-  dependencies:
-    os-name "^3.0.0"
-
 universal-user-agent@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.1.tgz#fd8d6cb773a679a709e967ef8288a31fcc03e557"
@@ -26543,11 +26468,6 @@ url-parse@^1.5.10, url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
-  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
In order to handle the rate limit issues caused by the massive number of commit statuses created by the github-checks-reporter, we've moved to a method of reporting statuses that is based on builkite job status, and can unify the FTR config groups into a single status (unless there is a failure).

We can now remove this dependency as we're not using it and don't expect to use it in the future.