### PR TITLE
DO NOT MERGE: [stateless] Simulate potential delays in ES (5s)

### DIFF
--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -345,6 +345,11 @@ exports.Cluster = class Cluster {
       ['cluster.routing.allocation.disk.threshold_enabled', 'false'],
       ['ingest.geoip.downloader.enabled', 'false'],
       ['search.check_ccs_compatibility', 'true'],
+      // Simulate the interval batching
+      ['indices.write_ack_delay_interval', '5s'],
+      // Simulate the S3 call:
+      // using 200ms because that's the upper limit according to https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+      ['indices.write_ack_delay_randomness_bound', '200ms'],
     ]);
 
     // options.esArgs overrides the default esArg values


### PR DESCRIPTION
## Summary

We want to simulate the potential delays in ES caused by the re-architecture for stateless.

We don't intend to merge these changes. But we still want to measure how our CI and the Kibana UX might be affected.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
