### PR TITLE
[DOCS] Fix hard-coded link in create rule API

### DIFF
--- a/docs/api/alerting/create_rule.asciidoc
+++ b/docs/api/alerting/create_rule.asciidoc
@@ -21,7 +21,7 @@ WARNING: This API supports <<token-api-authentication>> only.
 `space_id`::
   (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
 
-WARNING: As part of the {kibana-ref-all}/master/sharing-saved-objects.html[Sharing Saved Objects] effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
+WARNING: As part of the <<sharing-saved-objects,Sharing Saved Objects>> effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
 
 `id`::
   (Optional, string) Specifies a UUID v1 or v4 to use instead of a randomly generated ID.


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/issues/2518

This PR replaces a hard-coded link that includes `master`, which would case this type of failure when we switch to `main`:

> 16:25:18 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.17/create-rule-api.html contains broken links to:
16:25:18 INFO:build_docs:   - en/kibana/master/sharing-saved-objects.html