### PR TITLE
[ResponseOps][Stack Connectors] Add helptext for Opsgenie connector

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/close_alert.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/close_alert.tsx
@@ -40,6 +40,7 @@ const AdditionalOptions: React.FC<AdditionalOptionsProps> = ({
             data-test-subj="opsgenie-source-row"
             fullWidth
             label={i18n.SOURCE_FIELD_LABEL}
+            helpText={i18n.OPSGENIE_SOURCE_HELP}
           >
             <TextFieldWithMessageVariables
               index={index}
@@ -51,7 +52,12 @@ const AdditionalOptions: React.FC<AdditionalOptionsProps> = ({
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiFormRow data-test-subj="opsgenie-user-row" fullWidth label={i18n.USER_FIELD_LABEL}>
+          <EuiFormRow
+            data-test-subj="opsgenie-user-row"
+            fullWidth
+            label={i18n.USER_FIELD_LABEL}
+            helpText={i18n.OPSGENIE_USER_HELP}
+          >
             <TextFieldWithMessageVariables
               index={index}
               editAction={editOptionalSubAction}
@@ -107,6 +113,7 @@ const CloseAlertComponent: React.FC<CloseAlertProps> = ({
         error={errors['subActionParams.alias']}
         isInvalid={isAliasInvalid}
         label={i18n.ALIAS_REQUIRED_FIELD_LABEL}
+        helpText={i18n.OPSGENIE_ALIAS_HELP}
       >
         <TextFieldWithMessageVariables
           index={index}

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/additional_options.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/additional_options.tsx
@@ -35,6 +35,7 @@ const AdditionalOptionsComponent: React.FC<AdditionalOptionsProps> = ({
             data-test-subj="opsgenie-entity-row"
             fullWidth
             label={i18n.ENTITY_FIELD_LABEL}
+            helpText={i18n.OPSGENIE_ENTITY_HELP}
           >
             <TextFieldWithMessageVariables
               index={index}
@@ -50,6 +51,7 @@ const AdditionalOptionsComponent: React.FC<AdditionalOptionsProps> = ({
             data-test-subj="opsgenie-source-row"
             fullWidth
             label={i18n.SOURCE_FIELD_LABEL}
+            helpText={i18n.OPSGENIE_SOURCE_HELP}
           >
             <TextFieldWithMessageVariables
               index={index}
@@ -62,7 +64,12 @@ const AdditionalOptionsComponent: React.FC<AdditionalOptionsProps> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />
-      <EuiFormRow data-test-subj="opsgenie-user-row" fullWidth label={i18n.USER_FIELD_LABEL}>
+      <EuiFormRow
+        data-test-subj="opsgenie-user-row"
+        fullWidth
+        label={i18n.USER_FIELD_LABEL}
+        helpText={i18n.OPSGENIE_USER_HELP}
+      >
         <TextFieldWithMessageVariables
           index={index}
           editAction={editOptionalSubAction}

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/index.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/index.tsx
@@ -92,7 +92,12 @@ const FormView: React.FC<FormViewProps> = ({
         inputTargetValue={subActionParams?.description}
         label={i18n.DESCRIPTION_FIELD_LABEL}
       />
-      <EuiFormRow data-test-subj="opsgenie-alias-row" fullWidth label={i18n.ALIAS_FIELD_LABEL}>
+      <EuiFormRow
+        data-test-subj="opsgenie-alias-row"
+        fullWidth
+        label={i18n.ALIAS_FIELD_LABEL}
+        helpText={i18n.OPSGENIE_ALIAS_HELP}
+      >
         <TextFieldWithMessageVariables
           index={index}
           editAction={editOptionalSubAction}

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
@@ -74,7 +74,7 @@ export const ENTITY_FIELD_LABEL = i18n.translate(
 
 export const TAGS_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.tagsHelp', {
   defaultMessage:
-    'Type one or more custom identifying tags for this case. Press enter after each tag to begin a new one.',
+    'Press enter after each tag to begin a new one.',
 });
 
 export const TAGS_FIELD_LABEL = i18n.translate(
@@ -113,5 +113,25 @@ export const RULE_TAGS_DESCRIPTION = i18n.translate(
   'xpack.stackConnectors.components.opsgenie.ruleTagsDescription',
   {
     defaultMessage: 'The tags of the rule.',
-  }
+  } 
 );
+
+export const OPSGENIE_ALIAS_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldAliasHelpText', {
+  defaultMessage:
+    'The unique alert identifier used for de-deduplication in OpsGenie.',
+});
+
+export const OPSGENIE_ENTITY_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldEntityHelpText', {
+defaultMessage:
+  'The domain of the alert. For example, the server or application name.',
+});
+
+export const OPSGENIE_SOURCE_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldSourceHelpText', {
+defaultMessage:
+  'The diplay name for the source of the alert.',
+});
+
+export const OPSGENIE_USER_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldUserHelpText', {
+defaultMessage:
+  'The display name for the owner.',
+});

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
@@ -114,31 +114,3 @@ export const RULE_TAGS_DESCRIPTION = i18n.translate(
     defaultMessage: 'The tags of the rule.',
   }
 );
-
-export const OPSGENIE_ALIAS_HELP = i18n.translate(
-  'xpack.cases.createCase.opsGenieFieldAliasHelpText',
-  {
-    defaultMessage: 'The unique alert identifier used for de-deduplication in OpsGenie.',
-  }
-);
-
-export const OPSGENIE_ENTITY_HELP = i18n.translate(
-  'xpack.cases.createCase.opsGenieFieldEntityHelpText',
-  {
-    defaultMessage: 'The domain of the alert. For example, the server or application name.',
-  }
-);
-
-export const OPSGENIE_SOURCE_HELP = i18n.translate(
-  'xpack.cases.createCase.opsGenieFieldSourceHelpText',
-  {
-    defaultMessage: 'The diplay name for the source of the alert.',
-  }
-);
-
-export const OPSGENIE_USER_HELP = i18n.translate(
-  'xpack.cases.createCase.opsGenieFieldUserHelpText',
-  {
-    defaultMessage: 'The display name for the owner.',
-  }
-);

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/create_alert/translations.ts
@@ -73,8 +73,7 @@ export const ENTITY_FIELD_LABEL = i18n.translate(
 );
 
 export const TAGS_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.tagsHelp', {
-  defaultMessage:
-    'Press enter after each tag to begin a new one.',
+  defaultMessage: 'Press enter after each tag to begin a new one.',
 });
 
 export const TAGS_FIELD_LABEL = i18n.translate(
@@ -113,25 +112,33 @@ export const RULE_TAGS_DESCRIPTION = i18n.translate(
   'xpack.stackConnectors.components.opsgenie.ruleTagsDescription',
   {
     defaultMessage: 'The tags of the rule.',
-  } 
+  }
 );
 
