### PR TITLE
[APM] Add pagination to source map API

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/merge_package_policy_with_apm.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/merge_package_policy_with_apm.ts
@@ -12,7 +12,10 @@ import {
   getPackagePolicyWithAgentConfigurations,
   PackagePolicy,
 } from './register_fleet_policy_callbacks';
-import { getPackagePolicyWithSourceMap, listArtifacts } from './source_maps';
+import {
+  getPackagePolicyWithSourceMap,
+  listSourceMapArtifacts,
+} from './source_maps';
 
 export async function mergePackagePolicyWithApm({
   packagePolicy,
@@ -24,7 +27,7 @@ export async function mergePackagePolicyWithApm({
   fleetPluginStart: NonNullable<APMPluginStartDependencies['fleet']>;
 }) {
   const agentConfigurations = await listConfigurations(internalESClient);
-  const artifacts = await listArtifacts({ fleetPluginStart });
+  const { artifacts } = await listSourceMapArtifacts({ fleetPluginStart });
   return getPackagePolicyWithAgentConfigurations(
     getPackagePolicyWithSourceMap({ packagePolicy, artifacts }),
     agentConfigurations

--- a/x-pack/plugins/apm/server/routes/fleet/source_maps.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/source_maps.ts
@@ -50,14 +50,18 @@ function getApmArtifactClient(fleetPluginStart: FleetPluginStart) {
 
 export async function listArtifacts({
   fleetPluginStart,
+  perPage = 20,
+  page = 1,
 }: {
   fleetPluginStart: FleetPluginStart;
+  perPage?: number;
+  page?: number;
 }) {
   const apmArtifactClient = getApmArtifactClient(fleetPluginStart);
   const fleetArtifactsResponse = await apmArtifactClient.listArtifacts({
     kuery: 'type: sourcemap',
-    perPage: 20,
-    page: 1,
+    perPage,
+    page,
     sortOrder: 'desc',
     sortField: 'created',
   });

--- a/x-pack/plugins/apm/server/routes/fleet/source_maps.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/source_maps.ts
@@ -32,23 +32,22 @@ export type FleetPluginStart = NonNullable<APMPluginStartDependencies['fleet']>;
 
 const doUnzip = promisify(unzip);
 
-function decodeArtifacts(artifacts: Artifact[]): Promise<ArtifactSourceMap[]> {
-  return Promise.all(
-    artifacts.map(async (artifact) => {
-      const body = await doUnzip(Buffer.from(artifact.body, 'base64'));
-      return {
-        ...artifact,
-        body: JSON.parse(body.toString()) as ApmArtifactBody,
-      };
-    })
-  );
+async function unzipArtifactBody(
+  artifact: Artifact
+): Promise<ArtifactSourceMap> {
+  const body = await doUnzip(Buffer.from(artifact.body, 'base64'));
+
+  return {
+    ...artifact,
+    body: JSON.parse(body.toString()) as ApmArtifactBody,
+  };
 }
 
 function getApmArtifactClient(fleetPluginStart: FleetPluginStart) {
   return fleetPluginStart.createArtifactsClient('apm');
 }
 
-export async function listArtifacts({
+export async function listSourceMapArtifacts({
   fleetPluginStart,
   perPage = 20,
   page = 1,
@@ -58,7 +57,7 @@ export async function listArtifacts({
   page?: number;
 }) {
   const apmArtifactClient = getApmArtifactClient(fleetPluginStart);
-  const fleetArtifactsResponse = await apmArtifactClient.listArtifacts({
+  const artifactsResponse = await apmArtifactClient.listArtifacts({
     kuery: 'type: sourcemap',
     perPage,
     page,
@@ -66,7 +65,11 @@ export async function listArtifacts({
     sortField: 'created',
   });
 
-  return decodeArtifacts(fleetArtifactsResponse.items);
+  const artifacts = await Promise.all(
+    artifactsResponse.items.map(unzipArtifactBody)
+  );
+
+  return { artifacts, total: artifactsResponse.total };
 }
 
 export async function createApmArtifact({
@@ -145,8 +148,7 @@ export async function updateSourceMapsOnFleetPolicies({
   savedObjectsClient: SavedObjectsClientContract;
   elasticsearchClient: ElasticsearchClient;
 }) {
-  const artifacts = await listArtifacts({ fleetPluginStart });
-
+  const { artifacts } = await listSourceMapArtifacts({ fleetPluginStart });
   const apmFleetPolicies = await getApmPackagePolicies({
     core,
     fleetPluginStart,

--- a/x-pack/plugins/apm/server/routes/source_maps/route.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/route.ts
@@ -12,7 +12,7 @@ import { Artifact } from '@kbn/fleet-plugin/server';
 import {
   createApmArtifact,
   deleteApmArtifact,
-  listArtifacts,
+  listSourceMapArtifacts,
   updateSourceMapsOnFleetPolicies,
   getCleanedBundleFilePath,
   ArtifactSourceMap,
@@ -49,18 +49,19 @@ const listSourceMapRoute = createApmServerRoute({
   async handler({
     params,
     plugins,
-  }): Promise<{ artifacts: ArtifactSourceMap[] } | undefined> {
+  }): Promise<{ artifacts: ArtifactSourceMap[]; total: number } | undefined> {
     const { page, perPage } = params.query;
 
     try {
       const fleetPluginStart = await plugins.fleet?.start();
       if (fleetPluginStart) {
-        const artifacts = await listArtifacts({
+        const { artifacts, total } = await listSourceMapArtifacts({
           fleetPluginStart,
           page,
           perPage,
         });
-        return { artifacts };
+
+        return { artifacts, total };
       }
     } catch (e) {
       throw Boom.internal(

--- a/x-pack/plugins/apm/server/routes/source_maps/route.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/route.ts
@@ -7,7 +7,7 @@
 import Boom from '@hapi/boom';
 import * as t from 'io-ts';
 import { SavedObjectsClientContract } from '@kbn/core/server';
-import { jsonRt } from '@kbn/io-ts-utils';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
 import { Artifact } from '@kbn/fleet-plugin/server';
 import {
   createApmArtifact,
@@ -40,13 +40,26 @@ export type SourceMap = t.TypeOf<typeof sourceMapRt>;
 const listSourceMapRoute = createApmServerRoute({
   endpoint: 'GET /api/apm/sourcemaps',
   options: { tags: ['access:apm'] },
+  params: t.partial({
+    query: t.partial({
+      page: toNumberRt,
+      perPage: toNumberRt,
+    }),
+  }),
   async handler({
+    params,
     plugins,
   }): Promise<{ artifacts: ArtifactSourceMap[] } | undefined> {
+    const { page, perPage } = params.query;
+
     try {
       const fleetPluginStart = await plugins.fleet?.start();
       if (fleetPluginStart) {
-        const artifacts = await listArtifacts({ fleetPluginStart });
+        const artifacts = await listArtifacts({
+          fleetPluginStart,
+          page,
+          perPage,
+        });
         return { artifacts };
       }
     } catch (e) {

--- a/x-pack/test/apm_api_integration/tests/sourcemaps/sourcemaps.ts
+++ b/x-pack/test/apm_api_integration/tests/sourcemaps/sourcemaps.ts
@@ -108,21 +108,24 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       it('can list source maps', async () => {
         const sourcemaps = await listSourcemaps();
-        expect(sourcemaps).to.not.empty();
+        expect(sourcemaps.length).to.be(15);
       });
 
       it('can paginate source maps', async () => {
         const firstPageItems = await listSourcemaps({ page: 1, perPage: 5 });
         expect(first(firstPageItems)?.identifier).to.eql('my_service-1.0.14');
         expect(last(firstPageItems)?.identifier).to.eql('my_service-1.0.10');
+        expect(firstPageItems.length).to.be(5);
 
         const secondPageItems = await listSourcemaps({ page: 2, perPage: 5 });
         expect(first(secondPageItems)?.identifier).to.eql('my_service-1.0.9');
         expect(last(secondPageItems)?.identifier).to.eql('my_service-1.0.5');
+        expect(secondPageItems.length).to.be(5);
 
         const thirdPageItems = await listSourcemaps({ page: 3, perPage: 5 });
         expect(first(thirdPageItems)?.identifier).to.eql('my_service-1.0.4');
         expect(last(thirdPageItems)?.identifier).to.eql('my_service-1.0.0');
+        expect(thirdPageItems.length).to.be(5);
       });
 
       it('returns newest source maps first', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/145884

Adds ability to paginate source map result via `page` and `perPage`.

The request `GET /api/apm/sourcemaps?page=2&perPage=10`, will return:

```json
{ "artifacts": [], "total": 0 }
```

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->