### PR TITLE
added fix for add and edit integrations page not loading for beta versions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
@@ -70,7 +70,7 @@ export const CreatePackagePolicyMultiPage: CreatePackagePolicyParams = ({
     data: packageInfoData,
     error: packageInfoError,
     isLoading: isPackageInfoLoading,
-  } = useGetPackageInfoByKey(pkgName, pkgVersion);
+  } = useGetPackageInfoByKey(pkgName, pkgVersion, { prerelease: true });
 
   const {
     agentPolicy,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -99,7 +99,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     data: packageInfoData,
     error: packageInfoError,
     isLoading: isPackageInfoLoading,
-  } = useGetPackageInfoByKey(pkgName, pkgVersion);
+  } = useGetPackageInfoByKey(pkgName, pkgVersion, { prerelease: true });
   const packageInfo = useMemo(() => {
     if (packageInfoData && packageInfoData.item) {
       return packageInfoData.item;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -265,7 +265,8 @@ export const EditPackagePolicyForm = memo<{
 
             const { data: packageData } = await sendGetPackageInfoByKey(
               _packageInfo!.name,
-              _packageInfo!.version
+              _packageInfo!.version,
+              { prerelease: true }
             );
 
             if (packageData?.item) {


### PR DESCRIPTION
## Summary

Caused by https://github.com/elastic/kibana/pull/143853

Noticed while testing that a beta version Add and Edit integrations page was not loading due to the last changes of the linked pr.

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/90178898/199517621-c399dacf-ae1d-4679-8cb7-79e9f3d8275d.png">
<img width="1478" alt="image" src="https://user-images.githubusercontent.com/90178898/199517838-821f2869-d300-441d-a4e2-d6a15d92cd9d.png">

