### PR TITLE
[Fleet] Change log level when fleet server host is not found in the policy

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -4263,6 +4263,7 @@
             "type": "boolean"
           },
           "fleet_server_hosts": {
+            "deprecated": true,
             "type": "array",
             "items": {
               "type": "string"

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2659,6 +2659,7 @@ components:
         has_seen_add_data_notice:
           type: boolean
         fleet_server_hosts:
+          deprecated: true
           type: array
           items:
             type: string

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/settings.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/settings.yaml
@@ -6,11 +6,12 @@ properties:
   has_seen_add_data_notice:
     type: boolean
   fleet_server_hosts:
+    deprecated: true
     type: array
     items:
       type: string
-  prerelease_integrations_enabled:   
-    type: boolean 
+  prerelease_integrations_enabled:
+    type: boolean
 required:
   - fleet_server_hosts
   - id

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -195,7 +195,7 @@ export async function getFullAgentPolicy(
       (err) => {
         appContextService
           .getLogger()
-          ?.warn(`Unable to fleet server hosts for policy ${agentPolicy?.id} : ${err.message}`);
+          ?.warn(`Unable to get fleet server hosts for policy ${agentPolicy?.id}: ${err.message}`);
 
         return;
       }

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -8,7 +8,13 @@
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { safeLoad } from 'js-yaml';
 
-import type { FullAgentPolicy, PackagePolicy, Output, FullAgentPolicyOutput } from '../../types';
+import type {
+  FullAgentPolicy,
+  AgentPolicy,
+  PackagePolicy,
+  Output,
+  FullAgentPolicyOutput,
+} from '../../types';
 import { agentPolicyService } from '../agent_policy';
 import { outputService } from '../output';
 import { dataTypes, outputType } from '../../../common/constants';
@@ -34,7 +40,7 @@ export async function getFullAgentPolicy(
   id: string,
   options?: { standalone: boolean }
 ): Promise<FullAgentPolicy | null> {
-  let agentPolicy;
+  let agentPolicy: AgentPolicy | null | undefined;
   const standalone = options?.standalone ?? false;
 
   try {
@@ -187,7 +193,9 @@ export async function getFullAgentPolicy(
   if (!standalone) {
     const fleetServerHost = await getFleetServerHostsForAgentPolicy(soClient, agentPolicy).catch(
       (err) => {
-        appContextService.getLogger()?.error(err);
+        appContextService
+          .getLogger()
+          ?.warn(`Unable to fleet server hosts for policy ${agentPolicy?.id} : ${err.message}`);
 
         return;
       }


### PR DESCRIPTION
## Description 

We log a message when we do not find fleet server hosts when generating the policy, that PR change the log level of that message and make it more explicit.

I also used that PR to mark the `fleet_server_hosts` field in the settings deprecated, as users should now use the `/fleet_server_hosts` endpoints

Related to #144898