### PR TITLE
[RAM] fix logger bug

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -2117,14 +2117,20 @@ export class RulesClient {
             taskIdsFailedToBeDeleted.push(status.id);
           }
         });
-        this.logger.debug(
-          `Successfully deleted schedules for underlying tasks: ${taskIdsSuccessfullyDeleted.join(
-            ', '
-          )}`
-        );
-        this.logger.error(
-          `Failure to delete schedules for underlying tasks: ${taskIdsFailedToBeDeleted.join(', ')}`
-        );
+        if (taskIdsSuccessfullyDeleted.length) {
+          this.logger.debug(
+            `Successfully deleted schedules for underlying tasks: ${taskIdsSuccessfullyDeleted.join(
+              ', '
+            )}`
+          );
+        }
+        if (taskIdsFailedToBeDeleted.length) {
+          this.logger.error(
+            `Failure to delete schedules for underlying tasks: ${taskIdsFailedToBeDeleted.join(
+              ', '
+            )}`
+          );
+        }
       } catch (error) {
         this.logger.error(
           `Failure to delete schedules for underlying tasks: ${taskIdsToDelete.join(


### PR DESCRIPTION
Resolves: https://github.com/elastic/kibana/issues/146097

## Summary

In this PR I'm fixing a bug for bulkDelete endpoint.
It loggers this error message: `[2022-11-22T15:19:31.182+01:00][ERROR][plugins.alerting] Failure to delete schedules for underlying tasks:` even if we do not have any failed to delete tasks.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->