### PR TITLE
[Profiling] Add TTL to cached frames and executables

### DIFF
--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -37,7 +37,7 @@ import { ProjectTimeQuery } from './query';
 const BASE64_FRAME_ID_LENGTH = 32;
 
 const CACHE_MAX_ITEMS = 100000;
-const CACHE_TTL_MICROSECONDS = 1000 * 60 * 5;
+const CACHE_TTL_MILLISECONDS = 1000 * 60 * 5;
 
 export type EncodedStackTrace = DedotObject<{
   // This field is a base64-encoded byte string. The string represents a
@@ -275,7 +275,7 @@ export async function mgetStackTraces({
 
 const frameLRU = new LRUCache<StackFrameID, StackFrame>({
   max: CACHE_MAX_ITEMS,
-  maxAge: CACHE_TTL_MICROSECONDS,
+  maxAge: CACHE_TTL_MILLISECONDS,
 });
 
 export async function mgetStackFrames({
@@ -347,7 +347,7 @@ export async function mgetStackFrames({
 
 const executableLRU = new LRUCache<FileID, Executable>({
   max: CACHE_MAX_ITEMS,
-  maxAge: CACHE_TTL_MICROSECONDS,
+  maxAge: CACHE_TTL_MILLISECONDS,
 });
 
 export async function mgetExecutables({

--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -36,6 +36,9 @@ import { ProjectTimeQuery } from './query';
 
 const BASE64_FRAME_ID_LENGTH = 32;
 
+const CACHE_MAX_ITEMS = 100000;
+const CACHE_TTL_MICROSECONDS = 1000 * 60 * 5;
+
 export type EncodedStackTrace = DedotObject<{
   // This field is a base64-encoded byte string. The string represents a
   // serialized list of frame IDs in which the order of frames are
@@ -270,7 +273,10 @@ export async function mgetStackTraces({
   return { stackTraces, totalFrames, stackFrameDocIDs, executableDocIDs };
 }
 
-const frameLRU = new LRUCache<StackFrameID, StackFrame>({ max: 100000 });
+const frameLRU = new LRUCache<StackFrameID, StackFrame>({
+  max: CACHE_MAX_ITEMS,
+  maxAge: CACHE_TTL_MICROSECONDS,
+});
 
 export async function mgetStackFrames({
   logger,
@@ -339,7 +345,10 @@ export async function mgetStackFrames({
   return stackFrames;
 }
 
-const executableLRU = new LRUCache<FileID, Executable>({ max: 100000 });
+const executableLRU = new LRUCache<FileID, Executable>({
+  max: CACHE_MAX_ITEMS,
+  maxAge: CACHE_TTL_MICROSECONDS,
+});
 
 export async function mgetExecutables({
   logger,


### PR DESCRIPTION
## Summary

This PR adds a default 5-minute TTL when caching profiling-related frame and executable records.

This addresses elastic/prodfiler#2735, which mentions that frame and executable records are no longer idempotent.

Benchmarking before and after this PR shows no significant change to the response latency.

Fixes https://github.com/elastic/prodfiler/issues/2735

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->