### PR TITLE
[8.6] [Enterprise Search] Split documents count into added and deleted docs (#145366)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs.tsx
@@ -61,9 +61,17 @@ export const SyncJobs: React.FC = () => {
       truncateText: true,
     },
     {
-      field: 'docsCount',
-      name: i18n.translate('xpack.enterpriseSearch.content.searchIndices.docsCount.columnTitle', {
-        defaultMessage: 'Docs count',
+      field: 'indexed_document_count',
+      name: i18n.translate('xpack.enterpriseSearch.content.searchIndices.addedDocs.columnTitle', {
+        defaultMessage: 'Docs added',
+      }),
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'deleted_document_count',
+      name: i18n.translate('xpack.enterpriseSearch.content.searchIndices.deletedDocs.columnTitle', {
+        defaultMessage: 'Docs deleted',
       }),
       sortable: true,
       truncateText: true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Enterprise Search] Split documents count into added and deleted docs (#145366)](https://github.com/elastic/kibana/pull/145366)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-11-16T16:48:32Z","message":"[Enterprise Search] Split documents count into added and deleted docs (#145366)","sha":"858b46922dfa709b6cb6a1d438750c5b890eb4ab","branchLabelMapping":{"^v8.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","auto-backport","Team:EnterpriseSearch","v8.6.0"],"number":145366,"url":"https://github.com/elastic/kibana/pull/145366","mergeCommit":{"message":"[Enterprise Search] Split documents count into added and deleted docs (#145366)","sha":"858b46922dfa709b6cb6a1d438750c5b890eb4ab"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.6.0","labelRegex":"^v8.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145366","number":145366,"mergeCommit":{"message":"[Enterprise Search] Split documents count into added and deleted docs (#145366)","sha":"858b46922dfa709b6cb6a1d438750c5b890eb4ab"}}]}] BACKPORT-->