### PR TITLE
[Security] Fix security privileges tests by removing Security Solution `file_operations_all` sub-feature from test assertions

### DIFF
--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -38,7 +38,6 @@ export default function ({ getService }: FtrProviderContext) {
         'actions_log_management_read',
         'host_isolation_all',
         'process_operations_all',
-        'file_operations_all',
       ],
       uptime: ['all', 'read', 'minimal_all', 'minimal_read'],
       securitySolutionCases: ['all', 'read', 'minimal_all', 'minimal_read', 'cases_delete'],

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -83,8 +83,7 @@ export default function ({ getService }: FtrProviderContext) {
   };
 
   describe('Privileges', () => {
-    // FLAKY: https://github.com/elastic/kibana/issues/145135
-    describe.skip('GET /api/security/privileges', () => {
+    describe('GET /api/security/privileges', () => {
       it('should return a privilege map with all known privileges, without actions', async () => {
         // If you're adding a privilege to the following, that's great!
         // If you're removing a privilege, this breaks backwards compatibility
@@ -193,8 +192,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     // In this non-Basic case, results should be exactly the same as not supplying the respectLicenseLevel flag
-    // FLAKY: https://github.com/elastic/kibana/issues/145136
-    describe.skip('GET /api/security/privileges?respectLicenseLevel=false', () => {
+    describe('GET /api/security/privileges?respectLicenseLevel=false', () => {
       it('should return a privilege map with all known privileges, without actions', async () => {
         // If you're adding a privilege to the following, that's great!
         // If you're removing a privilege, this breaks backwards compatibility

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -101,7 +101,6 @@ export default function ({ getService }: FtrProviderContext) {
               'actions_log_management_all',
               'actions_log_management_read',
               'all',
-              'file_operations_all',
               'host_isolation_all',
               'minimal_all',
               'minimal_read',

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
   describe('Privileges', () => {
-    // FLAKY: https://github.com/elastic/kibana/issues/145134
-    describe.skip('GET /api/security/privileges', () => {
+    describe('GET /api/security/privileges', () => {
       it('should return a privilege map with all known privileges, without actions', async () => {
         // If you're adding a privilege to the following, that's great!
         // If you're removing a privilege, this breaks backwards compatibility


### PR DESCRIPTION
## Summary

- Remove `file_operations_all` from list of sub-feature of SIEM (security solution). This sub-feature [was recently placed behind an experimental feature flag](https://github.com/elastic/kibana/pull/145042), which is disabled by default for 8.6.
- Un-skips tests


Fixes: #145134
Fixes: #145135
Fixes: #145136