-export const OPSGENIE_ALIAS_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldAliasHelpText', {
-  defaultMessage:
-    'The unique alert identifier used for de-deduplication in OpsGenie.',
-});
+export const OPSGENIE_ALIAS_HELP = i18n.translate(
+  'xpack.cases.createCase.opsGenieFieldAliasHelpText',
+  {
+    defaultMessage: 'The unique alert identifier used for de-deduplication in OpsGenie.',
+  }
+);
 
-export const OPSGENIE_ENTITY_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldEntityHelpText', {
-defaultMessage:
-  'The domain of the alert. For example, the server or application name.',
-});
+export const OPSGENIE_ENTITY_HELP = i18n.translate(
+  'xpack.cases.createCase.opsGenieFieldEntityHelpText',
+  {
+    defaultMessage: 'The domain of the alert. For example, the server or application name.',
+  }
+);
 
-export const OPSGENIE_SOURCE_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldSourceHelpText', {
-defaultMessage:
-  'The diplay name for the source of the alert.',
-});
+export const OPSGENIE_SOURCE_HELP = i18n.translate(
+  'xpack.cases.createCase.opsGenieFieldSourceHelpText',
+  {
+    defaultMessage: 'The diplay name for the source of the alert.',
+  }
+);
 
-export const OPSGENIE_USER_HELP = i18n.translate('xpack.cases.createCase.opsGenieFieldUserHelpText', {
-defaultMessage:
-  'The display name for the owner.',
-});
+export const OPSGENIE_USER_HELP = i18n.translate(
+  'xpack.cases.createCase.opsGenieFieldUserHelpText',
+  {
+    defaultMessage: 'The display name for the owner.',
+  }
+);

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
@@ -119,22 +119,30 @@ export const OPSGENIE_DOCUMENTATION = i18n.translate(
   }
 );
 
