### PR TITLE
[Cases] Update email content and footer

### DIFF
--- a/x-pack/plugins/cases/server/services/notifications/email_notification_service.test.ts
+++ b/x-pack/plugins/cases/server/services/notifications/email_notification_service.test.ts
@@ -51,7 +51,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -74,7 +74,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -102,7 +102,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['physical_dinosaur@elastic.co'],
     });
@@ -125,7 +125,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -156,7 +156,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/s/test-space/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n\r\n\r\n[View the case details](https://example.com/s/test-space/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -186,7 +186,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: defacement\r\n\r\n',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -209,7 +209,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: one, two\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\nTags: one, two\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });
@@ -232,7 +232,7 @@ describe('EmailNotificationService', () => {
         ],
       },
       message:
-        'You are assigned to an Elastic Kibana Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
+        'You are assigned to an Elastic Case.\r\n\r\nTitle: Super Bad Security Issue\r\n\r\nStatus: open\r\n\r\nSeverity: low\r\n\r\n\r\n\r\n[View the case details](https://example.com/app/security/cases/mock-id-1)',
       subject: '[Elastic][Cases] Super Bad Security Issue',
       to: ['damaged_raccoon@elastic.co', 'physical_dinosaur@elastic.co', 'wet_dingo@elastic.co'],
     });

