### PR TITLE
[Lens] Updates Series color tooltip

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/color_picker.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/color_picker.tsx
@@ -27,7 +27,7 @@ const tooltipContent = {
   }),
   disabled: i18n.translate('xpack.lens.configPanel.color.tooltip.disabled', {
     defaultMessage:
-      'Individual series cannot be custom colored when the layer includes a “Break down by.“',
+      'You are unable to apply custom colors to individual series when the layer includes a "Break down by" field.',
   }),
 };
 


### PR DESCRIPTION
## Summary

Updates the Series color tooltip to:

`You are unable to apply custom colors to individual series when the layer includes a "Break down by" field.`

