### PR TITLE
[babel/node] invalidate cache when synth pkg map is updated

### DIFF
--- a/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
+++ b/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
@@ -41,6 +41,7 @@ import * as babel from '@babel/core';
 import { addHook } from 'pirates';
 import { REPO_ROOT, UPSTREAM_BRANCH } from '@kbn/utils';
 import sourceMapSupport from 'source-map-support';
+import { readHashOfPackageMap } from '@kbn/synthetic-package-map';
 
 import { Cache } from './cache';
 
@@ -83,6 +84,7 @@ function getBabelOptions(path: string) {
  */
 function determineCachePrefix() {
   const json = JSON.stringify({
+    synthPkgMapHash: readHashOfPackageMap(),
     babelVersion: babel.version,
     // get a config for a fake js, ts, and tsx file to make sure we
     // capture conditional config portions based on the file extension


### PR DESCRIPTION
Extend the base cache key of the `node_auto_transpilation` cache with the hash of the "synthetic package map" which tells babel where to resolve all of the `@kbn/...-plugin` module IDs. When one of those IDs or the location of one of those paths changes we need to invalidate this cache and rebuild the babel output of files even if their content hasn't changed.