### PR TITLE
[Profiling] Add APIs to clear frame and executable caches

### DIFF
--- a/x-pack/plugins/profiling/common/index.ts
+++ b/x-pack/plugins/profiling/common/index.ts
@@ -27,6 +27,8 @@ export function getRoutePaths() {
     TopNThreads: `${BASE_ROUTE_PATH}/topn/threads`,
     TopNTraces: `${BASE_ROUTE_PATH}/topn/traces`,
     Flamechart: `${BASE_ROUTE_PATH}/flamechart`,
+    CacheExecutables: `${BASE_ROUTE_PATH}/cache/executables`,
+    CacheStackFrames: `${BASE_ROUTE_PATH}/cache/stackframes`,
   };
 }
 

--- a/x-pack/plugins/profiling/server/routes/cache.ts
+++ b/x-pack/plugins/profiling/server/routes/cache.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RouteRegisterParameters } from '.';
+import { getRoutePaths } from '../../common';
+import { handleRouteHandlerError } from '../utils/handle_route_error_handler';
+import { clearExecutableCache, clearStackFrameCache } from './stacktrace';
+
+export function registerCacheExecutablesRoute({ router, logger }: RouteRegisterParameters) {
+  const paths = getRoutePaths();
+  router.delete(
+    {
+      path: paths.CacheExecutables,
+      validate: {},
+    },
+    async (context, request, response) => {
+      try {
+        logger.info(`clearing executable cache`);
+        const numDeleted = clearExecutableCache();
+        logger.info(`removed ${numDeleted} executables from cache`);
+
+        return response.ok({});
+      } catch (error) {
+        return handleRouteHandlerError({ error, logger, response });
+      }
+    }
+  );
+}
+
+export function registerCacheStackFramesRoute({ router, logger }: RouteRegisterParameters) {
+  const paths = getRoutePaths();
+  router.delete(
+    {
+      path: paths.CacheStackFrames,
+      validate: {},
+    },
+    async (context, request, response) => {
+      try {
+        logger.info(`clearing stackframe cache`);
+        const numDeleted = clearStackFrameCache();
+        logger.info(`removed ${numDeleted} stackframes from cache`);
+
+        return response.ok({});
+      } catch (error) {
+        return handleRouteHandlerError({ error, logger, response });
+      }
+    }
+  );
+}

--- a/x-pack/plugins/profiling/server/routes/index.ts
+++ b/x-pack/plugins/profiling/server/routes/index.ts
@@ -12,6 +12,8 @@ import {
   ProfilingRequestHandlerContext,
 } from '../types';
 
+import { registerCacheExecutablesRoute, registerCacheStackFramesRoute } from './cache';
+
 import { registerFlameChartSearchRoute } from './flamechart';
 import { registerTopNFunctionsSearchRoute } from './functions';
 
@@ -33,6 +35,8 @@ export interface RouteRegisterParameters {
 }
 
 export function registerRoutes(params: RouteRegisterParameters) {
+  registerCacheExecutablesRoute(params);
+  registerCacheStackFramesRoute(params);
   registerFlameChartSearchRoute(params);
   registerTopNFunctionsSearchRoute(params);
   registerTraceEventsTopNContainersSearchRoute(params);

--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -278,6 +278,13 @@ const frameLRU = new LRUCache<StackFrameID, StackFrame>({
   maxAge: CACHE_TTL_MILLISECONDS,
 });
 
+// clearStackFrameCache clears the entire cache and returns the number of deleted items
+export function clearStackFrameCache(): number {
+  const numDeleted = frameLRU.length;
+  frameLRU.reset();
+  return numDeleted;
+}
+
 export async function mgetStackFrames({
   logger,
   client,
@@ -349,6 +356,13 @@ const executableLRU = new LRUCache<FileID, Executable>({
   max: CACHE_MAX_ITEMS,
   maxAge: CACHE_TTL_MILLISECONDS,
 });
+
+// clearExecutableCache clears the entire cache and returns the number of deleted items
+export function clearExecutableCache(): number {
+  const numDeleted = executableLRU.length;
+  executableLRU.reset();
+  return numDeleted;
+}
 
 export async function mgetExecutables({
   logger,


### PR DESCRIPTION
This PR adds two endpoints to clear each respective cache:

* `DELETE {BASE_KIBANA_PATH}/api/profiling/v1/cache/executables`
* `DELETE {BASE_KIBANA_PATH}/api/profiling/v1/cache/stackframes`

Related to https://github.com/elastic/prodfiler/issues/2759

#### Design choices

1. The `DELETE` method was chosen instead of `PUT` or `POST` since the given semantics of `DELETE` matches the expected behavior for the related issue.
2. Each endpoint will remove all items from the respective cache. A separate API for each cache allows us to selectively clear the necessary cache without the downsides of a catch-all endpoint to clear all caches. This gives us the flexibility to add more endpoints if needed. Given the tradeoff between complexity now or later, it was decided to implement general invalidation now with the option to invalidate specific items later.
3. The RESTful design allows us to clear specific items later (e.g. `DELETE {BASE_KIBANA_PATH}/api/profiling/v1/cache/executables/{ID}` could clear only executable `ID` from the cache).
4. Each endpoint returns an empty payload on success. However, the Kibana logs reflect the actions taken and how many cache items were affected.
5. The stacktrace cache was ignored since it was not affected by symbols written to Elasticsearch.
6. Each endpoint is not directly accessible from UI since it is expected that the endpoints will be called outside of Kibana. However, the endpoints can be called manually from the browser's console.

<!--ONMERGE {"backportTargets":["8.5","8.6"]} ONMERGE-->