### PR TITLE
Wrap only inventory page with waffle providers

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -68,65 +68,70 @@ export const InfrastructurePage = ({ match }: RouteComponentProps) => {
     <EuiErrorBoundary>
       <SourceProvider sourceId="default">
         <AlertPrefillProvider>
-          <WaffleOptionsProvider>
-            <WaffleTimeProvider>
-              <WaffleFiltersProvider>
-                <InfraMLCapabilitiesProvider>
-                  <HelpCenterContent
-                    feedbackLink="https://discuss.elastic.co/c/metrics"
-                    appName={i18n.translate('xpack.infra.header.infrastructureHelpAppName', {
-                      defaultMessage: 'Metrics',
-                    })}
-                  />
+          <InfraMLCapabilitiesProvider>
+            <HelpCenterContent
+              feedbackLink="https://discuss.elastic.co/c/metrics"
+              appName={i18n.translate('xpack.infra.header.infrastructureHelpAppName', {
+                defaultMessage: 'Metrics',
+              })}
+            />
 
-                  {setHeaderActionMenu && theme$ && (
-                    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
-                      <EuiHeaderLinks gutterSize="xs">
-                        <EuiHeaderLink color={'text'} {...settingsLinkProps}>
-                          {settingsTabTitle}
-                        </EuiHeaderLink>
-                        <Route path={'/inventory'} component={AnomalyDetectionFlyout} />
-                        <MetricsAlertDropdown />
-                        <EuiHeaderLink
-                          href={kibana.services?.application?.getUrlForApp('/integrations/browse')}
-                          color="primary"
-                          iconType="indexOpen"
-                        >
-                          {ADD_DATA_LABEL}
-                        </EuiHeaderLink>
-                      </EuiHeaderLinks>
-                    </HeaderMenuPortal>
-                  )}
-                  <Switch>
-                    <Route path={'/inventory'} component={SnapshotPage} />
-                    <Route
-                      path={'/explorer'}
-                      render={(props) => (
-                        <WithSource>
-                          {({ configuration, createDerivedIndexPattern }) => (
-                            <MetricsExplorerOptionsContainer>
-                              <WithMetricsExplorerOptionsUrlState />
-                              {configuration ? (
-                                <PageContent
-                                  configuration={configuration}
-                                  createDerivedIndexPattern={createDerivedIndexPattern}
-                                />
-                              ) : (
-                                <SourceLoadingPage />
-                              )}
-                            </MetricsExplorerOptionsContainer>
-                          )}
-                        </WithSource>
-                      )}
-                    />
-                    <Route path="/detail/:type/:node" component={MetricDetail} />
-                    <Route path={'/hosts'} component={HostsPage} />
-                    <Route path={'/settings'} component={MetricsSettingsPage} />
-                  </Switch>
-                </InfraMLCapabilitiesProvider>
-              </WaffleFiltersProvider>
-            </WaffleTimeProvider>
-          </WaffleOptionsProvider>
+            {setHeaderActionMenu && theme$ && (
+              <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+                <EuiHeaderLinks gutterSize="xs">
+                  <EuiHeaderLink color={'text'} {...settingsLinkProps}>
+                    {settingsTabTitle}
+                  </EuiHeaderLink>
+                  <Route path={'/inventory'} component={AnomalyDetectionFlyout} />
+                  <MetricsAlertDropdown />
+                  <EuiHeaderLink
+                    href={kibana.services?.application?.getUrlForApp('/integrations/browse')}
+                    color="primary"
+                    iconType="indexOpen"
+                  >
+                    {ADD_DATA_LABEL}
+                  </EuiHeaderLink>
+                </EuiHeaderLinks>
+              </HeaderMenuPortal>
+            )}
+            <Switch>
+              <Route
+                path={'/inventory'}
+                render={() => (
+                  <WaffleOptionsProvider>
+                    <WaffleTimeProvider>
+                      <WaffleFiltersProvider>
+                        <SnapshotPage />
+                      </WaffleFiltersProvider>
+                    </WaffleTimeProvider>
+                  </WaffleOptionsProvider>
+                )}
+              />
+              <Route
+                path={'/explorer'}
+                render={(props) => (
+                  <WithSource>
+                    {({ configuration, createDerivedIndexPattern }) => (
+                      <MetricsExplorerOptionsContainer>
+                        <WithMetricsExplorerOptionsUrlState />
+                        {configuration ? (
+                          <PageContent
+                            configuration={configuration}
+                            createDerivedIndexPattern={createDerivedIndexPattern}
+                          />
+                        ) : (
+                          <SourceLoadingPage />
+                        )}
+                      </MetricsExplorerOptionsContainer>
+                    )}
+                  </WithSource>
+                )}
+              />
+              <Route path="/detail/:type/:node" component={MetricDetail} />
+              <Route path={'/hosts'} component={HostsPage} />
+              <Route path={'/settings'} component={MetricsSettingsPage} />
+            </Switch>
+          </InfraMLCapabilitiesProvider>
         </AlertPrefillProvider>
       </SourceProvider>
     </EuiErrorBoundary>

--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -31,9 +31,6 @@ import { MetricDetail } from './metric_detail';
 import { MetricsSettingsPage } from './settings';
 import { HostsPage } from './hosts';
 import { SourceLoadingPage } from '../../components/source_loading_page';
-import { WaffleOptionsProvider } from './inventory_view/hooks/use_waffle_options';
-import { WaffleTimeProvider } from './inventory_view/hooks/use_waffle_time';
-import { WaffleFiltersProvider } from './inventory_view/hooks/use_waffle_filters';
 
 import { MetricsAlertDropdown } from '../../alerting/common/components/metrics_alert_dropdown';
 import { SavedViewProvider } from '../../containers/saved_view/saved_view';
@@ -95,18 +92,7 @@ export const InfrastructurePage = ({ match }: RouteComponentProps) => {
               </HeaderMenuPortal>
             )}
             <Switch>
