### PR TITLE
poc(slo): Create slo burn rate rule type

### DIFF
--- a/x-pack/plugins/observability/common/constants.ts
+++ b/x-pack/plugins/observability/common/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SLO_BURN_RATE_RULE_ID = 'slo.rules.burnRate';

--- a/x-pack/plugins/observability/public/components/slo/rules/burn_rate/editor.stories.tsx
+++ b/x-pack/plugins/observability/public/components/slo/rules/burn_rate/editor.stories.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+
+import { Editor as Component, Props } from './editor';
+
+export default {
+  title: 'app/SLO/BurnRateRule',
+  component: Component,
+  argTypes: {},
+};
+
+const Template: ComponentStory<typeof Component> = (props: Props) => <Component {...props} />;
+
+const defaultProps = {};
+
+export const BurnRateRule = Template.bind({});
+BurnRateRule.args = defaultProps;

--- a/x-pack/plugins/observability/public/components/slo/rules/burn_rate/editor.tsx
+++ b/x-pack/plugins/observability/public/components/slo/rules/burn_rate/editor.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiSpacer } from '@elastic/eui';
+import { TIME_UNITS } from '@kbn/triggers-actions-ui-plugin/public';
+import React from 'react';
+import { SLOSelector } from './slo_selector';
+
+export interface RuleParams {
+  windowSize?: number;
+  windowUnit?: TIME_UNITS;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Props {}
+
+export function Editor(props: Props) {
+  return (
+    <>
+      <SLOSelector />
+
+      <EuiSpacer size="m" />
+    </>
+  );
+}

--- a/x-pack/plugins/observability/public/components/slo/rules/burn_rate/index.ts
+++ b/x-pack/plugins/observability/public/components/slo/rules/burn_rate/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Editor } from './editor';
+
+// eslint-disable-next-line import/no-default-export
+export default Editor;

--- a/x-pack/plugins/observability/public/components/slo/rules/burn_rate/slo_selector.tsx
+++ b/x-pack/plugins/observability/public/components/slo/rules/burn_rate/slo_selector.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
+import React, { useState } from 'react';
+
+interface SLO {
+  id: string;
+  label: string;
+}
+
+export function SLOSelector() {
+  const availableSLOs = [
+    {
+      id: '78ab8460-5922-11ed-8eb7-bd8452a46829',
+      label: 'My Availability SLO',
+    },
+    {
+      id: 'a43fc160-555b-11ed-9340-37a8799092e9',
+      label: 'My Latency SLO',
+    },
+  ];
+  const [selectedSLO, setSelectedSLO] = useState<Array<EuiComboBoxOptionOption<SLO>>>([]);
+
+  const onChange = (slo: Array<EuiComboBoxOptionOption<SLO>>) => {
+    setSelectedSLO(slo);
+  };
+
+  return (
+    <EuiComboBox
+      aria-label="Select the SLO"
+      placeholder="Select the SLO"
+      options={availableSLOs}
+      selectedOptions={selectedSLO}
+      onChange={onChange}
+      isClearable={true}
+      singleSelection={true}
+    />
+  );
+}

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -52,9 +52,13 @@ import { getExploratoryViewEmbeddable } from './components/shared/exploratory_vi
 import { createExploratoryViewUrl } from './components/shared/exploratory_view/configurations/exploratory_view_url';
 import { createUseRulesLink } from './hooks/create_use_rules_link';
 import getAppDataView from './utils/observability_data_views/get_app_data_view';
