### PR TITLE
Fix placeholder for search bar

### DIFF
--- a/x-pack/plugins/security_solution/public/exceptions/translations/shared_list.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/translations/shared_list.ts
@@ -163,7 +163,7 @@ export const referenceErrorMessage = (referenceCount: number) =>
 export const EXCEPTION_LIST_SEARCH_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.all.exceptions.searchPlaceholder',
   {
-    defaultMessage: 'Search by name or list id',
+    defaultMessage: 'Search by name or list_id:id',
   }
 );
 


### PR DESCRIPTION
## Fix placeholder for search bar, which shows how to search for list_id

FIX: https://github.com/elastic/kibana/issues/145674

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->