### PR TITLE
[Renderers] always include baseTheme with charts theme

### DIFF
--- a/src/plugins/chart_expressions/expression_gauge/public/components/__snapshots__/gauge_component.test.tsx.snap
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/__snapshots__/gauge_component.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`GaugeComponent renders the chart 1`] = `
 >
   <Settings
     ariaUseDefaultSummary={true}
+    baseTheme={Object {}}
     debugState={false}
     noResults={
       <EmptyPlaceholder

--- a/src/plugins/chart_expressions/expression_gauge/public/components/gauge_component.tsx
+++ b/src/plugins/chart_expressions/expression_gauge/public/components/gauge_component.tsx
@@ -354,6 +354,7 @@ export const GaugeComponent: FC<GaugeRenderProps> = memo(
             noResults={<EmptyPlaceholder icon={icon} renderComplete={onRenderChange} />}
             debugState={window._echDebugStateFlag ?? false}
             theme={[{ background: { color: 'transparent' } }, chartTheme]}
+            baseTheme={chartsThemeService.useChartsBaseTheme()}
             ariaLabel={args.ariaLabel}
             ariaUseDefaultSummary={!args.ariaLabel}
             onRenderChange={onRenderChange}

--- a/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
@@ -589,6 +589,7 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
               debugState={window._echDebugStateFlag ?? false}
               tooltip={tooltip}
               theme={[themeOverrides, chartTheme]}
+              baseTheme={chartsThemeService.useChartsBaseTheme()}
               xDomain={{
                 min:
                   dateHistogramMeta && dateHistogramMeta.timeRange

--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -336,9 +336,11 @@ export const MetricVis = ({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollDimensions = useResizeObserver(scrollContainerRef.current);
 
+  const baseTheme = getThemeService().useChartsBaseTheme();
+
   const {
     metric: { minHeight },
-  } = getThemeService().useChartsBaseTheme();
+  } = baseTheme;
 
   useEffect(() => {
     const minimumRequiredVerticalSpace = minHeight * grid.length;
@@ -377,6 +379,7 @@ export const MetricVis = ({
               },
               chartTheme,
             ]}
+            baseTheme={baseTheme}
             onRenderChange={onRenderChange}
             onElementClick={(events) => {
               if (!filterable) {

--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -338,9 +338,7 @@ export const MetricVis = ({
 
   const baseTheme = getThemeService().useChartsBaseTheme();
 
-  const {
-    metric: { minHeight },
-  } = baseTheme;
+  const minHeight = chartTheme.metric?.minHeight ?? baseTheme.metric.minHeight;
 
   useEffect(() => {
     const minimumRequiredVerticalSpace = minHeight * grid.length;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/145308

In accordance with [the docs](https://github.com/elastic/kibana/blob/main/src/plugins/charts/public/services/theme/README.md) we should always provide both `baseTheme` and `theme` to the `Settings` component.

Before: 
<img width="995" alt="Screen Shot 2022-11-16 at 1 00 46 PM" src="https://user-images.githubusercontent.com/315764/202269953-5ce12105-8a1d-4c21-b917-677cd1590320.png">

After:
<img width="987" alt="Screen Shot 2022-11-16 at 1 01 25 PM" src="https://user-images.githubusercontent.com/315764/202269951-b8325a44-cbba-4d05-9a3a-e30acb42ec88.png">



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->