### PR TITLE
[Fleet] Fix max width issue in policy editor

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useState, Fragment, memo, useMemo } from 'react';
-import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiFlexGrid,
@@ -22,10 +21,6 @@ import type { PackagePolicyConfigValidationResults } from '../../../services';
 import { isAdvancedVar, validationHasErrors } from '../../../services';
 
 import { PackagePolicyInputVarField } from './package_policy_input_var_field';
-
-const FlexItemWithMaxWidth = styled(EuiFlexItem)`
-  max-width: calc(50% - ${(props) => props.theme.eui.euiSizeL});
-`;
 
 export const PackagePolicyInputConfig: React.FunctionComponent<{
   hasInputStreams: boolean;
@@ -101,7 +96,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <FlexItemWithMaxWidth>
+        <EuiFlexItem>
           <EuiFlexGroup direction="column" gutterSize="m">
             {requiredVars.map((varDef) => {
               const { name: varName, type: varType } = varDef;
@@ -191,7 +186,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
               </Fragment>
             ) : null}
           </EuiFlexGroup>
-        </FlexItemWithMaxWidth>
+        </EuiFlexItem>
       </EuiFlexGrid>
     );
   }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -42,11 +42,8 @@ import { PackagePolicyEditorDatastreamMappings } from '../../datastream_mappings
 import { PackagePolicyInputVarField } from './package_policy_input_var_field';
 import { useDataStreamId } from './hooks';
 
-const FlexItemWithMaxWidth = styled(EuiFlexItem)`
-  max-width: calc(50% - ${(props) => props.theme.eui.euiSizeL});
-`;
-
 const ScrollAnchor = styled.div`
+  display: none;
   scroll-margin-top: ${(props) => parseFloat(props.theme.eui.euiHeaderHeightCompensation) * 2}px;
 `;
 
@@ -78,7 +75,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     const defaultDataStreamId = useDataStreamId();
     const containerRef = useRef<HTMLDivElement>(null);
 
-    const isDefaultDatstream =
+    const isDefaultDatastream =
       !!defaultDataStreamId &&
       !!packagePolicyInputStream.id &&
       packagePolicyInputStream.id === defaultDataStreamId;
@@ -86,13 +83,13 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     const isInputOnlyPackage = packageInfo.type === 'input';
 
     useEffect(() => {
-      if (isDefaultDatstream && containerRef.current) {
+      if (isDefaultDatastream && containerRef.current) {
         containerRef.current.scrollIntoView();
       }
-    }, [isDefaultDatstream, containerRef]);
+    }, [isDefaultDatastream, containerRef]);
 
     // Showing advanced options toggle state
-    const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(isDefaultDatstream);
+    const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(isDefaultDatastream);
 
     // Errors state
     const hasErrors = forceShowErrors && validationHasErrors(inputStreamValidationResults);
@@ -180,7 +177,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
 
     return (
       <>
-        <EuiFlexGrid columns={2} id={isDefaultDatstream ? 'test123' : 'asas'}>
+        <EuiFlexGrid columns={2}>
           <ScrollAnchor ref={containerRef} />
           <EuiFlexItem>
             <EuiFlexGroup gutterSize="none" alignItems="flexStart">
@@ -227,7 +224,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          <FlexItemWithMaxWidth>
+          <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="m">
               {requiredVars.map((varDef) => {
                 if (!packagePolicyInputStream?.vars) return null;
@@ -415,7 +412,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                 ) : null}
               </Fragment>
             </EuiFlexGroup>
-          </FlexItemWithMaxWidth>
+          </EuiFlexItem>
         </EuiFlexGrid>
       </>
     );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/145909

Fix max width issue with Fleet policy editor, likely due to upstream EUI change and some custom CSS we had to fiddle with some flex widths.

https://user-images.githubusercontent.com/6766512/203139932-76055157-6c7c-4374-b723-109390084ad6.mov

Also fixed some typos/leftover code that was floating around here.
