### PR TITLE
[Fleet] Add docs for package verification GPG key

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -33,6 +33,9 @@ The address to use to reach the {package-manager} registry.
 The proxy address to use to reach the {package-manager} registry if an internet connection is not directly available.
 Refer to {fleet-guide}/air-gapped.html[Air-gapped environments] for details.
 
+`xpack.fleet.packageVerification.gpgKeyPath`::
+The path on disk to the GPG key used to verify the {package-manager} packages. In the event that Elastic's public key
+is reissued as a security precuation, you can use this setting to specify the new key.
 
 ==== {fleet} settings
 

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -34,8 +34,8 @@ The proxy address to use to reach the {package-manager} registry if an internet 
 Refer to {fleet-guide}/air-gapped.html[Air-gapped environments] for details.
 
 `xpack.fleet.packageVerification.gpgKeyPath`::
-The path on disk to the GPG key used to verify {package-manager} packages. In the event that Elastic's public key
-is reissued as a security precaution, you can use this setting to specify the new key.
+The path on disk to the GPG key used to verify {package-manager} packages. If the Elastic public key
+is ever reissued as a security precaution, you can use this setting to specify the new key.
 
 ==== {fleet} settings
 

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -34,8 +34,8 @@ The proxy address to use to reach the {package-manager} registry if an internet 
 Refer to {fleet-guide}/air-gapped.html[Air-gapped environments] for details.
 
 `xpack.fleet.packageVerification.gpgKeyPath`::
-The path on disk to the GPG key used to verify the {package-manager} packages. In the event that Elastic's public key
-is reissued as a security precuation, you can use this setting to specify the new key.
+The path on disk to the GPG key used to verify {package-manager} packages. In the event that Elastic's public key
+is reissued as a security precaution, you can use this setting to specify the new key.
 
 ==== {fleet} settings
 


### PR DESCRIPTION
## Summary

Document the `xpack.fleet.packageVerification.gpgKeyPath` setting in the Fleet settings docs.

