### PR TITLE
[8.5] update chromium MD5 checksum (#144553)

### DIFF
--- a/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
@@ -45,7 +45,7 @@ export class ChromiumArchivePaths {
       platform: 'darwin',
       architecture: 'x64',
       archiveFilename: 'chrome-mac.zip',
-      archiveChecksum: '5afc0d49865d55b69ea1ff65b9cc5794',
+      archiveChecksum: 'dd4d44ad97ba2fef5dc47d7f2a39ccaa',
       binaryChecksum: '4a7a663b2656d66ce975b00a30df3ab4',
       binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
       location: 'common',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [update chromium MD5 checksum (#144553)](https://github.com/elastic/kibana/pull/144553)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2022-11-03T21:23:07Z","message":"update chromium MD5 checksum (#144553)\n\n* update chromium MD5 checksum\r\n\r\n* only update md5 for intel","sha":"b94363417231d5c90536b5de2b6c218591e170df","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Reporting","release_note:skip","backport:skip","Team:Global Experience","v8.4.0","v8.6.0","v8.5.1","v8.4.4","v7.17.8"],"number":144553,"url":"https://github.com/elastic/kibana/pull/144553","mergeCommit":{"message":"update chromium MD5 checksum (#144553)\n\n* update chromium MD5 checksum\r\n\r\n* only update md5 for intel","sha":"b94363417231d5c90536b5de2b6c218591e170df"}},"sourceBranch":"main","suggestedTargetBranches":["8.4","8.5","7.17"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/144553","number":144553,"mergeCommit":{"message":"update chromium MD5 checksum (#144553)\n\n* update chromium MD5 checksum\r\n\r\n* only update md5 for intel","sha":"b94363417231d5c90536b5de2b6c218591e170df"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"7.17","label":"v7.17.8","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->