### PR TITLE
[Fleet] Add `?full` query param to deprecated package info API

### DIFF
--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -57,6 +57,7 @@ export const GetInfoRequestSchemaDeprecated = {
   query: schema.object({
     ignoreUnverified: schema.maybe(schema.boolean()),
     prerelease: schema.maybe(schema.boolean()),
+    full: schema.maybe(schema.boolean()),
   }),
 };
 


### PR DESCRIPTION
## Summary

The policy editor page still uses this deprecated API, so we need to add the new `?full` query parameter to its schema as well

Fixes https://github.com/elastic/kibana/issues/144982