### PR TITLE
[LaunchDarkly] Match deployment metadata format to Cloud UI convention

### DIFF
--- a/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.test.ts
@@ -43,12 +43,12 @@ describe('MetadataService', () => {
     });
 
     test(
-      'emits in_trial when trial_end_date is provided',
+      'emits inTrial when trialEndDate is provided',
       fakeSchedulers(async (advance) => {
         const initialMetadata = {
           userId: 'fake-user-id',
           kibanaVersion: 'version',
-          trial_end_date: new Date(0).toISOString(),
+          trialEndDate: new Date(0).toISOString(),
         };
         metadataService.setup(initialMetadata);
 
@@ -62,7 +62,7 @@ describe('MetadataService', () => {
         await new Promise((resolve) => process.nextTick(resolve)); // The timer triggers a promise, so we need to skip to the next tick
         await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual({
           ...initialMetadata,
-          in_trial: false,
+          inTrial: false,
         });
       })
     );
@@ -75,9 +75,9 @@ describe('MetadataService', () => {
     });
 
     test(
-      'emits has_data after resolving the `hasUserDataView`',
+      'emits hasData after resolving the `hasUserDataView`',
       fakeSchedulers(async (advance) => {
-        metadataService.start({ hasDataFetcher: async () => ({ has_data: true }) });
+        metadataService.start({ hasDataFetcher: async () => ({ hasData: true }) });
 
         // Still equals initialMetadata
         await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual(
@@ -89,7 +89,7 @@ describe('MetadataService', () => {
         await new Promise((resolve) => process.nextTick(resolve)); // The timer triggers a promise, so we need to skip to the next tick
         await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual({
           ...initialMetadata,
-          has_data: true,
+          hasData: true,
         });
       })
     );

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
@@ -48,13 +48,13 @@ export class MetadataService {
   public setup(initialUserMetadata: UserMetadata) {
     this._userMetadata$.next(initialUserMetadata);
 
-    // Calculate `in_trial` based on the `trial_end_date`.
+    // Calculate `inTrial` based on the `trialEndDate`.
     // Elastic Cloud allows customers to end their trials earlier or even extend it in some cases, but this is a good compromise for now.
     const trialEndDate = initialUserMetadata.trialEndDate;
     if (trialEndDate) {
       this.scheduleUntil(
         () => ({ inTrial: Date.now() <= new Date(trialEndDate).getTime() }),
-        // Stop recalculating in_trial when the user is no-longer in trial
+        // Stop recalculating inTrial when the user is no-longer in trial
         (metadata) => metadata.inTrial === false
       );
     }

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.ts
@@ -21,18 +21,18 @@ import {
 import { type Duration } from 'moment';
 
 export interface MetadataServiceStartContract {
-  hasDataFetcher: () => Promise<{ has_data: boolean }>;
+  hasDataFetcher: () => Promise<{ hasData: boolean }>;
 }
 
 export interface UserMetadata extends Record<string, string | boolean | number | undefined> {
   // Static values
   userId: string;
   kibanaVersion: string;
-  trial_end_date?: string;
-  is_elastic_staff_owned?: boolean;
+  trialEndDate?: string;
+  isElasticStaff?: boolean;
   // Dynamic/calculated values
-  in_trial?: boolean;
-  has_data?: boolean;
+  inTrial?: boolean;
+  hasData?: boolean;
 }
 
 export interface MetadataServiceConfig {
@@ -50,12 +50,12 @@ export class MetadataService {
 
     // Calculate `in_trial` based on the `trial_end_date`.
     // Elastic Cloud allows customers to end their trials earlier or even extend it in some cases, but this is a good compromise for now.
-    const trialEndDate = initialUserMetadata.trial_end_date;
+    const trialEndDate = initialUserMetadata.trialEndDate;
     if (trialEndDate) {
       this.scheduleUntil(
-        () => ({ in_trial: Date.now() <= new Date(trialEndDate).getTime() }),
+        () => ({ inTrial: Date.now() <= new Date(trialEndDate).getTime() }),
         // Stop recalculating in_trial when the user is no-longer in trial
-        (metadata) => metadata.in_trial === false
+        (metadata) => metadata.inTrial === false
       );
     }
   }
@@ -64,7 +64,7 @@ export class MetadataService {
     return this._userMetadata$.pipe(
       filter(Boolean), // Ensure we don't return undefined
       debounceTime(100), // Swallows multiple emissions that may occur during bootstrap
-      distinct((meta) => [meta.in_trial, meta.has_data].join('-')), // Checks if any of the dynamic fields have changed
+      distinct((meta) => [meta.inTrial, meta.hasData].join('-')), // Checks if any of the dynamic fields have changed
       shareReplay(1)
     );
   }
@@ -76,7 +76,7 @@ export class MetadataService {
     this.scheduleUntil(
       async () => hasDataFetcher(),
       // Stop checking the moment the user has any data
-      (metadata) => metadata.has_data === true
+      (metadata) => metadata.hasData === true
     );
   }
 

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.test.ts
@@ -128,9 +128,9 @@ describe('Cloud Experiments public plugin', () => {
         });
 
         expect(metadataServiceSetupSpy).toHaveBeenCalledWith({
-          is_elastic_staff_owned: true,
+          isElasticStaff: true,
           kibanaVersion: 'version',
-          trial_end_date: '2020-10-01T14:13:12.000Z',
+          trialEndDate: '2020-10-01T14:13:12.000Z',
           userId: '1c2412b751f056aef6e340efa5637d137442d489a4b1e3117071e7c87f8523f2',
         });
       });
@@ -170,7 +170,7 @@ describe('Cloud Experiments public plugin', () => {
       );
     });
 
-    test('triggers a userMetadataUpdate for `has_data`', async () => {
+    test('triggers a userMetadataUpdate for `hasData`', async () => {
       plugin.setup(coreMock.createSetup(), {
         cloud: { ...cloudMock.createSetup(), isCloudEnabled: true },
       });
@@ -184,7 +184,7 @@ describe('Cloud Experiments public plugin', () => {
       // For some reason, fakeSchedulers is not working on browser-side tests :shrug:
       expect(launchDarklyInstanceMock.updateUserMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
-          has_data: true,
+          hasData: true,
         })
       );
     });

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.ts
@@ -82,8 +82,8 @@ export class CloudExperimentsPlugin
       this.metadataService.setup({
         userId: sha256(deps.cloud.cloudId),
         kibanaVersion: this.kibanaVersion,
-        trial_end_date: deps.cloud.trialEndDate?.toISOString(),
-        is_elastic_staff_owned: deps.cloud.isElasticStaffOwned,
+        trialEndDate: deps.cloud.trialEndDate?.toISOString(),
+        isElasticStaff: deps.cloud.isElasticStaffOwned,
       });
     }
   }
@@ -98,7 +98,7 @@ export class CloudExperimentsPlugin
   ): CloudExperimentsPluginStart {
     if (cloud.isCloudEnabled) {
       this.metadataService.start({
-        hasDataFetcher: async () => ({ has_data: await dataViews.hasData.hasUserDataView() }),
+        hasDataFetcher: async () => ({ hasData: await dataViews.hasData.hasUserDataView() }),
       });
 
       // We only subscribe to the user metadata updates if Cloud is enabled.

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.test.ts
@@ -118,8 +118,8 @@ describe('Cloud Experiments server plugin', () => {
         expect(launchDarklyInstanceMock.updateUserMetadata).toHaveBeenCalledWith({
           userId: '1c2412b751f056aef6e340efa5637d137442d489a4b1e3117071e7c87f8523f2',
           kibanaVersion: coreMock.createPluginInitializerContext().env.packageInfo.version,
-          is_elastic_staff_owned: true,
-          trial_end_date: expect.any(String),
+          isElasticStaff: true,
+          trialEndDate: expect.any(String),
         });
       })
     );
@@ -165,7 +165,7 @@ describe('Cloud Experiments server plugin', () => {
       );
     });
 
-    test('triggers a userMetadataUpdate for `has_data`', async () => {
+    test('triggers a userMetadataUpdate for `hasData`', async () => {
       plugin.setup(coreMock.createSetup(), {
         cloud: { ...cloudMock.createSetup(), isCloudEnabled: true },
       });
@@ -177,7 +177,7 @@ describe('Cloud Experiments server plugin', () => {
       await new Promise((resolve) => setTimeout(resolve, 200)); // Waiting for scheduler and debounceTime to complete (don't know why fakeScheduler didn't work here).
       expect(launchDarklyInstanceMock.updateUserMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
-          has_data: true,
+          hasData: true,
         })
       );
     });

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.ts
@@ -89,8 +89,8 @@ export class CloudExperimentsPlugin
         // We use the Cloud ID as the userId in the Cloud Experiments
         userId: createSHA256Hash(deps.cloud.cloudId),
         kibanaVersion: this.initializerContext.env.packageInfo.version,
-        trial_end_date: deps.cloud.trialEndDate?.toISOString(),
-        is_elastic_staff_owned: deps.cloud.isElasticStaffOwned,
+        trialEndDate: deps.cloud.trialEndDate?.toISOString(),
+        isElasticStaff: deps.cloud.isElasticStaffOwned,
       });
 
       // We only subscribe to the user metadata updates if Cloud is enabled.
@@ -146,7 +146,7 @@ export class CloudExperimentsPlugin
   private async addHasDataMetadata(
     core: CoreStart,
     dataViews: DataViewsServerPluginStart
-  ): Promise<{ has_data: boolean }> {
+  ): Promise<{ hasData: boolean }> {
     const dataViewsService = await dataViews.dataViewsServiceFactory(
       core.savedObjects.createInternalRepository(),
       core.elasticsearch.client.asInternalUser,
@@ -154,7 +154,7 @@ export class CloudExperimentsPlugin
       true // Ignore capabilities checks
     );
     return {
-      has_data: await dataViewsService.hasUserDataView(),
+      hasData: await dataViewsService.hasUserDataView(),
     };
   }
 }


### PR DESCRIPTION
## Summary

@osmanis requested to change the name of the attributes sent to LaunchDarkly so they match the existing ones already reported by Cloud UI.

cc @arisonl 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
