### PR TITLE
[Lens] unify UI styles for warning messages

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/utils.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.test.tsx
@@ -12,7 +12,7 @@ import { getPrecisionErrorWarningMessages, cloneLayer } from './utils';
 import type { FormBasedPrivateState, GenericIndexPatternColumn } from './types';
 import type { FramePublicAPI } from '../../types';
 import type { DocLinksStart } from '@kbn/core/public';
-import { EuiButton } from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
 import { TermsIndexPatternColumn } from './operations';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -187,7 +187,7 @@ describe('indexpattern_datasource utils', () => {
       expect(warnings).toHaveLength(1);
       const DummyComponent = () => <>{warnings[0]}</>;
       const warningUi = shallow(<DummyComponent />);
-      warningUi.find(EuiButton).simulate('click');
+      warningUi.find(EuiLink).simulate('click');
       const stateSetter = setState.mock.calls[0][0];
       const newState = stateSetter(state);
       expect(newState.layers.id.columns.col1.label).toEqual('Rare values of category');

--- a/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
@@ -11,7 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { DocLinksStart, ThemeServiceStart } from '@kbn/core/public';
 import type { DatatableUtilitiesService } from '@kbn/data-plugin/common';
 import { TimeRange } from '@kbn/es-query';
-import { EuiLink, EuiTextColor, EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { groupBy, escape, uniq } from 'lodash';
@@ -116,7 +116,7 @@ const accuracyModeDisabledWarning = (
       id="xpack.lens.indexPattern.precisionErrorWarning.accuracyDisabled"
       defaultMessage="{name} might be an approximation. You can enable accuracy mode for more precise results, but note that it increases the load on the Elasticsearch cluster. {learnMoreLink}"
       values={{
-        name: <EuiTextColor color="accent">{columnName}</EuiTextColor>,
+        name: <strong>{columnName}</strong>,
         learnMoreLink: (
           <EuiLink href={docLink} color="text" target="_blank" external={true}>
             <FormattedMessage
@@ -128,11 +128,11 @@ const accuracyModeDisabledWarning = (
       }}
     />
     <EuiSpacer size="s" />
-    <EuiButton data-test-subj="lnsPrecisionWarningEnableAccuracy" onClick={enableAccuracyMode}>
+    <EuiLink data-test-subj="lnsPrecisionWarningEnableAccuracy" onClick={enableAccuracyMode}>
       {i18n.translate('xpack.lens.indexPattern.enableAccuracyMode', {
         defaultMessage: 'Enable accuracy mode',
       })}
-    </EuiButton>
+    </EuiLink>
   </>
 );
 
@@ -141,22 +141,22 @@ const accuracyModeEnabledWarning = (columnName: string, docLink: string) => (
     id="xpack.lens.indexPattern.precisionErrorWarning.accuracyEnabled"
     defaultMessage="{name} might be an approximation. For more precise results, try increasing the number of {topValues} or using {filters} instead. {learnMoreLink}"
     values={{
-      name: <EuiTextColor color="accent">{columnName}</EuiTextColor>,
+      name: <strong>{columnName}</strong>,
       topValues: (
-        <EuiTextColor color="subdued">
+        <strong>
           <FormattedMessage
             id="xpack.lens.indexPattern.precisionErrorWarning.topValues"
             defaultMessage="top values"
           />
-        </EuiTextColor>
+        </strong>
       ),
       filters: (
-        <EuiTextColor color="subdued">
+        <strong>
           <FormattedMessage
             id="xpack.lens.indexPattern.precisionErrorWarning.filters"
             defaultMessage="filters"
           />
-        </EuiTextColor>
+        </strong>
       ),
       learnMoreLink: (
         <EuiLink href={docLink} color="text" target="_blank" external={true}>
@@ -313,7 +313,7 @@ export function getPrecisionErrorWarningMessages(
                   id="xpack.lens.indexPattern.ascendingCountPrecisionErrorWarning"
                   defaultMessage="{name} for this visualization may be approximate due to how the data is indexed. Try sorting by rarity instead of ascending count of records. To learn more about this limit, {link}."
                   values={{
-                    name: <EuiTextColor color="accent">{column.name}</EuiTextColor>,
+                    name: <strong>{column.name}</strong>,
                     link: (
                       <EuiLink
                         href={docLinks.links.aggs.rare_terms}
@@ -330,7 +330,7 @@ export function getPrecisionErrorWarningMessages(
                   }}
                 />
                 <EuiSpacer size="s" />
-                <EuiButton
+                <EuiLink
                   onClick={() => {
                     setState((prevState) =>
                       mergeLayer({
@@ -355,7 +355,7 @@ export function getPrecisionErrorWarningMessages(
                   {i18n.translate('xpack.lens.indexPattern.switchToRare', {
                     defaultMessage: 'Rank by rarity',
                   })}
-                </EuiButton>
+                </EuiLink>
               </>
             );
           }


### PR DESCRIPTION
## Summary

This PR unify styles for different types of `PrecisionErrorWarnings`. 
@MichaelMarcialis highlighted this issue here:  https://github.com/elastic/kibana/pull/142985#issuecomment-1292164722

## Screen

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/20072247/200569254-e26b561d-dab4-45fa-8ac5-de1cfdbfccb1.png">

