### PR TITLE
change remote cluster from data to ftr-remote

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/ccs/ccs_console.js
+++ b/x-pack/test/stack_functional_integration/apps/ccs/ccs_console.js
@@ -28,12 +28,12 @@ export default function ({ getService, getPageObjects }) {
       });
       it('it should be able to access remote data', async () => {
         await PageObjects.console.enterRequest(
-          '\nGET data:makelogs工程-*/_search\n {\n "query": {\n "bool": {\n "must": [\n {"match": {"extension" : "jpg"'
+          '\nGET ftr-remote:makelogs工程-*/_search\n {\n "query": {\n "bool": {\n "must": [\n {"match": {"extension" : "jpg"'
         );
         await PageObjects.console.clickPlay();
         await retry.try(async () => {
           const actualResponse = await PageObjects.console.getResponse();
-          expect(actualResponse).to.contain('"_index": "data:makelogs工程-0"');
+          expect(actualResponse).to.contain('"_index": "ftr-remote:makelogs工程-0"');
         });
       });
     });

--- a/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
+++ b/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
@@ -124,7 +124,9 @@ export default ({ getService, getPageObjects }) => {
       log.debug(
         'create comma separated index patterns for ftr-remote and local makelogs工程 index pattern'
       );
-      await PageObjects.settings.createIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.settings.createIndexPattern(
+        'ftr-remote:makelogs工程-*,local:makelogs工程-*'
+      );
       const patternName = await PageObjects.settings.getIndexPageHeading();
       expect(patternName).to.be('ftr-remote:makelogs工程-*,local:makelogs工程-*');
     });
@@ -167,7 +169,9 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('ftr-remote:makelogs-star,local:makelogs-star should discover data from both clusters', async function () {
-      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.discover.selectIndexPattern(
+        'ftr-remote:makelogs工程-*,local:makelogs工程-*'
+      );
       await retry.tryForTime(40000, async () => {
         const hitCount = await PageObjects.discover.getHitCount();
         log.debug('### hit count = ' + hitCount);
@@ -176,7 +180,9 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should reload the saved search with persisted query to show the initial hit count', async function () {
-      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.discover.selectIndexPattern(
+        'ftr-remote:makelogs工程-*,local:makelogs工程-*'
+      );
       // apply query some changes
       await queryBar.setQuery('success');
       await queryBar.submitQuery();
@@ -190,7 +196,9 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should add a phrases filter', async function () {
-      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.discover.selectIndexPattern(
+        'ftr-remote:makelogs工程-*,local:makelogs工程-*'
+      );
       const hitCountNumber = await PageObjects.discover.getHitCount();
       const originalHitCount = parseInt(hitCountNumber.replace(/\,/g, ''));
       await filterBar.addFilter('extension.keyword', 'is', 'jpg');

--- a/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
+++ b/x-pack/test/stack_functional_integration/apps/ccs/ccs_discover.js
@@ -113,20 +113,20 @@ export default ({ getService, getPageObjects }) => {
       expect(patternName).to.be('local:makelogs工程*');
     });
 
-    it('create remote data makelogs index pattern', async () => {
-      log.debug('create remote data makelogs工程 index pattern');
-      await PageObjects.settings.createIndexPattern('data:makelogs工程*');
+    it('create ftr-remote makelogs index pattern', async () => {
+      log.debug('create ftr-remote makelogs工程 index pattern');
+      await PageObjects.settings.createIndexPattern('ftr-remote:makelogs工程*');
       const patternName = await PageObjects.settings.getIndexPageHeading();
-      expect(patternName).to.be('data:makelogs工程*');
+      expect(patternName).to.be('ftr-remote:makelogs工程*');
     });
 
-    it('create comma separated index patterns for data and local makelogs index pattern', async () => {
+    it('create comma separated index patterns for ftr-remote and local makelogs index pattern', async () => {
       log.debug(
-        'create comma separated index patterns for data and local makelogs工程 index pattern'
+        'create comma separated index patterns for ftr-remote and local makelogs工程 index pattern'
       );
-      await PageObjects.settings.createIndexPattern('data:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.settings.createIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
       const patternName = await PageObjects.settings.getIndexPageHeading();
-      expect(patternName).to.be('data:makelogs工程-*,local:makelogs工程-*');
+      expect(patternName).to.be('ftr-remote:makelogs工程-*,local:makelogs工程-*');
     });
 
     it('create index pattern for data from both clusters', async () => {
@@ -147,8 +147,8 @@ export default ({ getService, getPageObjects }) => {
       });
     });
 
-    it('data:makelogs(star) should discover data from remote', async function () {
-      await PageObjects.discover.selectIndexPattern('data:makelogs工程*');
+    it('ftr-remote:makelogs(star) should discover data from remote', async function () {
+      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程*');
       await retry.tryForTime(40000, async () => {
         const hitCount = await PageObjects.discover.getHitCount();
         log.debug('### hit count = ' + hitCount);
@@ -166,8 +166,8 @@ export default ({ getService, getPageObjects }) => {
       });
     });
 
-    it('data:makelogs-star,local:makelogs-star should discover data from both clusters', async function () {
-      await PageObjects.discover.selectIndexPattern('data:makelogs工程-*,local:makelogs工程-*');
+    it('ftr-remote:makelogs-star,local:makelogs-star should discover data from both clusters', async function () {
+      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
       await retry.tryForTime(40000, async () => {
         const hitCount = await PageObjects.discover.getHitCount();
         log.debug('### hit count = ' + hitCount);
@@ -176,7 +176,7 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should reload the saved search with persisted query to show the initial hit count', async function () {
-      await PageObjects.discover.selectIndexPattern('data:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
       // apply query some changes
       await queryBar.setQuery('success');
       await queryBar.submitQuery();
@@ -190,7 +190,7 @@ export default ({ getService, getPageObjects }) => {
     });
 
     it('should add a phrases filter', async function () {
-      await PageObjects.discover.selectIndexPattern('data:makelogs工程-*,local:makelogs工程-*');
+      await PageObjects.discover.selectIndexPattern('ftr-remote:makelogs工程-*,local:makelogs工程-*');
       const hitCountNumber = await PageObjects.discover.getHitCount();
       const originalHitCount = parseInt(hitCountNumber.replace(/\,/g, ''));
       await filterBar.addFilter('extension.keyword', 'is', 'jpg');


### PR DESCRIPTION
## Summary

This change is for CCS tests which only run in integration-test jobs.  This change aligns the name of the remote cluster to ftr-remote so that integration test can run all the existing CCS tests.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->