### PR TITLE
[storybook] avoid double-transpilation issue

### DIFF
--- a/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
+++ b/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
@@ -64,7 +64,7 @@ const IGNORE_PATTERNS = [
 
   // ignore any code in a .storybook directory, storybook loads ts-node (which is currently being installed by synthetics)
   // https://github.com/elastic/synthetics/issues/654
-  /[\/\\]\.storybook[\/\\]/,
+  /[\/\\](\.storybook[\/\\]|plugins[\/\\]controls[\/\\]storybook[\/\\]main\.ts)/,
 ];
 
 function getBabelOptions(path: string) {

--- a/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
+++ b/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
@@ -61,6 +61,10 @@ const IGNORE_PATTERNS = [
   // root `src` directory, in any test or __tests__ directory, or it
   // ends with .test.js, .test.ts, or .test.tsx
   /[\/\\]packages[\/\\](eslint-|kbn-)[^\/\\]+[\/\\](?!src[\/\\].*|(.+[\/\\])?(test|__tests__)[\/\\].+|.+\.test\.(js|ts|tsx)$)(.+$)/,
+
+  // ignore any code in a .storybook directory, storybook loads ts-node (which is currently being installed by synthetics)
+  // https://github.com/elastic/synthetics/issues/654
+  /[\/\\]\.storybook[\/\\]/,
 ];
 
 function getBabelOptions(path: string) {

--- a/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
+++ b/packages/kbn-optimizer/src/node/node_auto_tranpilation.ts
@@ -61,10 +61,6 @@ const IGNORE_PATTERNS = [
   // root `src` directory, in any test or __tests__ directory, or it
   // ends with .test.js, .test.ts, or .test.tsx
   /[\/\\]packages[\/\\](eslint-|kbn-)[^\/\\]+[\/\\](?!src[\/\\].*|(.+[\/\\])?(test|__tests__)[\/\\].+|.+\.test\.(js|ts|tsx)$)(.+$)/,
-
-  // ignore any code in a .storybook directory, storybook loads ts-node (which is currently being installed by synthetics)
-  // https://github.com/elastic/synthetics/issues/654
-  /[\/\\](\.storybook[\/\\]|plugins[\/\\]controls[\/\\]storybook[\/\\]main\.ts)/,
 ];
 
 function getBabelOptions(path: string) {

--- a/packages/kbn-storybook/src/lib/run_storybook_cli.ts
+++ b/packages/kbn-storybook/src/lib/run_storybook_cli.ts
@@ -12,6 +12,9 @@ import buildStandalone from '@storybook/react/standalone';
 import { Flags, run } from '@kbn/dev-cli-runner';
 import UiSharedDepsNpm from '@kbn/ui-shared-deps-npm';
 import * as UiSharedDepsSrc from '@kbn/ui-shared-deps-src';
+import { REPO_ROOT } from '@kbn/utils';
+// @ts-expect-error internal dep of storybook
+import interpret from 'interpret'; // eslint-disable-line import/no-extraneous-dependencies
 import * as constants from './constants';
 
 // Convert the flags to a Storybook loglevel
@@ -52,6 +55,12 @@ export function runStorybookCli({ configDir, name }: { configDir: string; name: 
       }
 
       logger.setLevel(getLogLevelFromFlags(flags));
+
+      // force storybook to use our transpilation rather than ts-node or anything else
+      interpret.extensions['.ts'] = [join(REPO_ROOT, 'src/setup_node_env')];
+      interpret.extensions['.tsx'] = [join(REPO_ROOT, 'src/setup_node_env')];
+      interpret.extensions['.jsx'] = [join(REPO_ROOT, 'src/setup_node_env')];
+
       await buildStandalone(config);
 
       // Line is only reached when building the static version


### PR DESCRIPTION
With the move to isolated modules, it has become clear that storybook is automatically loading the `ts-node` package and trying to transpile code on require even if the code is already transpiled by our own auto-transpilation on require logic. It seems like, in the version of storybook we are using the only way to disable this is to prevent this is to uninstall `ts-node` (lame). To fix this issue we can also disable our transpilation for the specific files that storybook will load with a simple ignore pattern.

I'll keep looking into how we might be able to disable storybook's use of ts-node, but I'm also trying to get synthetics to drop the ts-node dependency https://github.com/elastic/synthetics/issues/654