### PR TITLE
[TSVB] Unskips functional tests and fixes flakiness

### DIFF
--- a/test/functional/apps/visualize/group5/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/group5/_tsvb_time_series.ts
@@ -28,10 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const browser = getService('browser');
   const kibanaServer = getService('kibanaServer');
 
-  // Failing: See https://github.com/elastic/kibana/issues/145563
-  // Failing: See https://github.com/elastic/kibana/issues/145560
-  // Failing: See https://github.com/elastic/kibana/issues/139096
-  describe.skip('visual builder', function describeIndexTests() {
+  describe('visual builder', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles([
         'kibana_admin',

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -824,7 +824,8 @@ export class VisualBuilderPageObject extends FtrService {
 
   public async setMetricsGroupBy(option: string) {
     const groupBy = await this.testSubjects.find('groupBySelect');
-    await this.comboBox.setElement(groupBy, option, { clickWithMouse: true });
+    await this.comboBox.setElement(groupBy, option);
+    return await this.header.waitUntilLoadingHasFinished();
   }
 
   public async setMetricsGroupByTerms(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/145563
Closes https://github.com/elastic/kibana/issues/145562
Closes https://github.com/elastic/kibana/issues/145561
Closes https://github.com/elastic/kibana/issues/145560
Closes https://github.com/elastic/kibana/issues/145644
Closes https://github.com/elastic/kibana/issues/139096
Closes https://github.com/elastic/kibana/issues/145564

They also fail for the same reason in FF. They started fail when a change made by the operations team. 

For some reason while the list appears on the DOM the click by mouse doesn't work for the FF tests. I changed the helper a bit to not use it.
![image](https://user-images.githubusercontent.com/17003240/202997107-1ddcfd69-c935-4d0a-891f-1feb9d00ebb5.png)

Runner for tests (50 times) to ensure that nothing has broken https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1577#_

I couldn't run the firefox tests on the flaky runner (I get an error when initializing it) but these tests were failing every time we run them on FF locally I am quite optimistic that this change will stabilize them in FF too.
