### PR TITLE
[Security Solution] Increase default Cypress timeouts

### DIFF
--- a/x-pack/plugins/security_solution/cypress/cypress.config.ts
+++ b/x-pack/plugins/security_solution/cypress/cypress.config.ts
@@ -9,9 +9,9 @@ import { defineConfig } from 'cypress';
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
-  defaultCommandTimeout: 20000,
-  execTimeout: 20000,
-  pageLoadTimeout: 20000,
+  defaultCommandTimeout: 60000,
+  execTimeout: 60000,
+  pageLoadTimeout: 60000,
   screenshotsFolder: '../../../target/kibana-security-solution/cypress/screenshots',
   trashAssetsBeforeRuns: false,
   video: false,

--- a/x-pack/plugins/security_solution/cypress/cypress_ci.config.ts
+++ b/x-pack/plugins/security_solution/cypress/cypress_ci.config.ts
@@ -9,9 +9,9 @@ import { defineConfig } from 'cypress';
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
-  defaultCommandTimeout: 120000,
-  execTimeout: 120000,
-  pageLoadTimeout: 120000,
+  defaultCommandTimeout: 150000,
+  execTimeout: 150000,
+  pageLoadTimeout: 150000,
   numTestsKeptInMemory: 0,
   retries: {
     runMode: 2,


### PR DESCRIPTION
## Summary

The default timeouts are increased:

- Locally: from 20s to 60s
- On CI: from 120s to 150s

Reasoning:

- Locally for some of the devs many tests fail with timeouts pretty often and pretty randomly.
- It looks like on CI flakiness has increased recently.
