### PR TITLE
[8.5] [APM] Metadata API does not filter by environment (#144472)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
@@ -95,13 +95,14 @@ export function ServiceNodeMetrics() {
                 kuery,
                 start,
                 end,
+                environment,
               },
             },
           }
         );
       }
     },
-    [kuery, serviceName, serviceNodeName, start, end]
+    [kuery, serviceName, serviceNodeName, start, end, environment]
   );
 
   const { docLinks } = useApmPluginContext().core;

--- a/x-pack/plugins/apm/server/routes/service_nodes/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/service_nodes/queries.test.ts
@@ -45,6 +45,7 @@ describe('service node queries', () => {
         kuery: '',
         start: 0,
         end: 50000,
+        environment: ENVIRONMENT_ALL.value,
       })
     );
 
@@ -60,6 +61,7 @@ describe('service node queries', () => {
         kuery: '',
         start: 0,
         end: 50000,
+        environment: ENVIRONMENT_ALL.value,
       })
     );
 

--- a/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_node_metadata.ts
@@ -21,7 +21,6 @@ import {
   environmentQuery,
   serviceNodeNameQuery,
 } from '../../../common/utils/environment_query';
-import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 
 export async function getServiceNodeMetadata({
   kuery,
@@ -30,6 +29,7 @@ export async function getServiceNodeMetadata({
   setup,
   start,
   end,
+  environment,
 }: {
   kuery: string;
   serviceName: string;
@@ -37,6 +37,7 @@ export async function getServiceNodeMetadata({
   setup: Setup;
   start: number;
   end: number;
+  environment: string;
 }) {
   const { apmEventClient } = setup;
 
@@ -52,7 +53,7 @@ export async function getServiceNodeMetadata({
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             ...rangeQuery(start, end),
-            ...environmentQuery(ENVIRONMENT_ALL.value),
+            ...environmentQuery(environment),
             ...kqlQuery(kuery),
             ...serviceNodeNameQuery(serviceNodeName),
           ],

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -421,7 +421,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
       serviceName: t.string,
       serviceNodeName: t.string,
     }),
-    query: t.intersection([kueryRt, rangeRt]),
+    query: t.intersection([kueryRt, rangeRt, environmentRt]),
   }),
   options: { tags: ['access:apm'] },
   handler: async (
@@ -430,7 +430,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
     const setup = await setupRequest(resources);
     const { params } = resources;
     const { serviceName, serviceNodeName } = params.path;
-    const { kuery, start, end } = params.query;
+    const { kuery, start, end, environment } = params.query;
 
     return getServiceNodeMetadata({
       kuery,
@@ -439,6 +439,7 @@ const serviceNodeMetadataRoute = createApmServerRoute({
       serviceNodeName,
       start,
       end,
+      environment,
     });
   },
 });

--- a/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/get_service_node_metadata.spec.ts
@@ -28,6 +28,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           start: new Date(start).toISOString(),
           end: new Date(end).toISOString(),
           kuery: '',
+          environment: 'production',
         },
       },
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[APM] Metadata API does not filter by environment (#144472)](https://github.com/elastic/kibana/pull/144472)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Cauê Marcondes","email":"55978943+cauemarcondes@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-11-02T19:52:17Z","message":"[APM] Metadata API does not filter by environment (#144472)","sha":"56e8555d8b73178f041edff67b98fa0d5cc5e2d2","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:APM","v8.6.0","v8.5.1"],"number":144472,"url":"https://github.com/elastic/kibana/pull/144472","mergeCommit":{"message":"[APM] Metadata API does not filter by environment (#144472)","sha":"56e8555d8b73178f041edff67b98fa0d5cc5e2d2"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/144472","number":144472,"mergeCommit":{"message":"[APM] Metadata API does not filter by environment (#144472)","sha":"56e8555d8b73178f041edff67b98fa0d5cc5e2d2"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->