### PR TITLE
[Cloud Posture] track application views

### DIFF
--- a/x-pack/plugins/cloud_security_posture/kibana.json
+++ b/x-pack/plugins/cloud_security_posture/kibana.json
@@ -22,6 +22,6 @@
     "cloud",
     "licensing"
   ],
-  "requiredBundles": ["kibanaReact"],
+  "requiredBundles": ["kibanaReact", "usageCollection"],
   "optionalPlugins": ["usageCollection"]
 }

--- a/x-pack/plugins/cloud_security_posture/kibana.json
+++ b/x-pack/plugins/cloud_security_posture/kibana.json
@@ -22,5 +22,6 @@
     "cloud",
     "licensing"
   ],
-  "requiredBundles": ["kibanaReact", "usageCollection"]
+  "requiredBundles": ["kibanaReact"],
+  "optionalPlugins": ["usageCollection"]
 }

--- a/x-pack/plugins/cloud_security_posture/kibana.json
+++ b/x-pack/plugins/cloud_security_posture/kibana.json
@@ -22,6 +22,5 @@
     "cloud",
     "licensing"
   ],
-  "requiredBundles": ["kibanaReact"],
-  "optionalPlugins": ["usageCollection"]
+  "requiredBundles": ["kibanaReact", "usageCollection"]
 }

--- a/x-pack/plugins/cloud_security_posture/public/application/csp_router.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/application/csp_router.tsx
@@ -13,6 +13,7 @@ import { cloudPosturePages } from '../common/navigation/constants';
 import type { CloudSecurityPosturePageId, CspPageNavigationItem } from '../common/navigation/types';
 import { pageToComponentMapping } from './constants';
 import { SecuritySolutionContext } from './security_solution_context';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 type CspRouteProps = RouteProps & {
   path: string;
@@ -50,7 +51,9 @@ export const addSpyRouteComponentToRoute = (
     render: (props: RouteComponentProps) => (
       <>
         <SpyRoute pageName={route.id} />
-        <Component {...props} />
+        <TrackApplicationView viewId={route.id}>
+          <Component {...props} />
+        </TrackApplicationView>
       </>
     ),
   };

--- a/x-pack/plugins/cloud_security_posture/public/application/csp_router.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/application/csp_router.tsx
@@ -8,12 +8,12 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Redirect, Route, RouteComponentProps, type RouteProps, Switch } from 'react-router-dom';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { CLOUD_SECURITY_POSTURE_BASE_PATH, type CspSecuritySolutionContext } from '..';
 import { cloudPosturePages } from '../common/navigation/constants';
 import type { CloudSecurityPosturePageId, CspPageNavigationItem } from '../common/navigation/types';
 import { pageToComponentMapping } from './constants';
 import { SecuritySolutionContext } from './security_solution_context';
-import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 type CspRouteProps = RouteProps & {
   path: string;

--- a/x-pack/plugins/cloud_security_posture/public/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/types.ts
@@ -15,6 +15,10 @@ import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { FleetSetup, FleetStart } from '@kbn/fleet-plugin/public';
 import type { CspRouterProps } from './application/csp_router';
 import type { BreadcrumbEntry, CloudSecurityPosturePageId } from './common/navigation/types';
+import type {
+  UsageCollectionSetup,
+  UsageCollectionStart,
+} from '@kbn/usage-collection-plugin/public';
 
 /**
  * The cloud security posture's public plugin setup interface.
@@ -36,6 +40,7 @@ export interface CspClientPluginSetupDeps {
   fleet: FleetSetup;
   cloud: CloudSetup;
   // optional
+  usageCollection?: UsageCollectionSetup;
 }
 
 export interface CspClientPluginStartDeps {
@@ -47,6 +52,7 @@ export interface CspClientPluginStartDeps {
   fleet: FleetStart;
   licensing: LicensingPluginStart;
   // optional
+  usageCollection?: UsageCollectionStart;
 }
 
 /**

--- a/x-pack/plugins/cloud_security_posture/public/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/types.ts
@@ -13,12 +13,12 @@ import type { DataPublicPluginSetup, DataPublicPluginStart } from '@kbn/data-plu
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { FleetSetup, FleetStart } from '@kbn/fleet-plugin/public';
-import type { CspRouterProps } from './application/csp_router';
-import type { BreadcrumbEntry, CloudSecurityPosturePageId } from './common/navigation/types';
 import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
+import type { CspRouterProps } from './application/csp_router';
+import type { BreadcrumbEntry, CloudSecurityPosturePageId } from './common/navigation/types';
 
 /**
  * The cloud security posture's public plugin setup interface.

--- a/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
@@ -39,7 +39,6 @@ const CloudSecurityPosture = memo(() => {
   };
 
   return (
-    // TODO: Finer granularity of this needs to be implemented in the cloud security posture plugin
     <PluginTemplateWrapper>
       <TrackApplicationView viewId="cloud_security_posture">
         <SecuritySolutionPageWrapper noPadding noTimeline>


### PR DESCRIPTION
## Summary

the `usage_collection` plugin has a component (`TrackApplicationView`) that is used to wrap views and get metrics on their usage, like clicks/time on page. 

in addition to already tracking all our views under `cloud_security_posture` (all routes combined), 
we now track all routes defined in `cloudPosturePages` by their `id`: 

- `cloud_security_posture-findings` 
- `cloud_security_posture-benchmarks`
- `cloud_security_posture-dashboard`
- `cloud_security_posture-rules`

the tracking is under `securitySolutionUI`, as we don't register an app anymore, just render routes in `security_solution`


