### PR TITLE
[Synthetics] adjust synthetics preview toggle to indicate technical preview status

### DIFF
--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -57,7 +57,8 @@ export const uiSettings: Record<string, UiSettings> = {
       'xpack.observability.enableNewSyntheticsViewExperimentDescription',
       {
         defaultMessage:
-          'Enable new synthetic monitoring application in observability. Refresh the page to apply the setting.',
+          '{technicalPreviewLabel} Enable new synthetic monitoring application in observability. Refresh the page to apply the setting.',
+        values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
       }
     ),
     schema: schema.boolean(),

--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -54,7 +54,7 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     value: false,
     description: i18n.translate(
-      'xpack.observability.enableNewSyntheticsViewExperimentDescription',
+      'xpack.observability.enableNewSyntheticsViewExperimentDescriptionBeta',
       {
         defaultMessage:
           '{technicalPreviewLabel} Enable new synthetic monitoring application in observability. Refresh the page to apply the setting.',

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -23358,7 +23358,6 @@
     "xpack.observability.enableComparisonByDefaultDescription": "Activer la fonctionnalité de comparaison dans l’application APM",
     "xpack.observability.enableInspectEsQueriesExperimentDescription": "Inspectez les recherches Elasticsearch dans les réponses API.",
     "xpack.observability.enableInspectEsQueriesExperimentName": "Inspecter les recherches ES",
-    "xpack.observability.enableNewSyntheticsViewExperimentDescription": "Activez la nouvelle application de monitoring synthétique dans Observability. Actualisez la page pour appliquer le paramètre.",
     "xpack.observability.enableNewSyntheticsViewExperimentName": "Activer la nouvelle application de monitoring synthétique",
     "xpack.observability.exp.breakDownFilter.noBreakdown": "Pas de répartition",
     "xpack.observability.exp.breakDownFilter.unavailable": "La répartition par nom d'étape n'est pas disponible pour l'indicateur de durée de monitoring. Utilisez l'indicateur de durée d'étape pour répartir par nom d'étape.",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -23337,7 +23337,6 @@
     "xpack.observability.enableComparisonByDefaultDescription": "APMアプリで比較機能を有効にする",
     "xpack.observability.enableInspectEsQueriesExperimentDescription": "API応答でElasticsearchクエリを調査します。",
     "xpack.observability.enableInspectEsQueriesExperimentName": "ESクエリを調査",
-    "xpack.observability.enableNewSyntheticsViewExperimentDescription": "オブザーバビリティで新しい合成監視アプリケーションを有効にします。設定を適用するにはページを更新してください。",
     "xpack.observability.enableNewSyntheticsViewExperimentName": "新しい合成監視アプリケーションを有効にする",
     "xpack.observability.exp.breakDownFilter.noBreakdown": "内訳なし",
     "xpack.observability.exp.breakDownFilter.unavailable": "モニター期間メトリックでは、ステップ名内訳を使用できません。ステップ期間メトリックを使用して、ステップ名で分解します。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -23368,7 +23368,6 @@
     "xpack.observability.enableComparisonByDefaultDescription": "在 APM 应用中启用对比功能",
     "xpack.observability.enableInspectEsQueriesExperimentDescription": "检查 API 响应中的 Elasticsearch 查询。",
     "xpack.observability.enableInspectEsQueriesExperimentName": "检查 ES 查询",
-    "xpack.observability.enableNewSyntheticsViewExperimentDescription": "在 Observability 中启用新的组合监测应用程序。刷新页面可应用该设置。",
     "xpack.observability.enableNewSyntheticsViewExperimentName": "启用新的组合监测应用程序",
     "xpack.observability.exp.breakDownFilter.noBreakdown": "无细目",
     "xpack.observability.exp.breakDownFilter.unavailable": "步骤名称细目不可用于监测持续时间指标。使用步骤持续时间指标以按步骤名称细分。",


### PR DESCRIPTION
## Summary

Resolves #144914

Adjusts Synthetics UI toggle to indicate technical preview status

<img width="1002" alt="Screen Shot 2022-11-09 at 2 34 24 PM" src="https://user-images.githubusercontent.com/11356435/200925214-c2f81d17-7b6e-445b-9f63-7b562327546d.png">


<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->