### PR TITLE
[Security Solution] Fix success bulk edit toast message

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -289,6 +289,32 @@ describe('Detection rules, bulk edit', () => {
       checkTagsInTagsFilter(resultingTagsInFilter);
     });
 
+    it('Display success toast after adding tags', () => {
+      const tagsToBeAdded = ['tag-to-add-1', 'tag-to-add-2'];
+
+      // check if only pre-populated tags exist in the tags filter
+      checkTagsInTagsFilter(prePopulatedTags);
+
+      cy.get(EUI_FILTER_SELECT_ITEM)
+        .should('have.length', prePopulatedTags.length)
+        .each(($el, index) => {
+          cy.wrap($el).should('have.text', prePopulatedTags[index]);
+        });
+
+      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+
+      // open add tags form and add 2 new tags
+      openBulkEditAddTagsForm();
+      typeTags(tagsToBeAdded);
+      submitBulkEditForm();
+      waitForBulkEditActionToFinish({ rulesCount: expectedNumberOfCustomRulesToBeEdited });
+
+      cy.get(TOASTER_BODY).should(
+        'have.text',
+        `You've successfully updated ${expectedNumberOfCustomRulesToBeEdited} rules`
+      );
+    });
+
     it('Overwrite tags in custom rules', () => {
       const tagsToOverwrite = ['overwrite-tag-1'];
 
@@ -390,6 +416,25 @@ describe('Detection rules, bulk edit', () => {
       // check if rule has been updated
       goToTheRuleDetailsOf(RULE_NAME);
       hasIndexPatterns(resultingIndexPatterns.join(''));
+    });
+
+    it('Display success toast after editing the index pattern', () => {
+      const indexPattersToBeAdded = ['index-to-add-1-*', 'index-to-add-2-*'];
+
+      // select only rules that are not ML
+      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      unselectRuleByName(getMachineLearningRule().name);
+
+      openBulkEditAddIndexPatternsForm();
+      typeIndexPatterns(indexPattersToBeAdded);
+      submitBulkEditForm();
+
+      waitForBulkEditActionToFinish({ rulesCount: expectedNumberOfNotMLRules });
+
+      cy.get(TOASTER_BODY).should(
+        'have.text',
+        `You've successfully updated ${expectedNumberOfNotMLRules} rules. If you did not select to apply changes to rules using Kibana data views, those rules were not updated and will continue using data views.`
+      );
     });
 
     it('Overwrite index patterns in custom rules', () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/translations.ts
@@ -6,7 +6,11 @@
  */
 
 import type { HTTPError } from '../../../../../common/detection_engine/types';
-import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
+import type { BulkActionEditPayload } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
+import {
+  BulkActionEditType,
+  BulkActionType,
+} from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import * as i18n from '../../../../detections/pages/detection_engine/rules/translations';
 import type { BulkActionResponse, BulkActionSummary } from '../../api/api';
 
@@ -32,7 +36,10 @@ export function summarizeBulkSuccess(action: BulkActionType): string {
   }
 }
 
-export function explainBulkSuccess(action: BulkActionType, summary: BulkActionSummary): string {
+export function explainBulkSuccess(
+  action: Exclude<BulkActionType, BulkActionType.edit>,
+  summary: BulkActionSummary
+): string {
   switch (action) {
     case BulkActionType.export:
       return getExportSuccessToastMessage(summary.succeeded, summary.total);
@@ -48,10 +55,27 @@ export function explainBulkSuccess(action: BulkActionType, summary: BulkActionSu
 
     case BulkActionType.disable:
       return i18n.RULES_BULK_DISABLE_SUCCESS_DESCRIPTION(summary.succeeded);
-
-    case BulkActionType.edit:
-      return i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(summary.succeeded);
   }
+}
+
+export function explainBulkEditSuccess(
+  editPayload: BulkActionEditPayload[],
+  summary: BulkActionSummary
+): string {
+  if (
+    editPayload.some(
+      (x) =>
+        x.type === BulkActionEditType.add_index_patterns ||
+        x.type === BulkActionEditType.set_index_patterns ||
+        x.type === BulkActionEditType.delete_index_patterns
+    )
+  ) {
+    return `${i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(summary.succeeded)}. ${
+      i18n.RULES_BULK_EDIT_SUCCESS_INDEX_EDIT_DESCRIPTION
+    }`;
+  }
+
+  return i18n.RULES_BULK_EDIT_SUCCESS_DESCRIPTION(summary.succeeded);
 }
 
 export function summarizeBulkError(action: BulkActionType): string {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_bulk_export.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_bulk_export.ts
@@ -7,21 +7,15 @@
 
 import { useCallback } from 'react';
 import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
-import type { UseAppToasts } from '../../../../common/hooks/use_app_toasts';
-import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
-import { downloadBlob } from '../../../../common/utils/download_blob';
-import * as i18n from '../../../../detections/pages/detection_engine/rules/translations';
 import { useRulesTableContextOptional } from '../../../rule_management_ui/components/rules_table/rules_table/rules_table_context';
-import { getExportedRulesCounts } from '../../../rule_management_ui/components/rules_table/helpers';
 import { useBulkExportMutation } from '../../api/hooks/use_bulk_export_mutation';
-import { showBulkErrorToast } from './show_bulk_error_toast';
-import { showBulkSuccessToast } from './show_bulk_success_toast';
+import { useShowBulkErrorToast } from './use_show_bulk_error_toast';
 import type { QueryOrIds } from '../../api/api';
 import { useGuessRuleIdsForBulkAction } from './use_guess_rule_ids_for_bulk_action';
 
 export function useBulkExport() {
-  const toasts = useAppToasts();
   const { mutateAsync } = useBulkExportMutation();
+  const showBulkErrorToast = useShowBulkErrorToast();
   const guessRuleIdsForBulkAction = useGuessRuleIdsForBulkAction();
   const rulesTableContext = useRulesTableContextOptional();
   const setLoadingRules = rulesTableContext?.actions.setLoadingRules;
@@ -35,35 +29,13 @@ export function useBulkExport() {
         });
         return await mutateAsync(queryOrIds);
       } catch (error) {
-        showBulkErrorToast(toasts, BulkActionType.export, error);
+        showBulkErrorToast(BulkActionType.export, error);
       } finally {
         setLoadingRules?.({ ids: [], action: null });
       }
     },
-    [guessRuleIdsForBulkAction, setLoadingRules, mutateAsync, toasts]
+    [guessRuleIdsForBulkAction, setLoadingRules, mutateAsync, showBulkErrorToast]
   );
 
   return { bulkExport };
-}
-
-/**
- * downloads exported rules, received from export action
- * @param params.response - Blob results with exported rules
- * @param params.toasts - {@link UseAppToasts} toasts service
- * @param params.onSuccess - {@link OnActionSuccessCallback} optional toast to display when action successful
- * @param params.onError - {@link OnActionErrorCallback} optional toast to display when action failed
- */
-export async function downloadExportedRules({
-  response,
-  toasts,
-}: {
-  response: Blob;
-  toasts: UseAppToasts;
-}) {
-  try {
-    downloadBlob(response, `${i18n.EXPORT_FILENAME}.ndjson`);
-    showBulkSuccessToast(toasts, BulkActionType.export, await getExportedRulesCounts(response));
-  } catch (error) {
-    showBulkErrorToast(toasts, BulkActionType.export, error);
-  }
 }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_bulk_export.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_bulk_export.ts
@@ -29,7 +29,7 @@ export function useBulkExport() {
         });
         return await mutateAsync(queryOrIds);
       } catch (error) {
-        showBulkErrorToast(BulkActionType.export, error);
+        showBulkErrorToast({ actionType: BulkActionType.export, error });
       } finally {
         setLoadingRules?.({ ids: [], action: null });
       }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
