### PR TITLE
[Files] Copy updates and file picker single select

### DIFF
--- a/examples/files_example/public/components/file_picker.tsx
+++ b/examples/files_example/public/components/file_picker.tsx
@@ -27,6 +27,7 @@ export const MyFilePicker: FunctionComponent<Props> = ({ onClose, onDone, onUplo
       onDone={onDone}
       onUpload={(n) => onUpload(n.map(({ id }) => id))}
       pageSize={50}
+      multiple
     />
   );
 };

--- a/src/plugins/files/public/components/file_picker/components/empty_prompt.tsx
+++ b/src/plugins/files/public/components/file_picker/components/empty_prompt.tsx
@@ -15,9 +15,10 @@ import { i18nTexts } from '../i18n_texts';
 
 interface Props {
   kind: string;
+  multiple: boolean;
 }
 
-export const UploadFilesPrompt: FunctionComponent<Props> = ({ kind }) => {
+export const EmptyPrompt: FunctionComponent<Props> = ({ kind, multiple }) => {
   const { state } = useFilePickerContext();
   return (
     <EuiEmptyPrompt
@@ -34,6 +35,7 @@ export const UploadFilesPrompt: FunctionComponent<Props> = ({ kind }) => {
         <UploadFile
           kind={kind}
           immediate
+          multiple={multiple}
           onDone={(file) => {
             state.selectFile(file.map(({ id }) => id));
             state.retry();

--- a/src/plugins/files/public/components/file_picker/components/empty_prompt.tsx
+++ b/src/plugins/files/public/components/file_picker/components/empty_prompt.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import type { FunctionComponent } from 'react';
 import { UploadFile } from '../../upload_file';
 import { useFilePickerContext } from '../context';
@@ -24,11 +24,6 @@ export const EmptyPrompt: FunctionComponent<Props> = ({ kind, multiple }) => {
     <EuiEmptyPrompt
       data-test-subj="emptyPrompt"
       title={<h3>{i18nTexts.emptyStatePrompt}</h3>}
-      body={
-        <EuiText color="subdued" size="s">
-          <p>{i18nTexts.emptyStatePromptSubtitle}</p>
-        </EuiText>
-      }
       titleSize="s"
       actions={[
         // TODO: We can remove this once the entire modal is an upload area

--- a/src/plugins/files/public/components/file_picker/components/modal_footer.tsx
+++ b/src/plugins/files/public/components/file_picker/components/modal_footer.tsx
@@ -22,9 +22,10 @@ interface Props {
   kind: string;
   onDone: SelectButtonProps['onClick'];
   onUpload?: FilePickerProps['onUpload'];
+  multiple: boolean;
 }
 
-export const ModalFooter: FunctionComponent<Props> = ({ kind, onDone, onUpload }) => {
+export const ModalFooter: FunctionComponent<Props> = ({ kind, onDone, onUpload, multiple }) => {
   const { state } = useFilePickerContext();
   const onUploadStart = useCallback(() => state.setIsUploading(true), [state]);
   const onUploadEnd = useCallback(() => state.setIsUploading(false), [state]);
@@ -53,7 +54,7 @@ export const ModalFooter: FunctionComponent<Props> = ({ kind, onDone, onUpload }
             onUploadEnd={onUploadEnd}
             kind={kind}
             initialPromptText={i18nTexts.uploadFilePlaceholderText}
-            multiple
+            multiple={multiple}
             compressed
           />
         </div>

--- a/src/plugins/files/public/components/file_picker/components/title.tsx
+++ b/src/plugins/files/public/components/file_picker/components/title.tsx
@@ -11,8 +11,12 @@ import type { FunctionComponent } from 'react';
 import { EuiTitle } from '@elastic/eui';
 import { i18nTexts } from '../i18n_texts';
 
-export const Title: FunctionComponent = () => (
+interface Props {
+  multiple: boolean;
+}
+
+export const Title: FunctionComponent<Props> = ({ multiple }) => (
   <EuiTitle>
-    <h2>{i18nTexts.title}</h2>
+    <h2>{multiple ? i18nTexts.titleMultiple : i18nTexts.title}</h2>
   </EuiTitle>
 );

--- a/src/plugins/files/public/components/file_picker/context.tsx
+++ b/src/plugins/files/public/components/file_picker/context.tsx
@@ -23,17 +23,19 @@ const FilePickerCtx = createContext<FilePickerContextValue>(
 interface FilePickerContextProps {
   kind: string;
   pageSize: number;
+  multiple: boolean;
 }
 export const FilePickerContext: FunctionComponent<FilePickerContextProps> = ({
   kind,
   pageSize,
+  multiple,
   children,
 }) => {
   const filesContext = useFilesContext();
   const { client } = filesContext;
   const state = useMemo(
-    () => createFilePickerState({ pageSize, client, kind }),
-    [pageSize, client, kind]
+    () => createFilePickerState({ pageSize, client, kind, uploadMultiple: multiple }),
+    [pageSize, client, kind, multiple]
   );
   useEffect(() => state.dispose, [state]);
   return (

--- a/src/plugins/files/public/components/file_picker/context.tsx
+++ b/src/plugins/files/public/components/file_picker/context.tsx
@@ -34,7 +34,7 @@ export const FilePickerContext: FunctionComponent<FilePickerContextProps> = ({
   const filesContext = useFilesContext();
   const { client } = filesContext;
   const state = useMemo(
-    () => createFilePickerState({ pageSize, client, kind, uploadMultiple: multiple }),
+    () => createFilePickerState({ pageSize, client, kind, selectMultiple: multiple }),
     [pageSize, client, kind, multiple]
   );
   useEffect(() => state.dispose, [state]);

--- a/src/plugins/files/public/components/file_picker/file_picker.stories.tsx
+++ b/src/plugins/files/public/components/file_picker/file_picker.stories.tsx
@@ -27,6 +27,7 @@ const defaultProps: FilePickerProps = {
   kind,
   onDone: action('done!'),
   onClose: action('close!'),
+  multiple: true,
 };
 
 export default {
@@ -198,3 +199,25 @@ TryFilter.decorators = [
     );
   },
 ];
+
+export const SingleSelect = Template.bind({});
+SingleSelect.decorators = [
+  (Story) => (
+    <FilesContext
+      client={
+        {
+          getDownloadHref: () => `data:image/png;base64,${base64dLogo}`,
+          list: async (): Promise<FilesClientResponses['list']> => ({
+            files: [createFileJSON(), createFileJSON(), createFileJSON()],
+            total: 1,
+          }),
+        } as unknown as FilesClient
+      }
+    >
+      <Story />
+    </FilesContext>
+  ),
+];
+SingleSelect.args = {
+  multiple: undefined,
+};

--- a/src/plugins/files/public/components/file_picker/file_picker.test.tsx
+++ b/src/plugins/files/public/components/file_picker/file_picker.test.tsx
@@ -30,7 +30,7 @@ describe('FilePicker', () => {
   async function initTestBed(props?: Partial<Props>) {
     const createTestBed = registerTestBed((p: Props) => (
       <FilesContext client={client}>
-        <FilePicker {...p} />
+        <FilePicker multiple {...p} />
       </FilesContext>
     ));
 

--- a/src/plugins/files/public/components/file_picker/file_picker_state.test.ts
+++ b/src/plugins/files/public/components/file_picker/file_picker_state.test.ts
@@ -32,6 +32,7 @@ describe('FilePickerState', () => {
       client: filesClient,
       pageSize: 20,
       kind: 'test',
+      uploadMultiple: true,
     });
   });
   it('starts off empty', () => {
@@ -179,6 +180,22 @@ describe('FilePickerState', () => {
       const query$ = cold(queryInput).pipe(tap((q) => filePickerState.setQuery(q)));
       expectObservable(merge(upload$, query$)).toBe('---a-a|');
       expectObservable(filePickerState.files$).toBe('a------', { a: [] });
+    });
+  });
+  describe('single selection', () => {
+    beforeEach(() => {
+      filePickerState = createFilePickerState({
+        client: filesClient,
+        pageSize: 20,
+        kind: 'test',
+        uploadMultiple: false,
+      });
+    });
+    it('allows only one file to be selected', () => {
+      filePickerState.selectFile('a');
+      expect(filePickerState.getSelectedFileIds()).toEqual(['a']);
+      filePickerState.selectFile(['b', 'a', 'c']);
+      expect(filePickerState.getSelectedFileIds()).toEqual(['b']);
     });
   });
 });

--- a/src/plugins/files/public/components/file_picker/file_picker_state.test.ts
+++ b/src/plugins/files/public/components/file_picker/file_picker_state.test.ts
@@ -32,7 +32,7 @@ describe('FilePickerState', () => {
       client: filesClient,
       pageSize: 20,
       kind: 'test',
-      uploadMultiple: true,
+      selectMultiple: true,
     });
   });
   it('starts off empty', () => {
@@ -188,7 +188,7 @@ describe('FilePickerState', () => {
         client: filesClient,
         pageSize: 20,
         kind: 'test',
-        uploadMultiple: false,
+        selectMultiple: false,
       });
     });
     it('allows only one file to be selected', () => {

--- a/src/plugins/files/public/components/file_picker/file_picker_state.ts
+++ b/src/plugins/files/public/components/file_picker/file_picker_state.ts
@@ -56,7 +56,8 @@ export class FilePickerState {
   constructor(
     private readonly client: FilesClient,
     private readonly kind: string,
-    public readonly pageSize: number
+    public readonly pageSize: number,
+    private selectMultiple: boolean
   ) {
     this.subscriptions = [
       this.query$
@@ -105,8 +106,18 @@ export class FilePickerState {
     this.internalIsLoading$.next(value);
   }
 
+  /**
+   * If multiple selection is not configured, this will take the first file id
+   * if an array of file ids was provided.
+   */
   public selectFile = (fileId: string | string[]): void => {
-    (Array.isArray(fileId) ? fileId : [fileId]).forEach((id) => this.fileSet.add(id));
+    const fileIds = Array.isArray(fileId) ? fileId : [fileId];
+    if (!this.selectMultiple) {
+      this.fileSet.clear();
+      this.fileSet.add(fileIds[0]);
+    } else {
+      for (const id of fileIds) this.fileSet.add(id);
+    }
     this.sendNextSelectedFiles();
   };
 
@@ -216,11 +227,13 @@ interface CreateFilePickerArgs {
   client: FilesClient;
   kind: string;
   pageSize: number;
+  uploadMultiple: boolean;
 }
 export const createFilePickerState = ({
   pageSize,
   client,
   kind,
+  uploadMultiple,
 }: CreateFilePickerArgs): FilePickerState => {
-  return new FilePickerState(client, kind, pageSize);
+  return new FilePickerState(client, kind, pageSize, uploadMultiple);
 };

--- a/src/plugins/files/public/components/file_picker/file_picker_state.ts
+++ b/src/plugins/files/public/components/file_picker/file_picker_state.ts
@@ -227,13 +227,13 @@ interface CreateFilePickerArgs {
   client: FilesClient;
   kind: string;
   pageSize: number;
-  uploadMultiple: boolean;
+  selectMultiple: boolean;
 }
 export const createFilePickerState = ({
   pageSize,
   client,
   kind,
-  uploadMultiple,
+  selectMultiple,
 }: CreateFilePickerArgs): FilePickerState => {
-  return new FilePickerState(client, kind, pageSize, uploadMultiple);
+  return new FilePickerState(client, kind, pageSize, selectMultiple);
 };

--- a/src/plugins/files/public/components/file_picker/i18n_texts.ts
+++ b/src/plugins/files/public/components/file_picker/i18n_texts.ts
@@ -12,17 +12,17 @@ export const i18nTexts = {
   title: i18n.translate('files.filePicker.title', {
     defaultMessage: 'Select a file',
   }),
+  titleMultiple: i18n.translate('files.filePicker.titleMultiple', {
+    defaultMessage: 'Select files',
+  }),
   loadingFilesErrorTitle: i18n.translate('files.filePicker.error.loadingTitle', {
     defaultMessage: 'Could not load files',
   }),
   retryButtonLabel: i18n.translate('files.filePicker.error.retryButtonLabel', {
     defaultMessage: 'Retry',
   }),
-  emptyStatePrompt: i18n.translate('files.filePicker.emptyStatePrompt', {
-    defaultMessage: 'No files found',
-  }),
-  emptyStatePromptSubtitle: i18n.translate('files.filePicker.emptyStatePromptSubtitle', {
-    defaultMessage: 'Upload your first file.',
+  emptyStatePrompt: i18n.translate('files.filePicker.emptyStatePromptTitle', {
+    defaultMessage: 'Upload your first file',
   }),
   selectFileLabel: i18n.translate('files.filePicker.selectFileButtonLable', {
     defaultMessage: 'Select file',
@@ -36,7 +36,7 @@ export const i18nTexts = {
     defaultMessage: 'my-file-*',
   }),
   emptyFileGridPrompt: i18n.translate('files.filePicker.emptyGridPrompt', {
-    defaultMessage: 'No files matched filter',
+    defaultMessage: 'No files match your filter',
   }),
   loadMoreButtonLabel: i18n.translate('files.filePicker.loadMoreButtonLabel', {
     defaultMessage: 'Load more',


### PR DESCRIPTION
## Summary

* Several copy updates (for e.g., https://github.com/elastic/kibana/pull/143111#discussion_r1006255026)
* Adds new flag to support selecting a single or multiple files


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
