### PR TITLE
[APM] Disable refresh in ML links (#144390)

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.test.tsx
@@ -23,7 +23,7 @@ describe('MLExplorerLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/explorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now-4h))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
+      `"/app/ml/explorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
     );
   });
 

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
@@ -7,11 +7,9 @@
 
 import React, { ReactNode } from 'react';
 import { EuiLink } from '@elastic/eui';
-import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { useMlHref, ML_PAGES } from '@kbn/ml-plugin/public';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
-import { TimePickerRefreshInterval } from '../../date_picker/typings';
 
 interface Props {
   children?: ReactNode;
@@ -39,17 +37,10 @@ export function useExplorerHref({ jobId }: { jobId: string }) {
   } = useApmPluginContext();
   const { urlParams } = useLegacyUrlParams();
 
-  const timePickerRefreshIntervalDefaults =
-    core.uiSettings.get<TimePickerRefreshInterval>(
-      UI_SETTINGS.TIMEPICKER_REFRESH_INTERVAL_DEFAULTS
-    );
-
   const {
     // hardcoding a custom default of 1 hour since the default kibana timerange of 15 minutes is shorter than the ML interval
     rangeFrom = 'now-1h',
     rangeTo = 'now',
-    refreshInterval = timePickerRefreshIntervalDefaults.value,
-    refreshPaused = timePickerRefreshIntervalDefaults.pause,
   } = urlParams;
 
   const href = useMlHref(ml, core.http.basePath.get(), {
@@ -57,7 +48,7 @@ export function useExplorerHref({ jobId }: { jobId: string }) {
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: refreshPaused, value: refreshInterval },
+      refreshInterval: { pause: true, value: 10000 },
     },
   });
 

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlmanage_jobs_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlmanage_jobs_link.test.tsx
@@ -17,6 +17,6 @@ test('MLManageJobsLink', async () => {
   } as Location);
 
   expect(href).toMatchInlineSnapshot(
-    `"/app/ml/jobs?_a=(jobs:(queryText:'groups:(apm)'))&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-5h,to:now-2h))"`
+    `"/app/ml/jobs?_a=(jobs:(queryText:'groups:(apm)'))&_g=(refreshInterval:(pause:!t,value:10000),time:(from:now-5h,to:now-2h))"`
   );
 });

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.test.tsx
@@ -23,7 +23,7 @@ describe('MLSingleMetricLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:()))"`
+      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:()))"`
     );
   });
   it('should produce the correct URL with jobId, serviceName, and transactionType', async () => {
@@ -42,7 +42,7 @@ describe('MLSingleMetricLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-test,transaction.type:request))))"`
+      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-test,transaction.type:request))))"`
     );
   });
 

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
@@ -7,11 +7,9 @@
 
 import React, { ReactNode } from 'react';
 import { EuiLink } from '@elastic/eui';
-import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { useMlHref, ML_PAGES } from '@kbn/ml-plugin/public';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
-import { TimePickerRefreshInterval } from '../../date_picker/typings';
 
 interface Props {
   children?: ReactNode;
@@ -40,7 +38,7 @@ export function MLSingleMetricLink({
   );
 }
 
-export function useSingleMetricHref({
+function useSingleMetricHref({
   jobId,
   serviceName,
   transactionType,
@@ -55,17 +53,10 @@ export function useSingleMetricHref({
   } = useApmPluginContext();
   const { urlParams } = useLegacyUrlParams();
 
-  const timePickerRefreshIntervalDefaults =
-    core.uiSettings.get<TimePickerRefreshInterval>(
-      UI_SETTINGS.TIMEPICKER_REFRESH_INTERVAL_DEFAULTS
-    );
-
   const {
     // hardcoding a custom default of 1 hour since the default kibana timerange of 15 minutes is shorter than the ML interval
     rangeFrom = 'now-1h',
     rangeTo = 'now',
-    refreshInterval = timePickerRefreshIntervalDefaults.value,
-    refreshPaused = timePickerRefreshIntervalDefaults.pause,
   } = urlParams;
 
   const entities =
@@ -83,7 +74,7 @@ export function useSingleMetricHref({
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: refreshPaused, value: refreshInterval },
+      refreshInterval: { pause: true, value: 10000 },
       ...entities,
     },
   });

--- a/x-pack/plugins/apm/public/hooks/use_ml_manage_jobs_href.ts
+++ b/x-pack/plugins/apm/public/hooks/use_ml_manage_jobs_href.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import { UI_SETTINGS } from '@kbn/data-plugin/public';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
-import { TimePickerRefreshInterval } from '../components/shared/date_picker/typings';
 import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../context/url_params_context/use_url_params';
 
@@ -19,17 +17,10 @@ export function useMlManageJobsHref({ jobId }: { jobId?: string } = {}) {
 
   const { urlParams } = useLegacyUrlParams();
 
-  const timePickerRefreshIntervalDefaults =
-    core.uiSettings.get<TimePickerRefreshInterval>(
-      UI_SETTINGS.TIMEPICKER_REFRESH_INTERVAL_DEFAULTS
-    );
-
   const {
     // hardcoding a custom default of 1 hour since the default kibana timerange of 15 minutes is shorter than the ML interval
     rangeFrom = 'now-1h',
     rangeTo = 'now',
-    refreshInterval = timePickerRefreshIntervalDefaults.value,
-    refreshPaused = timePickerRefreshIntervalDefaults.pause,
   } = urlParams;
 
   const mlADLink = useMlHref(ml, core.http.basePath.get(), {
@@ -39,7 +30,7 @@ export function useMlManageJobsHref({ jobId }: { jobId?: string } = {}) {
       jobId,
       globalState: {
         time: { from: rangeFrom, to: rangeTo },
-        refreshInterval: { pause: refreshPaused, value: refreshInterval },
+        refreshInterval: { pause: true, value: 10000 },
       },
     },
   });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/143621

# Backport

This will backport the following commits from `8.5` to `main`:
 - [[8.5] [APM] Disable refresh in ML links (#144390)](https://github.com/elastic/kibana/pull/144390)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2022-11-02T13:24:52Z","message":"[8.5] [APM] Disable refresh in ML links (#144390)","sha":"0f79e349cd508bcc98515c5f434379d933fc9deb","branchLabelMapping":{"^v8.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","Team:APM"],"number":144390,"url":"https://github.com/elastic/kibana/pull/144390","mergeCommit":{"message":"[8.5] [APM] Disable refresh in ML links (#144390)","sha":"0f79e349cd508bcc98515c5f434379d933fc9deb"}},"sourceBranch":"8.5","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->