### PR TITLE
[Cloud Posture] highlight selected table item

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -112,7 +112,7 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
   const [tab, setTab] = useState<FindingsTab>(tabs[0]);
 
   return (
-    <EuiFlyout ownFocus={false} onClose={onClose}>
+    <EuiFlyout onClose={onClose}>
       <EuiFlyoutHeader>
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
@@ -14,7 +14,6 @@ import {
   type CriteriaWithPagination,
   type EuiTableActionsColumnType,
   type EuiTableFieldDataColumnType,
-  EuiThemeComputed,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CspFinding } from '../../../../common/schemas/csp_finding';

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
@@ -8,11 +8,13 @@ import React, { useMemo, useState } from 'react';
 import {
   EuiEmptyPrompt,
   EuiBasicTable,
+  useEuiTheme,
   type Pagination,
   type EuiBasicTableProps,
   type CriteriaWithPagination,
   type EuiTableActionsColumnType,
   type EuiTableFieldDataColumnType,
+  EuiThemeComputed,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CspFinding } from '../../../../common/schemas/csp_finding';
@@ -24,6 +26,7 @@ import {
   getExpandColumn,
   type OnAddFilter,
 } from '../layout/findings_layout';
+import { getSelectedRowStyle } from '../utils/utils';
 
 type TableProps = Required<EuiBasicTableProps<CspFinding>>;
 
@@ -44,10 +47,12 @@ const FindingsTableComponent = ({
   setTableOptions,
   onAddFilter,
 }: Props) => {
+  const { euiTheme } = useEuiTheme();
   const [selectedFinding, setSelectedFinding] = useState<CspFinding>();
 
   const getRowProps = (row: CspFinding) => ({
     'data-test-subj': TEST_SUBJECTS.getFindingsTableRowTestId(row.resource.id),
+    style: getSelectedRowStyle(euiTheme, row, selectedFinding),
   });
 
   const getCellProps = (row: CspFinding, column: EuiTableFieldDataColumnType<CspFinding>) => ({

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/resource_findings/resource_findings_table.tsx
@@ -13,6 +13,7 @@ import {
   type EuiBasicTableColumn,
   type EuiTableActionsColumnType,
   type EuiBasicTableProps,
+  useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CspFinding } from '../../../../../common/schemas/csp_finding';
@@ -23,6 +24,7 @@ import {
   type OnAddFilter,
 } from '../../layout/findings_layout';
 import { FindingsRuleFlyout } from '../../findings_flyout/findings_flyout';
+import { getSelectedRowStyle } from '../../utils/utils';
 
 interface Props {
   items: CspFinding[];
@@ -41,7 +43,12 @@ const ResourceFindingsTableComponent = ({
   setTableOptions,
   onAddFilter,
 }: Props) => {
+  const { euiTheme } = useEuiTheme();
   const [selectedFinding, setSelectedFinding] = useState<CspFinding>();
+
+  const getRowProps = (row: CspFinding) => ({
+    style: getSelectedRowStyle(euiTheme, row, selectedFinding),
+  });
 
   const columns: [
     EuiTableActionsColumnType<CspFinding>,
@@ -83,6 +90,7 @@ const ResourceFindingsTableComponent = ({
         onChange={setTableOptions}
         pagination={pagination}
         sorting={sorting}
+        rowProps={getRowProps}
       />
       {selectedFinding && (
         <FindingsRuleFlyout

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/utils/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/utils/utils.ts
@@ -6,12 +6,13 @@
  */
 
 import { buildEsQuery, type Query } from '@kbn/es-query';
-import { EuiBasicTableProps, Pagination } from '@elastic/eui';
+import type { EuiBasicTableProps, EuiThemeComputed, Pagination } from '@elastic/eui';
 import { useCallback, useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { estypes } from '@elastic/elasticsearch';
 import type { FindingsBaseProps, FindingsBaseURLQuery } from '../types';
 import { useKibana } from '../../../common/hooks/use_kibana';
+import type { CspFinding } from '../../../../common/schemas/csp_finding';
 export { getFilters } from './get_filters';
 
 const getBaseQuery = ({ dataView, query, filters }: FindingsBaseURLQuery & FindingsBaseProps) => {
@@ -128,3 +129,14 @@ export const getAggregationCount = (buckets: estypes.AggregationsStringRareTerms
     failed: failed?.doc_count || 0,
   };
 };
+
+const isSelectedRow = (row: CspFinding, selected?: CspFinding) =>
+  row.resource.id === selected?.resource.id && row.rule.id === selected?.rule.id;
+
+export const getSelectedRowStyle = (
+  theme: EuiThemeComputed,
+  row: CspFinding,
+  selected?: CspFinding
+): React.CSSProperties => ({
+  background: isSelectedRow(row, selected) ? theme.colors.highlight : undefined,
+});


### PR DESCRIPTION
this is a [quick wins](https://docs.google.com/spreadsheets/d/1Bs-_nQkmab1be_6HYZi6B4gA1VSTAcWXYaPYMtmcwJ4/edit#gid=0) task


this PR updates the `latest_findings` and `resource_findings` tables to match the UX of the rules page to highlight selected row and close the flyout when user clicks outside of the flyout. 

https://user-images.githubusercontent.com/20814186/202179003-cd77b4d5-e32a-4d31-9a0b-3de085b4cf62.mov

