### PR TITLE
[DOCS] Add redirect for alerts and actions

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -420,3 +420,8 @@ This page has been deleted. Refer to <<osquery>>.
 == Sync machine learning objects API
 
 This page has been deleted. Refer to <<machine-learning-api-sync>>.
+
+[role="exclude",id="managing-alerts-and-actions"]
+== Alerts and Actions
+
+This page has been deleted. Refer to <<alerting-getting-started>>.


### PR DESCRIPTION
## Summary

This PR adds a redirect for the following page, which does not exist after 7.12: https://www.elastic.co/guide/en/kibana/7.12/managing-alerts-and-actions.html



<!--ONMERGE {"backportTargets":["7.13","7.14","7.15","7.16","7.17","8.0","8.1","8.2","8.3","8.4","8.5"]} ONMERGE-->