### PR TITLE
[Security Solution] Show correct `Privileges Required` page for unauthorized paths

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { NoPrivilegesPage } from './no_privileges';
+export { NoPrivilegesPage, NoPrivileges } from './no_privileges';

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { NoPrivilegesPage } from './no_privileges';

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+
+import { EuiPageTemplate_Deprecated as EuiPageTemplate } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../page_wrapper';
+import { EmptyPage } from '../empty_page';
+import { useKibana } from '../../lib/kibana';
+import * as i18n from './translations';
+
+interface NoPrivilegesPageProps {
+  subPluginKey?: string;
+}
+
+export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(
+  ({ subPluginKey = 'this page' }) => {
+    const { docLinks } = useKibana().services;
+    const emptyPageActions = useMemo(
+      () => ({
+        feature: {
+          icon: 'documents',
+          label: i18n.GO_TO_DOCUMENTATION,
+          url: `${docLinks.links.siem.privileges}`,
+          target: '_blank',
+        },
+      }),
+      [docLinks]
+    );
+    return (
+      <SecuritySolutionPageWrapper>
+        <EuiPageTemplate template="centeredContent">
+          <EmptyPage
+            actions={emptyPageActions}
+            message={i18n.NO_PERMISSIONS_MSG(subPluginKey)}
+            data-test-subj="no_feature_permissions-alerts"
+            title={i18n.NO_PERMISSIONS_TITLE}
+          />
+        </EuiPageTemplate>
+      </SecuritySolutionPageWrapper>
+    );
+  }
+);
+
+NoPrivilegesPage.displayName = 'NoPrivilegePage';

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -17,8 +17,20 @@ interface NoPrivilegesPageProps {
   pageName?: string;
 }
 
-export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName = 'this page' }) => {
+export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName }) => {
+  return (
+    <SecuritySolutionPageWrapper>
+      <EuiPageTemplate template="centeredContent">
+        <NoPrivileges pageName={pageName} />
+      </EuiPageTemplate>
+    </SecuritySolutionPageWrapper>
+  );
+});
+NoPrivilegesPage.displayName = 'NoPrivilegePage';
+
+export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName = 'this page' }) => {
   const { docLinks } = useKibana().services;
+
   const emptyPageActions = useMemo(
     () => ({
       feature: {
@@ -30,18 +42,14 @@ export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName = 
     }),
     [docLinks]
   );
+
   return (
-    <SecuritySolutionPageWrapper>
-      <EuiPageTemplate template="centeredContent">
-        <EmptyPage
-          actions={emptyPageActions}
-          message={i18n.NO_PERMISSIONS_MSG(pageName)}
-          data-test-subj="no_feature_permissions-alerts"
-          title={i18n.NO_PERMISSIONS_TITLE}
-        />
-      </EuiPageTemplate>
-    </SecuritySolutionPageWrapper>
+    <EmptyPage
+      actions={emptyPageActions}
+      message={i18n.NO_PERMISSIONS_MSG(pageName)}
+      data-test-subj="no_feature_permissions-alerts"
+      title={i18n.NO_PERMISSIONS_TITLE}
+    />
   );
 });
-
-NoPrivilegesPage.displayName = 'NoPrivilegePage';
+NoPrivileges.displayName = 'NoPrivileges';

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -14,36 +14,34 @@ import { useKibana } from '../../lib/kibana';
 import * as i18n from './translations';
 
 interface NoPrivilegesPageProps {
-  subPluginKey?: string;
+  pageName?: string;
 }
 
