### PR TITLE
Fix spacing in popovers in Rule Detail and Alert Detail as a result of Eui spacing updates

### DIFF
--- a/x-pack/plugins/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/header_actions.tsx
@@ -94,7 +94,7 @@ export function HeaderActions({ alert }: HeaderActionsProps) {
           </EuiButton>
         }
       >
-        <EuiFlexGroup direction="column" alignItems="flexStart">
+        <EuiFlexGroup direction="column" alignItems="flexStart" gutterSize="s">
           <EuiButtonEmpty
             size="s"
             color="text"

--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -308,21 +308,19 @@ export function RuleDetailsPage() {
                       </EuiButton>
                     }
                   >
-                    <EuiFlexGroup direction="column" alignItems="flexStart">
+                    <EuiFlexGroup direction="column" alignItems="flexStart" gutterSize="s">
                       <EuiButtonEmpty
                         data-test-subj="editRuleButton"
                         size="s"
                         iconType="pencil"
                         onClick={handleEditRule}
                       >
-                        <EuiSpacer size="s" />
                         <EuiText size="s">
                           {i18n.translate('xpack.observability.ruleDetails.editRule', {
                             defaultMessage: 'Edit rule',
                           })}
                         </EuiText>
                       </EuiButtonEmpty>
-                      <EuiSpacer size="s" />
                       <EuiButtonEmpty
                         size="s"
                         iconType="trash"
@@ -336,11 +334,9 @@ export function RuleDetailsPage() {
                           })}
                         </EuiText>
                       </EuiButtonEmpty>
-                      <EuiSpacer size="s" />
                     </EuiFlexGroup>
                   </EuiPopover>
                 </EuiFlexItem>
-                <EuiSpacer size="s" />
               </EuiFlexGroup>,
             ]
           : [],


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/145987

## Summary

This fixes spacing in the popovers in Rule Detail and Alert Detail header actions components.

<img width="219" alt="Screenshot 2022-11-23 at 13 09 07" src="https://user-images.githubusercontent.com/535564/203557408-be09418e-0d6f-4416-bb0f-a301a14138c7.png">
