### PR TITLE
[ResponseOps][Alerting] Fixing flaky test in x-pack/test/alerting_api_integration/spaces_only/tests/alerting/builtin_alert_types/es_query/rule·ts

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/builtin_alert_types/es_query/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/builtin_alert_types/es_query/rule.ts
@@ -37,8 +37,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     createEsDocumentsInGroups,
   } = getRuleServices(getService);
 
-  // Failing: See https://github.com/elastic/kibana/issues/143870
-  describe.skip('rule', async () => {
+  describe('rule', async () => {
     let endDate: string;
     let connectorId: string;
     const objectRemover = new ObjectRemover(supertest);
@@ -221,6 +220,8 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     ].forEach(([searchType, initData]) =>
       it(`runs correctly: use epoch millis - threshold on hit count < > for ${searchType} search type`, async () => {
         // write documents from now to the future end date in groups
+        const endDateMillis = Date.now() + (RULE_INTERVALS_TO_WRITE - 1) * RULE_INTERVAL_MILLIS;
+        endDate = new Date(endDateMillis).toISOString();
         await createEsDocumentsInGroups(ES_GROUPS_TO_WRITE, endDate);
         await initData();
 
@@ -239,7 +240,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
 
           // during the first execution, the latestTimestamp value should be empty
           // since this rule always fires, the latestTimestamp value should be updated each execution
-          if (!i) {
+          if (i === 0) {
             expect(previousTimestamp).to.be.empty();
           } else {
             expect(previousTimestamp).not.to.be.empty();


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/143870
Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1526
