### PR TITLE
[Synthetics] Monitor saved objects - add migratedType to synthetics monitor 8.6.0 migration

### DIFF
--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations/monitors/8.6.0.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations/monitors/8.6.0.ts
@@ -7,6 +7,7 @@
 import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-plugin/server';
 import { SavedObjectUnsanitizedDoc } from '@kbn/core/server';
 import { ConfigKey, SyntheticsMonitorWithSecrets } from '../../../../../../common/runtime_types';
+import { SYNTHETICS_MONITOR_ENCRYPTED_TYPE } from '../../synthetics_monitor';
 
 export const migration860 = (encryptedSavedObjects: EncryptedSavedObjectsPluginSetup) => {
   return encryptedSavedObjects.createMigration<
@@ -31,5 +32,6 @@ export const migration860 = (encryptedSavedObjects: EncryptedSavedObjectsPluginS
         },
       };
     },
+    migratedType: SYNTHETICS_MONITOR_ENCRYPTED_TYPE,
   });
 };

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/saved_objects.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/saved_objects.ts
@@ -10,12 +10,14 @@ import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-p
 
 import { privateLocationsSavedObject } from './private_locations';
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../../common/constants';
-import { secretKeys } from '../../../../common/constants/monitor_management';
 import { DynamicSettings } from '../../../../common/runtime_types';
 import { UMSavedObjectsQueryFn } from '../adapters';
 import { UptimeConfig } from '../../../../common/config';
 import { settingsObjectId, umDynamicSettings } from './uptime_settings';
-import { syntheticsMonitorType, getSyntheticsMonitorSavedObjectType } from './synthetics_monitor';
+import {
+  getSyntheticsMonitorSavedObjectType,
+  SYNTHETICS_MONITOR_ENCRYPTED_TYPE,
+} from './synthetics_monitor';
 import { syntheticsServiceApiKey } from './service_api_key';
 
 export const registerUptimeSavedObjects = (
@@ -33,19 +35,7 @@ export const registerUptimeSavedObjects = (
     attributesToEncrypt: new Set(['apiKey']),
   });
 
-  encryptedSavedObjects.registerType({
-    type: syntheticsMonitorType,
-    attributesToEncrypt: new Set([
-      'secrets',
-      /* adding secretKeys to the list of attributes to encrypt ensures
-       * that secrets are never stored on the resulting saved object,
-       * even in the presence of developer error.
-       *
-       * In practice, all secrets should be stored as a single JSON
-       * payload on the `secrets` key. This ensures performant decryption. */
-      ...secretKeys,
-    ]),
-  });
+  encryptedSavedObjects.registerType(SYNTHETICS_MONITOR_ENCRYPTED_TYPE);
 };
 
 export interface UMSavedObjectsAdapter {

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/synthetics_monitor.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/synthetics_monitor.ts
@@ -7,9 +7,24 @@
 import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-plugin/server';
 import { SavedObjectsType } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
+import { secretKeys } from '../../../../common/constants/monitor_management';
 import { monitorMigrations } from './migrations/monitors';
 
 export const syntheticsMonitorType = 'synthetics-monitor';
+
+export const SYNTHETICS_MONITOR_ENCRYPTED_TYPE = {
+  type: syntheticsMonitorType,
+  attributesToEncrypt: new Set([
+    'secrets',
+    /* adding secretKeys to the list of attributes to encrypt ensures
+     * that secrets are never stored on the resulting saved object,
+     * even in the presence of developer error.
+     *
+     * In practice, all secrets should be stored as a single JSON
+     * payload on the `secrets` key. This ensures performant decryption. */
+    ...secretKeys,
+  ]),
+};
 
 export const getSyntheticsMonitorSavedObjectType = (
   encryptedSavedObjects: EncryptedSavedObjectsPluginSetup


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/144915

Adds the `migratedType` to the synthetics monitor saved object migration for 8.6.0. This value represents the schema for the encrypted saved object. Although it hasn't changed from 8.5.0 -> 8.6.0, it is recommended to always include this value explicitly. 