### PR TITLE
fix(NA): wrongly spread stripInternal and rootDir configs across packages

### DIFF
--- a/packages/analytics/client/tsconfig.json
+++ b/packages/analytics/client/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/analytics/shippers/elastic_v3/browser/tsconfig.json
+++ b/packages/analytics/shippers/elastic_v3/browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/analytics/shippers/elastic_v3/common/tsconfig.json
+++ b/packages/analytics/shippers/elastic_v3/common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/analytics/shippers/elastic_v3/server/tsconfig.json
+++ b/packages/analytics/shippers/elastic_v3/server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/analytics/shippers/fullstory/tsconfig.json
+++ b/packages/analytics/shippers/fullstory/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/analytics/shippers/gainsight/tsconfig.json
+++ b/packages/analytics/shippers/gainsight/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/content-management/table_list/tsconfig.json
+++ b/packages/content-management/table_list/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/analytics/core-analytics-browser-internal/tsconfig.json
+++ b/packages/core/analytics/core-analytics-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/analytics/core-analytics-browser-mocks/tsconfig.json
+++ b/packages/core/analytics/core-analytics-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/analytics/core-analytics-browser/tsconfig.json
+++ b/packages/core/analytics/core-analytics-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/analytics/core-analytics-server-internal/tsconfig.json
+++ b/packages/core/analytics/core-analytics-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/analytics/core-analytics-server-mocks/tsconfig.json
+++ b/packages/core/analytics/core-analytics-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/analytics/core-analytics-server/tsconfig.json
+++ b/packages/core/analytics/core-analytics-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/application/core-application-browser-internal/tsconfig.json
+++ b/packages/core/application/core-application-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/application/core-application-browser-internal/tsconfig.json
+++ b/packages/core/application/core-application-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/application/core-application-browser-mocks/tsconfig.json
+++ b/packages/core/application/core-application-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/application/core-application-browser-mocks/tsconfig.json
+++ b/packages/core/application/core-application-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/application/core-application-browser/tsconfig.json
+++ b/packages/core/application/core-application-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/application/core-application-browser/tsconfig.json
+++ b/packages/core/application/core-application-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/application/core-application-common/tsconfig.json
+++ b/packages/core/application/core-application-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/application/core-application-common/tsconfig.json
+++ b/packages/core/application/core-application-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/apps/core-apps-browser-internal/tsconfig.json
+++ b/packages/core/apps/core-apps-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/apps/core-apps-browser-mocks/tsconfig.json
+++ b/packages/core/apps/core-apps-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/base/core-base-browser-internal/tsconfig.json
+++ b/packages/core/base/core-base-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/base/core-base-browser-mocks/tsconfig.json
+++ b/packages/core/base/core-base-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/base/core-base-common-internal/tsconfig.json
+++ b/packages/core/base/core-base-common-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/base/core-base-common/tsconfig.json
+++ b/packages/core/base/core-base-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/base/core-base-server-internal/tsconfig.json
+++ b/packages/core/base/core-base-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/base/core-base-server-mocks/tsconfig.json
+++ b/packages/core/base/core-base-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-browser-internal/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/capabilities/core-capabilities-browser-internal/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-browser-mocks/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/capabilities/core-capabilities-browser-mocks/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-common/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-server-internal/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-server-mocks/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/capabilities/core-capabilities-server/tsconfig.json
+++ b/packages/core/capabilities/core-capabilities-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/chrome/core-chrome-browser-internal/tsconfig.json
+++ b/packages/core/chrome/core-chrome-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/chrome/core-chrome-browser-mocks/tsconfig.json
+++ b/packages/core/chrome/core-chrome-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/chrome/core-chrome-browser/tsconfig.json
+++ b/packages/core/chrome/core-chrome-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/config/core-config-server-internal/tsconfig.json
+++ b/packages/core/config/core-config-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-browser-internal/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-browser-mocks/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-browser/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-common/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-server-internal/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-server-mocks/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/deprecations/core-deprecations-server/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/deprecations/core-deprecations-server/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-browser-internal/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-browser-mocks/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-browser/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-server-internal/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-server-mocks/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/doc-links/core-doc-links-server/tsconfig.json
+++ b/packages/core/doc-links/core-doc-links-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/tsconfig.json
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-mocks/tsconfig.json
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/tsconfig.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/elasticsearch/core-elasticsearch-server-mocks/tsconfig.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/elasticsearch/core-elasticsearch-server/tsconfig.json
+++ b/packages/core/elasticsearch/core-elasticsearch-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/environment/core-environment-server-internal/tsconfig.json
+++ b/packages/core/environment/core-environment-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/environment/core-environment-server-mocks/tsconfig.json
+++ b/packages/core/environment/core-environment-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-browser-internal/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-browser-mocks/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-browser/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-common/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-server-internal/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-server-mocks/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/execution-context/core-execution-context-server/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/fatal-errors/core-fatal-errors-browser-internal/tsconfig.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/fatal-errors/core-fatal-errors-browser-mocks/tsconfig.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/fatal-errors/core-fatal-errors-browser/tsconfig.json
+++ b/packages/core/fatal-errors/core-fatal-errors-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/http/core-http-browser-internal/tsconfig.json
+++ b/packages/core/http/core-http-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-browser-mocks/tsconfig.json
+++ b/packages/core/http/core-http-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-browser/tsconfig.json
+++ b/packages/core/http/core-http-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-common/tsconfig.json
+++ b/packages/core/http/core-http-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-context-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-context-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-context-server-mocks/tsconfig.json
+++ b/packages/core/http/core-http-context-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-request-handler-context-server/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-resources-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-resources-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-resources-server-mocks/tsconfig.json
+++ b/packages/core/http/core-http-resources-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-resources-server/tsconfig.json
+++ b/packages/core/http/core-http-resources-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-router-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-router-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-router-server-mocks/tsconfig.json
+++ b/packages/core/http/core-http-router-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-server-mocks/tsconfig.json
+++ b/packages/core/http/core-http-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/http/core-http-server/tsconfig.json
+++ b/packages/core/http/core-http-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-browser-internal/tsconfig.json
+++ b/packages/core/i18n/core-i18n-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-browser-mocks/tsconfig.json
+++ b/packages/core/i18n/core-i18n-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-browser/tsconfig.json
+++ b/packages/core/i18n/core-i18n-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-server-internal/tsconfig.json
+++ b/packages/core/i18n/core-i18n-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/i18n/core-i18n-server-internal/tsconfig.json
+++ b/packages/core/i18n/core-i18n-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-server-mocks/tsconfig.json
+++ b/packages/core/i18n/core-i18n-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/i18n/core-i18n-server/tsconfig.json
+++ b/packages/core/i18n/core-i18n-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/injected-metadata/core-injected-metadata-browser-internal/tsconfig.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/injected-metadata/core-injected-metadata-browser-mocks/tsconfig.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/injected-metadata/core-injected-metadata-browser/tsconfig.json
+++ b/packages/core/injected-metadata/core-injected-metadata-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/injected-metadata/core-injected-metadata-common-internal/tsconfig.json
+++ b/packages/core/injected-metadata/core-injected-metadata-common-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/integrations/core-integrations-browser-internal/tsconfig.json
+++ b/packages/core/integrations/core-integrations-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/integrations/core-integrations-browser-mocks/tsconfig.json
+++ b/packages/core/integrations/core-integrations-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/lifecycle/core-lifecycle-browser-internal/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/lifecycle/core-lifecycle-browser-mocks/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/lifecycle/core-lifecycle-browser/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/lifecycle/core-lifecycle-server-internal/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/lifecycle/core-lifecycle-server-mocks/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/lifecycle/core-lifecycle-server/tsconfig.json
+++ b/packages/core/lifecycle/core-lifecycle-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/logging/core-logging-browser-internal/tsconfig.json
+++ b/packages/core/logging/core-logging-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/logging/core-logging-browser-mocks/tsconfig.json
+++ b/packages/core/logging/core-logging-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/logging/core-logging-common-internal/tsconfig.json
+++ b/packages/core/logging/core-logging-common-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/logging/core-logging-server-internal/tsconfig.json
+++ b/packages/core/logging/core-logging-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/logging/core-logging-server-mocks/tsconfig.json
+++ b/packages/core/logging/core-logging-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/logging/core-logging-server/tsconfig.json
+++ b/packages/core/logging/core-logging-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/metrics/core-metrics-collectors-server-internal/tsconfig.json
+++ b/packages/core/metrics/core-metrics-collectors-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/metrics/core-metrics-collectors-server-mocks/tsconfig.json
+++ b/packages/core/metrics/core-metrics-collectors-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/metrics/core-metrics-server-internal/tsconfig.json
+++ b/packages/core/metrics/core-metrics-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/metrics/core-metrics-server-mocks/tsconfig.json
+++ b/packages/core/metrics/core-metrics-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/metrics/core-metrics-server/tsconfig.json
+++ b/packages/core/metrics/core-metrics-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/mount-utils/core-mount-utils-browser-internal/tsconfig.json
+++ b/packages/core/mount-utils/core-mount-utils-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/mount-utils/core-mount-utils-browser/tsconfig.json
+++ b/packages/core/mount-utils/core-mount-utils-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/node/core-node-server-internal/tsconfig.json
+++ b/packages/core/node/core-node-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/node/core-node-server-mocks/tsconfig.json
+++ b/packages/core/node/core-node-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/node/core-node-server/tsconfig.json
+++ b/packages/core/node/core-node-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/notifications/core-notifications-browser-internal/tsconfig.json
+++ b/packages/core/notifications/core-notifications-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/notifications/core-notifications-browser-mocks/tsconfig.json
+++ b/packages/core/notifications/core-notifications-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/notifications/core-notifications-browser/tsconfig.json
+++ b/packages/core/notifications/core-notifications-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/overlays/core-overlays-browser-internal/tsconfig.json
+++ b/packages/core/overlays/core-overlays-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/overlays/core-overlays-browser-mocks/tsconfig.json
+++ b/packages/core/overlays/core-overlays-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/overlays/core-overlays-browser/tsconfig.json
+++ b/packages/core/overlays/core-overlays-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/plugins/core-plugins-base-server-internal/tsconfig.json
+++ b/packages/core/plugins/core-plugins-base-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/plugins/core-plugins-browser-internal/tsconfig.json
+++ b/packages/core/plugins/core-plugins-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/plugins/core-plugins-browser-mocks/tsconfig.json
+++ b/packages/core/plugins/core-plugins-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/plugins/core-plugins-browser/tsconfig.json
+++ b/packages/core/plugins/core-plugins-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/plugins/core-plugins-server-internal/tsconfig.json
+++ b/packages/core/plugins/core-plugins-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/plugins/core-plugins-server-mocks/tsconfig.json
+++ b/packages/core/plugins/core-plugins-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/plugins/core-plugins-server/tsconfig.json
+++ b/packages/core/plugins/core-plugins-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/preboot/core-preboot-server-internal/tsconfig.json
+++ b/packages/core/preboot/core-preboot-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/preboot/core-preboot-server-mocks/tsconfig.json
+++ b/packages/core/preboot/core-preboot-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/preboot/core-preboot-server/tsconfig.json
+++ b/packages/core/preboot/core-preboot-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/rendering/core-rendering-browser-internal/tsconfig.json
+++ b/packages/core/rendering/core-rendering-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/rendering/core-rendering-browser-mocks/tsconfig.json
+++ b/packages/core/rendering/core-rendering-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/rendering/core-rendering-server-internal/tsconfig.json
+++ b/packages/core/rendering/core-rendering-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/rendering/core-rendering-server-mocks/tsconfig.json
+++ b/packages/core/rendering/core-rendering-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/root/core-root-browser-internal/tsconfig.json
+++ b/packages/core/root/core-root-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/saved-objects/core-saved-objects-api-browser/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-api-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-api-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-api-server/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-api-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-base-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-base-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-browser-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-browser-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-browser/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-common/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-import-export-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-import-export-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-import-export-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-import-export-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-import-export-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-import-export-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-import-export-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-import-export-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-migration-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-migration-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/saved-objects/core-saved-objects-server-mocks/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-server/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/saved-objects/core-saved-objects-utils-server/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-utils-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/status/core-status-common-internal/tsconfig.json
+++ b/packages/core/status/core-status-common-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/status/core-status-common/tsconfig.json
+++ b/packages/core/status/core-status-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/status/core-status-server-internal/tsconfig.json
+++ b/packages/core/status/core-status-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/status/core-status-server-mocks/tsconfig.json
+++ b/packages/core/status/core-status-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/status/core-status-server/tsconfig.json
+++ b/packages/core/status/core-status-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/test-helpers/core-test-helpers-deprecations-getters/tsconfig.json
+++ b/packages/core/test-helpers/core-test-helpers-deprecations-getters/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/test-helpers/core-test-helpers-http-setup-browser/tsconfig.json
+++ b/packages/core/test-helpers/core-test-helpers-http-setup-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/test-helpers/core-test-helpers-so-type-serializer/tsconfig.json
+++ b/packages/core/test-helpers/core-test-helpers-so-type-serializer/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/test-helpers/core-test-helpers-test-utils/tsconfig.json
+++ b/packages/core/test-helpers/core-test-helpers-test-utils/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/theme/core-theme-browser-internal/tsconfig.json
+++ b/packages/core/theme/core-theme-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/theme/core-theme-browser-mocks/tsconfig.json
+++ b/packages/core/theme/core-theme-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/theme/core-theme-browser/tsconfig.json
+++ b/packages/core/theme/core-theme-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-browser-internal/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-browser-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-browser-mocks/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-browser-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-browser/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/core/ui-settings/core-ui-settings-common/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-common/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-server-internal/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-server-mocks/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/ui-settings/core-ui-settings-server/tsconfig.json
+++ b/packages/core/ui-settings/core-ui-settings-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/usage-data/core-usage-data-base-server-internal/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-base-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/usage-data/core-usage-data-base-server-internal/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-base-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/usage-data/core-usage-data-server-internal/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-server-internal/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/usage-data/core-usage-data-server-mocks/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-server-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/core/usage-data/core-usage-data-server/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/core/usage-data/core-usage-data-server/tsconfig.json
+++ b/packages/core/usage-data/core-usage-data-server/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/home/sample_data_card/tsconfig.json
+++ b/packages/home/sample_data_card/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/home/sample_data_tab/tsconfig.json
+++ b/packages/home/sample_data_tab/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/home/sample_data_types/tsconfig.json
+++ b/packages/home/sample_data_types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/kbn-ace/tsconfig.json
+++ b/packages/kbn-ace/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": false,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-ambient-storybook-types/tsconfig.json
+++ b/packages/kbn-ambient-storybook-types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/kbn-ambient-storybook-types/tsconfig.json
+++ b/packages/kbn-ambient-storybook-types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": "src",
     "stripInternal": false,
     "types": []
   },

