### PR TITLE
check that the sample data menu is really open, retry

### DIFF
--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -131,7 +131,12 @@ export class HomePageObject extends FtrService {
   async launchSampleDataSet(id: string) {
     await this.addSampleDataSet(id);
     await this.common.closeToastIfExists();
-    await this.testSubjects.click(`launchSampleDataSet${id}`);
+    await this.retry.try(async () => {
+      await this.testSubjects.click(`launchSampleDataSet${id}`);
+      await this.find.byCssSelector(
+        `.euiPopover-isOpen[data-test-subj="launchSampleDataSet${id}"]`
+      );
+    });
   }
 
   async clickAllKibanaPlugins() {


### PR DESCRIPTION
## Summary

I've hit failures locally from `https://github.com/elastic/kibana/blob/8.5/x-pack/test/upgrade/apps/reporting/reporting_smoke_tests.ts` where it fails to find the sample data`dashboard` link to click.  That must mean that the menu isn't open but the screenshots aren't really tall enough to see that.  This PR adds a retry loop to verify the menu is really open when we expect it to be.

Note that we can't just check that the data-test-subj for the menu exists because it always exists on the page.  We have to check the `euiPopover-isOpen` class is present on that element.

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->