### PR TITLE
[Fleet] Expand `privileges.indices` field in Fleet manifest parser

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -516,6 +516,10 @@ export function parseDataStreamElasticsearchEntry(
     parsedElasticsearchEntry.privileges = elasticsearch.privileges;
   }
 
+  if (elasticsearch?.['privileges.indices']) {
+    parsedElasticsearchEntry.privileges = { indices: elasticsearch['privileges.indices'] };
+  }
+
   if (elasticsearch?.source_mode) {
     parsedElasticsearchEntry.source_mode = elasticsearch.source_mode;
   }


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/pull/144567

Fixes a failure in synthetics functional tests by ensuring we handle the dot notation `privileges.indices` field in data stream manifests. 

Would like to find a unit test to update so we can capture this case in test coverage, but want to make sure CI is green here before going too far. 