### PR TITLE
Correct "{prev-major-last}" to 7.17

### DIFF
--- a/docs/management/upgrade-assistant/index.asciidoc
+++ b/docs/management/upgrade-assistant/index.asciidoc
@@ -10,7 +10,7 @@ The assistant identifies deprecated settings in your configuration,
 enables you to see if you are using deprecated features,
 and guides you through the process of resolving issues.
 
-IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to {prev-major-last}**.
+IMPORTANT: To upgrade to 8.0 or later, **you must first upgrade to 7.17**.
 
 If you have indices that were created prior to 7.0,
 you can use the assistant to reindex them so they can be accessed from 8.0. 


### PR DESCRIPTION
Currently the page shows "{prev-major-last}" instead of "7.17" for some reason, this PR would correct that

## Summary

This is currently shown when people browse to https://www.elastic.co/guide/en/kibana/7.17/upgrade-assistant.html : 

![image](https://user-images.githubusercontent.com/94469565/201962359-65c48b95-fb59-4406-aefa-5d3fb95be2b4.png)

This would correct it to 7.17.