### PR TITLE
[TIP] Add link to TI from Security Overview dashboard

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.test.tsx
@@ -22,6 +22,9 @@ import {
 } from '../../../common/mock';
 import { mockTheme } from './mock';
 import { tGridReducer } from '@kbn/timelines-plugin/public';
+import { createKibanaContextProviderMock } from '../../../common/lib/kibana/kibana_react.mock';
+
+const MockKibanaContextProvider = createKibanaContextProviderMock();
 
 jest.mock('../../../common/lib/kibana');
 
@@ -53,7 +56,9 @@ describe('CtiDisabledModule', () => {
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider theme={mockTheme}>
-            <CtiDisabledModule />
+            <MockKibanaContextProvider>
+              <CtiDisabledModule />
+            </MockKibanaContextProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_enabled_module.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_enabled_module.test.tsx
@@ -24,6 +24,9 @@ import { mockTheme, mockProps, mockTiDataSources, mockCtiLinksResponse } from '.
 import { useCtiDashboardLinks } from '../../containers/overview_cti_links';
 import { useTiDataSources } from '../../containers/overview_cti_links/use_ti_data_sources';
 import { tGridReducer } from '@kbn/timelines-plugin/public';
+import { createKibanaContextProviderMock } from '../../../common/lib/kibana/kibana_react.mock';
+
+const MockKibanaContextProvider = createKibanaContextProviderMock();
 
 jest.mock('../../../common/lib/kibana');
 
@@ -63,7 +66,9 @@ describe('CtiEnabledModule', () => {
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider theme={mockTheme}>
-            <CtiEnabledModule {...mockProps} />
+            <MockKibanaContextProvider>
+              <CtiEnabledModule {...mockProps} />
+            </MockKibanaContextProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/index.test.tsx
@@ -24,6 +24,9 @@ import { mockTheme, mockProps, mockTiDataSources, mockCtiLinksResponse } from '.
 import { useTiDataSources } from '../../containers/overview_cti_links/use_ti_data_sources';
 import { useCtiDashboardLinks } from '../../containers/overview_cti_links';
 import { tGridReducer } from '@kbn/timelines-plugin/public';
+import { createKibanaContextProviderMock } from '../../../common/lib/kibana/kibana_react.mock';
+
+const MockKibanaContextProvider = createKibanaContextProviderMock();
 
 jest.mock('../../../common/lib/kibana');
 
@@ -63,7 +66,9 @@ describe('ThreatIntelLinkPanel', () => {
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider theme={mockTheme}>
-            <ThreatIntelLinkPanel {...mockProps} />
+            <MockKibanaContextProvider>
+              <ThreatIntelLinkPanel {...mockProps} />
+            </MockKibanaContextProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>
@@ -71,6 +76,7 @@ describe('ThreatIntelLinkPanel', () => {
 
     expect(wrapper.find('[data-test-subj="cti-enabled-module"]').length).toEqual(1);
     expect(wrapper.find('[data-test-subj="cti-enable-integrations-button"]').length).toEqual(0);
+    expect(wrapper.find('[data-test-subj="cti-view-indicators"]').length).toBeGreaterThan(0);
   });
 
   it('renders CtiDisabledModule when Threat Intel module is disabled', () => {
@@ -78,7 +84,9 @@ describe('ThreatIntelLinkPanel', () => {
       <Provider store={store}>
         <I18nProvider>
           <ThemeProvider theme={mockTheme}>
-            <ThreatIntelLinkPanel {...mockProps} allTiDataSources={[]} />
+            <MockKibanaContextProvider>
+              <ThreatIntelLinkPanel {...mockProps} allTiDataSources={[]} />
+            </MockKibanaContextProvider>
           </ThemeProvider>
         </I18nProvider>
       </Provider>

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -8,6 +8,8 @@
 import React, { useMemo } from 'react';
 import type { EuiTableFieldDataColumnType } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { SecurityPageName } from '../../../../common/constants';
+import { SecuritySolutionLinkButton } from '../../../common/components/links';
 
 import * as i18n from './translations';
 import type { LinkPanelListItem } from '../link_panel';
@@ -62,6 +64,20 @@ export const ThreatIntelPanelView: React.FC<LinkPanelViewProps> = ({
             />
           ),
           [totalCount]
+        ),
+        button: useMemo(
+          () => (
+            <SecuritySolutionLinkButton
+              data-test-subj="cti-view-indicators"
+              deepLinkId={SecurityPageName.threatIntelligenceIndicators}
+            >
+              <FormattedMessage
+                id="xpack.securitySolution.overview.threatIndicatorsAction"
+                defaultMessage="View indicators"
+              />
+            </SecuritySolutionLinkButton>
+          ),
+          []
         ),
       }}
     />


### PR DESCRIPTION
## Summary

Here, I am adding the missing link leading to the Threat Intelligence plugin's Indicators Screen.

![image](https://user-images.githubusercontent.com/11671118/201702184-f930c82b-5ec7-4895-bc78-15c47c1a9987.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