--- a/packages/kbn-ambient-ui-types/tsconfig.json
+++ b/packages/kbn-ambient-ui-types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "@types/react",
     ]

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -5,7 +5,6 @@
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "node"
     ]

--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "node"

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-apm-config-loader/tsconfig.json
+++ b/packages/kbn-apm-config-loader/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-axe-config/tsconfig.json
+++ b/packages/kbn-axe-config/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-bazel-packages/tsconfig.json
+++ b/packages/kbn-bazel-packages/tsconfig.json
@@ -5,7 +5,6 @@
     "emitDeclarationOnly": true,
     "checkJs": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-bazel-runner/tsconfig.json
+++ b/packages/kbn-bazel-runner/tsconfig.json
@@ -5,7 +5,6 @@
     "emitDeclarationOnly": true,
     "checkJs": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-cases-components/tsconfig.json
+++ b/packages/kbn-cases-components/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-ci-stats-core/tsconfig.json
+++ b/packages/kbn-ci-stats-core/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-ci-stats-performance-metrics/tsconfig.json
+++ b/packages/kbn-ci-stats-performance-metrics/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-ci-stats-reporter/tsconfig.json
+++ b/packages/kbn-ci-stats-reporter/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-cli-dev-mode/tsconfig.json
+++ b/packages/kbn-cli-dev-mode/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-coloring/tsconfig.json
+++ b/packages/kbn-coloring/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-config-mocks/tsconfig.json
+++ b/packages/kbn-config-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-config/tsconfig.json
+++ b/packages/kbn-config/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-config/tsconfig.json
+++ b/packages/kbn-config/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-crypto-browser/tsconfig.json
+++ b/packages/kbn-crypto-browser/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-cli-errors/tsconfig.json
+++ b/packages/kbn-dev-cli-errors/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-cli-runner/tsconfig.json
+++ b/packages/kbn-dev-cli-runner/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-proc-runner/tsconfig.json
+++ b/packages/kbn-dev-proc-runner/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-dev-utils/tsconfig.json
+++ b/packages/kbn-dev-utils/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-doc-links/tsconfig.json
+++ b/packages/kbn-doc-links/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-doc-links/tsconfig.json
+++ b/packages/kbn-doc-links/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-archiver/tsconfig.json
+++ b/packages/kbn-es-archiver/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-errors/tsconfig.json
+++ b/packages/kbn-es-errors/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-query/tsconfig.json
+++ b/packages/kbn-es-query/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es-types/tsconfig.json
+++ b/packages/kbn-es-types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-es/tsconfig.json
+++ b/packages/kbn-es/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
-    "outDir": "target/types"
+    "outDir": "target_types"
   },
   "include": [
     "**/*.ts",

--- a/packages/kbn-eslint-plugin-disable/tsconfig.json
+++ b/packages/kbn-eslint-plugin-disable/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-eslint-plugin-imports/tsconfig.json
+++ b/packages/kbn-eslint-plugin-imports/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-failed-test-reporter-cli/tsconfig.json
+++ b/packages/kbn-failed-test-reporter-cli/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-field-types/tsconfig.json
+++ b/packages/kbn-field-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "declaration": true,
     "emitDeclarationOnly": true,
     "types": [

--- a/packages/kbn-find-used-node-modules/tsconfig.json
+++ b/packages/kbn-find-used-node-modules/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-ftr-common-functional-services/tsconfig.json
+++ b/packages/kbn-ftr-common-functional-services/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-ftr-screenshot-filename/tsconfig.json
+++ b/packages/kbn-ftr-screenshot-filename/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-generate/templates/package/tsconfig.json.ejs
+++ b/packages/kbn-generate/templates/package/tsconfig.json.ejs
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
     <%_ if (pkg.web) { _%>
       "jest",

--- a/packages/kbn-generate/tsconfig.json
+++ b/packages/kbn-generate/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-get-repo-files/tsconfig.json
+++ b/packages/kbn-get-repo-files/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-guided-onboarding/tsconfig.json
+++ b/packages/kbn-guided-onboarding/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-handlebars/tsconfig.json
+++ b/packages/kbn-handlebars/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-hapi-mocks/tsconfig.json
+++ b/packages/kbn-hapi-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-i18n-react/tsconfig.json
+++ b/packages/kbn-i18n-react/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-i18n/tsconfig.json
+++ b/packages/kbn-i18n/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-import-resolver/tsconfig.json
+++ b/packages/kbn-import-resolver/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-io-ts-utils/tsconfig.json
+++ b/packages/kbn-io-ts-utils/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-io-ts-utils/tsconfig.json
+++ b/packages/kbn-io-ts-utils/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-jest-serializers/tsconfig.json
+++ b/packages/kbn-jest-serializers/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-journeys/tsconfig.json
+++ b/packages/kbn-journeys/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "mocha",
       "node"

--- a/packages/kbn-kibana-manifest-schema/tsconfig.json
+++ b/packages/kbn-kibana-manifest-schema/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-language-documentation-popover/tsconfig.json
+++ b/packages/kbn-language-documentation-popover/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node",

--- a/packages/kbn-logging-mocks/tsconfig.json
+++ b/packages/kbn-logging-mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-logging/tsconfig.json
+++ b/packages/kbn-logging/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-managed-vscode-config-cli/tsconfig.json
+++ b/packages/kbn-managed-vscode-config-cli/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-managed-vscode-config/tsconfig.json
+++ b/packages/kbn-managed-vscode-config/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-optimizer-webpack-helpers/tsconfig.json
+++ b/packages/kbn-optimizer-webpack-helpers/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-optimizer/tsconfig.json
+++ b/packages/kbn-optimizer/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-performance-testing-dataset-extractor/tsconfig.json
+++ b/packages/kbn-performance-testing-dataset-extractor/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-plugin-discovery/tsconfig.json
+++ b/packages/kbn-plugin-discovery/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "checkJs": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-react-field/tsconfig.json
+++ b/packages/kbn-react-field/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node",

--- a/packages/kbn-repo-source-classifier-cli/tsconfig.json
+++ b/packages/kbn-repo-source-classifier-cli/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-repo-source-classifier/tsconfig.json
+++ b/packages/kbn-repo-source-classifier/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-rule-data-utils/tsconfig.json
+++ b/packages/kbn-rule-data-utils/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-rule-data-utils/tsconfig.json
+++ b/packages/kbn-rule-data-utils/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-securitysolution-exception-list-components/tsconfig.json
+++ b/packages/kbn-securitysolution-exception-list-components/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target/types",
+    "outDir": "./target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-shared-svg/tsconfig.json
+++ b/packages/kbn-shared-svg/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-shared-ux-utility/tsconfig.json
+++ b/packages/kbn-shared-ux-utility/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/kbn-some-dev-log/tsconfig.json
+++ b/packages/kbn-some-dev-log/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-sort-package-json/tsconfig.json
+++ b/packages/kbn-sort-package-json/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-stdio-dev-helpers/tsconfig.json
+++ b/packages/kbn-stdio-dev-helpers/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-synthetic-package-map/tsconfig.json
+++ b/packages/kbn-synthetic-package-map/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "node"
     ]

--- a/packages/kbn-telemetry-tools/tsconfig.json
+++ b/packages/kbn-telemetry-tools/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test-jest-helpers/tsconfig.json
+++ b/packages/kbn-test-jest-helpers/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": ["jest", "node"]
   },
   "include": [

--- a/packages/kbn-test-jest-helpers/tsconfig.json
+++ b/packages/kbn-test-jest-helpers/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": ["jest", "node"]
   },

--- a/packages/kbn-test-subj-selector/tsconfig.json
+++ b/packages/kbn-test-subj-selector/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test/tsconfig.json
+++ b/packages/kbn-test/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": ["jest", "node"]
   },

