### PR TITLE
[Guided onboarding] Implement error handling 

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_button.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_button.tsx
@@ -46,8 +46,8 @@ export const GuideButton = ({
   isGuidePanelOpen,
   navigateToLandingPage,
 }: GuideButtonProps) => {
-  // TODO handle loading, error state
-  // https://github.com/elastic/kibana/issues/139799, https://github.com/elastic/kibana/issues/139798
+  // TODO handle loading state
+  // https://github.com/elastic/kibana/issues/139799
 
   // if there is no active guide
   if (!pluginState || !pluginState.activeGuide || !pluginState.activeGuide.isActive) {

--- a/src/plugins/guided_onboarding/public/plugin.tsx
+++ b/src/plugins/guided_onboarding/public/plugin.tsx
@@ -10,7 +10,14 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import * as Rx from 'rxjs';
 import { I18nProvider } from '@kbn/i18n-react';
-import { CoreSetup, CoreStart, Plugin, CoreTheme, ApplicationStart } from '@kbn/core/public';
+import {
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  CoreTheme,
+  ApplicationStart,
+  NotificationsStart,
+} from '@kbn/core/public';
 
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import type {
@@ -33,7 +40,7 @@ export class GuidedOnboardingPlugin
     core: CoreStart,
     { cloud }: AppPluginStartDependencies
   ): GuidedOnboardingPluginStart {
-    const { chrome, http, theme, application } = core;
+    const { chrome, http, theme, application, notifications } = core;
 
     // Initialize services
     apiService.setup(http, !!cloud?.isCloudEnabled);
@@ -48,6 +55,7 @@ export class GuidedOnboardingPlugin
             theme$: theme.theme$,
             api: apiService,
             application,
+            notifications,
           }),
       });
     }
@@ -65,16 +73,18 @@ export class GuidedOnboardingPlugin
     theme$,
     api,
     application,
