### PR TITLE
[Synthetics UI] Filter history stats by location

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_complete_count.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_complete_count.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { ReportTypes } from '@kbn/observability-plugin/public';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { useMonitorQueryId } from '../hooks/use_monitor_query_id';
+import { useSelectedLocation } from '../hooks/use_selected_location';
 
 interface MonitorCompleteCountProps {
   from: string;
@@ -22,8 +23,9 @@ export const MonitorCompleteCount = (props: MonitorCompleteCountProps) => {
   const { ExploratoryViewEmbeddable } = observability;
 
   const monitorId = useMonitorQueryId();
+  const selectedLocation = useSelectedLocation();
 
-  if (!monitorId) {
+  if (!monitorId || !selectedLocation) {
     return null;
   }
 
@@ -34,7 +36,10 @@ export const MonitorCompleteCount = (props: MonitorCompleteCountProps) => {
       attributes={[
         {
           time: props,
-          reportDefinitions: { config_id: [monitorId] },
+          reportDefinitions: {
+            'monitor.id': [monitorId],
+            'observer.geo.name': [selectedLocation.label],
+          },
           dataType: 'synthetics',
           selectedMetricField: 'monitor_complete',
           name: 'synthetics-series-1',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_complete_sparklines.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_complete_sparklines.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { useMonitorQueryId } from '../hooks/use_monitor_query_id';
+import { useSelectedLocation } from '../hooks/use_selected_location';
 
 interface Props {
   from: string;
@@ -21,10 +22,11 @@ export const MonitorCompleteSparklines = (props: Props) => {
   const { ExploratoryViewEmbeddable } = observability;
 
   const monitorId = useMonitorQueryId();
+  const selectedLocation = useSelectedLocation();
 
   const { euiTheme } = useEuiTheme();
 
-  if (!monitorId) {
+  if (!monitorId || !selectedLocation) {
     return null;
   }
 
@@ -38,7 +40,10 @@ export const MonitorCompleteSparklines = (props: Props) => {
         {
           seriesType: 'area',
           time: props,
-          reportDefinitions: { 'monitor.id': [monitorId] },
+          reportDefinitions: {
+            'monitor.id': [monitorId],
+            'observer.geo.name': [selectedLocation.label],
+          },
           dataType: 'synthetics',
           selectedMetricField: 'state.id',
           name: 'Monitor complete',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_total_runs_count.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_total_runs_count.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { ReportTypes } from '@kbn/observability-plugin/public';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { useMonitorQueryId } from '../hooks/use_monitor_query_id';
+import { useSelectedLocation } from '../hooks/use_selected_location';
 
 interface MonitorTotalRunsCountProps {
   from: string;
@@ -22,8 +23,9 @@ export const MonitorTotalRunsCount = (props: MonitorTotalRunsCountProps) => {
   const { ExploratoryViewEmbeddable } = observability;
 
   const monitorId = useMonitorQueryId();
+  const selectedLocation = useSelectedLocation();
 
-  if (!monitorId) {
+  if (!monitorId || !selectedLocation) {
     return null;
   }
 
@@ -34,7 +36,10 @@ export const MonitorTotalRunsCount = (props: MonitorTotalRunsCountProps) => {
       attributes={[
         {
           time: props,
-          reportDefinitions: { config_id: [monitorId] },
+          reportDefinitions: {
+            'monitor.id': [monitorId],
+            'observer.geo.name': [selectedLocation.label],
+          },
           dataType: 'synthetics',
           selectedMetricField: 'monitor_total_runs',
           name: 'synthetics-series-1',


### PR DESCRIPTION
## Summary

Related to #144857. Ensure the stats in the history page also take into account the monitor location.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->