### PR TITLE
[8.6] Upgrade EUI to v67.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.4.0-canary.1",
     "@elastic/ems-client": "8.3.3",
-    "@elastic/eui": "67.1.9",
+    "@elastic/eui": "67.1.10",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -84,6 +84,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.3.3': ['Elastic License 2.0'],
-  '@elastic/eui@67.1.9': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@67.1.10': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,10 +1527,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@67.1.9":
-  version "67.1.9"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-67.1.9.tgz#7d84ed27288d08e30110506a4e3177ad4c6f9520"
-  integrity sha512-VvMNhXMVBzMNXPCES0gF1K4xmT9uawrx5sdEjgeB8LNODVMSRFXT2jiUMZPF5mdRh23ZJrAVcy0BSAY7Tu/LJA==
+"@elastic/eui@67.1.10":
+  version "67.1.10"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-67.1.10.tgz#05ba7b35c937532b8455936b025330b383155224"
+  integrity sha512-QLuhtuMsSalTI0y2kcrCOJdDUv6Amk8qkfp5Zs/a4f8lNnZbG2PORleYGf1EiaVjKRuppo5VDYlXwgCMgQcP1g==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary
`eui@67.1.9` ⏩ `eui@67.1.10`

This backport fixes EuiFlyout bugs affecting Observability. It is meant to go directly into 8.6.

## [`67.1.10`](https://github.com/elastic/eui/tree/v67.1.10)

- Added the `euiMaxBreakpoint` and `euiMinBreakpoint` CSS-in-JS utilities for creating min/max-width media queries ([#6431](https://github.com/elastic/eui/pull/6431))

**Bug fixes**

- Fixed missing slide-in animation on `EuiCollapsibleNav`s and left-side `EuiFlyout`s ([#6422](https://github.com/elastic/eui/pull/6422))
- Fixed multiple component media queries for consumers with custom theme breakpoints ([#6431](https://github.com/elastic/eui/pull/6431))