### PR TITLE
[DOCS] Fix links in Kibana troubleshooting

### DIFF
--- a/docs/user/troubleshooting/using-server-logs.asciidoc
+++ b/docs/user/troubleshooting/using-server-logs.asciidoc
@@ -34,7 +34,7 @@ logging.loggers:
     level: debug
     appenders: [file]
 ----
-WARNING: Kibana's `file` appender is configured to produce logs in https://www.elastic.co/guide/en/ecs/master/ecs-reference.html[ECS JSON] format. It's the only format that includes the meta information necessary for https://www.elastic.co/guide/en/apm/agent/nodejs/current/log-correlation.html[log correlation] out-of-the-box.
+WARNING: Kibana's `file` appender is configured to produce logs in {ecs-ref}/ecs-reference.html[ECS JSON] format. It's the only format that includes the meta information necessary for {apm-node-ref}/log-correlation.html[log correlation] out-of-the-box.
 
 The next step is to define what https://www.elastic.co/observability[observability tools] are available. 
 For a better experience, set up an https://www.elastic.co/guide/en/apm/get-started/current/observability-integrations.html[Observability integration] provided by Elastic to debug your application with the <<debugging-logs-apm-ui, APM UI.>>
@@ -42,16 +42,16 @@ To debug something quickly without setting up additional tooling, you can work w
 
 [[debugging-logs-apm-ui]]
 ==== APM UI
-*Prerequisites* {kib} logs are configured to be in https://www.elastic.co/guide/en/ecs/master/ecs-reference.html[ECS JSON] format to include tracing identifiers.
+*Prerequisites* {kib} logs are configured to be in {ecs-ref}/ecs-reference.html[ECS JSON] format to include tracing identifiers.
 
 To debug {kib} with the APM UI, you must set up the APM infrastructure. You can find instructions for the setup process
 https://www.elastic.co/guide/en/apm/get-started/current/observability-integrations.html[on the Observability integrations page].
 
-Once you set up the APM infrastructure, you can enable the APM agent and put {kib} under load to collect APM events. To analyze the collected metrics and logs, use the APM UI as demonstrated https://www.elastic.co/guide/en/kibana/master/transactions.html#transaction-trace-sample[in the docs].
+Once you set up the APM infrastructure, you can enable the APM agent and put {kib} under load to collect APM events. To analyze the collected metrics and logs, use the APM UI as demonstrated {kibana-ref}/transactions.html#transaction-trace-sample[in the docs].
 
 [[plain-kibana-logs]]
 ==== Plain {kib} logs
-*Prerequisites* {kib} logs are configured to be in https://www.elastic.co/guide/en/ecs/master/ecs-reference.html[ECS JSON] format to include tracing identifiers.
+*Prerequisites* {kib} logs are configured to be in {ecs-ref}/ecs-reference.html[ECS JSON] format to include tracing identifiers.
 
 Open {kib} Logs and search for an operation you are interested in.
 For example, suppose you want to investigate the response times for queries to the `/api/telemetry/v2/clusters/_stats` {kib} endpoint.


### PR DESCRIPTION
Relates https://github.com/elastic/docs/issues/2518

This PR changes the links in https://www.elastic.co/guide/en/kibana/master/kibana-troubleshooting-kibana-server-logs.html, so that they no longer have hard-coded references to "master". Otherwise, the following build errors occur when we rename that branch:

```
 16:25:18 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.5/kibana-troubleshooting-kibana-server-logs.html contains broken links to:
16:25:18 INFO:build_docs:   - en/ecs/master/ecs-reference.html
16:25:18 INFO:build_docs:   - en/kibana/master/transactions.html
```
