### PR TITLE
[Security Solution] Rename the Technical Preview toggle in the Rules table

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -49,7 +49,14 @@ export const PAGE_TITLE = i18n.translate('xpack.securitySolution.detectionEngine
 export const EXPERIMENTAL_ON = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.experimentalOn',
   {
-    defaultMessage: 'Technical preview: On',
+    defaultMessage: 'Advanced sorting',
+  }
+);
+
+export const EXPERIMENTAL_OFF = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.experimentalOff',
+  {
+    defaultMessage: 'Advanced sorting',
   }
 );
 
@@ -57,14 +64,7 @@ export const EXPERIMENTAL_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.experimentalDescription',
   {
     defaultMessage:
-      'The experimental rules table view is in technical preview and allows for advanced sorting capabilities. If you experience performance issues when working with the table, you can turn this setting off.',
-  }
-);
-
-export const EXPERIMENTAL_OFF = i18n.translate(
-  'xpack.securitySolution.detectionEngine.rules.experimentalOff',
-  {
-    defaultMessage: 'Technical preview: Off',
+      'Turn this on to enable sorting for all table columns. You can turn it off if you encounter table performance issues.',
   }
 );
 


### PR DESCRIPTION
## Summary

Replaces the "**Technical preview**" wording with the new "**Advanced sorting**", effectively making this feature GA.

## Screenshots

**Before:**

<img width="1347" alt="Screenshot 2022-11-08 at 10 36 49" src="https://user-images.githubusercontent.com/7359339/200529328-60fedc78-7d4e-4a28-b610-03adb94ef9e1.png">

**After:**

<img width="1526" alt="Screenshot 2022-11-08 at 19 18 34" src="https://user-images.githubusercontent.com/7359339/200644318-7dd67f9b-fc73-4a14-b34b-71f783cb8df7.png">

https://user-images.githubusercontent.com/7359339/200644352-6d2e1954-2a1d-4f02-8b08-d02b3aecf2a6.mov

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
  - https://github.com/elastic/security-docs/issues/2683
