### PR TITLE
[Osquery] Fix Global Packs 

### DIFF
--- a/x-pack/plugins/osquery/common/schemas/common/utils.ts
+++ b/x-pack/plugins/osquery/common/schemas/common/utils.ts
@@ -84,7 +84,7 @@ export const convertShardsToArray = (
   reduce(
     shards,
     (acc, value, key) => {
-      if (value) {
+      if (value != null) {
         acc.push({
           policy: {
             key,

--- a/x-pack/plugins/osquery/public/packs/form/index.tsx
+++ b/x-pack/plugins/osquery/public/packs/form/index.tsx
@@ -242,16 +242,19 @@ const PackFormComponent: React.FC<PackFormProps> = ({
             <NameField euiFieldProps={euiFieldProps} />
           </EuiFlexItem>
         </EuiFlexGroup>
+        <EuiSpacer size="m" />
 
         <EuiFlexGroup>
           <EuiFlexItem>
             <DescriptionField euiFieldProps={euiFieldProps} />
           </EuiFlexItem>
         </EuiFlexGroup>
+        <EuiSpacer size="m" />
 
         <EuiFlexGroup>
           <PackTypeSelectable packType={packType} setPackType={changePackType} />
         </EuiFlexGroup>
+        <EuiSpacer size="m" />
 
         {packType === 'policy' && (
           <>
@@ -260,6 +263,7 @@ const PackFormComponent: React.FC<PackFormProps> = ({
                 <PolicyIdComboBoxField options={availableOptions} />
               </EuiFlexItem>
             </EuiFlexGroup>
+            <EuiSpacer size="m" />
 
             <EuiFlexGroup>
               <EuiFlexItem>
@@ -274,6 +278,7 @@ const PackFormComponent: React.FC<PackFormProps> = ({
                 </StyledEuiAccordion>
               </EuiFlexItem>
             </EuiFlexGroup>
+            <EuiSpacer size="m" />
           </>
         )}
 

--- a/x-pack/plugins/osquery/public/packs/form/shards/pack_shards_field.tsx
+++ b/x-pack/plugins/osquery/public/packs/form/shards/pack_shards_field.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { InternalFieldErrors } from 'react-hook-form';
 import { useFieldArray, useForm, useFormContext } from 'react-hook-form';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
@@ -40,15 +40,26 @@ const PackShardsFieldComponent = ({ options }: PackShardsFieldProps) => {
 
   const rootShards = watchRoot('shards');
 
+  const initialShardsArray = useMemo(() => {
+    const initialConvertedShards = convertShardsToArray(rootShards, agentPoliciesById);
+    if (!isEmpty(initialConvertedShards)) {
+      if (initialConvertedShards[initialConvertedShards.length - 1].policy.key) {
+        return [...initialConvertedShards, defaultShardData];
+      }
+
+      return initialConvertedShards;
+    }
+
+    return [defaultShardData];
+  }, [agentPoliciesById, rootShards]);
+
   const { control, watch, getFieldState, formState, resetField, setValue } = useForm<{
     shardsArray: ShardsArray;
   }>({
     mode: 'all',
     shouldUnregister: true,
     defaultValues: {
-      shardsArray: !isEmpty(convertShardsToArray(rootShards, agentPoliciesById))
-        ? [...convertShardsToArray(rootShards, agentPoliciesById), defaultShardData]
-        : [defaultShardData],
+      shardsArray: initialShardsArray,
     },
   });
   const { fields, remove, append } = useFieldArray({
@@ -108,6 +119,7 @@ const PackShardsFieldComponent = ({ options }: PackShardsFieldProps) => {
             control={control}
             options={options}
           />
+          <EuiSpacer size="xs" />
         </div>
       ))}
     </>


### PR DESCRIPTION
This PR solves multiple issues:
- add more padding between form fields ✅ 
- fix adding a redundant row to shards if we specify percentage without policy name ✅ 
- 0 percentage shard gets moved to policies ✅ 

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->