### PR TITLE
[Guided onboarding] Update search guide step 1 url

### DIFF
--- a/src/plugins/guided_onboarding/public/constants/guides_config/search.ts
+++ b/src/plugins/guided_onboarding/public/constants/guides_config/search.ts
@@ -35,8 +35,8 @@ export const searchConfig: GuideConfig = {
         }),
       ],
       location: {
-        appID: 'enterpriseSearch',
-        path: '',
+        appID: 'enterpriseSearchContent',
+        path: '/search_indices/new_index',
       },
     },
     {


### PR DESCRIPTION
This PR updates step 1 of the Enterprise Search onboarding guide to take users directly to the "New search index" page.

Follow up to https://github.com/elastic/kibana/pull/144488.