### PR TITLE
Add a refresh:false when deleting action_task_params

### DIFF
--- a/x-pack/plugins/actions/server/lib/task_runner_factory.test.ts
+++ b/x-pack/plugins/actions/server/lib/task_runner_factory.test.ts
@@ -304,7 +304,9 @@ test('cleans up action_task_params object', async () => {
 
   await taskRunner.run();
 
-  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', { refresh: false });
+  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', {
+    refresh: false,
+  });
 });
 
 test('task runner should implement CancellableTask cancel method with logging warning message', async () => {
@@ -367,7 +369,9 @@ test('runs successfully when cleanup fails and logs the error', async () => {
 
   await taskRunner.run();
 
-  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', { refresh: false });
+  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', {
+    refresh: false,
+  });
   expect(taskRunnerFactoryInitializerParams.logger.error).toHaveBeenCalledWith(
     'Failed to cleanup action_task_params object [id="3"]: Fail'
   );

--- a/x-pack/plugins/actions/server/lib/task_runner_factory.test.ts
+++ b/x-pack/plugins/actions/server/lib/task_runner_factory.test.ts
@@ -304,7 +304,7 @@ test('cleans up action_task_params object', async () => {
 
   await taskRunner.run();
 
-  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3');
+  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', { refresh: false });
 });
 
 test('task runner should implement CancellableTask cancel method with logging warning message', async () => {
@@ -367,7 +367,7 @@ test('runs successfully when cleanup fails and logs the error', async () => {
 
   await taskRunner.run();
 
-  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3');
+  expect(services.savedObjectsClient.delete).toHaveBeenCalledWith('action_task_params', '3', { refresh: false });
   expect(taskRunnerFactoryInitializerParams.logger.error).toHaveBeenCalledWith(
     'Failed to cleanup action_task_params object [id="3"]: Fail'
   );

--- a/x-pack/plugins/actions/server/lib/task_runner_factory.ts
+++ b/x-pack/plugins/actions/server/lib/task_runner_factory.ts
@@ -171,7 +171,8 @@ export class TaskRunnerFactory {
             // Once support for legacy alert RBAC is dropped, this can be secured
             await getUnsecuredSavedObjectsClient(request).delete(
               ACTION_TASK_PARAMS_SAVED_OBJECT_TYPE,
-              actionTaskExecutorParams.actionTaskParamsId
+              actionTaskExecutorParams.actionTaskParamsId,
+              { refresh: false }
             );
           } catch (e) {
             // Log error only, we shouldn't fail the task because of an error here (if ever there's retry logic)


### PR DESCRIPTION
In this PR, I'm making rule actions run ~500ms faster (20ms to 1s faster) by avoiding to wait for a refresh to happen when deleting the `action_task_params` saved-object. This refresh made the delete operation run anywhere from ~20ms to 1s accounting for a large part of the action execution time.