### PR TITLE
[kbn-pm] Add uid check

### DIFF
--- a/scripts/kbn.js
+++ b/scripts/kbn.js
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+require('../src/setup_node_env/root');
 require('../src/setup_node_env/ensure_node_preserve_symlinks');
 require('../src/setup_node_env/node_version_validator');
 import('../kbn_pm/src/cli.mjs').catch(function (error) {

--- a/scripts/kbn.js
+++ b/scripts/kbn.js
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-require('../src/setup_node_env/root');
 require('../src/setup_node_env/ensure_node_preserve_symlinks');
+require('../src/setup_node_env/root');
 require('../src/setup_node_env/node_version_validator');
 import('../kbn_pm/src/cli.mjs').catch(function (error) {
   console.error('UNHANDLED EXCEPTION:', error.stack);


### PR DESCRIPTION
This adds the uid check we use in the kibana entrypoint to kbn-pm. `yarn kbn bootstrap` will exit if the uid is 0.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->