### PR TITLE
use functional/config.ccs.ts for stack_integration_tests

### DIFF
--- a/x-pack/test/stack_functional_integration/configs/config.stack_functional_integration_base.js
+++ b/x-pack/test/stack_functional_integration/configs/config.stack_functional_integration_base.js
@@ -28,12 +28,12 @@ const prepend = (testFile) => require.resolve(`${testsFolder}/${testFile}`);
 
 export default async ({ readConfigFile }) => {
   const apiConfig = await readConfigFile(require.resolve('../../api_integration/config'));
-  const xpackFunctionalConfig = await readConfigFile(
-    require.resolve('../../functional/config.base.js')
-  );
   const externalConf = consumeState(resolve(__dirname, stateFilePath)) ?? {
     TESTS_LIST: 'alerts',
   };
+  const xpackFunctionalConfig = await readConfigFile(
+    require.resolve('../../functional/config.ccs.ts')
+  );
   process.env.stack_functional_integration = true;
   logAll(log);
 


### PR DESCRIPTION
## Summary

This change allows us to run existing CCS tests [from the integration-test repo](https://github.com/elastic/integration-test/pull/605/files#diff-811a81d3275bfe45c4f93a1efc06d6977d581559c0e1248cd98f565f85a95109R72), specifically from 
`kibana/x-pack/test/stack_functional_integration/configs/config.stack_functional_integration_base.js`.

This change includes swapping the order of loading the variables from  qa/envvars/sh file and calling the ccs config so that the ccs config file sees that we have `REMOTE_CLUSTER_URL` set

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->