### PR TITLE
Extend session index fields mapping with a session creation timestamp.

### DIFF
--- a/x-pack/plugins/security/server/session_management/session.mock.ts
+++ b/x-pack/plugins/security/server/session_management/session.mock.ts
@@ -29,6 +29,7 @@ export const sessionMock = {
     provider: { type: 'basic', name: 'basic1' },
     idleTimeoutExpiration: null,
     lifespanExpiration: null,
+    createdAt: 1234567890,
     state: undefined,
     metadata: { index: sessionIndexMock.createValue(sessionValue.metadata?.index) },
     ...sessionValue,

--- a/x-pack/plugins/security/server/session_management/session.test.ts
+++ b/x-pack/plugins/security/server/session_management/session.test.ts
@@ -229,6 +229,7 @@ describe('Session', () => {
         value: {
           idleTimeoutExpiration: now + 1,
           lifespanExpiration: now + 1,
+          createdAt: 1234567890,
           metadata: { index: mockSessionIndexValue },
           provider: { name: 'basic1', type: 'basic' },
           sid: 'some-long-sid',
@@ -262,10 +263,49 @@ describe('Session', () => {
         value: {
           idleTimeoutExpiration: now + 1,
           lifespanExpiration: now + 1,
+          createdAt: 1234567890,
           metadata: { index: mockSessionIndexValue },
           provider: { name: 'basic1', type: 'basic' },
           sid: 'some-long-sid',
           state: 'some-state',
+        },
+      });
+      expect(mockSessionCookie.clear).not.toHaveBeenCalled();
+      expect(mockSessionIndex.invalidate).not.toHaveBeenCalled();
+    });
+
+    it('returns session value with 0 as `createdAt` if it is not set', async () => {
+      mockSessionCookie.get.mockResolvedValue(
+        sessionCookieMock.createValue({
+          aad: mockAAD,
+          idleTimeoutExpiration: now + 1,
+          lifespanExpiration: now + 1,
+        })
+      );
+
+      const mockSessionIndexValue = sessionIndexMock.createValue({
+        idleTimeoutExpiration: now - 1,
+        lifespanExpiration: now + 1,
+        createdAt: undefined,
+        content: await encryptContent(
+          { username: 'some-user', state: 'some-state', userProfileId: 'uid' },
+          mockAAD
+        ),
+      });
+      mockSessionIndex.get.mockResolvedValue(mockSessionIndexValue);
+
+      await expect(session.get(httpServerMock.createKibanaRequest())).resolves.toEqual({
+        error: null,
+        value: {
+          idleTimeoutExpiration: now + 1,
+          lifespanExpiration: now + 1,
+          createdAt: 0,
+          metadata: { index: mockSessionIndexValue },
+          provider: { name: 'basic1', type: 'basic' },
+          sid: 'some-long-sid',
+          state: 'some-state',
+          username: 'some-user',
+          userProfileId: 'uid',
         },
       });
       expect(mockSessionCookie.clear).not.toHaveBeenCalled();
@@ -282,6 +322,7 @@ describe('Session', () => {
         sid: mockSID,
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
       });
       mockSessionIndex.create.mockResolvedValue(mockSessionIndexValue);
 
@@ -301,6 +342,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
         metadata: { index: mockSessionIndexValue },
       });
 
@@ -314,6 +356,7 @@ describe('Session', () => {
         usernameHash: '8ac76453d769d4fd14b3f41ad4933f9bd64321972cd002de9b847e117435b08b',
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
       });
 
       // Properly creates session cookie value.
@@ -334,6 +377,7 @@ describe('Session', () => {
         sid: mockSID,
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
       });
       mockSessionIndex.create.mockResolvedValue(mockSessionIndexValue);
 
@@ -349,6 +393,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
         metadata: { index: mockSessionIndexValue },
       });
 
@@ -361,6 +406,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 456,
+        createdAt: 123456,
       });
 
       // Properly creates session cookie value.
@@ -442,6 +488,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 1,
+        createdAt: 1234567890,
         metadata: { index: mockSessionIndexValue },
       });
 
@@ -455,6 +502,7 @@ describe('Session', () => {
         usernameHash: '35133597af273830c3f139c72501e676338f28a39dca8ff62d5c2b8bfba75f69',
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 1,
+        createdAt: 1234567890,
         metadata: { primaryTerm: 1, sequenceNumber: 1 },
       });
 
