### PR TITLE
[Security Solution][Alerts] Unskip ML rule test suite

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/machine_learning.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/machine_learning.ts
@@ -64,8 +64,7 @@ export default ({ getService }: FtrProviderContext) => {
     rule_id: 'ml-rule-id',
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/142993
-  describe.skip('Machine learning type rules', () => {
+  describe('Machine learning type rules', () => {
     before(async () => {
       // Order is critical here: auditbeat data must be loaded before attempting to start the ML job,
       // as the job looks for certain indices on start


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/142993

The failure is in ES archiver, not the test, and there's seemingly nothing wrong with the ES archive.

Passed 100x here: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1564
