### PR TITLE
[ci] Set elasticsearch snapshot build timeout

### DIFF
--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -1,5 +1,6 @@
 steps:
   - command: .buildkite/scripts/steps/es_snapshots/build.sh
     label: Build ES Snapshot
+    timeout_in_minutes: 30
     agents:
       queue: c2-8


### PR DESCRIPTION
We had a few stalled builds that timed out after 1d.  Successful builds typically take 15m-18m.  This sets the timeout 30 minutes.

<!--ONMERGE {"backportTargets":["7.17","8.5"]} ONMERGE-->