### PR TITLE
[APM] Add Telemetry client

### DIFF
--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -7,58 +7,37 @@
 
 import { merge } from 'lodash';
 import { Logger, SavedObjectsClient } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import type { ESSearchRequest, ESSearchResponse } from '@kbn/es-types';
 import { ApmIndicesConfig } from '../../../routes/settings/apm_indices/get_apm_indices';
 import { tasks } from './tasks';
 import { APMDataTelemetry } from '../types';
+import { TelemetryClient } from '../telemetry_client';
 
 type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
 
-type TelemetryTaskExecutor = (params: {
+interface ExecutorParams {
+  telemetryClient: TelemetryClient;
   indices: ApmIndicesConfig;
-  search<
-    TSearchRequest extends ESSearchRequest & { index: string | string[] } & {
-      body: { timeout: string };
-    }
-  >(
-    params: TSearchRequest
-  ): Promise<ESSearchResponse<unknown, TSearchRequest>>;
-  indicesStats(
-    params: estypes.IndicesStatsRequest
-    // promise returned by client has an abort property
-    // so we cannot use its ReturnType
-  ): Promise<{
-    _all?: {
-      total?: { store?: { size_in_bytes?: number }; docs?: { count?: number } };
-    };
-    _shards?: {
-      total?: number;
-    };
-  }>;
-  transportRequest: (params: {
-    path: string;
-    method: 'get';
-  }) => Promise<unknown>;
   savedObjectsClient: ISavedObjectsClient;
-}) => Promise<APMDataTelemetry>;
+}
+
+type TelemetryTaskExecutor = (
+  params: ExecutorParams
+) => Promise<APMDataTelemetry>;
 
 export interface TelemetryTask {
   name: string;
   executor: TelemetryTaskExecutor;
 }
 
