### PR TITLE
[Cloud Posture] feat: enable auto update

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
@@ -80,7 +80,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "endpoint:user-artifact": "f94c250a52b30d0a2d32635f8b4c5bdabd1e25c0",
         "endpoint:user-artifact-manifest": "8c14d49a385d5d1307d956aa743ec78de0b2be88",
         "enterprise_search_telemetry": "fafcc8318528d34f721c42d1270787c52565bad5",
-        "epm-packages": "c4c39f20d6bcfff40994813ee0f2bab01d34b646",
+        "epm-packages": "cb22b422398a785e7e0565a19c6d4d5c7af6f2fd",
         "epm-packages-assets": "9fd3d6726ac77369249e9a973902c2cd615fc771",
         "event_loop_delays_daily": "d2ed39cf669577d90921c176499908b4943fb7bd",
         "exception-list": "fe8cc004fd2742177cdb9300f4a67689463faf9c",

--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -41,6 +41,7 @@ export const autoUpdatePackages = [
   FLEET_ENDPOINT_PACKAGE,
   FLEET_APM_PACKAGE,
   FLEET_SYNTHETICS_PACKAGE,
+  FLEET_CLOUD_SECURITY_POSTURE_PACKAGE,
 ];
 
 export const HIDDEN_API_REFERENCE_PACKAGES = [
@@ -49,7 +50,11 @@ export const HIDDEN_API_REFERENCE_PACKAGES = [
   FLEET_SYNTHETICS_PACKAGE,
 ];
 
-export const autoUpgradePoliciesPackages = [FLEET_APM_PACKAGE, FLEET_SYNTHETICS_PACKAGE];
+export const autoUpgradePoliciesPackages = [
+  FLEET_APM_PACKAGE,
+  FLEET_SYNTHETICS_PACKAGE,
+  FLEET_CLOUD_SECURITY_POSTURE_PACKAGE,
+];
 
 export const agentAssetTypes = {
   Input: 'input',

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -47,7 +47,7 @@ import {
   migratePackagePolicyToV840,
 } from './migrations/to_v8_4_0';
 import { migratePackagePolicyToV850, migrateAgentPolicyToV850 } from './migrations/to_v8_5_0';
-import { migrateSettingsToV860 } from './migrations/to_v8_6_0';
+import { migrateSettingsToV860, migrateInstallationToV860 } from './migrations/to_v8_6_0';
 
 /*
  * Saved object types and mappings
@@ -297,6 +297,7 @@ const getSavedObjectTypes = (
       '8.0.0': migrateInstallationToV800,
       '8.3.0': migrateInstallationToV830,
       '8.4.0': migrateInstallationToV840,
+      '8.6.0': migrateInstallationToV860,
     },
   },
   [ASSETS_SAVED_OBJECT_TYPE]: {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_6_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v8_6_0.ts
@@ -9,6 +9,9 @@ import type { SavedObjectMigrationFn } from '@kbn/core/server';
 
 import type { Settings } from '../../../common/types';
 
+import type { Installation } from '../../../common';
+import { FLEET_CLOUD_SECURITY_POSTURE_PACKAGE } from '../../../common/constants';
+
 export const migrateSettingsToV860: SavedObjectMigrationFn<Settings, Settings> = (
   settingsDoc,
   migrationContext
@@ -19,4 +22,13 @@ export const migrateSettingsToV860: SavedObjectMigrationFn<Settings, Settings> =
   settingsDoc.attributes.prerelease_integrations_enabled = false;
 
   return settingsDoc;
+};
+
+export const migrateInstallationToV860: SavedObjectMigrationFn<Installation, Installation> = (
+  installationDoc
+) => {
+  if (installationDoc.attributes.name === FLEET_CLOUD_SECURITY_POSTURE_PACKAGE) {
+    installationDoc.attributes.keep_policies_up_to_date = true;
+  }
+  return installationDoc;
 };


### PR DESCRIPTION
## Summary

Enable KSPM auto update for package and add migration to set package policies with `keep_policies_up_to_date` flag.
Closes https://github.com/elastic/kibana/issues/144525


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