+import { registerObservabilityRuleTypes } from './rules/register_observability_rule_types';
 
 export interface ConfigSchema {
   unsafe: {
+    slo: {
+      enabled: boolean;
+    };
     alertDetails: {
       apm: {
         enabled: boolean;
@@ -187,6 +191,8 @@ export class Plugin
         isDev: this.initContext.env.mode.dev,
       });
     };
+
+    registerObservabilityRuleTypes(config, this.observabilityRuleTypeRegistry);
 
     const appUpdater$ = this.appUpdater$;
     const app = {

--- a/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { lazy } from 'react';
+import { i18n } from '@kbn/i18n';
+import { ALERT_REASON } from '@kbn/rule-data-utils';
+
+import { ConfigSchema } from '../plugin';
+import { ObservabilityRuleTypeRegistry } from './create_observability_rule_type_registry';
+import { SLO_BURN_RATE_RULE_ID } from '../../common/constants';
+
+export const registerObservabilityRuleTypes = (
+  config: ConfigSchema,
+  observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry
+) => {
+  if (config.unsafe.slo.enabled) {
+    observabilityRuleTypeRegistry.register({
+      id: SLO_BURN_RATE_RULE_ID,
+      description: i18n.translate('xpack.observability.slo.rules.burnRate.description', {
+        defaultMessage: 'Alert when SLO burn rate exceeds threshold',
+      }),
+      format: ({ fields }) => {
+        return {
+          reason: fields[ALERT_REASON]!,
+          link: '/unknown/slo',
+        };
+      },
+      iconClass: 'bell',
+      documentationUrl(docLinks) {
+        return '/unknown/docs';
+      },
+      ruleParamsExpression: lazy(() => import('../components/slo/rules/burn_rate')),
+      validate: () => ({
+        errors: [],
+      }),
+      requiresAppContext: false,
+      defaultActionMessage: i18n.translate(
+        'xpack.observability.slo.rules.burnRate.defaultActionMessage',
+        { defaultMessage: `\\{\\{alert\\}\\} - \\{\\{context\\}\\}` }
+      ),
+    });
+  }
+};

--- a/x-pack/plugins/observability/server/common/constants.ts
+++ b/x-pack/plugins/observability/server/common/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const OBSERVABILITY_FEATURE_ID = 'observability';

--- a/x-pack/plugins/observability/server/domain/models/duration.ts
+++ b/x-pack/plugins/observability/server/domain/models/duration.ts
@@ -39,6 +39,27 @@ class Duration {
   }
 }
 
+const toDurationUnit = (unit: string): DurationUnit => {
+  switch (unit) {
+    case 'm':
+      return DurationUnit.Minute;
+    case 'h':
+      return DurationUnit.Hour;
+    case 'd':
+      return DurationUnit.Day;
+    case 'w':
+      return DurationUnit.Week;
+    case 'M':
+      return DurationUnit.Month;
+    case 'Q':
+      return DurationUnit.Quarter;
+    case 'y':
+      return DurationUnit.Year;
+    default:
+      throw new Error('invalid duration unit');
+  }
+};
+
 const toMomentUnitOfTime = (unit: DurationUnit): moment.unitOfTime.Diff => {
   switch (unit) {
     case DurationUnit.Minute:
@@ -60,4 +81,4 @@ const toMomentUnitOfTime = (unit: DurationUnit): moment.unitOfTime.Diff => {
   }
 };
 
-export { Duration, DurationUnit, toMomentUnitOfTime };
+export { Duration, DurationUnit, toMomentUnitOfTime, toDurationUnit };

--- a/x-pack/plugins/observability/server/lib/rules/register_rule_types.ts
+++ b/x-pack/plugins/observability/server/lib/rules/register_rule_types.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginSetupContract } from '@kbn/alerting-plugin/server';
+import { Logger } from '@kbn/core/server';
+import { createLifecycleExecutor, IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import { sloBurnRateRuleType } from './slo_burn_rate';
+
+export function registerRuleTypes(
+  alertingPlugin: PluginSetupContract,
+  logger: Logger,
+  ruleDataClient: IRuleDataClient
+) {
+  const createLifecycleRuleExecutor = createLifecycleExecutor(logger.get('rules'), ruleDataClient);
+  alertingPlugin.registerType(sloBurnRateRuleType(createLifecycleRuleExecutor));
+}

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import uuid from 'uuid';
+import { IUiSettingsClient, SavedObjectsClientContract } from '@kbn/core/server';
+import {
+  ElasticsearchClientMock,
+  elasticsearchServiceMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
+import { LifecycleAlertService, LifecycleAlertServices } from '@kbn/rule-registry-plugin/server';
+import { PublicAlertFactory } from '@kbn/alerting-plugin/server/alert/create_alert_factory';
+import { ISearchStartSearchSource } from '@kbn/data-plugin/public';
+import { MockedLogger } from '@kbn/logging-mocks';
+import { SanitizedRuleConfig } from '@kbn/alerting-plugin/common';
+import { Alert, RuleExecutorServices } from '@kbn/alerting-plugin/server';
+import {
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils';
+import { AlertStates } from '@kbn/infra-plugin/common/alerting/logs/log_threshold/types';
+import {
+  BurnRateAlertContext,
+  BurnRateAlertState,
+  BurnRateAllowedActionGroups,
+  BurnRateRuleParams,
+  FIRED_ACTION,
+  getRuleExecutor,
+} from './executor';
+import { aStoredSLO, createSLO } from '../../../services/slo/fixtures/slo';
+import { SLO } from '../../../domain/models';
+
+const commonEsResponse = {
+  took: 100,
+  timed_out: false,
+  _shards: {
+    total: 0,
+    successful: 0,
+    skipped: 0,
+    failed: 0,
+  },
+  hits: {
+    hits: [],
+  },
+};
+
+const BURN_RATE_THRESHOLD = 2;
+const BURN_RATE_ABOVE_THRESHOLD = BURN_RATE_THRESHOLD + 0.01;
+const BURN_RATE_BELOW_THRESHOLD = BURN_RATE_THRESHOLD - 0.01;
+
+describe('BurnRateRuleExecutor', () => {
+  let esClientMock: ElasticsearchClientMock;
+  let soClientMock: jest.Mocked<SavedObjectsClientContract>;
+  let loggerMock: jest.Mocked<MockedLogger>;
+  let alertWithLifecycleMock: jest.MockedFn<LifecycleAlertService>;
+  let alertFactoryMock: jest.Mocked<
+    PublicAlertFactory<BurnRateAlertState, BurnRateAlertContext, BurnRateAllowedActionGroups>
+  >;
+  let searchSourceClientMock: jest.Mocked<ISearchStartSearchSource>;
+  let uiSettingsClientMock: jest.Mocked<IUiSettingsClient>;
+  let servicesMock: RuleExecutorServices<
+    BurnRateAlertState,
+    BurnRateAlertContext,
+    BurnRateAllowedActionGroups
+  > &
+    LifecycleAlertServices<BurnRateAlertState, BurnRateAlertContext, BurnRateAllowedActionGroups>;
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    soClientMock = savedObjectsClientMock.create();
+    alertWithLifecycleMock = jest.fn();
+    alertFactoryMock = {
+      create: jest.fn(),
+      done: jest.fn(),
+      alertLimit: { getValue: jest.fn(), setLimitReached: jest.fn() },
+    };
+    loggerMock = loggingSystemMock.createLogger();
+    servicesMock = {
+      alertWithLifecycle: alertWithLifecycleMock,
+      savedObjectsClient: soClientMock,
+      scopedClusterClient: { asCurrentUser: esClientMock, asInternalUser: esClientMock },
+      alertFactory: alertFactoryMock,
+      searchSourceClient: searchSourceClientMock,
+      uiSettingsClient: uiSettingsClientMock,
+      shouldWriteAlerts: jest.fn(),
+      shouldStopExecution: jest.fn(),
+      getAlertStartedDate: jest.fn(),
+      getAlertUuid: jest.fn(),
+      getAlertByAlertUuid: jest.fn(),
+    };
+  });
+
+  it('does not schedule an alert when both windows burn rates are below the threshold', async () => {
+    const slo = createSLO({ objective: { target: 0.9 } });
+    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    esClientMock.search.mockResolvedValue(
+      generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_BELOW_THRESHOLD)
+    );
+    alertFactoryMock.done.mockReturnValueOnce({ getRecoveredAlerts: () => [] });
+
+    const executor = getRuleExecutor();
+    await executor({
+      params: someRuleParams({ sloId: slo.id, threshold: BURN_RATE_THRESHOLD }),
+      startedAt: new Date(),
+      services: servicesMock,
+      executionId: 'irrelevant',
+      logger: loggerMock,
+      previousStartedAt: null,
+      rule: {} as SanitizedRuleConfig,
+      spaceId: 'irrelevant',
+      state: {},
+    });
+
+    expect(alertWithLifecycleMock).not.toBeCalled();
+  });
+
+  it('does not schedule an alert when the long window burn rate is below the threshold', async () => {
+    const slo = createSLO({ objective: { target: 0.9 } });
+    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    esClientMock.search.mockResolvedValue(
+      generateEsResponse(slo, BURN_RATE_ABOVE_THRESHOLD, BURN_RATE_BELOW_THRESHOLD)
+    );
+    alertFactoryMock.done.mockReturnValueOnce({ getRecoveredAlerts: () => [] });
+
+    const executor = getRuleExecutor();
+    await executor({
+      params: someRuleParams({ sloId: slo.id, threshold: BURN_RATE_THRESHOLD }),
+      startedAt: new Date(),
+      services: servicesMock,
+      executionId: 'irrelevant',
+      logger: loggerMock,
+      previousStartedAt: null,
+      rule: {} as SanitizedRuleConfig,
+      spaceId: 'irrelevant',
+      state: {},
+    });
+
+    expect(alertWithLifecycleMock).not.toBeCalled();
+  });
+
+  it('does not schedule an alert when the short window burn rate is below the threshold', async () => {
+    const slo = createSLO({ objective: { target: 0.9 } });
+    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    esClientMock.search.mockResolvedValue(
+      generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_ABOVE_THRESHOLD)
+    );
+    alertFactoryMock.done.mockReturnValueOnce({ getRecoveredAlerts: () => [] });
+
+    const executor = getRuleExecutor();
+    await executor({
+      params: someRuleParams({ sloId: slo.id, threshold: BURN_RATE_THRESHOLD }),
+      startedAt: new Date(),
+      services: servicesMock,
+      executionId: 'irrelevant',
+      logger: loggerMock,
+      previousStartedAt: null,
+      rule: {} as SanitizedRuleConfig,
+      spaceId: 'irrelevant',
+      state: {},
+    });
+
+    expect(alertWithLifecycleMock).not.toBeCalled();
+  });
+
+  it('schedules an alert when both windows burn rate have reached the threshold', async () => {
+    const slo = createSLO({ objective: { target: 0.9 } });
+    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    esClientMock.search.mockResolvedValue(
+      generateEsResponse(slo, BURN_RATE_THRESHOLD, BURN_RATE_THRESHOLD)
+    );
+    const alertMock: Partial<Alert> = {
+      scheduleActions: jest.fn(),
+      replaceState: jest.fn(),
+    };
+    alertWithLifecycleMock.mockImplementation(() => alertMock as any);
+    alertFactoryMock.done.mockReturnValueOnce({ getRecoveredAlerts: () => [] });
+
+    const executor = getRuleExecutor();
+    await executor({
+      params: someRuleParams({ sloId: slo.id, threshold: BURN_RATE_THRESHOLD }),
+      startedAt: new Date(),
+      services: servicesMock,
+      executionId: 'irrelevant',
+      logger: loggerMock,
+      previousStartedAt: null,
+      rule: {} as SanitizedRuleConfig,
+      spaceId: 'irrelevant',
+      state: {},
+    });
+
+    expect(alertWithLifecycleMock).toBeCalledWith({
+      id: `alert-${slo.id}-${slo.revision}`,
+      fields: {
+        [ALERT_REASON]:
+          'The burn rate for the past 1h is 2 and for the past 5m is 2. Alert when above 2 for both windows',
+        [ALERT_EVALUATION_THRESHOLD]: 2,
+        [ALERT_EVALUATION_VALUE]: 2,
+      },
+    });
+    expect(alertMock.scheduleActions).toBeCalledWith(
+      FIRED_ACTION.id,
+      expect.objectContaining({
+        longWindow: { burnRate: 2, duration: '1h' },
+        shortWindow: { burnRate: 2, duration: '5m' },
+        threshold: 2,
+        reason:
+          'The burn rate for the past 1h is 2 and for the past 5m is 2. Alert when above 2 for both windows',
+      })
+    );
+    expect(alertMock.replaceState).toBeCalledWith({ alertState: AlertStates.ALERT });
+  });
+
+  it('sets the context on the recovered alerts', async () => {
+    const slo = createSLO({ objective: { target: 0.9 } });
+    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    esClientMock.search.mockResolvedValue(
+      generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_ABOVE_THRESHOLD)
+    );
+    const alertMock: Partial<Alert> = {
+      setContext: jest.fn(),
+    };
+    alertFactoryMock.done.mockReturnValueOnce({ getRecoveredAlerts: () => [alertMock] as any });
+
+    const executor = getRuleExecutor();
+
+    await executor({
+      params: someRuleParams({ sloId: slo.id, threshold: BURN_RATE_THRESHOLD }),
+      startedAt: new Date(),
+      services: servicesMock,
+      executionId: 'irrelevant',
+      logger: loggerMock,
+      previousStartedAt: null,
+      rule: {} as SanitizedRuleConfig,
+      spaceId: 'irrelevant',
+      state: {},
+    });
+
+    expect(alertWithLifecycleMock).not.toBeCalled();
+    expect(alertMock.setContext).toBeCalledWith(
+      expect.objectContaining({
+        longWindow: { burnRate: 2.01, duration: '1h' },
+        shortWindow: { burnRate: 1.99, duration: '5m' },
+        threshold: 2,
+      })
+    );
+  });
+});
+
+function someRuleParams(params: Partial<BurnRateRuleParams> = {}): BurnRateRuleParams {
+  return {
+    sloId: uuid(),
+    threshold: 2,
+    longWindow: { duration: 1, unit: 'h' },
+    shortWindow: { duration: 5, unit: 'm' },
+    ...params,
+  };
+}
+
+function generateEsResponse(slo: SLO, shortWindowBurnRate: number, longWindowBurnRate: number) {
+  return {
+    ...commonEsResponse,
+    aggregations: {
+      SHORT_WINDOW: { buckets: [generateBucketForBurnRate(slo, shortWindowBurnRate)] },
+      LONG_WINDOW: { buckets: [generateBucketForBurnRate(slo, longWindowBurnRate)] },
+    },
+  };
+}
+
+function generateBucketForBurnRate(slo: SLO, burnRate: number) {
+  const total = 100;
+  const good = total * (1 - burnRate + slo.objective.target * burnRate);
+  return { good: { value: good }, total: { value: total } };
+}

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { RuleTypeState } from '@kbn/alerting-plugin/server';
+import {
+  ActionGroupIdsOf,
+  AlertInstanceContext as AlertContext,
+  AlertInstanceState as AlertState,
+} from '@kbn/alerting-plugin/common';
+import {
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils';
+import { LifecycleRuleExecutor } from '@kbn/rule-registry-plugin/server';
+
+import { Duration, toDurationUnit } from '../../../domain/models';
+import { DefaultSLIClient, KibanaSavedObjectsSLORepository } from '../../../services/slo';
+import { computeBurnRate } from '../../../domain/services';
+
+export enum AlertStates {
+  OK,
+  ALERT,
+  NO_DATA,
+  ERROR,
+}
+
+export type BurnRateRuleParams = {
+  sloId: string;
+  threshold: number;
+  longWindow: { duration: number; unit: string };
+  shortWindow: { duration: number; unit: string };
+} & Record<string, any>;
+export type BurnRateRuleTypeState = RuleTypeState & {};
+export type BurnRateAlertState = AlertState;
+export type BurnRateAlertContext = AlertContext;
+export type BurnRateAllowedActionGroups = ActionGroupIdsOf<typeof FIRED_ACTION>;
+
+const SHORT_WINDOW = 'SHORT_WINDOW';
+const LONG_WINDOW = 'LONG_WINDOW';
+
+export const getRuleExecutor = (): LifecycleRuleExecutor<
+  BurnRateRuleParams,
+  BurnRateRuleTypeState,
+  BurnRateAlertState,
+  BurnRateAlertContext,
+  BurnRateAllowedActionGroups
+> =>
+  async function executor({ services, params, startedAt }): Promise<void> {
+    const {
+      alertWithLifecycle,
+      savedObjectsClient: soClient,
+      scopedClusterClient: esClient,
+      alertFactory,
+    } = services;
+
+    const sloRepository = new KibanaSavedObjectsSLORepository(soClient);
+    const sliClient = new DefaultSLIClient(esClient.asCurrentUser);
+    const slo = await sloRepository.findById(params.sloId);
+
+    const longWindowDuration = new Duration(
+      params.longWindow.duration,
+      toDurationUnit(params.longWindow.unit)
+    );
+    const shortWindowDuration = new Duration(
+      params.shortWindow.duration,
+      toDurationUnit(params.shortWindow.unit)
+    );
+
+    const sliData = await sliClient.fetchSLIDataFrom(slo, [
+      { name: LONG_WINDOW, duration: longWindowDuration },
+      { name: SHORT_WINDOW, duration: shortWindowDuration },
+    ]);
+
+    const longWindowBurnRate = computeBurnRate(slo, sliData[LONG_WINDOW]);
+    const shortWindowBurnRate = computeBurnRate(slo, sliData[SHORT_WINDOW]);
+
+    const shouldAlert =
+      longWindowBurnRate >= params.threshold && shortWindowBurnRate >= params.threshold;
+    if (shouldAlert) {
+      const reason = `The burn rate for the past ${longWindowDuration.format()} is ${longWindowBurnRate} and for the past ${shortWindowDuration.format()} is ${shortWindowBurnRate}. Alert when above ${
+        params.threshold
+      } for both windows`;
+
+      const context = {
+        longWindow: { burnRate: longWindowBurnRate, duration: longWindowDuration.format() },
+        reason,
+        shortWindow: { burnRate: shortWindowBurnRate, duration: shortWindowDuration.format() },
+        threshold: params.threshold,
+        timestamp: startedAt.toISOString(),
+      };
+
+      const alert = alertWithLifecycle({
+        id: `alert-${slo.id}-${slo.revision}`,
+        fields: {
+          [ALERT_REASON]: reason,
+          [ALERT_EVALUATION_THRESHOLD]: params.threshold,
+          [ALERT_EVALUATION_VALUE]: Math.min(longWindowBurnRate, shortWindowBurnRate),
+        },
+      });
+
+      alert.scheduleActions(FIRED_ACTION.id, context);
+      alert.replaceState({ alertState: AlertStates.ALERT });
+    }
+
+    const { getRecoveredAlerts } = alertFactory.done();
+    const recoveredAlerts = getRecoveredAlerts();
+    for (const recoveredAlert of recoveredAlerts) {
+      const context = {
+        longWindow: { burnRate: longWindowBurnRate, duration: longWindowDuration.format() },
+        shortWindow: { burnRate: shortWindowBurnRate, duration: shortWindowDuration.format() },
+        threshold: params.threshold,
+        timestamp: startedAt.toISOString(),
+      };
+
+      recoveredAlert.setContext(context);
+    }
+  };
+
+const FIRED_ACTION_ID = 'slo.burnRate.fired';
+export const FIRED_ACTION = {
+  id: FIRED_ACTION_ID,
+  name: i18n.translate('xpack.observability.slo.alerting.burnRate.fired', {
+    defaultMessage: 'Alert',
+  }),
+};

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/index.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './register';
+export * from './executor';

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/register.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { i18n } from '@kbn/i18n';
+import { LicenseType } from '@kbn/licensing-plugin/server';
+import {
+  reasonActionVariableDescription,
+  timestampActionVariableDescription,
+} from '@kbn/infra-plugin/server/lib/alerting/common/messages';
+import { createLifecycleExecutor } from '@kbn/rule-registry-plugin/server';
+
+import { SLO_BURN_RATE_RULE_ID } from '../../../../common/constants';
+import { FIRED_ACTION, getRuleExecutor } from './executor';
+
+const windowSchema = schema.object({
+  duration: schema.number(),
+  unit: schema.string(),
+});
+
+type CreateLifecycleExecutor = ReturnType<typeof createLifecycleExecutor>;
+
+export function sloBurnRateRuleType(createLifecycleRuleExecutor: CreateLifecycleExecutor) {
+  return {
+    id: SLO_BURN_RATE_RULE_ID,
+    name: i18n.translate('xpack.observability.slo.rules.burnRate.name', {
+      defaultMessage: 'SLO Burn Rate',
+    }),
+    validate: {
+      params: schema.object({
+        sloId: schema.string(),
+        threshold: schema.number(),
+        longWindow: windowSchema,
+        shortWindow: windowSchema,
+      }),
+    },
+    defaultActionGroupId: FIRED_ACTION.id,
+    actionGroups: [FIRED_ACTION],
+    producer: 'observability',
+    minimumLicenseRequired: 'basic' as LicenseType,
+    isExportable: true,
+    executor: createLifecycleRuleExecutor(getRuleExecutor()),
+    doesSetRecoveryContext: true,
+    actionVariables: {
+      context: [
+        { name: 'reason', description: reasonActionVariableDescription },
+        { name: 'timestamp', description: timestampActionVariableDescription },
+        { name: 'threshold', description: thresholdActionVariableDescription },
+        { name: 'longWindow', description: windowActionVariableDescription },
+        { name: 'shortWindow', description: windowActionVariableDescription },
+      ],
+    },
+  };
+}
+
+const thresholdActionVariableDescription = i18n.translate(
+  'xpack.observability.slo.alerting.thresholdDescription',
+  {
+    defaultMessage: 'The threshold value of the burn rate.',
+  }
+);
+
+const windowActionVariableDescription = i18n.translate(
+  'xpack.observability.slo.alerting.windowDescription',
+  {
+    defaultMessage: 'The window duration with the associated burn rate value.',
+  }
+);

--- a/x-pack/plugins/observability/server/lib/rules/types.ts
+++ b/x-pack/plugins/observability/server/lib/rules/types.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type RuleRegistrationContext = 'observability.slo';

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -11,11 +11,16 @@ import {
   Plugin,
   CoreSetup,
   DEFAULT_APP_CATEGORIES,
+  Logger,
 } from '@kbn/core/server';
-import { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
+import { PluginSetupContract } from '@kbn/alerting-plugin/server';
+import { Dataset, RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
 import { PluginSetupContract as FeaturesSetup } from '@kbn/features-plugin/server';
 import { createUICapabilities } from '@kbn/cases-plugin/common';
 import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { experimentalRuleFieldMap } from '@kbn/rule-registry-plugin/common/assets/field_maps/experimental_rule_field_map';
+import { mappingFromFieldMap } from '@kbn/rule-registry-plugin/common/mapping_from_field_map';
+import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/rule-registry-plugin/common/assets';
 import { ObservabilityConfig } from '.';
 import {
   bootstrapAnnotations,
@@ -27,6 +32,8 @@ import { registerRoutes } from './routes/register_routes';
 import { getGlobalObservabilityServerRouteRepository } from './routes/get_global_observability_server_route_repository';
 import { casesFeatureId, observabilityFeatureId } from '../common';
 import { slo } from './saved_objects';
+import { OBSERVABILITY_FEATURE_ID } from './common/constants';
+import { registerRuleTypes } from './lib/rules/register_rule_types';
 
 export type ObservabilityPluginSetup = ReturnType<ObservabilityPlugin['setup']>;
 
@@ -34,17 +41,20 @@ interface PluginSetup {
   features: FeaturesSetup;
   ruleRegistry: RuleRegistryPluginSetupContract;
   spaces: SpacesPluginStart;
+  alerting: PluginSetupContract;
 }
 
 export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
+  private logger: Logger;
+
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
+    this.logger = initContext.logger.get();
   }
 
   public setup(core: CoreSetup, plugins: PluginSetup) {
-    const config = this.initContext.config.get<ObservabilityConfig>();
-
     const casesCapabilities = createUICapabilities();
+    const config = this.initContext.config.get<ObservabilityConfig>();
 
     plugins.features.registerKibanaFeature({
       id: casesFeatureId,
@@ -138,20 +148,35 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
       });
     }
 
+    const { ruleDataService } = plugins.ruleRegistry;
+
     if (config.unsafe.slo.enabled) {
       core.savedObjects.registerType(slo);
+
+      const ruleDataClient = ruleDataService.initializeIndex({
+        feature: OBSERVABILITY_FEATURE_ID,
+        registrationContext: 'observability.slo',
+        dataset: Dataset.alerts,
+        componentTemplateRefs: [ECS_COMPONENT_TEMPLATE_NAME],
+        componentTemplates: [
+          {
+            name: 'mappings',
+            mappings: mappingFromFieldMap(experimentalRuleFieldMap, 'strict'),
+          },
+        ],
+      });
+
+      registerRuleTypes(plugins.alerting, this.logger, ruleDataClient);
     }
 
     const start = () => core.getStartServices().then(([coreStart]) => coreStart);
-
-    const { ruleDataService } = plugins.ruleRegistry;
 
     registerRoutes({
       core: {
         setup: core,
         start,
       },
-      logger: this.initContext.logger.get(),
+      logger: this.logger,
       repository: getGlobalObservabilityServerRouteRepository(config),
       ruleDataService,
     });

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -7,13 +7,17 @@
 
 import { cloneDeep } from 'lodash';
 import uuid from 'uuid';
+import { SavedObject } from '@kbn/core-saved-objects-common';
 
+import { SO_SLO_TYPE } from '../../../saved_objects';
+import { sloSchema } from '../../../types/schema';
 import {
   APMTransactionDurationIndicator,
   APMTransactionErrorRateIndicator,
   Indicator,
   KQLCustomIndicator,
   SLO,
+  StoredSLO,
 } from '../../../domain/models';
 import { CreateSLOParams } from '../../../types/rest_specs';
 import { Paginated } from '../slo_repository';
@@ -76,6 +80,15 @@ export const createSLOParams = (params: Partial<CreateSLOParams> = {}): CreateSL
   ...defaultSLO,
   ...params,
 });
+
+export const aStoredSLO = (slo: SLO): SavedObject<StoredSLO> => {
+  return {
+    id: slo.id,
+    attributes: sloSchema.encode(slo),
+    type: SO_SLO_TYPE,
+    references: [],
+  };
+};
 
 export const createSLO = (params: Partial<SLO> = {}): SLO => {
   const now = new Date();

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { SavedObject } from '@kbn/core-saved-objects-common';
 import {
   SavedObjectsClientContract,
   SavedObjectsErrorHelpers,
@@ -16,20 +15,11 @@ import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { SLO, StoredSLO } from '../../domain/models';
 import { SO_SLO_TYPE } from '../../saved_objects';
 import { KibanaSavedObjectsSLORepository } from './slo_repository';
-import { createAPMTransactionDurationIndicator, createSLO } from './fixtures/slo';
+import { createAPMTransactionDurationIndicator, createSLO, aStoredSLO } from './fixtures/slo';
 import { SLONotFound } from '../../errors';
 import { sloSchema } from '../../types/schema';
 
 const SOME_SLO = createSLO({ indicator: createAPMTransactionDurationIndicator() });
-
-function aStoredSLO(slo: SLO): SavedObject<StoredSLO> {
-  return {
-    id: slo.id,
-    attributes: sloSchema.encode(slo),
-    type: SO_SLO_TYPE,
-    references: [],
-  };
-}
 
 function aFindResponse(slo: SLO): SavedObjectsFindResponse<StoredSLO> {
   return {

--- a/x-pack/plugins/observability/server/types.ts
+++ b/x-pack/plugins/observability/server/types.ts
@@ -12,6 +12,7 @@ import type {
 } from '@kbn/core/server';
 import type { AlertingApiRequestHandlerContext } from '@kbn/alerting-plugin/server';
 import type { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
+import { OBSERVABILITY_FEATURE_ID } from './common/constants';
 
 export type {
   ObservabilityRouteCreateOptions,
@@ -20,6 +21,8 @@ export type {
   ObservabilityServerRouteRepository,
   ObservabilityAPIReturnType,
 } from './routes/types';
+
+export type ObservabilityFeatureId = typeof OBSERVABILITY_FEATURE_ID;
 
 /**
  * @internal


### PR DESCRIPTION
## 📝  Summary

Related to https://github.com/elastic/kibana/issues/143067

This POC includes some FE components, but don't look into it. It is some basic spaceholder.

This PR introduces a new rule type for SLO burn rate with its executor. The executor fetches the SLO from its repository, finds the SLI data for the configured rule's windows and computes the burn rate associated to them. An alert is scheduled when both window's burn rate reaches the configured threshold

The code is behind a feature flag

## ❓ Questions

The goal of this POC is to get feedback on the overall setup of the rule, and understand if I missed anything critical. I will then turn this POC into a proper PR for https://github.com/elastic/kibana/issues/145258

1. Is it ok to do nothing with the recovered alerts in the rule executor?
2. Am I missing anything regarding the backend?

## 🖼️ Screenshots 

Screenshot |
-- |
![image](https://user-images.githubusercontent.com/1376800/202017188-11ef2708-c7b0-423f-951e-d8686927bd4b.png) |
![image](https://user-images.githubusercontent.com/1376800/202017247-5a6193e8-c8a1-4df5-8851-6f2c18882ccd.png) |
![image](https://user-images.githubusercontent.com/1376800/202017549-a0c0aa66-cbc0-4609-914b-980389c8f35d.png) |
![image](https://user-images.githubusercontent.com/1376800/202019411-e61ec908-4f4b-438b-bc7d-82f467be7aed.png) |
