### PR TITLE
remove unnecessary import aliases

### DIFF
--- a/packages/kbn-ebt-tools/src/performance_metric_events/helpers.ts
+++ b/packages/kbn-ebt-tools/src/performance_metric_events/helpers.ts
@@ -28,7 +28,7 @@ export function registerPerformanceMetricEventType(
 /**
  * Report a `performance_metric` event type.
  * @param analytics The {@link AnalyticsClient} to report the events.
- * @param eventData The data to send, conforming the structure of a {@link MetricEvent}.
+ * @param eventData The data to send, conforming the structure of a {@link PerformanceMetricEvent}.
  */
 export function reportPerformanceMetricEvent(
   analytics: Pick<AnalyticsClient, 'reportEvent'>,

--- a/packages/kbn-ebt-tools/src/performance_metric_events/index.ts
+++ b/packages/kbn-ebt-tools/src/performance_metric_events/index.ts
@@ -5,8 +5,5 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-export type { PerformanceMetricEvent as MetricEvent } from './schema';
-export {
-  registerPerformanceMetricEventType as registerPerformanceMetricEventType,
-  reportPerformanceMetricEvent,
-} from './helpers';
+export type { PerformanceMetricEvent } from './schema';
+export { registerPerformanceMetricEventType, reportPerformanceMetricEvent } from './helpers';


### PR DESCRIPTION
This PR is just a simple refactor PR to remove unnecessary alias used in:

```
export { registerPerformanceMetricEventType as registerPerformanceMetricEventType } 
```

and export `PerformanceMetricEvent` rather than `MetricEvent` since it's more specific event type. 
**Note**: It was not imported elsewhere so it's not breaking change
```
export type { PerformanceMetricEvent as MetricEvent } from './schema';
```
