### PR TITLE
[8.5] [RAM] Allow more tags in the filter for rule list table (#145413)

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -1344,7 +1344,7 @@ export class RulesClient {
           terms: { field: 'alert.attributes.muteAll' },
         },
         tags: {
-          terms: { field: 'alert.attributes.tags', order: { _key: 'asc' } },
+          terms: { field: 'alert.attributes.tags', order: { _key: 'asc' }, size: 50 },
         },
         snoozed: {
           nested: {

--- a/x-pack/plugins/alerting/server/rules_client/tests/aggregate.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/aggregate.test.ts
@@ -212,7 +212,7 @@ describe('aggregate()', () => {
             },
           },
           tags: {
-            terms: { field: 'alert.attributes.tags', order: { _key: 'asc' } },
+            terms: { field: 'alert.attributes.tags', order: { _key: 'asc' }, size: 50 },
           },
         },
       },
@@ -267,7 +267,7 @@ describe('aggregate()', () => {
             },
           },
           tags: {
-            terms: { field: 'alert.attributes.tags', order: { _key: 'asc' } },
+            terms: { field: 'alert.attributes.tags', order: { _key: 'asc' }, size: 50 },
           },
         },
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[RAM] Allow more tags in the filter for rule list table (#145413)](https://github.com/elastic/kibana/pull/145413)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Xavier Mouligneau","email":"xavier.mouligneau@elastic.co"},"sourceCommit":{"committedDate":"2022-11-16T20:55:18Z","message":"[RAM] Allow more tags in the filter for rule list table (#145413)\n\n## Summary\r\n\r\nAllow more tags in the filter for the rule list table. This an easy win\r\nbefore creating a specific API to get more tags for the filter an dit\r\nwill help this [SDH](https://github.com/elastic/sdh-kibana/issues/3281)\r\n\r\nTo make sure that this change won't impact performance we test it the\r\naggregation with GB of data and we did not see any reason to worry about\r\nit.","sha":"b536a16d7be5ce26dcda48e29127d592736cee46","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","impact:low","Team:ResponseOps","v8.6.0","v8.7.0","v8.5.2"],"number":145413,"url":"https://github.com/elastic/kibana/pull/145413","mergeCommit":{"message":"[RAM] Allow more tags in the filter for rule list table (#145413)\n\n## Summary\r\n\r\nAllow more tags in the filter for the rule list table. This an easy win\r\nbefore creating a specific API to get more tags for the filter an dit\r\nwill help this [SDH](https://github.com/elastic/sdh-kibana/issues/3281)\r\n\r\nTo make sure that this change won't impact performance we test it the\r\naggregation with GB of data and we did not see any reason to worry about\r\nit.","sha":"b536a16d7be5ce26dcda48e29127d592736cee46"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/145451","number":145451,"state":"MERGED","mergeCommit":{"sha":"2fb77778e231bb3a946ea19c06b64af512177a8c","message":"[8.6] [RAM] Allow more tags in the filter for rule list table (#145413) (#145451)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.6`:\n- [[RAM] Allow more tags in the filter for rule list table\n(#145413)](https://github.com/elastic/kibana/pull/145413)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Xavier\nMouligneau\",\"email\":\"xavier.mouligneau@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2022-11-16T20:55:18Z\",\"message\":\"[RAM]\nAllow more tags in the filter for rule list table (#145413)\\n\\n##\nSummary\\r\\n\\r\\nAllow more tags in the filter for the rule list table.\nThis an easy win\\r\\nbefore creating a specific API to get more tags for\nthe filter an dit\\r\\nwill help this\n[SDH](https://github.com/elastic/sdh-kibana/issues/3281)\\r\\n\\r\\nTo make\nsure that this change won't impact performance we test it\nthe\\r\\naggregation with GB of data and we did not see any reason to\nworry\nabout\\r\\nit.\",\"sha\":\"b536a16d7be5ce26dcda48e29127d592736cee46\",\"branchLabelMapping\":{\"^v8.7.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:skip\",\"impact:low\",\"Team:ResponseOps\",\"v8.6.0\",\"v8.7.0\"],\"number\":145413,\"url\":\"https://github.com/elastic/kibana/pull/145413\",\"mergeCommit\":{\"message\":\"[RAM]\nAllow more tags in the filter for rule list table (#145413)\\n\\n##\nSummary\\r\\n\\r\\nAllow more tags in the filter for the rule list table.\nThis an easy win\\r\\nbefore creating a specific API to get more tags for\nthe filter an dit\\r\\nwill help this\n[SDH](https://github.com/elastic/sdh-kibana/issues/3281)\\r\\n\\r\\nTo make\nsure that this change won't impact performance we test it\nthe\\r\\naggregation with GB of data and we did not see any reason to\nworry\nabout\\r\\nit.\",\"sha\":\"b536a16d7be5ce26dcda48e29127d592736cee46\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.6\"],\"targetPullRequestStates\":[{\"branch\":\"8.6\",\"label\":\"v8.6.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.7.0\",\"labelRegex\":\"^v8.7.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/145413\",\"number\":145413,\"mergeCommit\":{\"message\":\"[RAM]\nAllow more tags in the filter for rule list table (#145413)\\n\\n##\nSummary\\r\\n\\r\\nAllow more tags in the filter for the rule list table.\nThis an easy win\\r\\nbefore creating a specific API to get more tags for\nthe filter an dit\\r\\nwill help this\n[SDH](https://github.com/elastic/sdh-kibana/issues/3281)\\r\\n\\r\\nTo make\nsure that this change won't impact performance we test it\nthe\\r\\naggregation with GB of data and we did not see any reason to\nworry\nabout\\r\\nit.\",\"sha\":\"b536a16d7be5ce26dcda48e29127d592736cee46\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Xavier Mouligneau <xavier.mouligneau@elastic.co>"}},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145413","number":145413,"mergeCommit":{"message":"[RAM] Allow more tags in the filter for rule list table (#145413)\n\n## Summary\r\n\r\nAllow more tags in the filter for the rule list table. This an easy win\r\nbefore creating a specific API to get more tags for the filter an dit\r\nwill help this [SDH](https://github.com/elastic/sdh-kibana/issues/3281)\r\n\r\nTo make sure that this change won't impact performance we test it the\r\naggregation with GB of data and we did not see any reason to worry about\r\nit.","sha":"b536a16d7be5ce26dcda48e29127d592736cee46"}},{"branch":"8.5","label":"v8.5.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->