### PR TITLE
Add default data view patterns to all timeline analyzer requests

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { useDeepEqualSelector } from '../../common/hooks/use_selector';
 import {
@@ -14,7 +15,7 @@ import {
   endSelector,
 } from '../../common/components/super_date_picker/selectors';
 import { SourcererScopeName } from '../../common/store/sourcerer/model';
-import { useSourcererDataView } from '../../common/containers/sourcerer';
+import { useSourcererDataView, getScopeFromPath } from '../../common/containers/sourcerer';
 import { sourcererSelectors } from '../../common/store';
 
 export function useTimelineDataFilters(isActiveTimelines: boolean) {
@@ -49,13 +50,18 @@ export function useTimelineDataFilters(isActiveTimelines: boolean) {
     []
   );
   const defaultDataView = useDeepEqualSelector(getDefaultDataViewSelector);
+  const { pathname } = useLocation();
+  const { selectedPatterns: nonTimelinePatterns } = useSourcererDataView(
+    getScopeFromPath(pathname)
+  );
 
   const { selectedPatterns: timelinePatterns } = useSourcererDataView(SourcererScopeName.timeline);
 
-  const selectedPatterns = useMemo(
-    () => (isActiveTimelines ? timelinePatterns : defaultDataView.patternList),
-    [defaultDataView.patternList, isActiveTimelines, timelinePatterns]
-  );
+  const selectedPatterns = useMemo(() => {
+    return isActiveTimelines
+      ? [...new Set([...timelinePatterns, ...defaultDataView.patternList])]
+      : [...new Set([...nonTimelinePatterns, ...defaultDataView.patternList])];
+  }, [isActiveTimelines, timelinePatterns, nonTimelinePatterns, defaultDataView.patternList]);
 
   return {
     selectedPatterns,


### PR DESCRIPTION
## Summary

Fix analyzer doesn't open when "only alerts" checkbox is selected. 


https://user-images.githubusercontent.com/1490444/200281259-9d5b02aa-a3fe-4f9a-a753-a7f477c33ec6.mov


TODO

- [ ] Add tests
- [ ] Verify if there are links to the timeline that add `event.kind:signal` and instead check "only alerts" checkbox
 
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

