### PR TITLE
[Cases] Fix selected label in the assignees filtering

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/assignees_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/assignees_filter.test.tsx
@@ -132,12 +132,30 @@ describe('AssigneesFilterPopover', () => {
 
     await waitFor(async () => {
       userEvent.click(screen.getByTestId('options-filter-popover-button-assignees'));
-      expect(screen.getByText('1 assignee filtered')).toBeInTheDocument();
+      expect(screen.getByText('1 filter selected')).toBeInTheDocument();
     });
 
     await waitForEuiPopoverOpen();
 
     expect(screen.getByText('Damaged Raccoon')).toBeInTheDocument();
+  });
+
+  it('shows the total when the multiple users are selected', async () => {
+    const props = {
+      ...defaultProps,
+      selectedAssignees: [userProfiles[0], userProfiles[1]],
+    };
+    appMockRender.render(<AssigneesFilterPopover {...props} />);
+
+    await waitFor(async () => {
+      userEvent.click(screen.getByTestId('options-filter-popover-button-assignees'));
+      expect(screen.getByText('2 filters selected')).toBeInTheDocument();
+    });
+
+    await waitForEuiPopoverOpen();
+
+    expect(screen.getByText('Damaged Raccoon')).toBeInTheDocument();
+    expect(screen.getByText('Physical Dinosaur')).toBeInTheDocument();
   });
 
   it('shows three users when initially rendered', async () => {

--- a/x-pack/plugins/cases/public/components/all_cases/translations.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/translations.ts
@@ -127,7 +127,7 @@ export const CLEAR_FILTERS = i18n.translate(
 
 export const TOTAL_ASSIGNEES_FILTERED = (total: number) =>
   i18n.translate('xpack.cases.allCasesView.totalFilteredUsers', {
-    defaultMessage: '{total, plural, one {# assignee} other {# assignees}} filtered',
+    defaultMessage: '{total, plural, one {# filter} other {# filters}} selected',
     values: { total },
   });
 


### PR DESCRIPTION
## Summary

With the introduction of the "No assignees" filtering in https://github.com/elastic/kibana/pull/143390 we no longer have assignees for filtering. Having the text say "1 assignee selected" when selecting the "No assignees" filtering is misleading. This PR fixes this issue with the label.

<img width="536" alt="Screenshot 2022-11-14 at 3 52 28 PM" src="https://user-images.githubusercontent.com/7871006/201680341-e007931f-e9d2-4e5f-96d9-0909f4478bc8.png">
<img width="536" alt="Screenshot 2022-11-14 at 3 52 20 PM" src="https://user-images.githubusercontent.com/7871006/201680344-76b8bf04-8d0e-48ee-97ab-0d860f076f3f.png">
<img width="551" alt="Screenshot 2022-11-14 at 3 51 48 PM" src="https://user-images.githubusercontent.com/7871006/201680346-a3525a41-cef2-43a9-aa89-7d9238bb3944.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
