### PR TITLE
[Fleet] When parsing archive, handle dot notation for `elasticsearch.privileges`

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -122,4 +122,32 @@ describe('parseDataStreamElasticsearchEntry', () => {
       'index_template.settings': { 'index.lifecycle.name': 'reference' },
     });
   });
+  it('Should handle non-dotted values for privileges', () => {
+    expect(
+      parseDataStreamElasticsearchEntry({
+        privileges: {
+          indices: ['read'],
+          cluster: ['test'],
+        },
+      })
+    ).toEqual({
+      privileges: {
+        indices: ['read'],
+        cluster: ['test'],
+      },
+    });
+  });
+  it('Should handle dotted values for privileges', () => {
+    expect(
+      parseDataStreamElasticsearchEntry({
+        'privileges.indices': ['read'],
+        'privileges.cluster': ['test'],
+      })
+    ).toEqual({
+      privileges: {
+        indices: ['read'],
+        cluster: ['test'],
+      },
+    });
+  });
 });

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -62,13 +62,13 @@ const expandDottedField = (dottedFieldName: string, val: unknown): object => {
   }
 };
 
-export const expandDottedObject = (dottedObj: object) => {
+export const expandDottedObject = (dottedObj: object = {}) => {
   if (typeof dottedObj !== 'object' || Array.isArray(dottedObj)) {
     return dottedObj;
   }
   return Object.entries(dottedObj).reduce(
     (acc, [key, val]) => merge(acc, expandDottedField(key, val)),
-    {}
+    {} as Record<string, any>
   );
 };
 
@@ -507,31 +507,29 @@ export function parseDataStreamElasticsearchEntry(
   ingestPipeline?: string
 ) {
   const parsedElasticsearchEntry: Record<string, any> = {};
-
+  const expandedElasticsearch = expandDottedObject(elasticsearch);
   if (ingestPipeline) {
     parsedElasticsearchEntry['ingest_pipeline.name'] = ingestPipeline;
   }
 
-  if (elasticsearch?.privileges) {
-    parsedElasticsearchEntry.privileges = elasticsearch.privileges;
+  if (expandedElasticsearch?.privileges) {
+    parsedElasticsearchEntry.privileges = expandedElasticsearch.privileges;
   }
 
-  if (elasticsearch?.source_mode) {
-    parsedElasticsearchEntry.source_mode = elasticsearch.source_mode;
+  if (expandedElasticsearch?.source_mode) {
+    parsedElasticsearchEntry.source_mode = expandedElasticsearch.source_mode;
   }
 
-  const indexTemplateMappings =
-    elasticsearch?.index_template?.mappings || elasticsearch?.['index_template.mappings'];
-  if (indexTemplateMappings) {
-    parsedElasticsearchEntry['index_template.mappings'] =
-      expandDottedEntries(indexTemplateMappings);
+  if (expandedElasticsearch?.index_template?.mappings) {
+    parsedElasticsearchEntry['index_template.mappings'] = expandDottedEntries(
+      expandedElasticsearch.index_template.mappings
+    );
   }
 
-  const indexTemplateSettings =
-    elasticsearch?.index_template?.settings || elasticsearch?.['index_template.settings'];
-  if (indexTemplateSettings) {
-    parsedElasticsearchEntry['index_template.settings'] =
-      expandDottedEntries(indexTemplateSettings);
+  if (expandedElasticsearch?.index_template?.settings) {
+    parsedElasticsearchEntry['index_template.settings'] = expandDottedEntries(
+      expandedElasticsearch.index_template.settings
+    );
   }
 
   return parsedElasticsearchEntry;


### PR DESCRIPTION
## Summary

Another bug I found while working on manifest parsing. We see privilerges specified in 2 ways, we were not handling the second case when installing a package from archive:

```
elasticsearch:
    privileges:
        cluster: ["blah"]
```
And 

```
elasticsearch:
    privileges.cluster: ["blah"]
```



<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->