### PR TITLE
[Lens] Color with red used columns that don't exist on the dataview 

### DIFF
--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -385,7 +385,7 @@ export function getTextBasedDatasource({
 
       render(
         <EuiButtonEmpty
-          color={customLabel ? 'primary' : 'danger'}
+          color={customLabel && selectedField ? 'primary' : 'danger'}
           onClick={() => {}}
           data-test-subj="lns-dimensionTrigger-textBased"
         >


### PR DESCRIPTION
This fixes a bug I introduced here https://github.com/elastic/kibana/pull/144306

We want when the user duplicates a column to not color it as red but we want to color it as red when a column is used and then the user changes the dataview from the text based query.

![lens](https://user-images.githubusercontent.com/17003240/200526375-f3833420-5ace-4bc9-a40d-86e7bf15becd.gif)
