### PR TITLE
[Graph] Move codeownership to kibana-visualizations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,6 @@
 /test/functional/apps/discover/ @elastic/kibana-data-discovery
 /test/functional/apps/context/ @elastic/kibana-data-discovery
 /test/api_integration/apis/unified_field_list/ @elastic/kibana-data-discovery
-/x-pack/plugins/graph/ @elastic/kibana-data-discovery
-/x-pack/test/functional/apps/graph @elastic/kibana-data-discovery
 /src/plugins/unified_field_list/ @elastic/kibana-data-discovery
 /src/plugins/unified_histogram/ @elastic/kibana-data-discovery
 /src/plugins/saved_objects_finder/ @elastic/kibana-data-discovery
@@ -49,6 +47,8 @@
 /test/functional/apps/visualize/ @elastic/kibana-visualizations
 /src/plugins/expressions/ @elastic/kibana-visualizations
 /src/plugins/unified_search/ @elastic/kibana-visualizations
+/x-pack/plugins/graph/ @elastic/kibana-data-discovery
+/x-pack/test/functional/apps/graph @elastic/kibana-data-discovery
 
 # Application Services
 /examples/dashboard_embeddable_examples/ @elastic/kibana-app-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,8 +47,8 @@
 /test/functional/apps/visualize/ @elastic/kibana-visualizations
 /src/plugins/expressions/ @elastic/kibana-visualizations
 /src/plugins/unified_search/ @elastic/kibana-visualizations
-/x-pack/plugins/graph/ @elastic/kibana-data-discovery
-/x-pack/test/functional/apps/graph @elastic/kibana-data-discovery
+/x-pack/plugins/graph/ @elastic/kibana-visualizations
+/x-pack/test/functional/apps/graph @elastic/kibana-visualizations
 
 # Application Services
 /examples/dashboard_embeddable_examples/ @elastic/kibana-app-services


### PR DESCRIPTION
## Summary

Moves codeownership of the graph plugin to `kibana-visualizations`