-              <Route
-                path={'/inventory'}
-                render={() => (
-                  <WaffleOptionsProvider>
-                    <WaffleTimeProvider>
-                      <WaffleFiltersProvider>
-                        <SnapshotPage />
-                      </WaffleFiltersProvider>
-                    </WaffleTimeProvider>
-                  </WaffleOptionsProvider>
-                )}
-              />
+              <Route path={'/inventory'} component={SnapshotPage} />
               <Route
                 path={'/explorer'}
                 render={(props) => (

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/index.tsx
@@ -17,12 +17,14 @@ import { useMetricsBreadcrumbs } from '../../../hooks/use_metrics_breadcrumbs';
 import { LayoutView } from './components/layout_view';
 import { SavedViewProvider } from '../../../containers/saved_view/saved_view';
 import { DEFAULT_WAFFLE_VIEW_STATE } from './hooks/use_waffle_view_state';
-import { useWaffleOptionsContext } from './hooks/use_waffle_options';
+import { useWaffleOptionsContext, WaffleOptionsProvider } from './hooks/use_waffle_options';
 import { MetricsPageTemplate } from '../page_template';
 import { inventoryTitle } from '../../../translations';
 import { SavedViews } from './components/saved_views';
 import { SnapshotContainer } from './components/snapshot_container';
 import { fullHeightContentStyles } from '../../../page_template.styles';
+import { WaffleTimeProvider } from './hooks/use_waffle_time';
+import { WaffleFiltersProvider } from './hooks/use_waffle_filters';
 
 export const SnapshotPage = () => {
   const {
@@ -50,38 +52,44 @@ export const SnapshotPage = () => {
       ) : metricIndicesExist ? (
         <>
           <div className={APP_WRAPPER_CLASS}>
-            <SavedViewProvider
-              shouldLoadDefault={optionsSource === 'default'}
-              viewType={'inventory-view'}
-              defaultViewState={DEFAULT_WAFFLE_VIEW_STATE}
-            >
-              <MetricsPageTemplate
-                hasData={metricIndicesExist}
-                pageHeader={{
-                  pageTitle: inventoryTitle,
-                  rightSideItems: [<SavedViews />],
-                }}
-                pageSectionProps={{
-                  contentProps: {
-                    css: fullHeightContentStyles,
-                  },
-                }}
-              >
-                <SnapshotContainer
-                  render={({ loading, nodes, reload, interval }) => (
-                    <>
-                      <FilterBar interval={interval} />
-                      <LayoutView
-                        loading={loading}
-                        nodes={nodes}
-                        reload={reload}
-                        interval={interval}
+            <WaffleOptionsProvider>
+              <WaffleTimeProvider>
+                <WaffleFiltersProvider>
+                  <SavedViewProvider
+                    shouldLoadDefault={optionsSource === 'default'}
+                    viewType={'inventory-view'}
+                    defaultViewState={DEFAULT_WAFFLE_VIEW_STATE}
+                  >
+                    <MetricsPageTemplate
+                      hasData={metricIndicesExist}
+                      pageHeader={{
+                        pageTitle: inventoryTitle,
+                        rightSideItems: [<SavedViews />],
+                      }}
+                      pageSectionProps={{
+                        contentProps: {
+                          css: fullHeightContentStyles,
+                        },
+                      }}
+                    >
+                      <SnapshotContainer
+                        render={({ loading, nodes, reload, interval }) => (
+                          <>
+                            <FilterBar interval={interval} />
+                            <LayoutView
+                              loading={loading}
+                              nodes={nodes}
+                              reload={reload}
+                              interval={interval}
+                            />
+                          </>
+                        )}
                       />
-                    </>
-                  )}
-                />
-              </MetricsPageTemplate>
-            </SavedViewProvider>
+                    </MetricsPageTemplate>
+                  </SavedViewProvider>
+                </WaffleFiltersProvider>
+              </WaffleTimeProvider>
+            </WaffleOptionsProvider>
           </div>
         </>
       ) : hasFailedLoadingSource ? (


### PR DESCRIPTION
This PR gives a simplified solution to https://github.com/elastic/kibana/pull/144462. 
As discussed with @neptunian there is no need to persist the filters between infrastructure pages because if those filters are needed there is an option to save the view and to keep them or to copy the URL and share it. The logic to persist the filters will only add extra complexity to the `waffle` state handling which won't give a lot of value as there is another way to save the filters/time/query.