--- a/packages/kbn-tooling-log/tsconfig.json
+++ b/packages/kbn-tooling-log/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-type-summarizer-cli/tsconfig.json
+++ b/packages/kbn-type-summarizer-cli/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-type-summarizer-core/tsconfig.json
+++ b/packages/kbn-type-summarizer-core/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-type-summarizer/tsconfig.json
+++ b/packages/kbn-type-summarizer/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-typed-react-router-config/tsconfig.json
+++ b/packages/kbn-typed-react-router-config/tsconfig.json
@@ -5,7 +5,6 @@
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "node",
       "jest"

--- a/packages/kbn-typed-react-router-config/tsconfig.json
+++ b/packages/kbn-typed-react-router-config/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "node",

--- a/packages/kbn-ui-shared-deps-npm/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-npm/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-shared-deps-src/tsconfig.json
+++ b/packages/kbn-ui-shared-deps-src/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "types": [
       "node",
     ]

--- a/packages/kbn-ui-theme/tsconfig.json
+++ b/packages/kbn-ui-theme/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": ["node"]
   },

--- a/packages/kbn-ui-theme/tsconfig.json
+++ b/packages/kbn-ui-theme/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": ["node"]
   },
   "include": [

--- a/packages/kbn-user-profile-components/tsconfig.json
+++ b/packages/kbn-user-profile-components/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-user-profile-components/tsconfig.json
+++ b/packages/kbn-user-profile-components/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-utility-types-jest/tsconfig.json
+++ b/packages/kbn-utility-types-jest/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "jest",
       "node"

--- a/packages/kbn-utility-types-jest/tsconfig.json
+++ b/packages/kbn-utility-types-jest/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "jest",

--- a/packages/kbn-utility-types/tsconfig.json
+++ b/packages/kbn-utility-types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": true,
     "types": [
       "node"
     ]

--- a/packages/kbn-utility-types/tsconfig.json
+++ b/packages/kbn-utility-types/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "./target_types",
+    "outDir": "target_types",
     "stripInternal": true,
     "types": [
       "node"

--- a/packages/kbn-yarn-lock-validator/tsconfig.json
+++ b/packages/kbn-yarn-lock-validator/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/packages/shared-ux/avatar/solution/tsconfig.json
+++ b/packages/shared-ux/avatar/solution/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/avatar/user_profile/impl/tsconfig.json
+++ b/packages/shared-ux/avatar/user_profile/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/button/exit_full_screen/impl/tsconfig.json
+++ b/packages/shared-ux/button/exit_full_screen/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/button/exit_full_screen/mocks/tsconfig.json
+++ b/packages/shared-ux/button/exit_full_screen/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/button/exit_full_screen/types/tsconfig.json
+++ b/packages/shared-ux/button/exit_full_screen/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/button_toolbar/tsconfig.json
+++ b/packages/shared-ux/button_toolbar/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/card/no_data/impl/tsconfig.json
+++ b/packages/shared-ux/card/no_data/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/card/no_data/mocks/tsconfig.json
+++ b/packages/shared-ux/card/no_data/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/card/no_data/types/tsconfig.json
+++ b/packages/shared-ux/card/no_data/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/link/redirect_app/impl/tsconfig.json
+++ b/packages/shared-ux/link/redirect_app/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/link/redirect_app/mocks/tsconfig.json
+++ b/packages/shared-ux/link/redirect_app/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/link/redirect_app/types/tsconfig.json
+++ b/packages/shared-ux/link/redirect_app/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "rxjs",
       "@types/react",

--- a/packages/shared-ux/markdown/impl/tsconfig.json
+++ b/packages/shared-ux/markdown/impl/tsconfig.json
@@ -4,11 +4,10 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",
-      "react", 
+      "react",
       "@kbn/ambient-ui-types",
     ]
   },

