### PR TITLE
[Security Solution][List details page]: Fix number of linked rules count 

### DIFF
--- a/x-pack/plugins/security_solution/public/exceptions/api/list_api.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/api/list_api.ts
@@ -51,6 +51,10 @@ export const getListRules = async (listId: string) => {
     const abortCtrl = new AbortController();
     const { data: rules } = await fetchRules({
       signal: abortCtrl.signal,
+      pagination: {
+        page: 1,
+        perPage: 10000,
+      },
     });
     abortCtrl.abort();
     return rules.reduce((acc: Rule[], rule, index) => {


### PR DESCRIPTION
## Summary

- Addresses https://github.com/elastic/kibana/issues/145807
- Getting all Rules by passing all the pagination object as in the Rule Exceptions page



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->