### PR TITLE
adding missing action types to Agent activity UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -259,6 +259,16 @@ const actionNames: {
     completedText: 'updated settings',
     cancelledText: 'update settings',
   },
+  POLICY_CHANGE: {
+    inProgressText: 'Changing policy of',
+    completedText: 'changed policy',
+    cancelledText: 'change policy',
+  },
+  INPUT_ACTION: {
+    inProgressText: 'Input action in progress of',
+    completedText: 'input action completed',
+    cancelledText: 'input action',
+  },
   ACTION: { inProgressText: 'Actioning', completedText: 'actioned', cancelledText: 'action' },
 };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/144411

Added missing UI mappings to Agent activity flyout: INPUT_ACTION, POLICY_CHANGE actions

<img width="571" alt="image" src="https://user-images.githubusercontent.com/90178898/199524678-96d7dc9b-fa3a-41e1-86fc-426dc332a849.png">
<img width="510" alt="image" src="https://user-images.githubusercontent.com/90178898/199524734-63e6152a-9957-47fa-83f9-788a29f3c288.png">
