### PR TITLE
[Fleet] Fix add fleet server host from advanced tab

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_fleet_server_host.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_fleet_server_host.ts
@@ -12,6 +12,7 @@ import {
   useComboInput,
   useInput,
   useSwitchInput,
+  validateInputs,
 } from '../../../hooks';
 import type { FleetServerHost } from '../../../types';
 
@@ -44,10 +45,16 @@ export const useFleetServerHost = (): FleetServerHostForm => {
   const isDefaultInput = useSwitchInput(false, isPreconfigured || fleetServerHost?.is_default);
   const hostUrlsInput = useComboInput('hostUrls', [], validateFleetServerHosts, isPreconfigured);
 
-  const validate = useCallback(
-    () => hostUrlsInput.validate() && nameInput.validate(),
-    [hostUrlsInput, nameInput]
+  const inputs = useMemo(
+    () => ({
+      nameInput,
+      isDefaultInput,
+      hostUrlsInput,
+    }),
+    [nameInput, isDefaultInput, hostUrlsInput]
   );
+
+  const validate = useCallback(() => validateInputs(inputs), [inputs]);
 
   const { data, resendRequest: refreshGetFleetServerHosts } = useGetFleetServerHosts();
 
@@ -97,10 +104,6 @@ export const useFleetServerHost = (): FleetServerHostForm => {
     isFleetServerHostSubmitted,
     setFleetServerHost,
     validate,
-    inputs: {
-      hostUrlsInput,
-      nameInput,
-      isDefaultInput,
-    },
+    inputs,
   };
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/add_fleet_server_host.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/steps/add_fleet_server_host.tsx
@@ -79,10 +79,10 @@ export const AddFleetServerHostStepContent = ({
         id: 'fleet-server-host',
         is_preconfigured: false,
       };
-      setFleetServerHost(newFleetServerHost);
+
       if (validate()) {
-        setSubmittedFleetServerHost(newFleetServerHost);
         setFleetServerHost(await saveFleetServerHost(newFleetServerHost));
+        setSubmittedFleetServerHost(newFleetServerHost);
       }
     } catch (err) {
       notifications.toasts.addError(err, {


### PR DESCRIPTION
## Summary

Resolve #145509

It was possible to add an empty Fleet server host from the advanced tab when adding a new Fleet (the bug was only client side no proper Fleet server host where created)

That PR fix that now when trying to add an empty fleet server host you got a proper error message:

<img width="637" alt="Screen Shot 2022-11-17 at 3 17 03 PM" src="https://user-images.githubusercontent.com/1336873/202551277-ed5fb251-a161-4670-99a1-5f813962aa0c.png">

## How to reproduce

See the original issue for more info

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->