### PR TITLE
[Canvas] Fixes broken data view sort

### DIFF
--- a/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.component.tsx
+++ b/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.component.tsx
@@ -31,12 +31,12 @@ export const ESDataViewSelect: React.FunctionComponent<ESDataViewSelectProps> = 
   onFocus,
   onBlur,
 }) => {
-  const selectedDataView = dataViews.find((view) => value === view.title) as DataView;
+  const selectedDataView = dataViews.find((view) => value === view.title) as DataViewOption;
 
   const selectedOption = selectedDataView
-    ? { value: selectedDataView.title, label: selectedDataView.name }
+    ? { value: selectedDataView.title, label: selectedDataView.name || selectedDataView.title }
     : { value, label: value };
-  const options = dataViews.map(({ name, title }) => ({ value: title, label: name }));
+  const options = dataViews.map(({ name, title }) => ({ value: title, label: name || title }));
 
   return (
     <EuiComboBox

--- a/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.tsx
+++ b/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.tsx
@@ -36,7 +36,12 @@ export const ESDataViewSelect: FC<ESDataViewSelectProps> = (props) => {
       }
 
       setLoading(false);
-      setDataViews(sortBy(newDataViews, 'name'));
+      setDataViews(
+        sortBy(newDataViews, ({ name, title }) => {
+          return name || title || '';
+        })
+      );
+
       if (!value && newDataViews.length) {
         onChange(newDataViews[0].title);
       }

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -29,6 +29,7 @@ import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { BfetchPublicSetup } from '@kbn/bfetch-plugin/public';
 import { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { featureCatalogueEntry } from './feature_catalogue_entry';
 import { CanvasAppLocatorDefinition } from '../common/locator';
 import { SESSIONSTORAGE_LASTPATH, CANVAS_APP } from '../common/lib/constants';
@@ -62,6 +63,7 @@ export interface CanvasStartDeps {
   uiActions: UiActionsStart;
   charts: ChartsPluginStart;
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   presentationUtil: PresentationUtilPluginStart;
   visualizations: VisualizationsStart;
   spaces?: SpacesPluginStart;

--- a/x-pack/plugins/canvas/public/services/kibana/data_views.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/data_views.ts
@@ -25,7 +25,7 @@ export type DataViewsServiceFactory = KibanaPluginServiceFactory<
 export const dataViewsServiceFactory: DataViewsServiceFactory = ({ startPlugins }, { notify }) => ({
   getDataViews: async () => {
     try {
-      const dataViews = await startPlugins.data.dataViews.getIdsWithTitle();
+      const dataViews = await startPlugins.dataViews.getIdsWithTitle();
       return dataViews.map(({ id, name, title }) => ({ id, name, title } as DataView));
     } catch (e) {
       notify.error(e, { title: strings.getIndicesFetchErrorMessage() });
@@ -34,14 +34,14 @@ export const dataViewsServiceFactory: DataViewsServiceFactory = ({ startPlugins 
     return [];
   },
   getFields: async (dataViewTitle: string) => {
-    const dataView = await startPlugins.data.dataViews.create({ title: dataViewTitle });
+    const dataView = await startPlugins.dataViews.create({ title: dataViewTitle });
 
     return dataView.fields
       .filter((field) => !field.name.startsWith('_'))
       .map((field) => field.name);
   },
   getDefaultDataView: async () => {
-    const dataView = await startPlugins.data.dataViews.getDefaultDataView();
+    const dataView = await startPlugins.dataViews.getDefaultDataView();
 
     return dataView
       ? { id: dataView.id, name: dataView.name, title: dataView.getIndexPattern() }


### PR DESCRIPTION
## Summary

Closes #146171.

This sorting function for the data view options was assuming that `name` was always defined, but with some legacy data views/index patterns, `name` is not defined and only `title` is. This changes the sort function to use `name` or `title` when sorting, so it doesn't error out when `name` or `title` is missing. I also noticed that we were still using the data plugin here instead of the data views plugin directly, so I fixed that too.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->