### PR TITLE
[8.6] Fix SO service status when migration is disabled (#145693)

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.test.ts
@@ -17,8 +17,9 @@ import {
   registerRoutesMock,
   typeRegistryInstanceMock,
 } from './saved_objects_service.test.mocks';
-import { BehaviorSubject } from 'rxjs';
-import { RawPackageInfo, Env } from '@kbn/config';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { skip } from 'rxjs/operators';
+import { type RawPackageInfo, Env } from '@kbn/config';
 import { ByteSizeValue } from '@kbn/config-schema';
 import { REPO_ROOT } from '@kbn/utils';
 import { getEnvOptions } from '@kbn/config-mocks';
@@ -247,6 +248,21 @@ describe('SavedObjectsService', () => {
         const { getTypeRegistry } = await soService.setup(createSetupDeps());
 
         expect(getTypeRegistry()).toBe(typeRegistryInstanceMock);
+      });
+    });
+
+    describe('status$', () => {
+      it('return correct value when migration is skipped', async () => {
+        const coreContext = createCoreContext({ skipMigration: true });
+        const soService = new SavedObjectsService(coreContext);
+        const setup = await soService.setup(createSetupDeps());
+        await soService.start(createStartDeps(false));
+
+        const serviceStatus = await firstValueFrom(setup.status$.pipe(skip(1)));
+        expect(serviceStatus.level.toString()).toEqual('available');
+        expect(serviceStatus.summary).toEqual(
+          'SavedObjects service has completed migrations and is available'
+        );
       });
     });
   });

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Subject, Observable, firstValueFrom } from 'rxjs';
+import { Subject, Observable, firstValueFrom, of } from 'rxjs';
 import { filter, take, switchMap } from 'rxjs/operators';
 import type { Logger } from '@kbn/logging';
 import type { ServiceStatus } from '@kbn/core-status-common';
@@ -148,9 +148,13 @@ export class SavedObjectsService
 
     registerCoreObjectTypes(this.typeRegistry);
 
+    const skipMigration = this.config.migration.skip;
+
     return {
       status$: calculateStatus$(
-        this.migrator$.pipe(switchMap((migrator) => migrator.getStatus$())),
+        skipMigration
+          ? of({ status: 'completed' })
+          : this.migrator$.pipe(switchMap((migrator) => migrator.getStatus$())),
         elasticsearch.status$
       ),
       setClientFactoryProvider: (provider) => {

--- a/src/core/server/integration_tests/saved_objects/migrations/skip_migration.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/skip_migration.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+import Fs from 'fs';
+import Util from 'util';
+import { firstValueFrom } from 'rxjs';
+import * as kbnTestServer from '../../../../test_helpers/kbn_server';
+import { Root } from '@kbn/core-root-server-internal';
+
+const logFilePath = Path.join(__dirname, 'cleanup.log');
+const asyncUnlink = Util.promisify(Fs.unlink);
+
+async function removeLogFile() {
+  // ignore errors if it doesn't exist
+  await asyncUnlink(logFilePath).catch(() => void 0);
+}
+
+function createRoot({ skipMigration }: { skipMigration: boolean }) {
+  return kbnTestServer.createRootWithCorePlugins(
+    {
+      migrations: {
+        skip: skipMigration,
+      },
+      logging: {
+        appenders: {
+          file: {
+            type: 'file',
+            fileName: logFilePath,
+            layout: {
+              type: 'json',
+            },
+          },
+        },
+        loggers: [
+          {
+            name: 'root',
+            appenders: ['file'],
+            level: 'info',
+          },
+        ],
+      },
+    },
+    {
+      oss: true,
+    }
+  );
+}
+
+describe('starting with `migration.skip: true` when indices are up to date', () => {
+  let esServer: kbnTestServer.TestElasticsearchUtils;
+  let root: Root;
+
+  beforeAll(async () => {
+    await removeLogFile();
+  });
+
+  afterAll(async () => {
+    if (root) {
+      await root.shutdown();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+  });
+
+  it('starts and display the correct service status', async () => {
+    const { startES } = kbnTestServer.createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+      settings: {
+        es: {
+          license: 'basic',
+        },
+      },
+    });
+    esServer = await startES();
+
+    // booting root a first time to setup the indices
+    root = createRoot({ skipMigration: false });
+    await root.preboot();
+    await root.setup();
+    await root.start();
+    await root.shutdown();
+
+    // booting another root with migration skipped this time
+    root = createRoot({ skipMigration: true });
+    await root.preboot();
+    const setup = await root.setup();
+    await root.start();
+
+    const status = await firstValueFrom(setup.status.core$);
+    expect(status.savedObjects.level.toString()).toEqual('available');
+    expect(status.savedObjects.summary).toEqual(
+      'SavedObjects service has completed migrations and is available'
+    );
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Fix SO service status when migration is disabled (#145693)](https://github.com/elastic/kibana/pull/145693)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2022-11-21T08:02:52Z","message":"Fix SO service status when migration is disabled (#145693)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/145558\r\n\r\nhave the SO service status properly be green instead of being stuck to\r\nred when the SO migration was skipped using `migration.skip: true`.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"75100868427f10ec8ed19a2bae811263c0ded311","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:prev-minor","v8.6.0","v8.7.0"],"number":145693,"url":"https://github.com/elastic/kibana/pull/145693","mergeCommit":{"message":"Fix SO service status when migration is disabled (#145693)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/145558\r\n\r\nhave the SO service status properly be green instead of being stuck to\r\nred when the SO migration was skipped using `migration.skip: true`.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"75100868427f10ec8ed19a2bae811263c0ded311"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145693","number":145693,"mergeCommit":{"message":"Fix SO service status when migration is disabled (#145693)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/145558\r\n\r\nhave the SO service status properly be green instead of being stuck to\r\nred when the SO migration was skipped using `migration.skip: true`.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"75100868427f10ec8ed19a2bae811263c0ded311"}}]}] BACKPORT-->