### PR TITLE
[8.5] [ML] Explain Log Rate Spikes: Wrap analysis in try/catch block.

### DIFF
--- a/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
+++ b/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
@@ -157,524 +157,534 @@ export const defineExplainLogRateSpikesRoute = (
       }
 
       async function runAnalysis() {
-        isRunning = true;
-        logDebugMessage('Reset.');
-        push(resetAction());
-        pushPingWithTimeout();
-        logDebugMessage('Load field candidates.');
-        push(
-          updateLoadingStateAction({
-            ccsWarning: false,
-            loaded,
-            loadingState: i18n.translate(
-              'xpack.aiops.explainLogRateSpikes.loadingState.loadingFieldCandidates',
-              {
-                defaultMessage: 'Loading field candidates.',
-              }
-            ),
-          })
-        );
-
-        let fieldCandidates: Awaited<ReturnType<typeof fetchFieldCandidates>>;
         try {
-          fieldCandidates = await fetchFieldCandidates(client, request.body);
-        } catch (e) {
-          logger.error(`Failed to fetch field candidates, got: \n${e.toString()}`);
-          pushError(`Failed to fetch field candidates.`);
-          end();
-          return;
-        }
-
-        loaded += LOADED_FIELD_CANDIDATES;
-
-        push(
-          updateLoadingStateAction({
-            ccsWarning: false,
-            loaded,
-            loadingState: i18n.translate(
-              'xpack.aiops.explainLogRateSpikes.loadingState.identifiedFieldCandidates',
-              {
-                defaultMessage:
-                  'Identified {fieldCandidatesCount, plural, one {# field candidate} other {# field candidates}}.',
-                values: {
-                  fieldCandidatesCount: fieldCandidates.length,
-                },
-              }
-            ),
-          })
-        );
-
-        if (fieldCandidates.length === 0) {
-          endWithUpdatedLoadingState();
-        } else if (shouldStop) {
-          end();
-          return;
-        }
-
-        const changePoints: ChangePoint[] = [];
-        const fieldsToSample = new Set<string>();
-        const chunkSize = 10;
-        let chunkCount = 0;
-
-        const fieldCandidatesChunks = chunk(fieldCandidates, chunkSize);
-
-        logDebugMessage('Fetch p-values.');
-
-        for (const fieldCandidatesChunk of fieldCandidatesChunks) {
-          chunkCount++;
-          logDebugMessage(`Fetch p-values. Chunk ${chunkCount} of ${fieldCandidatesChunks.length}`);
-          let pValues: Awaited<ReturnType<typeof fetchChangePointPValues>>;
-          try {
-            pValues = await fetchChangePointPValues(
-              client,
-              request.body,
-              fieldCandidatesChunk,
-              logger,
-              pushError
-            );
-          } catch (e) {
-            logger.error(
-              `Failed to fetch p-values for ${JSON.stringify(
-                fieldCandidatesChunk
-              )}, got: \n${e.toString()}`
-            );
-            pushError(`Failed to fetch p-values for ${JSON.stringify(fieldCandidatesChunk)}.`);
-            // Still continue the analysis even if chunks of p-value queries fail.
-            continue;
-          }
-
-          if (pValues.length > 0) {
-            pValues.forEach((d) => {
-              fieldsToSample.add(d.fieldName);
-            });
-            changePoints.push(...pValues);
-          }
-
-          loaded += (1 / fieldCandidatesChunks.length) * PROGRESS_STEP_P_VALUES;
-          if (pValues.length > 0) {
-            push(addChangePointsAction(pValues));
-          }
+          isRunning = true;
+          logDebugMessage('Reset.');
+          push(resetAction());
+          pushPingWithTimeout();
+          logDebugMessage('Load field candidates.');
           push(
             updateLoadingStateAction({
               ccsWarning: false,
               loaded,
               loadingState: i18n.translate(
-                'xpack.aiops.explainLogRateSpikes.loadingState.identifiedFieldValuePairs',
+                'xpack.aiops.explainLogRateSpikes.loadingState.loadingFieldCandidates',
                 {
-                  defaultMessage:
-                    'Identified {fieldValuePairsCount, plural, one {# significant field/value pair} other {# significant field/value pairs}}.',
-                  values: {
-                    fieldValuePairsCount: changePoints?.length ?? 0,
-                  },
+                  defaultMessage: 'Loading field candidates.',
                 }
               ),
             })
           );
 
-          if (shouldStop) {
-            logDebugMessage('shouldStop fetching p-values.');
-
+          let fieldCandidates: Awaited<ReturnType<typeof fetchFieldCandidates>>;
+          try {
+            fieldCandidates = await fetchFieldCandidates(client, request.body);
+          } catch (e) {
+            logger.error(`Failed to fetch field candidates, got: \n${e.toString()}`);
+            pushError(`Failed to fetch field candidates.`);
             end();
             return;
           }
-        }
 
-        if (changePoints?.length === 0) {
-          logDebugMessage('Stopping analysis, did not find change points.');
-          endWithUpdatedLoadingState();
-          return;
-        }
-
-        const histogramFields: [NumericHistogramField] = [
-          { fieldName: request.body.timeFieldName, type: KBN_FIELD_TYPES.DATE },
-        ];
-
-        logDebugMessage('Fetch overall histogram.');
-
-        let overallTimeSeries: NumericChartData | undefined;
-        try {
-          overallTimeSeries = (
-            (await fetchHistogramsForFields(
-              client,
-              request.body.index,
-              { match_all: {} },
-              // fields
-              histogramFields,
-              // samplerShardSize
-              -1,
-              undefined
-            )) as [NumericChartData]
-          )[0];
-        } catch (e) {
-          logger.error(`Failed to fetch the overall histogram data, got: \n${e.toString()}`);
-          pushError(`Failed to fetch overall histogram data.`);
-          // Still continue the analysis even if loading the overall histogram fails.
-        }
-
-        function pushHistogramDataLoadingState() {
-          push(
-            updateLoadingStateAction({
-              ccsWarning: false,
-              loaded,
-              loadingState: i18n.translate(
-                'xpack.aiops.explainLogRateSpikes.loadingState.loadingHistogramData',
-                {
-                  defaultMessage: 'Loading histogram data.',
-                }
-              ),
-            })
-          );
-        }
-
-        if (groupingEnabled) {
-          logDebugMessage('Group results.');
+          loaded += LOADED_FIELD_CANDIDATES;
 
           push(
             updateLoadingStateAction({
               ccsWarning: false,
               loaded,
               loadingState: i18n.translate(
-                'xpack.aiops.explainLogRateSpikes.loadingState.groupingResults',
+                'xpack.aiops.explainLogRateSpikes.loadingState.identifiedFieldCandidates',
                 {
-                  defaultMessage: 'Transforming significant field/value pairs into groups.',
+                  defaultMessage:
+                    'Identified {fieldCandidatesCount, plural, one {# field candidate} other {# field candidates}}.',
+                  values: {
+                    fieldCandidatesCount: fieldCandidates.length,
+                  },
                 }
               ),
             })
           );
 
-          // To optimize the `frequent_items` query, we identify duplicate change points by count attributes.
-          // Note this is a compromise and not 100% accurate because there could be change points that
-          // have the exact same counts but still don't co-occur.
-          const duplicateIdentifier: Array<keyof ChangePoint> = [
-            'doc_count',
-            'bg_count',
-            'total_doc_count',
-            'total_bg_count',
+          if (fieldCandidates.length === 0) {
+            endWithUpdatedLoadingState();
+          } else if (shouldStop) {
+            end();
+            return;
+          }
+
+          const changePoints: ChangePoint[] = [];
+          const fieldsToSample = new Set<string>();
+          const chunkSize = 10;
+          let chunkCount = 0;
+
+          const fieldCandidatesChunks = chunk(fieldCandidates, chunkSize);
+
+          logDebugMessage('Fetch p-values.');
+
+          for (const fieldCandidatesChunk of fieldCandidatesChunks) {
+            chunkCount++;
+            logDebugMessage(
+              `Fetch p-values. Chunk ${chunkCount} of ${fieldCandidatesChunks.length}`
+            );
+            let pValues: Awaited<ReturnType<typeof fetchChangePointPValues>>;
+            try {
+              pValues = await fetchChangePointPValues(
+                client,
+                request.body,
+                fieldCandidatesChunk,
+                logger,
+                pushError
+              );
+            } catch (e) {
+              logger.error(
+                `Failed to fetch p-values for ${JSON.stringify(
+                  fieldCandidatesChunk
+                )}, got: \n${e.toString()}`
+              );
+              pushError(`Failed to fetch p-values for ${JSON.stringify(fieldCandidatesChunk)}.`);
+              // Still continue the analysis even if chunks of p-value queries fail.
+              continue;
+            }
+
+            if (pValues.length > 0) {
+              pValues.forEach((d) => {
+                fieldsToSample.add(d.fieldName);
+              });
+              changePoints.push(...pValues);
+            }
+
+            loaded += (1 / fieldCandidatesChunks.length) * PROGRESS_STEP_P_VALUES;
+            if (pValues.length > 0) {
+              push(addChangePointsAction(pValues));
+            }
+            push(
+              updateLoadingStateAction({
+                ccsWarning: false,
+                loaded,
+                loadingState: i18n.translate(
+                  'xpack.aiops.explainLogRateSpikes.loadingState.identifiedFieldValuePairs',
+                  {
+                    defaultMessage:
+                      'Identified {fieldValuePairsCount, plural, one {# significant field/value pair} other {# significant field/value pairs}}.',
+                    values: {
+                      fieldValuePairsCount: changePoints?.length ?? 0,
+                    },
+                  }
+                ),
+              })
+            );
+
+            if (shouldStop) {
+              logDebugMessage('shouldStop fetching p-values.');
+
+              end();
+              return;
+            }
+          }
+
+          if (changePoints?.length === 0) {
+            logDebugMessage('Stopping analysis, did not find change points.');
+            endWithUpdatedLoadingState();
+            return;
+          }
+
+          const histogramFields: [NumericHistogramField] = [
+            { fieldName: request.body.timeFieldName, type: KBN_FIELD_TYPES.DATE },
           ];
 
-          // These are the deduplicated change points we pass to the `frequent_items` aggregation.
-          const deduplicatedChangePoints = dropDuplicates(changePoints, duplicateIdentifier);
+          logDebugMessage('Fetch overall histogram.');
 
-          // We use the grouped change points to later repopulate
-          // the `frequent_items` result with the missing duplicates.
-          const groupedChangePoints = groupDuplicates(changePoints, duplicateIdentifier).filter(
-            (g) => g.group.length > 1
-          );
-
+          let overallTimeSeries: NumericChartData | undefined;
           try {
-            const { fields, df } = await fetchFrequentItems(
-              client,
-              request.body.index,
-              JSON.parse(request.body.searchQuery) as estypes.QueryDslQueryContainer,
-              deduplicatedChangePoints,
-              request.body.timeFieldName,
-              request.body.deviationMin,
-              request.body.deviationMax,
-              logger,
-              pushError
+            overallTimeSeries = (
+              (await fetchHistogramsForFields(
+                client,
+                request.body.index,
+                { match_all: {} },
+                // fields
+                histogramFields,
+                // samplerShardSize
+                -1,
+                undefined
+              )) as [NumericChartData]
+            )[0];
+          } catch (e) {
+            logger.error(`Failed to fetch the overall histogram data, got: \n${e.toString()}`);
+            pushError(`Failed to fetch overall histogram data.`);
+            // Still continue the analysis even if loading the overall histogram fails.
+          }
+
+          function pushHistogramDataLoadingState() {
+            push(
+              updateLoadingStateAction({
+                ccsWarning: false,
+                loaded,
+                loadingState: i18n.translate(
+                  'xpack.aiops.explainLogRateSpikes.loadingState.loadingHistogramData',
+                  {
+                    defaultMessage: 'Loading histogram data.',
+                  }
+                ),
+              })
+            );
+          }
+
+          if (groupingEnabled) {
+            logDebugMessage('Group results.');
+
+            push(
+              updateLoadingStateAction({
+                ccsWarning: false,
+                loaded,
+                loadingState: i18n.translate(
+                  'xpack.aiops.explainLogRateSpikes.loadingState.groupingResults',
+                  {
+                    defaultMessage: 'Transforming significant field/value pairs into groups.',
+                  }
+                ),
+              })
             );
 
-            if (fields.length > 0 && df.length > 0) {
-              // The way the `frequent_items` aggregations works could return item sets that include
-              // field/value pairs that are not part of the original list of significant change points.
-              // This cleans up groups and removes those unrelated field/value pairs.
-              const filteredDf = df
-                .map((fi) => {
-                  fi.set = Object.entries(fi.set).reduce<ItemsetResult['set']>(
-                    (set, [field, value]) => {
-                      if (
-                        changePoints.some((cp) => cp.fieldName === field && cp.fieldValue === value)
-                      ) {
-                        set[field] = value;
-                      }
-                      return set;
-                    },
-                    {}
-                  );
-                  fi.size = Object.keys(fi.set).length;
-                  return fi;
-                })
-                .filter((fi) => fi.size > 1);
+            // To optimize the `frequent_items` query, we identify duplicate change points by count attributes.
+            // Note this is a compromise and not 100% accurate because there could be change points that
+            // have the exact same counts but still don't co-occur.
+            const duplicateIdentifier: Array<keyof ChangePoint> = [
+              'doc_count',
+              'bg_count',
+              'total_doc_count',
+              'total_bg_count',
+            ];
 
-              // `frequent_items` returns lot of different small groups of field/value pairs that co-occur.
-              // The following steps analyse these small groups, identify overlap between these groups,
-              // and then summarize them in larger groups where possible.
+            // These are the deduplicated change points we pass to the `frequent_items` aggregation.
+            const deduplicatedChangePoints = dropDuplicates(changePoints, duplicateIdentifier);
 
-              // Get a tree structure based on `frequent_items`.
-              const { root } = getSimpleHierarchicalTree(filteredDf, true, false, fields);
+            // We use the grouped change points to later repopulate
+            // the `frequent_items` result with the missing duplicates.
+            const groupedChangePoints = groupDuplicates(changePoints, duplicateIdentifier).filter(
+              (g) => g.group.length > 1
+            );
 
-              // Each leave of the tree will be a summarized group of co-occuring field/value pairs.
-              const treeLeaves = getSimpleHierarchicalTreeLeaves(root, []);
-
-              // To be able to display a more cleaned up results table in the UI, we identify field/value pairs
-              // that occur in multiple groups. This will allow us to highlight field/value pairs that are
-              // unique to a group in a better way. This step will also re-add duplicates we identified in the
-              // beginning and didn't pass on to the `frequent_items` agg.
-              const fieldValuePairCounts = getFieldValuePairCounts(treeLeaves);
-              const changePointGroups = markDuplicates(treeLeaves, fieldValuePairCounts).map(
-                (g) => {
-                  const group = [...g.group];
-
-                  for (const groupItem of g.group) {
-                    const { duplicate } = groupItem;
-                    const duplicates = groupedChangePoints.find((d) =>
-                      d.group.some(
-                        (dg) =>
-                          dg.fieldName === groupItem.fieldName &&
-                          dg.fieldValue === groupItem.fieldValue
-                      )
-                    );
-
-                    if (duplicates !== undefined) {
-                      group.push(
-                        ...duplicates.group.map((d) => {
-                          return {
-                            fieldName: d.fieldName,
-                            fieldValue: d.fieldValue,
-                            duplicate,
-                          };
-                        })
-                      );
-                    }
-                  }
-
-                  return {
-                    ...g,
-                    group,
-                  };
-                }
+            try {
+              const { fields, df } = await fetchFrequentItems(
+                client,
+                request.body.index,
+                JSON.parse(request.body.searchQuery) as estypes.QueryDslQueryContainer,
+                deduplicatedChangePoints,
+                request.body.timeFieldName,
+                request.body.deviationMin,
+                request.body.deviationMax,
+                logger,
+                pushError
               );
 
-              // Some field/value pairs might not be part of the `frequent_items` result set, for example
-              // because they don't co-occur with other field/value pairs or because of the limits we set on the query.
-              // In this next part we identify those missing pairs and add them as individual groups.
-              const missingChangePoints = deduplicatedChangePoints.filter((cp) => {
-                return !changePointGroups.some((cpg) => {
-                  return cpg.group.some(
-                    (d) => d.fieldName === cp.fieldName && d.fieldValue === cp.fieldValue
-                  );
-                });
-              });
-
-              changePointGroups.push(
-                ...missingChangePoints.map(
-                  ({ fieldName, fieldValue, doc_count: docCount, pValue }) => {
-                    const duplicates = groupedChangePoints.find((d) =>
-                      d.group.some(
-                        (dg) => dg.fieldName === fieldName && dg.fieldValue === fieldValue
-                      )
+              if (fields.length > 0 && df.length > 0) {
+                // The way the `frequent_items` aggregations works could return item sets that include
+                // field/value pairs that are not part of the original list of significant change points.
+                // This cleans up groups and removes those unrelated field/value pairs.
+                const filteredDf = df
+                  .map((fi) => {
+                    fi.set = Object.entries(fi.set).reduce<ItemsetResult['set']>(
+                      (set, [field, value]) => {
+                        if (
+                          changePoints.some(
+                            (cp) => cp.fieldName === field && cp.fieldValue === value
+                          )
+                        ) {
+                          set[field] = value;
+                        }
+                        return set;
+                      },
+                      {}
                     );
-                    if (duplicates !== undefined) {
-                      return {
-                        id: `${stringHash(
-                          JSON.stringify(
-                            duplicates.group.map((d) => ({
+                    fi.size = Object.keys(fi.set).length;
+                    return fi;
+                  })
+                  .filter((fi) => fi.size > 1);
+
+                // `frequent_items` returns lot of different small groups of field/value pairs that co-occur.
+                // The following steps analyse these small groups, identify overlap between these groups,
+                // and then summarize them in larger groups where possible.
+
+                // Get a tree structure based on `frequent_items`.
+                const { root } = getSimpleHierarchicalTree(filteredDf, true, false, fields);
+
+                // Each leave of the tree will be a summarized group of co-occuring field/value pairs.
+                const treeLeaves = getSimpleHierarchicalTreeLeaves(root, []);
+
+                // To be able to display a more cleaned up results table in the UI, we identify field/value pairs
+                // that occur in multiple groups. This will allow us to highlight field/value pairs that are
+                // unique to a group in a better way. This step will also re-add duplicates we identified in the
+                // beginning and didn't pass on to the `frequent_items` agg.
+                const fieldValuePairCounts = getFieldValuePairCounts(treeLeaves);
+                const changePointGroups = markDuplicates(treeLeaves, fieldValuePairCounts).map(
+                  (g) => {
+                    const group = [...g.group];
+
+                    for (const groupItem of g.group) {
+                      const { duplicate } = groupItem;
+                      const duplicates = groupedChangePoints.find((d) =>
+                        d.group.some(
+                          (dg) =>
+                            dg.fieldName === groupItem.fieldName &&
+                            dg.fieldValue === groupItem.fieldValue
+                        )
+                      );
+
+                      if (duplicates !== undefined) {
+                        group.push(
+                          ...duplicates.group.map((d) => {
+                            return {
                               fieldName: d.fieldName,
                               fieldValue: d.fieldValue,
-                            }))
-                          )
-                        )}`,
-                        group: duplicates.group.map((d) => ({
-                          fieldName: d.fieldName,
-                          fieldValue: d.fieldValue,
-                          duplicate: false,
-                        })),
-                        docCount,
-                        pValue,
-                      };
-                    } else {
-                      return {
-                        id: `${stringHash(JSON.stringify({ fieldName, fieldValue }))}`,
-                        group: [
-                          {
-                            fieldName,
-                            fieldValue,
-                            duplicate: false,
-                          },
-                        ],
-                        docCount,
-                        pValue,
-                      };
+                              duplicate,
+                            };
+                          })
+                        );
+                      }
                     }
+
+                    return {
+                      ...g,
+                      group,
+                    };
                   }
-                )
-              );
+                );
 
-              // Finally, we'll find out if there's at least one group with at least two items,
-              // only then will we return the groups to the clients and make the grouping option available.
-              const maxItems = Math.max(...changePointGroups.map((g) => g.group.length));
-
-              if (maxItems > 1) {
-                push(addChangePointsGroupAction(changePointGroups));
-              }
-
-              loaded += PROGRESS_STEP_GROUPING;
-
-              pushHistogramDataLoadingState();
-
-              logDebugMessage('Fetch group histograms.');
-
-              await asyncForEach(changePointGroups, async (cpg) => {
-                if (overallTimeSeries !== undefined) {
-                  const histogramQuery = {
-                    bool: {
-                      filter: cpg.group.map((d) => ({
-                        term: { [d.fieldName]: d.fieldValue },
-                      })),
-                    },
-                  };
-
-                  let cpgTimeSeries: NumericChartData;
-                  try {
-                    cpgTimeSeries = (
-                      (await fetchHistogramsForFields(
-                        client,
-                        request.body.index,
-                        histogramQuery,
-                        // fields
-                        [
-                          {
-                            fieldName: request.body.timeFieldName,
-                            type: KBN_FIELD_TYPES.DATE,
-                            interval: overallTimeSeries.interval,
-                            min: overallTimeSeries.stats[0],
-                            max: overallTimeSeries.stats[1],
-                          },
-                        ],
-                        // samplerShardSize
-                        -1,
-                        undefined
-                      )) as [NumericChartData]
-                    )[0];
-                  } catch (e) {
-                    logger.error(
-                      `Failed to fetch the histogram data for group #${
-                        cpg.id
-                      }, got: \n${e.toString()}`
+                // Some field/value pairs might not be part of the `frequent_items` result set, for example
+                // because they don't co-occur with other field/value pairs or because of the limits we set on the query.
+                // In this next part we identify those missing pairs and add them as individual groups.
+                const missingChangePoints = deduplicatedChangePoints.filter((cp) => {
+                  return !changePointGroups.some((cpg) => {
+                    return cpg.group.some(
+                      (d) => d.fieldName === cp.fieldName && d.fieldValue === cp.fieldValue
                     );
-                    pushError(`Failed to fetch the histogram data for group #${cpg.id}.`);
-                    return;
-                  }
-                  const histogram =
-                    overallTimeSeries.data.map((o, i) => {
-                      const current = cpgTimeSeries.data.find(
-                        (d1) => d1.key_as_string === o.key_as_string
-                      ) ?? {
-                        doc_count: 0,
-                      };
-                      return {
-                        key: o.key,
-                        key_as_string: o.key_as_string ?? '',
-                        doc_count_change_point: current.doc_count,
-                        doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
-                      };
-                    }) ?? [];
+                  });
+                });
 
-                  push(
-                    addChangePointsGroupHistogramAction([
-                      {
-                        id: cpg.id,
-                        histogram,
-                      },
-                    ])
-                  );
+                changePointGroups.push(
+                  ...missingChangePoints.map(
+                    ({ fieldName, fieldValue, doc_count: docCount, pValue }) => {
+                      const duplicates = groupedChangePoints.find((d) =>
+                        d.group.some(
+                          (dg) => dg.fieldName === fieldName && dg.fieldValue === fieldValue
+                        )
+                      );
+                      if (duplicates !== undefined) {
+                        return {
+                          id: `${stringHash(
+                            JSON.stringify(
+                              duplicates.group.map((d) => ({
+                                fieldName: d.fieldName,
+                                fieldValue: d.fieldValue,
+                              }))
+                            )
+                          )}`,
+                          group: duplicates.group.map((d) => ({
+                            fieldName: d.fieldName,
+                            fieldValue: d.fieldValue,
+                            duplicate: false,
+                          })),
+                          docCount,
+                          pValue,
+                        };
+                      } else {
+                        return {
+                          id: `${stringHash(JSON.stringify({ fieldName, fieldValue }))}`,
+                          group: [
+                            {
+                              fieldName,
+                              fieldValue,
+                              duplicate: false,
+                            },
+                          ],
+                          docCount,
+                          pValue,
+                        };
+                      }
+                    }
+                  )
+                );
+
+                // Finally, we'll find out if there's at least one group with at least two items,
+                // only then will we return the groups to the clients and make the grouping option available.
+                const maxItems = Math.max(...changePointGroups.map((g) => g.group.length));
+
+                if (maxItems > 1) {
+                  push(addChangePointsGroupAction(changePointGroups));
                 }
-              });
+
+                loaded += PROGRESS_STEP_GROUPING;
+
+                pushHistogramDataLoadingState();
+
+                logDebugMessage('Fetch group histograms.');
+
+                await asyncForEach(changePointGroups, async (cpg) => {
+                  if (overallTimeSeries !== undefined) {
+                    const histogramQuery = {
+                      bool: {
+                        filter: cpg.group.map((d) => ({
+                          term: { [d.fieldName]: d.fieldValue },
+                        })),
+                      },
+                    };
+
+                    let cpgTimeSeries: NumericChartData;
+                    try {
+                      cpgTimeSeries = (
+                        (await fetchHistogramsForFields(
+                          client,
+                          request.body.index,
+                          histogramQuery,
+                          // fields
+                          [
+                            {
+                              fieldName: request.body.timeFieldName,
+                              type: KBN_FIELD_TYPES.DATE,
+                              interval: overallTimeSeries.interval,
+                              min: overallTimeSeries.stats[0],
+                              max: overallTimeSeries.stats[1],
+                            },
+                          ],
+                          // samplerShardSize
+                          -1,
+                          undefined
+                        )) as [NumericChartData]
+                      )[0];
+                    } catch (e) {
+                      logger.error(
+                        `Failed to fetch the histogram data for group #${
+                          cpg.id
+                        }, got: \n${e.toString()}`
+                      );
+                      pushError(`Failed to fetch the histogram data for group #${cpg.id}.`);
+                      return;
+                    }
+                    const histogram =
+                      overallTimeSeries.data.map((o, i) => {
+                        const current = cpgTimeSeries.data.find(
+                          (d1) => d1.key_as_string === o.key_as_string
+                        ) ?? {
+                          doc_count: 0,
+                        };
+                        return {
+                          key: o.key,
+                          key_as_string: o.key_as_string ?? '',
+                          doc_count_change_point: current.doc_count,
+                          doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
+                        };
+                      }) ?? [];
+
+                    push(
+                      addChangePointsGroupHistogramAction([
+                        {
+                          id: cpg.id,
+                          histogram,
+                        },
+                      ])
+                    );
+                  }
+                });
+              }
+            } catch (e) {
+              logger.error(
+                `Failed to transform field/value pairs into groups, got: \n${e.toString()}`
+              );
+              pushError(`Failed to transform field/value pairs into groups.`);
             }
-          } catch (e) {
-            logger.error(
-              `Failed to transform field/value pairs into groups, got: \n${e.toString()}`
-            );
-            pushError(`Failed to transform field/value pairs into groups.`);
           }
-        }
 
-        loaded += PROGRESS_STEP_HISTOGRAMS_GROUPS;
+          loaded += PROGRESS_STEP_HISTOGRAMS_GROUPS;
 
-        logDebugMessage('Fetch field/value histograms.');
+          logDebugMessage('Fetch field/value histograms.');
 
-        // time series filtered by fields
-        if (changePoints && overallTimeSeries !== undefined) {
-          await asyncForEach(changePoints, async (cp) => {
-            if (overallTimeSeries !== undefined) {
-              const histogramQuery = {
-                bool: {
-                  filter: [
-                    {
-                      term: { [cp.fieldName]: cp.fieldValue },
-                    },
-                  ],
-                },
-              };
-
-              let cpTimeSeries: NumericChartData;
-
-              try {
-                cpTimeSeries = (
-                  (await fetchHistogramsForFields(
-                    client,
-                    request.body.index,
-                    histogramQuery,
-                    // fields
-                    [
+          // time series filtered by fields
+          if (changePoints && overallTimeSeries !== undefined) {
+            await asyncForEach(changePoints, async (cp) => {
+              if (overallTimeSeries !== undefined) {
+                const histogramQuery = {
+                  bool: {
+                    filter: [
                       {
-                        fieldName: request.body.timeFieldName,
-                        type: KBN_FIELD_TYPES.DATE,
-                        interval: overallTimeSeries.interval,
-                        min: overallTimeSeries.stats[0],
-                        max: overallTimeSeries.stats[1],
+                        term: { [cp.fieldName]: cp.fieldValue },
                       },
                     ],
-                    // samplerShardSize
-                    -1,
-                    undefined
-                  )) as [NumericChartData]
-                )[0];
-              } catch (e) {
-                logger.error(
-                  `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${
-                    cp.fieldValue
-                  }", got: \n${e.toString()}`
-                );
-                pushError(
-                  `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${cp.fieldValue}".`
-                );
-                return;
-              }
-
-              const histogram =
-                overallTimeSeries.data.map((o, i) => {
-                  const current = cpTimeSeries.data.find(
-                    (d1) => d1.key_as_string === o.key_as_string
-                  ) ?? {
-                    doc_count: 0,
-                  };
-                  return {
-                    key: o.key,
-                    key_as_string: o.key_as_string ?? '',
-                    doc_count_change_point: current.doc_count,
-                    doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
-                  };
-                }) ?? [];
-
-              const { fieldName, fieldValue } = cp;
-
-              loaded += (1 / changePoints.length) * PROGRESS_STEP_HISTOGRAMS;
-              pushHistogramDataLoadingState();
-              push(
-                addChangePointsHistogramAction([
-                  {
-                    fieldName,
-                    fieldValue,
-                    histogram,
                   },
-                ])
-              );
-            }
-          });
-        }
+                };
 
-        endWithUpdatedLoadingState();
+                let cpTimeSeries: NumericChartData;
+
+                try {
+                  cpTimeSeries = (
+                    (await fetchHistogramsForFields(
+                      client,
+                      request.body.index,
+                      histogramQuery,
+                      // fields
+                      [
+                        {
+                          fieldName: request.body.timeFieldName,
+                          type: KBN_FIELD_TYPES.DATE,
+                          interval: overallTimeSeries.interval,
+                          min: overallTimeSeries.stats[0],
+                          max: overallTimeSeries.stats[1],
+                        },
+                      ],
+                      // samplerShardSize
+                      -1,
+                      undefined
+                    )) as [NumericChartData]
+                  )[0];
+                } catch (e) {
+                  logger.error(
+                    `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${
+                      cp.fieldValue
+                    }", got: \n${e.toString()}`
+                  );
+                  pushError(
+                    `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${cp.fieldValue}".`
+                  );
+                  return;
+                }
+
+                const histogram =
+                  overallTimeSeries.data.map((o, i) => {
+                    const current = cpTimeSeries.data.find(
+                      (d1) => d1.key_as_string === o.key_as_string
+                    ) ?? {
+                      doc_count: 0,
+                    };
+                    return {
+                      key: o.key,
+                      key_as_string: o.key_as_string ?? '',
+                      doc_count_change_point: current.doc_count,
+                      doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
+                    };
+                  }) ?? [];
+
+                const { fieldName, fieldValue } = cp;
+
+                loaded += (1 / changePoints.length) * PROGRESS_STEP_HISTOGRAMS;
+                pushHistogramDataLoadingState();
+                push(
+                  addChangePointsHistogramAction([
+                    {
+                      fieldName,
+                      fieldValue,
+                      histogram,
+                    },
+                  ])
+                );
+              }
+            });
+          }
+
+          endWithUpdatedLoadingState();
+        } catch (e) {
+          logger.error(`Explain log rate spikes analysis failed to finish, got: \n${e.toString()}`);
+          pushError(`Explain log rate spikes analysis failed to finish.`);
+          end();
+        }
       }
 
       // Do not call this using `await` so it will run asynchronously while we return the stream already.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[ML] Explain Log Rate Spikes: Wrap analysis in try/catch block.](https://github.com/elastic/kibana/pull/143651)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Walter Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2022-10-20T13:05:44Z","message":"[ML] Explain Log Rate Spikes: Wrap analysis in try/catch block.\n\nThis wraps the analysis part in a try/catch block. We had individual try/catch blocks already to handle ES queries. Because the analysis is run async, if another error happens it would trigger an unresolved promise error and could crash Kibana server. Adding this additional try/catch block avoids this.","sha":"d5564507954e647bb87430769d27f79a92d0ef9b","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport pending",":ml","Feature:ML/AIOps","v8.6.0","v8.5.1"],"number":143651,"url":"https://github.com/elastic/kibana/pull/143651","mergeCommit":{"message":"[ML] Explain Log Rate Spikes: Wrap analysis in try/catch block.\n\nThis wraps the analysis part in a try/catch block. We had individual try/catch blocks already to handle ES queries. Because the analysis is run async, if another error happens it would trigger an unresolved promise error and could crash Kibana server. Adding this additional try/catch block avoids this.","sha":"d5564507954e647bb87430769d27f79a92d0ef9b"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/143651","number":143651,"mergeCommit":{"message":"[ML] Explain Log Rate Spikes: Wrap analysis in try/catch block.\n\nThis wraps the analysis part in a try/catch block. We had individual try/catch blocks already to handle ES queries. Because the analysis is run async, if another error happens it would trigger an unresolved promise error and could crash Kibana server. Adding this additional try/catch block avoids this.","sha":"d5564507954e647bb87430769d27f79a92d0ef9b"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->