### PR TITLE
[Fleet] Create cloud Fleet server host only if no default host is already configured

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -5072,6 +5072,14 @@
           "monitoring_output_id": {
             "type": "string",
             "nullable": true
+          },
+          "fleet_server_host_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "download_source_id": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -5221,10 +5229,20 @@
                 "type": "string"
               },
               "data_output_id": {
-                "type": "string"
+                "type": "string",
+                "nullable": true
               },
               "monitoring_output_id": {
-                "type": "string"
+                "type": "string",
+                "nullable": true
+              },
+              "fleet_server_host_id": {
+                "type": "string",
+                "nullable": true
+              },
+              "download_source_id": {
+                "type": "string",
+                "nullable": true
               },
               "revision": {
                 "type": "number"

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -3220,6 +3220,12 @@ components:
         monitoring_output_id:
           type: string
           nullable: true
+        fleet_server_host_id:
+          type: string
+          nullable: true
+        download_source_id:
+          type: string
+          nullable: true
       required:
         - name
         - namespace
@@ -3322,8 +3328,16 @@ components:
               type: string
             data_output_id:
               type: string
+              nullable: true
             monitoring_output_id:
               type: string
+              nullable: true
+            fleet_server_host_id:
+              type: string
+              nullable: true
+            download_source_id:
+              type: string
+              nullable: true
             revision:
               type: number
             agents:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
@@ -21,8 +21,16 @@ allOf:
         type: string
       data_output_id:
         type: string
+        nullable: true
       monitoring_output_id:
         type: string
+        nullable: true
+      fleet_server_host_id:
+        type: string
+        nullable: true
+      download_source_id:
+        type: string
+        nullable: true
       revision:
         type: number
       agents:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
@@ -22,6 +22,12 @@ properties:
   monitoring_output_id:
     type: string
     nullable: true
+  fleet_server_host_id:
+    type: string
+    nullable: true
+  download_source_id:
+    type: string
+    nullable: true
 required:
   - name
   - namespace

--- a/x-pack/plugins/fleet/server/services/preconfiguration/fleet_server_host.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/fleet_server_host.test.ts
@@ -4,17 +4,27 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 
 import { appContextService } from '../app_context';
+import { getDefaultFleetServerHost, createFleetServerHost } from '../fleet_server_host';
 
 import {
+  createCloudFleetServerHostIfNeeded,
   getCloudFleetServersHosts,
   getPreconfiguredFleetServerHostFromConfig,
 } from './fleet_server_host';
 
+jest.mock('../fleet_server_host');
 jest.mock('../app_context');
 
 const mockedAppContextService = appContextService as jest.Mocked<typeof appContextService>;
+const mockedGetDefaultFleetServerHost = getDefaultFleetServerHost as jest.MockedFunction<
+  typeof getDefaultFleetServerHost
+>;
+const mockedCreateFleetServerHost = createFleetServerHost as jest.MockedFunction<
+  typeof createFleetServerHost
+>;
 
 describe('getPreconfiguredFleetServerHostFromConfig', () => {
   it('should work with preconfigured fleetServerHosts', () => {
@@ -127,5 +137,67 @@ describe('getCloudFleetServersHosts', () => {
         "https://deployment-id-1.fleet.test.fr:9243",
       ]
     `);
+  });
+});
+
+describe('createCloudFleetServerHostIfNeeded', () => {
+  beforeEach(() => {
+    mockedCreateFleetServerHost.mockReset();
+  });
+  afterEach(() => {
+    mockedAppContextService.getCloud.mockReset();
+  });
+  it('should do nothing if there is no cloud fleet server hosts', async () => {
+    const soClient = savedObjectsClientMock.create();
+
+    await createCloudFleetServerHostIfNeeded(soClient);
+
+    expect(mockedCreateFleetServerHost).not.toBeCalled();
+  });
+
+  it('should do nothing if there is already an host configured', async () => {
+    const soClient = savedObjectsClientMock.create();
+    mockedAppContextService.getCloud.mockReturnValue({
+      cloudId:
+        'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+      isCloudEnabled: true,
+      deploymentId: 'deployment-id-1',
+      apm: {},
+    });
+    mockedGetDefaultFleetServerHost.mockResolvedValue({
+      id: 'test',
+    } as any);
+
+    await createCloudFleetServerHostIfNeeded(soClient);
+
+    expect(mockedCreateFleetServerHost).not.toBeCalled();
+  });
+
+  it('should create a new fleet server hosts if there is no host configured', async () => {
+    const soClient = savedObjectsClientMock.create();
+    mockedAppContextService.getCloud.mockReturnValue({
+      cloudId:
+        'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+      isCloudEnabled: true,
+      deploymentId: 'deployment-id-1',
+      apm: {},
+    });
+    mockedGetDefaultFleetServerHost.mockResolvedValue(null);
+    soClient.create.mockResolvedValue({
+      id: 'test-id',
+      attributes: {},
+    } as any);
+
+    await createCloudFleetServerHostIfNeeded(soClient);
+
+    expect(mockedCreateFleetServerHost).toBeCalledTimes(1);
+    expect(mockedCreateFleetServerHost).toBeCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        host_urls: ['https://deployment-id-1.fleet.us-east-1.aws.found.io'],
+        is_default: true,
+      }),
+      { id: 'fleet-default-fleet-server-host', overwrite: true, fromPreconfiguration: true }
+    );
   });
 });


### PR DESCRIPTION
## Summary

That PR change the creation of the cloud Fleet server host saved object to only create it if no default fleet server host is configured. Otherwise this will be a breaking change and user could have their default fleet server host updated when upgrading to 8.6.

That PR also fix some missing properties for the fleet server host feature in the openAPI spec.