### PR TITLE
[Cloud Posture] update findings indexing state text

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -77,7 +77,7 @@ const Indexing = () => (
       <h2>
         <FormattedMessage
           id="xpack.csp.noFindingsStates.indexing.indexingButtonTitle"
-          defaultMessage="No Findings Yet"
+          defaultMessage="Posture evaluation underway"
         />
       </h2>
     }


### PR DESCRIPTION
this is a [quick wins](https://docs.google.com/spreadsheets/d/1Bs-_nQkmab1be_6HYZi6B4gA1VSTAcWXYaPYMtmcwJ4/edit#gid=0) task


when users visit the findings page before CSP is done indexing latest findings, we show a text with "No findings yet" which was improved in this PR to a more descriptive text.  
 