### PR TITLE
[TriggersActionsUi] disable jest config in CI

### DIFF
--- a/.buildkite/disabled_jest_configs.json
+++ b/.buildkite/disabled_jest_configs.json
@@ -1,3 +1,4 @@
 [
+  "x-pack/plugins/triggers_actions_ui/jest.config.js",
   "x-pack/plugins/watcher/jest.config.js"
 ]


### PR DESCRIPTION
This PR disables the jest config on CI for `triggers_actions_ui` plugin as it has been failing regularly during the entire day.

We are not sure about what is the problem but when running this test suite the CI is logging `console.error` multiple times across many test files warning around tests not being properly wrapped or using unsupported syntax. Those should be fixed by the owning teams and I've opened an issue for that at https://github.com/elastic/kibana/issues/145188