### PR TITLE
[ML] Explain Log Rate Spikes: Additional functional tests with artificial logs dataset

### DIFF
--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -30,7 +30,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the saved search selection page`
       );
-      await aiops.explainLogRateSpikes.navigateToIndexPatternSelection();
+      await aiops.explainLogRateSpikesPage.navigateToIndexPatternSelection();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the explain log rate spikes page`
@@ -42,10 +42,10 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
     it(`${testData.suiteTitle} displays index details`, async () => {
       await ml.testExecution.logTestStep(`${testData.suiteTitle} displays the time range step`);
-      await aiops.explainLogRateSpikes.assertTimeRangeSelectorSectionExists();
+      await aiops.explainLogRateSpikesPage.assertTimeRangeSelectorSectionExists();
 
       await ml.testExecution.logTestStep(`${testData.suiteTitle} loads data for full time range`);
-      await aiops.explainLogRateSpikes.clickUseFullDataButton(
+      await aiops.explainLogRateSpikesPage.clickUseFullDataButton(
         testData.expected.totalDocCountFormatted
       );
       await headerPage.waitUntilLoadingHasFinished();
@@ -53,53 +53,53 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} displays elements in the doc count panel correctly`
       );
-      await aiops.explainLogRateSpikes.assertTotalDocCountHeaderExists();
-      await aiops.explainLogRateSpikes.assertTotalDocCountChartExists();
+      await aiops.explainLogRateSpikesPage.assertTotalDocCountHeaderExists();
+      await aiops.explainLogRateSpikesPage.assertTotalDocCountChartExists();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} displays elements in the page correctly`
       );
-      await aiops.explainLogRateSpikes.assertSearchPanelExists();
+      await aiops.explainLogRateSpikesPage.assertSearchPanelExists();
 
       await ml.testExecution.logTestStep('displays empty prompt');
-      await aiops.explainLogRateSpikes.assertNoWindowParametersEmptyPromptExists();
+      await aiops.explainLogRateSpikesPage.assertNoWindowParametersEmptyPromptExists();
 
       await ml.testExecution.logTestStep('clicks the document count chart to start analysis');
-      await aiops.explainLogRateSpikes.clickDocumentCountChart();
-      await aiops.explainLogRateSpikes.assertAnalysisSectionExists();
+      await aiops.explainLogRateSpikesPage.clickDocumentCountChart();
+      await aiops.explainLogRateSpikesPage.assertAnalysisSectionExists();
 
       await ml.testExecution.logTestStep('displays the no results found prompt');
-      await aiops.explainLogRateSpikes.assertNoResultsFoundEmptyPromptExists();
+      await aiops.explainLogRateSpikesPage.assertNoResultsFoundEmptyPromptExists();
 
       await ml.testExecution.logTestStep('adjusts the brushes to get analysis results');
-      await aiops.explainLogRateSpikes.assertRerunAnalysisButtonExists(false);
+      await aiops.explainLogRateSpikesPage.assertRerunAnalysisButtonExists(false);
 
       // Get the current width of the deviation brush for later comparison.
-      const brushSelectionWidthBefore = await aiops.explainLogRateSpikes.getBrushSelectionWidth(
+      const brushSelectionWidthBefore = await aiops.explainLogRateSpikesPage.getBrushSelectionWidth(
         'aiopsBrushDeviation'
       );
 
       // Get the px values for the timestamp we want to move the brush to.
-      const { targetPx, intervalPx } = await aiops.explainLogRateSpikes.getPxForTimestamp(
+      const { targetPx, intervalPx } = await aiops.explainLogRateSpikesPage.getPxForTimestamp(
         testData.brushTargetTimestamp
       );
 
       // Adjust the right brush handle
-      await aiops.explainLogRateSpikes.adjustBrushHandler(
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
         'aiopsBrushDeviation',
         'handle--e',
         targetPx + intervalPx
       );
 
       // Adjust the left brush handle
-      await aiops.explainLogRateSpikes.adjustBrushHandler(
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
         'aiopsBrushDeviation',
         'handle--w',
         targetPx
       );
 
       // Get the new brush selection width for later comparison.
-      const brushSelectionWidthAfter = await aiops.explainLogRateSpikes.getBrushSelectionWidth(
+      const brushSelectionWidthAfter = await aiops.explainLogRateSpikesPage.getBrushSelectionWidth(
         'aiopsBrushDeviation'
       );
 
@@ -110,18 +110,18 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       expect(brushSelectionWidthBefore).not.to.be(brushSelectionWidthAfter);
       expect(brushSelectionWidthAfter).not.to.be.greaterThan(intervalPx * 2);
 
-      await aiops.explainLogRateSpikes.assertRerunAnalysisButtonExists(true);
+      await aiops.explainLogRateSpikesPage.assertRerunAnalysisButtonExists(true);
 
       await ml.testExecution.logTestStep('rerun the analysis with adjusted settings');
 
-      await aiops.explainLogRateSpikes.clickRerunAnalysisButton(true);
-      await aiops.explainLogRateSpikes.assertProgressTitle('Progress: 100% — Done.');
+      await aiops.explainLogRateSpikesPage.clickRerunAnalysisButton(true);
+      await aiops.explainLogRateSpikesPage.assertProgressTitle('Progress: 100% — Done.');
 
       // The group switch should be disabled by default
-      await aiops.explainLogRateSpikes.assertSpikeAnalysisGroupSwitchExists(false);
+      await aiops.explainLogRateSpikesPage.assertSpikeAnalysisGroupSwitchExists(false);
 
       // Enabled grouping
-      await aiops.explainLogRateSpikes.clickSpikeAnalysisGroupSwitch(false);
+      await aiops.explainLogRateSpikesPage.clickSpikeAnalysisGroupSwitch(false);
 
       await aiops.explainLogRateSpikesAnalysisGroupsTable.assertSpikeAnalysisTableExists();
 

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_farequote.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_farequote.ts
@@ -65,7 +65,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await aiops.explainLogRateSpikesPage.assertNoWindowParametersEmptyPromptExists();
 
       await ml.testExecution.logTestStep('clicks the document count chart to start analysis');
-      await aiops.explainLogRateSpikesPage.clickDocumentCountChart();
+      await aiops.explainLogRateSpikesPage.clickDocumentCountChart(testData.chartClickCoordinates);
       await aiops.explainLogRateSpikesPage.assertAnalysisSectionExists();
 
       await ml.testExecution.logTestStep('displays the no results found prompt');

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_farequote.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_farequote.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import type { TestData } from './types';
+import type { TestDataEsArchive } from './types';
 import { farequoteDataViewTestData } from './test_data';
 
 const ES_INDEX = 'ft_farequote';
@@ -23,7 +23,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   // aiops / Explain Log Rate Spikes lives in the ML UI so we need some related services.
   const ml = getService('ml');
 
-  function runTests(testData: TestData) {
+  function runTests(testData: TestDataEsArchive) {
     it(`${testData.suiteTitle} loads the source data in explain log rate spikes`, async () => {
       await elasticChart.setNewChartUiDebugFlag(true);
 
@@ -81,7 +81,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
       // Get the px values for the timestamp we want to move the brush to.
       const { targetPx, intervalPx } = await aiops.explainLogRateSpikesPage.getPxForTimestamp(
-        testData.brushTargetTimestamp
+        testData.brushDeviationTargetTimestamp
       );
 
       // Adjust the right brush handle

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_logs.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes_logs.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sample } from 'lodash';
+
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import expect from '@kbn/expect';
+
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import type { TestData } from './types';
+import { artificialLogDataViewTestData } from './test_data';
+
+const DAY_MS = 86400000;
+const ES_INDEX = 'aiops_frequent_items_test';
+
+const DEVIATION_DATE = Date.now() - DAY_MS * 2;
+const BASELINE_DATE = DEVIATION_DATE - DAY_MS * 1;
+
+// Randomizes a timestamp to be +/- 12 hours
+function jiggleTimestamp(ts: number) {
+  return ts + Math.floor(Math.random() * DAY_MS) - DAY_MS / 2;
+}
+
+interface SampleDoc {
+  user: string;
+  response_code: string;
+  url: string;
+  version: string;
+  '@timestamp': number;
+}
+
+export default function ({ getPageObject, getService }: FtrProviderContext) {
+  const es = getService('es');
+  const headerPage = getPageObject('header');
+  const elasticChart = getService('elasticChart');
+  const aiops = getService('aiops');
+  const log = getService('log');
+
+  // aiops / Explain Log Rate Spikes lives in the ML UI so we need some related services.
+  const ml = getService('ml');
+
+  function runTests(testData: TestData) {
+    it(`${testData.suiteTitle} loads the source data in explain log rate spikes`, async () => {
+      await elasticChart.setNewChartUiDebugFlag(true);
+
+      await ml.testExecution.logTestStep(
+        `${testData.suiteTitle} loads the saved search selection page`
+      );
+      await aiops.explainLogRateSpikesPage.navigateToIndexPatternSelection();
+
+      await ml.testExecution.logTestStep(
+        `${testData.suiteTitle} loads the explain log rate spikes page`
+      );
+      await ml.jobSourceSelection.selectSourceForExplainLogRateSpikes(
+        testData.sourceIndexOrSavedSearch
+      );
+    });
+
+    it(`${testData.suiteTitle} displays index details`, async () => {
+      await ml.testExecution.logTestStep(`${testData.suiteTitle} displays the time range step`);
+      await aiops.explainLogRateSpikesPage.assertTimeRangeSelectorSectionExists();
+
+      await ml.testExecution.logTestStep(`${testData.suiteTitle} loads data for full time range`);
+      await aiops.explainLogRateSpikesPage.clickUseFullDataButton(
+        testData.expected.totalDocCountFormatted
+      );
+      await headerPage.waitUntilLoadingHasFinished();
+
+      await ml.testExecution.logTestStep(
+        `${testData.suiteTitle} displays elements in the doc count panel correctly`
+      );
+      await aiops.explainLogRateSpikesPage.assertTotalDocCountHeaderExists();
+      await aiops.explainLogRateSpikesPage.assertTotalDocCountChartExists();
+
+      await ml.testExecution.logTestStep(
+        `${testData.suiteTitle} displays elements in the page correctly`
+      );
+      await aiops.explainLogRateSpikesPage.assertSearchPanelExists();
+
+      await ml.testExecution.logTestStep('displays empty prompt');
+      await aiops.explainLogRateSpikesPage.assertNoWindowParametersEmptyPromptExists();
+
+      await ml.testExecution.logTestStep('clicks the document count chart to start analysis');
+      await aiops.explainLogRateSpikesPage.clickDocumentCountChart(testData.chartClickCoordinates);
+      await aiops.explainLogRateSpikesPage.assertAnalysisSectionExists();
+
+      await ml.testExecution.logTestStep('displays the no results found prompt');
+      await aiops.explainLogRateSpikesPage.assertNoResultsFoundEmptyPromptExists();
+
+      await ml.testExecution.logTestStep('adjusts the brushes to get analysis results');
+      await aiops.explainLogRateSpikesPage.assertRerunAnalysisButtonExists(false);
+
+      // Get the current width of the deviation brush for later comparison.
+      const brushSelectionWidthBefore = await aiops.explainLogRateSpikesPage.getBrushSelectionWidth(
+        'aiopsBrushDeviation'
+      );
+
+      // Get the px values for the timestamp we want to move the brush to.
+      const { targetPx, intervalPx } = await aiops.explainLogRateSpikesPage.getPxForTimestamp(
+        DEVIATION_DATE
+      );
+
+      // Adjust the right brush handle
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
+        'aiopsBrushDeviation',
+        'handle--e',
+        targetPx + intervalPx * 10
+      );
+
+      // Adjust the left brush handle
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
+        'aiopsBrushDeviation',
+        'handle--w',
+        targetPx - intervalPx * 10
+      );
+
+      // Get the px values for the timestamp we want to move the brush to.
+      const { targetPx: targetBaselinePx } = await aiops.explainLogRateSpikesPage.getPxForTimestamp(
+        BASELINE_DATE
+      );
+
+      // Adjust the right brush handle
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
+        'aiopsBrushBaseline',
+        'handle--e',
+        targetBaselinePx + intervalPx * 10
+      );
+
+      // Adjust the left brush handle
+      await aiops.explainLogRateSpikesPage.adjustBrushHandler(
+        'aiopsBrushBaseline',
+        'handle--w',
+        targetBaselinePx - intervalPx * 10
+      );
+
+      // Get the new brush selection width for later comparison.
+      const brushSelectionWidthAfter = await aiops.explainLogRateSpikesPage.getBrushSelectionWidth(
+        'aiopsBrushDeviation'
+      );
+
+      // Assert the adjusted brush: The selection width should have changed and
+      // we test if the selection is smaller than two bucket intervals.
+      // Finally, the adjusted brush should trigger
+      // a warning on the "Rerun analysis" button.
+      expect(brushSelectionWidthBefore).not.to.be(brushSelectionWidthAfter);
+      expect(brushSelectionWidthAfter).not.to.be.greaterThan(intervalPx * 21);
+
+      await aiops.explainLogRateSpikesPage.assertRerunAnalysisButtonExists(true);
+
+      await ml.testExecution.logTestStep('rerun the analysis with adjusted settings');
+
+      await aiops.explainLogRateSpikesPage.clickRerunAnalysisButton(true);
+      await aiops.explainLogRateSpikesPage.assertProgressTitle('Progress: 100% — Done.');
+
+      // The group switch should be disabled by default
+      await aiops.explainLogRateSpikesPage.assertSpikeAnalysisGroupSwitchExists(false);
+
+      // Enabled grouping
+      await aiops.explainLogRateSpikesPage.clickSpikeAnalysisGroupSwitch(false);
+
+      await aiops.explainLogRateSpikesAnalysisGroupsTable.assertSpikeAnalysisTableExists();
+
+      const analysisGroupsTable =
+        await aiops.explainLogRateSpikesAnalysisGroupsTable.parseAnalysisTable();
+
+      expect(analysisGroupsTable.length).to.be.greaterThan(0);
+
+      await ml.testExecution.logTestStep('expand table row');
+      await aiops.explainLogRateSpikesAnalysisGroupsTable.assertExpandRowButtonExists();
+      await aiops.explainLogRateSpikesAnalysisGroupsTable.expandRow();
+
+      const analysisTable = await aiops.explainLogRateSpikesAnalysisTable.parseAnalysisTable();
+      expect(analysisTable.length).to.be.greaterThan(0);
+    });
+  }
+
+  describe('explain log rate spikes - artificial log data', function () {
+    this.tags(['aiops']);
+
+    before(async () => {
+      try {
+        await es.indices.delete({ index: ES_INDEX });
+      } catch (e) {
+        log.error(`Error deleting index '${ES_INDEX}' in before() callback`);
+      }
+      // Create index with mapping
+      await es.indices.create({
+        index: ES_INDEX,
+        mappings: {
+          properties: {
+            user: { type: 'keyword' },
+            response_code: { type: 'keyword' },
+            url: { type: 'keyword' },
+            version: { type: 'keyword' },
+            '@timestamp': { type: 'date' },
+          },
+        },
+      });
+
+      // Index 10000 random docs using the bulk API
+      const bulkBody: estypes.BulkRequest<SampleDoc, SampleDoc>['body'] = [];
+
+      [...Array(10000)].forEach(() => {
+        const action = { index: { _index: ES_INDEX } };
+        const doc: SampleDoc = {
+          user: sample(['Peter', 'Paul', 'Mary']) as string,
+          response_code: sample(['200', '404', '500']) as string,
+          url: sample(['login.php', 'user.php', 'home.php']) as string,
+          version: 'v1.0.0',
+          '@timestamp': jiggleTimestamp(sample([BASELINE_DATE, DEVIATION_DATE]) as number),
+        };
+
+        // Don't add docs that match the exact pattern of the filter we want to base the test queries on
+        if (
+          !(
+            doc.user === 'Peter' &&
+            doc.response_code === '500' &&
+            (doc.url === 'home.php' || doc.url === 'login.php')
+          )
+        ) {
+          doc.user = sample(['Paul', 'Mary']) as string;
+        }
+
+        bulkBody.push(action);
+        bulkBody.push(doc);
+      });
+
+      // Now let's add items to the dataset to make some specific significant terms being returned as results
+      [...Array(3000)].forEach(() => {
+        bulkBody.push({ index: { _index: ES_INDEX } });
+        bulkBody.push({
+          user: 'Peter',
+          response_code: sample(['200', '404']) as string,
+          url: sample(['login.php', 'user.php', 'home.php']) as string,
+          version: 'v1.0.0',
+          '@timestamp': jiggleTimestamp(DEVIATION_DATE),
+        });
+
+        bulkBody.push({ index: { _index: ES_INDEX } });
+        bulkBody.push({
+          user: sample(['Paul', 'Mary']) as string,
+          response_code: '500',
+          url: sample(['login.php', 'home.php']) as string,
+          version: 'v1.0.0',
+          '@timestamp': jiggleTimestamp(DEVIATION_DATE),
+        });
+      });
+
+      await es.bulk({
+        refresh: 'wait_for',
+        body: bulkBody,
+      });
+
+      await ml.testResources.createIndexPatternIfNeeded(ES_INDEX, '@timestamp');
+
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      await ml.securityUI.loginAsMlPowerUser();
+    });
+
+    after(async () => {
+      await elasticChart.setNewChartUiDebugFlag(false);
+      await ml.testResources.deleteIndexPatternByTitle(ES_INDEX);
+      try {
+        await es.indices.delete({ index: ES_INDEX });
+      } catch (e) {
+        log.error(`Error deleting index '${ES_INDEX}' in after() callback`);
+      }
+    });
+
+    describe('with artificial logs', function () {
+      // Run tests on full farequote index.
+      it(`${artificialLogDataViewTestData.suiteTitle} loads the explain log rate spikes page`, async () => {
+        // Start navigation from the base of the ML app.
+        await ml.navigation.navigateToMl();
+        await elasticChart.setNewChartUiDebugFlag(true);
+      });
+
+      runTests(artificialLogDataViewTestData);
+    });
+  });
+}

--- a/x-pack/test/functional/apps/aiops/index.ts
+++ b/x-pack/test/functional/apps/aiops/index.ts
@@ -33,6 +33,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await ml.testResources.resetKibanaTimeZone();
     });
 
-    loadTestFile(require.resolve('./explain_log_rate_spikes'));
+    loadTestFile(require.resolve('./explain_log_rate_spikes_farequote'));
+    loadTestFile(require.resolve('./explain_log_rate_spikes_logs'));
   });
 }

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -41,7 +41,7 @@ export const artificialLogDataViewTestData: TestData = {
   brushTargetTimestamp: 1455033600000,
   chartClickCoordinates: [-200, 30],
   expected: {
-    totalDocCountFormatted: '16,000',
+    totalDocCountFormatted: '8,400',
     analysisGroupsTable: [{ group: 'response_code: 500user: Peter', docCount: '481' }],
     analysisTable: [
       {

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -12,6 +12,7 @@ export const farequoteDataViewTestData: TestData = {
   isSavedSearch: false,
   sourceIndexOrSavedSearch: 'ft_farequote',
   brushTargetTimestamp: 1455033600000,
+  chartClickCoordinates: [0, 0],
   expected: {
     totalDocCountFormatted: '86,374',
     analysisGroupsTable: [
@@ -28,6 +29,34 @@ export const farequoteDataViewTestData: TestData = {
         logRate: 'Chart type:bar chart',
         pValue: '4.66e-11',
         impact: 'High',
+      },
+    ],
+  },
+};
+
+export const artificialLogDataViewTestData: TestData = {
+  suiteTitle: 'artificial index pattern',
+  isSavedSearch: false,
+  sourceIndexOrSavedSearch: 'aiops_frequent_items_test',
+  brushTargetTimestamp: 1455033600000,
+  chartClickCoordinates: [-200, 30],
+  expected: {
+    totalDocCountFormatted: '16,000',
+    analysisGroupsTable: [{ group: 'response_code: 500user: Peter', docCount: '481' }],
+    analysisTable: [
+      {
+        fieldName: 'user',
+        fieldValue: 'Peter',
+        logRate: 'Chart type:bar chart',
+        pValue: '2.30e-41',
+        impact: 'High',
+      },
+      {
+        fieldName: 'response_code',
+        fieldValue: '500',
+        logRate: 'Chart type:bar chart',
+        pValue: '0.0000384',
+        impact: 'Medium',
       },
     ],
   },

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
-import { TestData } from './types';
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
-export const farequoteDataViewTestData: TestData = {
+import type { GeneratedDoc, TestDataEsArchive, TestDataGenerated } from './types';
+
+export const farequoteDataViewTestData: TestDataEsArchive = {
   suiteTitle: 'farequote index pattern',
   isSavedSearch: false,
   sourceIndexOrSavedSearch: 'ft_farequote',
-  brushTargetTimestamp: 1455033600000,
+  brushDeviationTargetTimestamp: 1455033600000,
+  brushIntervalFactor: 1,
   chartClickCoordinates: [0, 0],
   expected: {
     totalDocCountFormatted: '86,374',
@@ -34,12 +37,22 @@ export const farequoteDataViewTestData: TestData = {
   },
 };
 
-export const artificialLogDataViewTestData: TestData = {
+const REFERENCE_TS = 1669018354793;
+const DAY_MS = 86400000;
+const ES_INDEX = 'aiops_frequent_items_test';
+
+const DEVIATION_TS = REFERENCE_TS - DAY_MS * 2;
+const BASELINE_TS = DEVIATION_TS - DAY_MS * 1;
+
+export const artificialLogDataViewTestData: TestDataGenerated = {
   suiteTitle: 'artificial index pattern',
   isSavedSearch: false,
   sourceIndexOrSavedSearch: 'aiops_frequent_items_test',
-  brushTargetTimestamp: 1455033600000,
+  brushBaselineTargetTimestamp: BASELINE_TS + DAY_MS / 2,
+  brushDeviationTargetTimestamp: DEVIATION_TS + DAY_MS / 2,
+  brushIntervalFactor: 10,
   chartClickCoordinates: [-200, 30],
+  bulkBody: getArtificialLogsBulkBody(),
   expected: {
     totalDocCountFormatted: '8,400',
     analysisGroupsTable: [
@@ -57,3 +70,79 @@ export const artificialLogDataViewTestData: TestData = {
     ],
   },
 };
+
+function getArtificialLogsBulkBody() {
+  const bulkBody: estypes.BulkRequest<GeneratedDoc, GeneratedDoc>['body'] = [];
+  const action = { index: { _index: ES_INDEX } };
+  let tsOffset = 0;
+
+  // Creates docs evenly spread across baseline and deviation time frame
+  [BASELINE_TS, DEVIATION_TS].forEach((ts) => {
+    ['Peter', 'Paul', 'Mary'].forEach((user) => {
+      ['200', '404', '500'].forEach((responseCode) => {
+        ['login.php', 'user.php', 'home.php'].forEach((url) => {
+          // Don't add docs that match the exact pattern of the filter we want to base the test queries on
+          if (
+            !(
+              user === 'Peter' &&
+              responseCode === '500' &&
+              (url === 'home.php' || url === 'login.php')
+            )
+          ) {
+            tsOffset = 0;
+            [...Array(100)].forEach(() => {
+              tsOffset += DAY_MS / 100;
+              const doc: GeneratedDoc = {
+                user,
+                response_code: responseCode,
+                url,
+                version: 'v1.0.0',
+                '@timestamp': ts + tsOffset,
+              };
+
+              bulkBody.push(action);
+              bulkBody.push(doc);
+            });
+          }
+        });
+      });
+    });
+  });
+
+  // Now let's add items to the dataset to make some specific significant terms being returned as results
+  ['200', '404'].forEach((responseCode) => {
+    ['login.php', 'user.php', 'home.php'].forEach((url) => {
+      tsOffset = 0;
+      [...Array(300)].forEach(() => {
+        tsOffset += DAY_MS / 300;
+        bulkBody.push(action);
+        bulkBody.push({
+          user: 'Peter',
+          response_code: responseCode,
+          url,
+          version: 'v1.0.0',
+          '@timestamp': DEVIATION_TS + tsOffset,
+        });
+      });
+    });
+  });
+
+  ['Paul', 'Mary'].forEach((user) => {
+    ['login.php', 'home.php'].forEach((url) => {
+      tsOffset = 0;
+      [...Array(400)].forEach(() => {
+        tsOffset += DAY_MS / 400;
+        bulkBody.push(action);
+        bulkBody.push({
+          user,
+          response_code: '500',
+          url,
+          version: 'v1.0.0',
+          '@timestamp': DEVIATION_TS + tsOffset,
+        });
+      });
+    });
+  });
+
+  return bulkBody;
+}

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -42,21 +42,17 @@ export const artificialLogDataViewTestData: TestData = {
   chartClickCoordinates: [-200, 30],
   expected: {
     totalDocCountFormatted: '8,400',
-    analysisGroupsTable: [{ group: 'response_code: 500user: Peter', docCount: '481' }],
+    analysisGroupsTable: [
+      { group: 'user: Peter', docCount: '2081' },
+      { group: 'response_code: 500url: login.php', docCount: '834' },
+    ],
     analysisTable: [
       {
         fieldName: 'user',
         fieldValue: 'Peter',
         logRate: 'Chart type:bar chart',
-        pValue: '2.30e-41',
+        pValue: '2.78e-22',
         impact: 'High',
-      },
-      {
-        fieldName: 'response_code',
-        fieldValue: '500',
-        logRate: 'Chart type:bar chart',
-        pValue: '0.0000384',
-        impact: 'Medium',
       },
     ],
   },

--- a/x-pack/test/functional/apps/aiops/types.ts
+++ b/x-pack/test/functional/apps/aiops/types.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-export interface TestData {
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+export interface TestDataEsArchive {
   suiteTitle: string;
   isSavedSearch?: boolean;
   sourceIndexOrSavedSearch: string;
   rowsPerPage?: 10 | 25 | 50;
-  brushTargetTimestamp: number;
+  brushBaselineTargetTimestamp?: number;
+  brushDeviationTargetTimestamp: number;
+  brushIntervalFactor: number;
   chartClickCoordinates: [number, number];
   expected: {
     totalDocCountFormatted: string;
@@ -23,4 +27,16 @@ export interface TestData {
       impact: string;
     }>;
   };
+}
+
+export interface GeneratedDoc {
+  user: string;
+  response_code: string;
+  url: string;
+  version: string;
+  '@timestamp': number;
+}
+
+export interface TestDataGenerated extends TestDataEsArchive {
+  bulkBody: estypes.BulkRequest<GeneratedDoc, GeneratedDoc>['body'];
 }

--- a/x-pack/test/functional/apps/aiops/types.ts
+++ b/x-pack/test/functional/apps/aiops/types.ts
@@ -11,6 +11,7 @@ export interface TestData {
   sourceIndexOrSavedSearch: string;
   rowsPerPage?: 10 | 25 | 50;
   brushTargetTimestamp: number;
+  chartClickCoordinates: [number, number];
   expected: {
     totalDocCountFormatted: string;
     analysisGroupsTable: Array<{ group: string; docCount: string }>;

--- a/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
+++ b/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
-export function ExplainLogRateSpikesProvider({ getService }: FtrProviderContext) {
+export function ExplainLogRateSpikesPageProvider({ getService }: FtrProviderContext) {
   const browser = getService('browser');
   const elasticChart = getService('elasticChart');
   const testSubjects = getService('testSubjects');

--- a/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
+++ b/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
@@ -64,11 +64,15 @@ export function ExplainLogRateSpikesPageProvider({ getService }: FtrProviderCont
       await testSubjects.existOrFail(`aiopsNoResultsFoundEmptyPrompt`);
     },
 
-    async clickDocumentCountChart() {
+    async clickDocumentCountChart(chartClickCoordinates: [number, number]) {
       await elasticChart.waitForRenderComplete();
       const el = await elasticChart.getCanvas();
 
-      await browser.getActions().move({ x: 0, y: 0, origin: el._webElement }).click().perform();
+      await browser
+        .getActions()
+        .move({ x: chartClickCoordinates[0], y: chartClickCoordinates[1], origin: el._webElement })
+        .click()
+        .perform();
 
       await this.assertHistogramBrushesExist();
     },
@@ -154,7 +158,14 @@ export function ExplainLogRateSpikesPageProvider({ getService }: FtrProviderCont
       // Get the total count of bars and index of a bar for a given timestamp in the charts debug data.
       const bars = chartDebugData?.bars?.[0].bars ?? [];
       const barsCount = bars.length;
-      const targetDeviationBarIndex = bars.findIndex((b) => b.x === timestamp);
+
+      const closestTimestamp = bars
+        .map((d) => d.x)
+        .reduce(function (p, c) {
+          return Math.abs(c - timestamp) < Math.abs(p - timestamp) ? c : p;
+        });
+
+      const targetDeviationBarIndex = bars.findIndex((b) => b.x === closestTimestamp);
 
       // The pixel location based on the given timestamp, calculated by taking the share of the index value
       // over the total count of bars, normalized by the wrapping element's width.

--- a/x-pack/test/functional/services/aiops/index.ts
+++ b/x-pack/test/functional/services/aiops/index.ts
@@ -7,18 +7,18 @@
 
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
-import { ExplainLogRateSpikesProvider } from './explain_log_rate_spikes';
+import { ExplainLogRateSpikesPageProvider } from './explain_log_rate_spikes_page';
 import { ExplainLogRateSpikesAnalysisTableProvider } from './explain_log_rate_spikes_analysis_table';
 import { ExplainLogRateSpikesAnalysisGroupsTableProvider } from './explain_log_rate_spikes_analysis_groups_table';
 
 export function AiopsProvider(context: FtrProviderContext) {
-  const explainLogRateSpikes = ExplainLogRateSpikesProvider(context);
+  const explainLogRateSpikesPage = ExplainLogRateSpikesPageProvider(context);
   const explainLogRateSpikesAnalysisTable = ExplainLogRateSpikesAnalysisTableProvider(context);
   const explainLogRateSpikesAnalysisGroupsTable =
     ExplainLogRateSpikesAnalysisGroupsTableProvider(context);
 
   return {
-    explainLogRateSpikes,
+    explainLogRateSpikesPage,
     explainLogRateSpikesAnalysisTable,
     explainLogRateSpikesAnalysisGroupsTable,
   };


### PR DESCRIPTION
## Summary

Follow up to #145699.
Part of #142456.

Additional functional tests with artificial logs dataset.

This generates an artificial logs dataset with the purpose of asserting the case where grouping needs to identify 2 non-overlapping groups. The primary use case of the test is to track possible regressions related to when trying to improve `frequent_items` aggregation settings and the custom grouping code.

I plan to use the same approach for additional tests on the API integration side. Once I do this follow up I'll look into how some code that was duplicated for this PR can be consolidated.

![aiops-functional-test-0001](https://user-images.githubusercontent.com/230104/202762032-28155dd5-137f-4679-8f63-72bc2a06e368.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->