### PR TITLE
[ML] Fix Data Visualizer time picker showing even if data view has been configured not to use a time filter

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/date_picker_wrapper/date_picker_wrapper.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/date_picker_wrapper/date_picker_wrapper.tsx
@@ -69,8 +69,8 @@ function updateLastRefresh(timeRange?: OnRefreshProps) {
 }
 
 // FIXME: Consolidate this component with ML and AIOps's component
-export const DatePickerWrapper: FC<{ showDatePicker?: boolean; showRefresh?: boolean }> = ({
-  showDatePicker = true,
+export const DatePickerWrapper: FC<{ isAutoRefreshOnly?: boolean; showRefresh?: boolean }> = ({
+  isAutoRefreshOnly,
   showRefresh,
 }) => {
   const {
@@ -244,23 +244,21 @@ export const DatePickerWrapper: FC<{ showDatePicker?: boolean; showRefresh?: boo
       alignItems="center"
       className="mlNavigationMenu__datePickerWrapper"
     >
-      {showDatePicker ? (
-        <EuiFlexItem grow={false}>
-          <EuiSuperDatePicker
-            start={time.from}
-            end={time.to}
-            isPaused={refreshInterval.pause}
-            isAutoRefreshOnly={!isTimeRangeSelectorEnabled}
-            refreshInterval={refreshInterval.value || DEFAULT_REFRESH_INTERVAL_MS}
-            onTimeChange={updateTimeFilter}
-            onRefresh={updateLastRefresh}
-            onRefreshChange={updateInterval}
-            recentlyUsedRanges={recentlyUsedRanges}
-            dateFormat={dateFormat}
-            commonlyUsedRanges={commonlyUsedRanges}
-          />
-        </EuiFlexItem>
-      ) : null}
+      <EuiFlexItem grow={false}>
+        <EuiSuperDatePicker
+          start={time.from}
+          end={time.to}
+          isPaused={refreshInterval.pause}
+          isAutoRefreshOnly={!isTimeRangeSelectorEnabled || isAutoRefreshOnly}
+          refreshInterval={refreshInterval.value || DEFAULT_REFRESH_INTERVAL_MS}
+          onTimeChange={updateTimeFilter}
+          onRefresh={updateLastRefresh}
+          onRefreshChange={updateInterval}
+          recentlyUsedRanges={recentlyUsedRanges}
+          dateFormat={dateFormat}
+          commonlyUsedRanges={commonlyUsedRanges}
+        />
+      </EuiFlexItem>
 
       {showRefresh === true || !isTimeRangeSelectorEnabled ? (
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/data_visualizer/public/application/common/components/date_picker_wrapper/date_picker_wrapper.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/date_picker_wrapper/date_picker_wrapper.tsx
@@ -69,7 +69,10 @@ function updateLastRefresh(timeRange?: OnRefreshProps) {
 }
 
 // FIXME: Consolidate this component with ML and AIOps's component
-export const DatePickerWrapper: FC = () => {
+export const DatePickerWrapper: FC<{ showDatePicker?: boolean; showRefresh?: boolean }> = ({
+  showDatePicker = true,
+  showRefresh,
+}) => {
   const {
     services,
     notifications: { toasts },
@@ -241,23 +244,25 @@ export const DatePickerWrapper: FC = () => {
       alignItems="center"
       className="mlNavigationMenu__datePickerWrapper"
     >
-      <EuiFlexItem grow={false}>
-        <EuiSuperDatePicker
-          start={time.from}
-          end={time.to}
-          isPaused={refreshInterval.pause}
-          isAutoRefreshOnly={!isTimeRangeSelectorEnabled}
-          refreshInterval={refreshInterval.value || DEFAULT_REFRESH_INTERVAL_MS}
-          onTimeChange={updateTimeFilter}
-          onRefresh={updateLastRefresh}
-          onRefreshChange={updateInterval}
-          recentlyUsedRanges={recentlyUsedRanges}
-          dateFormat={dateFormat}
-          commonlyUsedRanges={commonlyUsedRanges}
-        />
-      </EuiFlexItem>
+      {showDatePicker ? (
+        <EuiFlexItem grow={false}>
+          <EuiSuperDatePicker
+            start={time.from}
+            end={time.to}
+            isPaused={refreshInterval.pause}
+            isAutoRefreshOnly={!isTimeRangeSelectorEnabled}
+            refreshInterval={refreshInterval.value || DEFAULT_REFRESH_INTERVAL_MS}
+            onTimeChange={updateTimeFilter}
+            onRefresh={updateLastRefresh}
+            onRefreshChange={updateInterval}
+            recentlyUsedRanges={recentlyUsedRanges}
+            dateFormat={dateFormat}
+            commonlyUsedRanges={commonlyUsedRanges}
+          />
+        </EuiFlexItem>
+      ) : null}
 
-      {isTimeRangeSelectorEnabled ? null : (
+      {showRefresh === true || !isTimeRangeSelectorEnabled ? (
         <EuiFlexItem grow={false}>
           <EuiButton
             fill
@@ -272,7 +277,7 @@ export const DatePickerWrapper: FC = () => {
             />
           </EuiButton>
         </EuiFlexItem>
-      )}
+      ) : null}
     </EuiFlexGroup>
   ) : null;
 };

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
@@ -449,6 +449,11 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
       language: searchQueryLanguage,
     });
   }, [data, searchQueryLanguage, searchString]);
+
+  const hasValidTimeField = useMemo(
+    () => currentDataView.timeFieldName !== undefined && currentDataView.timeFieldName !== '',
+    [currentDataView.timeFieldName]
+  );
   const helpLink = docLinks.links.ml.guide;
 
   return (
@@ -475,7 +480,7 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
                 gutterSize="s"
                 data-test-subj="dataVisualizerTimeRangeSelectorSection"
               >
-                {currentDataView.timeFieldName !== undefined && (
+                {hasValidTimeField ? (
                   <EuiFlexItem grow={false}>
                     <FullTimeRangeSelector
                       dataView={currentDataView}
@@ -484,9 +489,12 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
                       timefilter={timefilter}
                     />
                   </EuiFlexItem>
-                )}
+                ) : null}
                 <EuiFlexItem grow={false}>
-                  <DatePickerWrapper />
+                  <DatePickerWrapper
+                    showDatePicker={hasValidTimeField}
+                    showRefresh={!hasValidTimeField}
+                  />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPageContentHeader>

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
@@ -492,7 +492,7 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
                 ) : null}
                 <EuiFlexItem grow={false}>
                   <DatePickerWrapper
-                    showDatePicker={hasValidTimeField}
+                    isAutoRefreshOnly={!hasValidTimeField}
                     showRefresh={!hasValidTimeField}
                   />
                 </EuiFlexItem>

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_document_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/requests/get_document_stats.ts
@@ -124,7 +124,11 @@ export const getDocumentCountStats = async (
     },
   });
 
-  const hasTimeField = timeFieldName !== undefined && intervalMs !== undefined && intervalMs > 0;
+  const hasTimeField =
+    timeFieldName !== undefined &&
+    timeFieldName !== '' &&
+    intervalMs !== undefined &&
+    intervalMs > 0;
 
   const getSearchParams = (aggregations: unknown, trackTotalHits = false) => ({
     index,
@@ -159,7 +163,7 @@ export const getDocumentCountStats = async (
 
   // If time field is not defined, no need to show the document count chart
   // Just need to return the tracked total hits
-  if (timeFieldName === undefined) {
+  if (!hasTimeField) {
     const trackedTotalHits =
       typeof firstResp.rawResponse.hits.total === 'number'
         ? firstResp.rawResponse.hits.total


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/139480. It no longer shows the time picker showing even if the data view has been configured not to use a time filter.

Before:
<img width="1774" alt="Screen Shot 2022-11-22 at 16 18 16" src="https://user-images.githubusercontent.com/43350163/203433524-8579282f-8710-4fa3-bd5d-052402289537.png">


After:
<img width="1774" alt="Screen Shot 2022-11-22 at 16 17 48" src="https://user-images.githubusercontent.com/43350163/203433510-693aa4c5-a2fa-4ff7-9ba7-ef6af579fb11.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->