### PR TITLE
[Fleet] Fix all test package data streams + validation script

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -8,47 +8,33 @@ import { parseDefaultIngestPipeline, parseDataStreamElasticsearchEntry } from '.
 describe('parseDefaultIngestPipeline', () => {
   it('Should return undefined for stream without any elasticsearch dir', () => {
     expect(
-      parseDefaultIngestPipeline({
-        pkgKey: 'pkg-1.0.0',
-        paths: ['pkg-1.0.0/data_stream/stream1/manifest.yml'],
-        dataStreamPath: 'stream1',
-      })
+      parseDefaultIngestPipeline('pkg-1.0.0/data_stream/stream1/', [
+        'pkg-1.0.0/data_stream/stream1/manifest.yml',
+      ])
     ).toEqual(undefined);
   });
   it('Should return undefined for stream with non default ingest pipeline', () => {
     expect(
-      parseDefaultIngestPipeline({
-        pkgKey: 'pkg-1.0.0',
-        paths: [
-          'pkg-1.0.0/data_stream/stream1/manifest.yml',
-          'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/someotherpipeline.yml',
-        ],
-        dataStreamPath: 'stream1',
-      })
+      parseDefaultIngestPipeline('pkg-1.0.0/data_stream/stream1/', [
+        'pkg-1.0.0/data_stream/stream1/manifest.yml',
+        'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/someotherpipeline.yml',
+      ])
     ).toEqual(undefined);
   });
   it('Should return default for yml ingest pipeline', () => {
     expect(
-      parseDefaultIngestPipeline({
-        pkgKey: 'pkg-1.0.0',
-        paths: [
-          'pkg-1.0.0/data_stream/stream1/manifest.yml',
-          'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/default.yml',
-        ],
-        dataStreamPath: 'stream1',
-      })
+      parseDefaultIngestPipeline('pkg-1.0.0/data_stream/stream1/', [
+        'pkg-1.0.0/data_stream/stream1/manifest.yml',
+        'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/default.yml',
+      ])
     ).toEqual('default');
   });
   it('Should return default for json ingest pipeline', () => {
     expect(
-      parseDefaultIngestPipeline({
-        pkgKey: 'pkg-1.0.0',
-        paths: [
-          'pkg-1.0.0/data_stream/stream1/manifest.yml',
-          'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/default.json',
-        ],
-        dataStreamPath: 'stream1',
-      })
+      parseDefaultIngestPipeline('pkg-1.0.0/data_stream/stream1/', [
+        'pkg-1.0.0/data_stream/stream1/manifest.yml',
+        'pkg-1.0.0/data_stream/stream1/elasticsearch/ingest_pipeline/default.json',
+      ])
     ).toEqual('default');
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -308,7 +308,7 @@ export function parseAndVerifyDataStreams(
       );
     }
 
-    const ingestPipeline = parseDefaultIngestPipeline({ pkgKey, dataStreamPath, paths });
+    const ingestPipeline = parseDefaultIngestPipeline({ streamBasePath, dataStreamPath, paths });
     const streams = parseAndVerifyStreams(manifestStreams, dataStreamPath);
     const parsedElasticsearchEntry = parseDataStreamElasticsearchEntry(
       elasticsearch,
@@ -546,12 +546,16 @@ const isDefaultPipelineFile = (pipelinePath: string) =>
   pipelinePath.endsWith(DEFAULT_INGEST_PIPELINE_FILE_NAME_JSON);
 
 export function parseDefaultIngestPipeline(opts: {
-  pkgKey: string;
+  streamBasePath: string;
   paths: string[];
   dataStreamPath: string;
 }) {
-  const { pkgKey, paths, dataStreamPath } = opts;
-  const ingestPipelineDirPath = `${pkgKey}/data_stream/${dataStreamPath}/elasticsearch/ingest_pipeline`;
+  const { streamBasePath, paths, dataStreamPath } = opts;
+  const ingestPipelineDirPath = path.join(
+    streamBasePath,
+    dataStreamPath,
+    '/elasticsearch/ingest_pipeline'
+  );
   const defaultIngestPipelinePaths = paths.filter(
     (pipelinePath) =>
       pipelinePath.startsWith(ingestPipelineDirPath) && isDefaultPipelineFile(pipelinePath)

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.1.0/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.1.0/data_stream/test_stream/manifest.yml
@@ -2,3 +2,4 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.2.0-add-non-required-test-var/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.2.0-add-non-required-test-var/data_stream/test_stream/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input
     vars:
     - name: test_var
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.2.5-non-breaking-change/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.2.5-non-breaking-change/data_stream/test_stream/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input
     vars:
     - name: test_var
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.3.0-remove-test-var/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.3.0-remove-test-var/data_stream/test_stream/manifest.yml
@@ -2,10 +2,4 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
-    # vars:
-    # - name: test_var
-    #   type: text
-    #   title: Test Var
-    #   required: true
-    #   show_user: true
-    #   default: Test Value
+    title: test input

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.4.0-add-test-var-as-bool/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.4.0-add-test-var-as-bool/data_stream/test_stream/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input
     vars:
     - name: test_var
       type: bool

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.5.0-restructure-inputs/data_stream/test_stream_new/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.5.0-restructure-inputs/data_stream/test_stream_new/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input_new
+    title: test input new
     vars:
     - name: test_var_new
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.5.0-restructure-inputs/data_stream/test_stream_new_2/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.5.0-restructure-inputs/data_stream/test_stream_new_2/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input_new_2
+    title: test input new 2
     vars:
     - name: test_input_new_2_var_1
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.6.0-restructure-policy-templates/data_stream/test_stream_new/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.6.0-restructure-policy-templates/data_stream/test_stream_new/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input_new
+    title: test input new
     vars:
     - name: test_var_new
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.6.0-restructure-policy-templates/data_stream/test_stream_new_2/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.6.0-restructure-policy-templates/data_stream/test_stream_new_2/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input_new_2
+    title: test input new 2
     vars:
     - name: test_input_new_2_var_1
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.7.0-add-stream-with-no-vars/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.7.0-add-stream-with-no-vars/data_stream/test_stream/manifest.yml
@@ -2,3 +2,4 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.8.0-add-vars-to-stream-with-no-vars/data_stream/test_stream/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/package_policy_upgrade/0.8.0-add-vars-to-stream-with-no-vars/data_stream/test_stream/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input
     vars:
     - name: test_var_new
       type: text

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/with_required_variables/0.1.0/data_stream/log/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/with_required_variables/0.1.0/data_stream/log/manifest.yml
@@ -2,6 +2,7 @@ title: Test stream
 type: logs
 streams:
   - input: test_input
+    title: test input
     vars:
     - name: test_var_required
       type: string


### PR DESCRIPTION
## Summary

Follow on from https://github.com/elastic/kibana/pull/144432

I realised data stream validation wasn't working for the new test package validation script, so I've fixed that and all the resulting errors in our test packages.