### PR TITLE
[Synthetics] step details - test run details - fix breadcrumbs

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/ping/synthetics.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/ping/synthetics.ts
@@ -61,6 +61,7 @@ export const SyntheticsDataType = t.partial({
 
 export const JourneyStepType = t.intersection([
   t.partial({
+    config_id: t.string,
     monitor: t.partial({
       duration: t.type({
         us: t.number,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -11,18 +11,24 @@ import { EuiLink, EuiIcon } from '@elastic/eui';
 import { InPortal } from 'react-reverse-portal';
 import { MonitorDetailsLinkPortalNode } from './portals';
 
-export const MonitorDetailsLinkPortal = ({ name, id }: { name: string; id: string }) => {
+export const MonitorDetailsLinkPortal = ({
+  name,
+  configId,
+}: {
+  name: string;
+  configId: string;
+}) => {
   return (
     <InPortal node={MonitorDetailsLinkPortalNode}>
-      <MonitorDetailsLink name={name} id={id} />
+      <MonitorDetailsLink name={name} configId={configId} />
     </InPortal>
   );
 };
 
-export const MonitorDetailsLink = ({ name, id }: { name: string; id: string }) => {
+export const MonitorDetailsLink = ({ name, configId }: { name: string; configId: string }) => {
   const history = useHistory();
   const href = history.createHref({
-    pathname: `monitor/${id}`,
+    pathname: `monitor/${configId}`,
   });
   return (
     <EuiLink href={href}>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
@@ -10,6 +10,7 @@ import { EuiLoadingSpinner } from '@elastic/eui';
 import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { useTrackPageview, useFetcher } from '@kbn/observability-plugin/public';
+import { ConfigKey } from '../../../../../common/runtime_types';
 import { getServiceLocations } from '../../state';
 import { ServiceAllowedWrapper } from '../common/wrappers/service_allowed_wrapper';
 import { MonitorSteps } from './steps';
@@ -37,7 +38,10 @@ const MonitorEditPage: React.FC = () => {
   return data && !loading && !error ? (
     <MonitorForm defaultValues={data?.attributes}>
       <MonitorSteps stepMap={EDIT_MONITOR_STEPS} isEditFlow={true} />
-      <MonitorDetailsLinkPortal id={data?.id} name={data?.attributes.name} />
+      <MonitorDetailsLinkPortal
+        configId={data?.attributes[ConfigKey.CONFIG_ID]}
+        name={data?.attributes.name}
+      />
     </MonitorForm>
   ) : (
     <EuiLoadingSpinner />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
@@ -53,9 +53,9 @@ export const StepDetailPage = () => {
 
   return (
     <>
-      {data?.details?.journey && (
+      {data?.details?.journey?.config_id && (
         <MonitorDetailsLinkPortal
-          id={data.details.journey.monitor.id}
+          configId={data.details.journey.config_id}
           name={data.details.journey.monitor.name!}
         />
       )}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/hooks/use_test_run_details_breadcrumbs.ts
@@ -8,6 +8,7 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSelectedMonitor } from '../../monitor_details/hooks/use_selected_monitor';
 import { useBreadcrumbs } from '../../../hooks/use_breadcrumbs';
+import { ConfigKey } from '../../../../../../common/runtime_types';
 import { MONITOR_ROUTE, MONITORS_ROUTE } from '../../../../../../common/constants';
 import { PLUGIN } from '../../../../../../common/constants/plugin';
 
@@ -26,7 +27,10 @@ export const useTestRunDetailsBreadcrumbs = (
     },
     {
       text: monitor?.name ?? '',
-      href: `${appPath}${MONITOR_ROUTE.replace(':monitorId', monitor?.id ?? '')}`,
+      href: `${appPath}${MONITOR_ROUTE.replace(
+        ':monitorId',
+        monitor?.[ConfigKey.CONFIG_ID] ?? ''
+      )}`,
     },
     ...(extraCrumbs ?? []),
   ]);


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/145952

Fixes breadcrumbs for project monitors on step details page and test run details page, by standardizing the use of `config_id` for both UI and project monitors

### Testing
1. Create 1 project monitor and 1 UI monitor, both of type browser
2. Navigate to the test run detail page
3. Ensure the monitor breadcrumb works properly
![image](https://user-images.githubusercontent.com/11356435/203213141-d67f5411-0749-41be-a63f-654f34040fbf.png)
4. Navigate to the step detail page
5. Ensure the back breadcrumb works properly
![image](https://user-images.githubusercontent.com/11356435/203213058-b0577b40-a0bb-4d62-8119-1b5b4472cb9f.png)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->