### PR TITLE
[Osquery] Fix osquery attachment rerender

### DIFF
--- a/x-pack/plugins/osquery/public/shared_components/attachments/lazy_external_reference_content.tsx
+++ b/x-pack/plugins/osquery/public/shared_components/attachments/lazy_external_reference_content.tsx
@@ -21,6 +21,7 @@ export interface IExternalReferenceMetaDataProps {
     queryId: string;
   };
 }
+const AttachmentContent = lazy(() => import('./external_references_content'));
 
 export const getLazyExternalContent =
   // eslint-disable-next-line react/display-name
@@ -53,8 +54,6 @@ export const getLazyExternalContent =
         />
       );
     }
-
-    const AttachmentContent = lazy(() => import('./external_references_content'));
 
     return (
       <Suspense fallback={null}>


### PR DESCRIPTION
This PR fixes the issue with unnecessary rerender in Osquery attachment in Cases view. (https://github.com/elastic/kibana/issues/143731)

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->