### PR TITLE
[Files] Wait for all shards to be active

### DIFF
--- a/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -161,4 +161,16 @@ describe('Elasticsearch blob storage', () => {
     }
     expect(chunks.join('')).toEqual(fileBuffer.toString('utf-8'));
   });
+
+  it('successfully uploads multiple files in parallel', async () => {
+    esBlobStorage = createEsBlobStorage({ chunkSize: '1024B' });
+    await expect(
+      Promise.all([
+        esBlobStorage.upload(Readable.from([Buffer.alloc(2048, 'a')])),
+        esBlobStorage.upload(Readable.from([Buffer.alloc(2048, 'a')])),
+        esBlobStorage.upload(Readable.from([Buffer.alloc(2048, 'a')])),
+        esBlobStorage.upload(Readable.from([Buffer.alloc(2048, 'a')])),
+      ])
+    ).resolves.toEqual(expect.any(Array));
+  });
 });

--- a/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import sinon from 'sinon';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { Readable } from 'stream';
 import {
@@ -22,7 +21,7 @@ describe('Elasticsearch blob storage', () => {
   let manageKbn: TestKibanaUtils;
   let esBlobStorage: ElasticsearchBlobStorageClient;
   let esClient: ElasticsearchClient;
-  const sandbox = sinon.createSandbox();
+  let esGetSpy: jest.SpyInstance;
 
   beforeAll(async () => {
     ElasticsearchBlobStorageClient.configureConcurrentUpload(Infinity);
@@ -48,12 +47,12 @@ describe('Elasticsearch blob storage', () => {
 
   beforeEach(() => {
     esBlobStorage = createEsBlobStorage();
-    sandbox.spy(esClient, 'get');
+    esGetSpy = jest.spyOn(esClient, 'get');
   });
 
   afterEach(async () => {
     await esClient.indices.delete({ index: BLOB_STORAGE_SYSTEM_INDEX_NAME });
-    sandbox.restore();
+    jest.clearAllMocks();
   });
 
   it('sets up a new blob storage index after first write', async () => {
@@ -70,7 +69,7 @@ describe('Elasticsearch blob storage', () => {
       chunks.push(chunk);
     }
     expect(chunks.join('')).toBe('upload this');
-    expect((esClient.get as sinon.SinonSpy).calledOnce).toBe(true);
+    expect(esGetSpy).toHaveBeenCalledTimes(1);
   });
 
   /**
@@ -86,8 +85,9 @@ describe('Elasticsearch blob storage', () => {
     }
     expect(chunks.join('')).toBe('upload this');
     // Called once because we should have found 'last: true'
-    expect((esClient.get as sinon.SinonSpy).calledOnce).toBe(true);
-    expect((esClient.get as sinon.SinonSpy).args[0]).toEqual([
+    expect(esGetSpy).toHaveBeenCalledTimes(1);
+    expect(esGetSpy).toHaveBeenNthCalledWith(
+      1,
       {
         id: id + '.0',
         index: BLOB_STORAGE_SYSTEM_INDEX_NAME,
@@ -96,8 +96,8 @@ describe('Elasticsearch blob storage', () => {
       {
         headers: { accept: 'application/cbor' },
         asStream: true,
-      },
-    ]);
+      }
+    );
   });
 
   it('uploads and downloads a file of many chunks', async () => {


### PR DESCRIPTION
## Summary

There is a potential race-condition between creating files for the first time and shards being ready on the index that stores them in ES.

This PR adds a way for all subsequent calls to uploading files to only proceed once the destination index is created and all shards are ready.

- [x] Added functional test