### PR TITLE
Don't show "You have not been authorized to create any Rule types" message while request to get rule types is in flight

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
@@ -872,7 +872,7 @@ const NoAuthorizedRuleTypes = ({ operation }: { operation: string }) => (
       <h2>
         <FormattedMessage
           id="xpack.triggersActionsUI.sections.ruleForm.error.noAuthorizedRuleTypesTitle"
-          defaultMessage="You have not been authorized to {operation} any Rule types"
+          defaultMessage="You have not been authorized to {operation} any rule types"
           values={{ operation }}
         />
       </h2>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
@@ -169,6 +169,7 @@ export const RuleForm = ({
     ruleTypes,
     error: loadRuleTypesError,
     ruleTypeIndex,
+    ruleTypesIsLoading,
   } = useLoadRuleTypes({ filteredRuleTypes: ruleTypeToFilter });
 
   // load rule types
@@ -848,7 +849,7 @@ export const RuleForm = ({
           ) : null}
           {ruleTypeNodes}
         </>
-      ) : ruleTypeIndex ? (
+      ) : ruleTypeIndex && !ruleTypesIsLoading ? (
         <NoAuthorizedRuleTypes operation={operation} />
       ) : (
         <SectionLoading>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/145396.

## Summary

This PR makes sure `/api/alerting/rule_types` is done loading before it shows the available rules. Therefore, the UI will not default anymore to the "You have not been authorized to create any Rule types" message while the request is in flight.

https://user-images.githubusercontent.com/535564/202234522-2f6ff306-0fce-488b-9f18-249e0893c96f.mov



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->