### PR TITLE
[Cloud Posture] Adding cluster name to cluster card

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_finding.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_finding.ts
@@ -12,8 +12,10 @@ import type { CspRuleMetadata } from './csp_rule_metadata';
 export interface CspFinding {
   '@timestamp': string;
   cluster_id: string;
-  cluster?: {
-    name?: string;
+  orchestrator?: {
+    cluster?: {
+      name?: string;
+    };
   };
   result: CspFindingResult;
   resource: CspFindingResource;

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.test.ts
@@ -18,7 +18,11 @@ const mockClusterBuckets: ClusterBucket[] = [
             _id: '123',
             _index: '123',
             _source: {
-              cluster: { name: 'cluster_name' },
+              orchestrator: {
+                cluster: {
+                  name: 'cluster_name',
+                },
+              },
               rule: { benchmark: { name: 'CIS Kubernetes', id: 'cis_k8s' } },
               '@timestamp': '123',
             },

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -71,7 +71,7 @@ export const getClustersFromAggs = (clusters: ClusterBucket[]): ClusterWithoutTr
 
     const meta = {
       clusterId: cluster.key,
-      clusterName: latestFindingHit._source.cluster?.name,
+      clusterName: latestFindingHit._source.orchestrator?.cluster?.name,
       benchmarkName: latestFindingHit._source.rule.benchmark.name,
       benchmarkId: latestFindingHit._source.rule.benchmark.id,
       lastUpdate: latestFindingHit._source['@timestamp'],


### PR DESCRIPTION
## Summary
This PR completes the task of showing the real cluster name in the UI.

## In-Depth
As part of https://github.com/elastic/cloudbeat/issues/391, we extracted the Kubernetes cluster name when collecting findings. Now we just wish to present it in the cluster-card in our dashboard screen.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/19221736/200182980-b78bd257-e3f1-4b61-86e5-5073ddd892f8.png">
