### PR TITLE
added tooltip on last checkin message in agent details

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -188,13 +188,15 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
             description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
           },
         ].map(({ title, description }) => {
+          const tooltip =
+            typeof description === 'string' && description.length > 20 ? description : '';
           return (
             <EuiFlexGroup>
               <FlexItemWithMinWidth grow={3}>
                 <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
               </FlexItemWithMinWidth>
               <FlexItemWithMinWidth grow={7}>
-                <EuiDescriptionListDescription className="eui-textTruncate">
+                <EuiDescriptionListDescription className="eui-textTruncate" title={tooltip}>
                   {description}
                 </EuiDescriptionListDescription>
               </FlexItemWithMinWidth>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -196,9 +196,11 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                 <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
               </FlexItemWithMinWidth>
               <FlexItemWithMinWidth grow={7}>
-                <EuiDescriptionListDescription className="eui-textTruncate" title={tooltip}>
-                  {description}
-                </EuiDescriptionListDescription>
+                <EuiToolTip position="top" content={tooltip}>
+                  <EuiDescriptionListDescription className="eui-textTruncate">
+                    {description}
+                  </EuiDescriptionListDescription>
+                </EuiToolTip>
               </FlexItemWithMinWidth>
             </EuiFlexGroup>
           );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/144379

Added tooltip on agent details for the descriptions that are longer than 20 characters.
See an example with a long `Last checkin message`:

<img width="468" alt="image" src="https://user-images.githubusercontent.com/90178898/199485323-e29164c1-a1ed-477d-8587-9fafdd9cbcbb.png">


