### PR TITLE
[Enterprise Search] 3392 fix canceling syncs

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
@@ -39,7 +39,7 @@ describe('addConnector lib function', () => {
           must: [
             {
               term: {
-                connector_id: 'connectorId',
+                'connector.id': 'connectorId',
               },
             },
             {
@@ -63,7 +63,7 @@ describe('addConnector lib function', () => {
           must: [
             {
               term: {
-                connector_id: 'connectorId',
+                'connector.id': 'connectorId',
               },
             },
             {

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
@@ -21,7 +21,7 @@ export const cancelSyncs = async (
         must: [
           {
             term: {
-              connector_id: connectorId,
+              'connector.id': connectorId,
             },
           },
           {
@@ -45,7 +45,7 @@ export const cancelSyncs = async (
         must: [
           {
             term: {
-              connector_id: connectorId,
+              'connector.id': connectorId,
             },
           },
           {


### PR DESCRIPTION
This fixes broken functionality where syncs weren't being canceled, caused by a missed index mapping refactor.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->