### PR TITLE
[Security Solution][Alerts] Sort alert results to fix flaky test

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/threshold.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/threshold.ts
@@ -373,7 +373,7 @@ export default ({ getService }: FtrProviderContext) => {
           },
         };
         const { previewId } = await previewRule({ supertest, rule });
-        const previewAlerts = await getPreviewAlerts({ es, previewId });
+        const previewAlerts = await getPreviewAlerts({ es, previewId, sort: ['host.name'] });
 
         expect(previewAlerts[0]?._source?.host?.risk?.calculated_level).to.eql('Low');
         expect(previewAlerts[0]?._source?.host?.risk?.calculated_score_norm).to.eql(20);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/143992

Alert results can sometimes come back in different order if the sort is not specified, causing occasional test failures.
