### PR TITLE
[Lens] Exclude the reference layer from the cursor sync hook

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -275,8 +275,10 @@ export function XYChart({
     [uiState]
   );
 
+  // Exclude the reference layers from the cursor update
+  const cursorSyncLayers = filteredLayers.filter(isDataLayer);
   const handleCursorUpdate = useActiveCursor(chartsActiveCursorService, chartRef, {
-    datatables: filteredLayers.map(({ table }) => table),
+    datatables: cursorSyncLayers.map(({ table }) => table),
   });
 
   const onRenderChange = useCallback(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/144380

As described on the issue the bug exists when you have a Lens chart with a reference layer and the Group by this field switch set to true. 

The problem is that the reference layer is a very specific layer that messes with the useCursorSync hook logic. There is no need to use these layers for this functionality. What we need here to decide if this chart should sync or not the cursor are the  data layers.

![dashboard](https://user-images.githubusercontent.com/17003240/199430873-75314fb6-9f6d-446d-83b5-299307ce63d0.gif)