@@ -26,7 +26,10 @@ export function useDownloadExportedRules() {
     async (response: Blob) => {
       try {
         downloadBlob(response, DEFAULT_EXPORT_FILENAME);
-        showBulkSuccessToast(BulkActionType.export, await getExportedRulesCounts(response));
+        showBulkSuccessToast({
+          actionType: BulkActionType.export,
+          summary: await getExportedRulesCounts(response),
+        });
       } catch (error) {
         showBulkErrorToast(BulkActionType.export, error);
       }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
@@ -31,7 +31,7 @@ export function useDownloadExportedRules() {
           summary: await getExportedRulesCounts(response),
         });
       } catch (error) {
-        showBulkErrorToast(BulkActionType.export, error);
+        showBulkErrorToast({ actionType: BulkActionType.export, error });
       }
     },
     [showBulkSuccessToast, showBulkErrorToast]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
+import { downloadBlob } from '../../../../common/utils/download_blob';
+import * as i18n from '../../../../detections/pages/detection_engine/rules/translations';
+import { getExportedRulesCounts } from '../../../rule_management_ui/components/rules_table/helpers';
+import { useShowBulkErrorToast } from './use_show_bulk_error_toast';
+import { useShowBulkSuccessToast } from './use_show_bulk_success_toast';
+
+const DEFAULT_EXPORT_FILENAME = `${i18n.EXPORT_FILENAME}.ndjson`;
+
+/**
+ * downloads exported rules, received from export action
+ */
+export function useDownloadExportedRules() {
+  const showBulkSuccessToast = useShowBulkSuccessToast();
+  const showBulkErrorToast = useShowBulkErrorToast();
+
+  return useCallback(
+    async (response: Blob) => {
+      try {
+        downloadBlob(response, DEFAULT_EXPORT_FILENAME);
+        showBulkSuccessToast(BulkActionType.export, await getExportedRulesCounts(response));
+      } catch (error) {
+        showBulkErrorToast(BulkActionType.export, error);
+      }
+    },
+    [showBulkSuccessToast, showBulkErrorToast]
+  );
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_execute_bulk_action.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_execute_bulk_action.ts
@@ -54,7 +54,12 @@ export const useExecuteBulkAction = (options?: UseExecuteBulkActionOptions) => {
         sendTelemetry(bulkAction.type, response);
 
         if (!options?.suppressSuccessToast) {
-          showBulkSuccessToast(bulkAction.type, response.attributes.summary);
+          showBulkSuccessToast({
+            actionType: bulkAction.type,
+            summary: response.attributes.summary,
+            editPayload:
+              bulkAction.type === BulkActionType.edit ? bulkAction.editPayload : undefined,
+          });
         }
 
         return response;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_execute_bulk_action.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_execute_bulk_action.ts
@@ -64,7 +64,7 @@ export const useExecuteBulkAction = (options?: UseExecuteBulkActionOptions) => {
 
         return response;
       } catch (error) {
-        showBulkErrorToast(bulkAction.type, error);
+        showBulkErrorToast({ actionType: bulkAction.type, error });
       } finally {
         setLoadingRules?.({ ids: [], action: null });
       }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_error_toast.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_error_toast.ts
@@ -5,20 +5,24 @@
  * 2.0.
  */
 
+import { useCallback } from 'react';
 import type { HTTPError } from '../../../../../common/detection_engine/types';
-import type { UseAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import { explainBulkError, summarizeBulkError } from './translations';
 
-export function showBulkErrorToast(
-  toasts: UseAppToasts,
-  action: BulkActionType,
-  error: HTTPError
-): void {
-  toasts.addError(populateErrorStack(error), {
-    title: summarizeBulkError(action),
-    toastMessage: explainBulkError(action, error),
-  });
+export function useShowBulkErrorToast() {
+  const toasts = useAppToasts();
+
+  return useCallback(
+    (action: BulkActionType, error: HTTPError) => {
+      toasts.addError(populateErrorStack(error), {
+        title: summarizeBulkError(action),
+        toastMessage: explainBulkError(action, error),
+      });
+    },
+    [toasts]
+  );
 }
 
 function populateErrorStack(error: HTTPError): HTTPError {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_error_toast.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_error_toast.ts
@@ -11,14 +11,19 @@ import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import { explainBulkError, summarizeBulkError } from './translations';
 
+interface ShowBulkErrorToastProps {
+  actionType: BulkActionType;
+  error: HTTPError;
+}
+
 export function useShowBulkErrorToast() {
   const toasts = useAppToasts();
 
   return useCallback(
-    (action: BulkActionType, error: HTTPError) => {
+    ({ actionType, error }: ShowBulkErrorToastProps) => {
       toasts.addError(populateErrorStack(error), {
-        title: summarizeBulkError(action),
-        toastMessage: explainBulkError(action, error),
+        title: summarizeBulkError(actionType),
+        toastMessage: explainBulkError(actionType, error),
       });
     },
     [toasts]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_success_toast.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_success_toast.ts
@@ -8,17 +8,29 @@
 import { useCallback } from 'react';
 import type { BulkActionSummary } from '..';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
-import type { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
-import { explainBulkSuccess, summarizeBulkSuccess } from './translations';
+import type { BulkActionEditPayload } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
+import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
+import { explainBulkEditSuccess, explainBulkSuccess, summarizeBulkSuccess } from './translations';
+
+interface ShowBulkSuccessToastProps {
+  actionType: BulkActionType;
+  summary: BulkActionSummary;
+  editPayload?: BulkActionEditPayload[];
+}
 
 export function useShowBulkSuccessToast() {
   const toasts = useAppToasts();
 
   return useCallback(
-    (action: BulkActionType, summary: BulkActionSummary) => {
+    ({ actionType, summary, editPayload }: ShowBulkSuccessToastProps) => {
+      const text =
+        actionType === BulkActionType.edit
+          ? explainBulkEditSuccess(editPayload ?? [], summary)
+          : explainBulkSuccess(actionType, summary);
+
       toasts.addSuccess({
-        title: summarizeBulkSuccess(action),
-        text: explainBulkSuccess(action, summary),
+        title: summarizeBulkSuccess(actionType),
+        text,
       });
     },
     [toasts]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_success_toast.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/bulk_actions/use_show_bulk_success_toast.ts
@@ -5,18 +5,22 @@
  * 2.0.
  */
 
+import { useCallback } from 'react';
 import type { BulkActionSummary } from '..';
-import type { UseAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import { explainBulkSuccess, summarizeBulkSuccess } from './translations';
 
-export function showBulkSuccessToast(
-  toasts: UseAppToasts,
-  action: BulkActionType,
-  summary: BulkActionSummary
-): void {
-  toasts.addSuccess({
-    title: summarizeBulkSuccess(action),
-    text: explainBulkSuccess(action, summary),
-  });
+export function useShowBulkSuccessToast() {
+  const toasts = useAppToasts();
+
+  return useCallback(
+    (action: BulkActionType, summary: BulkActionSummary) => {
+      toasts.addSuccess({
+        title: summarizeBulkSuccess(action),
+        text: explainBulkSuccess(action, summary),
+      });
+    },
+    [toasts]
+  );
 }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
@@ -24,11 +24,9 @@ import { useStartTransaction } from '../../../../../common/lib/apm/use_start_tra
 import { canEditRuleWithActions } from '../../../../../common/utils/privileges';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import * as detectionI18n from '../../../../../detections/pages/detection_engine/translations';
-import {
-  downloadExportedRules,
-  useBulkExport,
-} from '../../../../rule_management/logic/bulk_actions/use_bulk_export';
+import { useBulkExport } from '../../../../rule_management/logic/bulk_actions/use_bulk_export';
 import { useExecuteBulkAction } from '../../../../rule_management/logic/bulk_actions/use_execute_bulk_action';
+import { useDownloadExportedRules } from '../../../../rule_management/logic/bulk_actions/use_download_exported_rules';
 import type { FilterOptions } from '../../../../rule_management/logic/types';
 import { convertRulesFilterToKQL } from '../../../../rule_management/logic/utils';
 import { getExportedRulesDetails } from '../helpers';
@@ -69,6 +67,7 @@ export const useBulkActions = ({
   const { startTransaction } = useStartTransaction();
   const { executeBulkAction } = useExecuteBulkAction();
   const { bulkExport } = useBulkExport();
+  const downloadExportedRules = useDownloadExportedRules();
 
   const {
     state: { isAllSelected, rules, loadingRuleIds, selectedRuleIds },
@@ -176,7 +175,7 @@ export const useBulkActions = ({
           return;
         }
 
-        await downloadExportedRules({ response, toasts });
+        await downloadExportedRules(response);
       };
 
       const handleBulkEdit = (bulkEditActionType: BulkActionEditType) => async () => {
@@ -461,6 +460,7 @@ export const useBulkActions = ({
       executeBulkActionsDryRun,
       filterOptions,
       completeBulkEditForm,
+      downloadExportedRules,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_rules_table_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_rules_table_actions.tsx
@@ -9,30 +9,27 @@ import type { DefaultItemAction } from '@elastic/eui';
 import { EuiToolTip } from '@elastic/eui';
 import React from 'react';
 import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
-import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { SINGLE_RULE_ACTIONS } from '../../../../common/lib/apm/user_actions';
 import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 import { useKibana } from '../../../../common/lib/kibana';
 import { canEditRuleWithActions } from '../../../../common/utils/privileges';
 import * as i18n from '../../../../detections/pages/detection_engine/rules/translations';
 import type { Rule } from '../../../rule_management/logic';
-import {
-  downloadExportedRules,
-  useBulkExport,
-} from '../../../rule_management/logic/bulk_actions/use_bulk_export';
+import { useBulkExport } from '../../../rule_management/logic/bulk_actions/use_bulk_export';
 import {
   goToRuleEditPage,
   useExecuteBulkAction,
 } from '../../../rule_management/logic/bulk_actions/use_execute_bulk_action';
+import { useDownloadExportedRules } from '../../../rule_management/logic/bulk_actions/use_download_exported_rules';
 import { useHasActionsPrivileges } from './use_has_actions_privileges';
 
 export const useRulesTableActions = (): Array<DefaultItemAction<Rule>> => {
   const { navigateToApp } = useKibana().services.application;
   const hasActionsPrivileges = useHasActionsPrivileges();
-  const toasts = useAppToasts();
   const { startTransaction } = useStartTransaction();
   const { executeBulkAction } = useExecuteBulkAction();
   const { bulkExport } = useBulkExport();
+  const downloadExportedRules = useDownloadExportedRules();
 
   return [
     {
@@ -86,10 +83,7 @@ export const useRulesTableActions = (): Array<DefaultItemAction<Rule>> => {
         startTransaction({ name: SINGLE_RULE_ACTIONS.EXPORT });
         const response = await bulkExport({ ids: [rule.id] });
         if (response) {
-          await downloadExportedRules({
-            response,
-            toasts,
-          });
+          await downloadExportedRules(response);
         }
       },
       enabled: (rule: Rule) => !rule.immutable,

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
@@ -17,21 +17,18 @@ import styled from 'styled-components';
 import { APP_UI_ID, SecurityPageName } from '../../../../../common/constants';
 import { BulkActionType } from '../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import { getRulesUrl } from '../../../../common/components/link_to/redirect_to_detection_engine';
-import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useBoolState } from '../../../../common/hooks/use_bool_state';
 import { SINGLE_RULE_ACTIONS } from '../../../../common/lib/apm/user_actions';
 import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 import { useKibana } from '../../../../common/lib/kibana';
 import { canEditRuleWithActions } from '../../../../common/utils/privileges';
 import type { Rule } from '../../../../detection_engine/rule_management/logic';
-import {
-  downloadExportedRules,
-  useBulkExport,
-} from '../../../../detection_engine/rule_management/logic/bulk_actions/use_bulk_export';
+import { useBulkExport } from '../../../../detection_engine/rule_management/logic/bulk_actions/use_bulk_export';
 import {
   goToRuleEditPage,
   useExecuteBulkAction,
 } from '../../../../detection_engine/rule_management/logic/bulk_actions/use_execute_bulk_action';
+import { useDownloadExportedRules } from '../../../../detection_engine/rule_management/logic/bulk_actions/use_download_exported_rules';
 import * as i18nActions from '../../../pages/detection_engine/rules/translations';
 import * as i18n from './translations';
 
@@ -62,10 +59,10 @@ const RuleActionsOverflowComponent = ({
 }: RuleActionsOverflowComponentProps) => {
   const [isPopoverOpen, , closePopover, togglePopover] = useBoolState();
   const { navigateToApp } = useKibana().services.application;
-  const toasts = useAppToasts();
   const { startTransaction } = useStartTransaction();
   const { executeBulkAction } = useExecuteBulkAction({ suppressSuccessToast: true });
   const { bulkExport } = useBulkExport();
+  const downloadExportedRules = useDownloadExportedRules();
 
   const onRuleDeletedCallback = useCallback(() => {
     navigateToApp(APP_UI_ID, {
@@ -117,10 +114,7 @@ const RuleActionsOverflowComponent = ({
                 closePopover();
                 const response = await bulkExport({ ids: [rule.id] });
                 if (response) {
-                  await downloadExportedRules({
-                    response,
-                    toasts,
-                  });
+                  await downloadExportedRules(response);
                 }
               }}
             >
@@ -155,8 +149,8 @@ const RuleActionsOverflowComponent = ({
       onRuleDeletedCallback,
       rule,
       startTransaction,
-      toasts,
       userHasPermissions,
+      downloadExportedRules,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -1071,9 +1071,17 @@ export const RULES_BULK_EDIT_SUCCESS_DESCRIPTION = (rulesCount: number) =>
     {
       values: { rulesCount },
       defaultMessage:
-        "You've successfully updated {rulesCount, plural, =1 {# rule} other {# rules}}. If you did not select to apply changes to rules using Kibana data views, those rules were not updated and will continue using data views.",
+        "You've successfully updated {rulesCount, plural, =1 {# rule} other {# rules}}",
     }
   );
+
+export const RULES_BULK_EDIT_SUCCESS_INDEX_EDIT_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.successIndexEditToastDescription',
+  {
+    defaultMessage:
+      'If you did not select to apply changes to rules using Kibana data views, those rules were not updated and will continue using data views.',
+  }
+);
 
 export const RULES_BULK_EDIT_FAILURE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.bulkActions.edit.errorToastTitle',


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/139897

## Summary

Fixes bulk edit success toast's message. Displays `You've successfully updated X rules. If you did not select to apply changes to rules using Kibana data views, those rules were not updated and will continue using data views.` when rule's index patterns were edited and `You've successfully updated X rules.` in the other cases.

*Before:*

https://user-images.githubusercontent.com/3775283/199676233-d3287d97-8e66-4938-bc80-7c643ca0e0ad.mov

*After:*

https://user-images.githubusercontent.com/3775283/199676250-0814ea26-a9bb-4402-a8db-8c2f0e394563.mov


### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
