### PR TITLE
DO NOT MERGE: [stateless] Simulate potential delays in ES (1s) + `.kibana`'s `refresh_interval` 5s

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
@@ -77,7 +77,7 @@ export const cloneIndex = ({
             // Set an explicit refresh interval so that we don't inherit the
             // value from incorrectly configured index templates (not required
             // after we adopt system indices)
-            refresh_interval: '1s',
+            refresh_interval: '5s',
             // Bump priority so that recovery happens before newer indices
             priority: 10,
             // Increase the fields limit beyond the default of 1000

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
@@ -93,7 +93,7 @@ export const createIndex = ({
             // Set an explicit refresh interval so that we don't inherit the
             // value from incorrectly configured index templates (not required
             // after we adopt system indices)
-            refresh_interval: '1s',
+            refresh_interval: '5s',
             // Bump priority so that recovery happens before newer indices
             priority: 10,
             // Increase the fields limit beyond the default of 1000

--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -346,7 +346,7 @@ exports.Cluster = class Cluster {
       ['ingest.geoip.downloader.enabled', 'false'],
       ['search.check_ccs_compatibility', 'true'],
       // Simulate the interval batching
-      ['indices.write_ack_delay_interval', '5s'],
+      ['indices.write_ack_delay_interval', '1s'],
       // Simulate the S3 call:
       // using 200ms because that's the upper limit according to https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
       ['indices.write_ack_delay_randomness_bound', '200ms'],

--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -345,6 +345,11 @@ exports.Cluster = class Cluster {
       ['cluster.routing.allocation.disk.threshold_enabled', 'false'],
       ['ingest.geoip.downloader.enabled', 'false'],
       ['search.check_ccs_compatibility', 'true'],
+      // Simulate the interval batching
+      ['indices.write_ack_delay_interval', '5s'],
+      // Simulate the S3 call:
+      // using 200ms because that's the upper limit according to https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+      ['indices.write_ack_delay_randomness_bound', '200ms'],
     ]);
 
     // options.esArgs overrides the default esArg values


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/146148, but testing out with `.kibana` adding `refresh_interval: '5s'` to the index' settings.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
