### PR TITLE
[Lens] Rearrange options

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/bucket_nesting_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/bucket_nesting_editor.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFormRow, EuiSwitch, EuiSelect } from '@elastic/eui';
+import { EuiFormRow, EuiSwitch, EuiSelect, EuiSpacer, EuiText } from '@elastic/eui';
 import { FormBasedLayer } from '../types';
 import { hasField } from '../pure_utils';
 import { GenericIndexPatternColumn } from '../operations';
@@ -62,26 +62,28 @@ export function BucketNestingEditor({
   if (aggColumns.length === 1) {
     const [target] = aggColumns;
     const useAsTopLevelAggCopy = i18n.translate('xpack.lens.indexPattern.useAsTopLevelAgg', {
-      defaultMessage: 'Group by this field first',
+      defaultMessage: 'Aggregate by this dimension first',
     });
     return (
-      <EuiFormRow label={useAsTopLevelAggCopy} display="columnCompressedSwitch" fullWidth>
-        <EuiSwitch
-          compressed
-          label={useAsTopLevelAggCopy}
-          showLabel={false}
-          data-test-subj="indexPattern-nesting-switch"
-          name="nestingSwitch"
-          checked={!prevColumn}
-          onChange={() => {
-            if (prevColumn) {
-              setColumns(nestColumn(layer.columnOrder, columnId, target.value));
-            } else {
-              setColumns(nestColumn(layer.columnOrder, target.value, columnId));
-            }
-          }}
-        />
-      </EuiFormRow>
+      <>
+        <EuiSpacer size="s" />
+        <EuiFormRow display="rowCompressed" hasChildLabel={false}>
+          <EuiSwitch
+            label={<EuiText size="xs">{useAsTopLevelAggCopy}</EuiText>}
+            data-test-subj="indexPattern-nesting-switch"
+            name="nestingSwitch"
+            checked={!prevColumn}
+            onChange={() => {
+              if (prevColumn) {
+                setColumns(nestColumn(layer.columnOrder, columnId, target.value));
+              } else {
+                setColumns(nestColumn(layer.columnOrder, target.value, columnId));
+              }
+            }}
+            compressed
+          />
+        </EuiFormRow>
+      </>
     );
   }
 

--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
@@ -845,7 +845,12 @@ export function DimensionEditor(props: DimensionEditorProps) {
       )}
 
       {shouldDisplayExtraOptions && <ParamEditor {...paramEditorProps} />}
-      {!selectedOperationDefinition?.handleDataSectionExtra && props.dataSectionExtra}
+      {!selectedOperationDefinition?.handleDataSectionExtra && (
+        <>
+          <EuiSpacer size="m" />
+          {props.dataSectionExtra}
+        </>
+      )}
     </>
   );
 

--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_editor.tsx
@@ -606,6 +606,7 @@ export function DimensionEditor(props: DimensionEditorProps) {
     setIsCloseable,
     paramEditorCustomProps,
     ReferenceEditor,
+    dataSectionExtra: props.dataSectionExtra,
     ...services,
   };
 
@@ -834,8 +835,17 @@ export function DimensionEditor(props: DimensionEditorProps) {
           operationDefinitionMap={operationDefinitionMap}
         />
       ) : null}
+      {!isFullscreen && !incompleteInfo && !hideGrouping && temporaryState === 'none' && (
+        <BucketNestingEditor
+          layer={state.layers[props.layerId]}
+          columnId={props.columnId}
+          setColumns={(columnOrder) => updateLayer({ columnOrder })}
+          getFieldByName={currentIndexPattern.getFieldByName}
+        />
+      )}
 
       {shouldDisplayExtraOptions && <ParamEditor {...paramEditorProps} />}
+      {!selectedOperationDefinition?.handleDataSectionExtra && props.dataSectionExtra}
     </>
   );
 
@@ -1142,15 +1152,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
                     },
                   });
                 }}
