### PR TITLE
[DOCS] Removes tag from 8.5.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,8 +41,6 @@ Review important information about the {kib} 8.5.x releases.
 [[release-notes-8.5.1]]
 == {kib} 8.5.1
 
-coming::[8.5.1]
-
 Review the following information about the {kib} 8.5.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.5.1 release notes.