### PR TITLE
[Cloud] More deployment metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -950,7 +950,7 @@ packages/kbn-plugin-helpers @elastic/kibana-operations
 packages/kbn-react-field @elastic/kibana-app-services
 packages/kbn-repo-source-classifier @elastic/kibana-operations
 packages/kbn-repo-source-classifier-cli @elastic/kibana-operations
-packages/kbn-rule-data-utils @elastic/security-detections-response @elastic/actionable-observability @elastic/response-ops
+packages/kbn-rule-data-utils @elastic/apm-ui
 packages/kbn-safer-lodash-set @elastic/kibana-security
 packages/kbn-securitysolution-autocomplete @elastic/security-solution-platform
 packages/kbn-securitysolution-es-utils @elastic/security-solution-platform

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -171,6 +171,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cloud.cname (string)',
         'xpack.cloud.deployment_url (string)',
         'xpack.cloud.is_elastic_staff_owned (boolean)',
+        'xpack.cloud.organization_created_at (string)',
         'xpack.cloud.trial_end_date (string)',
         'xpack.cloud_integrations.chat.chatURL (string)',
         // No PII. This is an escape patch to override LaunchDarkly's flag resolution mechanism for testing or quick fix.

--- a/x-pack/plugins/cloud/common/get_common_setup_contract.test.ts
+++ b/x-pack/plugins/cloud/common/get_common_setup_contract.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Observable } from 'rxjs';
+import { getCommonSetupContract } from './get_common_setup_contract';
+
+describe('getCommonSetupContract', () => {
+  test('it works fine with the minimal configuration', () => {
+    expect(getCommonSetupContract({})).toMatchInlineSnapshot(`
+      Object {
+        "cloudId": undefined,
+        "inTrial$": undefined,
+        "isElasticStaffOwned": undefined,
+        "isPaying$": undefined,
+        "organizationCreatedAt": undefined,
+        "trialEndDate": undefined,
+      }
+    `);
+  });
+
+  test('only with cloudId and isElasticStaffOwned', () => {
+    expect(getCommonSetupContract({ id: 'some_cloud_id', is_elastic_staff_owned: false }))
+      .toMatchInlineSnapshot(`
+      Object {
+        "cloudId": "some_cloud_id",
+        "inTrial$": undefined,
+        "isElasticStaffOwned": false,
+        "isPaying$": undefined,
+        "organizationCreatedAt": undefined,
+        "trialEndDate": undefined,
+      }
+    `);
+  });
+
+  test('with everything', () => {
+    expect(
+      getCommonSetupContract({
+        id: 'some_cloud_id',
+        is_elastic_staff_owned: false,
+        trial_end_date: '2022-11-04T00:00:00Z',
+        organization_created_at: '2020-10-04T00:00:00Z',
+      })
+    ).toStrictEqual({
+      cloudId: 'some_cloud_id',
+      isElasticStaffOwned: false,
+      trialEndDate: new Date('2022-11-04T00:00:00Z'),
+      inTrial$: expect.any(Observable),
+      isPaying$: expect.any(Observable),
+      organizationCreatedAt: new Date('2020-10-04T00:00:00Z'),
+    });
+  });
+});

--- a/x-pack/plugins/cloud/common/get_common_setup_contract.ts
+++ b/x-pack/plugins/cloud/common/get_common_setup_contract.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Observable } from 'rxjs';
+import { inTrialObservable } from './in_trial_observable';
+import { isPayingObservable } from './is_paying_observable';
+
+export interface CloudCommonSetupContract {
+  /**
+   * Cloud ID. Undefined if not running on Cloud.
+   */
+  cloudId?: string;
+  /**
+   * `true` if the Elastic Cloud organization that owns this deployment is owned by an Elastician. Only available when running on Elastic Cloud.
+   */
+  isElasticStaffOwned?: boolean;
+  /**
+   * When the Cloud Trial ends/ended for the organization that owns this deployment. Only available when running on Elastic Cloud.
+   */
+  trialEndDate?: Date;
+  /**
+   * Observable indicating whether the Cloud Organization is still in trial
+   */
+  inTrial$?: Observable<boolean>;
+  /**
+   * Observable indicating whether the Cloud Organization is a paying customer
+   */
+  isPaying$?: Observable<boolean>;
+  /**
+   * When the Cloud Organization was created on Elastic Cloud. Only available when running on Elastic Cloud.
+   */
+  organizationCreatedAt?: Date;
+}
+
+export interface CommonSetupConfig {
+  id?: string;
+  is_elastic_staff_owned?: boolean;
+  trial_end_date?: string;
+  organization_created_at?: string;
+}
+
+export function getCommonSetupContract(config: CommonSetupConfig): CloudCommonSetupContract {
+  const cloudId = config.id;
+  const isElasticStaffOwned = config.is_elastic_staff_owned;
+  const organizationCreatedAt = config.organization_created_at
+    ? new Date(config.organization_created_at)
+    : undefined;
+  const trialEndDate = config.trial_end_date ? new Date(config.trial_end_date) : undefined;
+  const inTrial$ = trialEndDate ? inTrialObservable(trialEndDate) : undefined;
+  const isPaying$ =
+    inTrial$ && typeof isElasticStaffOwned !== 'undefined'
+      ? isPayingObservable({ inTrial$, isElasticStaffOwned })
+      : undefined;
+
+  return {
+    cloudId,
+    isElasticStaffOwned,
+    trialEndDate,
+    inTrial$,
+    isPaying$,
+    organizationCreatedAt,
+  };
+}

