### PR TITLE
[Security Solution] Update ownership of rule_registry in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # used for the 'team' designator within Kibana Stats
 
 # Alerting commmunal ownership
-/x-pack/plugins/rule_registry/ @elastic/security-detections-response @elastic/actionable-observability @elastic/response-ops
+/x-pack/plugins/rule_registry/ @elastic/response-ops @elastic/actionable-observability
 
 # Data Discovery
 /src/plugins/discover/ @elastic/kibana-data-discovery


### PR DESCRIPTION
## Summary

In order to reduce the number of irrelevant PR review requests, this PR updates the CODEOWNERS file and removes the @elastic/security-detections-response team from code owners of the `rule_registry` plugin. This affects the following sub-teams:

- @elastic/security-detections-response-alerts. Although this team owns the alerts generation and indexing of the Detection Engine rule types (and this code depends on the `RuleDataClient`), they prefer not to be a code owner, because they keep getting pinged for PRs that don't need their review.
- @elastic/security-detections-response-rules area team. This team doesn't depend on the rule registry and doesn't do any work related to alerts-as-data.
- @elastic/security-solution-platform. This team won't be doing anything in the rule registry for the foreseeable future.
