### PR TITLE
[Enterprise Search] Only show specifically enabled filtering features

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/filtering/connector_filtering.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/filtering/connector_filtering.tsx
@@ -31,7 +31,8 @@ import { EditFilteringFlyout } from './edit_filtering_flyout';
 import { FilteringStateCallouts } from './filtering_callouts';
 
 export const ConnectorFiltering: React.FC = () => {
-  const { indexName } = useValues(IndexViewLogic);
+  const { indexName, hasAdvancedFilteringFeature, hasBasicFilteringFeature } =
+    useValues(IndexViewLogic);
   const { applyDraft, setLocalFilteringRules, setLocalAdvancedSnippet, setIsEditing } =
     useActions(ConnectorFilteringLogic);
   const { advancedSnippet, draftState, filteringRules, hasDraft, isEditing } =
@@ -41,6 +42,8 @@ export const ConnectorFiltering: React.FC = () => {
     <>
       {isEditing && (
         <EditFilteringFlyout
+          hasAdvancedFilteringFeature={hasAdvancedFilteringFeature}
+          hasBasicFilteringFeature={hasBasicFilteringFeature}
           revertLocalFilteringRules={() => setLocalFilteringRules(filteringRules)}
           revertLocalAdvancedFiltering={() => setLocalAdvancedSnippet(advancedSnippet)}
           setIsEditing={setIsEditing}
@@ -115,37 +118,39 @@ export const ConnectorFiltering: React.FC = () => {
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiPanel color="plain" hasShadow={false} hasBorder>
-            <EuiFlexGroup direction="column">
-              <EuiFlexItem>
-                <EuiTitle size="s">
-                  <h3>
-                    {i18n.translate(
-                      'xpack.enterpriseSearch.content.index.connector.filtering.basicFiltersTitle',
-                      {
-                        defaultMessage: 'Basic filters',
-                      }
-                    )}
-                  </h3>
-                </EuiTitle>
-                <EuiSpacer />
-                <EuiText size="s">
-                  <p>
-                    {i18n.translate(
-                      'xpack.enterpriseSearch.content.index.connector.filtering.basicFiltersDescription',
-                      {
-                        defaultMessage: 'These filters apply to documents in post-processing.',
-                      }
-                    )}
-                  </p>
-                </EuiText>
-              </EuiFlexItem>
-              <FilteringRulesTable filteringRules={filteringRules} showOrder />
-            </EuiFlexGroup>
-          </EuiPanel>
-        </EuiFlexItem>
-        {!!advancedSnippet && (
+        {hasBasicFilteringFeature && (
+          <EuiFlexItem>
+            <EuiPanel color="plain" hasShadow={false} hasBorder>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <EuiTitle size="s">
+                    <h3>
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.index.connector.filtering.basicFiltersTitle',
+                        {
+                          defaultMessage: 'Basic filters',
+                        }
+                      )}
+                    </h3>
+                  </EuiTitle>
+                  <EuiSpacer />
+                  <EuiText size="s">
+                    <p>
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.index.connector.filtering.basicFiltersDescription',
+                        {
+                          defaultMessage: 'These filters apply to documents in post-processing.',
+                        }
+                      )}
+                    </p>
+                  </EuiText>
+                </EuiFlexItem>
+                <FilteringRulesTable filteringRules={filteringRules} showOrder />
+              </EuiFlexGroup>
+            </EuiPanel>
+          </EuiFlexItem>
+        )}
+        {hasAdvancedFilteringFeature && !!advancedSnippet && (
           <EuiFlexItem>
             <EuiPanel color="plain" hasShadow={false} hasBorder>
               <EuiFlexGroup direction="column">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/filtering/edit_filtering_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/filtering/edit_filtering_flyout.tsx
@@ -23,6 +23,8 @@ import { EditFilteringTab } from './edit_filtering_tab';
 import { FilteringRulesTable } from './editable_filtering_rules_table';
 
 interface EditFilteringFlyoutProps {
+  hasAdvancedFilteringFeature: boolean;
+  hasBasicFilteringFeature: boolean;
   revertLocalAdvancedFiltering: () => void;
   revertLocalFilteringRules: () => void;
   setIsEditing: (value: boolean) => void;
@@ -34,39 +36,49 @@ enum FilteringTabs {
 }
 
 export const EditFilteringFlyout: React.FC<EditFilteringFlyoutProps> = ({
+  hasAdvancedFilteringFeature,
+  hasBasicFilteringFeature,
   revertLocalFilteringRules,
   revertLocalAdvancedFiltering,
   setIsEditing,
 }) => {
   const tabs: EuiTabbedContentTab[] = [
-    {
-      content: (
-        <EditFilteringTab revertAction={revertLocalFilteringRules}>
-          <FilteringRulesTable />
-        </EditFilteringTab>
-      ),
-      id: FilteringTabs.BASIC,
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.index.connector.filtering.basicTabTitle',
-        {
-          defaultMessage: 'Basic filters',
-        }
-      ),
-    },
-    {
-      content: (
-        <EditFilteringTab revertAction={revertLocalAdvancedFiltering}>
-          <AdvancedFilteringRules />
-        </EditFilteringTab>
-      ),
-      id: FilteringTabs.ADVANCED,
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.index.connector.filtering.advancedTabTitle',
-        {
-          defaultMessage: 'Advanced filters',
-        }
-      ),
-    },
+    ...(hasBasicFilteringFeature
+      ? [
+          {
+            content: (
+              <EditFilteringTab revertAction={revertLocalFilteringRules}>
+                <FilteringRulesTable />
+              </EditFilteringTab>
+            ),
+            id: FilteringTabs.BASIC,
+            name: i18n.translate(
+              'xpack.enterpriseSearch.content.index.connector.filtering.basicTabTitle',
+              {
+                defaultMessage: 'Basic filters',
+              }
+            ),
+          },
+        ]
+      : []),
+    ...(hasAdvancedFilteringFeature
+      ? [
+          {
+            content: (
+              <EditFilteringTab revertAction={revertLocalAdvancedFiltering}>
+                <AdvancedFilteringRules />
+              </EditFilteringTab>
+            ),
+            id: FilteringTabs.ADVANCED,
+            name: i18n.translate(
+              'xpack.enterpriseSearch.content.index.connector.filtering.advancedTabTitle',
+              {
+                defaultMessage: 'Advanced filters',
+              }
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (


### PR DESCRIPTION
This hides a specific filtering feature from the user if it's not enabled for the connector they're using.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->