### PR TITLE
[Security Solution][List details page]: Sort Manage rules table based on selection

### DIFF
--- a/packages/kbn-securitysolution-exception-list-components/src/list_header/list_header.styles.ts
+++ b/packages/kbn-securitysolution-exception-list-components/src/list_header/list_header.styles.ts
@@ -24,7 +24,7 @@ export const textCss = css`
   margin-left: ${euiThemeVars.euiSizeXS};
 `;
 export const descriptionContainerCss = css`
-  margin-top: -${euiThemeVars.euiSizeXXL};
+  margin-top: -${euiThemeVars.euiSizeL};
   margin-bottom: -${euiThemeVars.euiSizeL};
 `;
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
@@ -123,7 +123,6 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
           }
           selection={ruleSelectionValue}
           search={searchOptions}
-          //  sorting
           isSelectable
           data-test-subj="addExceptionToRulesTable"
         />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
@@ -96,7 +96,7 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
     () =>
       sortBy(rules, [
         (rule) => {
-          return initiallySelectedRules?.find((initRule) => initRule.rule_id === rule.rule_id);
+          return initiallySelectedRules?.find((initRule) => initRule.id === rule.id);
         },
       ]),
     [initiallySelectedRules, rules]
@@ -109,7 +109,7 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
         <EuiInMemoryTable<Rule>
           tableCaption="Rules table"
           items={sortedRulesBySelection}
-          itemId="rule_id"
+          itemId="id"
           loading={!isFetched}
           columns={getRulesTableColumn()}
           pagination={{

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
@@ -10,6 +10,7 @@ import type { CriteriaWithPagination } from '@elastic/eui';
 import { EuiSpacer, EuiPanel, EuiText, EuiInMemoryTable, EuiLoadingContent } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+import { sortBy } from 'lodash';
 import * as myI18n from './translations';
 import type { Rule } from '../../../../rule_management/logic/types';
 import { useFindRulesInMemory } from '../../../../rule_management_ui/components/rules_table/rules_table/use_find_rules_in_memory';
@@ -91,6 +92,15 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
     [rules]
   );
 
+  const sortedRulesBySelection = useMemo(
+    () =>
+      sortBy(rules, [
+        (rule) => {
+          return initiallySelectedRules?.find((initRule) => initRule.rule_id === rule.rule_id);
+        },
+      ]),
+    [initiallySelectedRules, rules]
+  );
   return (
     <EuiPanel color="subdued" borderRadius="none" hasShadow={false}>
       <>
@@ -98,8 +108,8 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
         <EuiSpacer size="s" />
         <EuiInMemoryTable<Rule>
           tableCaption="Rules table"
-          itemId="id"
-          items={rules}
+          items={sortedRulesBySelection}
+          itemId="rule_id"
           loading={!isFetched}
           columns={getRulesTableColumn()}
           pagination={{
@@ -113,7 +123,7 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
           }
           selection={ruleSelectionValue}
           search={searchOptions}
-          sorting
+          //  sorting
           isSelectable
           data-test-subj="addExceptionToRulesTable"
         />

--- a/x-pack/plugins/security_solution/public/exceptions/components/manage_rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/components/manage_rules/index.tsx
@@ -45,6 +45,7 @@ export const ManageRules: FC<ManageRulesProps> = memo(
     const complicatedFlyoutTitleId = useGeneratedHtmlId({
       prefix: 'complicatedFlyoutTitle',
     });
+
     return (
       <EuiFlyout
         hideCloseButton


### PR DESCRIPTION
## Summary

- Addresses https://github.com/elastic/kibana/issues/145807

- Sort table based on the `initiallySelectedRules` so it renders the selected on the first page

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->