### PR TITLE
[Profiling] Fix ordering of CPU incl. subfunctions in TopN Functions

### DIFF
--- a/x-pack/plugins/profiling/public/components/functions_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/functions_view/index.tsx
@@ -49,7 +49,7 @@ export function FunctionsView({ children }: { children: React.ReactElement }) {
         timeFrom: new Date(timeRange.start).getTime() / 1000,
         timeTo: new Date(timeRange.end).getTime() / 1000,
         startIndex: 0,
-        endIndex: 1000,
+        endIndex: 100000,
         kuery,
       });
     },
@@ -66,7 +66,7 @@ export function FunctionsView({ children }: { children: React.ReactElement }) {
         timeFrom: new Date(comparisonTimeRange.start).getTime() / 1000,
         timeTo: new Date(comparisonTimeRange.end).getTime() / 1000,
         startIndex: 0,
-        endIndex: 1000,
+        endIndex: 100000,
         kuery: comparisonKuery,
       });
     },

--- a/x-pack/plugins/profiling/public/components/topn_functions.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions.tsx
@@ -322,7 +322,7 @@ export const TopNFunctionsTable = ({
         : row[sortField];
     },
     [sortDirection]
-  );
+  ).slice(0, 100);
 
   return (
     <>

--- a/x-pack/plugins/profiling/public/components/topn_functions.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions.tsx
@@ -212,6 +212,9 @@ export const TopNFunctionsTable = ({
         defaultMessage: 'Rank',
       }),
       align: 'right',
+      render: (_, { rank }) => {
+        return <EuiText style={{ whiteSpace: 'nowrap', fontSize: 'inherit' }}>{rank}</EuiText>;
+      },
     },
     {
       field: TopNFunctionSortField.Frame,


### PR DESCRIPTION
Kibana client fetches all functions from the server.
Kibana client only shows the Top 100 functions, dependent on column sort order.

Fixes https://github.com/elastic/prodfiler/issues/2723

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->