### PR TITLE
fix autocomplete for fleet

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_string_input.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.test.tsx
@@ -385,7 +385,6 @@ describe('QueryStringInput', () => {
       'logstash-*',
       { type: 'id', value: '1' },
       { type: 'title', value: 'my-fake-index-pattern' },
-      { title: '.fleet-agents', fields: [] },
       stubIndexPattern,
     ];
     mockFetchIndexPatterns.mockClear();

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.test.tsx
@@ -385,6 +385,7 @@ describe('QueryStringInput', () => {
       'logstash-*',
       { type: 'id', value: '1' },
       { type: 'title', value: 'my-fake-index-pattern' },
+      { title: '.fleet-agents', fields: [] },
       stubIndexPattern,
     ];
     mockFetchIndexPatterns.mockClear();

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -31,11 +31,7 @@ import { compact, debounce, isEmpty, isEqual, isFunction, partition } from 'loda
 import { CoreStart, DocLinksStart, Toast } from '@kbn/core/public';
 import type { Query } from '@kbn/es-query';
 import { DataPublicPluginStart, getQueryLog } from '@kbn/data-plugin/public';
-import {
-  type DataView,
-  DataView as KibanaDataView,
-  DataViewsPublicPluginStart,
-} from '@kbn/data-views-plugin/public';
+import { type DataView, DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { PersistedLog } from '@kbn/data-plugin/public';
 import { getFieldSubtypeNested, KIBANA_USER_QUERY_LANGUAGE_KEY } from '@kbn/data-plugin/common';
 import { toMountPoint } from '@kbn/kibana-react-plugin/public';
@@ -184,11 +180,11 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
   };
 
   private fetchIndexPatterns = debounce(async () => {
-    const [objectPatterns = [], stringPatterns = []] = partition<
+    const [stringPatterns = [], objectPatterns = []] = partition<
       QueryStringInputProps['indexPatterns'][number],
       DataView
     >(this.props.indexPatterns || [], (indexPattern): indexPattern is DataView => {
-      return indexPattern instanceof KibanaDataView;
+      return typeof indexPattern === 'string';
     });
     const idOrTitlePatterns = stringPatterns.map((sp) =>
       typeof sp === 'string' ? { type: 'title', value: sp } : sp

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -188,10 +188,7 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
       QueryStringInputProps['indexPatterns'][number],
       DataView
     >(this.props.indexPatterns || [], (indexPattern): indexPattern is DataView => {
-      return (
-        indexPattern instanceof KibanaDataView ||
-        (indexPattern.hasOwnProperty('title') && indexPattern.hasOwnProperty('fields'))
-      );
+      return indexPattern instanceof KibanaDataView;
     });
     const idOrTitlePatterns = stringPatterns.map((sp) =>
       typeof sp === 'string' ? { type: 'title', value: sp } : sp

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -31,7 +31,11 @@ import { compact, debounce, isEmpty, isEqual, isFunction, partition } from 'loda
 import { CoreStart, DocLinksStart, Toast } from '@kbn/core/public';
 import type { Query } from '@kbn/es-query';
 import { DataPublicPluginStart, getQueryLog } from '@kbn/data-plugin/public';
-import { type DataView, DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import {
+  type DataView,
+  DataView as KibanaDataView,
+  DataViewsPublicPluginStart,
+} from '@kbn/data-views-plugin/public';
 import type { PersistedLog } from '@kbn/data-plugin/public';
 import { getFieldSubtypeNested, KIBANA_USER_QUERY_LANGUAGE_KEY } from '@kbn/data-plugin/common';
 import { toMountPoint } from '@kbn/kibana-react-plugin/public';
@@ -180,11 +184,14 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
   };
 
   private fetchIndexPatterns = debounce(async () => {
-    const [stringPatterns = [], objectPatterns = []] = partition<
+    const [objectPatterns = [], stringPatterns = []] = partition<
       QueryStringInputProps['indexPatterns'][number],
       DataView
     >(this.props.indexPatterns || [], (indexPattern): indexPattern is DataView => {
-      return typeof indexPattern === 'string';
+      return (
+        indexPattern instanceof KibanaDataView ||
+        (indexPattern.hasOwnProperty('title') && indexPattern.hasOwnProperty('fields'))
+      );
     });
     const idOrTitlePatterns = stringPatterns.map((sp) =>
       typeof sp === 'string' ? { type: 'title', value: sp } : sp

--- a/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx
@@ -55,7 +55,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
     usageCollection,
   } = useStartServices();
 
-  const [indexPatternFields, setIndexPatternFields] = useState<FieldSpec[]>();
+  const [dataView, setDataView] = useState<DataView | undefined>();
 
   const isQueryValid = useMemo(() => {
     if (!value || value === '') {
@@ -86,9 +86,14 @@ export const SearchBar: React.FunctionComponent<Props> = ({
             return true;
           }
         });
-        setIndexPatternFields(fields);
+        const fieldsMap = fields.reduce((acc: Record<string, FieldSpec>, curr: FieldSpec) => {
+          acc[curr.name] = curr;
+          return acc;
+        }, {});
+        const newDataView = await data.dataViews.create({ title: indexPattern, fields: fieldsMap });
+        setDataView(newDataView);
       } catch (err) {
-        setIndexPatternFields(undefined);
+        setDataView(undefined);
       }
     };
     fetchFields();
@@ -98,16 +103,7 @@ export const SearchBar: React.FunctionComponent<Props> = ({
     <NoWrapQueryStringInput
       iconType="search"
       disableLanguageSwitcher={true}
-      indexPatterns={
-        indexPatternFields
-          ? ([
-              {
-                title: indexPattern,
-                fields: indexPatternFields,
-              },
-            ] as DataView[])
-          : []
-      }
+      indexPatterns={dataView ? [dataView] : []}
       query={{
         query: value,
         language: 'kuery',


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/144217

The logic in `unified_search` looked for `DataView` type here: https://github.com/dej611/kibana/blob/a9e606149741c7f3da7b67452ad6400397526c68/src/plugins/unified_search/public/query_string_input/query_string_input.tsx#L182-L187

Fleet didn't use a `DataView` constructor to create a `DataView` object, so the `instanceof` comparison failed.
https://github.com/elastic/kibana/blob/c1070e63a1e591ab9a47eb6a61de35b65a1b52e6/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.tsx#L101-L109

I found a way to fix the issue by creating a `DataView` type object from fleet.

<img width="948" alt="image" src="https://user-images.githubusercontent.com/90178898/199543088-71b06144-d0d9-4a94-80b2-3f943e33c9c4.png">

