### PR TITLE
[Enterprise Search] Fix logic for long running and orphaned jobs 

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
@@ -68,23 +68,10 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
   });
 
   const errorResponse = await client.asCurrentUser.count({
-    index: CONNECTORS_JOBS_INDEX,
+    index: CONNECTORS_INDEX,
     query: {
-      bool: {
-        should: [
-          {
-            term: {
-              status: SyncStatus.ERROR,
-            },
-          },
-          {
-            range: {
-              last_seen: {
-                lt: moment().subtract(30, 'minutes').toISOString(),
-              },
-            },
-          },
-        ],
+      term: {
+        last_sync_status: SyncStatus.ERROR,
       },
     },
   });


### PR DESCRIPTION
This fixes the logic for long-running connector sync jobs: they should look at started_at rather than last_seen.
It also fixes the logic for orphaned jobs, which were displaying the opposite of what they should have been displaying.