### PR TITLE
[ML] Fix polling for notifications after leaving the ML app 

### DIFF
--- a/x-pack/plugins/ml/public/application/contexts/ml/ml_notifications_context.test.tsx
+++ b/x-pack/plugins/ml/public/application/contexts/ml/ml_notifications_context.test.tsx
@@ -209,6 +209,25 @@ describe('useMlNotifications', () => {
     expect(result.current.lastCheckedAt).toEqual(1664551009292);
   });
 
+  test('stops fetching notifications on leave', () => {
+    const { unmount } = renderHook(useMlNotifications, {
+      wrapper: MlNotificationsContextProvider,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(mockCountMessages).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(60001);
+    });
+    expect(mockCountMessages).toHaveBeenCalledTimes(1);
+  });
+
   test('does not start polling if requires capabilities are missing', () => {
     mockKibana.services.application.capabilities.ml = {
       canGetJobs: true,


### PR DESCRIPTION
## Summary

Fixes notifications count polling on app leave. The issue was with the `useMount` hook that doesn't support a callback execution on unmount. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->