### PR TITLE
[upgrade] change OK to Succeeded in rules test

### DIFF
--- a/x-pack/test/upgrade/apps/rules/rules_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/rules/rules_smoke_tests.ts
@@ -57,7 +57,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           expect(searchResults[0].name).to.contain(createdRuleName);
           expect(searchResults[0].interval).to.equal('1 min');
           expect(searchResults[0].status).to.equal('Enabled');
-          expect(searchResults[0].lastResponse).to.equal('Ok');
+          expect(searchResults[0].lastResponse).to.equal('Succeeded');
         });
       });
     });


### PR DESCRIPTION
## Summary

Rule "Last response" changed from OK to Succeeded.  See https://github.com/elastic/kibana/issues/136039

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->