-export const OPSGENIE_ALIAS_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldAliasHelpText', {
-  defaultMessage:
-    'The unique alert identifier used for de-deduplication in OpsGenie.',
-});
+export const OPSGENIE_ALIAS_HELP = i18n.translate(
+  'xpack.stackConnectors.components.opsgenie.fieldAliasHelpText',
+  {
+    defaultMessage: 'The unique alert identifier used for de-deduplication in OpsGenie.',
+  }
+);
 
-export const OPSGENIE_ENTITY_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldEntityHelpText', {
-defaultMessage:
-  'The domain of the alert. For example, the application name.',
-});
+export const OPSGENIE_ENTITY_HELP = i18n.translate(
+  'xpack.stackConnectors.components.opsgenie.fieldEntityHelpText',
+  {
+    defaultMessage: 'The domain of the alert. For example, the application name.',
+  }
+);
 
-export const OPSGENIE_SOURCE_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldSourceHelpText', {
-defaultMessage:
-  'The display name for the source of the alert.',
-});
+export const OPSGENIE_SOURCE_HELP = i18n.translate(
+  'xpack.stackConnectors.components.opsgenie.fieldSourceHelpText',
+  {
+    defaultMessage: 'The display name for the source of the alert.',
+  }
+);
 
-export const OPSGENIE_USER_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldUserHelpText', {
-defaultMessage:
-  'The display name for the owner.',
-});
+export const OPSGENIE_USER_HELP = i18n.translate(
+  'xpack.stackConnectors.components.opsgenie.fieldUserHelpText',
+  {
+    defaultMessage: 'The display name for the owner.',
+  }
+);

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
@@ -122,7 +122,7 @@ export const OPSGENIE_DOCUMENTATION = i18n.translate(
 export const OPSGENIE_ALIAS_HELP = i18n.translate(
   'xpack.stackConnectors.components.opsgenie.fieldAliasHelpText',
   {
-    defaultMessage: 'The unique alert identifier used for de-deduplication in OpsGenie.',
+    defaultMessage: 'The unique alert identifier used for de-deduplication in Opsgenie.',
   }
 );
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/stack/opsgenie/translations.ts
@@ -118,3 +118,23 @@ export const OPSGENIE_DOCUMENTATION = i18n.translate(
     defaultMessage: 'Opsgenie documentation',
   }
 );
+
+export const OPSGENIE_ALIAS_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldAliasHelpText', {
+  defaultMessage:
+    'The unique alert identifier used for de-deduplication in OpsGenie.',
+});
+
+export const OPSGENIE_ENTITY_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldEntityHelpText', {
+defaultMessage:
+  'The domain of the alert. For example, the application name.',
+});
+
+export const OPSGENIE_SOURCE_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldSourceHelpText', {
+defaultMessage:
+  'The display name for the source of the alert.',
+});
+
+export const OPSGENIE_USER_HELP = i18n.translate('xpack.stackConnectors.components.opsgenie.fieldUserHelpText', {
+defaultMessage:
+  'The display name for the owner.',
+});


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/142776

This PR adds help text to the UI fields related to testing the OpsGenie connector, based on some descriptions of the fields in https://support.atlassian.com/opsgenie/docs/alert-fields/

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### Screenshots

#### Before

Create alert:
![image](https://user-images.githubusercontent.com/26471269/201791163-5b01cc41-5caa-4492-ac20-844747ce76f7.png)

Close alert:

![image](https://user-images.githubusercontent.com/26471269/201795457-911d7024-b18a-4914-979e-d5886fd3eea5.png)


#### After

Create alert:

![image](https://user-images.githubusercontent.com/26471269/201795344-b154f40a-0e4e-422b-9754-9d2a92ce0efc.png)


Close alert:

![image](https://user-images.githubusercontent.com/26471269/201795083-a08d7de6-0686-447e-8673-cfc4fb8746e3.png)

