### PR TITLE
[8.5] [Synthetics Telemetry] Make consistent use of stackVersion (#143924)

### DIFF
--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/adapters/framework/adapter_types.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/adapters/framework/adapter_types.ts
@@ -57,7 +57,7 @@ export interface UptimeServerSetup {
   savedObjectsClient?: SavedObjectsClientContract;
   authSavedObjectsClient?: SavedObjectsClientContract;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
-  kibanaVersion: string;
+  stackVersion: string;
   logger: Logger;
   telemetry: TelemetryEventsSender;
   uptimeEsClient: UptimeESClient;

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/telemetry/types.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/telemetry/types.ts
@@ -41,7 +41,7 @@ export interface MonitorErrorEvent {
   code?: string;
   status?: number;
   url?: string;
-  kibanaVersion: string;
+  stackVersion: string;
 }
 
 export interface MonitorUpdateTelemetryChannelEvents {

--- a/x-pack/plugins/synthetics/server/plugin.ts
+++ b/x-pack/plugins/synthetics/server/plugin.ts
@@ -81,7 +81,7 @@ export class Plugin implements PluginType {
       config,
       router: core.http.createRouter(),
       cloud: plugins.cloud,
-      kibanaVersion: this.initContext.env.packageInfo.version,
+      stackVersion: this.initContext.env.packageInfo.version,
       basePath: core.http.basePath,
       logger: this.logger,
       telemetry: this.telemetryEventsSender,

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -199,7 +199,7 @@ export const syncNewMonitor = async ({
         errors: syncErrors,
         monitor: monitorSavedObject,
         isInlineScript: Boolean((normalizedMonitor as MonitorFields)[ConfigKey.SOURCE_INLINE]),
-        kibanaVersion: server.kibanaVersion,
+        stackVersion: server.stackVersion,
       })
     );
 

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/add_monitor_bulk.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/add_monitor_bulk.ts
@@ -138,7 +138,7 @@ const sendNewMonitorTelemetry = (
         errors,
         monitor,
         isInlineScript: Boolean((monitor.attributes as MonitorFields)[ConfigKey.SOURCE_INLINE]),
-        kibanaVersion: server.kibanaVersion,
+        stackVersion: server.stackVersion,
       })
     );
   }

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
@@ -28,7 +28,7 @@ export const deleteMonitorBulk = async ({
   syntheticsMonitorClient: SyntheticsMonitorClient;
   request: KibanaRequest;
 }) => {
-  const { logger, telemetry, kibanaVersion } = server;
+  const { logger, telemetry, stackVersion } = server;
   const spaceId = server.spaces.spacesService.getSpaceId(request);
 
   try {
@@ -56,7 +56,7 @@ export const deleteMonitorBulk = async ({
         telemetry,
         formatTelemetryDeleteEvent(
           monitor,
-          kibanaVersion,
+          stackVersion,
           new Date().toISOString(),
           Boolean((monitor.attributes as MonitorFields)[ConfigKey.SOURCE_INLINE]),
           errors

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/edit_monitor_bulk.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/edit_monitor_bulk.ts
@@ -106,7 +106,7 @@ export const syncEditedMonitorBulk = async ({
         formatTelemetryUpdateEvent(
           editedMonitorSavedObject as SavedObjectsUpdateResponse<EncryptedSyntheticsMonitor>,
           previousMonitor,
-          server.kibanaVersion,
+          server.stackVersion,
           Boolean((normalizedMonitor as MonitorFields)[ConfigKey.SOURCE_INLINE]),
           errors
         )

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
@@ -87,7 +87,7 @@ export const deleteMonitor = async ({
   syntheticsMonitorClient: SyntheticsMonitorClient;
   request: KibanaRequest;
 }) => {
-  const { logger, telemetry, kibanaVersion, encryptedSavedObjects } = server;
+  const { logger, telemetry, stackVersion, encryptedSavedObjects } = server;
   const spaceId = server.spaces.spacesService.getSpaceId(request);
 
   const encryptedSavedObjectsClient = encryptedSavedObjects.getClient();
@@ -131,7 +131,7 @@ export const deleteMonitor = async ({
       telemetry,
       formatTelemetryDeleteEvent(
         monitor,
-        kibanaVersion,
+        stackVersion,
         new Date().toISOString(),
         Boolean((normalizedMonitor.attributes as MonitorFields)[ConfigKey.SOURCE_INLINE]),
         errors

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -28,7 +28,7 @@ describe('syncEditedMonitor', () => {
 
   const serverMock: UptimeServerSetup = {
     uptimeEsClient: { search: jest.fn() },
-    kibanaVersion: null,
+    stackVersion: null,
     authSavedObjectsClient: {
       bulkUpdate: jest.fn(),
       get: jest.fn(),

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -175,7 +175,7 @@ export const syncEditedMonitor = async ({
       formatTelemetryUpdateEvent(
         editedMonitorSavedObject as SavedObjectsUpdateResponse<EncryptedSyntheticsMonitor>,
         previousMonitor,
-        server.kibanaVersion,
+        server.stackVersion,
         Boolean((normalizedMonitor as MonitorFields)[ConfigKey.SOURCE_INLINE]),
         errors
       )

--- a/x-pack/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.test.ts
@@ -32,7 +32,7 @@ import {
   sendTelemetryEvents,
 } from './monitor_upgrade_sender';
 
-const kibanaVersion = '8.2.0';
+const stackVersion = '8.2.0';
 const id = '123456';
 const errors = [
   {
@@ -91,12 +91,12 @@ describe('monitor upgrade telemetry helpers', () => {
   it('formats telemetry events', () => {
     const actual = formatTelemetryEvent({
       monitor: testConfig,
-      kibanaVersion,
+      stackVersion,
       isInlineScript: false,
       errors,
     });
     expect(actual).toEqual({
-      stackVersion: kibanaVersion,
+      stackVersion,
       configId: sha256.create().update(testConfig.id).hex(),
       locations: ['us_central', 'other'],
       locationsCount: 2,
@@ -131,11 +131,11 @@ describe('monitor upgrade telemetry helpers', () => {
           },
         }),
         isInlineScript,
-        kibanaVersion,
+        stackVersion,
         errors,
       });
       expect(actual).toEqual({
-        stackVersion: kibanaVersion,
+        stackVersion,
         configId: sha256.create().update(testConfig.id).hex(),
         locations: ['us_central', 'other'],
         locationsCount: 2,
@@ -157,12 +157,12 @@ describe('monitor upgrade telemetry helpers', () => {
     const actual = formatTelemetryUpdateEvent(
       createTestConfig({}, '2011-10-05T16:48:00.000Z'),
       testConfig,
-      kibanaVersion,
+      stackVersion,
       false,
       errors
     );
     expect(actual).toEqual({
-      stackVersion: kibanaVersion,
+      stackVersion,
       configId: sha256.create().update(testConfig.id).hex(),
       locations: ['us_central', 'other'],
       locationsCount: 2,
@@ -182,13 +182,13 @@ describe('monitor upgrade telemetry helpers', () => {
   it('handles formatting delete events', () => {
     const actual = formatTelemetryDeleteEvent(
       testConfig,
-      kibanaVersion,
+      stackVersion,
       '2011-10-05T16:48:00.000Z',
       false,
       errors
     );
     expect(actual).toEqual({
-      stackVersion: kibanaVersion,
+      stackVersion,
       configId: sha256.create().update(testConfig.id).hex(),
       locations: ['us_central', 'other'],
       locationsCount: 2,
@@ -218,7 +218,7 @@ describe('sendTelemetryEvents', () => {
   it('should queue telemetry events with generic error', () => {
     const event = formatTelemetryEvent({
       monitor: testConfig,
-      kibanaVersion,
+      stackVersion,
       isInlineScript: true,
       errors,
     });

--- a/x-pack/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
+++ b/x-pack/plugins/synthetics/server/routes/telemetry/monitor_upgrade_sender.ts
@@ -65,7 +65,7 @@ export function sendErrorTelemetryEvents(
 
 export function formatTelemetryEvent({
   monitor,
-  kibanaVersion,
+  stackVersion,
   isInlineScript,
   lastUpdatedAt,
   durationSinceLastUpdated,
@@ -73,7 +73,7 @@ export function formatTelemetryEvent({
   errors,
 }: {
   monitor: SavedObject<EncryptedSyntheticsMonitor>;
-  kibanaVersion: string;
+  stackVersion: string;
   isInlineScript: boolean;
   lastUpdatedAt?: string;
   durationSinceLastUpdated?: number;
@@ -83,6 +83,7 @@ export function formatTelemetryEvent({
   const { attributes } = monitor;
 
   return {
+    stackVersion,
     updatedAt: deletedAt || monitor.updated_at,
     lastUpdatedAt,
     durationSinceLastUpdated,
@@ -94,7 +95,6 @@ export function formatTelemetryEvent({
     locationsCount: attributes[ConfigKey.LOCATIONS].length,
     monitorNameLength: attributes[ConfigKey.NAME].length,
     monitorInterval: scheduleToMilli(attributes[ConfigKey.SCHEDULE]),
-    stackVersion: kibanaVersion,
     scriptType: getScriptType(attributes as Partial<MonitorFields>, isInlineScript),
     errors:
       errors && errors?.length
@@ -115,7 +115,7 @@ export function formatTelemetryEvent({
 export function formatTelemetryUpdateEvent(
   currentMonitor: SavedObjectsUpdateResponse<EncryptedSyntheticsMonitor>,
   previousMonitor: SavedObject<EncryptedSyntheticsMonitor>,
-  kibanaVersion: string,
+  stackVersion: string,
   isInlineScript: boolean,
   errors?: ServiceLocationErrors | null
 ) {
@@ -127,8 +127,8 @@ export function formatTelemetryUpdateEvent(
   }
 
   return formatTelemetryEvent({
+    stackVersion,
     monitor: currentMonitor as SavedObject<EncryptedSyntheticsMonitor>,
-    kibanaVersion,
     durationSinceLastUpdated,
     lastUpdatedAt: previousMonitor.updated_at,
     isInlineScript,
@@ -138,7 +138,7 @@ export function formatTelemetryUpdateEvent(
 
 export function formatTelemetryDeleteEvent(
   previousMonitor: SavedObject<EncryptedSyntheticsMonitor>,
-  kibanaVersion: string,
+  stackVersion: string,
   deletedAt: string,
   isInlineScript: boolean,
   errors?: ServiceLocationErrors | null
@@ -150,8 +150,8 @@ export function formatTelemetryDeleteEvent(
   }
 
   return formatTelemetryEvent({
+    stackVersion,
     monitor: previousMonitor as SavedObject<EncryptedSyntheticsMonitor>,
-    kibanaVersion,
     durationSinceLastUpdated,
     lastUpdatedAt: previousMonitor.updated_at,
     deletedAt,

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
@@ -202,7 +202,7 @@ export class ProjectMonitorFormatter {
         privateLocations: this.privateLocations,
         projectId: this.projectId,
         namespace: this.spaceId,
-        version: this.server.kibanaVersion,
+        version: this.server.stackVersion,
       });
 
       if (errors.length) {

--- a/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.test.ts
@@ -74,7 +74,7 @@ describe('checkAccountAccessStatus', () => {
     const apiClient = new ServiceAPIClient(
       jest.fn() as unknown as Logger,
       { tls: { certificate: 'crt', key: 'k' } } as ServiceConfig,
-      { isDev: false, kibanaVersion: '8.4' } as UptimeServerSetup
+      { isDev: false, stackVersion: '8.4' } as UptimeServerSetup
     );
 
     apiClient.locations = [

--- a/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/service_api_client.ts
@@ -35,14 +35,14 @@ export class ServiceAPIClient {
   public locations: PublicLocations;
   private logger: Logger;
   private readonly config?: ServiceConfig;
-  private readonly kibanaVersion: string;
+  private readonly stackVersion: string;
   private readonly server: UptimeServerSetup;
 
   constructor(logger: Logger, config: ServiceConfig, server: UptimeServerSetup) {
     this.config = config;
     const { username, password } = config ?? {};
     this.username = username;
-    this.kibanaVersion = server.kibanaVersion;
+    this.stackVersion = server.stackVersion;
 
     if (username && password) {
       this.authorization = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
@@ -96,7 +96,7 @@ export class ServiceAPIClient {
   }
 
   addVersionHeader(req: AxiosRequestConfig) {
-    req.headers = { ...req.headers, 'x-kibana-version': this.kibanaVersion };
+    req.headers = { ...req.headers, 'x-kibana-version': this.stackVersion };
     return req;
   }
 
@@ -157,7 +157,7 @@ export class ServiceAPIClient {
           data: {
             monitors: monitorsStreams,
             output,
-            stack_version: this.kibanaVersion,
+            stack_version: this.stackVersion,
             is_edit: isEdit,
           },
           headers:
@@ -198,7 +198,7 @@ export class ServiceAPIClient {
                 code: err.code,
                 status: err.response?.data?.status,
                 url,
-                kibanaVersion: this.server.kibanaVersion,
+                stackVersion: this.server.stackVersion,
               });
               if (err.response?.data?.reason) {
                 this.logger.error(err.response?.data?.reason);

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -179,7 +179,7 @@ export class SyntheticsService {
                   type: 'runTaskError',
                   code: e?.code,
                   status: e.status,
-                  kibanaVersion: service.server.kibanaVersion,
+                  stackVersion: service.server.stackVersion,
                 });
                 throw e;
               }
@@ -225,7 +225,7 @@ export class SyntheticsService {
         type: 'scheduleTaskError',
         code: e?.code,
         status: e.status,
-        kibanaVersion: this.server.kibanaVersion,
+        stackVersion: this.server.stackVersion,
       });
 
       this.logger?.error(
@@ -449,7 +449,7 @@ export class SyntheticsService {
                     type: 'runTaskError',
                     code: e?.code,
                     status: e.status,
-                    kibanaVersion: this.server.kibanaVersion,
+                    stackVersion: this.server.stackVersion,
                   });
                   resolve(null);
                 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Synthetics Telemetry] Make consistent use of stackVersion (#143924)](https://github.com/elastic/kibana/pull/143924)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad.muhammad@elastic.co"},"sourceCommit":{"committedDate":"2022-11-01T12:02:19Z","message":"[Synthetics Telemetry] Make consistent use of stackVersion (#143924)","sha":"c3934c6f8160d3ac2f8503f1c8d06e229fc65538","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","backport missing","v8.5.0","v8.6.0"],"number":143924,"url":"https://github.com/elastic/kibana/pull/143924","mergeCommit":{"message":"[Synthetics Telemetry] Make consistent use of stackVersion (#143924)","sha":"c3934c6f8160d3ac2f8503f1c8d06e229fc65538"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/143924","number":143924,"mergeCommit":{"message":"[Synthetics Telemetry] Make consistent use of stackVersion (#143924)","sha":"c3934c6f8160d3ac2f8503f1c8d06e229fc65538"}}]}] BACKPORT-->