### PR TITLE
[DOCS] Fix link in Kibana Add Data

### DIFF
--- a/docs/developer/best-practices/index.asciidoc
+++ b/docs/developer/best-practices/index.asciidoc
@@ -22,7 +22,7 @@ Are you planning with scalability in mind?
 
 Did you know {kib} makes a public statement about our commitment to
 creating an accessible product for people with disabilities?
-https://www.elastic.co/guide/en/kibana/master/accessibility.html[We do]!
+<<accessibility,We do>>!
 It’s very important all of our apps are accessible.
 
 * Learn how https://elastic.github.io/eui/#/guidelines/accessibility[EUI

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -13,7 +13,7 @@ All integrations are available in a single view, and
 image::images/add-integration.png[Integrations page from which you can choose integrations to start collecting and analyzing data]
 
 NOTE: When an integration is available for both
-https://www.elastic.co/guide/en/fleet/master/beats-agent-comparison.html[Elastic Agent and Beats],
+{fleet-guide}/beats-agent-comparison.html[Elastic Agent and Beats],
 the *Integrations* view defaults to the
 Elastic Agent integration, if it is generally available (GA).
 To show a


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/issues/2518

This PR replaces hard-coded links to master that exist in https://www.elastic.co/guide/en/kibana/master/connect-to-elasticsearch.html and https://www.elastic.co/guide/en/kibana/master/development-best-practices.html 

Otherwise, the following type of build errors occur when we shift to `main`:

> 16:25:18 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.16/connect-to-elasticsearch.html contains broken links to:
16:25:18 INFO:build_docs:   - en/fleet/master/beats-agent-comparison.html