### PR TITLE
[Fleet] Create file upload write indices on setup or package install

### DIFF
--- a/x-pack/plugins/fleet/common/constants/file_storage.ts
+++ b/x-pack/plugins/fleet/common/constants/file_storage.ts
@@ -10,3 +10,12 @@
 // found in `common/services/file_storage`
 export const FILE_STORAGE_METADATA_INDEX_PATTERN = '.fleet-files-*';
 export const FILE_STORAGE_DATA_INDEX_PATTERN = '.fleet-file-data-*';
+
+// which integrations support file upload and the name to use for the file upload index
+export const FILE_STORAGE_INTEGRATION_INDEX_NAMES: Readonly<Record<string, string>> = {
+  elastic_agent: 'agent',
+  endpoint: 'endpoint',
+};
+export const FILE_STORAGE_INTEGRATION_NAMES: Readonly<string[]> = Object.keys(
+  FILE_STORAGE_INTEGRATION_INDEX_NAMES
+);

--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -15,7 +15,7 @@ export const allowedExperimentalValues = Object.freeze({
   createPackagePolicyMultiPageLayout: true,
   packageVerification: true,
   showDevtoolsRequest: true,
-  showRequestDiagnostics: false,
+  diagnosticFileUploadEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/common/services/file_storage.ts
+++ b/x-pack/plugins/fleet/common/services/file_storage.ts
@@ -35,6 +35,11 @@ export const getFileDataIndexName = (integrationName: string): string => {
 };
 
 /**
+ * Returns the write index name for a given file upload alias name, this is the same for metadata and chunks
+ * @param aliasName
+ */
+export const getFileWriteIndexName = (aliasName: string) => aliasName + '-000001';
+/**
  * Returns back the integration name for a given File Data (chunks) index name.
  *
  * @example
@@ -63,3 +68,15 @@ export const getIntegrationNameFromFileDataIndexName = (indexName: string): stri
 
   throw new Error(`Index name ${indexName} does not seem to be a File Data storage index`);
 };
+
+export const getFileStorageWriteIndexBody = (aliasName: string) => ({
+  aliases: {
+    [aliasName]: {
+      is_write_index: true,
+    },
+  },
+  settings: {
+    'index.lifecycle.rollover_alias': aliasName,
+    'index.hidden': true,
+  },
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -38,7 +38,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
   const isUnenrolling = agent.status === 'unenrolling';
 
   const hasFleetServer = agentPolicy && policyHasFleetServer(agentPolicy);
-  const { showRequestDiagnostics } = ExperimentalFeaturesService.get();
+  const { diagnosticFileUploadEnabled } = ExperimentalFeaturesService.get();
 
   const onClose = useMemo(() => {
     if (onCancelReassign) {
@@ -95,7 +95,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
     </EuiContextMenuItem>,
   ];
 
-  if (showRequestDiagnostics) {
+  if (diagnosticFileUploadEnabled) {
     menuItems.push(
       <EuiContextMenuItem
         icon="download"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -68,7 +68,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
       navigateToApp(routeState.onDoneNavigateTo[0], routeState.onDoneNavigateTo[1]);
     }
   }, [routeState, navigateToApp]);
-  const { showRequestDiagnostics } = ExperimentalFeaturesService.get();
+  const { diagnosticFileUploadEnabled } = ExperimentalFeaturesService.get();
 
   const host = agentData?.item?.local_metadata?.host;
 
@@ -156,7 +156,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         isSelected: tabId === 'logs',
       },
     ];
-    if (showRequestDiagnostics) {
+    if (diagnosticFileUploadEnabled) {
       tabs.push({
         id: 'diagnostics',
         name: i18n.translate('xpack.fleet.agentDetails.subTabs.diagnosticsTab', {
@@ -167,7 +167,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
       });
     }
     return tabs;
-  }, [getHref, agentId, tabId, showRequestDiagnostics]);
+  }, [getHref, agentId, tabId, diagnosticFileUploadEnabled]);
 
   return (
     <AgentRefreshContext.Provider

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -82,7 +82,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   const agentCount = selectionMode === 'manual' ? selectedAgents.length : totalActiveAgents;
   const agents = selectionMode === 'manual' ? selectedAgents : currentQuery;
   const [tagsPopoverButton, setTagsPopoverButton] = useState<HTMLElement>();
-  const { showRequestDiagnostics } = ExperimentalFeaturesService.get();
+  const { diagnosticFileUploadEnabled } = ExperimentalFeaturesService.get();
 
   const menuItems = [
     {
@@ -171,7 +171,7 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
     },
   ];
 
-  if (showRequestDiagnostics) {
+  if (diagnosticFileUploadEnabled) {
     menuItems.push({
       name: (
         <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.test.tsx
@@ -56,7 +56,7 @@ describe('SearchAndFilterBar', () => {
       createPackagePolicyMultiPageLayout: true,
       packageVerification: true,
       showDevtoolsRequest: false,
-      showRequestDiagnostics: false,
+      diagnosticFileUploadEnabled: false,
     });
   });
   it('should show no Actions button when no agent is selected', async () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
@@ -38,7 +38,7 @@ export const TableRowActions: React.FunctionComponent<{
   const isUnenrolling = agent.status === 'unenrolling';
   const kibanaVersion = useKibanaVersion();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { showRequestDiagnostics } = ExperimentalFeaturesService.get();
+  const { diagnosticFileUploadEnabled } = ExperimentalFeaturesService.get();
   const menuItems = [
     <EuiContextMenuItem
       icon="inspect"
@@ -110,7 +110,7 @@ export const TableRowActions: React.FunctionComponent<{
       </EuiContextMenuItem>
     );
 
-    if (showRequestDiagnostics) {
+    if (diagnosticFileUploadEnabled) {
       menuItems.push(
         <EuiContextMenuItem
           icon="download"

--- a/x-pack/plugins/fleet/public/mock/create_test_renderer.tsx
+++ b/x-pack/plugins/fleet/public/mock/create_test_renderer.tsx
@@ -68,7 +68,7 @@ export const createFleetTestRendererMock = (): TestRenderer => {
     createPackagePolicyMultiPageLayout: true,
     packageVerification: true,
     showDevtoolsRequest: false,
-    showRequestDiagnostics: false,
+    diagnosticFileUploadEnabled: false,
   });
 
   const HookWrapper = memo(({ children }) => {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -9,8 +9,21 @@ import { merge, concat, uniqBy, omit } from 'lodash';
 import Boom from '@hapi/boom';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
+import type { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types';
+
+import {
+  FILE_STORAGE_INTEGRATION_INDEX_NAMES,
+  FILE_STORAGE_INTEGRATION_NAMES,
+} from '../../../../../common/constants';
+
 import { ElasticsearchAssetType } from '../../../../types';
-import { getPipelineNameForDatastream } from '../../../../../common/services';
+import {
+  getFileWriteIndexName,
+  getFileStorageWriteIndexBody,
+  getPipelineNameForDatastream,
+  getFileDataIndexName,
+  getFileMetadataIndexName,
+} from '../../../../../common/services';
 import type {
   RegistryDataStream,
   IndexTemplateEntry,
@@ -341,6 +354,36 @@ export async function ensureDefaultComponentTemplates(
   );
 }
 
+export async function ensureFileUploadWriteIndices(opts: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  integrationNames: string[];
+}) {
+  const { esClient, logger, integrationNames } = opts;
+
+  const integrationsWithFileUpload = integrationNames.filter((integration) =>
+    FILE_STORAGE_INTEGRATION_NAMES.includes(integration as any)
+  );
+
+  if (!integrationsWithFileUpload.length) return [];
+
+  const ensure = (aliasName: string) =>
+    ensureAliasHasWriteIndex({
+      esClient,
+      logger,
+      aliasName,
+      writeIndexName: getFileWriteIndexName(aliasName),
+      body: getFileStorageWriteIndexBody(aliasName),
+    });
+
+  return Promise.all(
+    integrationsWithFileUpload.flatMap((integrationName) => {
+      const indexName = FILE_STORAGE_INTEGRATION_INDEX_NAMES[integrationName];
+      return [ensure(getFileDataIndexName(indexName)), ensure(getFileMetadataIndexName(indexName))];
+    })
+  );
+}
+
 export async function ensureComponentTemplate(
   esClient: ElasticsearchClient,
   logger: Logger,
@@ -369,6 +412,37 @@ export async function ensureComponentTemplate(
   }
 
   return { isCreated: !existingTemplate };
+}
+
+export async function ensureAliasHasWriteIndex(opts: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  aliasName: string;
+  writeIndexName: string;
+  body: Omit<IndicesCreateRequest, 'index'>;
+}): Promise<void> {
+  const { esClient, logger, aliasName, writeIndexName, body } = opts;
+  const existingIndex = await retryTransientEsErrors(
+    () =>
+      esClient.indices.exists(
+        {
+          index: [aliasName],
+        },
+        {
+          ignore: [404],
+        }
+      ),
+    { logger }
+  );
+
+  if (!existingIndex) {
+    await retryTransientEsErrors(
+      () => esClient.indices.create({ index: writeIndexName, ...body }, { ignore: [404] }),
+      {
+        logger,
+      }
+    );
+  }
 }
 
 export function prepareTemplate({

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -354,6 +354,13 @@ export async function ensureDefaultComponentTemplates(
   );
 }
 
+/*
+ * Given a list of integration names, if the integrations support file upload
+ * then ensure that the alias has a matching write index, as we use "plain" indices
+ * not data streams.
+ * e.g .fleet-file-data-agent must have .fleet-file-data-agent-00001 as the write index
+ * before files can be uploaded.
+ */
 export async function ensureFileUploadWriteIndices(opts: {
   esClient: ElasticsearchClient;
   logger: Logger;

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
@@ -32,7 +32,10 @@ import type {
   PackageAssetReference,
   PackageVerificationResult,
 } from '../../../types';
-import { prepareToInstallTemplates } from '../elasticsearch/template/install';
+import {
+  ensureFileUploadWriteIndices,
+  prepareToInstallTemplates,
+} from '../elasticsearch/template/install';
 import { removeLegacyTemplates } from '../elasticsearch/template/remove_legacy';
 import {
   prepareToInstallPipelines,
@@ -213,6 +216,12 @@ export async function _installPackage({
     } catch (e) {
       logger.warn(`Error removing legacy templates: ${e.message}`);
     }
+
+    await ensureFileUploadWriteIndices({
+      integrationNames: [packageInfo.name],
+      esClient,
+      logger,
+    });
 
     // update current backing indices of each data stream
     await withPackageSpan('Update write indices', () =>

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -330,6 +330,18 @@ export async function getInstallationObject(options: {
   });
 }
 
+export async function getInstallationObjects(options: {
+  savedObjectsClient: SavedObjectsClientContract;
+  pkgNames: string[];
+}) {
+  const { savedObjectsClient, pkgNames } = options;
+  const res = await savedObjectsClient.bulkGet<Installation>(
+    pkgNames.map((pkgName) => ({ id: pkgName, type: PACKAGES_SAVED_OBJECT_TYPE }))
+  );
+
+  return res.saved_objects.filter((so) => so?.attributes);
+}
+
 export async function getInstallation(options: {
   savedObjectsClient: SavedObjectsClientContract;
   pkgName: string;
@@ -337,6 +349,14 @@ export async function getInstallation(options: {
 }) {
   const savedObject = await getInstallationObject(options);
   return savedObject?.attributes;
+}
+
+export async function getInstallationsByName(options: {
+  savedObjectsClient: SavedObjectsClientContract;
+  pkgNames: string[];
+}) {
+  const savedObjects = await getInstallationObjects(options);
+  return savedObjects.map((so) => so.attributes);
 }
 
 function sortByName(a: { name: string }, b: { name: string }) {

--- a/x-pack/plugins/fleet/server/services/setup.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup.test.ts
@@ -60,6 +60,7 @@ describe('setupFleet', () => {
     (upgradeManagedPackagePolicies as jest.Mock).mockResolvedValue([]);
 
     soClient.find.mockResolvedValue({ saved_objects: [] } as any);
+    soClient.bulkGet.mockResolvedValue({ saved_objects: [] } as any);
   });
 
   afterEach(async () => {

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -12,7 +12,7 @@ import pMap from 'p-map';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 
-import { AUTO_UPDATE_PACKAGES } from '../../common/constants';
+import { AUTO_UPDATE_PACKAGES, FILE_STORAGE_INTEGRATION_NAMES } from '../../common/constants';
 import type { PreconfigurationError } from '../../common/constants';
 import type {
   DefaultPackagesInstallationError,
@@ -36,7 +36,10 @@ import { ensureDefaultEnrollmentAPIKeyForAgentPolicy } from './api_keys';
 import { getRegistryUrl, settingsService } from '.';
 import { awaitIfPending } from './setup_utils';
 import { ensureFleetFinalPipelineIsInstalled } from './epm/elasticsearch/ingest_pipeline/install';
-import { ensureDefaultComponentTemplates } from './epm/elasticsearch/template/install';
+import {
+  ensureDefaultComponentTemplates,
+  ensureFileUploadWriteIndices,
+} from './epm/elasticsearch/template/install';
 import { getInstallations, reinstallPackageForInstallation } from './epm/packages';
 import { isPackageInstalled } from './epm/packages/install';
 import type { UpgradeManagedPackagePoliciesResult } from './managed_package_policies';
@@ -49,6 +52,7 @@ import {
   ensurePreconfiguredFleetServerHosts,
   getPreconfiguredFleetServerHostFromConfig,
 } from './preconfiguration/fleet_server_host';
+import { getInstallationsByName } from './epm/packages/get';
 
 export interface SetupStatus {
   isInitialized: boolean;
@@ -108,6 +112,7 @@ async function createSetupSideEffects(
     await ensureFleetGlobalEsAssets(soClient, esClient);
   }
 
+  await ensureFleetFileUploadIndices(soClient, esClient);
   // Ensure that required packages are always installed even if they're left out of the config
   const preconfiguredPackageNames = new Set(packages.map((pkg) => pkg.name));
 
@@ -168,6 +173,29 @@ async function createSetupSideEffects(
   };
 }
 
+/**
+ * Ensure ES assets shared by all Fleet index template are installed
+ */
+export async function ensureFleetFileUploadIndices(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient
+) {
+  const logger = appContextService.getLogger();
+
+  const installedFileUploadIntegrations = await getInstallationsByName({
+    savedObjectsClient: soClient,
+    pkgNames: FILE_STORAGE_INTEGRATION_NAMES,
+  });
+
+  if (!installedFileUploadIntegrations.length) return [];
+  const integrationNames = installedFileUploadIntegrations.map(({ name }) => name);
+  logger.debug(`Ensuring file upload write indices for ${integrationNames}`);
+  return ensureFileUploadWriteIndices({
+    esClient,
+    logger,
+    integrationNames,
+  });
+}
 /**
  * Ensure ES assets shared by all Fleet index template are installed
  */

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -184,7 +184,7 @@ export async function ensureFleetFileUploadIndices(
 
   const installedFileUploadIntegrations = await getInstallationsByName({
     savedObjectsClient: soClient,
-    pkgNames: FILE_STORAGE_INTEGRATION_NAMES,
+    pkgNames: [...FILE_STORAGE_INTEGRATION_NAMES],
   });
 
   if (!installedFileUploadIntegrations.length) return [];

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -180,8 +180,9 @@ export async function ensureFleetFileUploadIndices(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient
 ) {
+  const { diagnosticFileUploadEnabled } = appContextService.getExperimentalFeatures();
+  if (!diagnosticFileUploadEnabled) return;
   const logger = appContextService.getLogger();
-
   const installedFileUploadIntegrations = await getInstallationsByName({
     savedObjectsClient: soClient,
     pkgNames: [...FILE_STORAGE_INTEGRATION_NAMES],

--- a/x-pack/test/security_solution_endpoint/config.ts
+++ b/x-pack/test/security_solution_endpoint/config.ts
@@ -51,6 +51,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.fleet.packages.0.version=latest`,
         // set the packagerTaskInterval to 5s in order to speed up test executions when checking fleet artifacts
         '--xpack.securitySolution.packagerTaskInterval=5s',
+        // this will be removed in 8.7 when the file upload feature is released
+        `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`,
       ],
     },
     layout: {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/file_upload_index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/file_upload_index.ts
@@ -6,6 +6,10 @@
  */
 
 import expect from '@kbn/expect';
+import {
+  FILE_STORAGE_DATA_INDEX,
+  FILE_STORAGE_METADATA_INDEX,
+} from '@kbn/security-solution-plugin/common/endpoint/constants';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
@@ -14,14 +18,14 @@ export default function ({ getService }: FtrProviderContext) {
   describe('File upload indices', () => {
     it('should have created the file data index on install', async () => {
       const endpointFileUploadIndexExists = await esClient.indices.exists({
-        index: '.fleet-file-data-endpoint',
+        index: FILE_STORAGE_METADATA_INDEX,
       });
 
       expect(endpointFileUploadIndexExists).equal(true);
     });
     it('should have created the files index on install', async () => {
       const endpointFileUploadIndexExists = await esClient.indices.exists({
-        index: '.fleet-files-endpoint',
+        index: FILE_STORAGE_DATA_INDEX,
       });
 
       expect(endpointFileUploadIndexExists).equal(true);

--- a/x-pack/test/security_solution_endpoint_api_int/apis/file_upload_index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/file_upload_index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const esClient = getService('es');
+
+  describe('File upload indices', () => {
+    it('should have created the file data index on install', async () => {
+      const endpointFileUploadIndexExists = await esClient.indices.exists({
+        index: '.fleet-file-data-endpoint',
+      });
+
+      expect(endpointFileUploadIndexExists).equal(true);
+    });
+    it('should have created the files index on install', async () => {
+      const endpointFileUploadIndexExists = await esClient.indices.exists({
+        index: '.fleet-files-endpoint',
+      });
+
+      expect(endpointFileUploadIndexExists).equal(true);
+    });
+  });
+}

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -32,6 +32,7 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
     loadTestFile(require.resolve('./policy'));
     loadTestFile(require.resolve('./package'));
     loadTestFile(require.resolve('./endpoint_authz'));
+    loadTestFile(require.resolve('./file_upload_index'));
     loadTestFile(require.resolve('./endpoint_artifacts/trusted_apps'));
     loadTestFile(require.resolve('./endpoint_artifacts/event_filters'));
     loadTestFile(require.resolve('./endpoint_artifacts/host_isolation_exceptions'));

--- a/x-pack/test/security_solution_endpoint_api_int/config.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/config.ts
@@ -29,6 +29,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // always install Endpoint package by default when Fleet sets up
         `--xpack.fleet.packages.0.name=endpoint`,
         `--xpack.fleet.packages.0.version=latest`,
+        `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`, // this will be removed in 8.7 when the feature is released
       ],
     },
   };

--- a/x-pack/test/security_solution_endpoint_api_int/config.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/config.ts
@@ -29,7 +29,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // always install Endpoint package by default when Fleet sets up
         `--xpack.fleet.packages.0.name=endpoint`,
         `--xpack.fleet.packages.0.version=latest`,
-        `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`, // this will be removed in 8.7 when the feature is released
+        // this will be removed in 8.7 when the file upload feature is released
+        `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`,
       ],
     },
   };


### PR DESCRIPTION
## Summary

Part of #143459.

Create the write index for the diagnostic file upload feature on package install, also check installed packages on setup and create indices if they do not exist. 

This is behind a feature flag until the whole feature is released: `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`

As we use plain indices for file upload, before the files can be uploaded we need to create the write index e.g `.fleet-file-data-agent-00001` wjhich would be the write index for the alias `.fleet-file-data-agent`

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios