### PR TITLE
[Fleet] Bugifx - support dot notation for elasticsearch index_template fields in data stream manifest

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -54,6 +54,9 @@ describe('parseDefaultIngestPipeline', () => {
 });
 
 describe('parseDataStreamElasticsearchEntry', () => {
+  it('Should handle undefined elasticsearch', () => {
+    expect(parseDataStreamElasticsearchEntry()).toEqual({});
+  });
   it('Should handle empty elasticsearch', () => {
     expect(parseDataStreamElasticsearchEntry({})).toEqual({});
   });
@@ -106,6 +109,17 @@ describe('parseDataStreamElasticsearchEntry', () => {
           sort: { field: 'monitor.id' },
         },
       },
+    });
+  });
+  it('Should handle dotted values for mappings and settings', () => {
+    expect(
+      parseDataStreamElasticsearchEntry({
+        'index_template.mappings': { dynamic: false },
+        'index_template.settings': { 'index.lifecycle.name': 'reference' },
+      })
+    ).toEqual({
+      'index_template.mappings': { dynamic: false },
+      'index_template.settings': { 'index.lifecycle.name': 'reference' },
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -503,7 +503,7 @@ export function parseAndVerifyInputs(manifestInputs: any, location: string): Reg
 }
 
 export function parseDataStreamElasticsearchEntry(
-  elasticsearch: Record<string, any>,
+  elasticsearch?: Record<string, any>,
   ingestPipeline?: string
 ) {
   const parsedElasticsearchEntry: Record<string, any> = {};
@@ -520,16 +520,18 @@ export function parseDataStreamElasticsearchEntry(
     parsedElasticsearchEntry.source_mode = elasticsearch.source_mode;
   }
 
-  if (elasticsearch?.index_template?.mappings) {
-    parsedElasticsearchEntry['index_template.mappings'] = expandDottedEntries(
-      elasticsearch.index_template.mappings
-    );
+  const indexTemplateMappings =
+    elasticsearch?.index_template?.mappings || elasticsearch?.['index_template.mappings'];
+  if (indexTemplateMappings) {
+    parsedElasticsearchEntry['index_template.mappings'] =
+      expandDottedEntries(indexTemplateMappings);
   }
 
-  if (elasticsearch?.index_template?.settings) {
-    parsedElasticsearchEntry['index_template.settings'] = expandDottedEntries(
-      elasticsearch.index_template.settings
-    );
+  const indexTemplateSettings =
+    elasticsearch?.index_template?.settings || elasticsearch?.['index_template.settings'];
+  if (indexTemplateSettings) {
+    parsedElasticsearchEntry['index_template.settings'] =
+      expandDottedEntries(indexTemplateSettings);
   }
 
   return parsedElasticsearchEntry;


### PR DESCRIPTION
## Summary

`elasticsearch.index_template.settings` and `elasticsearch.index_template.mappings` are objects that can be defined in a data_stream manifest. We support 2 kinds of notation in package yaml:

```
index_template:
    mappings: 
        dynamic: false
```

And 

```
index_template.mappings: 
        dynamic: false
```

When reading a package from archive, we did not support the second notation.