### PR TITLE
[Telemetry] Use `GET /` to fetch the Cluster UUID

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.ts
@@ -25,6 +25,6 @@ export async function getClusterStats(esClient: ElasticsearchClient) {
  * @param esClient Scoped Elasticsearch client
  */
 export const getClusterUuids: ClusterDetailsGetter = async ({ esClient }) => {
-  const body = await esClient.cluster.stats({ timeout: TIMEOUT });
+  const body = await esClient.info({ filter_path: 'cluster_uuid' });
   return [{ clusterUuid: body.cluster_uuid }];
 };


### PR DESCRIPTION
## Summary

Resolves #145528.

When backporting to 7.17, we need to intercept the PR (it'll likely fail anyway) and change the `const body` with `const { body }`

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->