### PR TITLE
[Lens] Legacy metric expression types improvement.

### DIFF
--- a/src/plugins/visualizations/common/expression_functions/vis_dimension.ts
+++ b/src/plugins/visualizations/common/expression_functions/vis_dimension.ts
@@ -32,12 +32,14 @@ export type ExpressionValueVisDimension = ExpressionValueBoxed<
   }
 >;
 
-export const visDimension = (): ExpressionFunctionDefinition<
+export type ExpressionFunctionVisDimension = ExpressionFunctionDefinition<
   'visdimension',
   Datatable,
   Arguments,
   ExpressionValueVisDimension
-> => ({
+>;
+
+export const visDimension = (): ExpressionFunctionVisDimension => ({
   name: 'visdimension',
   help: i18n.translate('visualizations.function.visDimension.help', {
     defaultMessage: 'Generates visConfig dimension object',

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.test.ts
@@ -368,7 +368,9 @@ describe('metric_visualization', () => {
                     "type": "expression",
                   },
                 ],
-                "palette": Array [],
+                "percentageMode": Array [
+                  false,
+                ],
                 "showLabels": Array [
                   true,
                 ],

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -16,6 +16,13 @@ import { ColorMode, CustomPaletteState } from '@kbn/charts-plugin/common';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { IconChartMetric } from '@kbn/chart-icons';
 import { LayerTypes } from '@kbn/expression-xy-plugin/public';
+import {
+  buildExpression,
+  buildExpressionFunction,
+  ExpressionFunctionFont,
+  FontWeight,
+  TextAlignment,
+} from '@kbn/expressions-plugin/common';
 import { getSuggestions } from './metric_suggestions';
 import { Visualization, OperationMetadata, DatasourceLayers } from '../../types';
 import type { LegacyMetricState } from '../../../common/types';
@@ -97,6 +104,14 @@ const toExpression = (
   };
   const metricFontSize = labelToMetricFontSizeMap[state?.size || DEFAULT_TITLE_SIZE];
 
+  const fontFn = buildExpressionFunction<ExpressionFunctionFont>('font', {
+    align: (state?.textAlign || DEFAULT_TEXT_ALIGNMENT) as TextAlignment,
+    size: metricFontSize,
+    weight: '600' as FontWeight,
+    lHeight: metricFontSize * 1.5,
+    sizeUnit: labelFont.sizeUnit,
+  });
+
   return {
     type: 'expression',
     chain: [
@@ -106,24 +121,7 @@ const toExpression = (
         function: 'legacyMetricVis',
         arguments: {
           labelPosition: [state?.titlePosition || DEFAULT_TITLE_POSITION],
-          font: [
-            {
-              type: 'expression',
-              chain: [
-                {
-                  type: 'function',
-                  function: 'font',
-                  arguments: {
-                    align: [state?.textAlign || DEFAULT_TEXT_ALIGNMENT],
-                    size: [metricFontSize],
-                    weight: ['600'],
-                    lHeight: [metricFontSize * 1.5],
-                    sizeUnit: [labelFont.sizeUnit],
-                  },
-                },
-              ],
-            },
-          ],
+          font: [buildExpression([fontFn]).toAst()],
           labelFont: [
             {
               type: 'expression',

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -112,6 +112,13 @@ const toExpression = (
     sizeUnit: labelFont.sizeUnit,
   });
 
+  const labelFontFn = buildExpressionFunction<ExpressionFunctionFont>('font', {
+    align: (state?.textAlign || DEFAULT_TEXT_ALIGNMENT) as TextAlignment,
+    size: labelFont.size,
+    lHeight: labelFont.size * 1.5,
+    sizeUnit: labelFont.sizeUnit,
+  });
+
   return {
     type: 'expression',
     chain: [
@@ -122,23 +129,7 @@ const toExpression = (
         arguments: {
           labelPosition: [state?.titlePosition || DEFAULT_TITLE_POSITION],
           font: [buildExpression([fontFn]).toAst()],
-          labelFont: [
-            {
-              type: 'expression',
-              chain: [
-                {
-                  type: 'function',
-                  function: 'font',
-                  arguments: {
-                    align: [state?.textAlign || DEFAULT_TEXT_ALIGNMENT],
-                    size: [labelFont.size],
-                    lHeight: [labelFont.size * 1.5],
-                    sizeUnit: [labelFont.sizeUnit],
-                  },
-                },
-              ],
-            },
-          ],
+          labelFont: [buildExpression([labelFontFn]).toAst()],
           metric: [
             {
               type: 'expression',

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -23,6 +23,7 @@ import {
   FontWeight,
   TextAlignment,
 } from '@kbn/expressions-plugin/common';
+import { ExpressionFunctionVisDimension } from '@kbn/visualizations-plugin/common';
 import { getSuggestions } from './metric_suggestions';
 import { Visualization, OperationMetadata, DatasourceLayers } from '../../types';
 import type { LegacyMetricState } from '../../../common/types';
@@ -119,6 +120,10 @@ const toExpression = (
     sizeUnit: labelFont.sizeUnit,
   });
 
+  const visdimensionFn = buildExpressionFunction<ExpressionFunctionVisDimension>('visdimension', {
+    accessor: state.accessor,
+  });
+
   return {
     type: 'expression',
     chain: [
@@ -130,20 +135,7 @@ const toExpression = (
           labelPosition: [state?.titlePosition || DEFAULT_TITLE_POSITION],
           font: [buildExpression([fontFn]).toAst()],
           labelFont: [buildExpression([labelFontFn]).toAst()],
-          metric: [
-            {
-              type: 'expression',
-              chain: [
-                {
-                  type: 'function',
-                  function: 'visdimension',
-                  arguments: {
-                    accessor: [state.accessor],
-                  },
-                },
-              ],
-            },
-          ],
+          metric: [buildExpression([visdimensionFn]).toAst()],
           showLabels: [!attributes?.mode || attributes?.mode === 'full'],
           colorMode: !canColor ? [ColorMode.None] : [state?.colorMode || ColorMode.None],
           autoScale: [true],


### PR DESCRIPTION
## Summary
Completes part of https://github.com/elastic/kibana/issues/140555

Changed types for `Legacy metric` `toExpression` function in `Lens`.