### PR TITLE
Correct compute usage: sum over all invocations in a bucket

### DIFF
--- a/x-pack/plugins/apm/server/routes/metrics/serverless/get_compute_usage_chart.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/serverless/get_compute_usage_chart.ts
@@ -22,38 +22,10 @@ import {
   SERVICE_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { isFiniteNumber } from '../../../../common/utils/is_finite_number';
 import { getMetricsDateHistogramParams } from '../../../lib/helpers/metrics';
 import { GenericMetricsChart } from '../fetch_and_transform_metrics';
 import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
-
-/**
- * To calculate the compute usage we need to multiply the "system.memory.total" by "faas.billed_duration".
- * But the result of this calculation is in Bytes-milliseconds, as the "system.memory.total" is stored in bytes and the "faas.billed_duration" is stored in milliseconds.
- * But to calculate the overall cost AWS uses GB-second, so we need to convert the result to this unit.
- */
-const GB = 1024 ** 3;
-function calculateComputeUsageGBSeconds({
-  faasBilledDuration,
-  totalMemory,
-  countInvocations,
-}: {
-  faasBilledDuration?: number | null;
-  totalMemory?: number | null;
-  countInvocations?: number | null;
-}) {
-  if (
-    !isFiniteNumber(faasBilledDuration) ||
-    !isFiniteNumber(totalMemory) ||
-    !isFiniteNumber(countInvocations)
-  ) {
-    return 0;
-  }
-
-  const totalMemoryGB = totalMemory / GB;
-  const faasBilledDurationSec = faasBilledDuration / 1000;
-  return totalMemoryGB * faasBilledDurationSec * countInvocations;
-}
+import { calcComputeUsageGBSeconds } from './helper';
 
 export async function getComputeUsageChart({
   environment,
@@ -144,18 +116,20 @@ export async function getComputeUsageChart({
               ),
               key: 'compute_usage',
               type: 'bar',
-              overallValue: calculateComputeUsageGBSeconds({
-                faasBilledDuration: aggregations?.avgFaasBilledDuration.value,
-                totalMemory: aggregations?.avgTotalMemory.value,
-                countInvocations: aggregations?.countInvocations.value,
-              }),
+              overallValue:
+                calcComputeUsageGBSeconds({
+                  billedDuration: aggregations?.avgFaasBilledDuration.value,
+                  totalMemory: aggregations?.avgTotalMemory.value,
+                  countInvocations: aggregations?.countInvocations.value,
+                }) ?? 0,
               color: theme.euiColorVis0,
               data: timeseriesData.buckets.map((bucket) => {
-                const computeUsage = calculateComputeUsageGBSeconds({
-                  faasBilledDuration: bucket.avgFaasBilledDuration.value,
-                  totalMemory: bucket.avgTotalMemory.value,
-                  countInvocations: bucket.countInvocations.value,
-                });
+                const computeUsage =
+                  calcComputeUsageGBSeconds({
+                    billedDuration: bucket.avgFaasBilledDuration.value,
+                    totalMemory: bucket.avgTotalMemory.value,
+                    countInvocations: bucket.countInvocations.value,
+                  }) ?? 0;
                 return {
                   x: bucket.key,
                   y: computeUsage,

--- a/x-pack/plugins/apm/server/routes/metrics/serverless/get_compute_usage_chart.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/serverless/get_compute_usage_chart.ts
@@ -42,7 +42,11 @@ function calculateComputeUsageGBSeconds({
   totalMemory?: number | null;
   countInvocations?: number | null;
 }) {
-  if (!isFiniteNumber(faasBilledDuration) || !isFiniteNumber(totalMemory) || !isFiniteNumber(countInvocations)) {
+  if (
+    !isFiniteNumber(faasBilledDuration) ||
+    !isFiniteNumber(totalMemory) ||
+    !isFiniteNumber(countInvocations)
+  ) {
     return 0;
   }
 

--- a/x-pack/plugins/apm/server/routes/metrics/serverless/get_serverless_summary.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/serverless/get_serverless_summary.ts
@@ -120,6 +120,7 @@ export async function getServerlessSummary({
         faasBilledDurationAvg: { avg: { field: FAAS_BILLED_DURATION } },
         avgTotalMemory: { avg: { field: METRIC_SYSTEM_TOTAL_MEMORY } },
         avgFreeMemory: { avg: { field: METRIC_SYSTEM_FREE_MEMORY } },
+        countInvocations: { value_count: { field: FAAS_BILLED_DURATION } },
         sample: {
           top_metrics: {
             metrics: [{ field: HOST_ARCHITECTURE }],
@@ -160,6 +161,7 @@ export async function getServerlessSummary({
       transactionThroughput,
       billedDuration: response.aggregations?.faasBilledDurationAvg.value,
       totalMemory: response.aggregations?.avgTotalMemory.value,
+      countInvocations: response.aggregations?.countInvocations.value,
     }),
   };
 }

--- a/x-pack/plugins/apm/server/routes/metrics/serverless/helper.test.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/serverless/helper.test.ts
@@ -104,6 +104,7 @@ describe('calcEstimatedCost', () => {
           totalMemory: 536870912, // 0.5gb
           transactionThroughput: 100000,
           awsLambdaRequestCostPerMillion: 0.2,
+          countInvocations: 1,
         })
       ).toEqual(0.03);
     });
@@ -119,6 +120,7 @@ describe('calcEstimatedCost', () => {
           totalMemory: 536870912, // 0.5gb
           transactionThroughput: 200000,
           awsLambdaRequestCostPerMillion: 0.2,
+          countInvocations: 1,
         })
       ).toEqual(0.05);
     });

--- a/x-pack/plugins/apm/server/routes/metrics/serverless/helper.ts
+++ b/x-pack/plugins/apm/server/routes/metrics/serverless/helper.ts
@@ -47,17 +47,23 @@ const GB = 1024 ** 3;
 export function calcComputeUsageGBSeconds({
   billedDuration,
   totalMemory,
+  countInvocations,
 }: {
   billedDuration?: number | null;
   totalMemory?: number | null;
+  countInvocations?: number | null;
 }) {
-  if (!isFiniteNumber(billedDuration) || !isFiniteNumber(totalMemory)) {
+  if (
+    !isFiniteNumber(billedDuration) ||
+    !isFiniteNumber(totalMemory) ||
+    !isFiniteNumber(countInvocations)
+  ) {
     return undefined;
   }
 
   const totalMemoryGB = totalMemory / GB;
-  const billedDurationSec = billedDuration / 1000;
-  return totalMemoryGB * billedDurationSec;
+  const faasBilledDurationSec = billedDuration / 1000;
+  return totalMemoryGB * faasBilledDurationSec * countInvocations;
 }
 
 export function calcEstimatedCost({
@@ -67,6 +73,7 @@ export function calcEstimatedCost({
   billedDuration,
   totalMemory,
   awsLambdaRequestCostPerMillion,
+  countInvocations,
 }: {
   awsLambdaPriceFactor?: AWSLambdaPriceFactor;
   architecture?: AwsLambdaArchitecture;
@@ -74,11 +81,13 @@ export function calcEstimatedCost({
   billedDuration?: number | null;
   totalMemory?: number | null;
   awsLambdaRequestCostPerMillion?: number;
+  countInvocations?: number | null;
 }) {
   try {
     const computeUsage = calcComputeUsageGBSeconds({
       billedDuration,
       totalMemory,
+      countInvocations,
     });
     if (
       !awsLambdaPriceFactor ||

--- a/x-pack/test/apm_api_integration/tests/metrics/serverless/serverless_metrics_charts.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/metrics/serverless/serverless_metrics_charts.spec.ts
@@ -177,7 +177,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       describe('Compute usage', () => {
         const GBSeconds = 1024 * 1024 * 1024 * 1000;
-        const expectedValue = (memoryTotal * billedDurationMs) / GBSeconds;
         let computeUsageMetric: typeof serverlessMetrics.charts[0] | undefined;
         before(() => {
           computeUsageMetric = serverlessMetrics.charts.find((chart) => {
@@ -185,10 +184,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           });
         });
         it('returns correct overall value', () => {
+          const expectedValue =
+            ((memoryTotal * billedDurationMs) / GBSeconds) * numberOfTransactionsCreated * 2;
           expect(computeUsageMetric?.series[0].overallValue).to.equal(expectedValue);
         });
 
         it('returns correct mean value', () => {
+          const expectedValue = ((memoryTotal * billedDurationMs) / GBSeconds) * 2;
           const meanValue = meanBy(
             computeUsageMetric?.series[0]?.data.filter((item) => item.y !== 0),
             'y'
@@ -298,7 +300,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       describe('Compute usage', () => {
         const GBSeconds = 1024 * 1024 * 1024 * 1000;
-        const expectedValue = (memoryTotal * billedDurationMs) / GBSeconds;
         let computeUsageMetric: typeof serverlessMetrics.charts[0] | undefined;
         before(() => {
           computeUsageMetric = serverlessMetrics.charts.find((chart) => {
@@ -306,10 +307,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           });
         });
         it('returns correct overall value', () => {
+          const expectedValue =
+            ((memoryTotal * billedDurationMs) / GBSeconds) * numberOfTransactionsCreated;
           expect(computeUsageMetric?.series[0].overallValue).to.equal(expectedValue);
         });
 
         it('returns correct mean value', () => {
+          const expectedValue = (memoryTotal * billedDurationMs) / GBSeconds;
           const meanValue = meanBy(
             computeUsageMetric?.series[0]?.data.filter((item) => item.y !== 0),
             'y'


### PR DESCRIPTION
Currently the compute usage chart shows the average compute usage per invocation:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/866830/199427538-5a950a29-7cc9-42c8-9856-8d0b24be9172.png">

The problem is: when the throughput of a lambda function changes, the `compute usage` chart does not change (as the average compute usage per invocation is not changing), so is not indicating an overall increase in compute usage.

Therefore, we should rather show the **cumulative** (sum) compute usage per bucket rather than the average per invocation.

This PR fixes the above.
