### PR TITLE
[APM] Minor telemetry client refactor

### DIFF
--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -6,40 +6,21 @@
  */
 
 import { merge } from 'lodash';
-import { Logger, SavedObjectsClient } from '@kbn/core/server';
-import { ApmIndicesConfig } from '../../../routes/settings/apm_indices/get_apm_indices';
-import { tasks } from './tasks';
+import { Logger } from '@kbn/core/server';
+import { tasks, TelemetryTaskExecutorParams } from './tasks';
 import { APMDataTelemetry } from '../types';
-import { TelemetryClient } from '../telemetry_client';
 
-type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
-
-export interface TelemetryTaskExecutorParams {
-  telemetryClient: TelemetryClient;
-  indices: ApmIndicesConfig;
-  savedObjectsClient: ISavedObjectsClient;
-}
-
-type TelemetryTaskExecutor = (
-  params: TelemetryTaskExecutorParams
-) => Promise<APMDataTelemetry>;
-
-export interface TelemetryTask {
-  name: string;
-  executor: TelemetryTaskExecutor;
-}
-
-export type CollectTelemetryParams = TelemetryTaskExecutorParams & {
+type CollectTelemetryParams = TelemetryTaskExecutorParams & {
   isProd: boolean;
   logger: Logger;
 };
 
 export function collectDataTelemetry({
   indices,
-  logger,
   telemetryClient,
   savedObjectsClient,
   isProd,
+  logger,
 }: CollectTelemetryParams) {
   return tasks.reduce((prev, task) => {
     return prev.then(async (data) => {
@@ -47,8 +28,8 @@ export function collectDataTelemetry({
       try {
         const time = process.hrtime();
         const next = await task.executor({
-          telemetryClient,
           indices,
+          telemetryClient,
           savedObjectsClient,
         });
         const took = process.hrtime(time);

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -9,7 +9,7 @@ import { fromKueryExpression } from '@kbn/es-query';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { createHash } from 'crypto';
 import { flatten, merge, pickBy, sortBy, sum, uniq } from 'lodash';
-import { TelemetryTask } from '.';
+import { SavedObjectsClient } from '@kbn/core/server';
 import { AGENT_NAMES, RUM_AGENT_NAMES } from '../../../../common/agent_name';
 import {
   AGENT_NAME,
@@ -53,12 +53,27 @@ import { APMError } from '../../../../typings/es_schemas/ui/apm_error';
 import { AgentName } from '../../../../typings/es_schemas/ui/fields/agent';
 import { Span } from '../../../../typings/es_schemas/ui/span';
 import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
-import { APMPerService, APMTelemetry } from '../types';
+import { APMTelemetry, APMPerService, APMDataTelemetry } from '../types';
+import { ApmIndicesConfig } from '../../../routes/settings/apm_indices/get_apm_indices';
+import { TelemetryClient } from '../telemetry_client';
+
+type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
 const TIME_RANGES = ['1d', 'all'] as const;
 type TimeRange = typeof TIME_RANGES[number];
 
 const range1d = { range: { '@timestamp': { gte: 'now-1d' } } };
 const timeout = '5m';
+
+interface TelemetryTask {
+  name: string;
+  executor: (params: TelemetryTaskExecutorParams) => Promise<APMDataTelemetry>;
+}
+
+export interface TelemetryTaskExecutorParams {
+  telemetryClient: TelemetryClient;
+  indices: ApmIndicesConfig;
+  savedObjectsClient: ISavedObjectsClient;
+}
 
 export const tasks: TelemetryTask[] = [
   {


### PR DESCRIPTION
This just moves the types for tasks into the tasks file (where they belong). This was missed in https://github.com/elastic/kibana/pull/145208