### PR TITLE
[APM] Prefix services from synthtrace scenarios with “synth” instead of "opbeans"

### DIFF
--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace.ts
@@ -23,61 +23,61 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
       const transactionName = '240rpm/75% 1000ms';
       const successfulTimestamps = range.interval('1s').rate(3);
 
-      const opbeansRum = apm
-        .service({ name: 'opbeans-rum', environment: ENVIRONMENT, agentName: 'rum-js' })
+      const synthRum = apm
+        .service({ name: 'synth-rum', environment: ENVIRONMENT, agentName: 'rum-js' })
         .instance('my-instance');
-      const opbeansNode = apm
-        .service({ name: 'opbeans-node', environment: ENVIRONMENT, agentName: 'nodejs' })
+      const synthNode = apm
+        .service({ name: 'synth-node', environment: ENVIRONMENT, agentName: 'nodejs' })
         .instance('my-instance');
-      const opbeansGo = apm
-        .service({ name: 'opbeans-go', environment: ENVIRONMENT, agentName: 'go' })
+      const synthGo = apm
+        .service({ name: 'synth-go', environment: ENVIRONMENT, agentName: 'go' })
         .instance('my-instance');
 
       const traces = successfulTimestamps.generator((timestamp) => {
-        // opbeans-rum
-        return opbeansRum
+        // synth-rum
+        return synthRum
           .transaction({ transactionName })
           .duration(400)
           .timestamp(timestamp)
           .children(
-            // opbeans-rum -> opbeans-node
-            opbeansRum
+            // synth-rum -> synth-node
+            synthRum
               .span(
                 httpExitSpan({
                   spanName: 'GET /api/products/top',
-                  destinationUrl: 'http://opbeans-node:3000',
+                  destinationUrl: 'http://synth-node:3000',
                 })
               )
               .duration(300)
               .timestamp(timestamp)
 
               .children(
-                // opbeans-node
-                opbeansNode
-                  .transaction({ transactionName: 'Initial transaction in opbeans-node' })
+                // synth-node
+                synthNode
+                  .transaction({ transactionName: 'Initial transaction in synth-node' })
                   .duration(300)
                   .timestamp(timestamp)
                   .children(
-                    opbeansNode
-                      // opbeans-node -> opbeans-go
+                    synthNode
+                      // synth-node -> synth-go
                       .span(
                         httpExitSpan({
-                          spanName: 'GET opbeans-go:3000',
-                          destinationUrl: 'http://opbeans-go:3000',
+                          spanName: 'GET synth-go:3000',
+                          destinationUrl: 'http://synth-go:3000',
                         })
                       )
                       .timestamp(timestamp)
                       .duration(400)
 
                       .children(
-                        // opbeans-go
-                        opbeansGo
+                        // synth-go
+                        synthGo
 
-                          .transaction({ transactionName: 'Initial transaction in opbeans-go' })
+                          .transaction({ transactionName: 'Initial transaction in synth-go' })
                           .timestamp(timestamp)
                           .duration(200)
                           .children(
-                            opbeansGo
+                            synthGo
                               .span({ spanName: 'custom_operation', spanType: 'custom' })
                               .timestamp(timestamp)
                               .duration(100)

--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace_long.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace_long.ts
@@ -24,48 +24,48 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
       const traceDuration = 1100;
       const rootTransactionName = `${ratePerMinute}rpm / ${traceDuration}ms`;
 
-      const opbeansRum = apm
-        .service({ name: 'opbeans-rum', environment: ENVIRONMENT, agentName: 'rum-js' })
+      const synthRum = apm
+        .service({ name: 'synth-rum', environment: ENVIRONMENT, agentName: 'rum-js' })
         .instance('my-instance');
 
-      const opbeansNode = apm
-        .service({ name: 'opbeans-node', environment: ENVIRONMENT, agentName: 'nodejs' })
+      const synthNode = apm
+        .service({ name: 'synth-node', environment: ENVIRONMENT, agentName: 'nodejs' })
         .instance('my-instance');
 
-      const opbeansGo = apm
-        .service({ name: 'opbeans-go', environment: ENVIRONMENT, agentName: 'go' })
+      const synthGo = apm
+        .service({ name: 'synth-go', environment: ENVIRONMENT, agentName: 'go' })
         .instance('my-instance');
 
-      const opbeansDotnet = apm
-        .service({ name: 'opbeans-dotnet', environment: ENVIRONMENT, agentName: 'dotnet' })
+      const synthDotnet = apm
+        .service({ name: 'synth-dotnet', environment: ENVIRONMENT, agentName: 'dotnet' })
         .instance('my-instance');
 
-      const opbeansJava = apm
-        .service({ name: 'opbeans-java', environment: ENVIRONMENT, agentName: 'java' })
+      const synthJava = apm
+        .service({ name: 'synth-java', environment: ENVIRONMENT, agentName: 'java' })
         .instance('my-instance');
 
       const traces = timerange(from, to)
         .ratePerMinute(ratePerMinute)
         .generator((timestamp) => {
           return new DistributedTrace({
-            serviceInstance: opbeansRum,
+            serviceInstance: synthRum,
             transactionName: rootTransactionName,
             timestamp,
             children: (_) => {
               _.service({
                 repeat: 10,
-                serviceInstance: opbeansNode,
+                serviceInstance: synthNode,
                 transactionName: 'GET /nodejs/products',
                 latency: 100,
 
                 children: (_) => {
                   _.service({
-                    serviceInstance: opbeansGo,
+                    serviceInstance: synthGo,
                     transactionName: 'GET /go',
                     children: (_) => {
                       _.service({
                         repeat: 20,
-                        serviceInstance: opbeansJava,
+                        serviceInstance: synthJava,
                         transactionName: 'GET /java',
                         children: (_) => {
                           _.external({
@@ -84,19 +84,19 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
               });
 
               _.service({
-                serviceInstance: opbeansNode,
+                serviceInstance: synthNode,
                 transactionName: 'GET /nodejs/users',
                 latency: 100,
                 repeat: 10,
                 children: (_) => {
                   _.service({
-                    serviceInstance: opbeansGo,
+                    serviceInstance: synthGo,
                     transactionName: 'GET /go/security',
                     latency: 50,
                     children: (_) => {
                       _.service({
                         repeat: 10,
-                        serviceInstance: opbeansDotnet,
+                        serviceInstance: synthDotnet,
                         transactionName: 'GET /dotnet/cases/4',
                         latency: 50,
                         children: (_) =>

--- a/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -32,7 +32,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
 
       const instances = [...Array(numServices).keys()].map((index) =>
         apm
-          .service({ name: `opbeans-go-${index}`, environment: ENVIRONMENT, agentName: 'go' })
+          .service({ name: `synth-go-${index}`, environment: ENVIRONMENT, agentName: 'go' })
           .instance('instance')
       );
       const instanceSpans = (instance: Instance) => {


### PR DESCRIPTION
Tiny change: Services from apm-integration-testing are called "opbeans". To avoid confusing synthtrace generate services with apm-it generated services, I suggest we reserve the "opbeans" prefix to apm-it.