### PR TITLE
Remove buildbuddy cache

### DIFF
--- a/.buildkite/scripts/common/setup_bazel.sh
+++ b/.buildkite/scripts/common/setup_bazel.sh
@@ -43,6 +43,6 @@ EOF
 fi
 
 if [[ "$BAZEL_CACHE_MODE" != @(gcs|populate-local-gcs|none|) ]]; then
-  echo "invalid value for BAZEL_CACHE_MODE received ($BAZEL_CACHE_MODE), expected one of [gcs,populate-local-gcs|buildbuddy,none]"
+  echo "invalid value for BAZEL_CACHE_MODE received ($BAZEL_CACHE_MODE), expected one of [gcs,populate-local-gcs|none]"
   exit 1
 fi

--- a/.buildkite/scripts/common/setup_bazel.sh
+++ b/.buildkite/scripts/common/setup_bazel.sh
@@ -42,18 +42,7 @@ cat <<EOF >> $KIBANA_DIR/.bazelrc
 EOF
 fi
 
-if [[ "$BAZEL_CACHE_MODE" == "buildbuddy" ]]; then
-  echo "[bazel] enabling caching with Buildbuddy"
-cat <<EOF >> $KIBANA_DIR/.bazelrc
-  build --bes_results_url=https://app.buildbuddy.io/invocation/
-  build --bes_backend=grpcs://remote.buildbuddy.io
-  build --remote_cache=grpcs://remote.buildbuddy.io
-  build --remote_timeout=3600
-  build --remote_header=x-buildbuddy-api-key=$KIBANA_BUILDBUDDY_CI_API_KEY
-EOF
-fi
-
-if [[ "$BAZEL_CACHE_MODE" != @(gcs|populate-local-gcs|buildbuddy|none|) ]]; then
+if [[ "$BAZEL_CACHE_MODE" != @(gcs|populate-local-gcs|none|) ]]; then
   echo "invalid value for BAZEL_CACHE_MODE received ($BAZEL_CACHE_MODE), expected one of [gcs,populate-local-gcs|buildbuddy,none]"
   exit 1
 fi

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -145,9 +145,6 @@ export SYNTHETICS_REMOTE_KIBANA_URL
   export TEST_FAILURES_ES_PASSWORD
 }
 
-KIBANA_BUILDBUDDY_CI_API_KEY=$(retry 5 5 vault read -field=value secret/kibana-issues/dev/kibana-buildbuddy-ci-api-key)
-export KIBANA_BUILDBUDDY_CI_API_KEY
-
 BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE="$HOME/.kibana-ci-bazel-remote-cache-local-dev.json"
 export BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE
 retry 5 5 vault read -field=service_account_json secret/kibana-issues/dev/kibana-ci-bazel-remote-cache-local-dev > "$BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE"

--- a/.buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
+++ b/.buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
@@ -1,8 +1,7 @@
-#!/usr/bin/env bash
+    #!/usr/bin/env bash
 
 set -euo pipefail
 
-export BAZEL_CACHE_MODE=buildbuddy # Populate Buildbuddy bazel remote cache for linux
 export DISABLE_BOOTSTRAP_VALIDATION=true
 
 .buildkite/scripts/bootstrap.sh

--- a/.buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
+++ b/.buildkite/scripts/steps/on_merge_ts_refs_api_docs.sh
@@ -1,4 +1,4 @@
-    #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/dev/ci_setup/load_env_keys.sh
+++ b/src/dev/ci_setup/load_env_keys.sh
@@ -34,9 +34,6 @@ else
   PERCY_TOKEN=$(retry 5 vault read -field=value secret/kibana-issues/dev/percy)
   export PERCY_TOKEN
 
-  KIBANA_BUILDBUDDY_CI_API_KEY=$(retry 5 vault read -field=value secret/kibana-issues/dev/kibana-buildbuddy-ci-api-key)
-  export KIBANA_BUILDBUDDY_CI_API_KEY
-
   # remove vault related secrets
   unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_TOKEN VAULT_ADDR
 fi


### PR DESCRIPTION
We're using GCS for bazel now, this removes all remaining buildbuddy configuration.

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->