### PR TITLE
[8.5] Update dependency react-hook-form to ^7.38.0 (#143996)

### DIFF
--- a/package.json
+++ b/package.json
@@ -567,7 +567,7 @@
     "react-fast-compare": "^2.0.4",
     "react-focus-on": "^3.6.0",
     "react-grid-layout": "^1.3.4",
-    "react-hook-form": "^7.35.0",
+    "react-hook-form": "^7.38.0",
     "react-intl": "^2.8.0",
     "react-is": "^17.0.2",
     "react-markdown": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23110,10 +23110,10 @@ react-helmet-async@^1.0.7:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^7.35.0:
-  version "7.35.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.35.0.tgz#b133de48fc84b1e62f9277ba79dfbacd9bb13dd3"
-  integrity sha512-9CYdOed+Itbiu5VMVxW0PK9mBR3f0gDGJcZEyUSm0eJbDymQ913TRs2gHcQZZmfTC+rtxyDFRuelMxx/+xwMcw==
+react-hook-form@^7.38.0:
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.38.0.tgz#53d6a68df587ce4ce88352f63e0ecc7fc8779320"
+  integrity sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==
 
 react-input-autosize@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Update dependency react-hook-form to ^7.38.0 (#143996)](https://github.com/elastic/kibana/pull/143996)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"renovate[bot]","email":"29139614+renovate[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-10-26T13:01:10Z","message":"Update dependency react-hook-form to ^7.38.0 (#143996)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>","sha":"a6eafa9c5cd8014dbab69f2512c3b2cfe4c198c0","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","auto-backport","ci:all-cypress-suites","v8.6.0","v8.5.1"],"number":143996,"url":"https://github.com/elastic/kibana/pull/143996","mergeCommit":{"message":"Update dependency react-hook-form to ^7.38.0 (#143996)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>","sha":"a6eafa9c5cd8014dbab69f2512c3b2cfe4c198c0"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/143996","number":143996,"mergeCommit":{"message":"Update dependency react-hook-form to ^7.38.0 (#143996)\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>","sha":"a6eafa9c5cd8014dbab69f2512c3b2cfe4c198c0"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->