### PR TITLE
[ML] Explain Log Rate Spikes: Use bulk indexing for dummy data.

### DIFF
--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -139,7 +139,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/140848
   describe('explain log rate spikes', function () {
     this.tags(['aiops']);
     before(async () => {

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -175,19 +175,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         }),
       });
 
-      await es.index({
-        index: ES_INDEX,
-        body: {
-          '@timestamp': '2016-02-09T16:19:59.000Z',
-          '@version': 101,
-          airline: 'UAL',
-          custom_field: 'deviation',
-          responsetime: 10,
-          type: 'farequote',
-        },
-        refresh: 'wait_for',
-      });
-
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -13,11 +13,11 @@ export const farequoteDataViewTestData: TestData = {
   sourceIndexOrSavedSearch: 'ft_farequote',
   brushTargetTimestamp: 1455033600000,
   expected: {
-    totalDocCountFormatted: '86,375',
+    totalDocCountFormatted: '86,374',
     analysisGroupsTable: [
       { docCount: '297', group: 'airline: AAL' },
       {
-        docCount: '101',
+        docCount: '100',
         group: 'airline: UALcustom_field.keyword: deviation',
       },
     ],
@@ -26,7 +26,7 @@ export const farequoteDataViewTestData: TestData = {
         fieldName: 'airline',
         fieldValue: 'AAL',
         logRate: 'Chart type:bar chart',
-        pValue: '5.00e-11',
+        pValue: '4.66e-11',
         impact: 'High',
       },
     ],


### PR DESCRIPTION
## Summary

Part of #142456.

The functional tests added 100 docs with individual requests. This update uses bulk indexing to speed up preparing the data.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->