### PR TITLE
[Enterprise Search][ML Inference] disable ml inference pipeline delete

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/delete_inference_pipeline_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/delete_inference_pipeline_button.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
+
+import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
+
+import { DeleteInferencePipelineButton } from './delete_inference_pipeline_button';
+
+export const DEFAULT_VALUES: InferencePipeline = {
+  modelId: 'sample-bert-ner-model',
+  modelState: TrainedModelState.Started,
+  pipelineName: 'Sample Processor',
+  pipelineReferences: ['index@ml-inference'],
+  types: ['pytorch', 'ner'],
+};
+
+describe('DeleteInferencePipelineButton', () => {
+  const onClickHandler = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('renders button with defaults', () => {
+    const wrapper = shallow(
+      <DeleteInferencePipelineButton onClick={onClickHandler} pipeline={DEFAULT_VALUES} />
+    );
+    const tooltip = wrapper.find(EuiToolTip);
+    expect(tooltip).toHaveLength(0);
+
+    const btn = wrapper.find(EuiButtonEmpty);
+    expect(btn).toHaveLength(1);
+    expect(btn.prop('iconType')).toBe('trash');
+    expect(btn.prop('color')).toBe('text');
+    expect(btn.prop('children')).toBe('Delete pipeline');
+  });
+  it('renders disabled with tooltip with multiple references', () => {
+    const wrapper = shallow(
+      <DeleteInferencePipelineButton
+        onClick={onClickHandler}
+        pipeline={{
+          ...DEFAULT_VALUES,
+          pipelineReferences: ['index@ml-inference', 'other-index@ml-inference'],
+        }}
+      />
+    );
+    const tooltip = wrapper.find(EuiToolTip);
+    expect(tooltip).toHaveLength(1);
+
+    const btn = wrapper.find(EuiButtonEmpty);
+    expect(btn).toHaveLength(1);
+    expect(btn.prop('disabled')).toBe(true);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/delete_inference_pipeline_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/delete_inference_pipeline_button.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { InferencePipeline } from '../../../../../../common/types/pipelines';
+
+export interface DeleteInferencePipelineButtonProps {
+  'data-telemetry-id'?: string;
+  onClick: () => void;
+  pipeline: InferencePipeline;
+}
+
+const DELETE_PIPELINE_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.inferencePipelineCard.action.delete',
+  {
+    defaultMessage: 'Delete pipeline',
+  }
+);
+
+export const DeleteInferencePipelineButton: React.FC<DeleteInferencePipelineButtonProps> = (
+  props
+) => {
+  if (props.pipeline.pipelineReferences.length > 1) {
+    const indexReferences = props.pipeline.pipelineReferences
+      .map((mlPipeline) => mlPipeline.replace('@ml-inference', ''))
+      .join(', ');
+    return (
+      <EuiToolTip
+        position="top"
+        content={i18n.translate(
+          'xpack.enterpriseSearch.inferencePipelineCard.action.delete.disabledDescription',
+          {
+            defaultMessage:
+              'This inference pipeline cannot be deleted because it is used in multiple pipelines [{indexReferences}]. You must detach this pipeline from all but one ingest pipeline before it can be deleted.',
+            values: {
+              indexReferences,
+            },
+          }
+        )}
+      >
+        <EuiButtonEmpty
+          data-telemetry-id={props['data-telemetry-id']}
+          size="s"
+          flush="both"
+          iconType="trash"
+          color="text"
+          disabled
+        >
+          {DELETE_PIPELINE_LABEL}
+        </EuiButtonEmpty>
+      </EuiToolTip>
+    );
+  }
+  return (
+    <EuiButtonEmpty
+      data-telemetry-id={props['data-telemetry-id']}
+      size="s"
+      flush="both"
+      iconType="trash"
+      color="text"
+      onClick={props.onClick}
+    >
+      {DELETE_PIPELINE_LABEL}
+    </EuiButtonEmpty>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -36,6 +36,7 @@ import { IndexNameLogic } from '../index_name_logic';
 
 import { IndexViewLogic } from '../index_view_logic';
 
+import { DeleteInferencePipelineButton } from './delete_inference_pipeline_button';
 import { TrainedModelHealth } from './ml_model_health';
 import { PipelinesLogic } from './pipelines_logic';
 
@@ -129,19 +130,11 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => 
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <div>
-                      <EuiButtonEmpty
+                      <DeleteInferencePipelineButton
                         data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-inferencePipeline-deletePipeline`}
-                        size="s"
-                        flush="both"
-                        iconType="trash"
-                        color="text"
                         onClick={showConfirmDeleteModal}
-                      >
-                        {i18n.translate(
-                          'xpack.enterpriseSearch.inferencePipelineCard.action.delete',
-                          { defaultMessage: 'Delete pipeline' }
-                        )}
-                      </EuiButtonEmpty>
+                        pipeline={pipeline}
+                      />
                     </div>
                   </EuiFlexItem>
                 </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Disabled the delete pipeline action if the pipeline is used in more that one ml-inference parent pipeline.

### Screenshots
<img width="700" alt="image" src="https://user-images.githubusercontent.com/1972968/199113050-dbb7ca54-c4d7-469f-8e91-db0163d31c5c.png">
