### PR TITLE
[RAM] Return rules from bulk enable

### DIFF
--- a/x-pack/plugins/alerting/server/routes/bulk_enable_rules.test.ts
+++ b/x-pack/plugins/alerting/server/routes/bulk_enable_rules.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe('bulkEnableRulesRoute', () => {
   const bulkEnableRequest = { filter: '' };
-  const bulkEnableResult = { errors: [], total: 1, taskIdsFailedToBeEnabled: [] };
+  const bulkEnableResult = { errors: [], rules: [], total: 1, taskIdsFailedToBeEnabled: [] };
 
   it('should enable rules with proper parameters', async () => {
     const licenseState = licenseStateMock.create();

--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -2650,7 +2650,7 @@ export class RulesClient {
       action: 'ENABLE',
     });
 
-    const { errors, taskIdsToEnable } = await retryIfBulkEnableConflicts(
+    const { errors, rules, taskIdsToEnable } = await retryIfBulkEnableConflicts(
       this.logger,
       (filterKueryNode: KueryNode | null) =>
         this.bulkEnableRulesWithOCC({ filter: filterKueryNode }),
@@ -2679,7 +2679,17 @@ export class RulesClient {
       }
     }
 
-    return { errors, total, taskIdsFailedToBeEnabled };
+    const updatedRules = rules.map(({ id, attributes, references }) => {
+      return this.getAlertFromRaw(
+        id,
+        attributes.alertTypeId as string,
+        attributes as RawRule,
+        references,
+        false
+      );
+    });
+
+    return { errors, rules: updatedRules, total, taskIdsFailedToBeEnabled };
   };
 
   private bulkEnableRulesWithOCC = async ({ filter }: { filter: KueryNode | null }) => {
@@ -2693,7 +2703,7 @@ export class RulesClient {
         }
       );
 
-    const rulesToEnable: SavedObjectsBulkUpdateObject[] = [];
+    const rulesToEnable: Array<SavedObjectsBulkUpdateObject<RawRule>> = [];
     const taskIdsToEnable: string[] = [];
     const errors: BulkOperationError[] = [];
     const taskIdToRuleIdMapping: Record<string, string> = {};
@@ -2788,11 +2798,14 @@ export class RulesClient {
       overwrite: true,
     });
 
+    const rules: Array<SavedObjectsBulkUpdateObject<RawRule>> = [];
+
     result.saved_objects.forEach((rule) => {
       if (rule.error === undefined) {
         if (taskIdToRuleIdMapping[rule.id]) {
           taskIdsToEnable.push(taskIdToRuleIdMapping[rule.id]);
         }
+        rules.push(rule);
       } else {
         errors.push({
           message: rule.error.message ?? 'n/a',
@@ -2804,7 +2817,7 @@ export class RulesClient {
         });
       }
     });
-    return { errors, taskIdsToEnable };
+    return { errors, rules, taskIdsToEnable };
   };
 
   private apiKeyAsAlertAttributes(

--- a/x-pack/plugins/alerting/server/rules_client/tests/bulk_enable.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/bulk_enable.test.ts
@@ -153,10 +153,16 @@ describe('bulkEnableRules', () => {
         {
           id: 'id1',
           version: '1',
+          attributes: {
+            alertTypeId: '.index-threshold',
+          },
         } as SavedObject,
         {
           id: 'id2',
           version: '1',
+          attributes: {
+            alertTypeId: '.index-threshold',
+          },
         } as SavedObject,
       ],
     });
@@ -186,6 +192,26 @@ describe('bulkEnableRules', () => {
     expect(taskManager.bulkEnable).toHaveBeenCalledWith(['taskId1', 'taskId2']);
     expect(result).toStrictEqual({
       errors: [],
+      rules: [
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id1',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id2',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+      ],
       total: 2,
       taskIdsFailedToBeEnabled: [],
     });
@@ -197,6 +223,9 @@ describe('bulkEnableRules', () => {
         {
           id: 'id1',
           version: '1',
+          attributes: {
+            alertTypeId: '.index-threshold',
+          },
         } as SavedObject,
         {
           id: 'id2',
@@ -229,6 +258,17 @@ describe('bulkEnableRules', () => {
     expect(taskManager.bulkEnable).toHaveBeenCalledWith(['taskId1']);
     expect(result).toStrictEqual({
       errors: [{ message: 'UPS', rule: { id: 'id2', name: 'fakeName' }, status: 500 }],
+      rules: [
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id1',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+      ],
       total: 2,
       taskIdsFailedToBeEnabled: [],
     });
@@ -241,6 +281,9 @@ describe('bulkEnableRules', () => {
           {
             id: 'id1',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
           {
             id: 'id2',
@@ -308,6 +351,17 @@ describe('bulkEnableRules', () => {
     expect(taskManager.bulkEnable).toHaveBeenCalledWith(['taskId1']);
     expect(result).toStrictEqual({
       errors: [{ message: 'UPS', rule: { id: 'id2', name: 'fakeName' }, status: 409 }],
+      rules: [
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id1',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+      ],
       total: 2,
       taskIdsFailedToBeEnabled: [],
     });
@@ -320,6 +374,9 @@ describe('bulkEnableRules', () => {
           {
             id: 'id1',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
           {
             id: 'id2',
@@ -337,6 +394,9 @@ describe('bulkEnableRules', () => {
           {
             id: 'id2',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
         ],
       });
@@ -369,6 +429,26 @@ describe('bulkEnableRules', () => {
     expect(taskManager.bulkEnable).toHaveBeenCalledWith(['taskId1', 'taskId2']);
     expect(result).toStrictEqual({
       errors: [],
+      rules: [
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id1',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id2',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+      ],
       total: 2,
       taskIdsFailedToBeEnabled: [],
     });
@@ -414,20 +494,12 @@ describe('bulkEnableRules', () => {
     });
 
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
-      saved_objects: [
-        {
-          id: 'id1',
-          version: '1',
-        } as SavedObject,
-        {
-          id: 'id2',
-          version: '1',
-        } as SavedObject,
-      ],
+      saved_objects: [],
     });
 
     const result = await rulesClient.bulkEnableRules({ filter: 'fake_filter' });
 
+    expect(unsecuredSavedObjectsClient.bulkCreate).toBeCalledWith([], { overwrite: true });
     expect(result).toStrictEqual({
       errors: [
         {
@@ -439,6 +511,7 @@ describe('bulkEnableRules', () => {
           rule: { id: 'id2', name: 'fakeName' },
         },
       ],
+      rules: [],
       taskIdsFailedToBeEnabled: [],
       total: 2,
     });
@@ -459,10 +532,16 @@ describe('bulkEnableRules', () => {
         {
           id: 'id1',
           version: '1',
+          attributes: {
+            alertTypeId: '.index-threshold',
+          },
         } as SavedObject,
         {
           id: 'id2',
           version: '1',
+          attributes: {
+            alertTypeId: '.index-threshold',
+          },
         } as SavedObject,
       ],
     });
@@ -486,6 +565,26 @@ describe('bulkEnableRules', () => {
     expect(taskManager.bulkEnable).toHaveBeenCalledWith(['taskId1']);
     expect(result).toStrictEqual({
       errors: [],
+      rules: [
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id1',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+        {
+          actions: [],
+          alertTypeId: '.index-threshold',
+          id: 'id2',
+          notifyWhen: undefined,
+          params: undefined,
+          schedule: undefined,
+          snoozeSchedule: [],
+        },
+      ],
       total: 2,
       taskIdsFailedToBeEnabled: [],
     });
@@ -498,10 +597,16 @@ describe('bulkEnableRules', () => {
           {
             id: 'id1',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
           {
             id: 'id2',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
         ],
       });
@@ -532,6 +637,26 @@ describe('bulkEnableRules', () => {
       );
       expect(result).toStrictEqual({
         errors: [],
+        rules: [
+          {
+            actions: [],
+            alertTypeId: '.index-threshold',
+            id: 'id1',
+            notifyWhen: undefined,
+            params: undefined,
+            schedule: undefined,
+            snoozeSchedule: [],
+          },
+          {
+            actions: [],
+            alertTypeId: '.index-threshold',
+            id: 'id2',
+            notifyWhen: undefined,
+            params: undefined,
+            schedule: undefined,
+            snoozeSchedule: [],
+          },
+        ],
         total: 2,
         taskIdsFailedToBeEnabled: ['taskId2'],
       });
@@ -543,10 +668,16 @@ describe('bulkEnableRules', () => {
           {
             id: 'id1',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
           {
             id: 'id2',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
         ],
       });
@@ -562,6 +693,26 @@ describe('bulkEnableRules', () => {
       );
       expect(result).toStrictEqual({
         errors: [],
+        rules: [
+          {
+            actions: [],
+            alertTypeId: '.index-threshold',
+            id: 'id1',
+            notifyWhen: undefined,
+            params: undefined,
+            schedule: undefined,
+            snoozeSchedule: [],
+          },
+          {
+            actions: [],
+            alertTypeId: '.index-threshold',
+            id: 'id2',
+            notifyWhen: undefined,
+            params: undefined,
+            schedule: undefined,
+            snoozeSchedule: [],
+          },
+        ],
         taskIdsFailedToBeEnabled: ['taskId1', 'taskId2'],
         total: 2,
       });
@@ -577,6 +728,9 @@ describe('bulkEnableRules', () => {
           {
             id: 'id1',
             version: '1',
+            attributes: {
+              alertTypeId: '.index-threshold',
+            },
           } as SavedObject,
         ],
       });

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_enable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_enable.ts
@@ -21,7 +21,7 @@ export default ({ getService }: FtrProviderContext) => {
   describe('bulkEnableRules', () => {
     const objectRemover = new ObjectRemover(supertest);
 
-    after(() => objectRemover.removeAll());
+    afterEach(() => objectRemover.removeAll());
 
     const getScheduledTask = async (id: string) => {
       return await es.get({
@@ -40,7 +40,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: createdRule } = await supertest
             .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
             .set('kbn-xsrf', 'foo')
-            .send(getTestRuleData())
+            .send({ ...getTestRuleData(), enabled: false })
             .expect(200);
 
           const response = await supertestWithoutAuth
@@ -73,15 +73,49 @@ export default ({ getService }: FtrProviderContext) => {
             case 'superuser at space1':
             case 'space_1_all at space1':
             case 'space_1_all_with_restricted_fixture at space1':
-              expect(response.body).to.eql(defaultSuccessfulResponse);
               expect(response.statusCode).to.eql(200);
+              expect(response.body).to.eql({
+                total: 1,
+                rules: [
+                  {
+                    id: response.body.rules[0].id,
+                    notifyWhen: 'onThrottleInterval',
+                    enabled: true,
+                    name: 'abc',
+                    tags: ['foo'],
+                    consumer: 'alertsFixture',
+                    throttle: '1m',
+                    alertTypeId: 'test.noop',
+                    apiKeyOwner: response.body.rules[0].apiKeyOwner,
+                    createdBy: 'elastic',
+                    updatedBy: response.body.rules[0].updatedBy,
+                    muteAll: false,
+                    mutedInstanceIds: [],
+                    schedule: { interval: '1m' },
+                    actions: [],
+                    params: {},
+                    snoozeSchedule: [],
+                    updatedAt: response.body.rules[0].updatedAt,
+                    createdAt: response.body.rules[0].createdAt,
+                    scheduledTaskId: response.body.rules[0].scheduledTaskId,
+                    executionStatus: {
+                      lastDuration: 0,
+                      lastExecutionDate: response.body.rules[0].executionStatus.lastExecutionDate,
+                      status: 'pending',
+                    },
+                    monitoring: response.body.rules[0].monitoring,
+                  },
+                ],
+                errors: [],
+                taskIdsFailedToBeEnabled: [],
+              });
               break;
             default:
               throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
           }
         });
 
-        it('should handle bulk enable of one rule appropriately based on id  when consumer is the same as producer', async () => {
+        it('should handle bulk enable of one rule appropriately based on id when consumer is the same as producer', async () => {
           const { body: createdRule } = await supertest
             .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
             .set('kbn-xsrf', 'foo')

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_enable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_enable.ts
@@ -10,7 +10,7 @@ import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../scenarios';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 
-const defaultSuccessfulResponse = { total: 1, errors: [], taskIdsFailedToBeEnabled: [] };
+const defaultSuccessfulResponse = { total: 1, rules: [], errors: [], taskIdsFailedToBeEnabled: [] };
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {


### PR DESCRIPTION
Solves issue: https://github.com/elastic/kibana/issues/144941

## Summary

Now we return the actual rules which have been enabled like in bulkEnable API response. We are doing it for security solution to align with what they have now

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
