### PR TITLE
[Cloud Posture] add navigate to findings column in rules page

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -10,6 +10,7 @@ import { Query } from '@kbn/es-query';
 import { findingsNavigation } from '../navigation/constants';
 import { encodeQuery } from '../navigation/query_utils';
 import { FindingsBaseURLQuery } from '../../pages/findings/types';
+import { useCallback } from 'react';
 
 const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery, 'query'> => {
   const query =
@@ -35,12 +36,15 @@ const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery
 export const useNavigateFindings = () => {
   const history = useHistory();
 
-  return (query?: Query['query']) => {
-    history.push({
-      pathname: findingsNavigation.findings_default.path,
-      ...(query && { search: encodeQuery(getFindingsQuery(query)) }),
-    });
-  };
+  return useCallback(
+    (query?: Query['query']) => {
+      history.push({
+        pathname: findingsNavigation.findings_default.path,
+        ...(query && { search: encodeQuery(getFindingsQuery(query)) }),
+      });
+    },
+    [history.push]
+  );
 };
 
 export const useNavigateFindingsByResource = () => {

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -7,10 +7,10 @@
 
 import { useHistory } from 'react-router-dom';
 import { Query } from '@kbn/es-query';
+import { useCallback } from 'react';
 import { findingsNavigation } from '../navigation/constants';
 import { encodeQuery } from '../navigation/query_utils';
 import { FindingsBaseURLQuery } from '../../pages/findings/types';
-import { useCallback } from 'react';
 
 const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery, 'query'> => {
   const query =

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -43,7 +43,7 @@ export const useNavigateFindings = () => {
         ...(query && { search: encodeQuery(getFindingsQuery(query)) }),
       });
     },
-    [history.push]
+    [history]
   );
 };
 


### PR DESCRIPTION
this is a [quick wins](https://docs.google.com/spreadsheets/d/1Bs-_nQkmab1be_6HYZi6B4gA1VSTAcWXYaPYMtmcwJ4/edit#gid=0) task


added an icon column in rules page to navigate to a specific rule's findings:

https://user-images.githubusercontent.com/20814186/202260366-4fef7a65-976c-4e6f-b909-243a6bc8c26c.mov

