### PR TITLE
[Lens] Hide the random sampling settings from the UI

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -52,6 +52,9 @@ const initialActiveDimensionState = {
   isNew: false,
 };
 
+// hide the random sampling settings from the UI
+const DISPLAY_RANDOM_SAMPLING_SETTINGS = false;
+
 export function LayerPanel(
   props: Exclude<LayerPanelProps, 'state' | 'setState'> & {
     activeVisualization: Visualization;
@@ -323,12 +326,14 @@ export function LayerPanel(
           updateVisualization,
           () => setPanelSettingsOpen(true)
         ) || []),
-        ...(layerDatasource?.getSupportedActionsForLayer?.(
-          layerId,
-          layerDatasourceState,
-          (newState) => updateDatasource(datasourceId, newState),
-          () => setPanelSettingsOpen(true)
-        ) || []),
+        ...((DISPLAY_RANDOM_SAMPLING_SETTINGS &&
+          layerDatasource?.getSupportedActionsForLayer?.(
+            layerId,
+            layerDatasourceState,
+            (newState) => updateDatasource(datasourceId, newState),
+            () => setPanelSettingsOpen(true)
+          )) ||
+          []),
         ...getSharedActions({
           activeVisualization,
           core,
@@ -639,7 +644,8 @@ export function LayerPanel(
           })}
         </EuiPanel>
       </section>
-      {(layerDatasource?.renderLayerSettings || activeVisualization?.renderLayerSettings) && (
+      {((DISPLAY_RANDOM_SAMPLING_SETTINGS && layerDatasource?.renderLayerSettings) ||
+        activeVisualization?.renderLayerSettings) && (
         <FlyoutContainer
           panelRef={(el) => (settingsPanelRef.current = el)}
           isOpen={isPanelSettingsOpen}
@@ -655,7 +661,7 @@ export function LayerPanel(
         >
           <div id={layerId}>
             <div className="lnsIndexPatternDimensionEditor--padded lnsIndexPatternDimensionEditor--collapseNext">
-              {layerDatasource?.renderLayerSettings && (
+              {DISPLAY_RANDOM_SAMPLING_SETTINGS && layerDatasource?.renderLayerSettings && (
                 <NativeRenderer
                   render={layerDatasource.renderLayerSettings}
                   nativeProps={layerDatasourceConfigProps}

--- a/x-pack/test/functional/apps/lens/group1/layer_actions.ts
+++ b/x-pack/test/functional/apps/lens/group1/layer_actions.ts
@@ -13,7 +13,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const find = getService('find');
   const testSubjects = getService('testSubjects');
 
-  describe('lens layer actions tests', () => {
+  // skip random sampling FTs until we figure out next steps
+  describe.skip('lens layer actions tests', () => {
     it('should allow creation of lens xy chart', async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');


### PR DESCRIPTION
## Summary

Hides the random sampling layer settings from the UI until we decide how we want to introduce it to our users.

