### PR TITLE
[Enterprise Search] Update crawler2 configurations to v2

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -42,6 +42,6 @@ export const CONNECTORS_INDEX = '.elastic-connectors';
 export const CURRENT_CONNECTORS_INDEX = '.elastic-connectors-v1';
 export const CONNECTORS_JOBS_INDEX = '.elastic-connectors-sync-jobs';
 export const CONNECTORS_VERSION = 1;
-export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations';
+export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
 export const ANALYTICS_COLLECTIONS_INDEX = '.elastic-analytics-collections';
 export const ANALYTICS_VERSION = '1';

--- a/x-pack/plugins/enterprise_search/server/lib/crawler/fetch_crawlers.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/crawler/fetch_crawlers.ts
@@ -11,8 +11,8 @@ import { IScopedClusterClient } from '@kbn/core/server';
 import { Crawler, CrawlRequest } from '../../../common/types/crawler';
 import { fetchAll } from '../fetch_all';
 
-const CRAWLER_CONFIGURATIONS_INDEX = '.ent-search-actastic-crawler2_configurations';
-const CRAWLER_CRAWL_REQUESTS_INDEX = '.ent-search-actastic-crawler2_crawl_requests';
+const CRAWLER_CONFIGURATIONS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
+const CRAWLER_CRAWL_REQUESTS_INDEX = '.ent-search-actastic-crawler2_crawl_requests_v2';
 
 export const fetchMostRecentCrawlerRequestByConfigurationId = async (
   client: IScopedClusterClient,


### PR DESCRIPTION
## Summary

https://github.com/elastic/enterprise-search-team/issues/3208

The index `crawler2_configurations` was updated to v2 here: https://github.com/elastic/ent-search/pull/7041
This PR ensures that Kibana uses the correct index version.