### PR TITLE
fix issue with single agent schedule upgrade

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -162,15 +162,16 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
 
     try {
       setIsSubmitting(true);
-      const { error } = isSingleAgent
-        ? await sendPostAgentUpgrade((agents[0] as Agent).id, {
-            version,
-          })
-        : await sendPostBulkAgentUpgrade({
-            version,
-            agents: Array.isArray(agents) ? agents.map((agent) => agent.id) : agents,
-            ...rolloutOptions,
-          });
+      const { error } =
+        isSingleAgent && !isScheduled
+          ? await sendPostAgentUpgrade((agents[0] as Agent).id, {
+              version,
+            })
+          : await sendPostBulkAgentUpgrade({
+              version,
+              agents: Array.isArray(agents) ? agents.map((agent) => agent.id) : agents,
+              ...rolloutOptions,
+            });
       if (error) {
         if (error?.statusCode === 400) {
           setErrors(error?.message);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/144583

Fixing an issue with upgrading one agent in a scheduled time, the code was not respecting the start time.

When scheduling upgrade of one agent, using bulk API instead of single API, that doesn't support `start_time` parameter.

<img width="1755" alt="image" src="https://user-images.githubusercontent.com/90178898/199963801-6cc1b57f-a481-42cb-a37d-5f85caa2bc9f.png">
<img width="546" alt="image" src="https://user-images.githubusercontent.com/90178898/199963900-1b50e5a0-a2e1-4b4d-8281-1b7679f1e382.png">

