### PR TITLE
Fix rules management in list details

### DIFF
--- a/x-pack/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
@@ -26,9 +26,14 @@ import { ListExceptionItems } from '..';
 interface ListWithSearchComponentProps {
   list: ExceptionListSchema;
   isReadOnly: boolean;
+  refreshExceptions?: boolean;
 }
 
-const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({ list, isReadOnly }) => {
+const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({
+  list,
+  isReadOnly,
+  refreshExceptions,
+}) => {
   const {
     listName,
     exceptions,
@@ -50,7 +55,7 @@ const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({ list, isRea
     onPaginationChange,
     handleCancelExceptionItemFlyout,
     handleConfirmExceptionFlyout,
-  } = useListWithSearchComponent(list);
+  } = useListWithSearchComponent(list, refreshExceptions);
   return (
     <>
       {showAddExceptionFlyout ? (

--- a/x-pack/plugins/security_solution/public/exceptions/components/manage_rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/components/manage_rules/index.tsx
@@ -27,13 +27,21 @@ import * as i18n from '../../translations';
 interface ManageRulesProps {
   linkedRules: Rule[];
   showButtonLoader?: boolean;
+  saveIsDisabled?: boolean;
   onSave: () => void;
   onCancel: () => void;
   onRuleSelectionChange: (rulesSelectedToAdd: Rule[]) => void;
 }
 
 export const ManageRules: FC<ManageRulesProps> = memo(
-  ({ linkedRules, showButtonLoader, onSave, onCancel, onRuleSelectionChange }) => {
+  ({
+    linkedRules,
+    showButtonLoader,
+    saveIsDisabled = true,
+    onSave,
+    onCancel,
+    onRuleSelectionChange,
+  }) => {
     const complicatedFlyoutTitleId = useGeneratedHtmlId({
       prefix: 'complicatedFlyoutTitle',
     });
@@ -67,7 +75,12 @@ export const ManageRules: FC<ManageRulesProps> = memo(
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton isLoading={showButtonLoader} onClick={onSave} fill>
+              <EuiButton
+                isLoading={showButtonLoader}
+                disabled={saveIsDisabled}
+                onClick={onSave}
+                fill
+              >
                 {i18n.MANAGE_RULES_SAVE}
               </EuiButton>
             </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_exception_items/index.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_exception_items/index.ts
@@ -133,7 +133,6 @@ export const useListExceptionItems = ({
     lastUpdated,
     pagination,
     exceptionViewerStatus: viewerStatus,
-
     ruleReferences: exceptionListReferences,
     fetchItems,
     onDeleteException,

--- a/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_with_search/index.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_with_search/index.ts
@@ -18,10 +18,12 @@ import { ViewerStatus } from '@kbn/securitysolution-exception-list-components';
 import * as i18n from '../../translations';
 import { useListExceptionItems } from '..';
 
-export const useListWithSearchComponent = (list: ExceptionListSchema) => {
+export const useListWithSearchComponent = (
+  list: ExceptionListSchema,
+  refreshExceptions?: boolean
+) => {
   const [showAddExceptionFlyout, setShowAddExceptionFlyout] = useState(false);
   const [showEditExceptionFlyout, setShowEditExceptionFlyout] = useState(false);
-
   const [exceptionToEdit, setExceptionToEdit] = useState<ExceptionListItemSchema>();
   const [viewerStatus, setViewerStatus] = useState<ViewerStatus | string>(ViewerStatus.LOADING);
 
@@ -54,7 +56,7 @@ export const useListWithSearchComponent = (list: ExceptionListSchema) => {
 
   useEffect(() => {
     fetchItems(null, ViewerStatus.LOADING);
-  }, [fetchItems]);
+  }, [fetchItems, refreshExceptions]);
 
   const emptyViewerTitle = useMemo(() => {
     return viewerStatus === ViewerStatus.EMPTY ? i18n.EXCEPTION_LIST_EMPTY_VIEWER_TITLE : '';

--- a/x-pack/plugins/security_solution/public/exceptions/pages/list_detail_view/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/pages/list_detail_view/index.tsx
@@ -40,6 +40,8 @@ export const ListsDetailViewComponent: FC = () => {
     showReferenceErrorModal,
     referenceModalState,
     showManageButtonLoader,
+    refreshExceptions,
+    disableManageButton,
     onEditListDetails,
     onExportList,
     onManageRules,
@@ -76,7 +78,7 @@ export const ListsDetailViewComponent: FC = () => {
       />
 
       <AutoDownload blob={exportedList} name={listId} />
-      <ListWithSearch list={list} isReadOnly={isReadOnly} />
+      <ListWithSearch list={list} refreshExceptions={refreshExceptions} isReadOnly={isReadOnly} />
       <ReferenceErrorModal
         cancelText={i18n.REFERENCE_MODAL_CANCEL_BUTTON}
         confirmText={i18n.REFERENCE_MODAL_CONFIRM_BUTTON}
@@ -91,10 +93,11 @@ export const ListsDetailViewComponent: FC = () => {
       {showManageRulesFlyout ? (
         <ManageRules
           linkedRules={linkedRules as Rule[]}
+          showButtonLoader={showManageButtonLoader}
+          saveIsDisabled={disableManageButton}
           onSave={onSaveManageRules}
           onCancel={onCancelManageRules}
           onRuleSelectionChange={onRuleSelectionChange}
-          showButtonLoader={showManageButtonLoader}
         />
       ) : null}
     </>

--- a/x-pack/plugins/security_solution/public/exceptions/translations/list_details_view.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/translations/list_details_view.ts
@@ -121,13 +121,13 @@ export const MANAGE_RULES_DESCRIPTION = i18n.translate(
 export const DELETE_EXCEPTION_LIST = i18n.translate(
   'xpack.securitySolution.exceptionsTable.deleteExceptionList',
   {
-    defaultMessage: 'Delete Exception List',
+    defaultMessage: 'Delete exception list',
   }
 );
 
 export const EXPORT_EXCEPTION_LIST = i18n.translate(
   'xpack.securitySolution.exceptionsTable.exportExceptionList',
   {
-    defaultMessage: 'Export Exception List',
+    defaultMessage: 'Export exception list',
   }
 );

--- a/x-pack/plugins/security_solution/public/exceptions/translations/shared_list.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/translations/shared_list.ts
@@ -282,14 +282,14 @@ export const EXCEPTIONS = i18n.translate(
 export const CREATE_SHARED_LIST_BUTTON = i18n.translate(
   'xpack.securitySolution.exceptions.manageExceptions.createSharedListButton',
   {
-    defaultMessage: 'create shared list',
+    defaultMessage: 'Create shared list',
   }
 );
 
 export const CREATE_BUTTON_ITEM_BUTTON = i18n.translate(
   'xpack.securitySolution.exceptions.manageExceptions.createItemButton',
   {
-    defaultMessage: 'create exception item',
+    defaultMessage: 'Create exception item',
   }
 );
 


### PR DESCRIPTION
## Summary

Fix rules management in list details, by updating the rules references in the Exceptions cards when the List' rules get updated 

- Disable the Save button in Rule management, until the user changes the rules
-  Add `Refresh exceptions` to trigger fetching the Exceptions in any hook
- Apply Docs comments
- Prevent calling the Backend if the added items equal to the removed items