### PR TITLE
[TIP] Fix integrations discovery for TI PR pipeline

### DIFF
--- a/x-pack/test/threat_intelligence_cypress/runner.ts
+++ b/x-pack/test/threat_intelligence_cypress/runner.ts
@@ -26,7 +26,7 @@ const retrieveIntegrations = (chunksTotal: number, chunkIndex: number) => {
   const integrationsPaths = globby.sync(pattern);
   const chunkSize = Math.ceil(integrationsPaths.length / chunksTotal);
 
-  return chunk(integrationsPaths, chunkSize)[chunkIndex - 1];
+  return chunk(integrationsPaths, chunkSize)[chunkIndex - 1] || [];
 };
 
 export async function ThreatIntelligenceConfigurableCypressTestRunner(


### PR DESCRIPTION
## Summary

Fixed integration discovery in a CI snippet inherited from the Security plugin. Should help with failures on https://github.com/elastic/kibana/pull/145121.
