### PR TITLE
Remove task types that don't need concurrency limits

### DIFF
--- a/x-pack/plugins/ml/server/saved_objects/sync_task.ts
+++ b/x-pack/plugins/ml/server/saved_objects/sync_task.ts
@@ -41,7 +41,6 @@ export class SavedObjectsSyncService {
         description: "This task periodically syncs ML's saved objects",
         timeout: '1m',
         maxAttempts: 3,
-        maxConcurrency: 1,
 
         createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
           return {

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -152,7 +152,6 @@ export class SyntheticsService {
         description: 'This task periodically pushes saved monitors to Synthetics Service.',
         timeout: '1m',
         maxAttempts: 3,
-        maxConcurrency: 1,
 
         createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
           return {


### PR DESCRIPTION
In this PR, I'm removing the `maxConcurrency` from a few task types given they only have a single task created for each type. The concurrency setting limits how many tasks of such type a single Kibana process should handle at most, and internally requires a separate task claiming query to run every poll interval to claim those tasks.

With this PR, task manager goes from running 4 update_by_query requests to 2 every 3 seconds, removing stress put onto Elasticsearch.

For more details, see `maxConcurrency` here https://github.com/elastic/kibana/tree/main/x-pack/plugins/task_manager#task-definitions.