### PR TITLE
Add CSP header to all requests, including api requests

### DIFF
--- a/packages/core/http/core-http-resources-server-internal/src/http_resources_service.test.ts
+++ b/packages/core/http/core-http-resources-server-internal/src/http_resources_service.test.ts
@@ -57,6 +57,7 @@ describe('HttpResources service', () => {
       describe(`${name} register`, () => {
         const routeConfig: RouteConfig<any, any, any, 'get'> = { path: '/', validate: false };
         let register: HttpResources['register'];
+
         beforeEach(async () => {
           register = await initializer();
         });
@@ -81,32 +82,8 @@ describe('HttpResources service', () => {
               }
             );
           });
-
-          it('can attach headers, except the CSP header', async () => {
-            register(routeConfig, async (ctx, req, res) => {
-              return res.renderCoreApp({
-                headers: {
-                  'content-security-policy': "script-src 'unsafe-eval'",
-                  'x-kibana': '42',
-                },
-              });
-            });
-
-            const [[, routeHandler]] = router.get.mock.calls;
-
-            const responseFactory = createHttpResourcesResponseFactory();
-            await routeHandler(context, kibanaRequest, responseFactory);
-
-            expect(responseFactory.ok).toHaveBeenCalledWith({
-              body: '<body />',
-              headers: {
-                'x-kibana': '42',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
-              },
-            });
-          });
         });
