### PR TITLE
[APM] Metadata API does not filter by environment

### DIFF
--- a/x-pack/plugins/apm/public/components/app/metrics_details/service_node_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/metrics_details/service_node_metrics/index.tsx
@@ -93,13 +93,14 @@ export function ServiceNodeMetrics({ serviceNodeName }: Props) {
                 kuery,
                 start,
                 end,
+                environment,
               },
             },
           }
         );
       }
     },
-    [kuery, serviceName, serviceNodeName, start, end]
+    [kuery, serviceName, serviceNodeName, start, end, environment]
   );
 
   const { docLinks } = useApmPluginContext().core;

--- a/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
@@ -20,7 +20,6 @@ import {
   environmentQuery,
   serviceNodeNameQuery,
 } from '../../../common/utils/environment_query';
-import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
 export async function getServiceNodeMetadata({
@@ -30,6 +29,7 @@ export async function getServiceNodeMetadata({
   apmEventClient,
   start,
   end,
+  environment,
 }: {
   kuery: string;
   serviceName: string;
@@ -37,6 +37,7 @@ export async function getServiceNodeMetadata({
   apmEventClient: APMEventClient;
   start: number;
   end: number;
+  environment: string;
 }) {
   const params = {
     apm: {
@@ -50,7 +51,7 @@ export async function getServiceNodeMetadata({
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             ...rangeQuery(start, end),
-            ...environmentQuery(ENVIRONMENT_ALL.value),
+            ...environmentQuery(environment),
             ...kqlQuery(kuery),
             ...serviceNodeNameQuery(serviceNodeName),
           ],

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -426,7 +426,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
       serviceName: t.string,
       serviceNodeName: t.string,
     }),
-    query: t.intersection([kueryRt, rangeRt]),
+    query: t.intersection([kueryRt, rangeRt, environmentRt]),
   }),
   options: { tags: ['access:apm'] },
   handler: async (
@@ -435,7 +435,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
     const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName, serviceNodeName } = params.path;
-    const { kuery, start, end } = params.query;
+    const { kuery, start, end, environment } = params.query;
 
     return getServiceNodeMetadata({
       kuery,
@@ -444,6 +444,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
       serviceNodeName,
       start,
       end,
+      environment,
     });
   },
 });

--- a/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
@@ -28,6 +28,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           start: new Date(start).toISOString(),
           end: new Date(end).toISOString(),
           kuery: '',
+          environment: 'production',
         },
       },
     });


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/144468

Now it does 😎

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->