--- a/packages/shared-ux/markdown/mocks/tsconfig.json
+++ b/packages/shared-ux/markdown/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "node",
       "react"

--- a/packages/shared-ux/markdown/types/tsconfig.json
+++ b/packages/shared-ux/markdown/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "rxjs",
       "@types/react",

--- a/packages/shared-ux/page/analytics_no_data/impl/tsconfig.json
+++ b/packages/shared-ux/page/analytics_no_data/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/analytics_no_data/mocks/tsconfig.json
+++ b/packages/shared-ux/page/analytics_no_data/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/analytics_no_data/types/tsconfig.json
+++ b/packages/shared-ux/page/analytics_no_data/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/page/kibana_no_data/impl/tsconfig.json
+++ b/packages/shared-ux/page/kibana_no_data/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/kibana_no_data/mocks/tsconfig.json
+++ b/packages/shared-ux/page/kibana_no_data/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/kibana_no_data/types/tsconfig.json
+++ b/packages/shared-ux/page/kibana_no_data/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/page/kibana_template/impl/tsconfig.json
+++ b/packages/shared-ux/page/kibana_template/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/kibana_template/mocks/tsconfig.json
+++ b/packages/shared-ux/page/kibana_template/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/kibana_template/types/tsconfig.json
+++ b/packages/shared-ux/page/kibana_template/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/page/no_data/impl/tsconfig.json
+++ b/packages/shared-ux/page/no_data/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/no_data/mocks/tsconfig.json
+++ b/packages/shared-ux/page/no_data/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/no_data/types/tsconfig.json
+++ b/packages/shared-ux/page/no_data/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/page/no_data_config/impl/tsconfig.json
+++ b/packages/shared-ux/page/no_data_config/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/no_data_config/mocks/tsconfig.json
+++ b/packages/shared-ux/page/no_data_config/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/page/no_data_config/types/tsconfig.json
+++ b/packages/shared-ux/page/no_data_config/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/page/solution_nav/tsconfig.json
+++ b/packages/shared-ux/page/solution_nav/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/prompt/no_data_views/impl/tsconfig.json
+++ b/packages/shared-ux/prompt/no_data_views/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/prompt/no_data_views/mocks/tsconfig.json
+++ b/packages/shared-ux/prompt/no_data_views/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/prompt/no_data_views/types/tsconfig.json
+++ b/packages/shared-ux/prompt/no_data_views/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/router/impl/tsconfig.json
+++ b/packages/shared-ux/router/impl/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/router/mocks/tsconfig.json
+++ b/packages/shared-ux/router/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/router/mocks/tsconfig.json
+++ b/packages/shared-ux/router/mocks/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "rootDir": ".",
     "stripInternal": false,
     "types": [
       "jest",

--- a/packages/shared-ux/router/types/tsconfig.json
+++ b/packages/shared-ux/router/types/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": []
   },
   "include": [

--- a/packages/shared-ux/storybook/config/tsconfig.json
+++ b/packages/shared-ux/storybook/config/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",

--- a/packages/shared-ux/storybook/mock/tsconfig.json
+++ b/packages/shared-ux/storybook/mock/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "target_types",
-    "stripInternal": false,
     "types": [
       "jest",
       "node",


### PR DESCRIPTION
This PR makes consistent the usage of `stripInternal` across packages and also removes some wrongly used `rootDir` on those.