### PR TITLE
chore(NA): move Bazel --progress_report_interval from common to build option

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -51,9 +51,9 @@ query --incompatible_no_implicit_file_export
 common --color=yes
 common --show_progress
 common --show_task_finish
-common --progress_report_interval=10
 common --show_progress_rate_limit=10
-common --show_loading_progress
+build --progress_report_interval=10
+build --show_loading_progress
 build --show_result=1
 
 # Specifies desired output mode for running tests.


### PR DESCRIPTION
This PR fixes a Bazel option back to build that was being wrongly used as common. 