### PR TITLE
[ci-stats] ensure that all timing metadata values are of valid types

### DIFF
--- a/packages/kbn-ci-stats-reporter/src/report_time.ts
+++ b/packages/kbn-ci-stats-reporter/src/report_time.ts
@@ -19,7 +19,24 @@ export const getTimeReporter = (log: ToolingLog, group: string) => {
           group,
           id,
           ms: Date.now() - startTime,
-          meta,
+          meta: Object.fromEntries(
+            Object.entries(meta).flatMap(([k, v]) => {
+              const type = typeof v;
+              if (type === 'undefined') {
+                return [];
+              }
+
+              if (type === 'string' || type === 'number' || type === 'boolean') {
+                return [[k, v]];
+              }
+
+              if (Array.isArray(v) && v.every((i): i is string => typeof i === 'string')) {
+                return [[k, v]];
+              }
+
+              return [[k, JSON.stringify(v)]];
+            })
+          ),
         },
       ],
     });


### PR DESCRIPTION
I noticed while running `node scripts/functional_tests_server` that an error is logged when trying to report timing information, because a non-primative value is passed to ci-stats and triggers a JSON object to be sent as a metadata value, which ci-stats rejects with a 400.

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/1329312/203141728-b3154135-39fa-40da-a44a-fcad02a367c1.png">

This PR updates the `reportTime()` function to convert any metadata value that isn't a boolean, number, string, or array of strings, to a JSON string.