### PR TITLE
chore(NA): include .ijwb folder into the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ tsconfig.type_check.json
 .yarn-local-mirror
 
 # Bazel
+.ijwb
 /bazel
 /bazel-*
 .bazelrc.user


### PR DESCRIPTION
This PR adds `.ijwb` folder into the `.gitignore` file which is now being created after the latest IntelliJ update. It is related to the Bazel setup but for now it is needed.

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->