### PR TITLE
[PresentationUtils] Registry for embeddable links

### DIFF
--- a/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
@@ -52,7 +52,9 @@ interface UnwrappedEmbeddableFactory {
 
 export const EditorMenu = ({ dashboardContainer, createNewVisType }: Props) => {
   const {
+    data: { search },
     embeddable,
+    embeddableLinks,
     notifications: { toasts },
     settings: { uiSettings },
     usageCollection,
@@ -253,45 +255,66 @@ export const EditorMenu = ({ dashboardContainer, createNewVisType }: Props) => {
   });
 
   const getEditorMenuPanels = (closePopover: () => void) => {
-    return [
-      {
+    const registry = embeddableLinks.embeddableLinksRegistry.get();
+    const stateTransfer = embeddable.getStateTransfer();
+
+    return registry.map(({ appId, label }) => {
+      return {
         id: 0,
         items: [
-          ...visTypeAliases.map(getVisTypeAliasMenuItem),
-          ...Object.values(factoryGroupMap).map(({ id, appName, icon, panelId }) => ({
-            name: appName,
-            icon,
-            panel: panelId,
-            'data-test-subj': `dashboardEditorMenu-${id}Group`,
-          })),
-          ...ungroupedFactories.map((factory) => {
-            return getEmbeddableFactoryMenuItem(factory, closePopover);
-          }),
-          ...promotedVisTypes.map(getVisTypeMenuItem),
           {
-            name: aggsPanelTitle,
-            icon: 'visualizeApp',
-            panel: aggBasedPanelID,
-            'data-test-subj': `dashboardEditorAggBasedMenuItem`,
+            name: label,
+            onClick: () => {
+              stateTransfer.navigateToEditor(appId, {
+                state: {
+                  originatingApp: DashboardConstants.DASHBOARDS_ID,
+                  searchSessionId: search.session.getSessionId(),
+                },
+              });
+            },
           },
-          ...toolVisTypes.map(getVisTypeMenuItem),
         ],
-      },
-      {
-        id: aggBasedPanelID,
-        title: aggsPanelTitle,
-        items: aggsBasedVisTypes.map(getVisTypeMenuItem),
-      },
-      ...Object.values(factoryGroupMap).map(
-        ({ appName, panelId, factories: groupFactories }: FactoryGroup) => ({
-          id: panelId,
-          title: appName,
-          items: groupFactories.map((factory) => {
-            return getEmbeddableFactoryMenuItem(factory, closePopover);
-          }),
-        })
-      ),
-    ];
+      };
+    });
+    // return [
+    //   {
+    //     id: 0,
+    //     items: [
+    //       ...visTypeAliases.map(getVisTypeAliasMenuItem),
+    //       ...Object.values(factoryGroupMap).map(({ id, appName, icon, panelId }) => ({
+    //         name: appName,
+    //         icon,
+    //         panel: panelId,
+    //         'data-test-subj': `dashboardEditorMenu-${id}Group`,
+    //       })),
+    //       ...ungroupedFactories.map((factory) => {
+    //         return getEmbeddableFactoryMenuItem(factory, closePopover);
+    //       }),
+    //       ...promotedVisTypes.map(getVisTypeMenuItem),
+    //       {
+    //         name: aggsPanelTitle,
+    //         icon: 'visualizeApp',
+    //         panel: aggBasedPanelID,
+    //         'data-test-subj': `dashboardEditorAggBasedMenuItem`,
+    //       },
+    //       ...toolVisTypes.map(getVisTypeMenuItem),
+    //     ],
+    //   },
+    //   {
+    //     id: aggBasedPanelID,
+    //     title: aggsPanelTitle,
+    //     items: aggsBasedVisTypes.map(getVisTypeMenuItem),
+    //   },
+    //   ...Object.values(factoryGroupMap).map(
+    //     ({ appName, panelId, factories: groupFactories }: FactoryGroup) => ({
+    //       id: panelId,
+    //       title: appName,
+    //       items: groupFactories.map((factory) => {
+    //         return getEmbeddableFactoryMenuItem(factory, closePopover);
+    //       }),
+    //     })
+    //   ),
+    // ];
   };
   return (
     <SolutionToolbarPopover

--- a/src/plugins/dashboard/public/services/embeddable_links/embeddable_links_service.ts
+++ b/src/plugins/dashboard/public/services/embeddable_links/embeddable_links_service.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { KibanaPluginServiceFactory } from '@kbn/presentation-util-plugin/public';
+import type { DashboardStartDependencies } from '../../plugin';
+import type { DashboardEmbeddableLinksService } from './types';
+
+export type EmbeddableLinksServiceFactory = KibanaPluginServiceFactory<
+  DashboardEmbeddableLinksService,
+  DashboardStartDependencies
+>;
+
+export const embeddableLinksServiceFactory: EmbeddableLinksServiceFactory = ({ startPlugins }) => {
+  const {
+    presentationUtil: { embeddableLinksRegistry: embeddableLinksRegistry },
+  } = startPlugins;
+
+  return {
+    embeddableLinksRegistry,
+  };
+};

--- a/src/plugins/dashboard/public/services/embeddable_links/types.ts
+++ b/src/plugins/dashboard/public/services/embeddable_links/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
+
+export interface DashboardEmbeddableLinksService {
+  embeddableLinksRegistry: PresentationUtilPluginStart['embeddableLinksRegistry'];
+}

--- a/src/plugins/dashboard/public/services/plugin_services.ts
+++ b/src/plugins/dashboard/public/services/plugin_services.ts
@@ -24,6 +24,7 @@ import { dataServiceFactory } from './data/data_service';
 import { dataViewEditorServiceFactory } from './data_view_editor/data_view_editor_service';
 import { documentationLinksServiceFactory } from './documentation_links/documentation_links_service';
 import { embeddableServiceFactory } from './embeddable/embeddable_service';
+import { embeddableLinksServiceFactory } from './embeddable_links/embeddable_links_service';
 import { httpServiceFactory } from './http/http_service';
 import { initializerContextServiceFactory } from './initializer_context/initializer_context_service';
 import { navigationServiceFactory } from './navigation/navigation_service';
@@ -65,6 +66,7 @@ const providers: PluginServiceProviders<DashboardServices, DashboardPluginServic
   dataViewEditor: new PluginServiceProvider(dataViewEditorServiceFactory),
   documentationLinks: new PluginServiceProvider(documentationLinksServiceFactory),
   embeddable: new PluginServiceProvider(embeddableServiceFactory),
+  embeddableLinks: new PluginServiceProvider(embeddableLinksServiceFactory),
   http: new PluginServiceProvider(httpServiceFactory),
   initializerContext: new PluginServiceProvider(initializerContextServiceFactory),
   navigation: new PluginServiceProvider(navigationServiceFactory),

--- a/src/plugins/dashboard/public/services/types.ts
+++ b/src/plugins/dashboard/public/services/types.ts
@@ -21,6 +21,7 @@ import { DashboardDataService } from './data/types';
 import { DashboardDataViewEditorService } from './data_view_editor/types';
 import { DashboardDocumentationLinksService } from './documentation_links/types';
 import { DashboardEmbeddableService } from './embeddable/types';
+import { DashboardEmbeddableLinksService } from './embeddable_links/types';
 import { DashboardHTTPService } from './http/types';
 import { DashboardInitializerContextService } from './initializer_context/types';
 import { DashboardNavigationService } from './navigation/types';
@@ -51,6 +52,7 @@ export interface DashboardServices {
   dataViewEditor: DashboardDataViewEditorService; // this service is used only for the no data state
   documentationLinks: DashboardDocumentationLinksService;
   embeddable: DashboardEmbeddableService;
+  embeddableLinks: DashboardEmbeddableLinksService;
   http: DashboardHTTPService;
   initializerContext: DashboardInitializerContextService;
   navigation: DashboardNavigationService;

--- a/src/plugins/presentation_util/public/plugin.ts
+++ b/src/plugins/presentation_util/public/plugin.ts
@@ -42,6 +42,7 @@ export class PresentationUtilPlugin
     return {
       ContextProvider: pluginServices.getContextProvider(),
       labsService: pluginServices.getServices().labs,
+      embeddableLinksRegistry: pluginServices.getServices().embeddableLinks.registry,
       registerExpressionsLanguage,
     };
   }

--- a/src/plugins/presentation_util/public/services/create/registry.tsx
+++ b/src/plugins/presentation_util/public/services/create/registry.tsx
@@ -62,7 +62,6 @@ export class PluginServiceRegistry<Services, StartParameters = {}> {
         }, children)}
       </>
     );
