### PR TITLE
[Lens] move `ignoreGlobalFilters` to the annotation group 

### DIFF
--- a/src/plugins/event_annotation/common/event_annotation_group/index.ts
+++ b/src/plugins/event_annotation/common/event_annotation_group/index.ts
@@ -14,12 +14,14 @@ import type { EventAnnotationOutput } from '../types';
 export interface EventAnnotationGroupOutput {
   type: 'event_annotation_group';
   annotations: EventAnnotationOutput[];
+  ignoreGlobalFilters: boolean;
   dataView: IndexPatternExpressionType;
 }
 
 export interface EventAnnotationGroupArgs {
   annotations: EventAnnotationOutput[];
   dataView: IndexPatternExpressionType;
+  ignoreGlobalFilters: boolean;
 }
 
 export function eventAnnotationGroup(): ExpressionFunctionDefinition<
@@ -44,6 +46,16 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
           defaultMessage: 'Data view retrieved with indexPatternLoad',
         }),
       },
+      ignoreGlobalFilters: {
+        types: ['boolean'],
+        default: true,
+        help: i18n.translate(
+          'eventAnnotation.group.args.annotationConfigs.ignoreGlobalFilters.help',
+          {
+            defaultMessage: `Switch to ignore global filters for the annotation`,
+          }
+        ),
+      },
       annotations: {
         types: [
           'manual_point_event_annotation',
@@ -62,6 +74,7 @@ export function eventAnnotationGroup(): ExpressionFunctionDefinition<
         type: 'event_annotation_group',
         annotations: args.annotations.filter((annotation) => !annotation.isHidden),
         dataView: args.dataView,
+        ignoreGlobalFilters: args.ignoreGlobalFilters,
       };
     },
   };

--- a/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
@@ -314,7 +314,7 @@ function regroupForRequestOptimization(
             (dataView.timeFieldName ||
               dataView.fields.find((field) => field.type === 'date' && field.displayName)?.name);
 
-          const key = `${g.dataView.value.id}-${timeField}-${Boolean(current.ignoreGlobalFilters)}`;
+          const key = `${g.dataView.value.id}-${timeField}-${Boolean(g.ignoreGlobalFilters)}`;
           const subGroup = acc[key] as QueryGroup;
           if (subGroup) {
             let allFields = [...(subGroup.allFields || []), ...(current.extraFields || [])];
@@ -342,7 +342,7 @@ function regroupForRequestOptimization(
               timeField: timeField!,
               allFields,
               annotations: [current],
-              ignoreGlobalFilters: Boolean(current.ignoreGlobalFilters),
+              ignoreGlobalFilters: Boolean(g.ignoreGlobalFilters),
             },
           };
         }

--- a/src/plugins/event_annotation/common/query_point_event_annotation/index.ts
+++ b/src/plugins/event_annotation/common/query_point_event_annotation/index.ts
@@ -103,13 +103,6 @@ export const queryPointEventAnnotation: ExpressionFunctionDefinition<
         defaultMessage: `Switch to hide annotation`,
       }),
     },
