### PR TITLE
[8.5] [DOCS] Clarify alertId and index in add comment API (#145189)

### DIFF
--- a/docs/api/cases/cases-api-add-comment.asciidoc
+++ b/docs/api/cases/cases-api-add-comment.asciidoc
@@ -33,22 +33,28 @@ default space is used.
 === {api-request-body-title}
 
 `alertId`::
-(Required*, string or array of strings) The alert identifier. It is required
-only when `type` is `alert`. If it is an array, `index` must also be an array. preview:[]
+(Required*, string or array of strings) The alert identifiers. It is required
+only when `type` is `alert`. You can use an array of strings to add multiple
+alerts to a case, provided that they all relate to the same rule; `index` must
+also be an array with the same length or number of elements. Adding multiple
+alerts in this manner is recommended rather than calling the API multiple times.
+preview:[]
 
 `comment`::
 (Required*, string) The new comment. It is required only when `type` is `user`.
 
 `index`::
-(Required*, string or array of strings) The alert index. It is required only
-when `type` is `alert`. If it is an array, `alertId` must also be an array. preview:[]
+(Required*, string or array of strings) The alert indices. It is required only
+when `type` is `alert`. If you are adding multiple alerts to a case, use an array
+of strings; the position of each index name in the array must match the position
+of the corresponding alert identifier in the `alertId` array. preview:[]
 
 `owner`::
 (Required, string) The application that owns the case. Valid values are:
 `cases`, `observability`, or `securitySolution`.
 
 `rule`::
-(Required*, object) The rule that is associated with the alert. It is required
+(Required*, object) The rule that is associated with the alerts. It is required
 only when `type` is `alert`. preview:[]
 +
 .Properties of `rule`

--- a/docs/api/cases/cases-api-update-comment.asciidoc
+++ b/docs/api/cases/cases-api-update-comment.asciidoc
@@ -33,9 +33,11 @@ default space is used.
 === {api-request-body-title}
 
 `alertId`::
-(Required*, string or array of strings) The identifier for the alert. It is
-required only when `type` is `alert`. If it is an array, `index` must also be an
-array.preview:[]
+(Required*, string or array of strings) The alert identifiers. It is
+required only when `type` is `alert`. If you are adding multiple alerts to a
+case, use an array of strings; `index` must also be an array with the same
+length or number of elements in that case. Addings multiple alerts in this manner
+is recommended rather than calling the API multiple times.
 
 `comment`::
 (Required*, string) The updated comment. It is required only when `type` is
@@ -46,9 +48,10 @@ array.preview:[]
 <<cases-api-get-comments>>.
 
 `index`::
-(Required*, string or array of strings) The alert index. It is required only
-when `type` is `alert`. If it is an array, `alertId` must also be an array.
-preview:[]
+(Required*, string or array of strings) The alert indices. It is required only
+when `type` is `alert`. If you are adding multiple alerts to a case, use an
+array of strings; `alertId` must also be an array with the same length or number
+of elements. preview:[]
 
 `owner`::
 (Required, string) The application that owns the case. It can be `cases`,

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -3115,7 +3115,7 @@
       },
       "alert_identifiers": {
         "title": "Alert identifiers",
-        "description": "The alert identifier. It is required only when `type` is `alert`. If it is an array, `index` must also be an array with the same length or number of elements. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "oneOf": [
           {
             "type": "string"
@@ -3132,7 +3132,7 @@
       },
       "alert_indices": {
         "title": "Alert indices",
-        "description": "The alert index. It is required only when `type` is `alert`. If it is an array, `alertId` must also be an array with the same length or number of elements. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The alert indices. It is required only when `type` is `alert`.  If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "oneOf": [
           {
             "type": "string"
@@ -3148,7 +3148,7 @@
       },
       "rule": {
         "title": "Alerting rule",
-        "description": "The rule that is associated with the alert. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "type": "object",
         "x-technical-preview": true,
         "properties": {

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -2079,7 +2079,7 @@ components:
     alert_identifiers:
       title: Alert identifiers
       description: |
-        The alert identifier. It is required only when `type` is `alert`. If it is an array, `index` must also be an array with the same length or number of elements. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       oneOf:
         - type: string
         - type: array
@@ -2090,7 +2090,7 @@ components:
     alert_indices:
       title: Alert indices
       description: |
-        The alert index. It is required only when `type` is `alert`. If it is an array, `alertId` must also be an array with the same length or number of elements. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The alert indices. It is required only when `type` is `alert`.  If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       oneOf:
         - type: string
         - type: array
@@ -2100,7 +2100,7 @@ components:
     rule:
       title: Alerting rule
       description: |
-        The rule that is associated with the alert. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       type: object
       x-technical-preview: true
       properties:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
@@ -1,11 +1,11 @@
 title: Alert identifiers
 description: >
-  The alert identifier. It is required only when `type` is `alert`. If it is
-  an array, `index` must also be an array with the same length or number of
-  elements. This functionality is in technical preview and may be changed or
-  removed in a future release. Elastic will apply best effort to fix any issues,
-  but features in technical preview are not subject to the support SLA of
-  official GA features.
+  The alert identifiers. It is required only when `type` is `alert`. You can use
+  an array of strings to add multiple alerts to a case, provided that they all
+  relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended
+  rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply
+  best effort to fix any issues, but features in technical preview are not
+  subject to the support SLA of official GA features.
 oneOf:
   - type: string
   - type: array

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
@@ -1,11 +1,12 @@
 title: Alert indices
 description: >
-  The alert index. It is required only when `type` is `alert`. If it is an
-  array, `alertId` must also be an array with the same length or number of
-  elements. This functionality is in technical preview and may be changed or
-  removed in a future release. Elastic will apply best effort to fix any issues,
-  but features in technical preview are not subject to the support SLA of
-  official GA features.
+  The alert indices. It is required only when `type` is `alert`.  If you are
+  adding multiple alerts to a case, use an array of strings; the position of
+  each index name in the array must match the position of the corresponding
+  alert identifier in the `alertId` array. This functionality is in technical
+  preview and may be changed or removed in a future release. Elastic will apply
+  best effort to fix any issues, but features in technical preview are not
+  subject to the support SLA of official GA features.
 oneOf:
   - type: string
   - type: array

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
@@ -1,6 +1,6 @@
 title: Alerting rule
 description: >
-  The rule that is associated with the alert. It is required only when
+  The rule that is associated with the alerts. It is required only when
   `type` is `alert`. This functionality is in technical preview and may be
   changed or removed in a future release. Elastic will apply best effort to
   fix any issues, but features in technical preview are not subject to the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Clarify alertId and index in add comment API (#145189)](https://github.com/elastic/kibana/pull/145189)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2022-11-18T16:56:37Z","message":"[DOCS] Clarify alertId and index in add comment API (#145189)","sha":"74198264e1c887bc456e531ebe61e28c1b5fb4e3","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","docs","Feature:Cases","v8.6.0","v8.5.1","v8.7.0"],"number":145189,"url":"https://github.com/elastic/kibana/pull/145189","mergeCommit":{"message":"[DOCS] Clarify alertId and index in add comment API (#145189)","sha":"74198264e1c887bc456e531ebe61e28c1b5fb4e3"}},"sourceBranch":"main","suggestedTargetBranches":["8.5"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/145760","number":145760,"state":"MERGED","mergeCommit":{"sha":"16f1d027d609e3767a97372f40e294f62b4c69b5","message":"[8.6] [DOCS] Clarify alertId and index in add comment API (#145189) (#145760)"}},{"branch":"8.5","label":"v8.5.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145189","number":145189,"mergeCommit":{"message":"[DOCS] Clarify alertId and index in add comment API (#145189)","sha":"74198264e1c887bc456e531ebe61e28c1b5fb4e3"}}]}] BACKPORT-->