### PR TITLE
[APM] Fixes #144669: Incorrect “Learn more” link

### DIFF
--- a/x-pack/plugins/apm/server/tutorial/index.ts
+++ b/x-pack/plugins/apm/server/tutorial/index.ts
@@ -82,7 +82,7 @@ It allows you to monitor the performance of thousands of applications in real ti
 [Learn more]({learnMoreLink}).',
           values: {
             learnMoreLink:
-              '{config.docs.base_url}guide/en/apm/get-started/{config.docs.version}/index.html',
+              '{config.docs.base_url}guide/en/apm/guide/{config.docs.version}/index.html',
           },
         }
       ),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/144669

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->