### PR TITLE
Defined a smaller min-width for the cases modal.

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/all_cases_selector_modal.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/all_cases_selector_modal.tsx
@@ -29,7 +29,7 @@ export interface AllCasesSelectorModalProps {
 
 const Modal = styled(EuiModal)`
   ${({ theme }) => `
-    width: ${theme.eui.euiBreakpoints.xl};
+    min-width: ${theme.eui.euiBreakpoints.l};
     max-width: ${theme.eui.euiBreakpoints.xl};
   `}
 `;


### PR DESCRIPTION
## Summary

The existing cases modal now resizes based on screen size(to a minimum of `theme.eui.euiBreakpoints.l`).

### Screenshots

Before
<img width="1038" alt="Screenshot 2022-10-31 at 13 16 32" src="https://user-images.githubusercontent.com/1533137/199006010-00145f49-87be-4a9b-a9d6-e4a89c82bad6.png">

After
<img width="1039" alt="Screenshot 2022-10-31 at 13 16 57" src="https://user-images.githubusercontent.com/1533137/199006031-79f8914d-e1ad-4402-8754-1d8d3111a21d.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
