### PR TITLE
added settings action to agent activity flyout

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -254,6 +254,11 @@ const actionNames: {
     cancelledText: 'update tags',
   },
   CANCEL: { inProgressText: 'Cancelling', completedText: 'cancelled', cancelledText: '' },
+  SETTINGS: {
+    inProgressText: 'Updating settings of',
+    completedText: 'updated settings',
+    cancelledText: 'update settings',
+  },
   ACTION: { inProgressText: 'Actioning', completedText: 'actioned', cancelledText: 'action' },
 };
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/144299

Added SETTINGS action mapping to Agent activity flyout.

<img width="688" alt="image" src="https://user-images.githubusercontent.com/90178898/199456959-49de83b7-5a43-4421-838b-dfee1392d690.png">

To verify:
- change Agent log level in agent details, that triggers a SETTINGS action
- verify in Agent activity flyout that the right text shows up

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/90178898/199457210-663e394d-3e1a-41c4-8700-d07ae262de10.png">
