### PR TITLE
[Cloud Posture] change empty state link to add-integration screen

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '@kbn/cloud-security-posture-plugin/common/constants';
 import { pagePathGetters, pkgKeyFromPackageInfo } from '@kbn/fleet-plugin/public';
 import { useCisKubernetesIntegration } from '../api/use_cis_kubernetes_integration';
 import { useKibana } from '../hooks/use_kibana';
@@ -16,7 +17,8 @@ export const useCISIntegrationLink = (): string | undefined => {
   if (!cisIntegration.isSuccess) return;
 
   const path = pagePathGetters
-    .integration_details_overview({
+    .add_integration_to_policy({
+      integration: CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
       pkgkey: pkgKeyFromPackageInfo({
         name: cisIntegration.data.item.name,
         version: cisIntegration.data.item.version,

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '@kbn/cloud-security-posture-plugin/common/constants';
 import { pagePathGetters, pkgKeyFromPackageInfo } from '@kbn/fleet-plugin/public';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../../common/constants';
 import { useCisKubernetesIntegration } from '../api/use_cis_kubernetes_integration';
 import { useKibana } from '../hooks/use_kibana';
 


### PR DESCRIPTION
fixes #145338


now when users click the empty state link, they will be redirected to the add-integration screen. (instead of the integration page)

https://user-images.githubusercontent.com/20814186/202170572-1b4e0e4f-8f6e-4f96-862f-9d0bb0b929d1.mov