-
     return provider;
   }
 

--- a/src/plugins/presentation_util/public/services/plugin_services.ts
+++ b/src/plugins/presentation_util/public/services/plugin_services.ts
@@ -12,6 +12,7 @@ import {
   KibanaPluginServiceParams,
   PluginServiceProvider,
   PluginServiceRegistry,
+  KibanaPluginServiceFactory,
 } from './create';
 import { PresentationUtilPluginStartDeps } from '../types';
 
@@ -19,7 +20,40 @@ import { capabilitiesServiceFactory } from './capabilities/capabilities_service'
 import { dataViewsServiceFactory } from './data_views/data_views_service';
 import { dashboardsServiceFactory } from './dashboards/dashboards_service';
 import { labsServiceFactory } from './labs/labs_service';
-import { PresentationUtilServices } from './types';
+import { PresentationEmbeddablesService, PresentationUtilServices } from './types';
+
+type EmbeddableLinksServiceFactory = KibanaPluginServiceFactory<
+  PresentationEmbeddablesService,
+  PresentationUtilPluginStartDeps
+>;
+
+interface EmbeddableLink {
+  appId: string;
+  group?: string;
+  label?: string;
+  path?: string;
+  valueInput?: any;
+}
+
+export class EmbeddableLinksRegistry {
+  private embeddableLinks: EmbeddableLink[] = [];
+
+  constructor() {}
+
+  register(embeddableLink: EmbeddableLink) {
+    this.embeddableLinks.push(embeddableLink);
+  }
+
+  get() {
+    return this.embeddableLinks;
+  }
+}
+
+const embeddableLinkServiceFactory: EmbeddableLinksServiceFactory = ({ coreStart }) => {
+  const registry = new EmbeddableLinksRegistry();
+
+  return { registry };
+};
 
 export const providers: PluginServiceProviders<
   PresentationUtilServices,