-export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(
-  ({ subPluginKey = 'this page' }) => {
-    const { docLinks } = useKibana().services;
-    const emptyPageActions = useMemo(
-      () => ({
-        feature: {
-          icon: 'documents',
-          label: i18n.GO_TO_DOCUMENTATION,
-          url: `${docLinks.links.siem.privileges}`,
-          target: '_blank',
-        },
-      }),
-      [docLinks]
-    );
-    return (
-      <SecuritySolutionPageWrapper>
-        <EuiPageTemplate template="centeredContent">
-          <EmptyPage
-            actions={emptyPageActions}
-            message={i18n.NO_PERMISSIONS_MSG(subPluginKey)}
-            data-test-subj="no_feature_permissions-alerts"
-            title={i18n.NO_PERMISSIONS_TITLE}
-          />
-        </EuiPageTemplate>
-      </SecuritySolutionPageWrapper>
-    );
-  }
-);
+export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName = 'this page' }) => {
+  const { docLinks } = useKibana().services;
+  const emptyPageActions = useMemo(
+    () => ({
+      feature: {
+        icon: 'documents',
+        label: i18n.GO_TO_DOCUMENTATION,
+        url: `${docLinks.links.siem.privileges}`,
+        target: '_blank',
+      },
+    }),
+    [docLinks]
+  );
+  return (
+    <SecuritySolutionPageWrapper>
+      <EuiPageTemplate template="centeredContent">
+        <EmptyPage
+          actions={emptyPageActions}
+          message={i18n.NO_PERMISSIONS_MSG(pageName)}
+          data-test-subj="no_feature_permissions-alerts"
+          title={i18n.NO_PERMISSIONS_TITLE}
+        />
+      </EuiPageTemplate>
+    </SecuritySolutionPageWrapper>
+  );
+});
 
 NoPrivilegesPage.displayName = 'NoPrivilegePage';

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -28,7 +28,7 @@ export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName })
 });
 NoPrivilegesPage.displayName = 'NoPrivilegePage';
 
-export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName = 'this page' }) => {
+export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName }) => {
   const { docLinks } = useKibana().services;
 
   const emptyPageActions = useMemo(
@@ -43,10 +43,14 @@ export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName = 'thi
     [docLinks]
   );
 
+  const message = pageName
+    ? i18n.NO_PRIVILEGES_PER_PAGE_MESSAGE(pageName)
+    : i18n.NO_PRIVILEGES_DEFAULT_MESSAGE;
+
   return (
     <EmptyPage
       actions={emptyPageActions}
-      message={i18n.NO_PERMISSIONS_MSG(pageName)}
+      message={message}
       data-test-subj="noPrivilegesPage"
       title={i18n.NO_PERMISSIONS_TITLE}
     />

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -47,7 +47,7 @@ export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName = 'thi
     <EmptyPage
       actions={emptyPageActions}
       message={i18n.NO_PERMISSIONS_MSG(pageName)}
-      data-test-subj="no_feature_permissions-alerts"
+      data-test-subj="noPrivilegesPage"
       title={i18n.NO_PERMISSIONS_TITLE}
     />
   );

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
@@ -10,12 +10,20 @@ export const NO_PERMISSIONS_TITLE = i18n.translate('xpack.securitySolution.noPer
   defaultMessage: 'Privileges required',
 });
 