--- a/x-pack/plugins/cloud/common/in_trial_observable.test.ts
+++ b/x-pack/plugins/cloud/common/in_trial_observable.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fakeSchedulers } from 'rxjs-marbles/jest';
+import { firstValueFrom } from 'rxjs';
+import { inTrialObservable } from './in_trial_observable';
+
+describe('inTrialObservable', () => {
+  beforeEach(() => jest.useFakeTimers());
+
+  test('it emits the inTrial value as soon as the observable is created', async () => {
+    const inTrial$ = inTrialObservable(new Date(Date.now() + 120000));
+    await expect(firstValueFrom(inTrial$)).resolves.toEqual(true);
+  });
+
+  test(
+    'it emits true initially and then false after the expiry date',
+    fakeSchedulers(async (advance) => {
+      const inTrial$ = inTrialObservable(new Date(Date.now() + 120000));
+      await expect(firstValueFrom(inTrial$)).resolves.toEqual(true);
+      advance(120000);
+      await expect(firstValueFrom(inTrial$)).resolves.toEqual(false);
+    })
+  );
+
+  test(
+    'it emits false because the trialEndDate is in the past',
+    fakeSchedulers(async (advance) => {
+      const inTrial$ = inTrialObservable(new Date(Date.now() - 120000));
+      await expect(firstValueFrom(inTrial$)).resolves.toEqual(false);
+      advance(120000);
+      await expect(firstValueFrom(inTrial$)).resolves.toEqual(false);
+    })
+  );
+});

--- a/x-pack/plugins/cloud/common/in_trial_observable.ts
+++ b/x-pack/plugins/cloud/common/in_trial_observable.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { map, type Observable, shareReplay, timer, startWith } from 'rxjs';
+
+/**
+ * Returns an observable indicating whether the Cloud Organization is still in trial
+ * @param trialEndDate The date the trial ends
+ */
+export function inTrialObservable(trialEndDate: Date): Observable<boolean> {
+  return timer(trialEndDate).pipe(
+    map(() => false),
+    startWith(inTrial(trialEndDate)),
+    shareReplay(1)
+  );
+}
+
+/**
+ * Is trial end date due?
+ * @param trialEndDate The date the trial ends
+ * @remark Elastic Cloud allows customers to end their trials earlier or even extend it in some cases, but this is a good compromise for now.
+ */
+function inTrial(trialEndDate: Date): boolean {
+  return Date.now() <= trialEndDate.getTime();
+}

--- a/x-pack/plugins/cloud/common/index.ts
+++ b/x-pack/plugins/cloud/common/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { CloudCommonSetupContract } from './get_common_setup_contract';

--- a/x-pack/plugins/cloud/common/is_paying_observable.test.ts
+++ b/x-pack/plugins/cloud/common/is_paying_observable.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { firstValueFrom, of } from 'rxjs';
+import { isPayingObservable } from './is_paying_observable';
+
+describe('isPayingObservable', () => {
+  test.each`
+    inTrial  | isElasticStaffOwned | expected
+    ${true}  | ${true}             | ${false}
+    ${true}  | ${false}            | ${false}
+    ${false} | ${true}             | ${false}
+    ${false} | ${false}            | ${true}
+  `(
+    'returns $expected when inTrial: $inTrial and isElasticStaffOwned: $isElasticStaffOwned',
+    async ({ inTrial, isElasticStaffOwned, expected }) => {
+      const isPaying$ = isPayingObservable({ inTrial$: of(inTrial), isElasticStaffOwned });
+      await expect(firstValueFrom(isPaying$)).resolves.toEqual(expected);
+    }
+  );
+});