--- a/x-pack/plugins/cases/server/services/notifications/email_notification_service.ts
+++ b/x-pack/plugins/cases/server/services/notifications/email_notification_service.ts
@@ -56,7 +56,7 @@ export class EmailNotificationService implements NotificationService {
     publicBaseUrl?: IBasePath['publicBaseUrl']
   ) {
     const lineBreak = '\r\n\r\n';
-    let message = `You are assigned to an Elastic Kibana Case.${lineBreak}`;
+    let message = `You are assigned to an Elastic Case.${lineBreak}`;
     message = `${message}Title: ${theCase.attributes.title}${lineBreak}`;
     message = `${message}Status: ${theCase.attributes.status}${lineBreak}`;
     message = `${message}Severity: ${theCase.attributes.severity}${lineBreak}`;

--- a/x-pack/plugins/stack_connectors/server/connector_types/stack/email/index.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/stack/email/index.test.ts
@@ -436,7 +436,7 @@ describe('params validation', () => {
         "cc": Array [],
         "kibanaFooterLink": Object {
           "path": "/",
-          "text": "Go to Kibana",
+          "text": "Go to Elastic",
         },
         "message": "this is the message",
         "subject": "this is a test",
@@ -508,7 +508,7 @@ describe('execute()', () => {
     message: 'a message to you',
     kibanaFooterLink: {
       path: '/',
-      text: 'Go to Kibana',
+      text: 'Go to Elastic',
     },
   };
 
@@ -542,7 +542,7 @@ describe('execute()', () => {
 
       --
 
-      This message was sent by Kibana.",
+      This message was sent by Elastic.",
           "subject": "the subject",
         },
         "hasAuth": true,
@@ -593,7 +593,7 @@ describe('execute()', () => {
 
       --
 
-      This message was sent by Kibana.",
+      This message was sent by Elastic.",
           "subject": "the subject",
         },
         "hasAuth": false,
@@ -644,7 +644,7 @@ describe('execute()', () => {
 
       --
 
-      This message was sent by Kibana.",
+      This message was sent by Elastic.",
           "subject": "the subject",
         },
         "hasAuth": false,
@@ -707,7 +707,7 @@ describe('execute()', () => {
       message: '{{rogue}}',
       kibanaFooterLink: {
         path: '/',
-        text: 'Go to Kibana',
+        text: 'Go to Elastic',
       },
     };
     const variables = {
@@ -729,7 +729,7 @@ describe('execute()', () => {
         ],
         "kibanaFooterLink": Object {
           "path": "/",
-          "text": "Go to Kibana",
+          "text": "Go to Elastic",
         },
         "message": "\\\\*bold\\\\*",
         "subject": "*bold*",
@@ -738,7 +738,7 @@ describe('execute()', () => {
     `);
   });
 
-  test('provides a footer link to Kibana when publicBaseUrl is defined', async () => {
+  test('provides a footer link to Elastic when publicBaseUrl is defined', async () => {
     const connectorTypeWithPublicUrl = getConnectorType({
       publicBaseUrl: 'https://localhost:1234/foo/bar',
     });
@@ -752,11 +752,11 @@ describe('execute()', () => {
 
       --
 
-      This message was sent by Kibana. [Go to Kibana](https://localhost:1234/foo/bar)."
+      This message was sent by Elastic. [Go to Elastic](https://localhost:1234/foo/bar)."
     `);
   });
 
-  test('allows to generate a deep link into Kibana when publicBaseUrl is defined', async () => {
+  test('allows to generate a deep link into Elastic when publicBaseUrl is defined', async () => {
     const connectorTypeWithPublicUrl = getConnectorType({
       publicBaseUrl: 'https://localhost:1234/foo/bar',
     });
@@ -767,7 +767,7 @@ describe('execute()', () => {
         ...params,
         kibanaFooterLink: {
           path: '/my/app',
-          text: 'View this in Kibana',
+          text: 'View this in Elastic',
         },
       },
     };
@@ -781,7 +781,7 @@ describe('execute()', () => {
 
       --
 
-      This message was sent by Kibana. [View this in Kibana](https://localhost:1234/foo/bar/my/app)."
+      This message was sent by Elastic. [View this in Elastic](https://localhost:1234/foo/bar/my/app)."
     `);
   });
 

--- a/x-pack/plugins/stack_connectors/server/connector_types/stack/email/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/stack/email/index.ts
@@ -160,7 +160,7 @@ const ParamsSchemaProps = {
     path: schema.string({ defaultValue: '/' }),
     text: schema.string({
       defaultValue: i18n.translate('xpack.stackConnectors.email.kibanaFooterLinkText', {
-        defaultMessage: 'Go to Kibana',
+        defaultMessage: 'Go to Elastic',
       }),
     }),
   }),
@@ -396,12 +396,12 @@ function getFooterMessage({
 }) {
   if (!publicBaseUrl) {
     return i18n.translate('xpack.stackConnectors.email.sentByKibanaMessage', {
-      defaultMessage: 'This message was sent by Kibana.',
+      defaultMessage: 'This message was sent by Elastic.',
     });
   }
 
   return i18n.translate('xpack.stackConnectors.email.customViewInKibanaMessage', {
-    defaultMessage: 'This message was sent by Kibana. [{kibanaFooterLinkText}]({link}).',
+    defaultMessage: 'This message was sent by Elastic. [{kibanaFooterLinkText}]({link}).',
     values: {
       kibanaFooterLinkText: kibanaFooterLink.text,
       link: `${publicBaseUrl}${kibanaFooterLink.path === '/' ? '' : kibanaFooterLink.path}`,

--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/actions_simulators/server/ms_exchage_server_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/actions_simulators/server/ms_exchage_server_simulation.ts
@@ -43,8 +43,8 @@ export function initPlugin(router: IRouter, path: string) {
           cc: null,
           bcc: null,
           subject: 'email-subject',
-          html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Kibana. <a href=\"https://localhost:5601\">Go to Kibana</a>.</p>\n`,
-          text: 'email-message\n\n--\n\nThis message was sent by Kibana. [Go to Kibana](https://localhost:5601).',
+          html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Elastic. <a href=\"https://localhost:5601\">Go to Elastic</a>.</p>\n`,
+          text: 'email-message\n\n--\n\nThis message was sent by Elastic. [Go to Elastic](https://localhost:5601).',
           headers: {},
         },
       });

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/stack/email.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/stack/email.ts
@@ -124,8 +124,8 @@ export default function emailTest({ getService }: FtrProviderContext) {
               cc: null,
               bcc: null,
               subject: 'email-subject',
-              html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Kibana. <a href=\"https://localhost:5601\">Go to Kibana</a>.</p>\n`,
-              text: 'email-message\n\n--\n\nThis message was sent by Kibana. [Go to Kibana](https://localhost:5601).',
+              html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Elastic. <a href=\"https://localhost:5601\">Go to Elastic</a>.</p>\n`,
+              text: 'email-message\n\n--\n\nThis message was sent by Elastic. [Go to Elastic](https://localhost:5601).',
               headers: {},
             },
           });
@@ -147,10 +147,10 @@ export default function emailTest({ getService }: FtrProviderContext) {
         .then((resp: any) => {
           const { text, html } = resp.body.data.message;
           expect(text).to.eql(
-            '_italic_ **bold** https://elastic.co link\n\n--\n\nThis message was sent by Kibana. [Go to Kibana](https://localhost:5601).'
+            '_italic_ **bold** https://elastic.co link\n\n--\n\nThis message was sent by Elastic. [Go to Elastic](https://localhost:5601).'
           );
           expect(html).to.eql(
-            `<p><em>italic</em> <strong>bold</strong> <a href="https://elastic.co">https://elastic.co</a> link</p>\n<p>--</p>\n<p>This message was sent by Kibana. <a href=\"https://localhost:5601\">Go to Kibana</a>.</p>\n`
+            `<p><em>italic</em> <strong>bold</strong> <a href="https://elastic.co">https://elastic.co</a> link</p>\n<p>--</p>\n<p>This message was sent by Elastic. <a href=\"https://localhost:5601\">Go to Elastic</a>.</p>\n`
           );
         });
     });
@@ -166,7 +166,7 @@ export default function emailTest({ getService }: FtrProviderContext) {
             message: 'message',
             kibanaFooterLink: {
               path: '/my/path',
-              text: 'View my path in Kibana',
+              text: 'View my path in Elastic',
             },
           },
         })
@@ -174,10 +174,10 @@ export default function emailTest({ getService }: FtrProviderContext) {
         .then((resp: any) => {
           const { text, html } = resp.body.data.message;
           expect(text).to.eql(
-            'message\n\n--\n\nThis message was sent by Kibana. [View my path in Kibana](https://localhost:5601/my/path).'
+            'message\n\n--\n\nThis message was sent by Elastic. [View my path in Elastic](https://localhost:5601/my/path).'
           );
           expect(html).to.eql(
-            `<p>message</p>\n<p>--</p>\n<p>This message was sent by Kibana. <a href=\"https://localhost:5601/my/path\">View my path in Kibana</a>.</p>\n`
+            `<p>message</p>\n<p>--</p>\n<p>This message was sent by Elastic. <a href=\"https://localhost:5601/my/path\">View my path in Elastic</a>.</p>\n`
           );
         });
     });
@@ -325,8 +325,8 @@ export default function emailTest({ getService }: FtrProviderContext) {
               cc: null,
               bcc: null,
               subject: 'email-subject',
-              html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Kibana. <a href=\"https://localhost:5601\">Go to Kibana</a>.</p>\n`,
-              text: 'email-message\n\n--\n\nThis message was sent by Kibana. [Go to Kibana](https://localhost:5601).',
+              html: `<p>email-message</p>\n<p>--</p>\n<p>This message was sent by Elastic. <a href=\"https://localhost:5601\">Go to Elastic</a>.</p>\n`,
+              text: 'email-message\n\n--\n\nThis message was sent by Elastic. [Go to Elastic](https://localhost:5601).',
               headers: {},
             },
           });


### PR DESCRIPTION
## Summary

This PR replace `Kibana` with `Elastic` in the email content and footer.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->