-export const NO_PERMISSIONS_MSG = (pageName: string) =>
-  i18n.translate('xpack.securitySolution.noPermissionsMessage', {
+export const NO_PRIVILEGES_PER_PAGE_MESSAGE = (pageName: string) =>
+  i18n.translate('xpack.securitySolution.noPrivilegesPerPageMessage', {
     values: { pageName },
     defaultMessage:
       'To view {pageName}, you must update privileges. For more information, contact your Kibana administrator.',
   });
+
+export const NO_PRIVILEGES_DEFAULT_MESSAGE = i18n.translate(
+  'xpack.securitySolution.noPrivilegesDefaultMessage',
+  {
+    defaultMessage:
+      'To view this page, you must update privileges. For more information, contact your Kibana administrator.',
+  }
+);
 
 export const GO_TO_DOCUMENTATION = i18n.translate(
   'xpack.securitySolution.goToDocumentationButton',

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
@@ -10,11 +10,11 @@ export const NO_PERMISSIONS_TITLE = i18n.translate('xpack.securitySolution.noPer
   defaultMessage: 'Privileges required',
 });
 
-export const NO_PERMISSIONS_MSG = (subPluginKey: string) =>
+export const NO_PERMISSIONS_MSG = (pageName: string) =>
   i18n.translate('xpack.securitySolution.noPermissionsMessage', {
-    values: { subPluginKey },
+    values: { pageName },
     defaultMessage:
-      'To view {subPluginKey}, you must update privileges. For more information, contact your Kibana administrator.',
+      'To view {pageName}, you must update privileges. For more information, contact your Kibana administrator.',
   });
 
 export const GO_TO_DOCUMENTATION = i18n.translate(

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/translations.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+
+export const NO_PERMISSIONS_TITLE = i18n.translate('xpack.securitySolution.noPermissionsTitle', {
+  defaultMessage: 'Privileges required',
+});
+
+export const NO_PERMISSIONS_MSG = (subPluginKey: string) =>
+  i18n.translate('xpack.securitySolution.noPermissionsMessage', {
+    values: { subPluginKey },
+    defaultMessage:
+      'To view {subPluginKey}, you must update privileges. For more information, contact your Kibana administrator.',
+  });
+
+export const GO_TO_DOCUMENTATION = i18n.translate(
+  'xpack.securitySolution.goToDocumentationButton',
+  {
+    defaultMessage: 'View documentation',
+  }
+);

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/index.ts
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { PrivilegedRouteProps } from './privileged_route';
+export { PrivilegedRoute } from './privileged_route';

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Switch, MemoryRouter } from 'react-router-dom';
+import type { AppContextTestRender } from '../../../common/mock/endpoint';
+import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
+import { PrivilegedRoute } from './privileged_route';
+import type { PrivilegedRouteProps } from './privileged_route';
+
+describe('PrivilegedRoute', () => {
+  const componentTestId = 'component-to-render';
+
+  let renderProps: PrivilegedRouteProps;
+  let renderResult: ReturnType<AppContextTestRender['render']>;
+  let render: () => void;
+
+  beforeEach(() => {
+    renderProps = {
+      component: () => <div data-test-subj={componentTestId} />,
+      path: 'path',
+      privilege: true,
+    };
+
+    const renderer = createAppRootMockRenderer();
+
+    render = () => {
+      renderResult = renderer.render(
+        <MemoryRouter initialEntries={['path']}>
+          <Switch>
+            <PrivilegedRoute {...renderProps} />
+          </Switch>
+        </MemoryRouter>
+      );
+    };
+  });
+
+  it('renders component if it has privileges and on correct path', async () => {
+    render();
+
+    expect(renderResult.getByTestId(componentTestId)).toBeTruthy();
+    expect(renderResult.queryByText(/superuser/)).toBeNull();
+  });
+
+  it('renders NoPermission if does not have privileges', async () => {
+    renderProps.privilege = false;
+
+    render();
+
+    expect(renderResult.getByText(/superuser/)).toBeTruthy();
+    expect(renderResult.queryByTestId(componentTestId)).toBeNull();
+  });
+
+  it('renders nothing if path is different', async () => {
+    renderProps.path = 'different';
+
+    render();
+
+    expect(renderResult.queryByTestId(componentTestId)).toBeNull();
+    expect(renderResult.queryByText(/superuser/)).toBeNull();
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
@@ -17,6 +17,9 @@ import { AdministrationSubTab } from '../../types';
 jest.mock('../../../common/hooks/use_experimental_features');
 
 describe('PrivilegedRoute', () => {
+  const superuserPattern = /must have the superuser role/;
+  const rbacPattern = /you must update privileges/;
+
   const componentTestId = 'component-to-render';
   let featureFlags: { endpointRbacEnabled: boolean; endpointRbacV1Enabled: boolean };
 
@@ -59,8 +62,8 @@ describe('PrivilegedRoute', () => {
       render();
 
       expect(renderResult.getByTestId(componentTestId)).toBeTruthy();
-      expect(renderResult.queryByText(/superuser/)).toBeNull();
-      expect(renderResult.queryByText(/privileges/)).toBeNull();
+      expect(renderResult.queryByText(superuserPattern)).toBeNull();
+      expect(renderResult.queryByText(rbacPattern)).toBeNull();
     });
 
     it('renders nothing if path is different', async () => {
@@ -69,8 +72,8 @@ describe('PrivilegedRoute', () => {
       render();
 
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
-      expect(renderResult.queryByText(/superuser/)).toBeNull();
-      expect(renderResult.queryByText(/privileges/)).toBeNull();
+      expect(renderResult.queryByText(superuserPattern)).toBeNull();
+      expect(renderResult.queryByText(rbacPattern)).toBeNull();
     });
   };
 
@@ -82,8 +85,9 @@ describe('PrivilegedRoute', () => {
 
       render();
 
-      expect(renderResult.getByText(/superuser/)).toBeTruthy();
+      expect(renderResult.getByText(superuserPattern)).toBeTruthy();
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
+      expect(renderResult.queryByText(rbacPattern)).toBeNull();
     });
   });
 
@@ -102,7 +106,8 @@ describe('PrivilegedRoute', () => {
 
         render();
 
-        expect(renderResult.getByText(/privileges/)).toBeTruthy();
+        expect(renderResult.getByText(rbacPattern)).toBeTruthy();
+        expect(renderResult.queryByText(superuserPattern)).toBeNull();
         expect(renderResult.queryByTestId(componentTestId)).toBeNull();
       });
 
@@ -111,7 +116,8 @@ describe('PrivilegedRoute', () => {
 
         render();
 
-        expect(renderResult.getByText(/superuser/)).toBeTruthy();
+        expect(renderResult.getByText(superuserPattern)).toBeTruthy();
+        expect(renderResult.queryByText(rbacPattern)).toBeNull();
         expect(renderResult.queryByTestId(componentTestId)).toBeNull();
       });
     });
@@ -129,7 +135,8 @@ describe('PrivilegedRoute', () => {
 
       render();
 
-      expect(renderResult.getByText(/privileges/)).toBeTruthy();
+      expect(renderResult.getByText(rbacPattern)).toBeTruthy();
+      expect(renderResult.queryByText(superuserPattern)).toBeNull();
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
     });
   });

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
@@ -17,8 +17,8 @@ import { AdministrationSubTab } from '../../types';
 jest.mock('../../../common/hooks/use_experimental_features');
 
 describe('PrivilegedRoute', () => {
-  const superuserPattern = /must have the superuser role/;
-  const rbacPattern = /you must update privileges/;
+  const noPrivilegesPageTestId = 'noPrivilegesPage';
+  const noPermissionsPageTestId = 'noIngestPermissions';
 
   const componentTestId = 'component-to-render';
   let featureFlags: { endpointRbacEnabled: boolean; endpointRbacV1Enabled: boolean };
@@ -62,8 +62,8 @@ describe('PrivilegedRoute', () => {
       render();
 
       expect(renderResult.getByTestId(componentTestId)).toBeTruthy();
-      expect(renderResult.queryByText(superuserPattern)).toBeNull();
-      expect(renderResult.queryByText(rbacPattern)).toBeNull();
+      expect(renderResult.queryByTestId(noPermissionsPageTestId)).toBeNull();
+      expect(renderResult.queryByTestId(noPrivilegesPageTestId)).toBeNull();
     });
 
     it('renders nothing if path is different', async () => {
@@ -72,8 +72,8 @@ describe('PrivilegedRoute', () => {
       render();
 
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
-      expect(renderResult.queryByText(superuserPattern)).toBeNull();
-      expect(renderResult.queryByText(rbacPattern)).toBeNull();
+      expect(renderResult.queryByTestId(noPermissionsPageTestId)).toBeNull();
+      expect(renderResult.queryByTestId(noPrivilegesPageTestId)).toBeNull();
     });
   };
 
@@ -85,9 +85,9 @@ describe('PrivilegedRoute', () => {
 
       render();
 
-      expect(renderResult.getByText(superuserPattern)).toBeTruthy();
+      expect(renderResult.getByTestId(noPermissionsPageTestId)).toBeTruthy();
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
-      expect(renderResult.queryByText(rbacPattern)).toBeNull();
+      expect(renderResult.queryByTestId(noPrivilegesPageTestId)).toBeNull();
     });
   });
 
@@ -106,8 +106,8 @@ describe('PrivilegedRoute', () => {
 
         render();
 
-        expect(renderResult.getByText(rbacPattern)).toBeTruthy();
-        expect(renderResult.queryByText(superuserPattern)).toBeNull();
+        expect(renderResult.getByTestId(noPrivilegesPageTestId)).toBeTruthy();
+        expect(renderResult.queryByTestId(noPermissionsPageTestId)).toBeNull();
         expect(renderResult.queryByTestId(componentTestId)).toBeNull();
       });
 
@@ -116,8 +116,8 @@ describe('PrivilegedRoute', () => {
 
         render();
 
-        expect(renderResult.getByText(superuserPattern)).toBeTruthy();
-        expect(renderResult.queryByText(rbacPattern)).toBeNull();
+        expect(renderResult.getByTestId(noPermissionsPageTestId)).toBeTruthy();
+        expect(renderResult.queryByTestId(noPrivilegesPageTestId)).toBeNull();
         expect(renderResult.queryByTestId(componentTestId)).toBeNull();
       });
     });
@@ -135,8 +135,8 @@ describe('PrivilegedRoute', () => {
 
       render();
 
-      expect(renderResult.getByText(rbacPattern)).toBeTruthy();
-      expect(renderResult.queryByText(superuserPattern)).toBeNull();
+      expect(renderResult.getByTestId(noPrivilegesPageTestId)).toBeTruthy();
+      expect(renderResult.queryByTestId(noPermissionsPageTestId)).toBeNull();
       expect(renderResult.queryByTestId(componentTestId)).toBeNull();
     });
   });

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
@@ -13,6 +13,8 @@ import { PrivilegedRoute } from './privileged_route';
 import type { PrivilegedRouteProps } from './privileged_route';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { AdministrationSubTab } from '../../types';
