### PR TITLE
[Enterprise Search] Improve connector status signaling

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
@@ -9,14 +9,24 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiButton, EuiDescriptionList, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
+import { IndexViewLogic } from '../index_view_logic';
 
 import { ConnectorConfigurationForm } from './connector_configuration_form';
 import { ConnectorConfigurationLogic } from './connector_configuration_logic';
 
 export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
+  const { error } = useValues(IndexViewLogic);
   const { configView, isEditing } = useValues(ConnectorConfigurationLogic);
   const { setIsEditing } = useActions(ConnectorConfigurationLogic);
 
@@ -58,6 +68,21 @@ export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
           )
         )}
       </EuiFlexItem>
+      {!!error && (
+        <EuiFlexItem>
+          <EuiCallOut
+            color="danger"
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.indices.configurationConnector.config.error.title',
+              {
+                defaultMessage: 'Connector error',
+              }
+            )}
+          >
+            <EuiText size="s">{error}</EuiText>
+          </EuiCallOut>
+        </EuiFlexItem>
+      )}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
@@ -9,7 +9,7 @@ import { kea, MakeLogicType } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
-import { ConnectorConfiguration } from '../../../../../../common/types/connectors';
+import { ConnectorConfiguration, ConnectorStatus } from '../../../../../../common/types/connectors';
 import { Actions } from '../../../../shared/api_logic/create_api_logic';
 import {
   clearFlashMessages,
@@ -82,10 +82,18 @@ export const ConnectorConfigurationLogic = kea<
     values: [CachedFetchIndexApiLogic, ['indexData as index']],
   },
   events: ({ actions, values }) => ({
-    afterMount: () =>
+    afterMount: () => {
       actions.setConfigState(
         isConnectorIndex(values.index) ? values.index.connector.configuration : {}
-      ),
+      );
+      if (
+        isConnectorIndex(values.index) &&
+        (values.index.connector.status === ConnectorStatus.CREATED ||
+          values.index.connector.status === ConnectorStatus.NEEDS_CONFIGURATION)
+      ) {
+        actions.setIsEditing(true);
+      }
+    },
   }),
   listeners: ({ actions, values }) => ({
     apiError: (error) => flashAPIErrors(error),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -102,7 +102,10 @@ export const NativeConnectorConfiguration: React.FC = () => {
                 },
                 {
                   children: (
-                    <NativeConnectorConfigurationConfig nativeConnector={nativeConnector} />
+                    <NativeConnectorConfigurationConfig
+                      nativeConnector={nativeConnector}
+                      status={index.connector.status}
+                    />
                   ),
                   status: hasConfigured ? 'complete' : 'incomplete',
                   title: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -7,9 +7,11 @@
 
 import React from 'react';
 
-import { EuiSpacer, EuiLink, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiSpacer, EuiLink, EuiText, EuiFlexGroup, EuiFlexItem, EuiCallOut } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
+import { ConnectorStatus } from '../../../../../../../common/types/connectors';
 
 import { docLinks } from '../../../../../shared/doc_links';
 
@@ -18,11 +20,12 @@ import { NativeConnector } from '../types';
 
 interface NativeConnectorConfigurationConfigProps {
   nativeConnector: NativeConnector;
+  status: ConnectorStatus;
 }
 
 export const NativeConnectorConfigurationConfig: React.FC<
   NativeConnectorConfigurationConfigProps
-> = ({ nativeConnector }) => {
+> = ({ nativeConnector, status }) => {
   return (
     <ConnectorConfigurationConfig>
       <EuiText size="s">
@@ -62,6 +65,24 @@ export const NativeConnectorConfigurationConfig: React.FC<
           </EuiFlexItem>
         )}
       </EuiFlexGroup>
+
+      {status === ConnectorStatus.CONNECTED && (
+        <>
+          <EuiSpacer />
+          <EuiCallOut
+            iconType="check"
+            color="success"
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.connectorConnected',
+              {
+                defaultMessage:
+                  'Your connector {name} has connected to Enterprise Search successfully.',
+                values: { name: nativeConnector.name },
+              }
+            )}
+          />
+        </>
+      )}
     </ConnectorConfigurationConfig>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.test.ts
@@ -32,6 +32,7 @@ import { IndexViewLogic } from './index_view_logic';
 const DEFAULT_VALUES = {
   connector: undefined,
   connectorId: null,
+  error: null,
   fetchIndexApiData: undefined,
   fetchIndexApiStatus: Status.LOADING,
   hasAdvancedFilteringFeature: false,
@@ -244,6 +245,25 @@ describe('IndexViewLogic', () => {
       IndexViewLogic.actions.fetchIndex();
       expect(IndexViewLogic.actions.makeFetchIndexRequest).toHaveBeenCalledWith({
         indexName: 'indexName',
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('error', () => {
+      it('should return connector error if available', () => {
+        IndexViewLogic.actions.fetchIndexApiSuccess({
+          ...CONNECTOR_VALUES.index,
+          connector: { ...connectorIndex.connector, error: 'error' },
+        });
+        expect(IndexViewLogic.values.error).toEqual('error');
+      });
+      it('should return connector last sync error if available and error is undefined', () => {
+        IndexViewLogic.actions.fetchIndexApiSuccess({
+          ...CONNECTOR_VALUES.index,
+          connector: { ...connectorIndex.connector, last_sync_error: 'last sync error' },
+        });
+        expect(IndexViewLogic.values.error).toEqual('last sync error');
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -69,6 +69,7 @@ export interface IndexViewActions {
 export interface IndexViewValues {
   connector: Connector | undefined;
   connectorId: string | null;
+  error: string | undefined;
   fetchIndexApiData: typeof CachedFetchIndexApiLogic.values.fetchIndexApiData;
   fetchIndexApiStatus: Status;
   hasAdvancedFilteringFeature: boolean;
@@ -206,6 +207,13 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
     connectorId: [
       () => [selectors.indexData],
       (index) => (isConnectorViewIndex(index) ? index.connector.id : null),
+    ],
+    error: [
+      () => [selectors.indexData],
+      (index: ElasticsearchViewIndex) =>
+        isConnectorViewIndex(index)
+          ? index.connector.error || index.connector.last_sync_error
+          : null,
     ],
     hasAdvancedFilteringFeature: [
       () => [selectors.connector],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -21,16 +21,18 @@ import { CrawlDetailsFlyout } from './crawler/crawl_details_flyout/crawl_details
 import { CrawlRequestsPanel } from './crawler/crawl_requests_panel/crawl_requests_panel';
 import { CrawlerTotalStats } from './crawler_total_stats';
 import { GenerateApiKeyPanel } from './generate_api_key_panel';
+import { IndexViewLogic } from './index_view_logic';
 import { OverviewLogic } from './overview.logic';
 import { SyncJobs } from './sync_jobs/sync_jobs';
 
 export const SearchIndexOverview: React.FC = () => {
   const { indexData } = useValues(OverviewLogic);
+  const { error } = useValues(IndexViewLogic);
 
   return (
     <>
       <EuiSpacer />
-      {isConnectorIndex(indexData) && indexData.connector.error && (
+      {isConnectorIndex(indexData) && error && (
         <>
           <EuiCallOut
             iconType="alert"
@@ -43,7 +45,7 @@ export const SearchIndexOverview: React.FC = () => {
             )}
           >
             <EuiSpacer size="s" />
-            <EuiText size="s">{indexData.connector.error}</EuiText>
+            <EuiText size="s">{error}</EuiText>
           </EuiCallOut>
           <EuiSpacer />
         </>


### PR DESCRIPTION
This improves the connector status signals by:
- Showing the last sync's error if available and the connector doesn't have its own error
- Showing errors in the config page
- Showing a success message for connected native connectors

It also sets the configuration to edit mode if it needs configuration changes.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->