### PR TITLE
[Cloud Posture] track findings pages

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -54,13 +54,16 @@ export const findingsNavigation = {
   findings_default: {
     name: NAV_ITEMS_NAMES.FINDINGS,
     path: `${CLOUD_SECURITY_POSTURE_BASE_PATH}/findings/default`,
+    id: 'cloud_security_posture-findings-default',
   },
   findings_by_resource: {
     name: NAV_ITEMS_NAMES.FINDINGS,
     path: `${CLOUD_SECURITY_POSTURE_BASE_PATH}/findings/resource`,
+    id: 'cloud_security_posture-findings-resource',
   },
   resource_findings: {
     name: NAV_ITEMS_NAMES.FINDINGS,
     path: `${CLOUD_SECURITY_POSTURE_BASE_PATH}/findings/resource/:resourceId`,
+    id: 'cloud_security_posture-findings-resourceId',
   },
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { useCspSetupStatusApi } from '../../common/api/use_setup_status_api';
 import { NoFindingsStates } from '../../components/no_findings_states';
 import { CloudPosturePage } from '../../components/cloud_posture_page';
@@ -16,7 +17,6 @@ import { useLatestFindingsDataView } from '../../common/api/use_latest_findings_
 import { cloudPosturePages, findingsNavigation } from '../../common/navigation/constants';
 import { FindingsByResourceContainer } from './latest_findings_by_resource/findings_by_resource_container';
 import { LatestFindingsContainer } from './latest_findings/latest_findings_container';
-import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 export const Findings = () => {
   const location = useLocation();

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -16,6 +16,7 @@ import { useLatestFindingsDataView } from '../../common/api/use_latest_findings_
 import { cloudPosturePages, findingsNavigation } from '../../common/navigation/constants';
 import { FindingsByResourceContainer } from './latest_findings_by_resource/findings_by_resource_container';
 import { LatestFindingsContainer } from './latest_findings/latest_findings_container';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 export const Findings = () => {
   const location = useLocation();
@@ -57,7 +58,11 @@ export const Findings = () => {
           />
           <Route
             path={findingsNavigation.findings_default.path}
-            render={() => <LatestFindingsContainer dataView={dataViewQuery.data!} />}
+            render={() => (
+              <TrackApplicationView viewId={findingsNavigation.findings_default.id}>
+                <LatestFindingsContainer dataView={dataViewQuery.data!} />
+              </TrackApplicationView>
+            )}
           />
           <Route
             path={findingsNavigation.findings_by_resource.path}

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -32,6 +32,7 @@ import { ResourceFindings } from './resource_findings/resource_findings_containe
 import { ErrorCallout } from '../layout/error_callout';
 import { FindingsDistributionBar } from '../layout/findings_distribution_bar';
 import { LOCAL_STORAGE_PAGE_SIZE_FINDINGS_BY_RESOURCE_KEY } from '../../../../common/constants';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 const getDefaultQuery = ({
   query,
@@ -49,11 +50,19 @@ export const FindingsByResourceContainer = ({ dataView }: FindingsBaseProps) => 
     <Route
       exact
       path={findingsNavigation.findings_by_resource.path}
-      render={() => <LatestFindingsByResource dataView={dataView} />}
+      render={() => (
+        <TrackApplicationView viewId={findingsNavigation.findings_by_resource.id}>
+          <LatestFindingsByResource dataView={dataView} />
+        </TrackApplicationView>
+      )}
     />
     <Route
       path={findingsNavigation.resource_findings.path}
-      render={() => <ResourceFindings dataView={dataView} />}
+      render={() => (
+        <TrackApplicationView viewId={findingsNavigation.resource_findings.id}>
+          <ResourceFindings dataView={dataView} />
+        </TrackApplicationView>
+      )}
     />
   </Switch>
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_container.tsx
@@ -9,6 +9,7 @@ import { Route, Switch } from 'react-router-dom';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import type { Evaluation } from '../../../../common/types';
 import { CloudPosturePageTitle } from '../../../components/cloud_posture_page_title';
 import { FindingsSearchBar } from '../layout/findings_search_bar';
@@ -32,7 +33,6 @@ import { ResourceFindings } from './resource_findings/resource_findings_containe
 import { ErrorCallout } from '../layout/error_callout';
 import { FindingsDistributionBar } from '../layout/findings_distribution_bar';
 import { LOCAL_STORAGE_PAGE_SIZE_FINDINGS_BY_RESOURCE_KEY } from '../../../../common/constants';
-import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
 const getDefaultQuery = ({
   query,


### PR DESCRIPTION
in #144665 we wrapped all our root routes

the findings page has inner routes, which were wrapped too in this PR with `TrackApplicationView` :
- `cloud_security_posture-findings-default`
- `cloud_security_posture-findings-resource`
- `cloud_security_posture-findings-resourceId`