--- a/x-pack/plugins/cloud/common/is_paying_observable.ts
+++ b/x-pack/plugins/cloud/common/is_paying_observable.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { map, type Observable, shareReplay } from 'rxjs';
+
+export interface IsPayingOptions {
+  inTrial$: Observable<boolean>;
+  isElasticStaffOwned: boolean;
+}
+
+/**
+ * Returns an observable indicating if the Elastic Cloud Organization is a paying customer
+ * @param inTrial$ The in trial observable
+ * @param isElasticStaffOwned If the organization belongs to an Elastician
+ */
+export function isPayingObservable({
+  inTrial$,
+  isElasticStaffOwned,
+}: IsPayingOptions): Observable<boolean> {
+  return inTrial$.pipe(
+    // If the organization is in trial or belongs to an Elastician, we don't consider them as paying customers.
+    map((inTrial) => !(inTrial || isElasticStaffOwned)),
+    shareReplay(1)
+  );
+}

--- a/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.test.ts
+++ b/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { registerCloudDeploymentMetadataAnalyticsContext } from './register_cloud_deployment_id_analytics_context';
 
 describe('registerCloudDeploymentIdAnalyticsContext', () => {
@@ -21,12 +21,30 @@ describe('registerCloudDeploymentIdAnalyticsContext', () => {
     expect(analytics.registerContextProvider).not.toHaveBeenCalled();
   });
 
-  test('it registers the context provider and emits the cloudId', async () => {
-    registerCloudDeploymentMetadataAnalyticsContext(analytics, { id: 'cloud_id' });
+  test('it registers the static metadata context provider and emits the cloudId', async () => {
+    registerCloudDeploymentMetadataAnalyticsContext(analytics, { cloudId: 'cloud_id' });
     expect(analytics.registerContextProvider).toHaveBeenCalledTimes(1);
     const [{ context$ }] = analytics.registerContextProvider.mock.calls[0];
-    await expect(firstValueFrom(context$)).resolves.toEqual({
+    await expect(firstValueFrom(context$)).resolves.toEqual({ cloudId: 'cloud_id' });
+  });
+
+  test('it registers the inTrial context provider', async () => {
+    registerCloudDeploymentMetadataAnalyticsContext(analytics, {
       cloudId: 'cloud_id',
+      inTrial$: of(true),
     });
+    expect(analytics.registerContextProvider).toHaveBeenCalledTimes(2);
+    const [{ context$ }] = analytics.registerContextProvider.mock.calls[1];
+    await expect(firstValueFrom(context$)).resolves.toEqual({ cloudInTrial: true });
+  });
+
+  test('it registers the isPaying context provider', async () => {
+    registerCloudDeploymentMetadataAnalyticsContext(analytics, {
+      cloudId: 'cloud_id',
+      isPaying$: of(true),
+    });
+    expect(analytics.registerContextProvider).toHaveBeenCalledTimes(2);
+    const [{ context$ }] = analytics.registerContextProvider.mock.calls[1];
+    await expect(firstValueFrom(context$)).resolves.toEqual({ cloudIsPaying: true });
   });
 });

--- a/x-pack/plugins/cloud/public/mocks.tsx
+++ b/x-pack/plugins/cloud/public/mocks.tsx
@@ -20,6 +20,7 @@ function createSetupMock() {
     profileUrl: 'profile-url',
     organizationUrl: 'organization-url',
     isElasticStaffOwned: true,
+    organizationCreatedAt: new Date('2019-10-01T14:13:12Z'),
     trialEndDate: new Date('2020-10-01T14:13:12Z'),
     inTrial$: new BehaviorSubject<boolean>(true),
     isPaying$: new BehaviorSubject<boolean>(false),

--- a/x-pack/plugins/cloud/public/mocks.tsx
+++ b/x-pack/plugins/cloud/public/mocks.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { BehaviorSubject } from 'rxjs';
 
 import { CloudStart } from '.';
 
@@ -20,6 +21,8 @@ function createSetupMock() {
     organizationUrl: 'organization-url',
     isElasticStaffOwned: true,
     trialEndDate: new Date('2020-10-01T14:13:12Z'),
+    inTrial$: new BehaviorSubject<boolean>(true),
+    isPaying$: new BehaviorSubject<boolean>(false),
     registerCloudService: jest.fn(),
   };
 }

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
+import { of } from 'rxjs';
 import {
   createCollectorFetchContextMock,
   usageCollectionPluginMock,
 } from '@kbn/usage-collection-plugin/server/mocks';
-import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import type {
+  UsageCollectionSetup,
+  CollectorFetchContext,
+} from '@kbn/usage-collection-plugin/server';
 import { createCloudUsageCollector } from './cloud_usage_collector';
-import { CollectorFetchContext } from '@kbn/usage-collection-plugin/server';
 
 describe('createCloudUsageCollector', () => {
   let usageCollection: UsageCollectionSetup;
@@ -38,17 +41,21 @@ describe('createCloudUsageCollector', () => {
       });
     });
 
-    it('return inTrial boolean if trialEndDateIsProvided', async () => {
+    it('return inTrial and isPaying based on the provided observables', async () => {
       const collector = createCloudUsageCollector(usageCollection, {
         isCloudEnabled: true,
-        trialEndDate: '2020-10-01T14:30:16Z',
+        isElasticStaffOwned: false,
+        trialEndDate: new Date('2020-10-01T14:30:16Z'),
+        inTrial$: of(false),
+        isPaying$: of(true),
       });
 
       expect(await collector.fetch(collectorFetchContext)).toStrictEqual({
         isCloudEnabled: true,
-        isElasticStaffOwned: undefined,
-        trialEndDate: '2020-10-01T14:30:16Z',
+        isElasticStaffOwned: false,
+        trialEndDate: '2020-10-01T14:30:16.000Z',
         inTrial: false,
+        isPaying: true,
       });
     });
   });

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -26,6 +26,7 @@ const configSchema = schema.object({
   id: schema.maybe(schema.string()),
   organization_url: schema.maybe(schema.string()),
   profile_url: schema.maybe(schema.string()),
+  organization_created_at: schema.maybe(schema.string()),
   trial_end_date: schema.maybe(schema.string()),
   is_elastic_staff_owned: schema.maybe(schema.boolean()),
 });
@@ -40,6 +41,7 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
     id: true,
     organization_url: true,
     profile_url: true,
+    organization_created_at: true,
     trial_end_date: true,
     is_elastic_staff_owned: true,
   },

--- a/x-pack/plugins/cloud/server/mocks.ts
+++ b/x-pack/plugins/cloud/server/mocks.ts
@@ -15,6 +15,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
     deploymentId: 'deployment-id',
     isCloudEnabled: true,
     isElasticStaffOwned: true,
+    organizationCreatedAt: new Date('2019-10-01T14:13:12Z'),
     trialEndDate: new Date('2020-10-01T14:13:12Z'),
     inTrial$: new BehaviorSubject<boolean>(true),
     isPaying$: new BehaviorSubject<boolean>(false),

--- a/x-pack/plugins/cloud/server/mocks.ts
+++ b/x-pack/plugins/cloud/server/mocks.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { CloudSetup } from '.';
 
 function createSetupMock(): jest.Mocked<CloudSetup> {
@@ -15,6 +16,8 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
     isCloudEnabled: true,
     isElasticStaffOwned: true,
     trialEndDate: new Date('2020-10-01T14:13:12Z'),
+    inTrial$: new BehaviorSubject<boolean>(true),
+    isPaying$: new BehaviorSubject<boolean>(false),
     apm: {
       url: undefined,
       secretToken: undefined,

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -4971,13 +4971,16 @@
         "isCloudEnabled": {
           "type": "boolean"
         },
+        "isElasticStaffOwned": {
+          "type": "boolean"
+        },
         "trialEndDate": {
           "type": "date"
         },
         "inTrial": {
           "type": "boolean"
         },
-        "isElasticStaffOwned": {
+        "isPaying": {
           "type": "boolean"
         }
       }


### PR DESCRIPTION
## Summary

Part of #144218.

This PR adds the new fields `organizationCreatedAt` and `isPaying` to the contract of the `cloud` plugin.

Additionally, it centralizes how the `inTrial` boolean is calculated in one place so we can change it in the future if we see fit.

⚠️ In draft because we are still finalizing the discussions about how to best calculate `isPaying`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
