### PR TITLE
[8.6] [Cases] Fix create case form flaky tests (#145829)

### DIFF
--- a/x-pack/plugins/cases/public/components/connectors/jira/case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/case_fields.test.tsx
@@ -8,17 +8,20 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { omit } from 'lodash/fp';
+import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import { waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { useKibana } from '../../../common/lib/kibana';
 import { connector, issues } from '../mock';
 import { useGetIssueTypes } from './use_get_issue_types';
 import { useGetFieldsByIssueType } from './use_get_fields_by_issue_type';
 import Fields from './case_fields';
-import { waitFor } from '@testing-library/dom';
 import { useGetSingleIssue } from './use_get_single_issue';
 import { useGetIssues } from './use_get_issues';
-import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import { EuiComboBox } from '@elastic/eui';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 
 jest.mock('./use_get_issue_types');
 jest.mock('./use_get_fields_by_issue_type');
@@ -85,8 +88,10 @@ describe('Jira Fields', () => {
   };
 
   const onChange = jest.fn();
+  let mockedContext: AppMockRenderer;
 
   beforeEach(() => {
+    mockedContext = createAppMockRenderer();
     useGetIssueTypesMock.mockReturnValue(useGetIssueTypesResponse);
     useGetFieldsByIssueTypeMock.mockReturnValue(useGetFieldsByIssueTypeResponse);
     useGetSingleIssueMock.mockReturnValue(useGetSingleIssueResponse);
@@ -270,5 +275,38 @@ describe('Jira Fields', () => {
       });
 
     expect(onChange).toBeCalledWith({ issueType: '10007', parent: null, priority: null });
+  });
+
+  it('should submit Jira connector', async () => {
+    const { rerender } = mockedContext.render(
+      <Fields fields={fields} onChange={onChange} connector={connector} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Bug' }));
+      expect(screen.getByRole('option', { name: 'Low' }));
+    });
+
+    userEvent.selectOptions(screen.getByTestId('issueTypeSelect'), ['10007']);
+
+    rerender(
+      <Fields
+        fields={{ ...fields, issueType: '10007' }}
+        onChange={onChange}
+        connector={connector}
+      />
+    );
+
+    userEvent.selectOptions(screen.getByTestId('prioritySelect'), ['Low']);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    expect(onChange).toBeCalledWith({
+      issueType: '10007',
+      parent: null,
+      priority: 'Low',
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/resilient/case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/case_fields.test.tsx
@@ -9,12 +9,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import { EuiComboBox } from '@elastic/eui';
-import { waitFor } from '@testing-library/react';
+import { waitFor, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { connector } from '../mock';
 import { useGetIncidentTypes } from './use_get_incident_types';
 import { useGetSeverity } from './use_get_severity';
 import Fields from './case_fields';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 
 jest.mock('../../../common/lib/kibana');
 jest.mock('./use_get_incident_types');
@@ -62,8 +65,10 @@ describe('ResilientParamsFields renders', () => {
   };
 
   const onChange = jest.fn();
+  let mockedContext: AppMockRenderer;
 
   beforeEach(() => {
+    mockedContext = createAppMockRenderer();
     useGetIncidentTypesMock.mockReturnValue(useGetIncidentTypesResponse);
     useGetSeverityMock.mockReturnValue(useGetSeverityResponse);
     jest.clearAllMocks();
@@ -133,5 +138,41 @@ describe('ResilientParamsFields renders', () => {
       });
 
     expect(onChange).toHaveBeenCalledWith({ incidentTypes: ['19'], severityCode: '4' });
+  });
+
+  it('should submit a resilient connector', async () => {
+    const { rerender } = mockedContext.render(
+      <Fields fields={fields} onChange={onChange} connector={connector} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('incidentTypeComboBox')).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Low' }));
+    });
+
+    const checkbox = within(screen.getByTestId('incidentTypeComboBox')).getByTestId(
+      'comboBoxSearchInput'
+    );
+
+    userEvent.type(checkbox, 'Denial of Service{enter}');
+
+    rerender(
+      <Fields
+        fields={{ ...fields, incidentTypes: ['21'] }}
+        onChange={onChange}
+        connector={connector}
+      />
+    );
+
+    userEvent.selectOptions(screen.getByTestId('severitySelect'), ['4']);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    expect(onChange).toBeCalledWith({
+      incidentTypes: ['21'],
+      severityCode: '4',
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_itsm_case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_itsm_case_fields.test.tsx
@@ -6,14 +6,17 @@
  */
 
 import React from 'react';
-import { waitFor, act, render, screen } from '@testing-library/react';
+import { waitFor, act, render, screen, within } from '@testing-library/react';
 import { EuiSelect } from '@elastic/eui';
 import { mount } from 'enzyme';
+import userEvent from '@testing-library/user-event';
 
 import { useKibana } from '../../../common/lib/kibana';
 import { connector, choices as mockChoices } from '../mock';
 import type { Choice } from './types';
 import Fields from './servicenow_itsm_case_fields';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 
 let onChoicesSuccess = (c: Choice[]) => {};
 
@@ -26,6 +29,7 @@ jest.mock('./use_get_choices', () => ({
 }));
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
+let mockedContext: AppMockRenderer;
 
 describe('ServiceNowITSM Fields', () => {
   const fields = {
@@ -38,11 +42,12 @@ describe('ServiceNowITSM Fields', () => {
   const onChange = jest.fn();
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    mockedContext = createAppMockRenderer();
     useKibanaMock().services.triggersActionsUi.actionTypeRegistry.get = jest.fn().mockReturnValue({
       actionTypeTitle: '.servicenow',
       iconClass: 'logoSecurity',
     });
+    jest.clearAllMocks();
   });
 
   it('all params fields are rendered - isEdit: true', () => {
@@ -225,6 +230,82 @@ describe('ServiceNowITSM Fields', () => {
         subcategory: null,
         category: 'network',
       });
+    });
+  });
+
+  it('should submit a service now itsm connector', async () => {
+    const { rerender } = mockedContext.render(
+      <Fields fields={fields} onChange={onChange} connector={connector} />
+    );
+
+    act(() => {
+      onChoicesSuccess(mockChoices);
+    });
+
+    const severitySelect = screen.getByTestId('severitySelect');
+    const urgencySelect = screen.getByTestId('urgencySelect');
+    const impactSelect = screen.getByTestId('impactSelect');
+
+    await waitFor(() => {
+      expect(within(severitySelect).getByRole('option', { name: '2 - High' }));
+      expect(within(urgencySelect).getByRole('option', { name: '2 - High' }));
+      expect(within(impactSelect).getByRole('option', { name: '2 - High' }));
+
+      expect(screen.getByRole('option', { name: 'Software' }));
+    });
+
+    const selectables: Array<[HTMLElement, 'severity' | 'urgency' | 'impact']> = [
+      [severitySelect, 'severity'],
+      [urgencySelect, 'urgency'],
+      [impactSelect, 'impact'],
+    ];
+
+    let newFields = { ...fields };
+
+    selectables.forEach(([element, key]) => {
+      userEvent.selectOptions(element, ['2']);
+
+      rerender(
+        <Fields fields={{ ...newFields, [key]: '2' }} onChange={onChange} connector={connector} />
+      );
+
+      newFields = { ...newFields, [key]: '2' };
+    });
+
+    const categorySelect = screen.getByTestId('categorySelect');
+
+    await waitFor(() => {
+      expect(within(categorySelect).getByRole('option', { name: 'Software' }));
+    });
+
+    userEvent.selectOptions(categorySelect, ['software']);
+
+    rerender(
+      <Fields
+        fields={{ ...newFields, category: 'software' }}
+        onChange={onChange}
+        connector={connector}
+      />
+    );
+
+    const subcategorySelect = screen.getByTestId('subcategorySelect');
+
+    await waitFor(() => {
+      expect(within(subcategorySelect).getByRole('option', { name: 'Operation System' }));
+    });
+
+    userEvent.selectOptions(subcategorySelect, ['os']);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    expect(onChange).toBeCalledWith({
+      impact: '2',
+      severity: '2',
+      urgency: '2',
+      category: 'software',
+      subcategory: 'os',
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_sir_case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/servicenow_sir_case_fields.test.tsx
@@ -10,11 +10,14 @@ import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import { waitFor, act, render, screen } from '@testing-library/react';
 import { EuiSelect } from '@elastic/eui';
+import userEvent from '@testing-library/user-event';
 
 import { useKibana } from '../../../common/lib/kibana';
 import { connector, choices as mockChoices } from '../mock';
 import type { Choice } from './types';
 import Fields from './servicenow_sir_case_fields';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 
 let onChoicesSuccess = (_c: Choice[]) => {};
 
@@ -27,6 +30,7 @@ jest.mock('./use_get_choices', () => ({
 }));
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
+let mockedContext: AppMockRenderer;
 
 describe('ServiceNowSIR Fields', () => {
   const fields = {
@@ -42,6 +46,7 @@ describe('ServiceNowSIR Fields', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedContext = createAppMockRenderer();
     useKibanaMock().services.triggersActionsUi.actionTypeRegistry.get = jest.fn().mockReturnValue({
       actionTypeTitle: '.servicenow-sir',
       iconClass: 'logoSecurity',
@@ -281,6 +286,59 @@ describe('ServiceNowSIR Fields', () => {
           category: 'network',
         });
       });
+    });
+  });
+
+  it('should submit servicenow sir connector', async () => {
+    const { rerender } = mockedContext.render(
+      <Fields fields={fields} onChange={onChange} connector={connector} />
+    );
+
+    act(() => {
+      onChoicesSuccess(mockChoices);
+    });
+
+    userEvent.click(screen.getByTestId('destIpCheckbox'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: '1 - Critical' }));
+      expect(screen.getByRole('option', { name: 'Denial of Service' }));
+    });
+
+    userEvent.selectOptions(screen.getByTestId('prioritySelect'), ['1']);
+
+    rerender(
+      <Fields fields={{ ...fields, priority: '1' }} onChange={onChange} connector={connector} />
+    );
+
+    userEvent.selectOptions(screen.getByTestId('categorySelect'), ['Denial of Service']);
+
+    rerender(
+      <Fields
+        fields={{ ...fields, priority: '1', category: 'Denial of Service' }}
+        onChange={onChange}
+        connector={connector}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Single or distributed (DoS or DDoS)' }));
+    });
+
+    userEvent.selectOptions(screen.getByTestId('subcategorySelect'), ['26']);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    expect(onChange).toBeCalledWith({
+      destIp: false,
+      sourceIp: true,
+      malwareHash: true,
+      malwareUrl: true,
+      priority: '1',
+      category: 'Denial of Service',
+      subcategory: '26',
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import type { Screen } from '@testing-library/react';
-import { act, waitFor, within, screen } from '@testing-library/react';
+import { waitFor, within, screen } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 
 import { CaseSeverity, CommentType, ConnectorTypes } from '../../../common/api';
@@ -38,7 +38,6 @@ import type { CreateCaseFormFieldsProps } from './form';
 import { CreateCaseFormFields } from './form';
 import { SubmitCaseButton } from './submit_button';
 import { usePostPushToService } from '../../containers/use_post_push_to_service';
-import type { Choice } from '../connectors/servicenow/types';
 import userEvent from '@testing-library/user-event';
 import { connectorsMock } from '../../common/mock/connectors';
 import type { CaseAttachments } from '../../types';
@@ -143,7 +142,6 @@ describe('Create case', () => {
   const onFormSubmitSuccess = jest.fn();
   const afterCaseCreated = jest.fn();
   const createAttachments = jest.fn();
-  let onChoicesSuccess: (values: Choice[]) => void;
   let mockedContext: AppMockRenderer;
 
   beforeAll(() => {
@@ -160,12 +158,7 @@ describe('Create case', () => {
     useGetSeverityMock.mockReturnValue(useGetSeverityResponse);
     useGetIssueTypesMock.mockReturnValue(useGetIssueTypesResponse);
     useGetFieldsByIssueTypeMock.mockReturnValue(useGetFieldsByIssueTypeResponse);
-    useGetChoicesMock.mockImplementation(
-      ({ onSuccess }: { onSuccess: (values: Choice[]) => void }) => {
-        onChoicesSuccess = onSuccess;
-        return useGetChoicesResponse;
-      }
-    );
+    useGetChoicesMock.mockReturnValue(useGetChoicesResponse);
 
     (useGetTags as jest.Mock).mockImplementation(() => ({
       data: sampleTags,
@@ -224,8 +217,10 @@ describe('Create case', () => {
       userEvent.click(screen.getByTestId('create-case-submit'));
 
       await waitFor(() => {
-        expect(postCase).toBeCalledWith({ ...sampleDataWithoutTags, tags: sampleTags });
+        expect(postCase).toHaveBeenCalled();
       });
+
+      expect(postCase).toBeCalledWith({ ...sampleDataWithoutTags, tags: sampleTags });
     });
 
     it('should post a case on submit click with the selected severity', async () => {
@@ -253,10 +248,12 @@ describe('Create case', () => {
       userEvent.click(screen.getByTestId('create-case-submit'));
 
       await waitFor(() => {
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          severity: CaseSeverity.HIGH,
-        });
+        expect(postCase).toHaveBeenCalled();
+      });
+
+      expect(postCase).toBeCalledWith({
+        ...sampleDataWithoutTags,
+        severity: CaseSeverity.HIGH,
       });
     });
 
@@ -307,12 +304,12 @@ describe('Create case', () => {
       userEvent.click(syncAlertsButton);
       userEvent.click(screen.getByTestId('create-case-submit'));
 
-      await waitFor(() =>
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          settings: { syncAlerts: false },
-        })
-      );
+      await waitFor(() => expect(postCase).toHaveBeenCalled());
+
+      expect(postCase).toBeCalledWith({
+        ...sampleDataWithoutTags,
+        settings: { syncAlerts: false },
+      });
     });
 
     it('should set sync alerts to false when the sync feature setting is false', async () => {
@@ -337,12 +334,12 @@ describe('Create case', () => {
 
       userEvent.click(screen.getByTestId('create-case-submit'));
 
-      await waitFor(() =>
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          settings: { syncAlerts: false },
-        })
-      );
+      await waitFor(() => expect(postCase).toHaveBeenCalled());
+
+      expect(postCase).toBeCalledWith({
+        ...sampleDataWithoutTags,
+        settings: { syncAlerts: false },
+      });
     });
 
     it('should select LOW as the default severity', async () => {
@@ -391,23 +388,23 @@ describe('Create case', () => {
 
       userEvent.click(screen.getByTestId('create-case-submit'));
 
-      await waitFor(() =>
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          connector: {
-            fields: {
-              impact: null,
-              severity: null,
-              urgency: null,
-              category: null,
-              subcategory: null,
-            },
-            id: 'servicenow-1',
-            name: 'My Connector',
-            type: '.servicenow',
+      await waitFor(() => expect(postCase).toHaveBeenCalled());
+
+      expect(postCase).toBeCalledWith({
+        ...sampleDataWithoutTags,
+        connector: {
+          fields: {
+            impact: null,
+            severity: null,
+            urgency: null,
+            category: null,
+            subcategory: null,
           },
-        })
-      );
+          id: 'servicenow-1',
+          name: 'My Connector',
+          type: '.servicenow',
+        },
+      });
     });
 
     it('should default to none if the default connector does not exist in connectors', async () => {
@@ -440,76 +437,16 @@ describe('Create case', () => {
       userEvent.click(screen.getByTestId('create-case-submit'));
 
       await waitFor(() => {
-        expect(postCase).toBeCalledWith(sampleDataWithoutTags);
+        expect(postCase).toBeCalled();
         expect(pushCaseToExternalService).not.toHaveBeenCalled();
       });
+
+      expect(pushCaseToExternalService).not.toHaveBeenCalled();
+      expect(postCase).toBeCalledWith(sampleDataWithoutTags);
     });
   });
 
   describe('Step 2 - Connector Fields', () => {
-    it(`should submit and push to Jira connector`, async () => {
-      useGetConnectorsMock.mockReturnValue({
-        ...sampleConnectorData,
-        data: connectorsMock,
-      });
-
-      mockedContext.render(
-        <FormContext onSuccess={onFormSubmitSuccess}>
-          <CreateCaseFormFields {...defaultCreateCaseForm} />
-          <SubmitCaseButton />
-        </FormContext>
-      );
-
-      await waitForFormToRender(screen);
-      await fillFormReactTestingLib({ renderer: screen });
-
-      userEvent.click(screen.getByTestId('dropdown-connectors'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('dropdown-connector-jira-1')).toBeInTheDocument();
-      });
-
-      userEvent.click(screen.getByTestId('dropdown-connector-jira-1'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('issueTypeSelect')).toBeInTheDocument();
-        expect(screen.getByTestId('prioritySelect')).toBeInTheDocument();
-      });
-
-      userEvent.selectOptions(screen.getByTestId('issueTypeSelect'), ['10007']);
-      userEvent.selectOptions(screen.getByTestId('prioritySelect'), ['Low']);
-      userEvent.click(screen.getByTestId('create-case-submit'));
-
-      await waitFor(() => {
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          connector: {
-            id: 'jira-1',
-            name: 'Jira',
-            type: '.jira',
-            fields: { issueType: '10007', parent: null, priority: 'Low' },
-          },
-        });
-
-        expect(pushCaseToExternalService).toHaveBeenCalledWith({
-          caseId: sampleId,
-          connector: {
-            id: 'jira-1',
-            name: 'Jira',
-            type: '.jira',
-            fields: { issueType: '10007', parent: null, priority: 'Low' },
-          },
-        });
-
-        expect(onFormSubmitSuccess).toHaveBeenCalledWith({
-          id: sampleId,
-          ...sampleDataWithoutTags,
-        });
-      });
-    });
-
     it(`should submit and push to resilient connector`, async () => {
       useGetConnectorsMock.mockReturnValue({
         ...sampleConnectorData,
@@ -538,7 +475,7 @@ describe('Create case', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('incidentTypeComboBox')).toBeInTheDocument();
-        expect(screen.getByTestId('severitySelect')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Low' }));
       });
 
       const checkbox = within(screen.getByTestId('incidentTypeComboBox')).getByTestId(
@@ -550,198 +487,34 @@ describe('Create case', () => {
       userEvent.click(screen.getByTestId('create-case-submit'));
 
       await waitFor(() => {
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          connector: {
-            id: 'resilient-2',
-            name: 'My Connector 2',
-            type: '.resilient',
-            fields: { incidentTypes: ['21'], severityCode: '4' },
-          },
-        });
-
-        expect(pushCaseToExternalService).toHaveBeenCalledWith({
-          caseId: sampleId,
-          connector: {
-            id: 'resilient-2',
-            name: 'My Connector 2',
-            type: '.resilient',
-            fields: { incidentTypes: ['21'], severityCode: '4' },
-          },
-        });
-
-        expect(onFormSubmitSuccess).toHaveBeenCalledWith({
-          id: sampleId,
-          ...sampleDataWithoutTags,
-        });
-      });
-    });
-
-    it(`should submit and push to servicenow itsm connector`, async () => {
-      useGetConnectorsMock.mockReturnValue({
-        ...sampleConnectorData,
-        data: connectorsMock,
+        expect(postCase).toHaveBeenCalled();
+        expect(pushCaseToExternalService).toHaveBeenCalled();
+        expect(onFormSubmitSuccess).toHaveBeenCalled();
       });
 
-      mockedContext.render(
-        <FormContext onSuccess={onFormSubmitSuccess}>
-          <CreateCaseFormFields {...defaultCreateCaseForm} />
-          <SubmitCaseButton />
-        </FormContext>
-      );
-
-      await waitForFormToRender(screen);
-      await fillFormReactTestingLib({ renderer: screen });
-
-      userEvent.click(screen.getByTestId('dropdown-connectors'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('dropdown-connector-servicenow-1')).toBeInTheDocument();
+      expect(postCase).toBeCalledWith({
+        ...sampleDataWithoutTags,
+        connector: {
+          id: 'resilient-2',
+          name: 'My Connector 2',
+          type: '.resilient',
+          fields: { incidentTypes: ['21'], severityCode: '4' },
+        },
       });
 
-      userEvent.click(screen.getByTestId('dropdown-connector-servicenow-1'), undefined, {
-        skipPointerEventsCheck: true,
+      expect(pushCaseToExternalService).toHaveBeenCalledWith({
+        caseId: sampleId,
+        connector: {
+          id: 'resilient-2',
+          name: 'My Connector 2',
+          type: '.resilient',
+          fields: { incidentTypes: ['21'], severityCode: '4' },
+        },
       });
 
-      await waitFor(() => {
-        expect(onChoicesSuccess).toBeDefined();
-      });
-
-      // // we need the choices response to conditionally show the subcategory select
-      act(() => {
-        onChoicesSuccess(useGetChoicesResponse.choices);
-      });
-
-      ['severitySelect', 'urgencySelect', 'impactSelect'].forEach((subj) => {
-        userEvent.selectOptions(screen.getByTestId(subj), ['2']);
-      });
-
-      userEvent.selectOptions(screen.getByTestId('categorySelect'), ['software']);
-      userEvent.selectOptions(screen.getByTestId('subcategorySelect'), ['os']);
-      userEvent.click(screen.getByTestId('create-case-submit'));
-
-      await waitFor(() => {
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          connector: {
-            id: 'servicenow-1',
-            name: 'My Connector',
-            type: '.servicenow',
-            fields: {
-              impact: '2',
-              severity: '2',
-              urgency: '2',
-              category: 'software',
-              subcategory: 'os',
-            },
-          },
-        });
-
-        expect(pushCaseToExternalService).toHaveBeenCalledWith({
-          caseId: sampleId,
-          connector: {
-            id: 'servicenow-1',
-            name: 'My Connector',
-            type: '.servicenow',
-            fields: {
-              impact: '2',
-              severity: '2',
-              urgency: '2',
-              category: 'software',
-              subcategory: 'os',
-            },
-          },
-        });
-
-        expect(onFormSubmitSuccess).toHaveBeenCalledWith({
-          id: sampleId,
-          ...sampleDataWithoutTags,
-        });
-      });
-    });
-
-    it(`should submit and push to servicenow sir connector`, async () => {
-      useGetConnectorsMock.mockReturnValue({
-        ...sampleConnectorData,
-        data: connectorsMock,
-      });
-
-      mockedContext.render(
-        <FormContext onSuccess={onFormSubmitSuccess}>
-          <CreateCaseFormFields {...defaultCreateCaseForm} />
-          <SubmitCaseButton />
-        </FormContext>
-      );
-
-      await waitForFormToRender(screen);
-      await fillFormReactTestingLib({ renderer: screen });
-
-      userEvent.click(screen.getByTestId('dropdown-connectors'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('dropdown-connector-servicenow-sir')).toBeInTheDocument();
-      });
-
-      userEvent.click(screen.getByTestId('dropdown-connector-servicenow-sir'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(onChoicesSuccess).toBeDefined();
-      });
-
-      // we need the choices response to conditionally show the subcategory select
-      act(() => {
-        onChoicesSuccess(useGetChoicesResponse.choices);
-      });
-
-      userEvent.click(screen.getByTestId('destIpCheckbox'));
-      userEvent.selectOptions(screen.getByTestId('prioritySelect'), ['1']);
-      userEvent.selectOptions(screen.getByTestId('categorySelect'), ['Denial of Service']);
-      userEvent.selectOptions(screen.getByTestId('subcategorySelect'), ['26']);
-      userEvent.click(screen.getByTestId('create-case-submit'));
-
-      await waitFor(() => {
-        expect(postCase).toBeCalledWith({
-          ...sampleDataWithoutTags,
-          connector: {
-            id: 'servicenow-sir',
-            name: 'My Connector SIR',
-            type: '.servicenow-sir',
-            fields: {
-              destIp: false,
-              sourceIp: true,
-              malwareHash: true,
-              malwareUrl: true,
-              priority: '1',
-              category: 'Denial of Service',
-              subcategory: '26',
-            },
-          },
-        });
-
-        expect(pushCaseToExternalService).toHaveBeenCalledWith({
-          caseId: sampleId,
-          connector: {
-            id: 'servicenow-sir',
-            name: 'My Connector SIR',
-            type: '.servicenow-sir',
-            fields: {
-              destIp: false,
-              sourceIp: true,
-              malwareHash: true,
-              malwareUrl: true,
-              priority: '1',
-              category: 'Denial of Service',
-              subcategory: '26',
-            },
-          },
-        });
-
-        expect(onFormSubmitSuccess).toHaveBeenCalledWith({
-          id: sampleId,
-          ...sampleDataWithoutTags,
-        });
+      expect(onFormSubmitSuccess).toHaveBeenCalledWith({
+        id: sampleId,
+        ...sampleDataWithoutTags,
       });
     });
   });
@@ -774,14 +547,16 @@ describe('Create case', () => {
     userEvent.click(screen.getByTestId('create-case-submit'));
 
     await waitFor(() => {
-      expect(afterCaseCreated).toHaveBeenCalledWith(
-        {
-          id: sampleId,
-          ...sampleDataWithoutTags,
-        },
-        createAttachments
-      );
+      expect(afterCaseCreated).toHaveBeenCalled();
     });
+
+    expect(afterCaseCreated).toHaveBeenCalledWith(
+      {
+        id: sampleId,
+        ...sampleDataWithoutTags,
+      },
+      createAttachments
+    );
   });
 
   it('should call createAttachments with the attachments after the case is created', async () => {
@@ -824,9 +599,10 @@ describe('Create case', () => {
 
     userEvent.click(screen.getByTestId('create-case-submit'));
 
-    await waitForComponentToUpdate();
+    await waitFor(() => {
+      expect(createAttachments).toHaveBeenCalledTimes(1);
+    });
 
-    expect(createAttachments).toHaveBeenCalledTimes(1);
     expect(createAttachments).toHaveBeenCalledWith({
       caseId: 'case-id',
       data: attachments,
@@ -977,7 +753,9 @@ describe('Create case', () => {
       userEvent.click(await screen.findByText(`${userProfiles[0].user.full_name}`));
       userEvent.click(screen.getByTestId('create-case-submit'));
 
-      await waitForComponentToUpdate();
+      await waitFor(() => {
+        expect(postCase).toHaveBeenCalled();
+      });
 
       expect(postCase).toBeCalledWith({
         ...sampleDataWithoutTags,
@@ -997,6 +775,7 @@ describe('Create case', () => {
 
       await waitForFormToRender(screen);
       await waitForComponentToUpdate();
+
       expect(screen.queryByTestId('createCaseAssigneesComboBox')).toBeNull();
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Cases] Fix create case form flaky tests (#145829)](https://github.com/elastic/kibana/pull/145829)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2022-11-23T16:37:57Z","message":"[Cases] Fix create case form flaky tests (#145829)\n\n## Summary\r\n\r\nThe connectors in the create case form use `select` elements to display\r\nvarious fields. The values of the `select` are being fetched from the\r\nexternal service. To prevent flakiness we are waiting for the values to\r\nbe presented first before trying to select the value.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/142284,\r\nhttps://github.com/elastic/kibana/issues/142282,\r\nhttps://github.com/elastic/kibana/issues/143407\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cf0cde26a05623a9ba956ba7bb17e2389138a9bd","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Cases","backport:prev-minor","v8.7.0"],"number":145829,"url":"https://github.com/elastic/kibana/pull/145829","mergeCommit":{"message":"[Cases] Fix create case form flaky tests (#145829)\n\n## Summary\r\n\r\nThe connectors in the create case form use `select` elements to display\r\nvarious fields. The values of the `select` are being fetched from the\r\nexternal service. To prevent flakiness we are waiting for the values to\r\nbe presented first before trying to select the value.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/142284,\r\nhttps://github.com/elastic/kibana/issues/142282,\r\nhttps://github.com/elastic/kibana/issues/143407\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cf0cde26a05623a9ba956ba7bb17e2389138a9bd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145829","number":145829,"mergeCommit":{"message":"[Cases] Fix create case form flaky tests (#145829)\n\n## Summary\r\n\r\nThe connectors in the create case form use `select` elements to display\r\nvarious fields. The values of the `select` are being fetched from the\r\nexternal service. To prevent flakiness we are waiting for the values to\r\nbe presented first before trying to select the value.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/142284,\r\nhttps://github.com/elastic/kibana/issues/142282,\r\nhttps://github.com/elastic/kibana/issues/143407\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cf0cde26a05623a9ba956ba7bb17e2389138a9bd"}}]}] BACKPORT-->