### PR TITLE
[7.17] Bump nwsapi from v2.2.0 to v2.2.2 (#144001)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20325,9 +20325,9 @@ numeral@^2.0.6:
   integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
 
 nwsapi@^2.0.9, nwsapi@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
-  integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
+  integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
 nyc@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Bump nwsapi from v2.2.0 to v2.2.2 (#144001)](https://github.com/elastic/kibana/pull/144001)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Thomas Watson","email":"watson@elastic.co"},"sourceCommit":{"committedDate":"2022-10-27T17:21:53Z","message":"Bump nwsapi from v2.2.0 to v2.2.2 (#144001)","sha":"db6f06eaec98a7fdc0c0bbca8e6464bb70ef3506","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v8.6.0","v8.5.1"],"number":144001,"url":"https://github.com/elastic/kibana/pull/144001","mergeCommit":{"message":"Bump nwsapi from v2.2.0 to v2.2.2 (#144001)","sha":"db6f06eaec98a7fdc0c0bbca8e6464bb70ef3506"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/144001","number":144001,"mergeCommit":{"message":"Bump nwsapi from v2.2.0 to v2.2.2 (#144001)","sha":"db6f06eaec98a7fdc0c0bbca8e6464bb70ef3506"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/144119","number":144119,"state":"MERGED","mergeCommit":{"sha":"08a85996e81655077c4b6daafbb77d42c68bb796","message":"Bump nwsapi from v2.2.0 to v2.2.2 (#144001) (#144119)\n\n(cherry picked from commit db6f06eaec98a7fdc0c0bbca8e6464bb70ef3506)\n\nCo-authored-by: Thomas Watson <watson@elastic.co>"}}]}] BACKPORT-->