### PR TITLE
[Synthethics] Use `monitor.config_id` for the URLs

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_location.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_location.tsx
@@ -76,7 +76,7 @@ export const MonitorDetailsLocation: React.FC = () => {
                   onClick={() => {
                     closeLocationList();
                     services.application!.navigateToApp(PLUGIN.SYNTHETICS_PLUGIN_ID, {
-                      path: `/monitor/${monitor.id}?locationId=${fullLocation.id}`,
+                      path: `/monitor/${monitor.config_id}?locationId=${fullLocation.id}`,
                     });
                   }}
                 >


### PR DESCRIPTION
## Summary

Closes #145758


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->