### PR TITLE
[Lens] [Event Annotations] create API for Event Annotations Saved Object

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
@@ -82,6 +82,8 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "enterprise_search_telemetry": "fafcc8318528d34f721c42d1270787c52565bad5",
         "epm-packages": "fe3716a54188b3c71327fa060dd6780a674d3994",
         "epm-packages-assets": "9fd3d6726ac77369249e9a973902c2cd615fc771",
+        "event-annotation": "6e24d58d36b36f95d2944daac73d868eeeaeef07",
+        "event-annotation-group": "b95a4988dfa249af0e604c3ef76fd1c274fc5971",
         "event_loop_delays_daily": "d2ed39cf669577d90921c176499908b4943fb7bd",
         "exception-list": "fe8cc004fd2742177cdb9300f4a67689463faf9c",
         "exception-list-agnostic": "49fae8fcd1967cc4be45ba2a2c66c4afbc1e341b",

--- a/src/core/server/integration_tests/saved_objects/migrations/type_registrations.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/type_registrations.test.ts
@@ -41,6 +41,8 @@ const previouslyRegisteredTypes = [
   'csp-rule-template',
   'csp_rule',
   'dashboard',
+  'event-annotation',
+  'event-annotation-group',
   'endpoint:user-artifact',
   'endpoint:user-artifact-manifest',
   'enterprise_search_telemetry',

--- a/src/plugins/chart_expressions/expression_xy/public/plugin.ts
+++ b/src/plugins/chart_expressions/expression_xy/public/plugin.ts
@@ -83,7 +83,7 @@ export class ExpressionXyPlugin {
       const paletteService = await palettes.getPalettes();
 
       const { theme: kibanaTheme } = coreStart;
-      const eventAnnotationService = await eventAnnotation.getService();
+      const eventAnnotationService = await eventAnnotation.getService(coreStart);
       const useLegacyTimeAxis = core.uiSettings.get(LEGACY_TIME_AXIS);
 
       return {

--- a/src/plugins/event_annotation/common/constants.ts
+++ b/src/plugins/event_annotation/common/constants.ts
@@ -23,3 +23,6 @@ export const AvailableAnnotationIcons = {
   TAG: 'tag',
   TRIANGLE: 'triangle',
 } as const;
+
+export const EVENT_ANNOTATION_GROUP_TYPE = 'event-annotation-group';
+export const EVENT_ANNOTATION_TYPE = 'event-annotation';

--- a/src/plugins/event_annotation/common/index.ts
+++ b/src/plugins/event_annotation/common/index.ts
@@ -33,4 +33,7 @@ export type {
   QueryPointEventAnnotationConfig,
   AvailableAnnotationIcon,
   EventAnnotationOutput,
+  EventAnnotationGroupAttributes,
 } from './types';
+
+export { EVENT_ANNOTATION_TYPE, EVENT_ANNOTATION_GROUP_TYPE } from './constants';

--- a/src/plugins/event_annotation/common/types.ts
+++ b/src/plugins/event_annotation/common/types.ts
@@ -82,10 +82,20 @@ export type EventAnnotationConfig =
   | RangeEventAnnotationConfig
   | QueryPointEventAnnotationConfig;
 
+export interface EventAnnotationGroupAttributes {
+  title: string;
+  description?: string;
+  tags?: string[];
+  ignoreGlobalFilters?: boolean;
+}
+
 export interface EventAnnotationGroupConfig {
   annotations: EventAnnotationConfig[];
   indexPatternId: string;
   ignoreGlobalFilters?: boolean;
+  title?: string;
+  description?: string;
+  tags?: string[];
 }
 
 export type EventAnnotationArgs =

--- a/src/plugins/event_annotation/kibana.json
+++ b/src/plugins/event_annotation/kibana.json
@@ -11,6 +11,9 @@
     "expressions",
     "data"
   ],
+  "requiredBundles": [
+    "savedObjects"
+  ],
   "owner": {
     "name": "Vis Editors",
     "githubTeam": "kibana-visualizations"

--- a/src/plugins/event_annotation/public/components/event_annotation_group_saved_object_finder.tsx
+++ b/src/plugins/event_annotation/public/components/event_annotation_group_saved_object_finder.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { SavedObjectFinderUi } from '@kbn/saved-objects-plugin/public';
+import { CoreStart, SimpleSavedObject } from '@kbn/core/public';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+import { EVENT_ANNOTATION_GROUP_TYPE } from '../../common';
+
+export const EventAnnotationGroupSavedObjectFinder = ({
+  uiSettings,
+  savedObjects,
+  fixedPageSize = 10,
+  onChoose,
+}: {
+  uiSettings: IUiSettingsClient;
+  savedObjects: CoreStart['savedObjects'];
+  fixedPageSize: number;
+  onChoose: (value: {
+    id: string;
+    type: string;
+    fullName: string;
+    savedObject: SimpleSavedObject<unknown>;
+  }) => void;
+}) => {
+  return (
+    <SavedObjectFinderUi
+      key="searchSavedObjectFinder"
+      fixedPageSize={fixedPageSize}
+      onChoose={(id, type, fullName, savedObject) => {
+        onChoose({ id, type, fullName, savedObject });
+      }}
+      showFilter={false}
+      noItemsMessage={
+        <FormattedMessage
+          id="eventAnnotation.eventAnnotationGroup.savedObjectFinder.notFoundLabel"
+          defaultMessage="No matching annotation groups found."
+        />
+      }
+      savedObjectMetaData={savedObjectMetaData}
+      uiSettings={uiSettings}
+      savedObjects={savedObjects}
+    />
+  );
+};
+
+const savedObjectMetaData = [
+  {
+    type: EVENT_ANNOTATION_GROUP_TYPE,
+    getIconForSavedObject: () => 'annotation',
+    name: i18n.translate('eventAnnotation.eventAnnotationGroup.metadata.name', {
+      defaultMessage: 'Annotations Groups',
+    }),
+    includeFields: ['*'],
+  },
+];

--- a/src/plugins/event_annotation/public/event_annotation_service/index.tsx
+++ b/src/plugins/event_annotation/public/event_annotation_service/index.tsx
@@ -6,14 +6,16 @@
  * Side Public License, v 1.
  */
 
+import { CoreStart } from '@kbn/core/public';
+// import { EventAnnotationGroupConfig } from '../../common';
 import { EventAnnotationServiceType } from './types';
 
 export class EventAnnotationService {
   private eventAnnotationService?: EventAnnotationServiceType;
-  public async getService() {
+  public async getService(core: CoreStart) {
     if (!this.eventAnnotationService) {
       const { getEventAnnotationService } = await import('./service');
-      this.eventAnnotationService = getEventAnnotationService();
+      this.eventAnnotationService = getEventAnnotationService(core);
     }
     return this.eventAnnotationService;
   }

--- a/src/plugins/event_annotation/public/event_annotation_service/service.test.ts
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.test.ts
@@ -6,14 +6,138 @@
  * Side Public License, v 1.
  */
 
+import { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
+import { EventAnnotationConfig } from '../../common';
 import { getEventAnnotationService } from './service';
 import { EventAnnotationServiceType } from './types';
 
+const annotationGroupResolveMocks = {
+  nonExistingGroup: {
+    saved_object: {
+      attributes: {},
+      references: [],
+      id: 'nonExistingGroup',
+    },
+    outcome: 'exactMatch',
+  },
+  noAnnotations: {
+    saved_object: {
+      attributes: {
+        title: 'groupTitle',
+      },
+      type: 'event-annotation-group',
+      references: [
+        {
+          id: 'ipid',
+          name: 'ipid',
+          type: 'index-pattern',
+        },
+      ],
+    },
+    outcome: 'exactMatch',
+  },
+  multiAnnotations: {
+    saved_object: {
+      attributes: {
+        title: 'groupTitle',
+      },
+      id: 'multiAnnotations',
+      type: 'event-annotation-group',
+      references: [
+        {
+          id: 'ipid',
+          name: 'ipid',
+          type: 'index-pattern',
+        },
+      ],
+    },
+    outcome: 'exactMatch',
+  },
+};
+
+const annotationResolveMocks = {
+  nonExistingGroup: { savedObjects: [] },
+  noAnnotations: { savedObjects: [] },
+  multiAnnotations: {
+    savedObjects: [
+      {
+        id: 'annotation1',
+        attributes: {
+          id: 'annotation1',
+          type: 'manual',
+          key: { type: 'point_in_time' as const, timestamp: '2022-03-18T08:25:00.000Z' },
+          label: 'Event',
+          icon: 'triangle' as const,
+          color: 'red',
+          lineStyle: 'dashed' as const,
+          lineWidth: 3,
+        } as EventAnnotationConfig,
+        type: 'event-annotation',
+        references: [
+          {
+            id: 'multiAnnotations',
+            name: 'event_annotation_group_ref',
+            type: 'event-annotation-group',
+          },
+        ],
+      },
+      {
+        id: 'annotation2',
+        attributes: {
+          id: 'ann2',
+          label: 'Query based event',
+          icon: 'triangle',
+          color: 'red',
+          type: 'query',
+          timeField: 'timestamp',
+          key: {
+            type: 'point_in_time',
+          },
+          lineStyle: 'dashed',
+          lineWidth: 3,
+          filter: { type: 'kibana_query', query: '', language: 'kuery' },
+        } as EventAnnotationConfig,
+        type: 'event-annotation',
+        references: [
+          {
+            id: 'multiAnnotations',
+            name: 'event_annotation_group_ref',
+            type: 'event-annotation-group',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+let core: CoreStart;
+
 describe('Event Annotation Service', () => {
   let eventAnnotationService: EventAnnotationServiceType;
-  beforeAll(() => {
-    eventAnnotationService = getEventAnnotationService();
+  beforeEach(() => {
+    core = coreMock.createStart();
+    (core.savedObjects.client.resolve as jest.Mock).mockImplementation(
+      (_type, id: 'multiAnnotations' | 'noAnnotations' | 'nonExistingGroup') => {
+        return annotationGroupResolveMocks[id];
+      }
+    );
+    (core.savedObjects.client.create as jest.Mock).mockImplementation(() => {
+      return annotationGroupResolveMocks.multiAnnotations.saved_object;
+    });
+    (core.savedObjects.client.bulkCreate as jest.Mock).mockImplementation(() => {
+      return annotationResolveMocks.multiAnnotations;
+    });
+    (core.savedObjects.client.find as jest.Mock).mockImplementation(({ hasReference: { id } }) => {
+      const typedId = id as 'multiAnnotations' | 'noAnnotations' | 'nonExistingGroup';
+      return annotationResolveMocks[typedId];
+    });
+    eventAnnotationService = getEventAnnotationService(core);
   });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('toExpression', () => {
     it('should work for an empty list', () => {
       expect(eventAnnotationService.toExpression([])).toEqual([]);
@@ -317,5 +441,182 @@ describe('Event Annotation Service', () => {
         ]);
       }
     );
+  });
+  describe('loadAnnotationGroup', () => {
+    it('should not error when loading group doesnt exit', async () => {
+      expect(await eventAnnotationService.loadAnnotationGroup('nonExistingGroup')).toEqual({
+        annotations: [],
+        indexPatternId: undefined,
+        title: undefined,
+      });
+    });
+    it('should properly load an annotation group with no annotation', async () => {
+      expect(await eventAnnotationService.loadAnnotationGroup('noAnnotations')).toEqual({
+        annotations: [],
+        indexPatternId: 'ipid',
+        title: 'groupTitle',
+      });
+    });
+    it('should properly load an annotation group with a multiple annotation', async () => {
+      expect(await eventAnnotationService.loadAnnotationGroup('multiAnnotations')).toEqual({
+        annotations: [
+          annotationResolveMocks.multiAnnotations.savedObjects[0].attributes,
+          annotationResolveMocks.multiAnnotations.savedObjects[1].attributes,
+        ],
+        indexPatternId: 'ipid',
+        title: 'groupTitle',
+      });
+    });
+  });
+  describe('deleteAnnotationGroup', () => {
+    it('deletes annotation group along with annotations that reference them', async () => {
+      await eventAnnotationService.deleteAnnotationGroup('multiAnnotations');
+      expect(core.savedObjects.client.bulkDelete).toHaveBeenCalledWith([
+        { id: 'multiAnnotations', type: 'event-annotation-group' },
+        { id: 'annotation1', type: 'event-annotation' },
+        { id: 'annotation2', type: 'event-annotation' },
+      ]);
+    });
+  });
+  describe('createAnnotationGroup', () => {
+    it('creates annotation group along with annotations', async () => {
+      await eventAnnotationService.createAnnotationGroup({
+        title: 'newGroupTitle',
+        indexPatternId: 'ipid',
+        annotations: [
+          annotationResolveMocks.multiAnnotations.savedObjects[0].attributes,
+          annotationResolveMocks.multiAnnotations.savedObjects[1].attributes,
+        ],
+      });
+      expect(core.savedObjects.client.create).toHaveBeenCalledWith(
+        'event-annotation-group',
+        { title: 'newGroupTitle' },
+        {
+          references: [
+            {
+              id: 'ipid',
+              name: 'event-annotation-group_dataView-ref-ipid',
+              type: 'index-pattern',
+            },
+          ],
+        }
+      );
+      expect(core.savedObjects.client.bulkCreate).toHaveBeenCalledWith([
+        {
+          attributes: annotationResolveMocks.multiAnnotations.savedObjects[0].attributes,
+          id: 'annotation1',
+          references: [
+            {
+              id: 'multiAnnotations',
+              name: 'event-annotation_group-ref-annotation1',
+              type: 'event-annotation-group',
+            },
+          ],
+          type: 'event-annotation',
+        },
+        {
+          attributes: annotationResolveMocks.multiAnnotations.savedObjects[1].attributes,
+          id: 'ann2',
+          references: [
+            {
+              id: 'multiAnnotations',
+              name: 'event-annotation_group-ref-ann2',
+              type: 'event-annotation-group',
+            },
+          ],
+          type: 'event-annotation',
+        },
+      ]);
+    });
+  });
+  describe('updateAnnotationGroupAttributes', () => {
+    it('updates annotation group attributes', async () => {
+      await eventAnnotationService.updateAnnotationGroup(
+        { title: 'newTitle', indexPatternId: 'newId', annotations: [] },
+        'multiAnnotations'
+      );
+      expect(core.savedObjects.client.update).toHaveBeenCalledWith(
+        'event-annotation-group',
+        'multiAnnotations',
+        { title: 'newTitle' },
+        {
+          references: [
+            {
+              id: 'newId',
+              name: 'event-annotation-group_dataView-ref-newId',
+              type: 'index-pattern',
+            },
+          ],
+        }
+      );
+    });
+  });
+  describe('updateAnnotations', () => {
+    const upsert = [
+      {
+        id: 'annotation2',
+        label: 'Query based event',
+        icon: 'triangle',
+        color: 'red',
+        type: 'query',
+        timeField: 'timestamp',
+        key: {
+          type: 'point_in_time',
+        },
+        lineStyle: 'dashed',
+        lineWidth: 3,
+        filter: { type: 'kibana_query', query: '', language: 'kuery' },
+      },
+      {
+        id: 'annotation4',
+        label: 'Query based event',
+        type: 'query',
+        timeField: 'timestamp',
+        key: {
+          type: 'point_in_time',
+        },
+        filter: { type: 'kibana_query', query: '', language: 'kuery' },
+      },
+    ] as EventAnnotationConfig[];
+    it('updates annotations - deletes annotations', async () => {
+      await eventAnnotationService.updateAnnotations('multiAnnotations', {
+        delete: ['annotation1', 'annotation2'],
+      });
+      expect(core.savedObjects.client.bulkDelete).toHaveBeenCalledWith([
+        { id: 'annotation1', type: 'event-annotation' },
+        { id: 'annotation2', type: 'event-annotation' },
+      ]);
+    });
+    it('updates annotations - inserts new annotations', async () => {
+      await eventAnnotationService.updateAnnotations('multiAnnotations', { upsert });
+      expect(core.savedObjects.client.bulkCreate).toHaveBeenCalledWith([
+        {
+          id: 'annotation2',
+          type: 'event-annotation',
+          attributes: upsert[0],
+          overwrite: true,
+          references: [
+            {
+              id: 'multiAnnotations',
+              name: 'event-annotation-group-ref-annotation2',
+              type: 'event-annotation-group',
+            },
+          ],
+        },
+        {
+          id: 'annotation4',
+          type: 'event-annotation',
+          attributes: upsert[1],
+          overwrite: true,
+          references: [
+            {
+              id: 'multiAnnotations',
+              name: 'event-annotation-group-ref-annotation4',
+              type: 'event-annotation-group',
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/src/plugins/event_annotation/public/event_annotation_service/service.tsx
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.tsx
@@ -6,10 +6,18 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
 import { partition } from 'lodash';
 import { queryToAst } from '@kbn/data-plugin/common';
 import { ExpressionAstExpression } from '@kbn/expressions-plugin/common';
-import { EventAnnotationConfig } from '../../common';
+import { CoreStart, SavedObjectsClientContract, SimpleSavedObject } from '@kbn/core/public';
+import {
+  EventAnnotationConfig,
+  EventAnnotationGroupConfig,
+  EventAnnotationGroupAttributes,
+  EVENT_ANNOTATION_GROUP_TYPE,
+  EVENT_ANNOTATION_TYPE,
+} from '../../common';
 import { EventAnnotationServiceType } from './types';
 import {
   defaultAnnotationColor,
@@ -18,108 +26,179 @@ import {
   isRangeAnnotationConfig,
   isQueryAnnotationConfig,
 } from './helpers';
+import { EventAnnotationGroupSavedObjectFinder } from '../components/event_annotation_group_saved_object_finder';
 
 export function hasIcon(icon: string | undefined): icon is string {
   return icon != null && icon !== 'empty';
 }
 
-export function getEventAnnotationService(): EventAnnotationServiceType {
-  const annotationsToExpression = (annotations: EventAnnotationConfig[]) => {
-    const [queryBasedAnnotations, manualBasedAnnotations] = partition(
-      annotations,
-      isQueryAnnotationConfig
+export function getEventAnnotationService(core: CoreStart): EventAnnotationServiceType {
+  const client: SavedObjectsClientContract = core.savedObjects.client;
+
+  const loadAnnotationGroup = async (
+    savedObjectId: string
+  ): Promise<EventAnnotationGroupConfig> => {
+    const groupResponse = await client.resolve<EventAnnotationGroupAttributes>(
+      EVENT_ANNOTATION_GROUP_TYPE,
+      savedObjectId
     );
 
-    const expressions = [];
-
-    for (const annotation of manualBasedAnnotations) {
-      if (isRangeAnnotationConfig(annotation)) {
-        const { label, color, key, outside, id } = annotation;
-        const { timestamp: time, endTimestamp: endTime } = key;
-        expressions.push({
-          type: 'expression' as const,
-          chain: [
-            {
-              type: 'function' as const,
-              function: 'manual_range_event_annotation',
-              arguments: {
-                id: [id],
-                time: [time],
-                endTime: [endTime],
-                label: [label || defaultAnnotationLabel],
-                color: [color || defaultAnnotationRangeColor],
-                outside: [Boolean(outside)],
-                isHidden: [Boolean(annotation.isHidden)],
-              },
-            },
-          ],
-        });
-      } else {
-        const { label, color, lineStyle, lineWidth, icon, key, textVisibility, id } = annotation;
-        expressions.push({
-          type: 'expression' as const,
-          chain: [
-            {
-              type: 'function' as const,
-              function: 'manual_point_event_annotation',
-              arguments: {
-                id: [id],
-                time: [key.timestamp],
-                label: [label || defaultAnnotationLabel],
-                color: [color || defaultAnnotationColor],
-                lineWidth: [lineWidth || 1],
-                lineStyle: [lineStyle || 'solid'],
-                icon: hasIcon(icon) ? [icon] : ['triangle'],
-                textVisibility: [textVisibility || false],
-                isHidden: [Boolean(annotation.isHidden)],
-              },
-            },
-          ],
-        });
-      }
+    if (groupResponse.saved_object.error) {
+      throw groupResponse.saved_object.error;
     }
 
-    for (const annotation of queryBasedAnnotations) {
-      const {
-        id,
-        label,
-        color,
-        lineStyle,
-        lineWidth,
-        icon,
-        timeField,
-        textVisibility,
-        textField,
-        filter,
-        extraFields,
-      } = annotation;
-      expressions.push({
-        type: 'expression' as const,
-        chain: [
-          {
-            type: 'function' as const,
-            function: 'query_point_event_annotation',
-            arguments: {
-              id: [id],
-              timeField: timeField ? [timeField] : [],
-              label: [label || defaultAnnotationLabel],
-              color: [color || defaultAnnotationColor],
-              lineWidth: [lineWidth || 1],
-              lineStyle: [lineStyle || 'solid'],
-              icon: hasIcon(icon) ? [icon] : ['triangle'],
-              textVisibility: [textVisibility || false],
-              textField: textVisibility && textField ? [textField] : [],
-              filter: filter ? [queryToAst(filter)] : [],
-              extraFields: extraFields || [],
-              isHidden: [Boolean(annotation.isHidden)],
+    const annotations = (
+      await client.find<EventAnnotationConfig>({
+        type: EVENT_ANNOTATION_TYPE,
+        hasReference: {
+          type: EVENT_ANNOTATION_GROUP_TYPE,
+          id: savedObjectId,
+        },
+      })
+    ).savedObjects
+      .filter(({ error }) => !error)
+      .map((annotation) => annotation.attributes);
+
+    return {
+      title: groupResponse.saved_object.attributes.title,
+      description: groupResponse.saved_object.attributes.description,
+      tags: groupResponse.saved_object.attributes.tags,
+      ignoreGlobalFilters: groupResponse.saved_object.attributes.ignoreGlobalFilters,
+      indexPatternId: groupResponse.saved_object.references.find(
+        (ref) => ref.type === 'index-pattern'
+      )?.id!,
+      annotations,
+    };
+  };
+
+  const deleteAnnotationGroup = async (savedObjectId: string): Promise<void> => {
+    const annotationsSOs = (
+      await client.find({
+        type: EVENT_ANNOTATION_TYPE,
+        hasReference: {
+          type: EVENT_ANNOTATION_GROUP_TYPE,
+          id: savedObjectId,
+        },
+      })
+    ).savedObjects.map((annotation) => ({ id: annotation.id, type: EVENT_ANNOTATION_TYPE }));
+    await client.bulkDelete([
+      { type: EVENT_ANNOTATION_GROUP_TYPE, id: savedObjectId },
+      ...annotationsSOs,
+    ]);
+  };
+
+  const createAnnotationGroup = async (
+    group: EventAnnotationGroupConfig
+  ): Promise<{ id: string }> => {
+    const { title, description, tags, ignoreGlobalFilters, indexPatternId, annotations } = group;
+
+    const groupSavedObjectId = (
+      await client.create(
+        EVENT_ANNOTATION_GROUP_TYPE,
+        { title, description, tags, ignoreGlobalFilters },
+        {
+          references: [
+            {
+              type: 'index-pattern',
+              id: indexPatternId,
+              name: `event-annotation-group_dataView-ref-${indexPatternId}`,
             },
+          ],
+        }
+      )
+    ).id;
+
+    if (annotations && annotations.length) {
+      await client.bulkCreate(
+        annotations.map((annotation) => ({
+          type: EVENT_ANNOTATION_TYPE,
+          id: annotation.id,
+          attributes: annotation,
+          references: [
+            {
+              type: EVENT_ANNOTATION_GROUP_TYPE,
+              id: groupSavedObjectId,
+              name: `event-annotation_group-ref-${annotation.id}`, // do name have to be unique with id?
+            },
+          ],
+        }))
+      );
+    }
+    return { id: groupSavedObjectId };
+  };
+
+  const updateAnnotationGroup = async (
+    group: EventAnnotationGroupConfig,
+    savedObjectId: string
+  ): Promise<void> => {
+    const { title, description, tags, ignoreGlobalFilters, indexPatternId } = group;
+    await client.update(
+      EVENT_ANNOTATION_GROUP_TYPE,
+      savedObjectId,
+      { title, description, tags, ignoreGlobalFilters },
+      {
+        references: [
+          {
+            type: 'index-pattern',
+            id: indexPatternId,
+            name: `event-annotation-group_dataView-ref-${indexPatternId}`,
           },
         ],
-      });
-    }
-    return expressions;
+      }
+    );
   };
+
+  const updateAnnotations = async (
+    savedObjectId: string,
+    modifications: { delete?: string[]; upsert?: EventAnnotationConfig[] }
+  ): Promise<void> => {
+    if (modifications.delete && modifications.delete.length > 0) {
+      await client.bulkDelete(
+        modifications.delete.map((id) => ({ type: EVENT_ANNOTATION_TYPE, id }))
+      );
+    }
+
+    if (modifications.upsert && modifications.upsert.length > 0) {
+      const annotationsToUpdate = modifications.upsert.map((a) => ({
+        type: EVENT_ANNOTATION_TYPE,
+        attributes: a,
+        id: a.id,
+        overwrite: true,
+        references: [
+          {
+            type: EVENT_ANNOTATION_GROUP_TYPE,
+            id: savedObjectId,
+            name: `event-annotation-group-ref-${a.id}`,
+          },
+        ],
+      }));
+      await client.bulkCreate(annotationsToUpdate);
+    }
+  };
+
   return {
+    loadAnnotationGroup,
+    updateAnnotations,
+    updateAnnotationGroup,
+    createAnnotationGroup,
+    deleteAnnotationGroup,
+    renderEventAnnotationGroupSavedObjectFinder: (props: {
+      fixedPageSize: number;
+      onChoose: (value: {
+        id: string;
+        type: string;
+        fullName: string;
+        savedObject: SimpleSavedObject<unknown>;
+      }) => void;
+    }) => {
+      return (
+        <EventAnnotationGroupSavedObjectFinder
+          savedObjects={core.savedObjects}
+          uiSettings={core.uiSettings}
+          {...props}
+        />
+      );
+    },
     toExpression: annotationsToExpression,
     toFetchExpression: ({ interval, groups }) => {
       if (groups.length === 0) {
@@ -177,3 +256,99 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
     },
   };
 }
+
+const annotationsToExpression = (annotations: EventAnnotationConfig[]) => {
+  const [queryBasedAnnotations, manualBasedAnnotations] = partition(
+    annotations,
+    isQueryAnnotationConfig
+  );
+
+  const expressions = [];
+
+  for (const annotation of manualBasedAnnotations) {
+    if (isRangeAnnotationConfig(annotation)) {
+      const { label, color, key, outside, id } = annotation;
+      const { timestamp: time, endTimestamp: endTime } = key;
+      expressions.push({
+        type: 'expression' as const,
+        chain: [
+          {
+            type: 'function' as const,
+            function: 'manual_range_event_annotation',
+            arguments: {
+              id: [id],
+              time: [time],
+              endTime: [endTime],
+              label: [label || defaultAnnotationLabel],
+              color: [color || defaultAnnotationRangeColor],
+              outside: [Boolean(outside)],
+              isHidden: [Boolean(annotation.isHidden)],
+            },
+          },
+        ],
+      });
+    } else {
+      const { label, color, lineStyle, lineWidth, icon, key, textVisibility, id } = annotation;
+      expressions.push({
+        type: 'expression' as const,
+        chain: [
+          {
+            type: 'function' as const,
+            function: 'manual_point_event_annotation',
+            arguments: {
+              id: [id],
+              time: [key.timestamp],
+              label: [label || defaultAnnotationLabel],
+              color: [color || defaultAnnotationColor],
+              lineWidth: [lineWidth || 1],
+              lineStyle: [lineStyle || 'solid'],
+              icon: hasIcon(icon) ? [icon] : ['triangle'],
+              textVisibility: [textVisibility || false],
+              isHidden: [Boolean(annotation.isHidden)],
+            },
+          },
+        ],
+      });
+    }
+  }
+
+  for (const annotation of queryBasedAnnotations) {
+    const {
+      id,
+      label,
+      color,
+      lineStyle,
+      lineWidth,
+      icon,
+      timeField,
+      textVisibility,
+      textField,
+      filter,
+      extraFields,
+    } = annotation;
+    expressions.push({
+      type: 'expression' as const,
+      chain: [
+        {
+          type: 'function' as const,
+          function: 'query_point_event_annotation',
+          arguments: {
+            id: [id],
+            timeField: timeField ? [timeField] : [],
+            label: [label || defaultAnnotationLabel],
+            color: [color || defaultAnnotationColor],
+            lineWidth: [lineWidth || 1],
+            lineStyle: [lineStyle || 'solid'],
+            icon: hasIcon(icon) ? [icon] : ['triangle'],
+            textVisibility: [textVisibility || false],
+            textField: textVisibility && textField ? [textField] : [],
+            filter: filter ? [queryToAst(filter)] : [],
+            extraFields: extraFields || [],
+            isHidden: [Boolean(annotation.isHidden)],
+          },
+        },
+      ],
+    });
+  }
+  return expressions;
+};

--- a/src/plugins/event_annotation/public/event_annotation_service/types.ts
+++ b/src/plugins/event_annotation/public/event_annotation_service/types.ts
@@ -6,13 +6,34 @@
  * Side Public License, v 1.
  */
 
+import { SimpleSavedObject } from '@kbn/core-saved-objects-api-browser';
 import { ExpressionAstExpression } from '@kbn/expressions-plugin/common/ast';
 import { EventAnnotationConfig, EventAnnotationGroupConfig } from '../../common';
 
 export interface EventAnnotationServiceType {
+  loadAnnotationGroup: (savedObjectId: string) => Promise<EventAnnotationGroupConfig>;
+  deleteAnnotationGroup: (savedObjectId: string) => Promise<void>;
+  createAnnotationGroup: (group: EventAnnotationGroupConfig) => Promise<{ id: string }>;
+  updateAnnotations: (
+    savedObjectId: string,
+    modifications: { delete?: string[]; upsert?: EventAnnotationConfig[] }
+  ) => Promise<void>;
+  updateAnnotationGroup: (
+    group: EventAnnotationGroupConfig,
+    savedObjectId: string
+  ) => Promise<void>;
   toExpression: (props: EventAnnotationConfig[]) => ExpressionAstExpression[];
   toFetchExpression: (props: {
     interval: string;
     groups: EventAnnotationGroupConfig[];
   }) => ExpressionAstExpression[];
+  renderEventAnnotationGroupSavedObjectFinder: (props: {
+    fixedPageSize: number;
+    onChoose: (value: {
+      id: string;
+      type: string;
+      fullName: string;
+      savedObject: SimpleSavedObject<unknown>;
+    }) => void;
+  }) => JSX.Element;
 }

--- a/src/plugins/event_annotation/public/mocks.ts
+++ b/src/plugins/event_annotation/public/mocks.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { coreMock } from '@kbn/core/public/mocks';
 import { getEventAnnotationService } from './event_annotation_service/service';
 
 // not really mocking but avoiding async loading
-export const eventAnnotationServiceMock = getEventAnnotationService();
+export const eventAnnotationServiceMock = getEventAnnotationService(coreMock.createStart());

--- a/src/plugins/event_annotation/public/plugin.ts
+++ b/src/plugins/event_annotation/public/plugin.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Plugin, CoreSetup, CoreStart, IUiSettingsClient } from '@kbn/core/public';
+import { Plugin, CoreSetup, IUiSettingsClient, CoreStart } from '@kbn/core/public';
 import { ExpressionsSetup } from '@kbn/expressions-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { EventAnnotationService } from './event_annotation_service';

--- a/src/plugins/event_annotation/server/plugin.ts
+++ b/src/plugins/event_annotation/server/plugin.ts
@@ -15,6 +15,7 @@ import {
   manualRangeEventAnnotation,
   queryPointEventAnnotation,
 } from '../common';
+import { setupSavedObjects } from './saved_objects';
 // import { getFetchEventAnnotations } from './fetch_event_annotations';
 
 interface SetupDependencies {
@@ -36,6 +37,7 @@ export class EventAnnotationServerPlugin implements Plugin<object, object> {
     // dependencies.expressions.registerFunction(
     //   getFetchEventAnnotations({ getStartServices: core.getStartServices })
     // );
+    setupSavedObjects(core);
 
     return {};
   }

--- a/src/plugins/event_annotation/server/saved_objects.ts
+++ b/src/plugins/event_annotation/server/saved_objects.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  CoreSetup,
+  mergeSavedObjectMigrationMaps,
+  SavedObject,
+  SavedObjectMigrationMap,
+} from '@kbn/core/server';
+
+import type {
+  SavedObjectsClientContract,
+  SavedObjectsExportTransformContext,
+} from '@kbn/core/server';
+import { DataViewPersistableStateService } from '@kbn/data-views-plugin/common';
+import { EventAnnotationConfig } from '../common';
+import { EVENT_ANNOTATION_GROUP_TYPE, EVENT_ANNOTATION_TYPE } from '../common/constants';
+import { EventAnnotationGroupAttributes } from '../common/types';
+
+type EventAnnotationAttributes = EventAnnotationConfig;
+
+export const EVENT_ANNOTATIONS_INDEX = '.kibana_event_annotations';
+
+export function setupSavedObjects(coreSetup: CoreSetup) {
+  coreSetup.savedObjects.registerType({
+    name: EVENT_ANNOTATION_GROUP_TYPE,
+    hidden: false,
+    namespaceType: 'multiple-isolated',
+    indexPattern: EVENT_ANNOTATIONS_INDEX,
+    management: {
+      icon: 'questionInCircle',
+      defaultSearchField: 'title',
+      importableAndExportable: true,
+      getTitle: (obj: { attributes: EventAnnotationGroupAttributes }) => obj.attributes.title,
+      onExport: async (context, objects: Array<SavedObject<EventAnnotationGroupAttributes>>) =>
+        handleExport({ context, objects, coreSetup }),
+    },
+    migrations: () => {
+      const dataViewMigrations = DataViewPersistableStateService.getAllMigrations();
+      return mergeSavedObjectMigrationMaps(eventAnnotationGroupMigrations, dataViewMigrations);
+    },
+    mappings: {
+      properties: {
+        title: {
+          type: 'text',
+        },
+        description: {
+          type: 'text',
+        },
+        tags: {
+          type: 'keyword',
+        },
+        ignoreGlobalFilters: {
+          type: 'boolean',
+        },
+      },
+    },
+  });
+
+  coreSetup.savedObjects.registerType({
+    name: EVENT_ANNOTATION_TYPE,
+    indexPattern: EVENT_ANNOTATIONS_INDEX,
+    hidden: false,
+    namespaceType: 'multiple-isolated',
+    management: {
+      visibleInManagement: false,
+      importableAndExportable: true,
+    },
+    migrations: () => eventAnnotationMigrations,
+    mappings: {
+      properties: {
+        id: {
+          type: 'text',
+        },
+        type: {
+          type: 'text',
+        },
+        key: {
+          type: 'flattened',
+        },
+        color: {
+          type: 'text',
+        },
+        lineStyle: {
+          type: 'text',
+        },
+        icon: {
+          type: 'text',
+        },
+        label: {
+          type: 'text',
+        },
+        lineWidth: {
+          type: 'long',
+        },
+        extraFields: {
+          type: 'flattened',
+        },
+        filter: {
+          type: 'flattened',
+        },
+        outside: {
+          type: 'boolean',
+        },
+        textVisibility: {
+          type: 'boolean',
+        },
+        isHidden: {
+          type: 'boolean',
+        },
+        timeField: {
+          type: 'text',
+        },
+        textField: {
+          type: 'text',
+        },
+      },
+    },
+  });
+}
+
+export async function handleExport({
+  context,
+  objects,
+  coreSetup,
+}: {
+  context: SavedObjectsExportTransformContext;
+  objects: Array<SavedObject<EventAnnotationGroupAttributes>>;
+  coreSetup: CoreSetup;
+}): Promise<Array<SavedObject<EventAnnotationGroupAttributes | EventAnnotationAttributes>>> {
+  try {
+    if (objects.length <= 0) {
+      return [];
+    }
+    const [{ savedObjects }] = await coreSetup.getStartServices();
+    const savedObjectsClient = savedObjects.getScopedClient(context.request);
+
+    const annotationsSavedObjects = await getAnnotationsSavedObjects({
+      savedObjectsClient,
+      groupIds: objects.map((o) => o.id),
+    });
+
+    return [...objects, ...annotationsSavedObjects.flat()];
+  } catch (error) {
+    throw new Error('Error exporting annotations');
+  }
+}
+
+async function getAnnotationsSavedObjects({
+  savedObjectsClient,
+  groupIds,
+}: {
+  savedObjectsClient: SavedObjectsClientContract;
+  groupIds: string[];
+}): Promise<Array<SavedObject<EventAnnotationAttributes>>> {
+  const references = groupIds.map((id) => ({ type: EVENT_ANNOTATION_GROUP_TYPE, id }));
+
+  const finder = savedObjectsClient.createPointInTimeFinder<EventAnnotationAttributes>({
+    type: EVENT_ANNOTATION_TYPE,
+    hasReference: references,
+  });
+
+  let result: Array<SavedObject<EventAnnotationAttributes>> = [];
+  for await (const findResults of finder.find()) {
+    result = result.concat(findResults.saved_objects);
+  }
+
+  return result;
+}
+
+const eventAnnotationGroupMigrations: SavedObjectMigrationMap = {};
+
+const eventAnnotationMigrations: SavedObjectMigrationMap = {};

--- a/src/plugins/event_annotation/tsconfig.json
+++ b/src/plugins/event_annotation/tsconfig.json
@@ -20,5 +20,8 @@
     {
       "path": "../data/tsconfig.json"
     },
+    {
+      "path": "../../../src/plugins/saved_objects/tsconfig.json"
+    },
   ]
 }

--- a/x-pack/plugins/lens/public/visualizations/xy/index.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/index.ts
@@ -34,7 +34,7 @@ export class XyVisualization {
         await core.getStartServices();
       const [palettes, eventAnnotationService] = await Promise.all([
         charts.palettes.getPalettes(),
-        eventAnnotation.getService(),
+        eventAnnotation.getService(coreStart),
       ]);
       const useLegacyTimeAxis = core.uiSettings.get(LEGACY_TIME_AXIS);
       return getXyVisualization({


### PR DESCRIPTION
# Summary

Creates new types of saved objects: `event-annotation` and `event-annotation-group` according to the spec document. 

Adds EventAnnotationGroupSavedObjectFinder component that is just an adjusted SavedObjectFinderUI.

## TODO

1. Adhoc data views
Currently we don't save adhoc data views in the annotations groups saved objects. Solution proposed by Stratoula is to keep it similiar to how we store it in lens SO:
```
{
    "attributes": {
        "name": "Shut it down days",
        "description": "Days where no PRs should get in or else!",
        "internalReferences": [
            {
              "type": "index-pattern",
              "id": "27bd373d-e3b7-4dc0-8180-fc8f8c426bb0",
              "name": "indexpattern-datasource-layer-8cf249c9-b322-4e8a-8946-43984404595a"
            }
          ],
          "adHocDataViews": {
            "27bd373d-e3b7-4dc0-8180-fc8f8c426bb0": {
              "id": "27bd373d-e3b7-4dc0-8180-fc8f8c426bb0",
              "title": "kib*",
              "timeFieldName": "@timestamp",
              "sourceFilters": [],
              "fieldFormats": {},
              "runtimeFieldMap": {},
              "fieldAttrs": {},
              "allowNoIndex": false,
              "name": "kib*"
            }
          }
        }
}
```

2. `onDelete` hook doesn't exist so there's no way of removing single annotations when removing the group - this is an ongoing discussion with core team that likely has to be resolved before merging this PR. 

## Testing instructions (TBD)

These are just example snippets to present what this API actually adds. 

In Lens, modify `x-pack/plugins/lens/public/visualizations/xy/index.ts`(I've added a code review comment where it should be added). 

[annotation-SOs.zip](https://github.com/elastic/kibana/files/10066703/annotation-SOs.zip)

From SOM page, import these two zipped files. They contain two annotations groups. One with multiple annotations and one with no annotations. You also might want to modify `visibleInManagement: true` in a file `src/plugins/event_annotation/server/saved_objects.ts` to make sure the subobjects are being properly cleaned too during testing. After changing the flag to true, you will see `event-annotation` objects in SOM page. 

Functionalities to test:

### SOM Page

1. Importing in SO Management Page
- [ ] the files above are properly imported.
2. `onExport` in SO Management Page
- [ ] when exporting the imported group, it's properly exported (check NDJSON files)
- [ ] the annotations referencing the group are exported no matter the `Include related objects` setting
3. deleting in SO Management Page
- [ ] TO DEFINE: should deleting functionality be removed? Should it be extended? 

### Client-side API 

1. creating the group
- In Lens, modify `x-pack/plugins/lens/public/visualizations/xy/index.ts` and add the following lines (adjust to whatever modifications you want to check):
```
const createdGroup = await eventAnnotationService.createAnnotationGroup({"title":"new group","indexPatternId":"90943e30-9a47-11e8-b64d-95841ca0b247","annotations":[{"id":"annotation-9a47-11e8-b64d-95841cgh8792","type":"manual","key":{"type":"point_in_time","timestamp":"2022-03-18T08:25:00.000Z"},"label":"Event","icon":"triangle","color":"red","lineStyle":"dashed","lineWidth":3},{"id":"annotation2-9a47-11e8-b64d-95841cgh8792","label":"Query based event","icon":"triangle","color":"red","type":"query","timeField":"timestamp","key":{"type":"point_in_time"},"lineStyle":"dashed","lineWidth":3,"filter":{"type":"kibana_query","query":"","language":"kuery"}}]})
console.log(`createdGroup`, createdGroup)
```
- [ ] the new group is displayed in SOM page 

2. loading the group
- In Lens, modify `x-pack/plugins/lens/public/visualizations/xy/index.ts` and add the following lines (adjust to whatever modifications you want to check):
```
const id = 'be0bb9b0-6a54-11ed-b384-87940ac1860b'// empty group
// const id = '64cd59d0-6a54-11ed-b384-87940ac1860b'// 2 annotations group
// const id = TODO - check out the newly created group here too!
const loadedGroup = await eventAnnotationService.loadAnnotationGroup(id)
console.log(`loadedGroup`, loadedGroup)
```
- [ ] Loaded group shows the group and annotations properties

3. updating the group properties

- In Lens, modify `x-pack/plugins/lens/public/visualizations/xy/index.ts` and add the following lines (adjust to whatever modifications you want to check):
```
const id = '64cd59d0-6a54-11ed-b384-87940ac1860b'// 2 annotations group
await eventAnnotationService.updateAnnotationGroup({
 title: 'updatedTitle', description: 'updatedDescription', ignoreGlobalFilters: false, indexPatternId: 'ff959d40-b880-11e8-a6d9-e546fe2bba5f'
}, id)
const loadedGroup = await eventAnnotationService.loadAnnotationGroup(id)
console.log(`loadedGroup`, loadedGroup)
```
- [ ] Loading the group shows the updated changes

5. updating the annotations 
```
const id = '64cd59d0-6a54-11ed-b384-87940ac1860b'// 2 annotations group
await eventAnnotationService.updateAnnotations(id, {delete: ["annotation2-9010-4354-b64d-95841cgh8792"], upsert: [{
id: 'annotation-9010-4354-b64d-95841cgh8792', "type":"manual","key":{"type":"point_in_time","timestamp":"2022-01-01T01:01:00.000Z"},"label":"Updated","icon":"circle","color":"green"
}]})
const loadedGroup = await eventAnnotationService.loadAnnotationGroup(id)
console.log(`loadedGroup`, loadedGroup)
```

- [ ] Loading the group shows the updated changes

7. deleting the group 
In Lens, modify `x-pack/plugins/lens/public/visualizations/xy/index.ts` and add the following lines:
```
const id = '64cd59d0-6a54-11ed-b384-87940ac1860b'// 2 annotations group
await eventAnnotationService.deleteAnnotationGroup(id)
```

- [ ] The group and the subobjects don't exist anymore
