### PR TITLE
[Exploratory View] adjust formula for synthetics monitor availability

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
@@ -230,15 +230,20 @@ export class LensAttributes {
     alphabeticOrder?: boolean;
     size?: number;
   }): TermsIndexPatternColumn {
-    const { dataView, seriesConfig } = layerConfig;
+    const { dataView, seriesConfig, selectedMetricField } = layerConfig;
 
     const fieldMeta = dataView.getFieldByName(sourceField);
-
+    const { metricOptions } = seriesConfig;
     const { sourceField: yAxisSourceField } = seriesConfig.yAxisColumns[0];
 
     const labels = seriesConfig.labels ?? {};
 
-    const isFormulaColumn = yAxisSourceField === RECORDS_PERCENTAGE_FIELD;
+    const isFormulaColumn =
+      Boolean(
+        metricOptions &&
+          (metricOptions.find((option) => option.id === selectedMetricField) as MetricOption)
+            ?.formula
+      ) || yAxisSourceField === RECORDS_PERCENTAGE_FIELD;
 
     let orderBy: TermColumnParamsOrderBy = {
       type: 'column',

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -93,7 +93,7 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         label: 'Monitor availability',
         id: 'monitor_availability',
         columnType: FORMULA_COLUMN,
-        formula: "1- (count(kql='summary.down > 0') / count())",
+        formula: "1- (count(kql='summary.down > 0') / count(kql='summary: *'))",
       },
       {
         label: 'Monitor Errors',


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/143672

Adds global summary filter to availability metric

Also fixes an error where an invalid `orderBy` attribute was being applied to formula columns, causing invalid aggregation errors.

<img width="1374" alt="Screen Shot 2022-11-07 at 10 36 07 PM" src="https://user-images.githubusercontent.com/11356435/200470672-b1d26892-fb0b-4978-a76a-fee01fc8570b.png">

### Testing
1. Create an always down browser monitor
2. Navigate to exploratory view
3. Filter for that monitor
4. Ensure that availability is marked as 0%

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->