### PR TITLE
[Guided onboarding] Update copy per feedback

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_button.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_button.tsx
@@ -70,7 +70,7 @@ export const GuideButton = ({
           data-test-subj="guideButtonRedirect"
         >
           {i18n.translate('guidedOnboarding.guidedSetupRedirectButtonLabel', {
-            defaultMessage: 'Setup guide',
+            defaultMessage: 'Setup guides',
           })}
         </EuiButton>
       );

--- a/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
+++ b/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
@@ -58,8 +58,7 @@ export const QuitGuideModal = ({
         <EuiText>
           <p>
             {i18n.translate('guidedOnboarding.quitGuideModal.modalDescription', {
-              defaultMessage:
-                'You can restart the setup guide any time from the Help menu.',
+              defaultMessage: 'You can restart the setup guide any time from the Help menu.',
             })}
           </p>
         </EuiText>

--- a/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
+++ b/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
@@ -59,7 +59,7 @@ export const QuitGuideModal = ({
           <p>
             {i18n.translate('guidedOnboarding.quitGuideModal.modalDescription', {
               defaultMessage:
-                'You can restart anytime by opening the Setup guides link from the Help menu.',
+                'You can restart the setup guide any time from the Help menu.',
             })}
           </p>
         </EuiText>

--- a/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
+++ b/src/plugins/guided_onboarding/public/components/quit_guide_modal.tsx
@@ -59,7 +59,7 @@ export const QuitGuideModal = ({
           <p>
             {i18n.translate('guidedOnboarding.quitGuideModal.modalDescription', {
               defaultMessage:
-                'You can restart anytime by opening the Setup guide from the Help menu.',
+                'You can restart anytime by opening the Setup guides link from the Help menu.',
             })}
           </p>
         </EuiText>

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -81,7 +81,7 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
                   >
                     <FormattedMessage
                       id="home.addData.guidedOnboardingLinkLabel"
-                      defaultMessage="Setup guide"
+                      defaultMessage="Setup guides"
                     />
                   </EuiButton>
                 </EuiFlexItem>

--- a/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_links/public/plugin.tsx
@@ -32,7 +32,9 @@ export class CloudLinksPlugin
       core.chrome.registerGlobalHelpExtensionMenuLink({
         linkType: 'custom',
         href: core.http.basePath.prepend('/app/home#/getting_started'),
-        content: <FormattedMessage id="xpack.cloudLinks.setupGuide" defaultMessage="Setup guide" />,
+        content: (
+          <FormattedMessage id="xpack.cloudLinks.setupGuide" defaultMessage="Setup guides" />
+        ),
         'data-test-subj': 'cloudOnboardingSetupGuideLink',
         priority: 1000, // We want this link to be at the very top.
       });


### PR DESCRIPTION
This PR updates instances of "Setup guide" to "Setup guides" when it's used as a way to describe the guided onboarding landing page.

Follow-up to https://github.com/elastic/kibana/pull/145250

### Screenshots
// When there are no active guides the button in the header takes users to the guided onboarding landing page. In this scenario, the button copy will be: "Setup guides" (plural)
<img width="1645" alt="Screen Shot 2022-11-15 at 7 48 51 PM" src="https://user-images.githubusercontent.com/5226211/202056791-b26c0ca9-cc07-418f-bc06-ba18ed7fdfcf.png">

// If a guide is active, clicking the button will open the dropdown panel. In this scenario, the button in the header will be "Setup guide" (singular)
<img width="540" alt="Screen Shot 2022-11-15 at 7 50 05 PM" src="https://user-images.githubusercontent.com/5226211/202056795-781a3824-1bf5-43a7-bfe7-45e4a3ae2bea.png">

// Updated help link, which takes users to the guided onboarding landing page
<img width="289" alt="Screen Shot 2022-11-15 at 7 49 33 PM" src="https://user-images.githubusercontent.com/5226211/202056794-d28833ab-85e7-4363-a2dc-2d092d749cf7.png">


