### PR TITLE
[Flaky Tests] Event Loop Delays collector (midnight flakiness)

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -50,7 +50,7 @@ function createRawEventLoopDelaysDailyDocs(logger: Logger) {
   if (moment().endOf('day').diff(moment(), 'hour', true) < 1) {
     edgeDocumentToKeep--;
   }
-  logger.info(`The eldest document to keep is ${edgeDocumentToKeep} days old.`);
+  logger.info(`The oldest document to keep is ${edgeDocumentToKeep} days old.`);
 
   const rawEventLoopDelaysDaily = [
     createRawObject(moment.now()),

--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -45,7 +45,7 @@ function createRawObject(date: moment.MomentInput): SavedObject<EventLoopDelaysD
 
 function createRawEventLoopDelaysDailyDocs(logger: Logger) {
   let edgeDocumentToKeep = 3;
-  // If we are too close to midnight, let's reduce the age of the eldest document to keep.
+  // If we are too close to midnight, let's reduce the age of the oldest document to keep.
   // Otherwise, the rollups may delete it.
   if (moment().endOf('day').diff(moment(), 'hour', true) < 1) {
     edgeDocumentToKeep--;


### PR DESCRIPTION
## Summary

Resolves #111821 (hopefully)

Looking at the logs in the 2 recent errors, it still happens when too close to midnight.

The suite takes 1 minute to run (61-62s), although the test takes only 200-300ms.

I changed the approach to our previous attempt to fix it: instead of delaying the test, we now change the age of the eldest document to keep if we are too close to midnight: any runs during the day will test the edge case of 3 days old documents while tests close to midnight will test with 2 days old documents.

IMO, it is not necessary to run the flaky-test-runner in this one because these issues only happen when close to midnight.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