-    ignoreGlobalFilters: {
-      types: ['boolean'],
-      help: i18n.translate('eventAnnotation.queryAnnotation.args.ignoreGlobalFilters', {
-        defaultMessage: `Switch to ignore global filters for the annotation`,
-      }),
-      default: true,
-    },
   },
   fn: function fn(input: unknown, args: QueryPointEventAnnotationArgs) {
     return {

--- a/src/plugins/event_annotation/common/query_point_event_annotation/types.ts
+++ b/src/plugins/event_annotation/common/query_point_event_annotation/types.ts
@@ -15,7 +15,6 @@ export type QueryPointEventAnnotationArgs = {
   timeField?: string;
   extraFields?: string[];
   textField?: string;
-  ignoreGlobalFilters?: boolean;
 } & PointStyleProps;
 
 export type QueryPointEventAnnotationOutput = QueryPointEventAnnotationArgs & {

--- a/src/plugins/event_annotation/common/types.ts
+++ b/src/plugins/event_annotation/common/types.ts
@@ -72,7 +72,6 @@ export type QueryPointEventAnnotationConfig = {
   timeField?: string;
   textField?: string;
   extraFields?: string[];
-  ignoreGlobalFilters?: boolean;
   key: {
     type: 'point_in_time';
   };
@@ -86,6 +85,7 @@ export type EventAnnotationConfig =
 export interface EventAnnotationGroupConfig {
   annotations: EventAnnotationConfig[];
   indexPatternId: string;
+  ignoreGlobalFilters?: boolean;
 }
 
 export type EventAnnotationArgs =

--- a/src/plugins/event_annotation/public/event_annotation_service/service.test.ts
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.test.ts
@@ -122,7 +122,6 @@ describe('Event Annotation Service', () => {
                 icon: ['triangle'],
                 textVisibility: [false],
                 textField: [],
-                ignoreGlobalFilters: [false],
                 filter: [
                   {
                     chain: [
@@ -233,7 +232,6 @@ describe('Event Annotation Service', () => {
                 icon: ['triangle'],
                 textVisibility: [false],
                 textField: [],
-                ignoreGlobalFilters: [false],
                 filter: [
                   {
                     chain: [
@@ -297,7 +295,6 @@ describe('Event Annotation Service', () => {
                   icon: ['triangle'],
                   textVisibility: [textVisibility],
                   textField: expected ? [expected] : [],
-                  ignoreGlobalFilters: [false],
                   filter: [
                     {
                       chain: [

--- a/src/plugins/event_annotation/public/event_annotation_service/service.tsx
+++ b/src/plugins/event_annotation/public/event_annotation_service/service.tsx
@@ -92,7 +92,6 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
         textField,
         filter,
         extraFields,
-        ignoreGlobalFilters,
       } = annotation;
       expressions.push({
         type: 'expression' as const,
@@ -112,7 +111,6 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
               textField: textVisibility && textField ? [textField] : [],
               filter: filter ? [queryToAst(filter)] : [],
               extraFields: extraFields || [],
-              ignoreGlobalFilters: [Boolean(ignoreGlobalFilters)],
               isHidden: [Boolean(annotation.isHidden)],
             },
           },
@@ -130,7 +128,7 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
 
       const groupsExpressions = groups
         .filter((g) => g.annotations.some((a) => !a.isHidden))
-        .map(({ annotations, indexPatternId }): ExpressionAstExpression => {
+        .map(({ annotations, indexPatternId, ignoreGlobalFilters }): ExpressionAstExpression => {
           const indexPatternExpression: ExpressionAstExpression = {
             type: 'expression',
             chain: [
@@ -153,6 +151,7 @@ export function getEventAnnotationService(): EventAnnotationServiceType {
                 arguments: {
                   dataView: [indexPatternExpression],
                   annotations: [...annotationExpressions],
+                  ignoreGlobalFilters: [Boolean(ignoreGlobalFilters)],
                 },
               },
             ],

--- a/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
@@ -209,13 +209,10 @@ export const buildXYExpression = (
     .map((layer) => {
       return {
         ...layer,
+        ignoreGlobalFilters: layer.ignoreGlobalFilters,
         annotations: layer.annotations.map((c) => ({
           ...c,
           label: uniqueLabels[c.id],
-          ...(c.type === 'query'
-            ? // Move the ignore flag at the event level
-              { ignoreGlobalFilters: layer.ignoreGlobalFilters }
-            : {}),
         })),
       };
     });
@@ -369,6 +366,7 @@ export const buildXYExpression = (
                         ?.interval) ||
                     'auto',
                   groups: validAnnotationsLayers.map((layer) => ({
+                    ignoreGlobalFilters: layer.ignoreGlobalFilters,
                     indexPatternId: layer.indexPatternId,
                     annotations: layer.annotations.filter(isValidAnnotation),
                   })),

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/helpers.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/helpers.ts
@@ -97,7 +97,6 @@ export const sanitizeProperties = (annotation: EventAnnotationConfig) => {
       'textField',
       'filter',
       'extraFields',
-      'ignoreGlobalFilters',
     ]);
     return lineAnnotation;
   }


### PR DESCRIPTION
## Summary

This moves the setting `ignoreGlobalFilters` from `EventAnnotationConfig` to `EventAnnotationGroupConfig`. Before it didn't really matter where is is passed from the lens layer, but I want to keep the shape of the configs as close as possible to saved objects and `ignoreGlobalFilters` is a group property, not a single annotation. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
