### PR TITLE
[Security Solution] Add documentation url to `NoPrivileges` page

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -381,8 +381,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       exceptions: {
         value_lists: `${SECURITY_SOLUTION_DOCS}detections-ui-exceptions.html#manage-value-lists`,
       },
-      // todo: add link when ready, until then here is a fallback
-      privileges: `${SECURITY_SOLUTION_DOCS}sec-requirements.html`,
+      privileges: `${SECURITY_SOLUTION_DOCS}endpoint-management-req.html`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -381,6 +381,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       exceptions: {
         value_lists: `${SECURITY_SOLUTION_DOCS}detections-ui-exceptions.html#manage-value-lists`,
       },
+      // todo: add link when ready, until then here is a fallback
+      privileges: `${SECURITY_SOLUTION_DOCS}sec-requirements.html`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -283,6 +283,7 @@ export interface DocLinks {
     readonly exceptions: {
       value_lists: string;
     };
+    readonly privileges: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/no_privileges/no_privileges.tsx
@@ -10,37 +10,37 @@ import React, { useMemo } from 'react';
 import { EuiPageTemplate_Deprecated as EuiPageTemplate } from '@elastic/eui';
 import { SecuritySolutionPageWrapper } from '../page_wrapper';
 import { EmptyPage } from '../empty_page';
-import { useKibana } from '../../lib/kibana';
 import * as i18n from './translations';
 
 interface NoPrivilegesPageProps {
+  documentationUrl: string;
   pageName?: string;
 }
 
-export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(({ pageName }) => {
-  return (
-    <SecuritySolutionPageWrapper>
-      <EuiPageTemplate template="centeredContent">
-        <NoPrivileges pageName={pageName} />
-      </EuiPageTemplate>
-    </SecuritySolutionPageWrapper>
-  );
-});
+export const NoPrivilegesPage = React.memo<NoPrivilegesPageProps>(
+  ({ pageName, documentationUrl }) => {
+    return (
+      <SecuritySolutionPageWrapper>
+        <EuiPageTemplate template="centeredContent">
+          <NoPrivileges pageName={pageName} documentationUrl={documentationUrl} />
+        </EuiPageTemplate>
+      </SecuritySolutionPageWrapper>
+    );
+  }
+);
 NoPrivilegesPage.displayName = 'NoPrivilegePage';
 
-export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName }) => {
-  const { docLinks } = useKibana().services;
-
+export const NoPrivileges = React.memo<NoPrivilegesPageProps>(({ pageName, documentationUrl }) => {
   const emptyPageActions = useMemo(
     () => ({
       feature: {
         icon: 'documents',
         label: i18n.GO_TO_DOCUMENTATION,
-        url: `${docLinks.links.siem.privileges}`,
+        url: documentationUrl,
         target: '_blank',
       },
     }),
-    [docLinks]
+    [documentationUrl]
   );
 
   const message = pageName

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -32,7 +32,7 @@ export const PrivilegedRoute = memo(({ component, hasPrivilege, path }: Privileg
       (isEndpointRbacV1Enabled && path === MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH);
 
     componentToRender = shouldUseMissingPrivilegesScreen
-      ? () => <NoPrivilegesPage documentationUrl={docLinks.links.siem.privileges} />
+      ? () => <NoPrivilegesPage documentationUrl={docLinks.links.securitySolution.privileges} />
       : NoPermissions;
   }
 

--- a/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/privileged_route/privileged_route.tsx
@@ -10,6 +10,7 @@ import { Route } from '@kbn/kibana-react-plugin/public';
 import { NoPrivilegesPage } from '../../../common/components/no_privileges';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { NoPermissions } from '../no_permissons';
+import { useKibana } from '../../../common/lib/kibana';
 import { MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH } from '../../common/constants';
 
 export interface PrivilegedRouteProps {
@@ -19,6 +20,7 @@ export interface PrivilegedRouteProps {
 }
 
 export const PrivilegedRoute = memo(({ component, hasPrivilege, path }: PrivilegedRouteProps) => {
+  const { docLinks } = useKibana().services;
   const isEndpointRbacEnabled = useIsExperimentalFeatureEnabled('endpointRbacEnabled');
   const isEndpointRbacV1Enabled = useIsExperimentalFeatureEnabled('endpointRbacV1Enabled');
 
@@ -30,7 +32,7 @@ export const PrivilegedRoute = memo(({ component, hasPrivilege, path }: Privileg
       (isEndpointRbacV1Enabled && path === MANAGEMENT_ROUTING_RESPONSE_ACTIONS_HISTORY_PATH);
 
     componentToRender = shouldUseMissingPrivilegesScreen
-      ? () => <NoPrivilegesPage />
+      ? () => <NoPrivilegesPage documentationUrl={docLinks.links.siem.privileges} />
       : NoPermissions;
   }
 


### PR DESCRIPTION
## Summary

When a user doesn't have the needed Kibana Privileges, more precisely the sub-feature privileges for Security Management pages, they will see a _Privileges Required_ page. It is already merged, see https://github.com/elastic/security-team/issues/5222

What is missing is the correct URL for the documentation page. The goal of this PR is to add this link.

@joepeeples if it's possible for you to provide the link before feature-freeze, it would be awesome! 🙌  ✅ 
**update**: the doc link is now included, thanks @joepeeples!

<img width="647" alt="image" src="https://user-images.githubusercontent.com/39014407/201630368-d8351a22-4fd8-4dbb-a23d-672eed663905.png">