+    notifications,
   }: {
     targetDomElement: HTMLElement;
     theme$: Rx.Observable<CoreTheme>;
     api: ApiService;
     application: ApplicationStart;
+    notifications: NotificationsStart;
   }) {
     ReactDOM.render(
       <KibanaThemeProvider theme$={theme$}>
         <I18nProvider>
-          <GuidePanel api={api} application={application} />
+          <GuidePanel api={api} application={application} notifications={notifications} />
         </I18nProvider>
       </KibanaThemeProvider>,
       targetDomElement

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -10,6 +10,8 @@ import { HttpSetup } from '@kbn/core/public';
 import { BehaviorSubject, map, Observable, firstValueFrom, concat, of } from 'rxjs';
 import type { GuideState, GuideId, GuideStep, GuideStepIds } from '@kbn/guided-onboarding';
 
+import { API_BASE_PATH } from '../../common/constants';
+import { PluginState, PluginStatus } from '../../common/types';
 import { GuidedOnboardingApi } from '../types';
 import {
   getGuideConfig,
@@ -22,8 +24,6 @@ import {
   isStepReadyToComplete,
   isGuideActive,
 } from './helpers';
-import { API_BASE_PATH } from '../../common/constants';
-import { PluginState, PluginStatus } from '../../common/types';
 
 export class ApiService implements GuidedOnboardingApi {
   private isCloudEnabled: boolean | undefined;
@@ -89,9 +89,9 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Async operation to fetch state for all guides
+   * Async operation to fetch state for all guides.
    * This is useful for the onboarding landing page,
-   * where all guides are displayed with their corresponding status
+   * where all guides are displayed with their corresponding status.
    */
   public async fetchAllGuidesState(): Promise<{ state: GuideState[] } | undefined> {
     if (!this.isCloudEnabled) {
@@ -109,11 +109,11 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Updates the SO with the updated guide state and refreshes the observables
-   * This is largely used internally and for tests
-   * @param {GuideState} newState the updated guide state
+   * Updates the SO with the updated plugin state and refreshes the observables.
+   * This is largely used internally and for tests.
+   * @param {{status?: PluginStatus; guide?: GuideState}} state the updated plugin state
    * @param {boolean} panelState boolean to determine whether the dropdown panel should open or not
-   * @return {Promise} a promise with the updated guide state
+   * @return {Promise} a promise with the updated plugin state or undefined
    */
   public async updatePluginState(
     state: { status?: PluginStatus; guide?: GuideState },
@@ -143,11 +143,11 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Activates a guide by guideId
-   * This is useful for the onboarding landing page, when a user selects a guide to start or continue
+   * Activates a guide by guideId.
+   * This is useful for the onboarding landing page, when a user selects a guide to start or continue.
    * @param {GuideId} guideId the id of the guide (one of search, observability, security)
    * @param {GuideState} guide (optional) the selected guide state, if it exists (i.e., if a user is continuing a guide)
-   * @return {Promise} a promise with the updated guide state
+   * @return {Promise} a promise with the updated plugin state
    */
   public async activateGuide(
     guideId: GuideId,
@@ -199,10 +199,10 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Marks a guide as inactive
-   * This is useful for the dropdown panel, when a user quits a guide
+   * Marks a guide as inactive.
+   * This is useful for the dropdown panel, when a user quits a guide.
    * @param {GuideState} guide the selected guide state
-   * @return {Promise} a promise with the updated guide state
+   * @return {Promise} a promise with the updated plugin state
    */
   public async deactivateGuide(
     guide: GuideState
@@ -220,11 +220,11 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Completes a guide
-   * Updates the overall guide status to 'complete', and marks it as inactive
-   * This is useful for the dropdown panel, when the user clicks the "Continue using Elastic" button after completing all steps
+   * Completes a guide.
+   * Updates the overall guide status to 'complete', and marks it as inactive.
+   * This is useful for the dropdown panel, when the user clicks the "Continue using Elastic" button after completing all steps.
    * @param {GuideId} guideId the id of the guide (one of search, observability, security)
-   * @return {Promise} a promise with the updated guide state
+   * @return {Promise} a promise with the updated plugin state
    */
   public async completeGuide(guideId: GuideId): Promise<{ pluginState: PluginState } | undefined> {
     const pluginState = await firstValueFrom(this.fetchPluginState$());
@@ -268,11 +268,11 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Updates the selected step to 'in_progress' state
-   * This is useful for the dropdown panel, when the user clicks the "Start" button for the active step
+   * Updates the selected step to 'in_progress' state.
+   * This is useful for the dropdown panel, when the user clicks the "Start" button for the active step.
    * @param {GuideId} guideId the id of the guide (one of search, observability, security)
    * @param {GuideStepIds} stepId the id of the step
-   * @return {Promise} a promise with the updated guide state
+   * @return {Promise} a promise with the updated plugin state
    */
   public async startGuideStep(
     guideId: GuideId,
@@ -375,6 +375,12 @@ export class ApiService implements GuidedOnboardingApi {
     );
   }
 
+  /**
+   * Completes the guide step identified by the integration.
+   * A noop if the active step is not configured with the passed integration.
+   * @param {GuideId} integration the integration (package name) that identifies the active guide step
+   * @return {Promise} a promise with the updated state or undefined if the operation fails
+   */
   public async completeGuidedOnboardingForIntegration(
     integration?: string
   ): Promise<{ pluginState: PluginState } | undefined> {
@@ -390,8 +396,12 @@ export class ApiService implements GuidedOnboardingApi {
     }
   }
 
+  /**
+   * Sets the plugin state to "skipped".
+   * This is used on the landing page when the user clicks the button to skip the guided setup.
+   * @return {Promise} a promise with the updated state or undefined if the operation fails
+   */
   public async skipGuidedOnboarding(): Promise<{ pluginState: PluginState } | undefined> {
-    // TODO error handling and loading state
     return await this.updatePluginState({ status: 'skipped' }, false);
   }
 }

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -104,9 +104,7 @@ export class ApiService implements GuidedOnboardingApi {
     try {
       return await this.client.get<{ state: GuideState[] }>(`${API_BASE_PATH}/guides`);
     } catch (error) {
-      // TODO handle error
-      // eslint-disable-next-line no-console
-      console.error(error);
+      throw error;
     }
   }
 
@@ -140,9 +138,7 @@ export class ApiService implements GuidedOnboardingApi {
       this.isGuidePanelOpen$.next(panelState);
       return response;
     } catch (error) {
-      // TODO handle error
-      // eslint-disable-next-line no-console
-      console.error(error);
+      throw error;
     }
   }
 

--- a/src/plugins/home/public/application/components/guided_onboarding/__snapshots__/getting_started.test.tsx.snap
+++ b/src/plugins/home/public/application/components/guided_onboarding/__snapshots__/getting_started.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`getting started should render getting started component 1`] = `
         >
           <GuideCard
             activateGuide={[Function]}
-            addBasePath={[MockFunction]}
+            addBasePath={[Function]}
             guides={Array []}
             isDarkTheme={false}
             useCase="search"
@@ -68,7 +68,7 @@ exports[`getting started should render getting started component 1`] = `
         >
           <GuideCard
             activateGuide={[Function]}
-            addBasePath={[MockFunction]}
+            addBasePath={[Function]}
             guides={Array []}
             isDarkTheme={false}
             useCase="observability"
@@ -78,7 +78,7 @@ exports[`getting started should render getting started component 1`] = `
           key="linkCard-observabilityLink"
         >
           <ObservabilityLinkCard
-            addBasePath={[MockFunction]}
+            addBasePath={[Function]}
             isDarkTheme={false}
             navigateToApp={[MockFunction]}
           />
@@ -88,7 +88,7 @@ exports[`getting started should render getting started component 1`] = `
         >
           <GuideCard
             activateGuide={[Function]}
-            addBasePath={[MockFunction]}
+            addBasePath={[Function]}
             guides={Array []}
             isDarkTheme={false}
             useCase="security"

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
@@ -7,12 +7,14 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { ReactWrapper, shallow } from 'enzyme';
 import { findTestSubject, mountWithIntl } from '@kbn/test-jest-helpers';
 
 import { GettingStarted } from './getting_started';
 import { KEY_ENABLE_WELCOME } from '../home';
 import { act } from 'react-dom/test-utils';
+
+const mockFetchGuides = jest.fn();
 
 jest.mock('../../kibana_services', () => {
   const { chromeServiceMock, applicationServiceMock } =
@@ -35,7 +37,7 @@ jest.mock('../../kibana_services', () => {
         },
       },
       guidedOnboardingService: {
-        fetchAllGuidesState: jest.fn(),
+        fetchAllGuidesState: mockFetchGuides,
         skipGuidedOnboarding: jest.fn(),
       },
     }),
@@ -52,21 +54,54 @@ describe('getting started', () => {
       localStorage.setItem(KEY_ENABLE_WELCOME, storageItemValue);
     }
   });
+
   test('should render getting started component', async () => {
     const component = await shallow(<GettingStarted />);
 
     expect(component).toMatchSnapshot();
   });
 
+  test('displays loading indicator', async () => {
+    mockFetchGuides.mockImplementationOnce(() => {
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          resolve({ state: [] });
+        })
+      );
+    });
+
+    let component: ReactWrapper;
+    await act(async () => {
+      component = mountWithIntl(<GettingStarted />);
+    });
+    component!.update();
+    expect(findTestSubject(component!, 'onboarding--loadingIndicator').exists()).toBe(true);
+  });
+
+  test('displays error section', async () => {
+    mockFetchGuides.mockRejectedValueOnce(new Error('request failed'));
+
+    let component: ReactWrapper;
+    await act(async () => {
+      component = mountWithIntl(<GettingStarted />);
+    });
+    component!.update();
+    expect(findTestSubject(component!, 'onboarding--errorSection').exists()).toBe(true);
+  });
+
   test('skip button should disable home welcome screen', async () => {
-    const component = mountWithIntl(<GettingStarted />);
-    const skipButton = findTestSubject(component, 'onboarding--skipGuideLink');
+    mockFetchGuides.mockResolvedValueOnce({ state: [] });
+    let component: ReactWrapper;
+    await act(async () => {
+      component = mountWithIntl(<GettingStarted />);
+    });
+    const skipButton = findTestSubject(component!, 'onboarding--skipGuideLink');
 
     await act(async () => {
       await skipButton.simulate('click');
     });
 
-    component.update();
+    component!.update();
 
     expect(localStorage.getItem(KEY_ENABLE_WELCOME)).toBe('false');
   });

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
@@ -63,9 +63,10 @@ describe('getting started', () => {
       return new Promise((resolve) =>
         setTimeout(() => {
           resolve({ state: [] });
-        })
+        }, 1000)
       );
     });
+    mockApiService.setup(mockHttp, true);
 
     await act(async () => {
       testBed = registerTestBed(GettingStarted)();
@@ -76,6 +77,7 @@ describe('getting started', () => {
 
   test('displays error section', async () => {
     mockHttp.get.mockRejectedValueOnce(new Error('request failed'));
+    mockApiService.setup(mockHttp, true);
 
     await act(async () => {
       testBed = registerTestBed(GettingStarted)();
@@ -86,6 +88,7 @@ describe('getting started', () => {
 
   test('skip button should disable home welcome screen', async () => {
     mockHttp.get.mockResolvedValueOnce({ state: [] });
+    mockApiService.setup(mockHttp, true);
 
     await act(async () => {
       testBed = registerTestBed(GettingStarted)();

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { ReactWrapper, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { findTestSubject, mountWithIntl } from '@kbn/test-jest-helpers';
+import { findTestSubject, registerTestBed, TestBed } from '@kbn/test-jest-helpers';
 import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
 import { chromeServiceMock, applicationServiceMock, httpServiceMock } from '@kbn/core/public/mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
@@ -41,6 +41,7 @@ jest.mock('../../kibana_services', () => ({
 
 describe('getting started', () => {
   let storageItemValue: string | null;
+  let testBed: TestBed;
   beforeAll(() => {
     storageItemValue = localStorage.getItem(KEY_ENABLE_WELCOME);
     localStorage.removeItem(KEY_ENABLE_WELCOME);
@@ -66,38 +67,37 @@ describe('getting started', () => {
       );
     });
 
-    let component: ReactWrapper;
     await act(async () => {
-      component = mountWithIntl(<GettingStarted />);
+      testBed = registerTestBed(GettingStarted)();
     });
-    component!.update();
-    expect(findTestSubject(component!, 'onboarding--loadingIndicator').exists()).toBe(true);
+    testBed!.component.update();
+    expect(findTestSubject(testBed!.component, 'onboarding--loadingIndicator').exists()).toBe(true);
   });
 
   test('displays error section', async () => {
     mockHttp.get.mockRejectedValueOnce(new Error('request failed'));
 
-    let component: ReactWrapper;
     await act(async () => {
-      component = mountWithIntl(<GettingStarted />);
+      testBed = registerTestBed(GettingStarted)();
     });
-    component!.update();
-    expect(findTestSubject(component!, 'onboarding--errorSection').exists()).toBe(true);
+    testBed!.component.update();
+    expect(findTestSubject(testBed!.component, 'onboarding--errorSection').exists()).toBe(true);
   });
 
   test('skip button should disable home welcome screen', async () => {
     mockHttp.get.mockResolvedValueOnce({ state: [] });
-    let component: ReactWrapper;
+
     await act(async () => {
-      component = mountWithIntl(<GettingStarted />);
+      testBed = registerTestBed(GettingStarted)();
     });
-    const skipButton = findTestSubject(component!, 'onboarding--skipGuideLink');
+    testBed!.component.update();
+
+    const skipButton = findTestSubject(testBed!.component, 'onboarding--skipGuideLink');
 
     await act(async () => {
       await skipButton.simulate('click');
     });
-
-    component!.update();
+    testBed!.component.update();
 
     expect(localStorage.getItem(KEY_ENABLE_WELCOME)).toBe('false');
   });

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -163,7 +163,12 @@ export const GettingStarted = () => {
               })}
             </EuiText>
             <EuiSpacer />
-            <EuiButton iconSide="right" onClick={fetchGuidesState} iconType="refresh">
+            <EuiButton
+              iconSide="right"
+              onClick={fetchGuidesState}
+              iconType="refresh"
+              color="danger"
+            >
               {i18n.translate('home.guidedOnboarding.gettingStarted.errorSectionRefreshButton', {
                 defaultMessage: 'Refresh',
               })}

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -88,7 +88,7 @@ export const GettingStarted = () => {
 
   useEffect(() => {
     fetchGuidesState();
-  }, []);
+  }, [fetchGuidesState]);
 
   useEffect(() => {
     if (cloud?.isCloudEnabled === false) {

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -8,10 +8,12 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import {
+  EuiButton,
   EuiFlexGrid,
   EuiFlexItem,
   EuiHorizontalRule,
   EuiLink,
+  EuiLoadingSpinner,
   EuiPageTemplate,
   EuiPanel,
   EuiSpacer,
@@ -49,6 +51,8 @@ export const GettingStarted = () => {
   const { application, trackUiMetric, chrome, guidedOnboardingService, http, uiSettings, cloud } =
     getServices();
   const [guidesState, setGuidesState] = useState<GuideState[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
   const history = useHistory();
 
   useEffect(() => {
@@ -68,15 +72,23 @@ export const GettingStarted = () => {
   }, [chrome, trackUiMetric]);
 
   const fetchGuidesState = useCallback(async () => {
-    const allGuides = await guidedOnboardingService?.fetchAllGuidesState();
-    if (allGuides) {
-      setGuidesState(allGuides.state);
+    setIsLoading(true);
+    setIsError(false);
+    try {
+      const allGuides = await guidedOnboardingService?.fetchAllGuidesState();
+      setIsLoading(false);
+      if (allGuides) {
+        setGuidesState(allGuides.state);
+      }
+    } catch (error) {
+      setIsLoading(false);
+      setIsError(true);
     }
   }, [guidedOnboardingService]);
 
   useEffect(() => {
     fetchGuidesState();
-  }, [fetchGuidesState]);
+  }, []);
 
   useEffect(() => {
     if (cloud?.isCloudEnabled === false) {
@@ -85,7 +97,12 @@ export const GettingStarted = () => {
   }, [cloud, history]);
 
   const onSkip = async () => {
-    await guidedOnboardingService?.skipGuidedOnboarding();
+    try {
+      await guidedOnboardingService?.skipGuidedOnboarding();
+    } catch (error) {
+      // if the state update fails, it's safe to ignore the error
+    }
+
     trackUiMetric(METRIC_TYPE.CLICK, 'guided_onboarding__skipped');
     // disable welcome screen on the home page
     localStorage.setItem(KEY_ENABLE_WELCOME, JSON.stringify(false));
@@ -98,9 +115,65 @@ export const GettingStarted = () => {
 
   const isDarkTheme = uiSettings.get<boolean>('theme:darkMode');
   const activateGuide = async (useCase: UseCase, guideState?: GuideState) => {
-    await guidedOnboardingService?.activateGuide(useCase as GuideId, guideState);
-    // TODO error handling https://github.com/elastic/kibana/issues/139798
+    try {
+      await guidedOnboardingService?.activateGuide(useCase as GuideId, guideState);
+    } catch (err) {
+      getServices().toastNotifications.addDanger({
+        title: i18n.translate('home.guidedOnboarding.gettingStarted.activateGuide.errorMessage', {
+          defaultMessage: 'Unable to start the guide. Please try again later.',
+        }),
+        text: err.message,
+      });
+    }
   };
+
+  if (isLoading) {
+    return (
+      <KibanaPageTemplate.EmptyPrompt
+        title={<EuiLoadingSpinner size="xl" />}
+        body={
+          <EuiText color="subdued">
+            {i18n.translate('home.guidedOnboarding.gettingStarted.loadingIndicator', {
+              defaultMessage: 'Loading setup guide state...',
+            })}
+          </EuiText>
+        }
+        data-test-subj="onboarding--loadingIndicator"
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <KibanaPageTemplate.EmptyPrompt
+        iconType="alert"
+        color="danger"
+        title={
+          <h2>
+            {i18n.translate('home.guidedOnboarding.gettingStarted.errorSectionTitle', {
+              defaultMessage: 'Unable to load guide state',
+            })}
+          </h2>
+        }
+        body={
+          <>
+            <EuiText color="subdued">
+              {i18n.translate('home.guidedOnboarding.gettingStarted.errorSectionDescription', {
+                defaultMessage: 'There was an error loading the guide state. Try again later.',
+              })}
+            </EuiText>
+            <EuiSpacer />
+            <EuiButton iconSide="right" onClick={fetchGuidesState} iconType="refresh">
+              {i18n.translate('home.guidedOnboarding.gettingStarted.errorSectionRefreshButton', {
+                defaultMessage: 'Refresh',
+              })}
+            </EuiButton>
+          </>
+        }
+        data-test-subj="onboarding--errorSection"
+      />
+    );
+  }
 
   return (
     <KibanaPageTemplate panelled={false} grow>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/139798

This PR introduces error handling to the guided onboarding UI: when an API requests fails, we surface the error to the UI. In the UI we use a danger toast to let the user know about the error, so that they can try again. There is also a loading and error state on the landing page (see screenshots).

### Screenshots

Danger notification when an API request fails
<img width="376" alt="Screenshot 2022-11-14 at 16 01 57" src="https://user-images.githubusercontent.com/6585477/201941910-22eb76fe-5787-485c-9a87-ceb8add7e19c.png">


Screencast of a danger notification 

https://user-images.githubusercontent.com/6585477/201942914-d55bd3aa-e9e1-4ef5-8ddc-bc327c600109.mov



Screencast of the quit the guide modal

https://user-images.githubusercontent.com/6585477/201943444-3419a8d2-6982-4373-916c-0674e775e1f6.mov



Screencast of the landing page


https://user-images.githubusercontent.com/6585477/201963401-538f2e0b-fd64-4ccc-94f5-1baa182ef641.mov




### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

