### PR TITLE
[8.5] [Exploratory View] adjust forumla for synthetics monitor availability (#144868)

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
@@ -210,8 +210,8 @@ export class LensAttributes {
     const isFormulaColumn =
       Boolean(
         metricOptions &&
-        (metricOptions.find((option) => option.id === selectedMetricField) as MetricOption)
-          ?.formula
+          (metricOptions.find((option) => option.id === selectedMetricField) as MetricOption)
+            ?.formula
       ) || yAxisSourceField === RECORDS_PERCENTAGE_FIELD;
 
     return {
@@ -231,15 +231,15 @@ export class LensAttributes {
         missingBucket: false,
         ...(isFormulaColumn
           ? {
-            orderAgg: {
-              label: 'Count of records',
-              dataType: 'number',
-              operationType: 'count',
-              isBucketed: false,
-              scale: 'ratio',
-              sourceField: '___records___',
-            },
-          }
+              orderAgg: {
+                label: 'Count of records',
+                dataType: 'number',
+                operationType: 'count',
+                isBucketed: false,
+                scale: 'ratio',
+                sourceField: '___records___',
+              },
+            }
           : {}),
       },
     };
@@ -906,15 +906,15 @@ export class LensAttributes {
           },
           ...(breakdown && sourceField !== USE_BREAK_DOWN_COLUMN && breakdown !== PERCENTILE
             ? // do nothing since this will be used a x axis source
-            {
-              [`breakdown-column-${layerId}`]: this.getBreakdownColumn({
-                layerId,
-                sourceField: breakdown,
-                indexPattern: layerConfig.indexPattern,
-                labels: layerConfig.seriesConfig.labels,
-                layerConfig,
-              }),
-            }
+              {
+                [`breakdown-column-${layerId}`]: this.getBreakdownColumn({
+                  layerId,
+                  sourceField: breakdown,
+                  indexPattern: layerConfig.indexPattern,
+                  labels: layerConfig.seriesConfig.labels,
+                  layerConfig,
+                }),
+              }
             : {}),
           ...this.getChildYAxises(layerConfig, layerId, columnFilter),
         },
@@ -980,17 +980,17 @@ export class LensAttributes {
              * if not, use the secondary y axis (left) */
             axisMode:
               layerConfig.indexPattern.fieldFormatMap[layerConfig.selectedMetricField]?.id ===
-                this.layerConfigs[0].indexPattern.fieldFormatMap[
-                  this.layerConfigs[0].selectedMetricField
-                ]?.id
+              this.layerConfigs[0].indexPattern.fieldFormatMap[
+                this.layerConfigs[0].selectedMetricField
+              ]?.id
                 ? ('left' as YAxisMode)
                 : ('right' as YAxisMode),
           },
         ],
         xAccessor: `x-axis-column-layer${index}`,
         ...(layerConfig.breakdown &&
-          layerConfig.breakdown !== PERCENTILE &&
-          layerConfig.seriesConfig.xAxisColumn.sourceField !== USE_BREAK_DOWN_COLUMN
+        layerConfig.breakdown !== PERCENTILE &&
+        layerConfig.seriesConfig.xAxisColumn.sourceField !== USE_BREAK_DOWN_COLUMN
           ? { splitAccessor: `breakdown-column-layer${index}` }
           : {}),
         ...(this.layerConfigs[0].seriesConfig.yTitle

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -91,7 +91,7 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         label: 'Monitor availability',
         id: 'monitor_availability',
         columnType: FORMULA_COLUMN,
-        formula: "1- (count(kql='summary.down > 0') / count())",
+        formula: "1- (count(kql='summary.down > 0') / count(kql='summary: *'))",
       },
       {
         field: SUMMARY_UP,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Exploratory View] adjust forumla for synthetics monitor availability (#144868)](https://github.com/elastic/kibana/pull/144868)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dominique Clarke","email":"dominique.clarke@elastic.co"},"sourceCommit":{"committedDate":"2022-11-09T09:23:25Z","message":"[Exploratory View] adjust forumla for synthetics monitor availability (#144868)\n\nResolves https://github.com/elastic/kibana/issues/143672","sha":"1fdf78ff8ee7fbfeaeb2544a8c7c4210d956572f","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:uptime","v8.6.0","v8.5.1"],"number":144868,"url":"https://github.com/elastic/kibana/pull/144868","mergeCommit":{"message":"[Exploratory View] adjust forumla for synthetics monitor availability (#144868)\n\nResolves https://github.com/elastic/kibana/issues/143672","sha":"1fdf78ff8ee7fbfeaeb2544a8c7c4210d956572f"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/144868","number":144868,"mergeCommit":{"message":"[Exploratory View] adjust forumla for synthetics monitor availability (#144868)\n\nResolves https://github.com/elastic/kibana/issues/143672","sha":"1fdf78ff8ee7fbfeaeb2544a8c7c4210d956572f"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->