### PR TITLE
[Synthetics UI] Track state for last test run separatedly from the test run table

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/single_ping_result.tsx
@@ -16,7 +16,7 @@ import { i18n } from '@kbn/i18n';
 import { Ping } from '../../../../../../common/runtime_types';
 import { formatTestDuration } from '../../../utils/monitor_test_result/test_time_formats';
 
-export const SinglePingResult = ({ ping, loading }: { ping: Ping; loading: boolean }) => {
+export const SinglePingResult = ({ ping, loading }: { ping?: Ping; loading: boolean }) => {
   const ip = !loading ? ping?.resolve?.ip : undefined;
   const durationUs = !loading ? ping?.monitor?.duration?.us ?? NaN : NaN;
   const rtt = !loading ? ping?.resolve?.rtt?.us ?? NaN : NaN;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
@@ -8,7 +8,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ConfigKey } from '../../../../../../common/runtime_types';
-import { getMonitorRecentPingsAction, selectLatestPing, selectPingsLoading } from '../../../state';
+import { getMonitorLastRunAction, selectLastRunMetadata } from '../../../state';
 import { useSelectedLocation } from './use_selected_location';
 import { useSelectedMonitor } from './use_selected_monitor';
 
@@ -26,8 +26,7 @@ export const useMonitorLatestPing = (params?: UseMonitorLatestPingParams) => {
   const monitorId = params?.monitorId ?? monitor?.id;
   const locationLabel = params?.locationLabel ?? location?.label;
 
-  const latestPing = useSelector(selectLatestPing);
-  const pingsLoading = useSelector(selectPingsLoading);
+  const { data: latestPing, loading } = useSelector(selectLastRunMetadata);
 
   const latestPingId = latestPing?.monitor.id;
 
@@ -40,21 +39,21 @@ export const useMonitorLatestPing = (params?: UseMonitorLatestPingParams) => {
 
   useEffect(() => {
     if (monitorId && locationLabel && !isUpToDate) {
-      dispatch(getMonitorRecentPingsAction.get({ monitorId, locationId: locationLabel }));
+      dispatch(getMonitorLastRunAction.get({ monitorId, locationId: locationLabel }));
     }
   }, [dispatch, monitorId, locationLabel, isUpToDate]);
 
   if (!monitorId || !locationLabel) {
-    return { loading: pingsLoading, latestPing: null };
+    return { loading, latestPing: undefined };
   }
 
   if (!latestPing) {
-    return { loading: pingsLoading, latestPing: null };
+    return { loading, latestPing: undefined };
   }
 
   if (!isIdSame || !isLocationSame) {
-    return { loading: pingsLoading, latestPing: null };
+    return { loading, latestPing: undefined };
   }
 
-  return { loading: pingsLoading, latestPing };
+  return { loading, latestPing };
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -19,7 +19,6 @@ import {
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
-import { useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 
 import {
@@ -31,7 +30,6 @@ import {
 import { formatTestRunAt } from '../../../utils/monitor_test_result/test_time_formats';
 
 import { useSyntheticsSettingsContext } from '../../../contexts';
-import { selectLatestPing, selectPingsLoading } from '../../../state';
 import { BrowserStepsList } from '../../common/monitor_test_result/browser_steps_list';
 import { SinglePingResult } from '../../common/monitor_test_result/single_ping_result';
 import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/status_badge';
@@ -39,11 +37,11 @@ import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/
 import { useKibanaDateFormat } from '../../../../../hooks/use_kibana_date_format';
 import { useJourneySteps } from '../hooks/use_journey_steps';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
+import { useMonitorLatestPing } from '../hooks/use_monitor_latest_ping';
 
 export const LastTestRun = () => {
   const { euiTheme } = useEuiTheme();
-  const latestPing = useSelector(selectLatestPing);
-  const pingsLoading = useSelector(selectPingsLoading);
+  const { latestPing, loading: pingsLoading } = useMonitorLatestPing();
   const { monitor } = useSelectedMonitor();
 
   const { data: stepsData, loading: stepsLoading } = useJourneySteps(
@@ -97,7 +95,7 @@ const PanelHeader = ({
   loading,
 }: {
   monitor: EncryptedSyntheticsSavedMonitor | null;
-  latestPing: Ping;
+  latestPing?: Ping;
   loading: boolean;
 }) => {
   const { euiTheme } = useEuiTheme();

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_details_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_details_panel.tsx
@@ -19,18 +19,19 @@ import {
 } from '@elastic/eui';
 import { capitalize } from 'lodash';
 import { i18n } from '@kbn/i18n';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { MonitorTags } from './monitor_tags';
 import { MonitorEnabled } from '../../monitors_page/management/monitor_list_table/monitor_enabled';
 import { LocationsStatus } from './locations_status';
-import { getMonitorAction, selectLatestPing } from '../../../state';
+import { getMonitorAction } from '../../../state';
 import { ConfigKey } from '../../../../../../common/runtime_types';
+import { useMonitorLatestPing } from '../hooks/use_monitor_latest_ping';
 
 export const MonitorDetailsPanel = () => {
   const { euiTheme } = useEuiTheme();
-  const latestPing = useSelector(selectLatestPing);
+  const { latestPing } = useMonitorLatestPing();
 
   const { monitorId } = useParams<{ monitorId: string }>();
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
@@ -25,6 +25,11 @@ export const getMonitorAction = createAsyncAction<
   EncryptedSyntheticsSavedMonitor
 >('[MONITOR DETAILS] GET MONITOR');
 
+export const getMonitorLastRunAction = createAsyncAction<
+  { monitorId: string; locationId: string },
+  PingsResponse
+>('[MONITOR DETAILS] GET LAST RUN');
+
 export const getMonitorRecentPingsAction = createAsyncAction<
   {
     monitorId: string;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
@@ -21,6 +21,16 @@ export interface QueryParams {
   dateEnd: string;
 }
 
+export const fetchMonitorLastRun = async ({
+  monitorId,
+  locationId,
+}: {
+  monitorId: string;
+  locationId: string;
+}): Promise<PingsResponse> => {
+  return fetchMonitorRecentPings({ monitorId, locationId, size: 1 });
+};
+
 export const fetchMonitorRecentPings = async ({
   monitorId,
   locationId,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
@@ -7,8 +7,8 @@
 
 import { takeLeading } from 'redux-saga/effects';
 import { fetchEffectFactory } from '../utils/fetch_effect';
-import { getMonitorRecentPingsAction, getMonitorAction } from './actions';
-import { fetchSyntheticsMonitor, fetchMonitorRecentPings } from './api';
+import { getMonitorLastRunAction, getMonitorRecentPingsAction, getMonitorAction } from './actions';
+import { fetchSyntheticsMonitor, fetchMonitorRecentPings, fetchMonitorLastRun } from './api';
 
 export function* fetchSyntheticsMonitorEffect() {
   yield takeLeading(
@@ -20,6 +20,14 @@ export function* fetchSyntheticsMonitorEffect() {
     )
   );
 
+  yield takeLeading(
+    getMonitorLastRunAction.get,
+    fetchEffectFactory(
+      fetchMonitorLastRun,
+      getMonitorLastRunAction.success,
+      getMonitorLastRunAction.fail
+    )
+  );
   yield takeLeading(
     getMonitorAction.get,
     fetchEffectFactory(fetchSyntheticsMonitor, getMonitorAction.success, getMonitorAction.fail)

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -12,6 +12,7 @@ import { checkIsStalePing } from '../../utils/monitor_test_result/check_pings';
 import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import {
+  getMonitorLastRunAction,
   getMonitorRecentPingsAction,
   setMonitorDetailsLocationAction,
   getMonitorAction,
@@ -23,6 +24,10 @@ export interface MonitorDetailsState {
     data: Ping[];
     loading: boolean;
   };
+  lastRun: {
+    data?: Ping;
+    loading: boolean;
+  };
   syntheticsMonitorLoading: boolean;
   syntheticsMonitor: EncryptedSyntheticsSavedMonitor | null;
   error: IHttpSerializedFetchError | null;
@@ -31,6 +36,7 @@ export interface MonitorDetailsState {
 
 const initialState: MonitorDetailsState = {
   pings: { total: 0, data: [], loading: false },
+  lastRun: { loading: false },
   syntheticsMonitor: null,
   syntheticsMonitorLoading: false,
   error: null,
@@ -42,7 +48,17 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
     .addCase(setMonitorDetailsLocationAction, (state, action) => {
       state.selectedLocationId = action.payload;
     })
-
+    .addCase(getMonitorLastRunAction.get, (state, action) => {
+      state.lastRun.loading = true;
+      if (checkIsStalePing(action.payload.monitorId, state.lastRun.data)) {
+        state.lastRun.data = undefined;
+      }
+    })
+    .addCase(getMonitorLastRunAction.success, (state, action) => {
+      state.lastRun.loading = false;
+      state.lastRun.data = action.payload.pings[0];
+    })
+    .addCase(getMonitorLastRunAction.fail, (state, action) => {})
     .addCase(getMonitorRecentPingsAction.get, (state, action) => {
       state.pings.loading = true;
       state.pings.data = state.pings.data.filter(

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -58,7 +58,10 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       state.lastRun.loading = false;
       state.lastRun.data = action.payload.pings[0];
     })
-    .addCase(getMonitorLastRunAction.fail, (state, action) => {})
+    .addCase(getMonitorLastRunAction.fail, (state, action) => {
+      state.lastRun.loading = false;
+      state.error = action.payload;
+    })
     .addCase(getMonitorRecentPingsAction.get, (state, action) => {
       state.pings.loading = true;
       state.pings.data = state.pings.data.filter(

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/selectors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/selectors.ts
@@ -17,7 +17,7 @@ export const selectSelectedLocationId = createSelector(
   (state) => state.selectedLocationId
 );
 
-export const selectLatestPing = createSelector(getState, (state) => state.pings.data[0] ?? null);
+export const selectLastRunMetadata = createSelector(getState, (state) => state.lastRun);
 
 export const selectPingsLoading = createSelector(getState, (state) => state.pings.loading);
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -132,6 +132,63 @@ function getBrowserJourneyMockSlice() {
 
 function getMonitorDetailsMockSlice() {
   return {
+    lastRun: {
+      loading: false,
+      data: {
+        summary: { up: 1, down: 0 },
+        agent: {
+          name: 'cron-b010e1cc9518984e-27644714-4pd4h',
+          id: 'f8721d90-5aec-4815-a6f1-f4d4a6fb7482',
+          type: 'heartbeat',
+          ephemeral_id: 'd6a60494-5e52-418f-922b-8e90f0b4013c',
+          version: '8.3.0',
+        },
+        synthetics: {
+          journey: { name: 'inline', id: 'inline', tags: null },
+          type: 'heartbeat/summary',
+        },
+        monitor: {
+          duration: { us: 269722 },
+          origin: SourceType.UI,
+          name: 'One pixel monitor',
+          check_group: '051aba1c-0b74-11ed-9f0e-ba4e6fa109d5',
+          id: '4afd3980-0b72-11ed-9c10-b57918ea89d6',
+          timespan: { lt: '2022-07-24T17:24:06.094Z', gte: '2022-07-24T17:14:06.094Z' },
+          type: DataStream.BROWSER,
+          status: 'up',
+        },
+        url: {
+          scheme: 'data',
+          domain: '',
+          full: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+        observer: {
+          geo: {
+            continent_name: 'North America',
+            city_name: 'Iowa',
+            country_iso_code: 'US',
+            name: 'North America - US Central',
+            location: '41.8780, 93.0977',
+          },
+          hostname: 'cron-b010e1cc9518984e-27644714-4pd4h',
+          ip: ['10.1.11.162'],
+          mac: ['ba:4e:6f:a1:09:d5'],
+        },
+        '@timestamp': '2022-07-24T17:14:05.079Z',
+        ecs: { version: '8.0.0' },
+        config_id: '4afd3980-0b72-11ed-9c10-b57918ea89d6',
+        data_stream: { namespace: 'default', type: 'synthetics', dataset: 'browser' },
+        'event.type': 'journey/end',
+        event: {
+          agent_id_status: 'auth_metadata_missing',
+          ingested: '2022-07-24T17:14:07Z',
+          type: 'heartbeat/summary',
+          dataset: 'browser',
+        },
+        timestamp: '2022-07-24T17:14:05.079Z',
+        docId: 'AkYzMYIBqL6WCtugsFck',
+      },
+    },
     pings: {
       total: 3,
       data: [


### PR DESCRIPTION
Closes #144252. No screenshot because nothing changes visually.