### PR TITLE
[Security Solution] Skip flaky Cypress tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
@@ -33,7 +33,7 @@ import { getNewRule } from '../../objects/rule';
 
 const DEFAULT_RULE_REFRESH_INTERVAL_VALUE = 60000;
 
-describe('Alerts detection rules table auto-refresh', () => {
+describe.skip('Alerts detection rules table auto-refresh', () => {
   before(() => {
     cleanKibana();
     login();


### PR DESCRIPTION
## Summary

Some of the Cypress suites became flaky, the same flake was noticed in https://github.com/elastic/kibana/pull/142878 and https://github.com/elastic/kibana/pull/144598

Suites involved:

- `x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts`
- `x-pack/plugins/security_solution/cypress/e2e/cases/attach_alert_to_case.cy.ts`

This PR temporarily skips them.