### PR TITLE
[Guided Onboarding] Dropdown panel width fix

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -23,7 +23,7 @@ export const getGuidePanelStyles = (euiTheme: EuiThemeComputed) => ({
       bottom: 25px !important;
       right: 128px;
       border-radius: 6px;
-      width: 480px;
+      inline-size: 480px !important;
       height: auto;
       animation: euiModal 350ms cubic-bezier(0.34, 1.61, 0.7, 1);
       box-shadow: none;

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -312,6 +312,7 @@ export const GuidePanel = ({ api, application }: GuidePanelProps) => {
               justifyContent="center"
               gutterSize="xs"
               responsive={false}
+              wrap
             >
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty


### PR DESCRIPTION
## Summary

This resolves [issue #144766](https://github.com/elastic/kibana/issues/144766), the latest EUI upgrade breaks the panel width. The reason is the following:
![Group 625](https://user-images.githubusercontent.com/11224465/200543746-d3f65af3-b994-49fd-9b1e-9e2a7ef5d881.png)

I have changed the `width` attribute to `inline-size` to overwrite this, I also added `wrap` on the footer items, I think it was initially discussed not to add it, but looking at it again, I think it would be safer to add so that if someone is by chance using a very small screen/device the footer will appear properly.