### PR TITLE
[Uptime] Use absolute time instead of relative for TLS rule query

### DIFF
--- a/x-pack/plugins/synthetics/common/requests/get_certs_request_body.ts
+++ b/x-pack/plugins/synthetics/common/requests/get_certs_request_body.ts
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import DateMath from '@kbn/datemath';
 import { CertResult, GetCertsParams, Ping } from '../runtime_types';
 import { createEsQuery } from '../utils/es_search';
 
@@ -79,8 +81,8 @@ export const getCertsRequestBody = ({
             {
               range: {
                 'monitor.timespan': {
-                  gte: from,
-                  lte: to,
+                  gte: DateMath.parse(from)?.valueOf() ?? from,
+                  lte: DateMath.parse(to)?.valueOf() ?? to,
                 },
               },
             },

--- a/x-pack/plugins/synthetics/common/requests/get_certs_request_body.ts
+++ b/x-pack/plugins/synthetics/common/requests/get_certs_request_body.ts
@@ -26,6 +26,10 @@ export const DEFAULT_SIZE = 20;
 export const DEFAULT_FROM = 'now-20m';
 export const DEFAULT_TO = 'now';
 
+function absoluteDate(relativeDate: string) {
+  return DateMath.parse(relativeDate)?.valueOf() ?? relativeDate;
+}
+
 export const getCertsRequestBody = ({
   pageIndex,
   search,
@@ -81,8 +85,8 @@ export const getCertsRequestBody = ({
             {
               range: {
                 'monitor.timespan': {
-                  gte: DateMath.parse(from)?.valueOf() ?? from,
-                  lte: DateMath.parse(to)?.valueOf() ?? to,
+                  gte: absoluteDate(from),
+                  lte: absoluteDate(to),
                 },
               },
             },
@@ -97,7 +101,7 @@ export const getCertsRequestBody = ({
                         {
                           range: {
                             'tls.certificate_not_valid_before': {
-                              lte: notValidBefore,
+                              lte: absoluteDate(notValidBefore),
                             },
                           },
                         },
@@ -108,7 +112,7 @@ export const getCertsRequestBody = ({
                         {
                           range: {
                             'tls.certificate_not_valid_after': {
-                              lte: notValidAfter,
+                              lte: absoluteDate(notValidAfter),
                             },
                           },
                         },

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/requests/get_certs.test.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/requests/get_certs.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import DateMath from '@kbn/datemath';
+import moment from 'moment';
 import { getCerts } from './get_certs';
 import { getUptimeESMockClient } from './test_helpers';
 
@@ -82,6 +84,10 @@ describe('getCerts', () => {
   });
 
   it('parses query result and returns expected values', async () => {
+    const dateMathSpy = jest.spyOn(DateMath, 'parse');
+
+    dateMathSpy.mockReturnValueOnce(moment(10000));
+    dateMathSpy.mockReturnValueOnce(moment(10001));
     const { esClient, uptimeEsClient } = getUptimeESMockClient();
 
     esClient.search.mockResponseOnce({
@@ -178,8 +184,8 @@ describe('getCerts', () => {
                     Object {
                       "range": Object {
                         "monitor.timespan": Object {
-                          "gte": "now-2d",
-                          "lte": "now+1h",
+                          "gte": 10000,
+                          "lte": 10001,
                         },
                       },
                     },

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/requests/get_certs.test.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/requests/get_certs.test.ts
@@ -86,8 +86,7 @@ describe('getCerts', () => {
   it('parses query result and returns expected values', async () => {
     const dateMathSpy = jest.spyOn(DateMath, 'parse');
 
-    dateMathSpy.mockReturnValueOnce(moment(10000));
-    dateMathSpy.mockReturnValueOnce(moment(10001));
+    dateMathSpy.mockReturnValue(moment(10000));
     const { esClient, uptimeEsClient } = getUptimeESMockClient();
 
     esClient.search.mockResponseOnce({
@@ -185,7 +184,7 @@ describe('getCerts', () => {
                       "range": Object {
                         "monitor.timespan": Object {
                           "gte": 10000,
-                          "lte": 10001,
+                          "lte": 10000,
                         },
                       },
                     },
@@ -196,7 +195,7 @@ describe('getCerts', () => {
                           Object {
                             "range": Object {
                               "tls.certificate_not_valid_after": Object {
-                                "lte": "now+100d",
+                                "lte": 10000,
                               },
                             },
                           },


### PR DESCRIPTION
## Summary

Resolves #144131.

Changes the TLS rule query to use absolute time vs. relative. This will force ES to look at the time window that Kibana is attempting to use; this will help account for any kind of latency or discrepancy that may exist between the user's Elasticsearch cluster and their Kibana server.

### Testing

The output of the query should remain largely unchanged, except for part of the `filter` clause of the query. Before, it would look like:

```json
{                                                                                                                                                                                                                                           
  "range": {                                                                                                                                                                                                                                
    "monitor.timespan": {                                                                                                                                                                                                                   
      "gte": "now-5m",                                                                                                                                                                                                                      
      "lte": "now"                                                                                                                                                                                                                          
    }                                                                                                                                                                                                                                       
  }                                                                                                                                                                                                                                         
}
```

Now, it should look like:

```json
{                                                                                                                                                                                                                                           
  "range": {
    "monitor.timespan": {
      "gte": 1668542612658,
      "lte": 1668542912658
    }
  }
}
```

You should also ensure your alerts will work as intended. You can do this using the typical prescribed method of creating a TLS alert and then modifying the thresholds defined on the Uptime Settings page. Choose a domain to monitor with an http monitor, I chose https://elastic.co.

Then, navigate to the settings app, create a very high minimum age threshold, and see that your alert changes to an `active` state:

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/18429259/202040197-dcec57c8-238b-40df-9a20-0ad17b0a4cf2.png">

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->