+import { MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH } from '../../common/constants';
+import { MANAGEMENT_PATH } from '../../../../common/constants';
 
 jest.mock('../../../common/hooks/use_experimental_features');
 
@@ -101,8 +103,8 @@ describe('PrivilegedRoute', () => {
     describe('no privileges', () => {
       it('renders `you need to have privileges` on Response actions history', async () => {
         renderProps.hasPrivilege = false;
-        renderProps.path = AdministrationSubTab.responseActionsHistory;
-        currentPath = AdministrationSubTab.responseActionsHistory;
+        renderProps.path = MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH;
+        currentPath = `${MANAGEMENT_PATH}/${AdministrationSubTab.responseActionsHistory}`;
 
         render();
 

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.test.tsx
@@ -34,7 +34,7 @@ describe('PrivilegedRoute', () => {
     renderProps = {
       component: () => <div data-test-subj={componentTestId} />,
       path: 'path',
-      privilege: true,
+      hasPrivilege: true,
     };
 
     const renderer = createAppRootMockRenderer();
@@ -81,7 +81,7 @@ describe('PrivilegedRoute', () => {
     testCommonPathsForAllFeatureFlags();
 
     it('renders `you need to be superuser` if no privileges', async () => {
-      renderProps.privilege = false;
+      renderProps.hasPrivilege = false;
 
       render();
 
@@ -100,7 +100,7 @@ describe('PrivilegedRoute', () => {
 
     describe('no privileges', () => {
       it('renders `you need to have privileges` on Response actions history', async () => {
-        renderProps.privilege = false;
+        renderProps.hasPrivilege = false;
         renderProps.path = AdministrationSubTab.responseActionsHistory;
         currentPath = AdministrationSubTab.responseActionsHistory;
 
@@ -112,7 +112,7 @@ describe('PrivilegedRoute', () => {
       });
 
       it('renders `you need to be superuser` on other pages', async () => {
-        renderProps.privilege = false;
+        renderProps.hasPrivilege = false;
 
         render();
 
@@ -131,7 +131,7 @@ describe('PrivilegedRoute', () => {
     testCommonPathsForAllFeatureFlags();
 
     it('renders `you need to have RBAC privileges` if no privileges', async () => {
-      renderProps.privilege = false;
+      renderProps.hasPrivilege = false;
 
       render();
 

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -7,6 +7,7 @@
 import type { ComponentType } from 'react';
 import React, { memo } from 'react';
 import { Route } from '@kbn/kibana-react-plugin/public';
+import { NoPrivilegesPage } from '../../../common/components/no_privileges';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { NoPermissions } from '../no_permissons';
 import { AdministrationSubTab } from '../../types';
@@ -16,8 +17,6 @@ export interface PrivilegedRouteProps {
   component: ComponentType<{}>;
   privilege: boolean;
 }
-
-const DummyNoPrivilegesComponent = () => <div>{'you need to update your privileges'}</div>;
 
 export const PrivilegedRoute = memo(({ component, privilege, path }: PrivilegedRouteProps) => {
   const isEndpointRbacEnabled = useIsExperimentalFeatureEnabled('endpointRbacEnabled');
@@ -31,7 +30,7 @@ export const PrivilegedRoute = memo(({ component, privilege, path }: PrivilegedR
       (isEndpointRbacV1Enabled && path.includes(AdministrationSubTab.responseActionsHistory));
 
     componentToRender = shouldUseMissingPrivilegesScreen
-      ? DummyNoPrivilegesComponent
+      ? () => <NoPrivilegesPage />
       : NoPermissions;
   }
 

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ComponentType } from 'react';
+import React, { memo } from 'react';
+import { Route } from '@kbn/kibana-react-plugin/public';
+import { NoPermissions } from '../no_permissons';
+
+export interface PrivilegedRouteProps {
+  path: string;
+  component: ComponentType<{}>;
+  privilege: boolean;
+}
+
+export const PrivilegedRoute = memo(({ component, privilege, path }: PrivilegedRouteProps) => {
+  return <Route path={path} component={privilege ? component : NoPermissions} />;
+});
+PrivilegedRoute.displayName = 'PrivilegedRoute';

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -10,7 +10,7 @@ import { Route } from '@kbn/kibana-react-plugin/public';
 import { NoPrivilegesPage } from '../../../common/components/no_privileges';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { NoPermissions } from '../no_permissons';
-import { AdministrationSubTab } from '../../types';
+import { MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH } from '../../common/constants';
 
 export interface PrivilegedRouteProps {
   path: string;
@@ -27,7 +27,7 @@ export const PrivilegedRoute = memo(({ component, hasPrivilege, path }: Privileg
   if (!hasPrivilege) {
     const shouldUseMissingPrivilegesScreen =
       isEndpointRbacEnabled ||
-      (isEndpointRbacV1Enabled && path.includes(AdministrationSubTab.responseActionsHistory));
+      (isEndpointRbacV1Enabled && path === MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH);
 
     componentToRender = shouldUseMissingPrivilegesScreen
       ? () => <NoPrivilegesPage />

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -15,16 +15,16 @@ import { AdministrationSubTab } from '../../types';
 export interface PrivilegedRouteProps {
   path: string;
   component: ComponentType<{}>;
-  privilege: boolean;
+  hasPrivilege: boolean;
 }
 
-export const PrivilegedRoute = memo(({ component, privilege, path }: PrivilegedRouteProps) => {
+export const PrivilegedRoute = memo(({ component, hasPrivilege, path }: PrivilegedRouteProps) => {
   const isEndpointRbacEnabled = useIsExperimentalFeatureEnabled('endpointRbacEnabled');
   const isEndpointRbacV1Enabled = useIsExperimentalFeatureEnabled('endpointRbacV1Enabled');
 
   let componentToRender = component;
 
-  if (!privilege) {
+  if (!hasPrivilege) {
     const shouldUseMissingPrivilegesScreen =
       isEndpointRbacEnabled ||
       (isEndpointRbacV1Enabled && path.includes(AdministrationSubTab.responseActionsHistory));

--- a/x-pack/plugins/security_solution/public/management/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { ComponentType } from 'react';
 import React, { memo } from 'react';
 import { Switch, Redirect } from 'react-router-dom';
 import { Route } from '@kbn/kibana-react-plugin/public';
@@ -32,7 +31,7 @@ import { useUserPrivileges } from '../../common/components/user_privileges';
 import { HostIsolationExceptionsContainer } from './host_isolation_exceptions';
 import { BlocklistContainer } from './blocklist';
 import { ResponseActionsContainer } from './response_actions';
-import { NoPermissions } from '../components/no_permissons';
+import { PrivilegedRoute } from '../components/privileged_route';
 
 const EndpointTelemetry = () => (
   <TrackApplicationView viewId={SecurityPageName.endpoints}>
@@ -75,16 +74,6 @@ const ResponseActionsTelemetry = () => (
     <SpyRoute pageName={SecurityPageName.responseActionsHistory} />
   </TrackApplicationView>
 );
-
-interface PrivilegedRouteProps {
-  path: string;
-  component: ComponentType<{}>;
-  privilege: boolean;
-}
-
-const PrivilegedRoute = ({ component, privilege, path }: PrivilegedRouteProps) => {
-  return <Route path={path} component={privilege ? component : NoPermissions} />;
-};
 
 export const ManagementContainer = memo(() => {
   const {

--- a/x-pack/plugins/security_solution/public/management/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.tsx
@@ -96,22 +96,22 @@ export const ManagementContainer = memo(() => {
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_ENDPOINTS_PATH}
         component={EndpointTelemetry}
-        privilege={canReadEndpointList}
+        hasPrivilege={canReadEndpointList}
       />
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_POLICIES_PATH}
         component={PolicyTelemetry}
-        privilege={canReadPolicyManagement}
+        hasPrivilege={canReadPolicyManagement}
       />
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_TRUSTED_APPS_PATH}
         component={TrustedAppTelemetry}
-        privilege={canReadTrustedApplications}
+        hasPrivilege={canReadTrustedApplications}
       />
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_EVENT_FILTERS_PATH}
         component={EventFilterTelemetry}
-        privilege={canReadEventFilters}
+        hasPrivilege={canReadEventFilters}
       />
       <Route
         path={MANAGEMENT_ROUTING_HOST_ISOLATION_EXCEPTIONS_PATH}
@@ -120,12 +120,12 @@ export const ManagementContainer = memo(() => {
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_BLOCKLIST_PATH}
         component={BlocklistContainer}
-        privilege={canReadBlocklist}
+        hasPrivilege={canReadBlocklist}
       />
       <PrivilegedRoute
         path={MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH}
         component={ResponseActionsTelemetry}
-        privilege={canReadActionsLogManagement}
+        hasPrivilege={canReadActionsLogManagement}
       />
 
       {canReadEndpointList && (

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -25619,6 +25619,8 @@
     "xpack.securitySolution.networkTopNFlowTable.rows": "{numRows} {numRows, plural, =0 {ligne} =1 {ligne} other {lignes}}",
     "xpack.securitySolution.networkTopNFlowTable.unit": "{totalCount, plural, other {IP}}",
     "xpack.securitySolution.noPermissionsMessage": "Pour afficher {subPluginKey}, vous devez mettre à jour les privilèges. Pour en savoir plus, contactez votre administrateur Kibana.",
+    "xpack.securitySolution.noPrivilegesDefaultMessage": "Pour afficher cette page, vous devez mettre à jour les privilèges. Pour en savoir plus, contactez votre administrateur Kibana.",
+    "xpack.securitySolution.noPrivilegesPerPageMessage": "Pour afficher {pageName}, vous devez mettre à jour les privilèges. Pour en savoir plus, contactez votre administrateur Kibana.",
     "xpack.securitySolution.notes.youAreViewingNotesScreenReaderOnly": "Vous visualisez des notes pour l'événement de la ligne {row}. Appuyez sur la touche fléchée vers le haut lorsque vous aurez terminé pour revenir à l'événement.",
     "xpack.securitySolution.open.timeline.deleteTimelineModalTitle": "Supprimer \"{title}\" ?",
     "xpack.securitySolution.open.timeline.selectedTemplatesTitle": "Sélection de {selectedTemplates} {selectedTemplates, plural, =1 {modèle} other {modèles}} effectuée",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -25594,6 +25594,8 @@
     "xpack.securitySolution.networkTopNFlowTable.rows": "{numRows} {numRows, plural, other  {行}}",
     "xpack.securitySolution.networkTopNFlowTable.unit": "{totalCount, plural, other  {IP}}",
     "xpack.securitySolution.noPermissionsMessage": "{subPluginKey}を表示するには、権限を更新する必要があります。詳細については、Kibana管理者に連絡してください。",
+    "xpack.securitySolution.noPrivilegesPerPageMessage": "{pageName}を表示するには、権限を更新する必要があります。詳細については、Kibana管理者に連絡してください。",
+    "xpack.securitySolution.noPrivilegesDefaultMessage": "このページを表示するには、権限を更新する必要があります。詳細については、Kibana管理者に連絡してください。",
     "xpack.securitySolution.notes.youAreViewingNotesScreenReaderOnly": "行 {row} のイベントのメモを表示しています。完了したら上矢印キーを押して、イベントに戻ります。",
     "xpack.securitySolution.open.timeline.deleteTimelineModalTitle": "「{title}」を削除しますか？",
     "xpack.securitySolution.open.timeline.selectedTemplatesTitle": "{selectedTemplates} {selectedTemplates, plural, other  {個のテンプレート}}を選択しました",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25628,6 +25628,8 @@
     "xpack.securitySolution.networkTopNFlowTable.rows": "{numRows} {numRows, plural, other {行}}",
     "xpack.securitySolution.networkTopNFlowTable.unit": "{totalCount, plural, other {个 IP}}",
     "xpack.securitySolution.noPermissionsMessage": "要查看 {subPluginKey}，必须更新权限。有关详细信息，请联系您的 Kibana 管理员。",
+    "xpack.securitySolution.noPrivilegesPerPageMessage": "要查看 {pageName}，必须更新权限。有关详细信息，请联系您的 Kibana 管理员。",
+    "xpack.securitySolution.noPrivilegesDefaultMessage": "要查看此页面，必须更新权限。有关详细信息，请联系您的 Kibana 管理员。",
     "xpack.securitySolution.notes.youAreViewingNotesScreenReaderOnly": "您正在查看事件在第 {row} 行的备注。完成后，按向上箭头键可返回到事件。",
     "xpack.securitySolution.open.timeline.deleteTimelineModalTitle": "删除“{title}”？",
     "xpack.securitySolution.open.timeline.selectedTemplatesTitle": "已选择 {selectedTemplates} 个{selectedTemplates, plural, other {模板}}",


### PR DESCRIPTION
## Summary

The goal is to show a _Privileges required_  or _Superuser required_ message to users if they want to access a page in Security Management they don't have access for, based on feature flags.

`<PrivilegedRouter>` decides which message to show:
- current version (no feature flags): _superuser required_ for all pages
- v1 (`endpointRbacV1Enabled`):
   - _privileges required_ only for _Response actions history_
   - _superuser required_ for other pages
- v2 (`endpointRbacEnabled`): _privileges required_ for all pages

To test it:
- change the feature flags,
- create a non-superuser user, with different Kibana privileges
- and check the urls for Security Management pages, e.g. http://localhost:5601/app/security/administration/response_actions_history

Without feature flags:
<img width="998" alt="image" src="https://user-images.githubusercontent.com/39014407/200780212-e16246a0-76d4-4c8a-a9b9-6b2b4466e7b8.png">

v1/v2 for Response actions history:
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/39014407/200780408-c80ca58b-9d06-47cd-beb9-c764ef5f1380.png">


### Dev note
A refactor PR for reusing the new `<NoPrivilegesPage>` component in 3 other places inside security solution plugin is ~coming soon.~ here: https://github.com/elastic/kibana/pull/144886

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
