### PR TITLE
[Dashboard] Use Shared UX ExitFullScreen button

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -31,6 +31,7 @@ import {
 import type { Query } from '@kbn/es-query';
 import type { RefreshInterval } from '@kbn/data-plugin/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import { ExitFullScreenButtonKibanaProvider } from '@kbn/shared-ux-button-exit-full-screen';
 
 import { DASHBOARD_CONTAINER_TYPE } from '../../dashboard_constants';
 import { createPanelState } from './panel';
@@ -86,6 +87,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
 
   /** Services that are used in the Dashboard container code */
   private analyticsService;
+  private chrome;
   private theme$;
 
   /**
@@ -146,6 +148,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       settings: {
         theme: { theme$: this.theme$ },
       },
+      chrome: this.chrome,
     } = pluginServices.getServices());
 
     if (
@@ -323,11 +326,13 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     ReactDOM.render(
       <I18nProvider>
         <KibanaThemeProvider theme$={this.theme$}>
-          <DashboardViewport
-            container={this}
-            controlGroup={this.controlGroup}
-            onDataLoaded={this.onDataLoaded.bind(this)}
-          />
+          <ExitFullScreenButtonKibanaProvider coreStart={{ chrome: this.chrome }}>
+            <DashboardViewport
+              container={this}
+              controlGroup={this.controlGroup}
+              onDataLoaded={this.onDataLoaded.bind(this)}
+            />
+          </ExitFullScreenButtonKibanaProvider>
         </KibanaThemeProvider>
       </I18nProvider>,
       dom

--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
@@ -17,8 +17,7 @@ import {
 import { ViewMode } from '@kbn/embeddable-plugin/public';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import { context } from '@kbn/kibana-react-plugin/public';
-import { ExitFullScreenButton as ExitFullScreenButtonUi } from '@kbn/kibana-react-plugin/public';
-import { CoreStart } from '@kbn/core/public';
+import { ExitFullScreenButton } from '@kbn/shared-ux-button-exit-full-screen';
 
 import { DashboardContainer, DashboardLoadedInfo } from '../dashboard_container';
 import { DashboardGrid } from '../grid';
@@ -106,7 +105,6 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
 
     const {
       settings: { isProjectEnabledInLabs, uiSettings },
-      chrome,
     } = pluginServices.getServices();
     const controlsEnabled = isProjectEnabledInLabs('labs:dashboard:dashboardControls');
 
@@ -147,10 +145,8 @@ export class DashboardViewport extends React.Component<DashboardViewportProps, S
           className={useMargins ? 'dshDashboardViewport-withMargins' : 'dshDashboardViewport'}
         >
           {isFullScreenMode && (
-            // TODO: Replace with Shared UX ExitFullScreenButton once https://github.com/elastic/kibana/issues/140311 is resolved
-            <ExitFullScreenButtonUi
-              chrome={chrome as CoreStart['chrome']}
-              onExitFullScreenMode={this.onExitFullScreenMode}
+            <ExitFullScreenButton
+              onExit={this.onExitFullScreenMode}
               toggleChrome={!isEmbeddedExternally}
             />
           )}

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -75,7 +75,7 @@ export class DashboardPageObject extends FtrService {
   public async clickFullScreenMode() {
     this.log.debug(`clickFullScreenMode`);
     await this.testSubjects.click('dashboardFullScreenMode');
-    await this.testSubjects.exists('exitFullScreenModeLogo');
+    await this.testSubjects.exists('exitFullScreenModeButton');
     await this.waitForRenderComplete();
   }
 
@@ -99,17 +99,15 @@ export class DashboardPageObject extends FtrService {
   }
 
   public async exitFullScreenLogoButtonExists() {
-    // TODO: Replace every instance of `exitFullScreenModeLogo` with `exitFullScreenModeButton` once the new Shared UX
-    // full screen button can be used (i.e. after https://github.com/elastic/kibana/issues/140311 is resolved)
-    return await this.testSubjects.exists('exitFullScreenModeLogo');
+    return await this.testSubjects.exists('exitFullScreenModeButton');
   }
 
   public async getExitFullScreenLogoButton() {
-    return await this.testSubjects.find('exitFullScreenModeLogo');
+    return await this.testSubjects.find('exitFullScreenModeButton');
   }
 
   public async clickExitFullScreenLogoButton() {
-    await this.testSubjects.click('exitFullScreenModeLogo');
+    await this.testSubjects.click('exitFullScreenModeButton');
     await this.waitForRenderComplete();
   }
 


### PR DESCRIPTION
## Summary

Replaces the deprecated ExitFullScreenButton with the Shared UX ExitFullScreenButton. 

I was perusing code and saw that https://github.com/elastic/kibana/issues/140311 was fixed. So I saw a quick fix to replace the deprecated component with the new and improved component.
