### PR TITLE
[Security Solution][Investigations] - Fix pagination

### DIFF
--- a/x-pack/plugins/timelines/public/container/index.tsx
+++ b/x-pack/plugins/timelines/public/container/index.tsx
@@ -347,6 +347,7 @@ export const useTimelineEventsHandler = ({
           from: startDate,
           to: endDate,
         },
+        filterStatus,
       };
 
       const newActivePage = deepEqual(prevSearchParameters, currentSearchParameters)
@@ -450,6 +451,7 @@ export const useTimelineEvents = ({
   indexNames,
   fields,
   filterQuery,
+  filterStatus,
   startDate,
   language = 'kuery',
   limit,
@@ -465,6 +467,7 @@ export const useTimelineEvents = ({
     endDate,
     entityType,
     excludeEcsData,
+    filterStatus,
     id,
     indexNames,
     fields,


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/elastic/kibana/issues/144975 .

Why this happened: Filter status was added here in this PR: https://github.com/elastic/kibana/pull/144291/files#diff-5796dde9b49a93dcce15ee9ea2133002123cbb9802033e07ae9db0c9739d08c6R266, but wasn't passed through here https://github.com/elastic/kibana/pull/142737/files#diff-6ab300638b4c9d274e5508a7a9d3f94ca62e3ead9839ad6d536c09affbbef877R443 . This led to a value of `undefined` always being passed for `filterStatus` within the query, preventing the necessary update in the `useEffect`. 


This PR re-introduces the pass through of that value.


https://user-images.githubusercontent.com/17211684/201157342-8e434d0d-fcac-42fb-b4c7-715e465156a6.mov