-export type CollectTelemetryParams = Parameters<TelemetryTaskExecutor>[0] & {
+export type CollectTelemetryParams = ExecutorParams & {
   isProd: boolean;
   logger: Logger;
 };
 
 export function collectDataTelemetry({
-  search,
   indices,
   logger,
-  indicesStats,
-  transportRequest,
+  telemetryClient,
   savedObjectsClient,
   isProd,
 }: CollectTelemetryParams) {
@@ -68,10 +47,8 @@ export function collectDataTelemetry({
       try {
         const time = process.hrtime();
         const next = await task.executor({
-          search,
+          telemetryClient,
           indices,
-          indicesStats,
-          transportRequest,
           savedObjectsClient,
         });
         const took = process.hrtime(time);

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -14,14 +14,14 @@ import { TelemetryClient } from '../telemetry_client';
 
 type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
 
-interface ExecutorParams {
+export interface TelemetryTaskExecutorParams {
   telemetryClient: TelemetryClient;
   indices: ApmIndicesConfig;
   savedObjectsClient: ISavedObjectsClient;
 }
 
 type TelemetryTaskExecutor = (
-  params: ExecutorParams
+  params: TelemetryTaskExecutorParams
 ) => Promise<APMDataTelemetry>;
 
 export interface TelemetryTask {
@@ -29,7 +29,7 @@ export interface TelemetryTask {
   executor: TelemetryTaskExecutor;
 }
 
-export type CollectTelemetryParams = ExecutorParams & {
+export type CollectTelemetryParams = TelemetryTaskExecutorParams & {
   isProd: boolean;
   logger: Logger;
 };

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -68,7 +68,9 @@ describe('data telemetry collection tasks', () => {
         },
       });
 
-      expect(await task?.executor({ search, indices } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         environments: {
           services_with_multiple_environments: 1,
           services_without_environment: 2,
@@ -92,7 +94,9 @@ describe('data telemetry collection tasks', () => {
           },
         });
 
-        expect(await task?.executor({ indices, search } as any)).toEqual({});
+        expect(
+          await task?.executor({ indices, telemetryClient: { search } } as any)
+        ).toEqual({});
       });
     });
 
@@ -135,7 +139,9 @@ describe('data telemetry collection tasks', () => {
           });
         });
 
-      expect(await task?.executor({ indices, search } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         aggregated_transactions: {
           current_implementation: {
             expected_metric_document_count: 1250,
@@ -184,7 +190,9 @@ describe('data telemetry collection tasks', () => {
         },
       });
 
-      expect(await task?.executor({ indices, search } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         cloud: {
           availability_zone: ['us-west-1', 'europe-west1-c'],
           provider: ['aws', 'gcp'],
@@ -197,7 +205,9 @@ describe('data telemetry collection tasks', () => {
       it('returns an empty map', async () => {
         const search = jest.fn().mockResolvedValueOnce({});
 
-        expect(await task?.executor({ indices, search } as any)).toEqual({
+        expect(
+          await task?.executor({ indices, telemetryClient: { search } } as any)
+        ).toEqual({
           cloud: {
             availability_zone: [],
             provider: [],
@@ -224,7 +234,9 @@ describe('data telemetry collection tasks', () => {
         },
       });
 
-      expect(await task?.executor({ indices, search } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         host: {
           os: { platform: ['linux', 'windows', 'macos'] },
         },
@@ -235,7 +247,9 @@ describe('data telemetry collection tasks', () => {
       it('returns an empty map', async () => {
         const search = jest.fn().mockResolvedValueOnce({});
 
-        expect(await task?.executor({ indices, search } as any)).toEqual({
+        expect(
+          await task?.executor({ indices, telemetryClient: { search } } as any)
+        ).toEqual({
           host: {
             os: {
               platform: [],
@@ -268,7 +282,9 @@ describe('data telemetry collection tasks', () => {
         );
       });
 
-      expect(await task?.executor({ indices, search } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         counts: {
           error: {
             '1d': 1,
@@ -330,7 +346,10 @@ describe('data telemetry collection tasks', () => {
         .mockResolvedValueOnce({ body: { count: 1 } });
 
       expect(
-        await task?.executor({ indices, transportRequest } as any)
+        await task?.executor({
+          indices,
+          telemetryClient: { transportRequest },
+        } as any)
       ).toEqual({
         integrations: {
           ml: {
@@ -345,7 +364,10 @@ describe('data telemetry collection tasks', () => {
         const transportRequest = jest.fn().mockResolvedValueOnce({});
 
         expect(
-          await task?.executor({ indices, transportRequest } as any)
+          await task?.executor({
+            indices,
+            telemetryClient: { transportRequest },
+          } as any)
         ).toEqual({
           integrations: {
             ml: {
@@ -366,7 +388,12 @@ describe('data telemetry collection tasks', () => {
         _shards: { total: 1 },
       });
 
-      expect(await task?.executor({ indices, indicesStats } as any)).toEqual({
+      expect(
+        await task?.executor({
+          indices,
+          telemetryClient: { indicesStats },
+        } as any)
+      ).toEqual({
         indices: {
           shards: {
             total: 1,
@@ -389,7 +416,12 @@ describe('data telemetry collection tasks', () => {
       it('returns zero values', async () => {
         const indicesStats = jest.fn().mockResolvedValueOnce({});
 
-        expect(await task?.executor({ indices, indicesStats } as any)).toEqual({
+        expect(
+          await task?.executor({
+            indices,
+            telemetryClient: { indicesStats },
+          } as any)
+        ).toEqual({
           indices: {
             shards: {
               total: 0,
@@ -434,7 +466,9 @@ describe('data telemetry collection tasks', () => {
         }
       });
 
-      expect(await task?.executor({ search, indices } as any)).toEqual({
+      expect(
+        await task?.executor({ indices, telemetryClient: { search } } as any)
+      ).toEqual({
         cardinality: {
           client: { geo: { country_iso_code: { rum: { '1d': 5 } } } },
           transaction: { name: { all_agents: { '1d': 3 }, rum: { '1d': 1 } } },
@@ -483,7 +517,11 @@ describe('data telemetry collection tasks', () => {
         ],
       });
 
-      expect(await task?.executor({ savedObjectsClient } as any)).toEqual({
+      expect(
+        await task?.executor({
+          savedObjectsClient,
+        } as any)
+      ).toEqual({
         service_groups: {
           kuery_fields: ['service.environment', 'agent.name'],
           total: 2,
@@ -535,7 +573,11 @@ describe('data telemetry collection tasks', () => {
         ],
       });
 
-      expect(await task?.executor({ savedObjectsClient } as any)).toEqual({
+      expect(
+        await task?.executor({
+          savedObjectsClient,
+        } as any)
+      ).toEqual({
         service_groups: {
           kuery_fields: ['service.environment', 'agent.name'],
           total: 2,

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
@@ -4,10 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Observable, firstValueFrom } from 'rxjs';
+
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { CoreSetup, Logger, SavedObjectsErrorHelpers } from '@kbn/core/server';
-import { unwrapEsResponse } from '@kbn/observability-plugin/server';
 import {
   TaskManagerSetupContract,
   TaskManagerStartContract,
@@ -18,19 +17,17 @@ import {
   APM_TELEMETRY_SAVED_OBJECT_TYPE,
 } from '../../../common/apm_saved_object_constants';
 import { getInternalSavedObjectsClient } from '../helpers/get_internal_saved_objects_client';
-import { getApmIndices } from '../../routes/settings/apm_indices/get_apm_indices';
-import {
-  collectDataTelemetry,
-  CollectTelemetryParams,
-} from './collect_data_telemetry';
+import { collectDataTelemetry } from './collect_data_telemetry';
 import { APMUsage } from './types';
 import { apmSchema } from './schema';
+import { getApmIndices } from '../../routes/settings/apm_indices/get_apm_indices';
+import { getTelemetryClient } from './telemetry_client';
 
 export const APM_TELEMETRY_TASK_NAME = 'apm-telemetry-task';
 
 export async function createApmTelemetry({
   core,
-  config$,
+  config,
   usageCollector,
   taskManager,
   logger,
@@ -38,7 +35,7 @@ export async function createApmTelemetry({
   isProd,
 }: {
   core: CoreSetup;
-  config$: Observable<APMConfig>;
+  config: APMConfig;
   usageCollector: UsageCollectionSetup;
   taskManager: TaskManagerSetupContract;
   logger: Logger;
@@ -60,40 +57,14 @@ export async function createApmTelemetry({
   });
 
   const savedObjectsClient = await getInternalSavedObjectsClient(core);
+  const indices = await getApmIndices({ config, savedObjectsClient });
+  const telemetryClient = await getTelemetryClient({ core });
 
   const collectAndStore = async () => {
-    const config = await firstValueFrom(config$);
-    const [{ elasticsearch }] = await core.getStartServices();
-    const esClient = elasticsearch.client;
-
-    const indices = await getApmIndices({
-      config,
-      savedObjectsClient,
-    });
-
-    const search: CollectTelemetryParams['search'] = (params) =>
-      unwrapEsResponse(
-        esClient.asInternalUser.search(params, { meta: true })
-      ) as any;
-
-    const indicesStats: CollectTelemetryParams['indicesStats'] = (params) =>
-      unwrapEsResponse(
-        esClient.asInternalUser.indices.stats(params, { meta: true })
-      );
-
-    const transportRequest: CollectTelemetryParams['transportRequest'] = (
-      params
-    ) =>
-      unwrapEsResponse(
-        esClient.asInternalUser.transport.request(params, { meta: true })
-      );
-
     const dataTelemetry = await collectDataTelemetry({
-      search,
       indices,
+      telemetryClient,
       logger,
-      indicesStats,
-      transportRequest,
       savedObjectsClient,
       isProd,
     });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/telemetry_client.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/telemetry_client.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { estypes } from '@elastic/elasticsearch';
+import { CoreSetup } from '@kbn/core/server';
+import { ESSearchRequest, ESSearchResponse } from '@kbn/es-types';
+import { unwrapEsResponse } from '@kbn/observability-plugin/server';
+
+interface RequiredSearchParams {
+  index: string | string[];
+  body: { size: number; track_total_hits: boolean | number; timeout: string };
+}
+
+export interface TelemetryClient {
+  search<TSearchRequest extends ESSearchRequest & RequiredSearchParams>(
+    params: TSearchRequest
+  ): Promise<ESSearchResponse<unknown, TSearchRequest>>;
+
+  indicesStats(
+    params: estypes.IndicesStatsRequest
+    // promise returned by client has an abort property
+    // so we cannot use its ReturnType
+  ): Promise<{
+    _all?: {
+      total?: { store?: { size_in_bytes?: number }; docs?: { count?: number } };
+    };
+    _shards?: {
+      total?: number;
+    };
+  }>;
+
+  transportRequest: (params: {
+    path: string;
+    method: 'get';
+  }) => Promise<unknown>;
+}
+
+export async function getTelemetryClient({
+  core,
+}: {
+  core: CoreSetup;
+}): Promise<TelemetryClient> {
+  const [{ elasticsearch }] = await core.getStartServices();
+  const esClient = elasticsearch.client;
+
+  return {
+    search: (params) =>
+      unwrapEsResponse(
+        esClient.asInternalUser.search(params, { meta: true })
+      ) as any,
+    indicesStats: (params) =>
+      unwrapEsResponse(
+        esClient.asInternalUser.indices.stats(params, { meta: true })
+      ),
+    transportRequest: (params) =>
+      unwrapEsResponse(
+        esClient.asInternalUser.transport.request(params, { meta: true })
+      ),
+  };
+}

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -92,7 +92,7 @@ export class APMPlugin
     ) {
       createApmTelemetry({
         core,
-        config$,
+        config: currentConfig,
         usageCollector: plugins.usageCollection,
         taskManager: plugins.taskManager,
         logger: this.logger,


### PR DESCRIPTION
Small improvement to APM telemetry. This adds a dedicated telemetry client. `track_total_hits` has been added as a required param.