### PR TITLE
Change default refresh interval to 60 seconds

### DIFF
--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -325,7 +325,7 @@ export function getUiSettings(
       }),
       value: `{
   "pause": true,
-  "value": 30000
+  "value": 60000
 }`,
       type: 'json',
       description: i18n.translate('data.advancedSettings.timepicker.refreshIntervalDefaultsText', {

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -325,7 +325,7 @@ export function getUiSettings(
       }),
       value: `{
   "pause": true,
-  "value": 10000
+  "value": 30000
 }`,
       type: 'json',
       description: i18n.translate('data.advancedSettings.timepicker.refreshIntervalDefaultsText', {

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -324,8 +324,8 @@ export function getUiSettings(
         defaultMessage: 'Time filter refresh interval',
       }),
       value: `{
-  "pause": false,
-  "value": 0
+  "pause": true,
+  "value": 10000
 }`,
       type: 'json',
       description: i18n.translate('data.advancedSettings.timepicker.refreshIntervalDefaultsText', {

--- a/test/functional/apps/discover/group1/_shared_links.ts
+++ b/test/functional/apps/discover/group1/_shared_links.ts
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const expectedUrl =
             baseUrl +
             '/app/discover?_t=1453775307251#' +
-            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:10000),time' +
+            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:30000),time' +
             ":(from:'2015-09-19T06:31:44.000Z',to:'2015-09" +
             "-23T18:31:44.000Z'))&_a=(columns:!(),filters:!(),index:'logstash-" +
             "*',interval:auto,query:(language:kuery,query:'')" +
@@ -102,7 +102,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             baseUrl +
             '/app/discover#' +
             '/view/ab12e3c0-f231-11e6-9486-733b1ac9221a' +
-            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A10000)' +
+            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A30000)' +
             "%2Ctime%3A(from%3A'2015-09-19T06%3A31%3A44.000Z'%2C" +
             "to%3A'2015-09-23T18%3A31%3A44.000Z'))";
           await PageObjects.discover.loadSavedSearch('A Saved Search');

--- a/test/functional/apps/discover/group1/_shared_links.ts
+++ b/test/functional/apps/discover/group1/_shared_links.ts
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const expectedUrl =
             baseUrl +
             '/app/discover?_t=1453775307251#' +
-            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:30000),time' +
+            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time' +
             ":(from:'2015-09-19T06:31:44.000Z',to:'2015-09" +
             "-23T18:31:44.000Z'))&_a=(columns:!(),filters:!(),index:'logstash-" +
             "*',interval:auto,query:(language:kuery,query:'')" +
@@ -102,7 +102,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             baseUrl +
             '/app/discover#' +
             '/view/ab12e3c0-f231-11e6-9486-733b1ac9221a' +
-            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A30000)' +
+            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A60000)' +
             "%2Ctime%3A(from%3A'2015-09-19T06%3A31%3A44.000Z'%2C" +
             "to%3A'2015-09-23T18%3A31%3A44.000Z'))";
           await PageObjects.discover.loadSavedSearch('A Saved Search');

--- a/test/functional/apps/discover/group1/_shared_links.ts
+++ b/test/functional/apps/discover/group1/_shared_links.ts
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const expectedUrl =
             baseUrl +
             '/app/discover?_t=1453775307251#' +
-            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time' +
+            '/?_g=(filters:!(),refreshInterval:(pause:!t,value:10000),time' +
             ":(from:'2015-09-19T06:31:44.000Z',to:'2015-09" +
             "-23T18:31:44.000Z'))&_a=(columns:!(),filters:!(),index:'logstash-" +
             "*',interval:auto,query:(language:kuery,query:'')" +
@@ -102,7 +102,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             baseUrl +
             '/app/discover#' +
             '/view/ab12e3c0-f231-11e6-9486-733b1ac9221a' +
-            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)' +
+            '?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A10000)' +
             "%2Ctime%3A(from%3A'2015-09-19T06%3A31%3A44.000Z'%2C" +
             "to%3A'2015-09-23T18%3A31%3A44.000Z'))";
           await PageObjects.discover.loadSavedSearch('A Saved Search');

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_refresh_interval.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_refresh_interval.ts
@@ -38,9 +38,9 @@ export const useRefreshInterval = (
 
     function initAutoRefresh() {
       const interval = globalState?.refreshInterval ?? timefilter.getRefreshInterval();
-      const { value } = interval;
+      const { pause, value } = interval;
 
-      if (value === 0) {
+      if (pause === true || value === 0) {
         // the auto refresher starts in an off state
         // so switch it on and set the interval to 30s
         timefilter.setRefreshInterval({

--- a/x-pack/plugins/ml/public/application/routing/routes/jobs_list.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/jobs_list.tsx
@@ -61,7 +61,7 @@ const PageWrapper: FC<PageProps> = ({ deps }) => {
 
   useEffect(() => {
     const refreshInterval =
-      refreshValue === 0 && refreshPause === true
+      refreshValue === 0 || refreshPause === true
         ? { pause: false, value: DEFAULT_REFRESH_INTERVAL_MS }
         : { pause: refreshPause, value: refreshValue };
     timefilter.setRefreshInterval(refreshInterval);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/70562

The default refresh interval is currently 0 which seems to be a bug. This PR changes it to 60 seconds and disables it by default (`pause=true`).

Related to: https://github.com/elastic/kibana/pull/144426