### PR TITLE
[typecheck] delete temporary target_types dirs in packages

### DIFF
--- a/src/dev/typescript/run_type_check_cli.ts
+++ b/src/dev/typescript/run_type_check_cli.ts
@@ -8,12 +8,14 @@
 
 import Path from 'path';
 import Fs from 'fs';
+import Fsp from 'fs/promises';
 
 import { run } from '@kbn/dev-cli-runner';
 import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/utils';
 import { Jsonc } from '@kbn/bazel-packages';
 import { runBazel } from '@kbn/bazel-runner';
+import { asyncForEachWithLimit } from '@kbn/std';
 import { BazelPackage, discoverBazelPackages } from '@kbn/bazel-packages';
 
 import { PROJECTS } from './projects';
@@ -198,9 +200,24 @@ export async function runTypeCheckCli() {
       // cleanup
       if (flagsReader.boolean('cleanup')) {
         await cleanupRootRefsConfig();
-        for (const path of created) {
-          Fs.unlinkSync(path);
-        }
+
+        await asyncForEachWithLimit(created, 40, async (path) => {
+          await Fsp.unlink(path);
+        });
+
+        await asyncForEachWithLimit(bazelPackages, 40, async (pkg) => {
+          const targetTypesPaths = Path.resolve(
+            REPO_ROOT,
+            'bazel-bin',
+            pkg.normalizedRepoRelativeDir,
+            'target_type'
+          );
+
+          await Fsp.rm(targetTypesPaths, {
+            force: true,
+            recursive: true,
+          });
+        });
       }
 
       if (pluginBuildResult.failed) {


### PR DESCRIPTION
When users run `node scripts/type_check` locally we build the `target_types` for each bazel package, which allows `tsc` to read the built types for every other package and `skipLibCheck` allows us to save a ton of time and focus errors on just the one instance that is meaningful to contributors.

The problem is that once the `target_types` directory is created is is never updated (because we don't build types in bootstrap or on watch) which prevents IDEs from reading the most recent types from the source code.

This change deletes the `target_types` output directory for each package after running the type check, allowing IDEs to get the most up-to-date types for packages moving forward while we are in this transitional state.