### PR TITLE
[Synthetics] Update monitor detail data on refresh

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_journey_steps.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_journey_steps.tsx
@@ -11,7 +11,7 @@ import { isStepEnd } from '../../common/monitor_test_result/browser_steps_list';
 import { JourneyStep, SyntheticsJourneyApiResponse } from '../../../../../../common/runtime_types';
 import { fetchJourneySteps } from '../../../state';
 
-export const useJourneySteps = (checkGroup?: string) => {
+export const useJourneySteps = (checkGroup?: string, lastRefresh?: number) => {
   const { stepIndex } = useParams<{ stepIndex: string }>();
   const { checkGroupId: urlCheckGroup } = useParams<{ checkGroupId: string }>();
 
@@ -23,7 +23,7 @@ export const useJourneySteps = (checkGroup?: string) => {
     }
 
     return fetchJourneySteps({ checkGroup: checkGroupId });
-  }, [checkGroupId]);
+  }, [checkGroupId, lastRefresh]);
 
   const isFailed =
     data?.steps.some(

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
@@ -11,9 +11,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSelectedMonitor } from './use_selected_monitor';
 import { useSelectedLocation } from './use_selected_location';
 import { getMonitorRecentPingsAction, selectMonitorPingsMetadata } from '../../../state';
-import { useSyntheticsRefreshContext } from '../../../contexts';
 
 interface UseMonitorPingsProps {
+  lastRefresh?: number;
   pageSize?: number;
   pageIndex?: number;
   from?: string;
@@ -22,7 +22,6 @@ interface UseMonitorPingsProps {
 
 export const useMonitorPings = (props?: UseMonitorPingsProps) => {
   const dispatch = useDispatch();
-  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const { monitor } = useSelectedMonitor();
   const location = useSelectedLocation();
@@ -46,8 +45,8 @@ export const useMonitorPings = (props?: UseMonitorPingsProps) => {
   }, [
     dispatch,
     monitorId,
-    lastRefresh,
     locationLabel,
+    props?.lastRefresh,
     props?.pageSize,
     props?.pageIndex,
     props?.from,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSelectedMonitor } from './use_selected_monitor';
 import { useSelectedLocation } from './use_selected_location';
 import { getMonitorRecentPingsAction, selectMonitorPingsMetadata } from '../../../state';
+import { useSyntheticsRefreshContext } from '../../../contexts';
 
 interface UseMonitorPingsProps {
   pageSize?: number;
@@ -21,6 +22,7 @@ interface UseMonitorPingsProps {
 
 export const useMonitorPings = (props?: UseMonitorPingsProps) => {
   const dispatch = useDispatch();
+  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const { monitor } = useSelectedMonitor();
   const location = useSelectedLocation();
@@ -44,6 +46,7 @@ export const useMonitorPings = (props?: UseMonitorPingsProps) => {
   }, [
     dispatch,
     monitorId,
+    lastRefresh,
     locationLabel,
     props?.pageSize,
     props?.pageIndex,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_monitor.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { ConfigKey } from '../../../../../../common/runtime_types';
+import { useSyntheticsRefreshContext } from '../../../contexts';
 import {
   getMonitorAction,
   selectEncryptedSyntheticsSavedMonitors,
@@ -24,6 +25,7 @@ export const useSelectedMonitor = () => {
     () => monitorsList.find((monitor) => monitor[ConfigKey.CONFIG_ID] === monitorId) ?? null,
     [monitorId, monitorsList]
   );
+  const { lastRefresh } = useSyntheticsRefreshContext();
   const { syntheticsMonitor, syntheticsMonitorLoading } = useSelector(selectorMonitorDetailsState);
   const dispatch = useDispatch();
 
@@ -42,6 +44,10 @@ export const useSelectedMonitor = () => {
       dispatch(getMonitorAction.get({ monitorId }));
     }
   }, [dispatch, monitorId, availableMonitor, syntheticsMonitorLoading]);
+
+  useEffect(() => {
+    dispatch(getMonitorAction.get({ monitorId }));
+  }, [dispatch, monitorId, lastRefresh]);
 
   return {
     monitor: availableMonitor,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/monitor_errors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/monitor_errors.tsx
@@ -12,11 +12,11 @@ import {
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { useMonitorQueryId } from '../hooks/use_monitor_query_id';
 import { FailedTestsCount } from './failed_tests_count';
-import { useGetUrlParams } from '../../../hooks';
+import { useAbsoluteDate, useGetUrlParams } from '../../../hooks';
 import { SyntheticsDatePicker } from '../../common/date_picker/synthetics_date_picker';
 import { MonitorErrorsCount } from '../monitor_summary/monitor_errors_count';
 import { ErrorsList } from './errors_list';
@@ -27,10 +27,7 @@ export const MonitorErrors = () => {
 
   const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
 
-  const time = useMemo(
-    () => ({ from: dateRangeStart, to: dateRangeEnd }),
-    [dateRangeEnd, dateRangeStart]
-  );
+  const time = useAbsoluteDate({ from: dateRangeStart, to: dateRangeEnd });
 
   const monitorId = useMonitorQueryId();
 
@@ -47,15 +44,11 @@ export const MonitorErrors = () => {
             <EuiFlexGroup>
               <EuiFlexItem>
                 {monitorId && (
-                  <MonitorErrorsCount
-                    to={dateRangeEnd}
-                    from={dateRangeStart}
-                    monitorId={[monitorId]}
-                  />
+                  <MonitorErrorsCount from={time.from} to={time.to} monitorId={[monitorId]} />
                 )}
               </EuiFlexItem>
               <EuiFlexItem>
-                <FailedTestsCount to={dateRangeEnd} from={dateRangeStart} />
+                <FailedTestsCount from={time.from} to={time.to} />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_history/monitor_history.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_history/monitor_history.tsx
@@ -7,7 +7,7 @@
 import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
-import { useUrlParams } from '../../../hooks';
+import { useAbsoluteDate, useUrlParams } from '../../../hooks';
 import { useDimensions } from '../../../hooks';
 import { SyntheticsDatePicker } from '../../common/date_picker/synthetics_date_picker';
 import { AvailabilityPanel } from '../monitor_summary/availability_panel';
@@ -29,6 +29,7 @@ const STATS_WIDTH_SINGLE_COLUMN_THRESHOLD = 360; // ✨ determined by trial and 
 export const MonitorHistory = () => {
   const [useGetUrlParams, updateUrlParams] = useUrlParams();
   const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
+  const { from, to } = useAbsoluteDate({ from: dateRangeStart, to: dateRangeEnd });
 
   const { elementRef: statsRef, width: statsWidth } = useDimensions<HTMLDivElement>();
   const statsColumns = statsWidth && statsWidth < STATS_WIDTH_SINGLE_COLUMN_THRESHOLD ? 1 : 2;
@@ -59,20 +60,20 @@ export const MonitorHistory = () => {
                 <EuiFlexItem>
                   <EuiFlexGroup gutterSize="xs">
                     <EuiFlexItem>
-                      <MonitorCompleteCount from={dateRangeStart} to={dateRangeEnd} />
+                      <MonitorCompleteCount from={from} to={to} />
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <MonitorCompleteSparklines from={dateRangeStart} to={dateRangeEnd} />
+                      <MonitorCompleteSparklines from={from} to={to} />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiFlexGroup gutterSize="xs">
                     <EuiFlexItem>
-                      <AvailabilityPanel from={dateRangeStart} to={dateRangeEnd} />
+                      <AvailabilityPanel from={from} to={to} />
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <AvailabilitySparklines from={dateRangeStart} to={dateRangeEnd} />
+                      <AvailabilitySparklines from={from} to={to} />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>
@@ -80,20 +81,12 @@ export const MonitorHistory = () => {
                   <EuiFlexGroup gutterSize="xs">
                     <EuiFlexItem>
                       {monitorId && (
-                        <MonitorErrorsCount
-                          from={dateRangeStart}
-                          to={dateRangeEnd}
-                          monitorId={[monitorId]}
-                        />
+                        <MonitorErrorsCount from={from} to={to} monitorId={[monitorId]} />
                       )}
                     </EuiFlexItem>
                     <EuiFlexItem>
                       {monitorId && (
-                        <MonitorErrorSparklines
-                          from={dateRangeStart}
-                          to={dateRangeEnd}
-                          monitorId={[monitorId]}
-                        />
+                        <MonitorErrorSparklines from={from} to={to} monitorId={[monitorId]} />
                       )}
                     </EuiFlexItem>
                   </EuiFlexGroup>
@@ -101,15 +94,15 @@ export const MonitorHistory = () => {
                 <EuiFlexItem>
                   <EuiFlexGroup gutterSize="xs">
                     <EuiFlexItem>
-                      <DurationPanel from={dateRangeStart} to={dateRangeEnd} />
+                      <DurationPanel from={from} to={to} />
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <DurationSparklines from={dateRangeStart} to={dateRangeEnd} />
+                      <DurationSparklines from={from} to={to} />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <MonitorTotalRunsCount from={dateRangeStart} to={dateRangeEnd} />
+                  <MonitorTotalRunsCount from={from} to={to} />
                 </EuiFlexItem>
               </EuiFlexGrid>
             </EuiPanel>
@@ -119,15 +112,15 @@ export const MonitorHistory = () => {
               <EuiTitle size="xs">
                 <h3>{DURATION_TREND_LABEL}</h3>
               </EuiTitle>
-              <MonitorDurationTrend from={dateRangeStart} to={dateRangeEnd} />
+              <MonitorDurationTrend from={from} to={to} />
             </EuiPanel>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
         <MonitorStatusPanel
-          from={dateRangeStart}
-          to={dateRangeEnd}
+          from={from}
+          to={to}
           showViewHistoryButton={false}
           periodCaption={''}
           brushable={true}
@@ -135,7 +128,7 @@ export const MonitorHistory = () => {
         />
       </EuiFlexItem>
       <EuiFlexItem>
-        <TestRunsTable from={dateRangeStart} to={dateRangeEnd} />
+        <TestRunsTable from={from} to={to} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_trend.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_trend.tsx
@@ -15,43 +15,39 @@ import { useSelectedLocation } from '../hooks/use_selected_location';
 interface MonitorDurationTrendProps {
   from: string;
   to: string;
-  lastRefresh: number;
 }
 
-export const MonitorDurationTrend = React.memo(
-  (props: MonitorDurationTrendProps) => {
-    const { observability } = useKibana<ClientPluginsStart>().services;
+export const MonitorDurationTrend = (props: MonitorDurationTrendProps) => {
+  const { observability } = useKibana<ClientPluginsStart>().services;
 
-    const { ExploratoryViewEmbeddable } = observability;
+  const { ExploratoryViewEmbeddable } = observability;
 
-    const monitorId = useMonitorQueryId();
-    const selectedLocation = useSelectedLocation();
+  const monitorId = useMonitorQueryId();
+  const selectedLocation = useSelectedLocation();
 
-    if (!selectedLocation || !monitorId) {
-      return null;
-    }
+  if (!selectedLocation || !monitorId) {
+    return null;
+  }
 
-    return (
-      <ExploratoryViewEmbeddable
-        customHeight="240px"
-        reportType="kpi-over-time"
-        attributes={Object.keys(metricsToShow).map((metric) => ({
-          dataType: 'synthetics',
-          time: props,
-          name: metricsToShow[metric],
-          selectedMetricField: 'monitor.duration.us',
-          reportDefinitions: {
-            'monitor.id': [monitorId],
-            'observer.geo.name': [selectedLocation?.label],
-          },
-          seriesType: 'line',
-          operationType: metric,
-        }))}
-      />
-    );
-  },
-  ({ lastRefresh }, { lastRefresh: next }) => lastRefresh !== next
-);
+  return (
+    <ExploratoryViewEmbeddable
+      customHeight="240px"
+      reportType="kpi-over-time"
+      attributes={Object.keys(metricsToShow).map((metric) => ({
+        dataType: 'synthetics',
+        time: props,
+        name: metricsToShow[metric],
+        selectedMetricField: 'monitor.duration.us',
+        reportDefinitions: {
+          'monitor.id': [monitorId],
+          'observer.geo.name': [selectedLocation?.label],
+        },
+        seriesType: 'line',
+        operationType: metric,
+      }))}
+    />
+  );
+};
 
 const MIN_LABEL = i18n.translate('xpack.synthetics.durationTrend.min', {
   defaultMessage: 'Min',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_trend.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/duration_trend.tsx
@@ -15,39 +15,43 @@ import { useSelectedLocation } from '../hooks/use_selected_location';
 interface MonitorDurationTrendProps {
   from: string;
   to: string;
+  lastRefresh: number;
 }
 
-export const MonitorDurationTrend = (props: MonitorDurationTrendProps) => {
-  const { observability } = useKibana<ClientPluginsStart>().services;
+export const MonitorDurationTrend = React.memo(
+  (props: MonitorDurationTrendProps) => {
+    const { observability } = useKibana<ClientPluginsStart>().services;
 
-  const { ExploratoryViewEmbeddable } = observability;
+    const { ExploratoryViewEmbeddable } = observability;
 
-  const monitorId = useMonitorQueryId();
-  const selectedLocation = useSelectedLocation();
+    const monitorId = useMonitorQueryId();
+    const selectedLocation = useSelectedLocation();
 
-  if (!selectedLocation || !monitorId) {
-    return null;
-  }
+    if (!selectedLocation || !monitorId) {
+      return null;
+    }
 
-  return (
-    <ExploratoryViewEmbeddable
-      customHeight="240px"
-      reportType="kpi-over-time"
-      attributes={Object.keys(metricsToShow).map((metric) => ({
-        dataType: 'synthetics',
-        time: props,
-        name: metricsToShow[metric],
-        selectedMetricField: 'monitor.duration.us',
-        reportDefinitions: {
-          'monitor.id': [monitorId],
-          'observer.geo.name': [selectedLocation?.label],
-        },
-        seriesType: 'line',
-        operationType: metric,
-      }))}
-    />
-  );
-};
+    return (
+      <ExploratoryViewEmbeddable
+        customHeight="240px"
+        reportType="kpi-over-time"
+        attributes={Object.keys(metricsToShow).map((metric) => ({
+          dataType: 'synthetics',
+          time: props,
+          name: metricsToShow[metric],
+          selectedMetricField: 'monitor.duration.us',
+          reportDefinitions: {
+            'monitor.id': [monitorId],
+            'observer.geo.name': [selectedLocation?.label],
+          },
+          seriesType: 'line',
+          operationType: metric,
+        }))}
+      />
+    );
+  },
+  ({ lastRefresh }, { lastRefresh: next }) => lastRefresh !== next
+);
 
 const MIN_LABEL = i18n.translate('xpack.synthetics.durationTrend.min', {
   defaultMessage: 'Min',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../../../../../common/runtime_types';
 import { formatTestRunAt } from '../../../utils/monitor_test_result/test_time_formats';
 
-import { useSyntheticsSettingsContext } from '../../../contexts';
+import { useSyntheticsRefreshContext, useSyntheticsSettingsContext } from '../../../contexts';
 import { BrowserStepsList } from '../../common/monitor_test_result/browser_steps_list';
 import { SinglePingResult } from '../../common/monitor_test_result/single_ping_result';
 import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/status_badge';
@@ -43,10 +43,12 @@ import { useMonitorLatestPing } from '../hooks/use_monitor_latest_ping';
 export const LastTestRun = () => {
   const { euiTheme } = useEuiTheme();
   const { latestPing, loading: pingsLoading } = useMonitorLatestPing();
+  const { lastRefresh } = useSyntheticsRefreshContext();
   const { monitor } = useSelectedMonitor();
 
   const { data: stepsData, loading: stepsLoading } = useJourneySteps(
-    latestPing?.monitor?.check_group
+    latestPing?.monitor?.check_group,
+    lastRefresh
   );
 
   const loading = stepsLoading || pingsLoading;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -32,10 +32,12 @@ import { AvailabilitySparklines } from './availability_sparklines';
 import { LastTestRun } from './last_test_run';
 import { LAST_10_TEST_RUNS, TestRunsTable } from './test_runs_table';
 import { MonitorErrorsCount } from './monitor_errors_count';
+import { useSyntheticsRefreshContext } from '../../../contexts';
 
 export const MonitorSummary = () => {
   const { from, loading } = useEarliestStartDate();
   const to = 'now';
+  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const monitorId = useMonitorQueryId();
 
@@ -105,7 +107,7 @@ export const MonitorSummary = () => {
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-                <MonitorDurationTrend from={from} to={to} />
+                <MonitorDurationTrend from={from} to={to} lastRefresh={lastRefresh} />
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -124,7 +126,7 @@ export const MonitorSummary = () => {
           <LastTestRun />
         </EuiFlexItem>
         <EuiFlexItem>
-          <StepDurationPanel />
+          <StepDurationPanel lastRefresh={lastRefresh} />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -32,12 +32,13 @@ import { AvailabilitySparklines } from './availability_sparklines';
 import { LastTestRun } from './last_test_run';
 import { LAST_10_TEST_RUNS, TestRunsTable } from './test_runs_table';
 import { MonitorErrorsCount } from './monitor_errors_count';
-import { useSyntheticsRefreshContext } from '../../../contexts';
+import { useAbsoluteDate } from '../../../hooks';
 
 export const MonitorSummary = () => {
-  const { from, loading } = useEarliestStartDate();
-  const to = 'now';
-  const { lastRefresh } = useSyntheticsRefreshContext();
+  const { from: fromRelative, loading } = useEarliestStartDate();
+  const toRelative = 'now';
+
+  const { from, to } = useAbsoluteDate({ from: fromRelative, to: toRelative });
 
   const monitorId = useMonitorQueryId();
 
@@ -107,7 +108,7 @@ export const MonitorSummary = () => {
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-                <MonitorDurationTrend from={from} to={to} lastRefresh={lastRefresh} />
+                <MonitorDurationTrend from={from} to={to} />
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -126,7 +127,7 @@ export const MonitorSummary = () => {
           <LastTestRun />
         </EuiFlexItem>
         <EuiFlexItem>
-          <StepDurationPanel lastRefresh={lastRefresh} />
+          <StepDurationPanel />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
@@ -20,7 +20,7 @@ import { useAbsoluteDate } from '../../../hooks';
 
 export const StepDurationPanel = ({ legendPosition }: { legendPosition?: Position }) => {
   const { observability } = useKibana<ClientPluginsStart>().services;
-  const { from, to } = useAbsoluteDate({ from: 'now-24h/h', to: 'now' });
+  const time = useAbsoluteDate({ from: 'now-24h/h', to: 'now' });
 
   const { ExploratoryViewEmbeddable } = observability;
 
@@ -62,6 +62,7 @@ export const StepDurationPanel = ({ legendPosition }: { legendPosition?: Positio
         legendPosition={legendPosition}
         attributes={[
           {
+            time,
             name: DURATION_BY_STEP_LABEL,
             reportDefinitions: {
               'monitor.id': [monitorId],
@@ -69,7 +70,6 @@ export const StepDurationPanel = ({ legendPosition }: { legendPosition?: Positio
             },
             selectedMetricField: isBrowser ? 'synthetics.step.duration.us' : 'monitor.duration.us',
             dataType: 'synthetics',
-            time: { from, to },
             breakdown: isBrowser ? 'synthetics.step.name.keyword' : 'observer.geo.name',
             operationType: 'last_value',
             seriesType: 'area_stacked',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/step_duration_panel.tsx
@@ -16,72 +16,69 @@ import { useMonitorQueryId } from '../hooks/use_monitor_query_id';
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { useSelectedLocation } from '../hooks/use_selected_location';
+import { useAbsoluteDate } from '../../../hooks';
 
-export const StepDurationPanel = React.memo(
-  ({ legendPosition, lastRefresh }: { legendPosition?: Position; lastRefresh: number }) => {
-    const { observability } = useKibana<ClientPluginsStart>().services;
+export const StepDurationPanel = ({ legendPosition }: { legendPosition?: Position }) => {
+  const { observability } = useKibana<ClientPluginsStart>().services;
+  const { from, to } = useAbsoluteDate({ from: 'now-24h/h', to: 'now' });
 
-    const { ExploratoryViewEmbeddable } = observability;
+  const { ExploratoryViewEmbeddable } = observability;
 
-    const { monitor } = useSelectedMonitor();
+  const { monitor } = useSelectedMonitor();
 
-    const monitorId = useMonitorQueryId();
+  const monitorId = useMonitorQueryId();
 
-    const selectedLocation = useSelectedLocation();
+  const selectedLocation = useSelectedLocation();
 
-    const isBrowser = monitor?.type === 'browser';
+  const isBrowser = monitor?.type === 'browser';
 
-    if (!selectedLocation) {
-      return null;
-    }
+  if (!selectedLocation) {
+    return null;
+  }
 
-    if (!monitorId) {
-      return null;
-    }
+  if (!monitorId) {
+    return null;
+  }
 
-    return (
-      <EuiPanel hasShadow={false} hasBorder>
-        <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h3>{isBrowser ? DURATION_BY_STEP_LABEL : DURATION_BY_LOCATION}</h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s" color="subdued">
-              {LAST_24H_LABEL}
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+  return (
+    <EuiPanel hasShadow={false} hasBorder>
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h3>{isBrowser ? DURATION_BY_STEP_LABEL : DURATION_BY_LOCATION}</h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="s" color="subdued">
+            {LAST_24H_LABEL}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-        <ExploratoryViewEmbeddable
-          axisTitlesVisibility={{ yLeft: false, yRight: false, x: false }}
-          customHeight={'300px'}
-          reportType={ReportTypes.KPI}
-          legendPosition={legendPosition}
-          attributes={[
-            {
-              name: DURATION_BY_STEP_LABEL,
-              reportDefinitions: {
-                'monitor.id': [monitorId],
-                'observer.geo.name': [selectedLocation?.label],
-              },
-              selectedMetricField: isBrowser
-                ? 'synthetics.step.duration.us'
-                : 'monitor.duration.us',
-              dataType: 'synthetics',
-              time: { from: 'now-24h/h', to: 'now' },
-              breakdown: isBrowser ? 'synthetics.step.name.keyword' : 'observer.geo.name',
-              operationType: 'last_value',
-              seriesType: 'area_stacked',
+      <ExploratoryViewEmbeddable
+        axisTitlesVisibility={{ yLeft: false, yRight: false, x: false }}
+        customHeight={'300px'}
+        reportType={ReportTypes.KPI}
+        legendPosition={legendPosition}
+        attributes={[
+          {
+            name: DURATION_BY_STEP_LABEL,
+            reportDefinitions: {
+              'monitor.id': [monitorId],
+              'observer.geo.name': [selectedLocation?.label],
             },
-          ]}
-        />
-      </EuiPanel>
-    );
-  },
-  ({ lastRefresh }, { lastRefresh: next }) => lastRefresh === next
-);
+            selectedMetricField: isBrowser ? 'synthetics.step.duration.us' : 'monitor.duration.us',
+            dataType: 'synthetics',
+            time: { from, to },
+            breakdown: isBrowser ? 'synthetics.step.name.keyword' : 'observer.geo.name',
+            operationType: 'last_value',
+            seriesType: 'area_stacked',
+          },
+        ]}
+      />
+    </EuiPanel>
+  );
+};
 
 const DURATION_BY_STEP_LABEL = i18n.translate('xpack.synthetics.detailsPanel.durationByStep', {
   defaultMessage: 'Duration by step',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -35,6 +35,7 @@ import { parseBadgeStatus, StatusBadge } from '../../common/monitor_test_result/
 import { useSelectedMonitor } from '../hooks/use_selected_monitor';
 import { useMonitorPings } from '../hooks/use_monitor_pings';
 import { JourneyScreenshot } from '../../common/screenshot/journey_screenshot';
+import { useSyntheticsRefreshContext } from '../../../contexts';
 
 type SortableField = 'timestamp' | 'monitor.status' | 'monitor.duration.us';
 
@@ -52,6 +53,7 @@ export const TestRunsTable = ({ paginable = true, from, to }: TestRunsTableProps
 
   const [sortField, setSortField] = useState<SortableField>('timestamp');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+  const { lastRefresh } = useSyntheticsRefreshContext();
   const {
     pings,
     total,
@@ -59,6 +61,7 @@ export const TestRunsTable = ({ paginable = true, from, to }: TestRunsTableProps
   } = useMonitorPings({
     from,
     to,
+    lastRefresh,
     pageSize: page.size,
     pageIndex: page.index,
   });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -38,19 +38,12 @@ export const OverviewPage: React.FC = () => {
 
   const dispatch = useDispatch();
 
-  const { refreshApp, lastRefresh } = useSyntheticsRefreshContext();
+  const { lastRefresh } = useSyntheticsRefreshContext();
   const { query } = useGetUrlParams();
   const { search } = useLocation();
 
   const pageState = useSelector(selectOverviewPageState);
   const { loading: locationsLoading, locationsLoaded } = useSelector(selectServiceLocationsState);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      refreshApp();
-    }, 1000 * 30);
-    return () => clearInterval(interval);
-  }, [refreshApp]);
 
   useEffect(() => {
     if (!locationsLoading && !locationsLoaded) {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -17,13 +17,10 @@ import { useJourneySteps } from '../monitor_details/hooks/use_journey_steps';
 import { StepDurationPanel } from '../monitor_details/monitor_summary/step_duration_panel';
 import { TestRunSteps } from './test_run_steps';
 import { useTestRunDetailsBreadcrumbs } from './hooks/use_test_run_details_breadcrumbs';
-import { useSyntheticsRefreshContext } from '../../contexts';
 
 export const TestRunDetails = () => {
   // Step index from starts at 1 in synthetics
   const [stepIndex, setStepIndex] = React.useState(1);
-
-  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const { data: stepsData, loading: stepsLoading, stepEnds } = useJourneySteps();
 
@@ -76,7 +73,7 @@ export const TestRunDetails = () => {
         <TestRunSteps isLoading={stepsLoading} steps={stepsData?.steps ?? []} />
       </EuiFlexItem>
       <EuiFlexItem grow={1}>
-        <StepDurationPanel lastRefresh={lastRefresh} legendPosition="bottom" />
+        <StepDurationPanel legendPosition="bottom" />
         <EuiSpacer size="m" />
         <MonitorDetailsPanel />
       </EuiFlexItem>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -17,10 +17,13 @@ import { useJourneySteps } from '../monitor_details/hooks/use_journey_steps';
 import { StepDurationPanel } from '../monitor_details/monitor_summary/step_duration_panel';
 import { TestRunSteps } from './test_run_steps';
 import { useTestRunDetailsBreadcrumbs } from './hooks/use_test_run_details_breadcrumbs';
+import { useSyntheticsRefreshContext } from '../../contexts';
 
 export const TestRunDetails = () => {
   // Step index from starts at 1 in synthetics
   const [stepIndex, setStepIndex] = React.useState(1);
+
+  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const { data: stepsData, loading: stepsLoading, stepEnds } = useJourneySteps();
 
@@ -73,7 +76,7 @@ export const TestRunDetails = () => {
         <TestRunSteps isLoading={stepsLoading} steps={stepsData?.steps ?? []} />
       </EuiFlexItem>
       <EuiFlexItem grow={1}>
-        <StepDurationPanel legendPosition="bottom" />
+        <StepDurationPanel lastRefresh={lastRefresh} legendPosition="bottom" />
         <EuiSpacer size="m" />
         <MonitorDetailsPanel />
       </EuiFlexItem>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
@@ -36,7 +36,7 @@ export const SyntheticsRefreshContextProvider: React.FC = ({ children }) => {
   useEffect(() => {
     const interval = setInterval(() => {
       refreshApp();
-    }, 1000 * 3);
+    }, 1000 * 30);
     return () => clearInterval(interval);
   }, [refreshApp]);
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 interface SyntheticsRefreshContext {
   lastRefresh: number;
@@ -24,14 +24,21 @@ export const SyntheticsRefreshContext = createContext(defaultContext);
 export const SyntheticsRefreshContextProvider: React.FC = ({ children }) => {
   const [lastRefresh, setLastRefresh] = useState<number>(Date.now());
 
-  const refreshApp = () => {
+  const refreshApp = useCallback(() => {
     const refreshTime = Date.now();
     setLastRefresh(refreshTime);
-  };
+  }, [setLastRefresh]);
 
   const value = useMemo(() => {
     return { lastRefresh, refreshApp };
-  }, [lastRefresh]);
+  }, [lastRefresh, refreshApp]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      refreshApp();
+    }, 1000 * 3);
+    return () => clearInterval(interval);
+  }, [refreshApp]);
 
   return <SyntheticsRefreshContext.Provider value={value} children={children} />;
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+export * from './use_absolute_date';
 export * from './use_url_params';
 export * from './use_breadcrumbs';
 export * from './use_service_allowed';

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_absolute_date.test.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_absolute_date.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import { renderHook } from '@testing-library/react-hooks';
+import moment, { Moment } from 'moment';
+import { useAbsoluteDate } from './use_absolute_date';
+
+describe('useAbsoluteDate', () => {
+  let datemathSpy: jest.SpyInstance<Moment | undefined>;
+
+  beforeEach(() => {
+    datemathSpy = jest.spyOn(datemath, 'parse');
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns a parsed value for `from` and `to`', () => {
+    datemathSpy.mockReturnValueOnce(moment('2022-11-18T18:54:06.342Z'));
+    datemathSpy.mockReturnValueOnce(moment('2022-11-19T18:54:06.342Z'));
+
+    const {
+      result: {
+        current: { from, to },
+      },
+    } = renderHook(() => useAbsoluteDate({ from: 'now-15m', to: 'now' }));
+
+    expect(datemathSpy).toHaveBeenCalledTimes(2);
+    expect(datemathSpy.mock.calls).toEqual([['now-15m'], ['now']]);
+    expect(from).toEqual('2022-11-18T18:54:06.342Z');
+    expect(to).toEqual('2022-11-19T18:54:06.342Z');
+  });
+
+  it('returns the original string if datemath cannot parse the value', () => {
+    datemathSpy.mockReturnValue(undefined);
+    const {
+      result: {
+        current: { from, to },
+      },
+    } = renderHook(() => useAbsoluteDate({ from: 'someinvalidvalue', to: 'anotherinvalidvalue' }));
+
+    expect(datemathSpy).toHaveBeenCalledTimes(2);
+    expect(datemathSpy.mock.calls).toEqual([['someinvalidvalue'], ['anotherinvalidvalue']]);
+    expect(from).toEqual('someinvalidvalue');
+    expect(to).toEqual('anotherinvalidvalue');
+  });
+});

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_absolute_date.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_absolute_date.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import { useMemo } from 'react';
+import { useSyntheticsRefreshContext } from '../contexts';
+
+export function useAbsoluteDate({ from, to }: { from: string; to: string }) {
+  const { lastRefresh } = useSyntheticsRefreshContext();
+  return useMemo(
+    () => ({
+      from: datemath.parse(from)?.toISOString() ?? from,
+      to: datemath.parse(to)?.toISOString() ?? to,
+    }),
+    // we want to recompute these any time the app refreshes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [from, to, lastRefresh]
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #143662.

Resolves #144367.

This patch will add refresh capabilities to the monitor detail page and its child views. Today, the page needs to be hard-refreshed in order for this to work.

### Arch changes

#### App-wide refresh interval

To simplify how auto-refreshing works, I have [extracted](https://github.com/elastic/kibana/pull/145468/files#diff-09f3a6de5b54c7d3933df933d83e963f6ff6a5c18a3d83238bd658623595fe35L47) the existing `interval` logic from the Overview page and put it into the [`RefreshContext`](https://github.com/elastic/kibana/pull/145468/files#diff-660f9a1ed6f641662eff6682448bac7d1b167b4ea518ddc43634192b2959be1fR36) itself. I am not overly fond of this solution, so if someone has a better suggestion for how to handle this, I am open to recommendations.

This refresh context also ties into the date picker components we use for some of these pages, so everything should continue to work seamlessly, but there's going to be a conflicting auto-refresh between date pickers and the internal context value itself. It might be worthwhile for us to discuss this in a tech sync and have a dedicated enhancement.

#### New absolute date formatting hook

I've introduced a [new hook for changing relative date values into absolute ISO strings](https://github.com/elastic/kibana/pull/145468/files#diff-48912058ac736ca8aece834bb50369cc5589b94b9c8b2b3e418e9d7690241525). This is because we are making extensive use of Exploratory View Embeddables, which do not have any kind of refresh mechanism exposed. The simplest way to get these to refresh when our `lastRefresh` field updates is to supply the embeddable with absolute values, which correspond directly to the existing `from` and `to` fields we're already using.

#### Existing hook updates

I have tried to avoid manipulating the existing behavior of our fetch hooks, but there were a few cases where I added optional parameters to them to support refresh functionality. It's worth extra attention to make sure we're not adding something that we should avoid for these hooks.

### Testing this PR

The best way to test this PR is to configure a monitor and open the detail pages for `Overview`, `History`, and `Errors`. Let your monitor run for some time and look at all the visualizations, while avoiding a hard refresh. If you run this patch from source, you can also modify the [interval](https://github.com/elastic/kibana/pull/145468/files#diff-660f9a1ed6f641662eff6682448bac7d1b167b4ea518ddc43634192b2959be1fR39) from `30s` to some smaller value if you want to make sure things are updating where they should more easily.


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->