### PR TITLE
[Synthetics UI] Monitor Status Panel (histogram) - Summary / History Page

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -8,5 +8,6 @@
 export enum SYNTHETICS_API_URLS {
   SYNTHETICS_OVERVIEW = '/internal/synthetics/overview',
   PINGS = '/internal/synthetics/pings',
+  PING_STATUSES = '/internal/synthetics/ping_statuses',
   OVERVIEW_STATUS = `/internal/synthetics/overview/status`,
 }

--- a/x-pack/plugins/synthetics/common/lib/schedule_to_time.ts
+++ b/x-pack/plugins/synthetics/common/lib/schedule_to_time.ts
@@ -12,6 +12,10 @@ export function scheduleToMilli(schedule: SyntheticsMonitorSchedule): number {
   return timeValue * getMilliFactorForScheduleUnit(schedule.unit);
 }
 
+export function scheduleToMinutes(schedule: SyntheticsMonitorSchedule): number {
+  return Math.floor(scheduleToMilli(schedule) / (60 * 1000));
+}
+
 function getMilliFactorForScheduleUnit(scheduleUnit: ScheduleUnit): number {
   switch (scheduleUnit) {
     case ScheduleUnit.SECONDS:

--- a/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
@@ -244,6 +244,24 @@ export const PingType = t.intersection([
 
 export type Ping = t.TypeOf<typeof PingType>;
 
+export const PingStatusType = t.intersection([
+  t.type({
+    timestamp: t.string,
+    docId: t.string,
+    config_id: t.string,
+    locationId: t.string,
+    summary: t.partial({
+      down: t.number,
+      up: t.number,
+    }),
+  }),
+  t.partial({
+    error: PingErrorType,
+  }),
+]);
+
+export type PingStatus = t.TypeOf<typeof PingStatusType>;
+
 // Convenience function for tests etc that makes an empty ping
 // object with the minimum of fields.
 export const makePing = (f: {
@@ -281,6 +299,15 @@ export const PingsResponseType = t.type({
 });
 
 export type PingsResponse = t.TypeOf<typeof PingsResponseType>;
+
+export const PingStatusesResponseType = t.type({
+  total: t.number,
+  pings: t.array(PingStatusType),
+  from: t.string,
+  to: t.string,
+});
+
+export type PingStatusesResponse = t.TypeOf<typeof PingStatusesResponseType>;
 
 export const GetPingsParamsType = t.intersection([
   t.type({

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_ping_statuses.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_ping_statuses.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  getMonitorPingStatusesAction,
+  selectIsMonitorStatusesLoading,
+  selectPingStatusesForMonitorAndLocationAsc,
+} from '../../../state';
+
+import { useSelectedMonitor } from './use_selected_monitor';
+import { useSelectedLocation } from './use_selected_location';
+
+export const usePingStatuses = ({
+  from,
+  to,
+  size,
+}: {
+  from: string | number;
+  to: string | number;
+  size: number;
+}) => {
+  const { monitor } = useSelectedMonitor();
+  const location = useSelectedLocation();
+
+  const pingStatusesSelector = useCallback(() => {
+    return selectPingStatusesForMonitorAndLocationAsc(monitor?.id ?? '', location?.label ?? '');
+  }, [monitor?.id, location?.label]);
+  const isLoading = useSelector(selectIsMonitorStatusesLoading);
+  const pingStatuses = useSelector(pingStatusesSelector());
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!isLoading && monitor?.id && location?.label && from && to && size) {
+      dispatch(
+        getMonitorPingStatusesAction.get({
+          monitorId: monitor.id,
+          locationId: location.label,
+          from,
+          to,
+          size,
+        })
+      );
+    }
+    // isLoading shouldn't be included in deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, monitor?.id, location?.label, from, to, size]);
+
+  return pingStatuses;
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_history/monitor_history.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_history/monitor_history.tsx
@@ -4,9 +4,37 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiText } from '@elastic/eui';
-import React from 'react';
+
+import React, { useCallback } from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { useUrlParams } from '../../../hooks';
+import { SyntheticsDatePicker } from '../../common/date_picker/synthetics_date_picker';
+import { MonitorStatusPanel } from '../monitor_status/monitor_status_panel';
 
 export const MonitorHistory = () => {
-  return <EuiText>Monitor history tab content</EuiText>;
+  const [useGetUrlParams, updateUrlParams] = useUrlParams();
+  const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
+
+  const handleStatusChartBrushed = useCallback(
+    ({ fromUtc, toUtc }) => {
+      updateUrlParams({ dateRangeStart: fromUtc, dateRangeEnd: toUtc });
+    },
+    [updateUrlParams]
+  );
+
+  return (
+    <>
+      <SyntheticsDatePicker fullWidth={true} />
+      <EuiSpacer size="m" />
+      <MonitorStatusPanel
+        from={dateRangeStart}
+        to={dateRangeEnd}
+        showViewHistoryButton={false}
+        periodCaption={''}
+        brushable={true}
+        onBrushed={handleStatusChartBrushed}
+      />
+      <EuiSpacer size="m" />
+    </>
+  );
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/labels.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/labels.ts
@@ -41,3 +41,10 @@ export const LAST_24_HOURS_LABEL = i18n.translate('xpack.synthetics.monitorDetai
 export const VIEW_HISTORY_LABEL = i18n.translate('xpack.synthetics.monitorDetails.viewHistory', {
   defaultMessage: 'View History',
 });
+
+export const BRUSH_AREA_MESSAGE = i18n.translate(
+  'xpack.synthetics.monitorDetails.brushArea.message',
+  {
+    defaultMessage: 'Brush an area for higher fidelity',
+  }
+);

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/labels.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/labels.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const AVAILABILITY_LABEL = i18n.translate(
+  'xpack.synthetics.monitorDetails.availability.label',
+  {
+    defaultMessage: 'Availability',
+  }
+);
+
+export const COMPLETE_LABEL = i18n.translate('xpack.synthetics.monitorDetails.complete.label', {
+  defaultMessage: 'Complete',
+});
+
+export const FAILED_LABEL = i18n.translate('xpack.synthetics.monitorDetails.failed.label', {
+  defaultMessage: 'Failed',
+});
+
+export const SKIPPED_LABEL = i18n.translate('xpack.synthetics.monitorDetails.skipped.label', {
+  defaultMessage: 'Skipped',
+});
+
+export const ERROR_LABEL = i18n.translate('xpack.synthetics.monitorDetails.error.label', {
+  defaultMessage: 'Error',
+});
+
+export const STATUS_LABEL = i18n.translate('xpack.synthetics.monitorDetails.status', {
+  defaultMessage: 'Status',
+});
+
+export const LAST_24_HOURS_LABEL = i18n.translate('xpack.synthetics.monitorDetails.last24Hours', {
+  defaultMessage: 'Last 24 hours',
+});
+
+export const VIEW_HISTORY_LABEL = i18n.translate('xpack.synthetics.monitorDetails.viewHistory', {
+  defaultMessage: 'View History',
+});

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import moment from 'moment';
+import { css } from '@emotion/react';
+import { useEuiTheme, EuiText } from '@elastic/eui';
+
+import {
+  TooltipTable,
+  TooltipTableBody,
+  TooltipHeader,
+  TooltipDivider,
+  TooltipTableRow,
+  TooltipTableCell,
+} from '@elastic/charts';
+
+import { MonitorStatusTimeBin, SUCCESS_VIZ_COLOR, DANGER_VIZ_COLOR } from './monitor_status_data';
+import * as labels from './labels';
+
+export const MonitorStatusCellTooltip = ({ timeBin }: { timeBin?: MonitorStatusTimeBin }) => {
+  const { euiTheme } = useEuiTheme();
+
+  if (!timeBin) {
+    return <>{''}</>;
+  }
+
+  const dateStr = moment(timeBin.start).format('LL');
+  const timeStartStr = moment(timeBin.start).format('HH:mm');
+  const timeEndStr = moment(timeBin.end).format('HH:mm');
+  const tooltipTitle = `${dateStr} @ ${timeStartStr} - ${timeEndStr}`;
+  const availabilityStr =
+    timeBin.ups + timeBin.downs > 0
+      ? `${Math.round((timeBin.ups / (timeBin.ups + timeBin.downs)) * 100)}%`
+      : '-';
+
+  return (
+    <>
+      <TooltipHeader>
+        <EuiText size="xs" css={css({ border: 0, fontWeight: euiTheme.font.weight.bold })}>
+          {tooltipTitle}
+        </EuiText>
+      </TooltipHeader>
+      <TooltipDivider />
+      <div css={css({ border: 0, padding: euiTheme.size.xs })}>
+        <TooltipTable>
+          <TooltipTableBody>
+            <TooltipTableRow>
+              <TooltipListRow label={labels.AVAILABILITY_LABEL} value={availabilityStr} />
+            </TooltipTableRow>
+            <TooltipTableRow>
+              <TooltipListRow
+                label={labels.COMPLETE_LABEL}
+                value={`${timeBin.ups}` ?? ''}
+                color={SUCCESS_VIZ_COLOR}
+              />
+            </TooltipTableRow>
+            <TooltipTableRow>
+              <TooltipListRow
+                label={labels.FAILED_LABEL}
+                value={`${timeBin.downs}` ?? ''}
+                color={DANGER_VIZ_COLOR}
+              />
+            </TooltipTableRow>
+          </TooltipTableBody>
+        </TooltipTable>
+      </div>
+    </>
+  );
+};
+
+const TooltipListRow = ({
+  color,
+  label,
+  value,
+}: {
+  color?: string;
+  label: string;
+  value: string;
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <TooltipTableCell
+        css={css({
+          outline: 0,
+          border: 0,
+          borderLeft: 4,
+          borderStyle: 'solid',
+          borderColor: color ?? 'transparent',
+          padding: euiTheme.size.s,
+        })}
+      >
+        <EuiText size="xs">{label}</EuiText>
+      </TooltipTableCell>
+      <TooltipTableCell> </TooltipTableCell>
+      <TooltipTableCell css={css({ border: 0, padding: euiTheme.size.xs, textAlign: 'right' })}>
+        <EuiText size="xs" css={css({ border: 0, fontWeight: euiTheme.font.weight.bold })}>
+          {value}
+        </EuiText>
+      </TooltipTableCell>
+    </>
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_chart_theme.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_chart_theme.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HeatmapStyle, RecursivePartial } from '@elastic/charts';
+import { EuiThemeComputed } from '@elastic/eui';
+import { CHART_CELL_WIDTH } from './monitor_status_data';
+
+export function getMonitorStatusChartTheme(
+  euiTheme: EuiThemeComputed,
+  brushable: boolean
+): RecursivePartial<HeatmapStyle> {
+  return {
+    grid: {
+      cellHeight: {
+        min: 20,
+      },
+      stroke: {
+        width: 0,
+        color: 'transparent',
+      },
+    },
+    maxRowHeight: 30,
+    maxColumnWidth: CHART_CELL_WIDTH,
+    cell: {
+      maxWidth: 'fill',
+      maxHeight: 3,
+      label: {
+        visible: false,
+      },
+      border: {
+        stroke: 'transparent',
+        strokeWidth: 0.5,
+      },
+    },
+    xAxisLabel: {
+      visible: true,
+      fontSize: 10,
+      fontFamily: euiTheme.font.family,
+      fontWeight: euiTheme.font.weight.light,
+      textColor: euiTheme.colors.subduedText,
+    },
+    yAxisLabel: {
+      visible: false,
+    },
+    brushTool: {
+      visible: brushable,
+      fill: euiTheme.colors.darkShade,
+    },
+  };
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
@@ -79,7 +79,7 @@ export function getColorBands(euiTheme: EuiThemeComputed, colorMode: EuiThemeCol
 }
 
 export function getSkippedVizColor(euiTheme: EuiThemeComputed) {
-  return euiTheme.colors.body;
+  return euiTheme.colors.lightestShade;
 }
 
 export function getErrorVizColor(euiTheme: EuiThemeComputed) {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import moment from 'moment';
+import { tint, VISUALIZATION_COLORS, EuiThemeComputed } from '@elastic/eui';
+import { PingStatus } from '../../../../../../common/runtime_types';
+
+export const SUCCESS_VIZ_COLOR = VISUALIZATION_COLORS[0];
+export const DANGER_VIZ_COLOR = VISUALIZATION_COLORS[VISUALIZATION_COLORS.length - 1];
+export const CHART_CELL_WIDTH = 17;
+
+export interface MonitorStatusTimeBucket {
+  start: number;
+  end: number;
+}
+
+export interface MonitorStatusTimeBin {
+  start: number;
+  end: number;
+  ups: number;
+  downs: number;
+
+  /**
+   * To color code the time bin on chart
+   */
+  value: number;
+}
+
+export function getColorBands(euiTheme: EuiThemeComputed) {
+  return [
+    { color: DANGER_VIZ_COLOR, start: -Infinity, end: -1 },
+    { color: DANGER_VIZ_COLOR, start: -1, end: -0.75 },
+    { color: tint(DANGER_VIZ_COLOR, 0.25), start: -0.75, end: -0.5 },
+    { color: tint(DANGER_VIZ_COLOR, 0.5), start: -0.5, end: -0.25 },
+    { color: tint(DANGER_VIZ_COLOR, 0.75), start: -0.25, end: -0.000000001 },
+    {
+      color: getSkippedVizColor(euiTheme),
+      start: -0.000000001,
+      end: 0.000000001,
+    },
+    { color: tint(SUCCESS_VIZ_COLOR, 0.5), start: 0.000000001, end: 0.25 },
+    { color: tint(SUCCESS_VIZ_COLOR, 0.35), start: 0.25, end: 0.5 },
+    { color: tint(SUCCESS_VIZ_COLOR, 0.2), start: 0.5, end: 0.8 },
+    { color: SUCCESS_VIZ_COLOR, start: 0.8, end: 1 },
+    { color: SUCCESS_VIZ_COLOR, start: 1, end: Infinity },
+  ];
+}
+
+export function getSkippedVizColor(euiTheme: EuiThemeComputed) {
+  return euiTheme.colors.body;
+}
+
+export function getErrorVizColor(euiTheme: EuiThemeComputed) {
+  return euiTheme.colors.dangerText;
+}
+
+export function getXAxisLabelFormatter(interval: number) {
+  return (value: string | number) => {
+    const m = moment(value);
+    const [hours, minutes] = [m.hours(), m.minutes()];
+    const isFirstBucketOfADay = hours === 0 && minutes <= 36;
+    const isIntervalAcrossDays = interval >= 24 * 60;
+    return moment(value).format(isFirstBucketOfADay || isIntervalAcrossDays ? 'l' : 'HH:mm');
+  };
+}
+
+export function createTimeBuckets(intervalMinutes: number, from: number, to: number) {
+  const currentMark = getEndTime(intervalMinutes, to);
+  const buckets: MonitorStatusTimeBucket[] = [];
+
+  let tick = currentMark;
+  let maxIterations = 5000;
+  while (tick >= from && maxIterations > 0) {
+    const start = tick - Math.floor(intervalMinutes * 60 * 1000);
+    buckets.unshift({ start, end: tick });
+    tick = start;
+    --maxIterations;
+  }
+
+  return buckets;
+}
+
+export function createStatusTimeBins(
+  timeBuckets: MonitorStatusTimeBucket[],
+  pingStatuses: PingStatus[]
+): MonitorStatusTimeBin[] {
+  let iPingStatus = 0;
+  return (timeBuckets ?? []).map((bucket) => {
+    const currentBin: MonitorStatusTimeBin = {
+      start: bucket.start,
+      end: bucket.end,
+      ups: 0,
+      downs: 0,
+      value: 0,
+    };
+    while (
+      iPingStatus < pingStatuses.length &&
+      moment(pingStatuses[iPingStatus].timestamp).valueOf() < bucket.end
+    ) {
+      currentBin.ups += pingStatuses[iPingStatus]?.summary.up ?? 0;
+      currentBin.downs += pingStatuses[iPingStatus]?.summary.down ?? 0;
+      currentBin.value = getStatusEffectiveValue(currentBin.ups, currentBin.downs);
+      iPingStatus++;
+    }
+
+    return currentBin;
+  });
+}
+
+export function indexBinsByEndTime(bins: MonitorStatusTimeBin[]) {
+  return bins.reduce((acc, cur) => {
+    return acc.set(cur.end, cur);
+  }, new Map<number, MonitorStatusTimeBin>());
+}
+
+export function dateToMilli(date: string | number | moment.Moment | undefined): number {
+  if (typeof date === 'number') {
+    return date;
+  }
+
+  let d = date;
+  if (typeof date === 'string') {
+    d = datemath.parse(date, { momentInstance: moment });
+  }
+
+  return moment(d).valueOf();
+}
+
+function getStatusEffectiveValue(ups: number, downs: number): number {
+  if (ups === downs) {
+    return -0.1;
+  }
+
+  return (ups - downs) / (ups + downs);
+}
+
+function getEndTime(intervalMinutes: number, to: number) {
+  const intervalUnderHour = Math.floor(intervalMinutes) % 60;
+
+  const upperBoundMinutes =
+    Math.ceil(new Date(to).getUTCMinutes() / intervalUnderHour) * intervalUnderHour;
+
+  return moment(to).utc().startOf('hour').add(upperBoundMinutes, 'minute').valueOf();
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
@@ -7,7 +7,14 @@
 
 import datemath from '@elastic/datemath';
 import moment from 'moment';
-import { tint, VISUALIZATION_COLORS, EuiThemeComputed } from '@elastic/eui';
+import {
+  tint,
+  transparentize,
+  VISUALIZATION_COLORS,
+  EuiThemeComputed,
+  EuiThemeColorModeStandard,
+  COLOR_MODES_STANDARD,
+} from '@elastic/eui';
 import type { BrushEvent } from '@elastic/charts';
 import { PingStatus } from '../../../../../../common/runtime_types';
 
@@ -49,21 +56,23 @@ export interface MonitorStatusPanelProps {
   onBrushed?: (timeBounds: { from: number; to: number; fromUtc: string; toUtc: string }) => void;
 }
 
-export function getColorBands(euiTheme: EuiThemeComputed) {
+export function getColorBands(euiTheme: EuiThemeComputed, colorMode: EuiThemeColorModeStandard) {
+  const colorTransitionFn = colorMode === COLOR_MODES_STANDARD.dark ? transparentize : tint;
+
   return [
     { color: DANGER_VIZ_COLOR, start: -Infinity, end: -1 },
     { color: DANGER_VIZ_COLOR, start: -1, end: -0.75 },
-    { color: tint(DANGER_VIZ_COLOR, 0.25), start: -0.75, end: -0.5 },
-    { color: tint(DANGER_VIZ_COLOR, 0.5), start: -0.5, end: -0.25 },
-    { color: tint(DANGER_VIZ_COLOR, 0.75), start: -0.25, end: -0.000000001 },
+    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.25), start: -0.75, end: -0.5 },
+    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.5), start: -0.5, end: -0.25 },
+    { color: colorTransitionFn(DANGER_VIZ_COLOR, 0.75), start: -0.25, end: -0.000000001 },
     {
       color: getSkippedVizColor(euiTheme),
       start: -0.000000001,
       end: 0.000000001,
     },
-    { color: tint(SUCCESS_VIZ_COLOR, 0.5), start: 0.000000001, end: 0.25 },
-    { color: tint(SUCCESS_VIZ_COLOR, 0.35), start: 0.25, end: 0.5 },
-    { color: tint(SUCCESS_VIZ_COLOR, 0.2), start: 0.5, end: 0.8 },
+    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.5), start: 0.000000001, end: 0.25 },
+    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.35), start: 0.25, end: 0.5 },
+    { color: colorTransitionFn(SUCCESS_VIZ_COLOR, 0.2), start: 0.5, end: 0.8 },
     { color: SUCCESS_VIZ_COLOR, start: 0.8, end: 1 },
     { color: SUCCESS_VIZ_COLOR, start: 1, end: Infinity },
   ];

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_data.ts
@@ -8,6 +8,7 @@
 import datemath from '@elastic/datemath';
 import moment from 'moment';
 import { tint, VISUALIZATION_COLORS, EuiThemeComputed } from '@elastic/eui';
+import type { BrushEvent } from '@elastic/charts';
 import { PingStatus } from '../../../../../../common/runtime_types';
 
 export const SUCCESS_VIZ_COLOR = VISUALIZATION_COLORS[0];
@@ -29,6 +30,23 @@ export interface MonitorStatusTimeBin {
    * To color code the time bin on chart
    */
   value: number;
+}
+
+export interface MonitorStatusPanelProps {
+  /**
+   * Either epoch in millis or Kibana date range e.g. 'now-24h'
+   */
+  from: string | number;
+
+  /**
+   * Either epoch in millis or Kibana date range e.g. 'now'
+   */
+  to: string | number;
+
+  brushable: boolean; // Whether to allow brushing on the chart to allow zooming in on data.
+  periodCaption?: string; // e.g. Last 24 Hours
+  showViewHistoryButton?: boolean;
+  onBrushed?: (timeBounds: { from: number; to: number; fromUtc: string; toUtc: string }) => void;
 }
 
 export function getColorBands(euiTheme: EuiThemeComputed) {
@@ -129,6 +147,13 @@ export function dateToMilli(date: string | number | moment.Moment | undefined): 
   }
 
   return moment(d).valueOf();
+}
+
+export function getBrushData(e: BrushEvent) {
+  const [from, to] = [Number(e.x?.[0]), Number(e.x?.[1])];
+  const [fromUtc, toUtc] = [moment(from).format(), moment(to).format()];
+
+  return { from, to, fromUtc, toUtc };
 }
 
 function getStatusEffectiveValue(ups: number, downs: number): number {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_header.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTitle,
+  EuiLink,
+} from '@elastic/eui';
+import { css } from '@emotion/css';
+import { useHistory } from 'react-router-dom';
+
+import { MONITOR_HISTORY_ROUTE } from '../../../../../../common/constants';
+import { stringifyUrlParams } from '../../../utils/url_params';
+import { useGetUrlParams } from '../../../hooks';
+
+import { useSelectedMonitor } from '../hooks/use_selected_monitor';
+
+import * as labels from './labels';
+import { MonitorStatusPanelProps } from './monitor_status_data';
+
+export const MonitorStatusHeader = ({
+  from,
+  to,
+  periodCaption,
+  showViewHistoryButton,
+}: MonitorStatusPanelProps) => {
+  const history = useHistory();
+  const params = useGetUrlParams();
+  const { monitor } = useSelectedMonitor();
+
+  const isLast24Hours = from === 'now-24h' && to === 'now';
+  const periodCaptionText = !!periodCaption
+    ? periodCaption
+    : isLast24Hours
+    ? labels.LAST_24_HOURS_LABEL
+    : '';
+
+  return (
+    <EuiFlexGroup
+      direction="row"
+      alignItems="baseline"
+      css={css`
+        margin-bottom: 0;
+      `}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>{labels.STATUS_LABEL}</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      {periodCaptionText ? (
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {periodCaptionText}
+          </EuiText>
+        </EuiFlexItem>
+      ) : null}
+      <EuiFlexItem grow={true} />
+
+      {showViewHistoryButton ? (
+        <EuiFlexItem grow={false}>
+          <EuiLink
+            href={
+              monitor?.id
+                ? history.createHref({
+                    pathname: MONITOR_HISTORY_ROUTE.replace(':monitorId', monitor?.id),
+                    search: stringifyUrlParams(
+                      { ...params, dateRangeStart: 'now-24h', dateRangeEnd: 'now' },
+                      true
+                    ),
+                  })
+                : undefined
+            }
+          >
+            <EuiButtonEmpty
+              data-test-subj="monitorStatusChartViewHistoryButton"
+              size="xs"
+              iconType="list"
+            >
+              {labels.VIEW_HISTORY_LABEL}
+            </EuiButtonEmpty>
+          </EuiLink>
+        </EuiFlexItem>
+      ) : null}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
@@ -9,12 +9,7 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/css';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, useEuiTheme } from '@elastic/eui';
 import * as labels from './labels';
-import {
-  DANGER_VIZ_COLOR,
-  getErrorVizColor,
-  getSkippedVizColor,
-  SUCCESS_VIZ_COLOR,
-} from './monitor_status_data';
+import { DANGER_VIZ_COLOR, getSkippedVizColor, SUCCESS_VIZ_COLOR } from './monitor_status_data';
 
 export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
   const { euiTheme } = useEuiTheme();
@@ -48,7 +43,11 @@ export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
       <LegendItem color={SUCCESS_VIZ_COLOR} label={labels.COMPLETE_LABEL} />
       <LegendItem color={DANGER_VIZ_COLOR} label={labels.FAILED_LABEL} />
       <LegendItem color={getSkippedVizColor(euiTheme)} label={labels.SKIPPED_LABEL} />
-      <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
+      {/*
+        // Hiding error for now until @elastic/chart's Heatmap chart supports annotations
+        // `getErrorVizColor` can be imported from './monitor_status_data'
+        <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
+      */}
 
       {brushable ? (
         <>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { css } from '@emotion/css';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, useEuiTheme } from '@elastic/eui';
+import * as labels from './labels';
+import {
+  DANGER_VIZ_COLOR,
+  getErrorVizColor,
+  getSkippedVizColor,
+  SUCCESS_VIZ_COLOR,
+} from './monitor_status_data';
+
+export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const LegendItem = useMemo(() => {
+    return ({
+      color,
+      label,
+      iconType = 'dot',
+    }: {
+      color: string;
+      label: string;
+      iconType?: string;
+    }) => (
+      <EuiFlexItem
+        css={css`
+          display: flex;
+          flex-direction: row;
+          gap: 2px;
+        `}
+        grow={false}
+      >
+        <EuiIcon type={iconType} color={color} />
+        <EuiText size="xs">{label}</EuiText>
+      </EuiFlexItem>
+    );
+  }, []);
+
+  return (
+    <EuiFlexGroup wrap={true} responsive={false}>
+      <LegendItem color={SUCCESS_VIZ_COLOR} label={labels.COMPLETE_LABEL} />
+      <LegendItem color={DANGER_VIZ_COLOR} label={labels.FAILED_LABEL} />
+      <LegendItem color={getSkippedVizColor(euiTheme)} label={labels.SKIPPED_LABEL} />
+      <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
+
+      {brushable ? (
+        <>
+          <EuiFlexItem aria-hidden={true} grow={true} />
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color={euiTheme.colors.subduedText}>
+              {labels.BRUSH_AREA_MESSAGE}
+            </EuiText>
+          </EuiFlexItem>
+        </>
+      ) : null}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -7,34 +7,18 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { throttle } from 'lodash';
-import { css } from '@emotion/css';
-import {
-  EuiPanel,
-  useEuiTheme,
-  EuiResizeObserver,
-  EuiThemeComputed,
-  EuiTitle,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiButtonEmpty,
-  EuiIcon,
-} from '@elastic/eui';
-
-import {
-  Chart,
-  Settings,
-  Heatmap,
-  ScaleType,
-  HeatmapStyle,
-  RecursivePartial,
-} from '@elastic/charts';
+import { EuiPanel, useEuiTheme, EuiResizeObserver } from '@elastic/eui';
+import { Chart, Settings, Heatmap, ScaleType } from '@elastic/charts';
 
 import { scheduleToMinutes } from '../../../../../../common/lib/schedule_to_time';
+import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { usePingStatuses } from '../hooks/use_ping_statuses';
+import { MonitorStatusHeader } from './monitor_status_header';
 import { MonitorStatusCellTooltip } from './monitor_status_cell_tooltip';
+import { MonitorStatusLegend } from './monitor_status_legend';
+import { getMonitorStatusChartTheme } from './monitor_status_chart_theme';
 import {
   getXAxisLabelFormatter,
   dateToMilli,
@@ -43,28 +27,9 @@ import {
   getColorBands,
   CHART_CELL_WIDTH,
   indexBinsByEndTime,
-  SUCCESS_VIZ_COLOR,
-  getSkippedVizColor,
-  getErrorVizColor,
-  DANGER_VIZ_COLOR,
+  getBrushData,
+  MonitorStatusPanelProps,
 } from './monitor_status_data';
-import * as labels from './labels';
-
-interface MonitorStatusPanelProps {
-  /**
-   * Either epoch in millis or Kibana date range e.g. 'now-24h'
-   */
-  from: string | number;
-
-  /**
-   * Either epoch in millis or Kibana date range e.g. 'now'
-   */
-  to: string | number;
-  brushable: boolean; // Whether to allow brushing on the chart to allow zooming in on data.
-  periodCaption?: string; // e.g. Last 24 Hours
-  showViewHistoryButton?: boolean;
-  onBrushed?: (timeBounds: { from: number; to: number }) => void;
-}
 
 export const MonitorStatusPanel = ({
   from = 'now-24h',
@@ -75,22 +40,25 @@ export const MonitorStatusPanel = ({
   onBrushed,
 }: MonitorStatusPanelProps) => {
   const { euiTheme } = useEuiTheme();
+  const { lastRefresh } = useSyntheticsRefreshContext();
   const { monitor } = useSelectedMonitor();
-  const monitorInterval = Math.max(
-    10,
-    monitor?.schedule ? scheduleToMinutes(monitor?.schedule) : 10
-  );
+  const monitorInterval = Math.max(3, monitor?.schedule ? scheduleToMinutes(monitor?.schedule) : 3);
 
   const fromMillis = dateToMilli(from);
   const toMillis = dateToMilli(to);
+  const totalMinutes = Math.ceil(toMillis - fromMillis) / (1000 * 60);
   const pingStatuses = usePingStatuses({
-    from,
-    to,
-    size: 24 * Math.ceil(60 / monitorInterval),
+    from: fromMillis,
+    to: toMillis,
+    size: Math.min(10000, Math.ceil((totalMinutes / monitorInterval) * 2)), // Acts as max size between from - to
+    monitorInterval,
+    lastRefresh,
   });
 
   const [binsAvailableByWidth, setBinsAvailableByWidth] = useState(50);
-  const intervalByWidth = Math.floor((24 * 60) / binsAvailableByWidth);
+  const intervalByWidth = Math.floor(
+    Math.max(monitorInterval, totalMinutes / binsAvailableByWidth)
+  );
 
   // Disabling deps warning as we wanna throttle the callback
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,53 +83,19 @@ export const MonitorStatusPanel = ({
   }, [intervalByWidth, pingStatuses, fromMillis, toMillis]);
 
   const heatmap = useMemo(() => {
-    return getChartTheme(euiTheme, brushable);
+    return getMonitorStatusChartTheme(euiTheme, brushable);
   }, [euiTheme, brushable]);
-
-  const isLast24Hours = from === 'now-24h' && to === 'now';
-  const periodCaptionText = !!periodCaption
-    ? periodCaption
-    : isLast24Hours
-    ? labels.LAST_24_HOURS_LABEL
-    : '';
 
   return (
     <EuiPanel hasShadow={false} hasBorder={true}>
-      <EuiFlexGroup
-        direction="row"
-        alignItems="baseline"
-        css={css`
-          margin-bottom: 0;
-        `}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="xs">
-            <h4>{labels.STATUS_LABEL}</h4>
-          </EuiTitle>
-        </EuiFlexItem>
-        {periodCaptionText ? (
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color={euiTheme.colors.subduedText}>
-              {periodCaptionText}
-            </EuiText>
-          </EuiFlexItem>
-        ) : null}
-        <EuiFlexItem grow={true} />
-
-        {showViewHistoryButton ? (
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color={euiTheme.colors.subduedText}>
-              <EuiButtonEmpty
-                data-test-subj="monitorStatusChartViewHistoryButton"
-                size="xs"
-                iconType="list"
-              >
-                {labels.VIEW_HISTORY_LABEL}
-              </EuiButtonEmpty>
-            </EuiText>
-          </EuiFlexItem>
-        ) : null}
-      </EuiFlexGroup>
+      <MonitorStatusHeader
+        from={from}
+        to={to}
+        brushable={brushable}
+        periodCaption={periodCaption}
+        showViewHistoryButton={showViewHistoryButton}
+        onBrushed={onBrushed}
+      />
 
       <EuiResizeObserver onResize={resizeHandler}>
         {(resizeRef) => (
@@ -179,7 +113,7 @@ export const MonitorStatusPanel = ({
                 }}
                 theme={{ heatmap }}
                 onBrushEnd={(brushArea) => {
-                  onBrushed?.({ from: Number(brushArea.x?.[0]), to: Number(brushArea.x?.[0]) });
+                  onBrushed?.(getBrushData(brushArea));
                 }}
               />
               <Heatmap
@@ -209,88 +143,7 @@ export const MonitorStatusPanel = ({
         )}
       </EuiResizeObserver>
 
-      <ChartLegend />
+      <MonitorStatusLegend brushable={brushable} />
     </EuiPanel>
   );
 };
-
-const ChartLegend = () => {
-  const { euiTheme } = useEuiTheme();
-
-  const LegendItem = useMemo(() => {
-    return ({
-      color,
-      label,
-      iconType = 'dot',
-    }: {
-      color: string;
-      label: string;
-      iconType?: string;
-    }) => (
-      <EuiFlexItem
-        css={css`
-          display: flex;
-          flex-direction: row;
-          gap: 2px;
-        `}
-        grow={false}
-      >
-        <EuiIcon type={iconType} color={color} />
-        <EuiText size="xs">{label}</EuiText>
-      </EuiFlexItem>
-    );
-  }, []);
-
-  return (
-    <EuiFlexGroup>
-      <LegendItem color={SUCCESS_VIZ_COLOR} label={labels.COMPLETE_LABEL} />
-      <LegendItem color={DANGER_VIZ_COLOR} label={labels.FAILED_LABEL} />
-      <LegendItem color={getSkippedVizColor(euiTheme)} label={labels.SKIPPED_LABEL} />
-      <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
-    </EuiFlexGroup>
-  );
-};
-
-function getChartTheme(
-  euiTheme: EuiThemeComputed,
-  brushable: boolean
-): RecursivePartial<HeatmapStyle> {
-  return {
-    grid: {
-      cellHeight: {
-        min: 20,
-      },
-      stroke: {
-        width: 0,
-        color: 'transparent',
-      },
-    },
-    maxRowHeight: 30,
-    maxColumnWidth: CHART_CELL_WIDTH,
-    cell: {
-      maxWidth: 'fill',
-      maxHeight: 3,
-      label: {
-        visible: false,
-      },
-      border: {
-        stroke: 'transparent',
-        strokeWidth: 0.5,
-      },
-    },
-    xAxisLabel: {
-      visible: true,
-      fontSize: 10,
-      fontFamily: euiTheme.font.family,
-      fontWeight: euiTheme.font.weight.light,
-      textColor: euiTheme.colors.subduedText,
-    },
-    yAxisLabel: {
-      visible: false,
-    },
-    brushTool: {
-      visible: brushable,
-      fill: euiTheme.colors.darkShade,
-    },
-  };
-}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -126,7 +126,7 @@ export const MonitorStatusPanel = ({
     : '';
 
   return (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} hasBorder={true}>
       <EuiFlexGroup
         direction="row"
         alignItems="baseline"

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -1,0 +1,296 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { throttle } from 'lodash';
+import { css } from '@emotion/css';
+import {
+  EuiPanel,
+  useEuiTheme,
+  EuiResizeObserver,
+  EuiThemeComputed,
+  EuiTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiButtonEmpty,
+  EuiIcon,
+} from '@elastic/eui';
+
+import {
+  Chart,
+  Settings,
+  Heatmap,
+  ScaleType,
+  HeatmapStyle,
+  RecursivePartial,
+} from '@elastic/charts';
+
+import { scheduleToMinutes } from '../../../../../../common/lib/schedule_to_time';
+
+import { useSelectedMonitor } from '../hooks/use_selected_monitor';
+import { usePingStatuses } from '../hooks/use_ping_statuses';
+import { MonitorStatusCellTooltip } from './monitor_status_cell_tooltip';
+import {
+  getXAxisLabelFormatter,
+  dateToMilli,
+  createTimeBuckets,
+  createStatusTimeBins,
+  getColorBands,
+  CHART_CELL_WIDTH,
+  indexBinsByEndTime,
+  SUCCESS_VIZ_COLOR,
+  getSkippedVizColor,
+  getErrorVizColor,
+  DANGER_VIZ_COLOR,
+} from './monitor_status_data';
+import * as labels from './labels';
+
+interface MonitorStatusPanelProps {
+  /**
+   * Either epoch in millis or Kibana date range e.g. 'now-24h'
+   */
+  from: string | number;
+
+  /**
+   * Either epoch in millis or Kibana date range e.g. 'now'
+   */
+  to: string | number;
+  brushable: boolean; // Whether to allow brushing on the chart to allow zooming in on data.
+  periodCaption?: string; // e.g. Last 24 Hours
+  showViewHistoryButton?: boolean;
+  onBrushed?: (timeBounds: { from: number; to: number }) => void;
+}
+
+export const MonitorStatusPanel = ({
+  from = 'now-24h',
+  to = 'now',
+  brushable = true,
+  periodCaption = undefined,
+  showViewHistoryButton = false,
+  onBrushed,
+}: MonitorStatusPanelProps) => {
+  const { euiTheme } = useEuiTheme();
+  const { monitor } = useSelectedMonitor();
+  const monitorInterval = Math.max(
+    10,
+    monitor?.schedule ? scheduleToMinutes(monitor?.schedule) : 10
+  );
+
+  const fromMillis = dateToMilli(from);
+  const toMillis = dateToMilli(to);
+  const pingStatuses = usePingStatuses({
+    from,
+    to,
+    size: 24 * Math.ceil(60 / monitorInterval),
+  });
+
+  const [binsAvailableByWidth, setBinsAvailableByWidth] = useState(50);
+  const intervalByWidth = Math.floor((24 * 60) / binsAvailableByWidth);
+
+  // Disabling deps warning as we wanna throttle the callback
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const resizeHandler = useCallback(
+    throttle((e: { width: number; height: number }) => {
+      setBinsAvailableByWidth(Math.floor(e.width / CHART_CELL_WIDTH));
+    }, 500),
+    []
+  );
+
+  const { timeBins, timeBinsByEndTime, xDomain } = useMemo(() => {
+    const timeBuckets = createTimeBuckets(intervalByWidth, fromMillis, toMillis);
+    const bins = createStatusTimeBins(timeBuckets, pingStatuses);
+    const indexedBins = indexBinsByEndTime(bins);
+
+    const timeDomain = {
+      min: bins?.[0]?.end ?? fromMillis,
+      max: bins?.[bins.length - 1]?.end ?? toMillis,
+    };
+
+    return { timeBins: bins, timeBinsByEndTime: indexedBins, xDomain: timeDomain };
+  }, [intervalByWidth, pingStatuses, fromMillis, toMillis]);
+
+  const heatmap = useMemo(() => {
+    return getChartTheme(euiTheme, brushable);
+  }, [euiTheme, brushable]);
+
+  const isLast24Hours = from === 'now-24h' && to === 'now';
+  const periodCaptionText = !!periodCaption
+    ? periodCaption
+    : isLast24Hours
+    ? labels.LAST_24_HOURS_LABEL
+    : '';
+
+  return (
+    <EuiPanel>
+      <EuiFlexGroup
+        direction="row"
+        alignItems="baseline"
+        css={css`
+          margin-bottom: 0;
+        `}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h4>{labels.STATUS_LABEL}</h4>
+          </EuiTitle>
+        </EuiFlexItem>
+        {periodCaptionText ? (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color={euiTheme.colors.subduedText}>
+              {periodCaptionText}
+            </EuiText>
+          </EuiFlexItem>
+        ) : null}
+        <EuiFlexItem grow={true} />
+
+        {showViewHistoryButton ? (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color={euiTheme.colors.subduedText}>
+              <EuiButtonEmpty
+                data-test-subj="monitorStatusChartViewHistoryButton"
+                size="xs"
+                iconType="list"
+              >
+                {labels.VIEW_HISTORY_LABEL}
+              </EuiButtonEmpty>
+            </EuiText>
+          </EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+
+      <EuiResizeObserver onResize={resizeHandler}>
+        {(resizeRef) => (
+          <div ref={resizeRef}>
+            <Chart css={{ height: 60 }}>
+              <Settings
+                showLegend={false}
+                xDomain={xDomain}
+                tooltip={{
+                  customTooltip: ({ values }) => (
+                    <MonitorStatusCellTooltip
+                      timeBin={timeBinsByEndTime.get(values?.[0]?.datum?.x)}
+                    />
+                  ),
+                }}
+                theme={{ heatmap }}
+                onBrushEnd={(brushArea) => {
+                  onBrushed?.({ from: Number(brushArea.x?.[0]), to: Number(brushArea.x?.[0]) });
+                }}
+              />
+              <Heatmap
+                id="monitor-details-monitor-status-chart"
+                colorScale={{
+                  type: 'bands',
+                  bands: getColorBands(euiTheme),
+                }}
+                data={timeBins}
+                xAccessor={(timeBin) => timeBin.end}
+                yAccessor={() => 'T'}
+                valueAccessor={(timeBin) => timeBin.value}
+                valueFormatter={(d) => d.toFixed(2)}
+                xAxisLabelFormatter={getXAxisLabelFormatter(intervalByWidth)}
+                timeZone="UTC"
+                xScale={{
+                  type: ScaleType.Time,
+                  interval: {
+                    type: 'calendar',
+                    unit: 'm',
+                    value: intervalByWidth,
+                  },
+                }}
+              />
+            </Chart>
+          </div>
+        )}
+      </EuiResizeObserver>
+
+      <ChartLegend />
+    </EuiPanel>
+  );
+};
+
+const ChartLegend = () => {
+  const { euiTheme } = useEuiTheme();
+
+  const LegendItem = useMemo(() => {
+    return ({
+      color,
+      label,
+      iconType = 'dot',
+    }: {
+      color: string;
+      label: string;
+      iconType?: string;
+    }) => (
+      <EuiFlexItem
+        css={css`
+          display: flex;
+          flex-direction: row;
+          gap: 2px;
+        `}
+        grow={false}
+      >
+        <EuiIcon type={iconType} color={color} />
+        <EuiText size="xs">{label}</EuiText>
+      </EuiFlexItem>
+    );
+  }, []);
+
+  return (
+    <EuiFlexGroup>
+      <LegendItem color={SUCCESS_VIZ_COLOR} label={labels.COMPLETE_LABEL} />
+      <LegendItem color={DANGER_VIZ_COLOR} label={labels.FAILED_LABEL} />
+      <LegendItem color={getSkippedVizColor(euiTheme)} label={labels.SKIPPED_LABEL} />
+      <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
+    </EuiFlexGroup>
+  );
+};
+
+function getChartTheme(
+  euiTheme: EuiThemeComputed,
+  brushable: boolean
+): RecursivePartial<HeatmapStyle> {
+  return {
+    grid: {
+      cellHeight: {
+        min: 20,
+      },
+      stroke: {
+        width: 0,
+        color: 'transparent',
+      },
+    },
+    maxRowHeight: 30,
+    maxColumnWidth: CHART_CELL_WIDTH,
+    cell: {
+      maxWidth: 'fill',
+      maxHeight: 3,
+      label: {
+        visible: false,
+      },
+      border: {
+        stroke: 'transparent',
+        strokeWidth: 0.5,
+      },
+    },
+    xAxisLabel: {
+      visible: true,
+      fontSize: 10,
+      fontFamily: euiTheme.font.family,
+      fontWeight: euiTheme.font.weight.light,
+      textColor: euiTheme.colors.subduedText,
+    },
+    yAxisLabel: {
+      visible: false,
+    },
+    brushTool: {
+      visible: brushable,
+      fill: euiTheme.colors.darkShade,
+    },
+  };
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -39,7 +39,7 @@ export const MonitorStatusPanel = ({
   showViewHistoryButton = false,
   onBrushed,
 }: MonitorStatusPanelProps) => {
-  const { euiTheme } = useEuiTheme();
+  const { euiTheme, colorMode } = useEuiTheme();
   const { lastRefresh } = useSyntheticsRefreshContext();
   const { monitor } = useSelectedMonitor();
   const monitorInterval = Math.max(3, monitor?.schedule ? scheduleToMinutes(monitor?.schedule) : 3);
@@ -120,7 +120,7 @@ export const MonitorStatusPanel = ({
                 id="monitor-details-monitor-status-chart"
                 colorScale={{
                   type: 'bands',
-                  bands: getColorBands(euiTheme),
+                  bands: getColorBands(euiTheme, colorMode),
                 }}
                 data={timeBins}
                 xAccessor={(timeBin) => timeBin.end}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/use_monitor_status_data.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/use_monitor_status_data.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { throttle } from 'lodash';
+
+import { scheduleToMinutes } from '../../../../../../common/lib/schedule_to_time';
+import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
+
+import { useSelectedMonitor } from '../hooks/use_selected_monitor';
+import { usePingStatuses } from '../hooks/use_ping_statuses';
+import {
+  dateToMilli,
+  createTimeBuckets,
+  createStatusTimeBins,
+  CHART_CELL_WIDTH,
+  indexBinsByEndTime,
+  MonitorStatusPanelProps,
+} from './monitor_status_data';
+
+export const useMonitorStatusData = ({
+  from,
+  to,
+}: Pick<MonitorStatusPanelProps, 'from' | 'to'>) => {
+  const { lastRefresh } = useSyntheticsRefreshContext();
+  const { monitor } = useSelectedMonitor();
+  const monitorInterval = Math.max(3, monitor?.schedule ? scheduleToMinutes(monitor?.schedule) : 3);
+
+  const fromMillis = dateToMilli(from);
+  const toMillis = dateToMilli(to);
+  const totalMinutes = Math.ceil(toMillis - fromMillis) / (1000 * 60);
+  const pingStatuses = usePingStatuses({
+    from: fromMillis,
+    to: toMillis,
+    size: Math.min(10000, Math.ceil((totalMinutes / monitorInterval) * 2)), // Acts as max size between from - to
+    monitorInterval,
+    lastRefresh,
+  });
+
+  const [binsAvailableByWidth, setBinsAvailableByWidth] = useState(50);
+  const intervalByWidth = Math.floor(
+    Math.max(monitorInterval, totalMinutes / binsAvailableByWidth)
+  );
+
+  // Disabling deps warning as we wanna throttle the callback
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleResize = useCallback(
+    throttle((e: { width: number; height: number }) => {
+      setBinsAvailableByWidth(Math.floor(e.width / CHART_CELL_WIDTH));
+    }, 500),
+    []
+  );
+
+  const { timeBins, timeBinsByEndTime, xDomain } = useMemo(() => {
+    const timeBuckets = createTimeBuckets(intervalByWidth, fromMillis, toMillis);
+    const bins = createStatusTimeBins(timeBuckets, pingStatuses);
+    const indexedBins = indexBinsByEndTime(bins);
+
+    const timeDomain = {
+      min: bins?.[0]?.end ?? fromMillis,
+      max: bins?.[bins.length - 1]?.end ?? toMillis,
+    };
+
+    return { timeBins: bins, timeBinsByEndTime: indexedBins, xDomain: timeDomain };
+  }, [intervalByWidth, pingStatuses, fromMillis, toMillis]);
+
+  return {
+    intervalByWidth,
+    timeBins,
+    xDomain,
+    handleResize,
+    getTimeBinByXValue: (xValue: number | undefined) =>
+      xValue === undefined ? undefined : timeBinsByEndTime.get(xValue),
+  };
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -111,7 +111,7 @@ export const MonitorSummary = () => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <MonitorStatusPanel
         from={'now-24h'}
         to={'now'}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -20,6 +20,7 @@ import { LoadWhenInView } from '@kbn/observability-plugin/public';
 
 import { useEarliestStartDate } from '../hooks/use_earliest_start_data';
 import { MonitorErrorSparklines } from './monitor_error_sparklines';
+import { MonitorStatusPanel } from '../monitor_status/monitor_status_panel';
 import { DurationSparklines } from './duration_sparklines';
 import { MonitorDurationTrend } from './duration_trend';
 import { StepDurationPanel } from './step_duration_panel';
@@ -110,8 +111,13 @@ export const MonitorSummary = () => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {/* <EuiSpacer size="l" /> */}
-      {/* <EuiPanel style={{ height: 100 }}>/!* TODO: Add status panel*!/</EuiPanel> */}
+      <EuiSpacer size="l" />
+      <MonitorStatusPanel
+        from={'now-24h'}
+        to={'now'}
+        brushable={false}
+        showViewHistoryButton={true}
+      />
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="m">
         <EuiFlexItem>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/index.ts
@@ -18,3 +18,4 @@ export * from './monitor_list';
 export * from './monitor_details';
 export * from './overview';
 export * from './browser_journey';
+export * from './ping_status';

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/actions.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PingStatusesResponse } from '../../../../../common/runtime_types';
+import { createAsyncAction } from '../utils/actions';
+
+import { PingStatusActionArgs } from './models';
+
+export const getMonitorPingStatusesAction = createAsyncAction<
+  PingStatusActionArgs,
+  PingStatusesResponse
+>('[PING STATUSES] GET PING STATUSES');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/api.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
+import {
+  PingStatusesResponse,
+  PingStatusesResponseType,
+} from '../../../../../common/runtime_types';
+import { apiService } from '../../../../utils/api_service';
+
+export const fetchMonitorPingStatuses = async ({
+  monitorId,
+  locationId,
+  from,
+  to,
+  size,
+}: {
+  monitorId: string;
+  locationId: string;
+  from: string;
+  to: string;
+  size: number;
+}): Promise<PingStatusesResponse> => {
+  const locations = JSON.stringify([locationId]);
+  const sort = 'desc';
+
+  return await apiService.get(
+    SYNTHETICS_API_URLS.PING_STATUSES,
+    { monitorId, from, to, locations, sort, size },
+    PingStatusesResponseType
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { takeEvery } from 'redux-saga/effects';
+import { fetchEffectFactory } from '../utils/fetch_effect';
+import { fetchMonitorPingStatuses } from './api';
+
+import { getMonitorPingStatusesAction } from './actions';
+
+export function* fetchPingStatusesEffect() {
+  yield takeEvery(
+    getMonitorPingStatusesAction.get,
+    fetchEffectFactory(
+      fetchMonitorPingStatuses,
+      getMonitorPingStatusesAction.success,
+      getMonitorPingStatusesAction.fail
+    )
+  );
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/index.ts
@@ -49,9 +49,9 @@ export const pingStatusReducer = createReducer(initialState, (builder) => {
         }
 
         state.pingStatuses[config_id][locationId][timestamp] = ping;
-
-        state.loading = false;
       });
+
+      state.loading = false;
     })
     .addCase(getMonitorPingStatusesAction.fail, (state, action) => {
       state.error = action.payload;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/index.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createReducer } from '@reduxjs/toolkit';
+
+import { PingStatus } from '../../../../../common/runtime_types';
+
+import { IHttpSerializedFetchError } from '../utils/http_error';
+
+import { getMonitorPingStatusesAction } from './actions';
+
+export interface PingStatusState {
+  pingStatuses: {
+    [monitorId: string]: {
+      [locationId: string]: {
+        [timestamp: string]: PingStatus;
+      };
+    };
+  };
+  loading: boolean;
+  error: IHttpSerializedFetchError | null;
+}
+
+const initialState: PingStatusState = {
+  pingStatuses: {},
+  loading: false,
+  error: null,
+};
+
+export const pingStatusReducer = createReducer(initialState, (builder) => {
+  builder
+    .addCase(getMonitorPingStatusesAction.get, (state) => {
+      state.loading = true;
+    })
+    .addCase(getMonitorPingStatusesAction.success, (state, action) => {
+      (action.payload.pings ?? []).forEach((ping) => {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { config_id, locationId, timestamp } = ping;
+        if (!state.pingStatuses[config_id]) {
+          state.pingStatuses[config_id] = {};
+        }
+
+        if (!state.pingStatuses[config_id][locationId]) {
+          state.pingStatuses[config_id][locationId] = {};
+        }
+
+        state.pingStatuses[config_id][locationId][timestamp] = ping;
+
+        state.loading = false;
+      });
+    })
+    .addCase(getMonitorPingStatusesAction.fail, (state, action) => {
+      state.error = action.payload;
+      state.loading = false;
+    });
+});
+
+export * from './actions';
+export * from './effects';
+export * from './selectors';

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/models.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/models.ts
@@ -5,5 +5,10 @@
  * 2.0.
  */
 
-export { syntheticsGetPingsRoute } from './get_pings';
-export { syntheticsGetPingStatusesRoute } from './get_ping_statuses';
+export interface PingStatusActionArgs {
+  monitorId: string;
+  locationId: string;
+  from: string | number;
+  to: string | number;
+  size: number;
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/selectors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/selectors.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSelector } from 'reselect';
+
+import { PingStatus } from '../../../../../common/runtime_types';
+import { SyntheticsAppState } from '../root_reducer';
+
+import { PingStatusState } from '.';
+
+type PingSelectorReturnType = (state: SyntheticsAppState) => PingStatus[];
+
+const getState = (appState: SyntheticsAppState) => appState.pingStatus;
+
+export const selectIsMonitorStatusesLoading = createSelector(getState, (state) => state.loading);
+
+export const selectPingStatusesForMonitorAndLocationAsc = (
+  monitorId: string,
+  locationId: string
+): PingSelectorReturnType =>
+  createSelector([(state: SyntheticsAppState) => state.pingStatus], (state: PingStatusState) => {
+    return Object.values(state?.pingStatuses?.[monitorId]?.[locationId] ?? {}).sort(
+      (a, b) => Number(new Date(a.timestamp)) - Number(new Date(b.timestamp))
+    );
+  });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
@@ -14,6 +14,7 @@ import { fetchMonitorListEffect, upsertMonitorEffect } from './monitor_list';
 import { fetchMonitorOverviewEffect, fetchOverviewStatusEffect } from './overview';
 import { fetchServiceLocationsEffect } from './service_locations';
 import { browserJourneyEffects } from './browser_journey';
+import { fetchPingStatusesEffect } from './ping_status';
 
 export const rootEffect = function* root(): Generator {
   yield all([
@@ -27,5 +28,6 @@ export const rootEffect = function* root(): Generator {
     fork(browserJourneyEffects),
     fork(fetchOverviewStatusEffect),
     fork(fetchNetworkEventsEffect),
+    fork(fetchPingStatusesEffect),
   ]);
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/root_reducer.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/root_reducer.ts
@@ -17,6 +17,7 @@ import { serviceLocationsReducer, ServiceLocationsState } from './service_locati
 import { monitorOverviewReducer, MonitorOverviewState } from './overview';
 import { BrowserJourneyState } from './browser_journey/models';
 import { browserJourneyReducer } from './browser_journey';
+import { PingStatusState, pingStatusReducer } from './ping_status';
 
 export interface SyntheticsAppState {
   ui: UiState;
@@ -28,6 +29,7 @@ export interface SyntheticsAppState {
   overview: MonitorOverviewState;
   browserJourney: BrowserJourneyState;
   networkEvents: NetworkEventsState;
+  pingStatus: PingStatusState;
 }
 
 export const rootReducer = combineReducers<SyntheticsAppState>({
@@ -40,4 +42,5 @@ export const rootReducer = combineReducers<SyntheticsAppState>({
   overview: monitorOverviewReducer,
   browserJourney: browserJourneyReducer,
   networkEvents: networkEventsReducer,
+  pingStatus: pingStatusReducer,
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -105,6 +105,7 @@ export const mockState: SyntheticsAppState = {
   monitorDetails: getMonitorDetailsMockSlice(),
   browserJourney: getBrowserJourneyMockSlice(),
   networkEvents: {},
+  pingStatus: getPingStatusesMockSlice(),
 };
 
 function getBrowserJourneyMockSlice() {
@@ -415,4 +416,33 @@ function getMonitorDetailsMockSlice() {
     error: null,
     selectedLocationId: 'us_central',
   };
+}
+
+function getPingStatusesMockSlice() {
+  const monitorDetails = getMonitorDetailsMockSlice();
+
+  return {
+    pingStatuses: monitorDetails.pings.data.reduce((acc, cur) => {
+      if (!acc[cur.monitor.id]) {
+        acc[cur.monitor.id] = {};
+      }
+
+      if (!acc[cur.monitor.id][cur.observer.geo.name]) {
+        acc[cur.monitor.id][cur.observer.geo.name] = {};
+      }
+
+      acc[cur.monitor.id][cur.observer.geo.name][cur.timestamp] = {
+        timestamp: cur.timestamp,
+        error: undefined,
+        locationId: cur.observer.geo.name,
+        config_id: cur.config_id,
+        docId: cur.docId,
+        summary: cur.summary,
+      };
+
+      return acc;
+    }, {} as SyntheticsAppState['pingStatus']['pingStatuses']),
+    loading: false,
+    error: null,
+  } as SyntheticsAppState['pingStatus'];
 }

--- a/x-pack/plugins/synthetics/server/common/pings/query_pings.ts
+++ b/x-pack/plugins/synthetics/server/common/pings/query_pings.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { UMElasticsearchQueryFn } from '../../legacy_uptime/lib/adapters/framework';
+import {
+  Field,
+  QueryDslFieldAndFormat,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { UMElasticsearchQueryFnParams } from '../../legacy_uptime/lib/adapters/framework';
 import {
   GetPingsParams,
   HttpResponseBody,
@@ -60,18 +64,35 @@ function isStringArray(value: unknown): value is string[] {
   throw Error('Excluded locations can only be strings');
 }
 
-export const queryPings: UMElasticsearchQueryFn<GetPingsParams, PingsResponse> = async ({
-  uptimeEsClient,
-  dateRange: { from, to },
-  index,
-  monitorId,
-  status,
-  sort,
-  size: sizeParam,
-  pageIndex,
-  locations,
-  excludedLocations,
-}) => {
+type QueryFields = Array<QueryDslFieldAndFormat | Field>;
+type GetParamsWithFields<F> = UMElasticsearchQueryFnParams<
+  GetPingsParams & { fields: QueryFields; fieldsExtractorFn: (doc: any) => F }
+>;
+type GetParamsWithoutFields = UMElasticsearchQueryFnParams<GetPingsParams>;
+
+export function queryPings(
+  params: UMElasticsearchQueryFnParams<GetPingsParams>
+): Promise<PingsResponse>;
+
+export function queryPings<F>(
+  params: UMElasticsearchQueryFnParams<GetParamsWithFields<F>>
+): Promise<{ total: number; pings: F[] }>;
+
+export async function queryPings<F>(
+  params: GetParamsWithFields<F> | GetParamsWithoutFields
+): Promise<PingsResponse | { total: number; pings: F[] }> {
+  const {
+    uptimeEsClient,
+    dateRange: { from, to },
+    index,
+    monitorId,
+    status,
+    sort,
+    size: sizeParam,
+    pageIndex,
+    locations,
+    excludedLocations,
+  } = params;
   const size = sizeParam ?? DEFAULT_PAGE_SIZE;
 
   const searchBody = {
@@ -92,6 +113,8 @@ export const queryPings: UMElasticsearchQueryFn<GetPingsParams, PingsResponse> =
     ...((locations ?? []).length > 0
       ? { post_filter: { terms: { 'observer.geo.name': locations as unknown as string[] } } }
       : {}),
+    _source: true,
+    fields: [] as QueryFields,
   };
 
   // if there are excluded locations, add a clause to the query's filter
@@ -108,6 +131,23 @@ export const queryPings: UMElasticsearchQueryFn<GetPingsParams, PingsResponse> =
         ],
       },
     });
+  }
+
+  // If fields are queried, only query the subset of asked fields and omit _source
+  if (isGetParamsWithFields(params)) {
+    searchBody._source = false;
+    searchBody.fields = params.fields;
+
+    const {
+      body: {
+        hits: { hits, total },
+      },
+    } = await uptimeEsClient.search({ body: searchBody });
+
+    return {
+      total: total.value,
+      pings: hits.map((doc: any) => params.fieldsExtractorFn(doc)),
+    };
   }
 
   const {
@@ -133,4 +173,10 @@ export const queryPings: UMElasticsearchQueryFn<GetPingsParams, PingsResponse> =
     total: total.value,
     pings,
   };
-};
+}
+
+function isGetParamsWithFields<F>(
+  params: GetParamsWithFields<F> | GetParamsWithoutFields
+): params is GetParamsWithFields<F> {
+  return (params as GetParamsWithFields<F>).fields?.length > 0;
+}

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/adapters/framework/adapter_types.ts
@@ -35,11 +35,13 @@ import type { TelemetryEventsSender } from '../../telemetry/sender';
 import type { UptimeRouter } from '../../../../types';
 import { UptimeConfig } from '../../../../../common/config';
 
+export type UMElasticsearchQueryFnParams<P> = {
+  uptimeEsClient: UptimeEsClient;
+  esClient?: IScopedClusterClient;
+} & P;
+
 export type UMElasticsearchQueryFn<P, R = any> = (
-  params: {
-    uptimeEsClient: UptimeEsClient;
-    esClient?: IScopedClusterClient;
-  } & P
+  params: UMElasticsearchQueryFnParams<P>
 ) => Promise<R>;
 
 export type UMSavedObjectsQueryFn<T = any, P = undefined> = (

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -28,7 +28,7 @@ import { editSyntheticsMonitorRoute } from './monitor_cruds/edit_monitor';
 import { addSyntheticsMonitorRoute } from './monitor_cruds/add_monitor';
 import { addSyntheticsProjectMonitorRoute } from './monitor_cruds/add_monitor_project';
 import { addSyntheticsProjectMonitorRouteLegacy } from './monitor_cruds/add_monitor_project_legacy';
-import { syntheticsGetPingsRoute } from './pings';
+import { syntheticsGetPingsRoute, syntheticsGetPingStatusesRoute } from './pings';
 import { createGetCurrentStatusRoute } from './status/current_status';
 import {
   SyntheticsRestApiRouteFactory,
@@ -56,6 +56,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   getServiceAllowedRoute,
   getAPIKeySyntheticsRoute,
   syntheticsGetPingsRoute,
+  syntheticsGetPingStatusesRoute,
   getHasZipUrlMonitorRoute,
   createGetCurrentStatusRoute,
 ];

--- a/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
@@ -20,8 +20,18 @@ export const syntheticsGetPingStatusesRoute: UMRestApiRouteFactory = (libs: UMSe
     query: getPingsRouteQuerySchema,
   },
   handler: async ({ uptimeEsClient, request, response }): Promise<any> => {
-    const { from, to, index, monitorId, status, sort, size, locations, excludedLocations } =
-      request.query;
+    const {
+      from,
+      to,
+      index,
+      monitorId,
+      status,
+      sort,
+      size,
+      pageIndex,
+      locations,
+      excludedLocations,
+    } = request.query;
 
     const result = await queryPings<PingStatus>({
       uptimeEsClient,
@@ -31,6 +41,7 @@ export const syntheticsGetPingStatusesRoute: UMRestApiRouteFactory = (libs: UMSe
       status,
       sort,
       size,
+      pageIndex,
       locations: locations ? JSON.parse(locations) : [],
       excludedLocations,
       fields: ['@timestamp', 'config_id', 'summary.*', 'error.*', 'observer.geo.name'],

--- a/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+import { PingError, PingStatus } from '../../../common/runtime_types';
+import { UMServerLibs } from '../../legacy_uptime/lib/lib';
+import { UMRestApiRouteFactory } from '../../legacy_uptime/routes/types';
+import { queryPings } from '../../common/pings/query_pings';
+
+import { getPingsRouteQuerySchema } from './get_pings';
+
+export const syntheticsGetPingStatusesRoute: UMRestApiRouteFactory = (libs: UMServerLibs) => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.PING_STATUSES,
+  validate: {
+    query: getPingsRouteQuerySchema,
+  },
+  handler: async ({ uptimeEsClient, request, response }): Promise<any> => {
+    const { from, to, index, monitorId, status, sort, size, locations, excludedLocations } =
+      request.query;
+
+    const result = await queryPings<PingStatus>({
+      uptimeEsClient,
+      dateRange: { from, to },
+      index,
+      monitorId,
+      status,
+      sort,
+      size,
+      locations: locations ? JSON.parse(locations) : [],
+      excludedLocations,
+      fields: ['@timestamp', 'config_id', 'summary.*', 'error.*', 'observer.geo.name'],
+      fieldsExtractorFn: extractPingStatus,
+    });
+
+    return {
+      ...result,
+      from,
+      to,
+    };
+  },
+});
+
+function grabPingError(doc: any): PingError | undefined {
+  const docContainsError = Object.keys(doc).some((key) => key.startsWith('error.'));
+  if (!docContainsError) {
+    return undefined;
+  }
+
+  return {
+    code: doc.fields['error.code']?.[0],
+    id: doc.fields['error.id']?.[0],
+    stack_trace: doc.fields['error.stack_trace']?.[0],
+    type: doc.fields['error.type']?.[0],
+    message: doc.fields['error.message']?.[0],
+  };
+}
+
+function extractPingStatus(doc: any) {
+  return {
+    timestamp: doc.fields['@timestamp']?.[0],
+    docId: doc._id,
+    config_id: doc.fields.config_id?.[0],
+    locationId: doc.fields['observer.geo.name']?.[0],
+    summary: { up: doc.fields['summary.up']?.[0], down: doc.fields['summary.down']?.[0] },
+    error: grabPingError(doc),
+  } as PingStatus;
+}

--- a/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/get_ping_statuses.ts
@@ -57,7 +57,7 @@ export const syntheticsGetPingStatusesRoute: UMRestApiRouteFactory = (libs: UMSe
 });
 
 function grabPingError(doc: any): PingError | undefined {
-  const docContainsError = Object.keys(doc).some((key) => key.startsWith('error.'));
+  const docContainsError = Object.keys(doc?.fields ?? {}).some((key) => key.startsWith('error.'));
   if (!docContainsError) {
     return undefined;
   }

--- a/x-pack/plugins/synthetics/server/routes/pings/get_pings.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/get_pings.ts
@@ -11,22 +11,24 @@ import { UMServerLibs } from '../../legacy_uptime/lib/lib';
 import { UMRestApiRouteFactory } from '../../legacy_uptime/routes/types';
 import { queryPings } from '../../common/pings/query_pings';
 
+export const getPingsRouteQuerySchema = schema.object({
+  from: schema.string(),
+  to: schema.string(),
+  locations: schema.maybe(schema.string()),
+  excludedLocations: schema.maybe(schema.string()),
+  monitorId: schema.maybe(schema.string()),
+  index: schema.maybe(schema.number()),
+  size: schema.maybe(schema.number()),
+  pageIndex: schema.maybe(schema.number()),
+  sort: schema.maybe(schema.string()),
+  status: schema.maybe(schema.string()),
+});
+
 export const syntheticsGetPingsRoute: UMRestApiRouteFactory = (libs: UMServerLibs) => ({
   method: 'GET',
   path: SYNTHETICS_API_URLS.PINGS,
   validate: {
-    query: schema.object({
-      from: schema.string(),
-      to: schema.string(),
-      locations: schema.maybe(schema.string()),
-      excludedLocations: schema.maybe(schema.string()),
-      monitorId: schema.maybe(schema.string()),
-      index: schema.maybe(schema.number()),
-      size: schema.maybe(schema.number()),
-      pageIndex: schema.maybe(schema.number()),
-      sort: schema.maybe(schema.string()),
-      status: schema.maybe(schema.string()),
-    }),
+    query: getPingsRouteQuerySchema,
   },
   handler: async ({ uptimeEsClient, request, response }): Promise<any> => {
     const {


### PR DESCRIPTION
Closes #141903

## Summary

This PR adds the Monitor **Status** panel which consists of a histogram chart, on Synthetics -> Go to _a Monitor_ -> Monitor Summary | Monitor History pages. The histogram represents monitor Failed or Complete runs over time, with variation of the colors representing monitor Availability.

Chart maintains a minimum width of the time slices to not let slots reduce to faint lines when a large set of data is plotted. If window resizes, it'll recalculate the slice time range based on the available width.

The same component is used on both Monitor Summary and Monitor History pages, with the following changes:
- On Monitor Summary page, the time bounds will always be the last 24 hours and the chart is not brushable/zoomable.
- On Monitor History page, the time bounds are the ones selected in the app's Time Selector  (SyntheticsDatePicker). Chart is brushable on this page and brushing the chart will update the time range in the Time Selector.

### Notes
- **Explore** button as shown in the designs is not implemented due to limitations in Exploratory View/Lens.
- The Error Annotations (red warning icons shown in the design) are not implemented in this PR due to limitations in @elastic/charts' Heatmap chart.

### How to test
1. Setup Kibana so that you are able to create or push synthetics monitors.
2. In Kibana -> Advanced Settings, enable Synthetics.
3. Create or push a few monitors with relatively high frequencies so that you can test a few monitor runs plotted on the chart.
4. Wait for the documents to come back.
5. Goto Synthetics ->  _From ... menu of a monitor select_ "Go to Monitor".
6. Observe the **Status** panel and make sure you see the failed or completed test runs plotted appropriately. You can check the **Last 10 Test Runs** to confirm if data has been ingested.
7. Click **View History** and make sure it navigates to the History page.
8. On the History page, brush the chart to zoom in on a set of test runs and make sure that it changes the time in the Time Selector accordingly.
9. Change the time in the Time Selector and observe that the chart plots the data per the specified time range.

_Note_: You can also use this [deployment](https://p.elstc.co/paste/-tV0+10z#X4m1legX1b512lO6ow9vSmLd9ktwmHU6BQ4hx2vQpHP) to test (if it's still live).

**Video**

https://user-images.githubusercontent.com/2748376/199543972-ac408c55-9d64-4960-b734-c9357878af51.mov

**Screenshots**
<img width="2560" alt="Screenshot 2022-11-02 at 17 12 54" src="https://user-images.githubusercontent.com/2748376/199543544-15cf1d44-e322-4a18-85f4-1caea84a69ff.png">

![Screenshot 2022-11-02 at 17 06 32](https://user-images.githubusercontent.com/2748376/199543741-e0427d58-0983-458f-8447-9c2221bf5530.png)
<img width="1776" alt="Screenshot 2022-11-02 at 17 07 29" src="https://user-images.githubusercontent.com/2748376/199543837-ed60f823-3fa6-4f73-a557-b747cb3ccb2f.png">

<img src="https://user-images.githubusercontent.com/2748376/199664308-15250493-836f-4e51-b9dd-0c0b48d8c1b1.png" width="390">

