### PR TITLE
[Security Solution] add deleted file update task

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/lib/files/check_deleted_files_task.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/files/check_deleted_files_task.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
+import { TaskStatus } from '@kbn/task-manager-plugin/server';
+import type { CoreSetup } from '@kbn/core/server';
+import type { ElasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { ElasticsearchBlobStorageClient } from '@kbn/files-plugin/server/blob_storage_service';
+
+import { CheckDeletedFilesTask, TYPE, VERSION } from './check_deleted_files_task';
+import { createMockEndpointAppContext } from '../../mocks';
+import type { EndpointAppContext } from '../../types';
+import {
+  FILE_STORAGE_DATA_INDEX,
+  FILE_STORAGE_METADATA_INDEX,
+} from '../../../../common/endpoint/constants';
+
+const MOCK_TASK_INSTANCE = {
+  id: `${TYPE}:${VERSION}`,
+  runAt: new Date(),
+  attempts: 0,
+  ownerId: '',
+  status: TaskStatus.Running,
+  startedAt: new Date(),
+  scheduledAt: new Date(),
+  retryAt: new Date(),
+  params: {},
+  state: {},
+  taskType: TYPE,
+};
+
+describe('check deleted files task', () => {
+  const { createSetup: coreSetupMock } = coreMock;
+  const { createSetup: tmSetupMock, createStart: tmStartMock } = taskManagerMock;
+
+  let mockTask: CheckDeletedFilesTask;
+  let mockCore: CoreSetup;
+  let mockTaskManagerSetup: jest.Mocked<TaskManagerSetupContract>;
+  let mockEndpointAppContext: EndpointAppContext;
+  beforeEach(() => {
+    mockCore = coreSetupMock();
+    mockTaskManagerSetup = tmSetupMock();
+    mockEndpointAppContext = createMockEndpointAppContext();
+    mockTask = new CheckDeletedFilesTask({
+      endpointAppContext: mockEndpointAppContext,
+      core: mockCore,
+      taskManager: mockTaskManagerSetup,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('task lifecycle', () => {
+    it('should create task', () => {
+      expect(mockTask).toBeInstanceOf(CheckDeletedFilesTask);
+    });
+
+    it('should register task', () => {
+      expect(mockTaskManagerSetup.registerTaskDefinitions).toHaveBeenCalled();
+    });
+
+    it('should schedule task', async () => {
+      const mockTaskManagerStart = tmStartMock();
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+      expect(mockTaskManagerStart.ensureScheduled).toHaveBeenCalled();
+    });
+  });
+
+  describe('task logic', () => {
+    let esClient: ElasticsearchClientMock;
+    ElasticsearchBlobStorageClient.configureConcurrentUpload(1);
+
+    beforeEach(async () => {
+      const [{ elasticsearch }] = await mockCore.getStartServices();
+      esClient = elasticsearch.client.asInternalUser as ElasticsearchClientMock;
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    const runTask = async (taskInstance = MOCK_TASK_INSTANCE) => {
+      const mockTaskManagerStart = tmStartMock();
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+      const createTaskRunner =
+        mockTaskManagerSetup.registerTaskDefinitions.mock.calls[0][0][TYPE].createTaskRunner;
+      const taskRunner = createTaskRunner({ taskInstance });
+      return taskRunner.run();
+    };
+
+    it('should attempt to update deleted files', async () => {
+      // mock getReadyFiles search
+      esClient.search
+        .mockResolvedValueOnce({
+          took: 5,
+          timed_out: false,
+          _shards: {
+            total: 1,
+            successful: 1,
+            skipped: 0,
+            failed: 0,
+          },
+          hits: {
+            total: {
+              value: 1,
+              relation: 'eq',
+            },
+            hits: [
+              {
+                _id: 'metadata-testid1',
+                _index: FILE_STORAGE_METADATA_INDEX,
+                _source: { file: { status: 'READY' } },
+              },
+              {
+                _id: 'metadata-testid2',
+                _index: FILE_STORAGE_METADATA_INDEX,
+                _source: { file: { status: 'READY' } },
+              },
+            ],
+          },
+        })
+        // mock doFilesHaveChunks search
+        .mockResolvedValueOnce({
+          took: 5,
+          timed_out: false,
+          _shards: {
+            total: 1,
+            successful: 1,
+            skipped: 0,
+            failed: 0,
+          },
+          hits: {
+            total: {
+              value: 0,
+              relation: 'eq',
+            },
+            hits: [
+              {
+                _id: 'data-testid1',
+                _index: FILE_STORAGE_DATA_INDEX,
+                _source: {
+                  bid: 'metadata-testid1',
+                },
+              },
+            ],
+          },
+        });
+
+      await runTask();
+
+      expect(esClient.updateByQuery).toHaveBeenCalledWith({
+        index: FILE_STORAGE_METADATA_INDEX,
+        query: {
+          ids: {
+            values: ['metadata-testid2'],
+          },
+        },
+        refresh: true,
+        script: {
+          lang: 'painless',
+          source: "ctx._source.file.Status = 'DELETED'",
+        },
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/server/endpoint/lib/files/check_deleted_files_task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/files/check_deleted_files_task.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type {
+  ConcreteTaskInstance,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { throwUnrecoverableError } from '@kbn/task-manager-plugin/server';
+
+import type { EndpointAppContext } from '../../types';
+import {
+  fileIdsWithoutChunks,
+  getFilesByStatus,
+  updateFilesStatus,
+} from '../../services/actions/action_files';
+
+export const TYPE = 'endpoint:check-deleted-files-task';
+export const VERSION = '1.0.0';
+const TITLE = 'Security Solution Endpoint Deleted Files Periodic Tasks';
+const TIMEOUT = '2m';
+const SCOPE = ['securitySolution'];
+const INTERVAL = '5m';
+
+export interface CheckDeletedFilesTaskSetupContract {
+  endpointAppContext: EndpointAppContext;
+  core: CoreSetup;
+  taskManager: TaskManagerSetupContract;
+}
+
+export interface CheckDeletedFilesTaskStartContract {
+  taskManager: TaskManagerStartContract;
+}
+
+export class CheckDeletedFilesTask {
+  private logger: Logger;
+  private wasStarted: boolean = false;
+
+  constructor(setupContract: CheckDeletedFilesTaskSetupContract) {
+    const { endpointAppContext, core, taskManager } = setupContract;
+    this.logger = endpointAppContext.logFactory.get(this.getTaskId());
+
+    taskManager.registerTaskDefinitions({
+      [TYPE]: {
+        title: TITLE,
+        timeout: TIMEOUT,
+        createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
+          return {
+            run: async () => {
+              return this.runTask(taskInstance, core);
+            },
+            cancel: async () => {},
+          };
+        },
+      },
+    });
+  }
+
+  public start = async ({ taskManager }: CheckDeletedFilesTaskStartContract) => {
+    if (!taskManager) {
+      this.logger.error('missing required service during start');
+      return;
+    }
+
+    this.wasStarted = true;
+
+    try {
+      await taskManager.ensureScheduled({
+        id: this.getTaskId(),
+        taskType: TYPE,
+        scope: SCOPE,
+        schedule: {
+          interval: INTERVAL,
+        },
+        state: {},
+        params: { version: VERSION },
+      });
+    } catch (e) {
+      this.logger.debug(`Error scheduling task, received ${e.message}`);
+    }
+  };
+
+  private getTaskId = (): string => {
+    return `${TYPE}:${VERSION}`;
+  };
+
+  private runTask = async (taskInstance: ConcreteTaskInstance, core: CoreSetup) => {
+    if (!this.wasStarted) {
+      this.logger.debug('[runTask()] Aborted. Task not started yet');
+      return;
+    }
+
+    // Check that this task is current
+    if (taskInstance.id !== this.getTaskId()) {
+      throwUnrecoverableError(new Error('Outdated task version'));
+    }
+
+    const [{ elasticsearch }] = await core.getStartServices();
+    const esClient = elasticsearch.client.asInternalUser;
+
+    const readyFiles = await getFilesByStatus(esClient);
+    if (!readyFiles?.hits?.hits.length) return;
+
+    const deletedFileIds = await fileIdsWithoutChunks(
+      esClient,
+      readyFiles.hits.hits.map((hit) => hit._id)
+    );
+    if (!deletedFileIds.length) return;
+
+    this.logger.info(`Attempting to update ${deletedFileIds.length} files to DELETED status`);
+    const updatedFiles = await updateFilesStatus(esClient, deletedFileIds, 'DELETED');
+    if (updatedFiles?.failures?.length) {
+      this.logger.warn(`Failed to update ${updatedFiles.failures.length} files to DELETED status`);
+    }
+  };
+}

--- a/x-pack/plugins/security_solution/server/endpoint/lib/files/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/files/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './check_deleted_files_task';

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -110,6 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
         'cleanup_failed_action_executions',
         'cloud_security_posture-stats_task',
         'dashboard_telemetry',
+        'endpoint:check-deleted-files-task',
         'endpoint:metadata-check-transforms-task',
         'endpoint:user-artifact-packager',
         'fleet:reassign_action:retry',


### PR DESCRIPTION
## Summary

Add task to check for endpoint files that are status `READY` and update them to `DELETED` if no file chunks exist. This PR is only for endpoint files. Will address [other file types and move this logic into fleet](https://github.com/elastic/kibana/issues/143459#issuecomment-1298758917) in a follow up PR.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