@@ -29,6 +63,7 @@ export const providers: PluginServiceProviders<
   labs: new PluginServiceProvider(labsServiceFactory),
   dataViews: new PluginServiceProvider(dataViewsServiceFactory),
   dashboards: new PluginServiceProvider(dashboardsServiceFactory),
+  embeddableLinks: new PluginServiceProvider(embeddableLinkServiceFactory),
 };
 
 export const pluginServices = new PluginServices<PresentationUtilServices>();

--- a/src/plugins/presentation_util/public/services/types.ts
+++ b/src/plugins/presentation_util/public/services/types.ts
@@ -10,16 +10,23 @@ import { PresentationLabsService } from './labs/types';
 import { PresentationDashboardsService } from './dashboards/types';
 import { PresentationCapabilitiesService } from './capabilities/types';
 import { PresentationDataViewsService } from './data_views/types';
+import type { EmbeddableLinksRegistry } from './plugin_services';
+
+interface PresentationEmbeddablesService {
+  registry: EmbeddableLinksRegistry;
+}
 
 export interface PresentationUtilServices {
   dashboards: PresentationDashboardsService;
   dataViews: PresentationDataViewsService;
   capabilities: PresentationCapabilitiesService;
   labs: PresentationLabsService;
+  embeddableLinks: PresentationEmbeddablesService;
 }
 
 export type {
   PresentationCapabilitiesService,
   PresentationDashboardsService,
   PresentationLabsService,
+  PresentationEmbeddablesService,
 };

--- a/src/plugins/presentation_util/public/types.ts
+++ b/src/plugins/presentation_util/public/types.ts
@@ -9,6 +9,7 @@
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { registerExpressionsLanguage } from '.';
 import { PresentationLabsService } from './services/labs/types';
+import { PresentationEmbeddablesService } from './services/types';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PresentationUtilPluginSetup {}
@@ -16,6 +17,7 @@ export interface PresentationUtilPluginSetup {}
 export interface PresentationUtilPluginStart {
   ContextProvider: React.FC;
   labsService: PresentationLabsService;
+  embeddableLinksRegistry: PresentationEmbeddablesService['registry'];
   registerExpressionsLanguage: typeof registerExpressionsLanguage;
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -283,6 +283,11 @@ export class LensPlugin {
         setUsageCollectionStart(plugins.usageCollection);
       }
 
+      plugins.presentationUtil.embeddableLinksRegistry.register({
+        appId: APP_ID,
+        label: NOT_INTERNATIONALIZED_PRODUCT_NAME,
+      });
+
       initMemoizedErrorNotification(coreStart);
 
       return {


### PR DESCRIPTION
Proof of concept for embeddables to register creation options with Presentation Util plugin

The embeddable registry will be used to populate the "Select type" popover in Dashboard and Canvas. 

Embeddables will have several options for registering with PresentationUtil. 
1. Embeddables such as Lens and Maps will register use the state transfer service to navigate to an editor app
2. Embeddables like log stream may immediately create a new panel with the default input.
3. Embeddables like Machine Learning may open an inline editor to get user input.
