### PR TITLE
[Synthetics] Update status count viz on monitor upsert

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/effects.ts
@@ -6,6 +6,7 @@
  */
 
 import { takeLatest, takeLeading } from 'redux-saga/effects';
+import { fetchUpsertSuccessAction } from '../monitor_list';
 import { fetchEffectFactory } from '../utils/fetch_effect';
 import {
   fetchMonitorOverviewAction,
@@ -28,7 +29,7 @@ export function* fetchMonitorOverviewEffect() {
 
 export function* fetchOverviewStatusEffect() {
   yield takeLatest(
-    [fetchOverviewStatusAction.get, quietFetchOverviewStatusAction.get],
+    [fetchOverviewStatusAction.get, quietFetchOverviewStatusAction.get, fetchUpsertSuccessAction],
     fetchEffectFactory(
       fetchOverviewStatus,
       fetchOverviewStatusAction.success,


### PR DESCRIPTION
## Summary

Resolves #145845.

This resolves the issue of count not updating when a monitor is enabled/disabled by listening for the `success` version of the saved object upsert action. This way, any time the frontend verifies that a monitor has had its state changed, we'll update the status count as a secondary effect.

This could introduce some risk if we start using that action in some sort of batched way in the future, but at present it seems to only be driven by direct 1:1 user input to the Actions Popover component that we've reused in the detail flyout and on the overview cards.

## Testing this PR

You can simply create some managed monitors and change their state from the Overview page.

![20221121122624](https://user-images.githubusercontent.com/18429259/203121081-2c1232b7-8f62-4d93-bec8-4f98e4bc7433.gif)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->