### PR TITLE
Add features mapping for connectors

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -40,7 +40,12 @@ describe('Setup Indices', () => {
       },
       description: { type: 'text' },
       error: { type: 'keyword' },
-      features: { type: 'keyword' },
+      features: {
+        properties: {
+          filtering_advanced_config: { type: 'boolean' },
+          filtering_rules: { type: 'boolean' },
+        },
+      },
       filtering: {
         properties: {
           active: {

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -40,6 +40,7 @@ describe('Setup Indices', () => {
       },
       description: { type: 'text' },
       error: { type: 'keyword' },
+      features: { type: 'keyword' },
       filtering: {
         properties: {
           active: {

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -32,6 +32,7 @@ const connectorMappingsProperties: Record<string, MappingProperty> = {
   configuration: { type: 'object' },
   description: { type: 'text' },
   error: { type: 'keyword' },
+  features: { type: 'keyword' },
   filtering: {
     properties: {
       active: {

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -32,7 +32,12 @@ const connectorMappingsProperties: Record<string, MappingProperty> = {
   configuration: { type: 'object' },
   description: { type: 'text' },
   error: { type: 'keyword' },
-  features: { type: 'keyword' },
+  features: {
+    properties: {
+      filtering_advanced_config: { type: 'boolean' },
+      filtering_rules: { type: 'boolean' },
+    },
+  },
   filtering: {
     properties: {
       active: {


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/enterprise-search-team/issues/3254

this augments the mappings for `.elastic-connectors` to include the `features` field

#### Related PRs
- https://github.com/elastic/ent-search/pull/7027
- https://github.com/elastic/connectors-ruby/pull/408