### PR TITLE
advanced option added for env_vars feature in endpoint

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -168,6 +168,17 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'linux.advanced.capture_env_vars',
+    first_supported_version: '8.6',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.capture_env_vars',
+      {
+        defaultMessage:
+          'The list of environment variables to capture (up to five), separated by commas.',
+      }
+    ),
+  },
+  {
     key: 'linux.advanced.tty_io.max_event_interval_seconds',
     first_supported_version: '8.5',
     documentation: i18n.translate(


### PR DESCRIPTION
## Summary
Adds an advanced option to allow users to configure up to 5 env vars to capture in endpoint events.

<!--ONMERGE {"backportTargets":["8.5"]} ONMERGE-->