-              />
-            )}
-
-            {!isFullscreen && !incompleteInfo && !hideGrouping && temporaryState === 'none' && (
-              <BucketNestingEditor
-                layer={state.layers[props.layerId]}
-                columnId={props.columnId}
-                setColumns={(columnOrder) => updateLayer({ columnOrder })}
-                getFieldByName={currentIndexPattern.getFieldByName}
               />
             )}
 

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
@@ -199,6 +199,7 @@ export interface ParamEditorProps<
   operationDefinitionMap: Record<string, GenericOperationDefinition>;
   paramEditorCustomProps?: ParamEditorCustomProps;
   isReferenced?: boolean;
+  dataSectionExtra?: React.ReactNode;
 }
 
 export interface FieldInputProps<C> {
@@ -443,6 +444,10 @@ interface BaseOperationDefinitionProps<
    *    more than 5 values returned or 6 if the "Other" bucket is enabled)
    */
   getMaxPossibleNumValues?: (column: C) => number;
+  /**
+   * Boolean flag whether the data section extra element passed in from the visualization is handled by the param editor of the operation or whether the datasource general logic should be used.
+   */
+  handleDataSectionExtra?: boolean;
 }
 
 interface BaseBuildColumnArgs {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/range_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/range_editor.tsx
@@ -121,6 +121,23 @@ const BaseRangeEditor = ({
 
   return (
     <>
+      <EuiSpacer size="s" />
+      <EuiFormRow display="rowCompressed" hasChildLabel={false}>
+        <EuiSwitch
+          label={
+            <EuiText size="xs">
+              {i18n.translate('xpack.lens.indexPattern.ranges.includeEmptyRows', {
+                defaultMessage: 'Include empty rows',
+              })}
+            </EuiText>
+          }
+          checked={Boolean(includeEmptyRows)}
+          onChange={() => {
+            onChangeIncludeEmptyRows(!includeEmptyRows);
+          }}
+          compressed
+        />
+      </EuiFormRow>
       <EuiFormRow
         label={granularityLabel}
         data-test-subj="indexPattern-ranges-section-label"
@@ -177,23 +194,6 @@ const BaseRangeEditor = ({
           defaultMessage: 'Create custom ranges',
         })}
       </EuiButtonEmpty>
-      <EuiSpacer size="s" />
-      <EuiFormRow display="rowCompressed" hasChildLabel={false}>
-        <EuiSwitch
-          label={
-            <EuiText size="xs">
-              {i18n.translate('xpack.lens.indexPattern.ranges.includeEmptyRows', {
-                defaultMessage: 'Include empty rows',
-              })}
-            </EuiText>
-          }
-          checked={Boolean(includeEmptyRows)}
-          onChange={() => {
-            onChangeIncludeEmptyRows(!includeEmptyRows);
-          }}
-          compressed
-        />
-      </EuiFormRow>
     </>
   );
 };

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
@@ -560,6 +560,7 @@ export const termsOperation: OperationDefinition<
 The top values of a specified field ranked by the chosen metric.
       `,
   }),
+  handleDataSectionExtra: true,
   paramEditor: function ParamEditor({
     layer,
     paramEditorUpdater,
@@ -570,6 +571,7 @@ The top values of a specified field ranked by the chosen metric.
     ReferenceEditor,
     paramEditorCustomProps,
     activeData,
+    dataSectionExtra,
     ...rest
   }) {
     const [incompleteColumn, setIncompleteColumn] = useState<IncompleteColumn | undefined>(
@@ -929,6 +931,7 @@ The top values of a specified field ranked by the chosen metric.
             }}
           />
         </EuiFormRow>
+        {dataSectionExtra}
         {!hasRestrictions && (
           <>
             <EuiSpacer size="m" />

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
@@ -931,7 +931,12 @@ The top values of a specified field ranked by the chosen metric.
             }}
           />
         </EuiFormRow>
-        {dataSectionExtra}
+        {dataSectionExtra && (
+          <>
+            <EuiSpacer size="m" />
+            {dataSectionExtra}
+          </>
+        )}
         {!hasRestrictions && (
           <>
             <EuiSpacer size="m" />

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -18,6 +18,7 @@ import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import type { ExpressionsStart, DatatableColumnType } from '@kbn/expressions-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { euiThemeVars } from '@kbn/ui-theme';
 import {
   DatasourceDimensionEditorProps,
   DatasourceDataPanelProps,
@@ -482,6 +483,16 @@ export function getTextBasedDatasource({
               }}
             />
           </EuiFormRow>
+          {props.dataSectionExtra && (
+            <div
+              style={{
+                paddingLeft: euiThemeVars.euiSize,
+                paddingRight: euiThemeVars.euiSize,
+              }}
+            >
+              {props.dataSectionExtra}
+            </div>
+          )}
         </KibanaThemeProvider>,
         domElement
       );

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -730,6 +730,23 @@ export function LayerPanel(
                   layerType: activeVisualization.getLayerType(layerId, visualizationState),
                   indexPatterns: dataViews.indexPatterns,
                   activeData: layerVisualizationConfigProps.activeData,
+                  dataSectionExtra: !isFullscreen &&
+                    !activeDimension.isNew &&
+                    activeVisualization.renderDimensionEditorDataExtra && (
+                      <NativeRenderer
+                        render={activeVisualization.renderDimensionEditorDataExtra}
+                        nativeProps={{
+                          ...layerVisualizationConfigProps,
+                          groupId: activeGroup.groupId,
+                          accessor: activeId,
+                          datasource,
+                          setState: props.updateVisualization,
+                          addLayer: props.addLayer,
+                          removeLayer: props.onRemoveLayer,
+                          panelRef,
+                        }}
+                      />
+                    ),
                 }}
               />
             )}

--- a/x-pack/plugins/lens/public/shared_components/collapse_setting.tsx
+++ b/x-pack/plugins/lens/public/shared_components/collapse_setting.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiIcon, EuiSelect, EuiSpacer, EuiToolTip } from '@elastic/eui';
+import { EuiFormRow, EuiIcon, EuiSelect, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { CollapseFunction } from '../../common/expressions';
@@ -27,7 +27,6 @@ export function CollapseSetting({
 }) {
   return (
     <>
-      <EuiSpacer size="m" />
       <EuiFormRow
         label={
           <EuiToolTip

--- a/x-pack/plugins/lens/public/shared_components/collapse_setting.tsx
+++ b/x-pack/plugins/lens/public/shared_components/collapse_setting.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiIcon, EuiSelect, EuiToolTip } from '@elastic/eui';
+import { EuiFormRow, EuiIcon, EuiSelect, EuiSpacer, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { CollapseFunction } from '../../common/expressions';
@@ -26,36 +26,39 @@ export function CollapseSetting({
   onChange: (value: CollapseFunction) => void;
 }) {
   return (
-    <EuiFormRow
-      label={
-        <EuiToolTip
-          delay="long"
-          position="top"
-          content={i18n.translate('xpack.lens.collapse.infoIcon', {
-            defaultMessage:
-              'Do not show this dimension in the visualization and aggregate all metric values which have the same value for this dimension into a single number.',
-          })}
-        >
-          <span>
-            {i18n.translate('xpack.lens.collapse.label', { defaultMessage: 'Collapse by' })}
-            {''}
-            <EuiIcon type="questionInCircle" color="subdued" size="s" className="eui-alignTop" />
-          </span>
-        </EuiToolTip>
-      }
-      display="columnCompressed"
-      fullWidth
-    >
-      <EuiSelect
+    <>
+      <EuiSpacer size="m" />
+      <EuiFormRow
+        label={
+          <EuiToolTip
+            delay="long"
+            position="top"
+            content={i18n.translate('xpack.lens.collapse.infoIcon', {
+              defaultMessage:
+                'Do not show this dimension in the visualization and aggregate all metric values which have the same value for this dimension into a single number.',
+            })}
+          >
+            <span>
+              {i18n.translate('xpack.lens.collapse.label', { defaultMessage: 'Collapse by' })}
+              {''}
+              <EuiIcon type="questionInCircle" color="subdued" size="s" className="eui-alignTop" />
+            </span>
+          </EuiToolTip>
+        }
+        display="rowCompressed"
         fullWidth
-        compressed
-        data-test-subj="indexPattern-collapse-by"
-        options={options}
-        value={value}
-        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-          onChange(e.target.value as CollapseFunction);
-        }}
-      />
-    </EuiFormRow>
+      >
+        <EuiSelect
+          fullWidth
+          compressed
+          data-test-subj="indexPattern-collapse-by"
+          options={options}
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            onChange(e.target.value as CollapseFunction);
+          }}
+        />
+      </EuiFormRow>
+    </>
   );
 }

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -617,6 +617,7 @@ export type DatasourceDimensionEditorProps<T = unknown> = DatasourceDimensionPro
   supportStaticValue: boolean;
   paramEditorCustomProps?: ParamEditorCustomProps;
   enableFormatSelector: boolean;
+  dataSectionExtra?: React.ReactNode;
   formatSelectorOptions: FormatSelectorOptions | undefined;
 };
 
@@ -1131,7 +1132,7 @@ export interface Visualization<T = unknown, P = unknown> {
   ) => ((cleanupElement: Element) => void) | void;
 
   /**
-   * Additional editor that gets rendered inside the dimension popover.
+   * Additional editor that gets rendered inside the dimension popover in the "appearance" section.
    * This can be used to configure dimension-specific options
    */
   renderDimensionEditor?: (
@@ -1139,10 +1140,18 @@ export interface Visualization<T = unknown, P = unknown> {
     props: VisualizationDimensionEditorProps<T>
   ) => ((cleanupElement: Element) => void) | void;
   /**
-   * Additional editor that gets rendered inside the dimension popover.
+   * Additional editor that gets rendered inside the dimension popover in an additional section below "appearance".
    * This can be used to configure dimension-specific options
    */
   renderDimensionEditorAdditionalSection?: (
+    domElement: Element,
+    props: VisualizationDimensionEditorProps<T>
+  ) => ((cleanupElement: Element) => void) | void;
+  /**
+   * Additional editor that gets rendered inside the data section.
+   * This can be used to configure dimension-specific options
+   */
+  renderDimensionEditorDataExtra?: (
     domElement: Element,
     props: VisualizationDimensionEditorProps<T>
   ) => ((cleanupElement: Element) => void) | void;

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/dimension_editor.tsx
@@ -95,17 +95,6 @@ export function TableDimensionEditor(
 
   return (
     <>
-      {props.groupId === 'rows' && (
-        <CollapseSetting
-          value={column.collapseFn || ''}
-          onChange={(collapseFn) => {
-            setState({
-              ...state,
-              columns: updateColumnWith(state, accessor, { collapseFn }),
-            });
-          }}
-        />
-      )}
       <EuiFormRow
         display="columnCompressed"
         fullWidth
@@ -354,6 +343,34 @@ export function TableDimensionEditor(
             }}
           />
         </EuiFormRow>
+      )}
+    </>
+  );
+}
+
+export function TableDimensionDataExtraEditor(
+  props: VisualizationDimensionEditorProps<DatatableVisualizationState> & {
+    paletteService: PaletteRegistry;
+  }
+) {
+  const { state, setState, accessor } = props;
+  const column = state.columns.find(({ columnId }) => accessor === columnId);
+
+  if (!column) return null;
+  if (column.isTransposed) return null;
+
+  return (
+    <>
+      {props.groupId === 'rows' && (
+        <CollapseSetting
+          value={column.collapseFn || ''}
+          onChange={(collapseFn) => {
+            setState({
+              ...state,
+              columns: updateColumnWith(state, accessor, { collapseFn }),
+            });
+          }}
+        />
       )}
     </>
   );

--- a/x-pack/plugins/lens/public/visualizations/datatable/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/visualization.tsx
@@ -25,7 +25,7 @@ import type {
   DatasourceLayers,
   Suggestion,
 } from '../../types';
-import { TableDimensionEditor } from './components/dimension_editor';
+import { TableDimensionDataExtraEditor, TableDimensionEditor } from './components/dimension_editor';
 import { TableDimensionEditorAdditionalSection } from './components/dimension_editor_addtional_section';
 import type { LayerType } from '../../../common';
 import { getDefaultSummaryLabel } from '../../../common/expressions/datatable/summary';
@@ -353,6 +353,17 @@ export const getDatatableVisualization = ({
       <KibanaThemeProvider theme$={theme.theme$}>
         <I18nProvider>
           <TableDimensionEditorAdditionalSection {...props} paletteService={paletteService} />
+        </I18nProvider>
+      </KibanaThemeProvider>,
+      domElement
+    );
+  },
+
+  renderDimensionEditorDataExtra(domElement, props) {
+    render(
+      <KibanaThemeProvider theme$={theme.theme$}>
+        <I18nProvider>
+          <TableDimensionDataExtraEditor {...props} paletteService={paletteService} />
         </I18nProvider>
       </KibanaThemeProvider>,
       domElement

--- a/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
@@ -329,6 +329,23 @@ export function DimensionEditor(
           }}
         />
       )}
+    </>
+  );
+}
+
+export function DimensionDataExtraEditor(
+  props: VisualizationDimensionEditorProps<PieVisualizationState> & {
+    paletteService: PaletteRegistry;
+  }
+) {
+  const currentLayer = props.state.layers.find((layer) => layer.layerId === props.layerId);
+
+  if (!currentLayer) {
+    return null;
+  }
+
+  return (
+    <>
       <CollapseSetting
         value={currentLayer?.collapseFns?.[props.accessor] || ''}
         onChange={(collapseFn) => {

--- a/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../../common';
 import { suggestions } from './suggestions';
 import { PartitionChartsMeta } from './partition_charts_meta';
-import { DimensionEditor, PieToolbar } from './toolbar';
+import { DimensionDataExtraEditor, DimensionEditor, PieToolbar } from './toolbar';
 import { checkTableForContainsSmallValues } from './render_helpers';
 
 function newLayerState(layerId: string): PieLayerState {
@@ -353,6 +353,16 @@ export const getPieVisualization = ({
       <KibanaThemeProvider theme$={kibanaTheme.theme$}>
         <I18nProvider>
           <DimensionEditor {...props} paletteService={paletteService} />
+        </I18nProvider>
+      </KibanaThemeProvider>,
+      domElement
+    );
+  },
+  renderDimensionEditorDataExtra(domElement, props) {
+    render(
+      <KibanaThemeProvider theme$={kibanaTheme.theme$}>
+        <I18nProvider>
+          <DimensionDataExtraEditor {...props} paletteService={paletteService} />
         </I18nProvider>
       </KibanaThemeProvider>,
       domElement

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -29,7 +29,10 @@ import {
 } from '../../utils';
 import { getSuggestions } from './xy_suggestions';
 import { XyToolbar } from './xy_config_panel';
-import { DimensionEditor } from './xy_config_panel/dimension_editor';
+import {
+  DataDimensionEditorDataSectionExtra,
+  DimensionEditor,
+} from './xy_config_panel/dimension_editor';
 import { LayerHeader, LayerHeaderContent } from './xy_config_panel/layer_header';
 import type { Visualization, AccessorConfig, FramePublicAPI, Suggestion } from '../../types';
 import type { FormBasedPersistedState } from '../../datasources/form_based/types';
@@ -600,6 +603,45 @@ export const getXyVisualization = ({
             }}
           >
             {dimensionEditor}
+          </KibanaContextProvider>
+        </I18nProvider>
+      </KibanaThemeProvider>,
+      domElement
+    );
+  },
+
+  renderDimensionEditorDataExtra(domElement, props) {
+    const allProps = {
+      ...props,
+      datatableUtilities: data.datatableUtilities,
+      formatFactory: fieldFormats.deserialize,
+      paletteService,
+    };
+    const layer = props.state.layers.find((l) => l.layerId === props.layerId)!;
+    if (isReferenceLayer(layer)) {
+      return;
+    }
+    if (isAnnotationsLayer(layer)) {
+      return;
+    }
+
+    render(
+      <KibanaThemeProvider theme$={kibanaTheme.theme$}>
+        <I18nProvider>
+          <KibanaContextProvider
+            services={{
+              appName: 'lens',
+              storage,
+              uiSettings: core.uiSettings,
+              data,
+              fieldFormats,
+              savedObjects: core.savedObjects,
+              docLinks: core.docLinks,
+              http: core.http,
+              unifiedSearch,
+            }}
+          >
+            <DataDimensionEditorDataSectionExtra {...allProps} />
           </KibanaContextProvider>
         </I18nProvider>
       </KibanaThemeProvider>,

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/dimension_editor.tsx
@@ -130,12 +130,6 @@ export function DataDimensionEditor(
   if (props.groupId === 'breakdown') {
     return (
       <>
-        <CollapseSetting
-          value={layer.collapseFn || ''}
-          onChange={(collapseFn) => {
-            setLocalState(updateLayer(localState, { ...layer, collapseFn }, index));
-          }}
-        />
         {!layer.collapseFn && (
           <PalettePicker
             palettes={props.paletteService}
@@ -216,4 +210,35 @@ export function DataDimensionEditor(
       </EuiFormRow>
     </>
   );
+}
+
+export function DataDimensionEditorDataSectionExtra(
+  props: VisualizationDimensionEditorProps<State> & {
+    formatFactory: FormatFactory;
+    paletteService: PaletteRegistry;
+  }
+) {
+  const { state, layerId } = props;
+  const index = state.layers.findIndex((l) => l.layerId === layerId);
+  const layer = state.layers[index] as XYDataLayerConfig;
+
+  const { inputValue: localState, handleInputChange: setLocalState } = useDebouncedValue<XYState>({
+    value: props.state,
+    onChange: props.setState,
+  });
+
+  if (props.groupId === 'breakdown') {
+    return (
+      <>
+        <CollapseSetting
+          value={layer.collapseFn || ''}
+          onChange={(collapseFn) => {
+            setLocalState(updateLayer(localState, { ...layer, collapseFn }, index));
+          }}
+        />
+      </>
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/138075

## Group by this field

This PR moves the "Group by this field" below the field selector. I renamed it to "Aggregate by this dimension first" (instead of field) because it's more accurate - this isn't really about the field and also a thing for the "Filters" function which doesn't have a field:
<img width="355" alt="Screenshot 2022-11-09 at 12 29 29" src="https://user-images.githubusercontent.com/1508364/200818974-f5dc304f-2457-4604-8a0a-c94ed1d50b83.png">
<img width="355" alt="Screenshot 2022-11-09 at 12 29 33" src="https://user-images.githubusercontent.com/1508364/200818978-f48e42e8-f2df-43c8-8479-d6cac205fafa.png">
<img width="353" alt="Screenshot 2022-11-09 at 12 29 38" src="https://user-images.githubusercontent.com/1508364/200818983-2c00f8de-06ee-4d9a-82d6-14c161e0b91f.png">
<img width="353" alt="Screenshot 2022-11-09 at 12 29 44" src="https://user-images.githubusercontent.com/1508364/200818986-e76a6d88-a6a1-4897-8fad-f0d56027c1d1.png">

Drive-by change: Move the "Include empty rows" up above the granularity slider for intervals to match the date histogram order

## Collapse by

It also moves "Collapse by" into the data section (relevant for xy breakdown, table rows and partition slices)
<img width="357" alt="Screenshot 2022-11-09 at 12 36 53" src="https://user-images.githubusercontent.com/1508364/200820679-afb8e08b-a91b-46ef-8111-c09cfdb51865.png">
<img width="353" alt="Screenshot 2022-11-09 at 12 36 59" src="https://user-images.githubusercontent.com/1508364/200820682-4f416404-4693-46cd-80df-7c868deadc44.png">
<img width="355" alt="Screenshot 2022-11-09 at 12 36 40" src="https://user-images.githubusercontent.com/1508364/200820669-0fab52da-7fa1-4fff-b183-8d5c7e4695b9.png">
<img width="360" alt="Screenshot 2022-11-09 at 12 36 46" src="https://user-images.githubusercontent.com/1508364/200820675-837e3736-9519-42a6-98ca-9a9bae9840f1.png">

Also works for text based:
<img width="360" alt="Screenshot 2022-11-09 at 12 47 08" src="https://user-images.githubusercontent.com/1508364/200822518-e76dd9b5-df9f-4289-a468-0b63bfa1988c.png">


## Technical details

For the collapse by part I had to add another form render hook to the visualization `renderDimensionEditorDataExtra` which is passed to the datasource dimension editor so it can be rendered in the right place. On the datasource side the integration for text based is very straight forward, for form based there are two flavors - just render below the operation edit options or pass to the operation editor (used for terms)