### PR TITLE
Make test that checks for registered rules not dependent on order of registration

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/check_registered_rule_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/check_registered_rule_types.ts
@@ -22,9 +22,7 @@ export default function createRegisteredRuleTypeTests({ getService }: FtrProvide
         .expect(200)
         .then((response) => response.body);
 
-      expect(
-        registeredRuleTypes.filter((ruleType: string) => !ruleType.startsWith('test.'))
-      ).to.eql([
+      const ruleTypes = [
         'example.always-firing',
         'transform_health',
         '.index-threshold',
@@ -66,7 +64,11 @@ export default function createRegisteredRuleTypeTests({ getService }: FtrProvide
         'apm.anomaly',
         'apm.error_rate',
         'apm.transaction_error_rate',
-      ]);
+      ];
+
+      expect(
+        registeredRuleTypes.sort().filter((ruleType: string) => !ruleType.startsWith('test.'))
+      ).to.eql(ruleTypes.sort());
     });
   });
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/156987

## Summary

This change makes the test that checks for rule type registrations with the ruleRegistry not dependent on the order in which they are registered in Kibana.

### Why?

The order in which rules are registered in the code base can change. That should not trigger a failure of the test.  

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->