+
         describe('renderAnonymousCoreApp', () => {
           it('formats successful response', async () => {
             register(routeConfig, async (ctx, req, res) => {
@@ -127,32 +104,8 @@ describe('HttpResources service', () => {
               }
             );
           });
-
-          it('can attach headers, except the CSP header', async () => {
-            register(routeConfig, async (ctx, req, res) => {
-              return res.renderAnonymousCoreApp({
-                headers: {
-                  'content-security-policy': "script-src 'unsafe-eval'",
-                  'x-kibana': '42',
-                },
-              });
-            });
-
-            const [[, routeHandler]] = router.get.mock.calls;
-
-            const responseFactory = createHttpResourcesResponseFactory();
-            await routeHandler(context, kibanaRequest, responseFactory);
-
-            expect(responseFactory.ok).toHaveBeenCalledWith({
-              body: '<body />',
-              headers: {
-                'x-kibana': '42',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
-              },
-            });
-          });
         });
+
         describe('renderHtml', () => {
           it('formats successful response', async () => {
             const htmlBody = '<html><body /></html>';
@@ -167,20 +120,17 @@ describe('HttpResources service', () => {
               body: htmlBody,
               headers: {
                 'content-type': 'text/html',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
 
-          it('can attach headers, except the CSP & "content-type" headers', async () => {
+          it('can attach headers, except the "content-type" header', async () => {
             const htmlBody = '<html><body /></html>';
             register(routeConfig, async (ctx, req, res) => {
               return res.renderHtml({
                 body: htmlBody,
                 headers: {
                   'content-type': 'text/html5',
-                  'content-security-policy': "script-src 'unsafe-eval'",
                   'x-kibana': '42',
                 },
               });
@@ -196,12 +146,11 @@ describe('HttpResources service', () => {
               headers: {
                 'content-type': 'text/html',
                 'x-kibana': '42',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
         });
+
         describe('renderJs', () => {
           it('formats successful response', async () => {
             const jsBody = 'alert(1);';
@@ -216,20 +165,17 @@ describe('HttpResources service', () => {
               body: jsBody,
               headers: {
                 'content-type': 'text/javascript',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
 
-          it('can attach headers, except the CSP & "content-type" headers', async () => {
+          it('can attach headers, except the "content-type" header', async () => {
             const jsBody = 'alert(1);';
             register(routeConfig, async (ctx, req, res) => {
               return res.renderJs({
                 body: jsBody,
                 headers: {
                   'content-type': 'text/html',
-                  'content-security-policy': "script-src 'unsafe-eval'",
                   'x-kibana': '42',
                 },
               });
@@ -245,12 +191,11 @@ describe('HttpResources service', () => {
               headers: {
                 'content-type': 'text/javascript',
                 'x-kibana': '42',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
         });
+
         describe('renderCss', () => {
           it('formats successful response', async () => {
             const cssBody = `body {border: 1px solid red;}`;
@@ -265,20 +210,17 @@ describe('HttpResources service', () => {
               body: cssBody,
               headers: {
                 'content-type': 'text/css',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });
 
-          it('can attach headers, except the CSP & "content-type" headers', async () => {
+          it('can attach headers, except the "content-type" header', async () => {
             const cssBody = `body {border: 1px solid red;}`;
             register(routeConfig, async (ctx, req, res) => {
               return res.renderCss({
                 body: cssBody,
                 headers: {
                   'content-type': 'text/css5',
-                  'content-security-policy': "script-src 'unsafe-eval'",
                   'x-kibana': '42',
                 },
               });
@@ -294,8 +236,6 @@ describe('HttpResources service', () => {
               headers: {
                 'content-type': 'text/css',
                 'x-kibana': '42',
-                'content-security-policy':
-                  "script-src 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
               },
             });
           });

--- a/packages/core/http/core-http-resources-server-internal/src/http_resources_service.ts
+++ b/packages/core/http/core-http-resources-server-internal/src/http_resources_service.ts
@@ -101,7 +101,6 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
     request: KibanaRequest,
     response: KibanaResponseFactory
   ): HttpResourcesServiceToolkit {
-    const cspHeader = deps.http.csp.header;
     return {
       async renderCoreApp(options: HttpResourcesRenderOptions = {}) {
         const apmConfig = getApmConfig(request.url.pathname);
@@ -116,7 +115,7 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
 
         return response.ok({
           body,
-          headers: { ...options.headers, 'content-security-policy': cspHeader },
+          headers: options.headers,
         });
       },
       async renderAnonymousCoreApp(options: HttpResourcesRenderOptions = {}) {
@@ -132,7 +131,7 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
 
         return response.ok({
           body,
-          headers: { ...options.headers, 'content-security-policy': cspHeader },
+          headers: options.headers,
         });
       },
       renderHtml(options: HttpResourcesResponseOptions) {
@@ -141,7 +140,6 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
           headers: {
             ...options.headers,
             'content-type': 'text/html',
-            'content-security-policy': cspHeader,
           },
         });
       },
@@ -151,7 +149,6 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
           headers: {
             ...options.headers,
             'content-type': 'text/javascript',
-            'content-security-policy': cspHeader,
           },
         });
       },
@@ -161,7 +158,6 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
           headers: {
             ...options.headers,
             'content-type': 'text/css',
-            'content-security-policy': cspHeader,
           },
         });
       },

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -102,6 +102,8 @@ export class HttpService
       },
     });
 
+    registerCoreHandlers(prebootSetup, config, this.env);
+
     if (this.shouldListen(config)) {
       this.log.debug('starting preboot server');
       await this.prebootServer.start();

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
@@ -248,19 +248,28 @@ describe('customHeaders pre-response handler', () => {
     toolkit = createToolkit();
   });
 
-  it('adds the kbn-name header to the response', () => {
-    const config = createConfig({ name: 'my-server-name' });
+  it('adds the kbn-name and Content-Security-Policy headers to the response', () => {
+    const config = createConfig({
+      name: 'my-server-name',
+      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
+    });
     const handler = createCustomHeadersPreResponseHandler(config as HttpConfig);
 
     handler({} as any, {} as any, toolkit);
 
     expect(toolkit.next).toHaveBeenCalledTimes(1);
-    expect(toolkit.next).toHaveBeenCalledWith({ headers: { 'kbn-name': 'my-server-name' } });
+    expect(toolkit.next).toHaveBeenCalledWith({
+      headers: {
+        'Content-Security-Policy': 'foo',
+        'kbn-name': 'my-server-name',
+      },
+    });
   });
 
   it('adds the security headers and custom headers defined in the configuration', () => {
     const config = createConfig({
       name: 'my-server-name',
+      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
       securityResponseHeaders: {
         headerA: 'value-A',
         headerB: 'value-B', // will be overridden by the custom response header below
@@ -276,6 +285,7 @@ describe('customHeaders pre-response handler', () => {
     expect(toolkit.next).toHaveBeenCalledTimes(1);
     expect(toolkit.next).toHaveBeenCalledWith({
       headers: {
+        'Content-Security-Policy': 'foo',
         'kbn-name': 'my-server-name',
         headerA: 'value-A',
         headerB: 'x',
@@ -283,11 +293,13 @@ describe('customHeaders pre-response handler', () => {
     });
   });
 
-  it('preserve the kbn-name value from server.name if defined in custom headders ', () => {
+  it('do not allow overwrite of the kbn-name and Content-Security-Policy headers if defined in custom headders ', () => {
     const config = createConfig({
       name: 'my-server-name',
+      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
       customResponseHeaders: {
         'kbn-name': 'custom-name',
+        'Content-Security-Policy': 'custom-csp',
         headerA: 'value-A',
         headerB: 'value-B',
       },
@@ -300,6 +312,7 @@ describe('customHeaders pre-response handler', () => {
     expect(toolkit.next).toHaveBeenCalledWith({
       headers: {
         'kbn-name': 'my-server-name',
+        'Content-Security-Policy': 'foo',
         headerA: 'value-A',
         headerB: 'value-B',
       },

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
@@ -61,12 +61,18 @@ export const createVersionCheckPostAuthHandler = (kibanaVersion: string): OnPost
 };
 
 export const createCustomHeadersPreResponseHandler = (config: HttpConfig): OnPreResponseHandler => {
-  const { name: serverName, securityResponseHeaders, customResponseHeaders } = config;
+  const {
+    name: serverName,
+    securityResponseHeaders,
+    customResponseHeaders,
+    csp: { header: cspHeader },
+  } = config;
 
   return (request, response, toolkit) => {
     const additionalHeaders = {
       ...securityResponseHeaders,
       ...customResponseHeaders,
+      'Content-Security-Policy': cspHeader,
       [KIBANA_NAME_HEADER]: serverName,
     };
 

--- a/packages/core/http/core-http-server-mocks/src/test_utils.ts
+++ b/packages/core/http/core-http-server-mocks/src/test_utils.ts
@@ -26,6 +26,7 @@ const createConfigService = () => {
   configService.atPath.mockImplementation((path) => {
     if (path === 'server') {
       return new BehaviorSubject({
+        name: 'kibana',
         hosts: ['localhost'],
         maxPayload: new ByteSizeValue(1024),
         autoListen: true,


### PR DESCRIPTION
Previously `/api/*` requests didn't include a `Content-Security-Policy` header, now they do.

Closes #143871

## Note to reviewers

I've tried to add tests that validate that 1) `kbn-name` and `Content-Security-Policy` cannot be overwitten by plugins/route handlers and 2) all routes are now covered, both `/api/*` and otherwise. It was difficult to find a good place to test this, but I think what I have now in the PR coveres it. Please verify

## Release note

Adds a `Content-Security-Policy` header to all `/api/*` responses. Any Kibana HTTP endpoint starting with `/api/*` previously didn't include a `Content-Security-Policy` header, but will now share the same header as the regular Kibana HTTP routes.

## Todo

- [x] Figure out what type of release note, if any, should be accompanied by this PR and author it
- [x] Figure out if this PR should be backported to 7.17
- [x] Update tests to validate that `/api/*` requests now have a `Content-Security-Policy` header (I think this is now indirectly checked by the new lifecycle test added in this PR since that's validating any route)
- [x] Update tests to validate that the `Content-Security-Policy` header cannot be overwritten, similar to the old tests
- [x] Investigate: When configuring Kibana with an enrolment token it seems that the page is rendered differently and not caught by the expected preResponse handler

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->