@@ -501,6 +549,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 1,
+        createdAt: 1234567890,
         metadata: { index: mockSessionIndexValue },
       });
 
@@ -513,6 +562,7 @@ describe('Session', () => {
         provider: { name: 'basic1', type: 'basic' },
         idleTimeoutExpiration: now + 123,
         lifespanExpiration: now + 1,
+        createdAt: 1234567890,
         metadata: { primaryTerm: 1, sequenceNumber: 1 },
       });
 

--- a/x-pack/plugins/security/server/session_management/session.ts
+++ b/x-pack/plugins/security/server/session_management/session.ts
@@ -52,6 +52,12 @@ export interface SessionValue {
   lifespanExpiration: number | null;
 
   /**
+   * The Unix time in ms which is the time when the session was initially created. The value can also be 0 indicating
+   * the migrated session that was created before `createdAt` field was introduced.
+   */
+  createdAt: number;
+
+  /**
    * Session value that is fed to the authentication provider. The shape is unknown upfront and
    * entirely determined by the authentication provider that owns the current session.
    */
@@ -206,7 +212,10 @@ export class Session {
   async create(
     request: KibanaRequest,
     sessionValue: Readonly<
-      Omit<SessionValue, 'sid' | 'idleTimeoutExpiration' | 'lifespanExpiration' | 'metadata'>
+      Omit<
+        SessionValue,
+        'sid' | 'idleTimeoutExpiration' | 'lifespanExpiration' | 'createdAt' | 'metadata'
+      >
     >
   ) {
     const [sid, aad] = await Promise.all([
@@ -226,6 +235,7 @@ export class Session {
       ...publicSessionValue,
       ...sessionExpirationInfo,
       sid,
+      createdAt: Date.now(),
       usernameHash: username && Session.getUsernameHash(username),
       content: await this.crypto.encrypt(JSON.stringify({ username, userProfileId, state }), aad),
     });
@@ -258,7 +268,10 @@ export class Session {
       sessionValue.provider,
       sessionCookieValue.lifespanExpiration
     );
-    const { username, userProfileId, state, metadata, ...publicSessionInfo } = sessionValue;
+    // We filter out the `createdAt` field and rely on the one stored in `metadata.index` since it isn't
+    // supposed to be updated after it was initially set during creation.
+    const { username, userProfileId, state, metadata, createdAt, ...publicSessionInfo } =
+      sessionValue;
 
     // First try to store session in the index and only then in the cookie to make sure cookie is
     // only updated if server side session is created successfully.
@@ -483,6 +496,8 @@ export class Session {
       username,
       userProfileId,
       state,
+      // If the session was created before `createdAt` field was introduced, we set it to 0.
+      createdAt: publicSessionValue.createdAt ?? 0,
       metadata: { index: sessionIndexValue },
     };
   }

--- a/x-pack/plugins/security/server/session_management/session.ts
+++ b/x-pack/plugins/security/server/session_management/session.ts
@@ -252,7 +252,7 @@ export class Session {
   }
 
   /**
-   * Creates or updates session value for the specified request.
+   * Updates session value for the specified request.
    * @param request Request instance to set session value for.
    * @param sessionValue Session value parameters.
    */

--- a/x-pack/plugins/security/server/session_management/session_cookie.ts
+++ b/x-pack/plugins/security/server/session_management/session_cookie.ts
@@ -122,7 +122,7 @@ export class SessionCookie {
   }
 
   /**
-   * Creates or updates session value for the specified request.
+   * Sets session value for the specified request.
    * @param request Request instance to set session value for.
    * @param sessionValue Session value parameters.
    */

--- a/x-pack/plugins/security/server/session_management/session_index.mock.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.mock.ts
@@ -25,6 +25,7 @@ export const sessionIndexMock = {
     provider: { type: 'basic', name: 'basic1' },
     idleTimeoutExpiration: null,
     lifespanExpiration: null,
+    createdAt: 1234567890,
     content: 'some-encrypted-content',
     metadata: { primaryTerm: 1, sequenceNumber: 1 },
     ...sessionValue,

--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -20,7 +20,11 @@ import type { AuditLogger } from '../audit';
 import { auditLoggerMock } from '../audit/mocks';
 import { ConfigSchema, createConfig } from '../config';
 import { securityMock } from '../mocks';
-import { getSessionIndexSettings, SessionIndex } from './session_index';
+import {
+  getSessionIndexSettings,
+  SESSION_INDEX_MAPPINGS_VERSION_META_FIELD_NAME,
+  SessionIndex,
+} from './session_index';
 import { sessionIndexMock } from './session_index.mock';
 
 describe('Session index', () => {
@@ -166,6 +170,98 @@ describe('Session index', () => {
       });
     });
 
+    it('updates mappings for existing index without version in the meta', async () => {
+      mockElasticsearchClient.indices.existsTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.exists.mockResponse(true);
+      mockElasticsearchClient.indices.getMapping.mockResolvedValue({
+        [indexName]: {
+          mappings: { _meta: {} },
+        },
+      });
+
+      await sessionIndex.initialize();
+
+      assertExistenceChecksPerformed();
+
+      expect(mockElasticsearchClient.indices.deleteTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.create).not.toHaveBeenCalled();
+
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledWith({
+        index: indexName,
+        name: aliasName,
+      });
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledWith({ index: indexName });
+      expect(mockElasticsearchClient.indices.putMapping).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.putMapping).toHaveBeenCalledWith({
+        index: indexName,
+        ...getSessionIndexSettings({ indexName, aliasName }).mappings,
+      });
+    });
+
+    it('updates mappings for existing index if version in meta is lower than the current version', async () => {
+      mockElasticsearchClient.indices.existsTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.exists.mockResponse(true);
+      mockElasticsearchClient.indices.getMapping.mockResolvedValue({
+        [indexName]: {
+          mappings: { _meta: { [SESSION_INDEX_MAPPINGS_VERSION_META_FIELD_NAME]: '8.6.9' } },
+        },
+      });
+
+      await sessionIndex.initialize();
+
+      assertExistenceChecksPerformed();
+
+      expect(mockElasticsearchClient.indices.deleteTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.create).not.toHaveBeenCalled();
+
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledWith({
+        index: indexName,
+        name: aliasName,
+      });
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledWith({ index: indexName });
+      expect(mockElasticsearchClient.indices.putMapping).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.putMapping).toHaveBeenCalledWith({
+        index: indexName,
+        ...getSessionIndexSettings({ indexName, aliasName }).mappings,
+      });
+    });
+
+    it('does not update mappings for existing index if version in meta is greater or equal to the current version', async () => {
+      mockElasticsearchClient.indices.existsTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.exists.mockResponse(true);
+      mockElasticsearchClient.indices.getMapping.mockResolvedValue({
+        [indexName]: {
+          mappings: { _meta: { [SESSION_INDEX_MAPPINGS_VERSION_META_FIELD_NAME]: '8.7.0' } },
+        },
+      });
+
+      await sessionIndex.initialize();
+
+      assertExistenceChecksPerformed();
+
+      expect(mockElasticsearchClient.indices.deleteTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.create).not.toHaveBeenCalled();
+
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.putAlias).toHaveBeenCalledWith({
+        index: indexName,
+        name: aliasName,
+      });
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledTimes(1);
+      expect(mockElasticsearchClient.indices.getMapping).toHaveBeenCalledWith({ index: indexName });
+      expect(mockElasticsearchClient.indices.putMapping).not.toHaveBeenCalled();
+    });
+
     it('creates index if it does not exist', async () => {
       mockElasticsearchClient.indices.existsTemplate.mockResponse(false);
       mockElasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
@@ -177,6 +273,8 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.indices.deleteTemplate).not.toHaveBeenCalled();
       expect(mockElasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
       expect(mockElasticsearchClient.indices.putAlias).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.getMapping).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.putMapping).not.toHaveBeenCalled();
       expect(mockElasticsearchClient.indices.create).toHaveBeenCalledWith(
         getSessionIndexSettings({ indexName, aliasName })
       );


### PR DESCRIPTION
## Summary

To support initial phase of the current sessions limiting functionality described in https://github.com/elastic/kibana/issues/18162#issuecomment-1313605895 we need to know when session was created to pick the oldest one to displace.

In this PR I introduced:
* A new `createdAt` field in the Kibana session index mappings
* A logic to update mappings if the session index exists, but the mappings are outdated
* A logic to set `createdAt` field when Kibana creates a new session

__Fixes: https://github.com/elastic/kibana/issues/145097__


