### PR TITLE
[Upgrade Assistant] Add execution context

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/app.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/app.tsx
@@ -189,8 +189,10 @@ export const App = ({ history }: { history: ScopedHistory }) => {
 export const RootComponent = (dependencies: AppDependencies) => {
   const {
     history,
-    core: { i18n, application, http },
+    core: { i18n, application, http, executionContext },
   } = dependencies.services;
+
+  executionContext.set({ type: 'application', page: 'upgradeAssistant' });
 
   return (
     <RedirectAppLinks application={application} className={APP_WRAPPER_CLASS}>


### PR DESCRIPTION
## Summary

Using core provided execution context so we can track and identify which actions are performed while in the Upgrade Assistant management application.

This helps out in the following scenarios:

* Tracing HTTP requests (and requests to Elasticsearch)
* EBT traces
* APM traces

According to existing traces, other management applications already set this same value to identify the management section the user is in. As an example: https://github.com/elastic/kibana/blob/98f73d674a40c09936df6dc1b12fc0337cece614/x-pack/plugins/snapshot_restore/public/application/app.tsx#L48-L51



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
