### PR TITLE
[+DOC] Alert Action Context

### DIFF
--- a/docs/user/alerting/create-and-manage-rules.asciidoc
+++ b/docs/user/alerting/create-and-manage-rules.asciidoc
@@ -118,6 +118,14 @@ Each action type exposes different properties. For example, an email action allo
 [role="screenshot"]
 image::images/rule-flyout-action-details.png[UI for defining an email action]
 
+You can attach more than one action. Clicking the *Add action* button will prompt you to select another rule type and repeat the above steps again.
+
+[NOTE]
+==============================================
+Actions are not required on rules. You can run a rule without actions to
+understand its behavior, then <<action-settings,configure actions>> later.
+==============================================
+
 [float]
 [[defining-rules-actions-variables]]
 ===== Action variables
@@ -145,17 +153,29 @@ Some cases exist where the variable values will be "escaped", when used in a con
 
 Mustache also supports "triple braces" of the form `{{{variable name}}}`, which indicates no escaping should be done at all.  Care should be used when using this form, as it could end up rendering the variable content in such a way as to make the resulting parameter invalid or formatted incorrectly.
 
+[float]
+[[defining-rules-actions-variable-context]]
+===== Action variable context
+
 Each rule type defines additional variables as properties of the variable `context`.  For example, if a rule type defines a variable `value`, it can be used in an action parameter as `{{context.value}}`.  
 
-For diagnostic or exploratory purposes, action variables whose values are objects, such as `context`, can be referenced directly as variables.  The resulting value will be a JSON representation of the object.  For example, if an action parameter includes `{{context}}`, it will expand to the JSON representation of all the variables and values provided by the rule type.
+For diagnostic or exploratory purposes, action variables whose values are objects, such as `context`, can be referenced directly as variables. The resulting value will be a JSON representation of the object.  For example, if an action parameter includes `{{context}}`, it will expand to the JSON representation of all the variables and values provided by the rule type. To see all variables, use `{{.}} `.
 
-You can attach more than one action. Clicking the *Add action* button will prompt you to select another rule type and repeat the above steps again.
+For situations where your rule response returns arrays of data, you can loop through the `context` by
 
-[NOTE]
-==============================================
-Actions are not required on rules. You can run a rule without actions to
-understand its behavior, then <<action-settings,configure actions>> later.
-==============================================
+[source]
+--------------------------------------------------
+{{#context}}{{.}}{{/context}}
+--------------------------------------------------
+
+For example, looping through search result hits may appear
+
+[source]
+--------------------------------------------------
+triggering data was:
+{{#context.hits}} - {{_source.message}}
+{{/context.hits}}
+--------------------------------------------------
 
 [float]
 [[controlling-rules]]

--- a/docs/user/alerting/create-and-manage-rules.asciidoc
+++ b/docs/user/alerting/create-and-manage-rules.asciidoc
@@ -104,7 +104,7 @@ image::images/rule-flyout-rule-conditions.png[UI for defining rule conditions on
 [[defining-rules-actions-details]]
 ==== Action type and details
 
-To receive notifications when a rule meets the defined conditions, you must add one or more actions. Start by selecting a type of connector for your action:
+Actions are optional when you create a rule. However, to receive notifications when a rule meets the defined conditions, you must add one or more actions. Start by selecting a type of connector for your action:
 
 [role="screenshot"]
 image::images/rule-flyout-connector-type-selection.png[UI for selecting an action type]
@@ -119,12 +119,6 @@ Each action type exposes different properties. For example, an email action allo
 image::images/rule-flyout-action-details.png[UI for defining an email action]
 
 You can attach more than one action. Clicking the *Add action* button will prompt you to select another rule type and repeat the above steps again.
-
-[NOTE]
-==============================================
-Actions are not required on rules. You can run a rule without actions to
-understand its behavior, then <<action-settings,configure actions>> later.
-==============================================
 
 [float]
 [[defining-rules-actions-variables]]
@@ -159,7 +153,7 @@ Mustache also supports "triple braces" of the form `{{{variable name}}}`, which 
 
 Each rule type defines additional variables as properties of the variable `context`.  For example, if a rule type defines a variable `value`, it can be used in an action parameter as `{{context.value}}`.  
 
-For diagnostic or exploratory purposes, action variables whose values are objects, such as `context`, can be referenced directly as variables. The resulting value will be a JSON representation of the object.  For example, if an action parameter includes `{{context}}`, it will expand to the JSON representation of all the variables and values provided by the rule type. To see all variables, use `{{.}} `.
+For diagnostic or exploratory purposes, action variables whose values are objects, such as `context`, can be referenced directly as variables. The resulting value will be a JSON representation of the object.  For example, if an action parameter includes `{{context}}`, it will expand to the JSON representation of all the variables and values provided by the rule type. To see alert-specific variables, use `{{.}} `.
 
 For situations where your rule response returns arrays of data, you can loop through the `context` by
 


### PR DESCRIPTION
👋 howdy, team!

## Summary
Doc request https://github.com/elastic/kibana/issues/131271 is still a high pain point, the hope of this PR is to
- provide direct doc link to the `{{context}}` paragraph (currently scroll-hidden under an image)
- append common info requests, how to
    - see all variables (during exploration)
    - loop through `context`, esp. related to rule search response

### Checklist

Delete any items that are not applicable to this PR. ✓

### Risk Matrix

Delete this section if it is not applicable to this PR. ✓

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->