### PR TITLE
[Synthetics] Uses the default `success` and `danger` colors for badges

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_status.tsx
@@ -7,13 +7,11 @@
 import React from 'react';
 import { EuiBadge, EuiDescriptionList, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useTheme } from '@kbn/observability-plugin/public';
 
 import { useSelectedMonitor } from './hooks/use_selected_monitor';
 import { useMonitorLatestPing } from './hooks/use_monitor_latest_ping';
 
 export const MonitorDetailsStatus: React.FC = () => {
-  const theme = useTheme();
   const { latestPing, loading: pingsLoading } = useMonitorLatestPing();
 
   const { monitor } = useSelectedMonitor();
@@ -29,9 +27,9 @@ export const MonitorDetailsStatus: React.FC = () => {
   ) : !latestPing ? (
     <EuiBadge color="default">{PENDING_LABEL}</EuiBadge>
   ) : latestPing.monitor.status === 'up' ? (
-    <EuiBadge color={theme.eui.euiColorVis0}>{isBrowserType ? SUCCESS_LABEL : UP_LABEL}</EuiBadge>
+    <EuiBadge color="success">{isBrowserType ? SUCCESS_LABEL : UP_LABEL}</EuiBadge>
   ) : (
-    <EuiBadge color={theme.eui.euiColorVis9}>{isBrowserType ? FAILED_LABEL : DOWN_LABEL}</EuiBadge>
+    <EuiBadge color="danger">{isBrowserType ? FAILED_LABEL : DOWN_LABEL}</EuiBadge>
   );
 
   return <EuiDescriptionList listItems={[{ title: STATUS_LABEL, description: badge }]} />;


### PR DESCRIPTION
## Summary

Resolves #144362.

Corrects the status badge at the top of the detail page so it will display the default `danger` and `success` colors per the rest of the page.

**After:**

<img width="1449" alt="Untitled 3" src="https://user-images.githubusercontent.com/18429259/202034177-1bff38d2-29fd-49a1-8b53-b51952ac18bd.png">

Likewise, success color corresponds:

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/18429259/202036053-80ca2f5b-57c9-4026-b5dc-6d24a947c0d9.png">


**Before:**

<img width="1110" alt="Untitled 2" src="https://user-images.githubusercontent.com/18429259/202033915-09b80e03-80d8-42e6-a0f1-5defa00bb3ac.png">

Likewise, success color did not correspond:

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/18429259/202036102-b80af6ba-d48c-4d09-aff5-239f93614ea9.png">
