### PR TITLE
[8.6] [Canvas] Fixes broken data view sort (#146209)

### DIFF
--- a/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.component.tsx
+++ b/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.component.tsx
@@ -31,12 +31,12 @@ export const ESDataViewSelect: React.FunctionComponent<ESDataViewSelectProps> = 
   onFocus,
   onBlur,
 }) => {
-  const selectedDataView = dataViews.find((view) => value === view.title) as DataView;
+  const selectedDataView = dataViews.find((view) => value === view.title) as DataViewOption;
 
   const selectedOption = selectedDataView
-    ? { value: selectedDataView.title, label: selectedDataView.name }
+    ? { value: selectedDataView.title, label: selectedDataView.name || selectedDataView.title }
     : { value, label: value };
-  const options = dataViews.map(({ name, title }) => ({ value: title, label: name }));
+  const options = dataViews.map(({ name, title }) => ({ value: title, label: name || title }));
 
   return (
     <EuiComboBox

--- a/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.tsx
+++ b/x-pack/plugins/canvas/public/components/es_data_view_select/es_data_view_select.tsx
@@ -36,7 +36,12 @@ export const ESDataViewSelect: FC<ESDataViewSelectProps> = (props) => {
       }
 
       setLoading(false);
-      setDataViews(sortBy(newDataViews, 'name'));
+      setDataViews(
+        sortBy(newDataViews, ({ name, title }) => {
+          return name || title || '';
+        })
+      );
+
       if (!value && newDataViews.length) {
         onChange(newDataViews[0].title);
       }

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -29,6 +29,7 @@ import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { BfetchPublicSetup } from '@kbn/bfetch-plugin/public';
 import { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { featureCatalogueEntry } from './feature_catalogue_entry';
 import { CanvasAppLocatorDefinition } from '../common/locator';
 import { SESSIONSTORAGE_LASTPATH, CANVAS_APP } from '../common/lib/constants';
@@ -62,6 +63,7 @@ export interface CanvasStartDeps {
   uiActions: UiActionsStart;
   charts: ChartsPluginStart;
   data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
   presentationUtil: PresentationUtilPluginStart;
   visualizations: VisualizationsStart;
   spaces?: SpacesPluginStart;

--- a/x-pack/plugins/canvas/public/services/kibana/data_views.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/data_views.ts
@@ -25,7 +25,7 @@ export type DataViewsServiceFactory = KibanaPluginServiceFactory<
 export const dataViewsServiceFactory: DataViewsServiceFactory = ({ startPlugins }, { notify }) => ({
   getDataViews: async () => {
     try {
-      const dataViews = await startPlugins.data.dataViews.getIdsWithTitle();
+      const dataViews = await startPlugins.dataViews.getIdsWithTitle();
       return dataViews.map(({ id, name, title }) => ({ id, name, title } as DataView));
     } catch (e) {
       notify.error(e, { title: strings.getIndicesFetchErrorMessage() });
@@ -34,14 +34,14 @@ export const dataViewsServiceFactory: DataViewsServiceFactory = ({ startPlugins 
     return [];
   },
   getFields: async (dataViewTitle: string) => {
-    const dataView = await startPlugins.data.dataViews.create({ title: dataViewTitle });
+    const dataView = await startPlugins.dataViews.create({ title: dataViewTitle });
 
     return dataView.fields
       .filter((field) => !field.name.startsWith('_'))
       .map((field) => field.name);
   },
   getDefaultDataView: async () => {
-    const dataView = await startPlugins.data.dataViews.getDefaultDataView();
+    const dataView = await startPlugins.dataViews.getDefaultDataView();
 
     return dataView
       ? { id: dataView.id, name: dataView.name, title: dataView.getIndexPattern() }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Canvas] Fixes broken data view sort (#146209)](https://github.com/elastic/kibana/pull/146209)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Catherine Liu","email":"catherine.liu@elastic.co"},"sourceCommit":{"committedDate":"2022-11-23T20:54:10Z","message":"[Canvas] Fixes broken data view sort (#146209)\n\n## Summary\r\n\r\nCloses #146171.\r\n\r\nThis sorting function for the data view options was assuming that `name`\r\nwas always defined, but with some legacy data views/index patterns,\r\n`name` is not defined and only `title` is. This changes the sort\r\nfunction to use `name` or `title` when sorting, so it doesn't error out\r\nwhen `name` or `title` is missing. I also noticed that we were still\r\nusing the data plugin here instead of the data views plugin directly, so\r\nI fixed that too.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"87e88694f2ef3c32e0ace5a35704f992fcef2f0a","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","review","Team:Presentation","loe:hours","release_note:skip","impact:critical","Feature:Canvas","v8.6.0","v8.7.0"],"number":146209,"url":"https://github.com/elastic/kibana/pull/146209","mergeCommit":{"message":"[Canvas] Fixes broken data view sort (#146209)\n\n## Summary\r\n\r\nCloses #146171.\r\n\r\nThis sorting function for the data view options was assuming that `name`\r\nwas always defined, but with some legacy data views/index patterns,\r\n`name` is not defined and only `title` is. This changes the sort\r\nfunction to use `name` or `title` when sorting, so it doesn't error out\r\nwhen `name` or `title` is missing. I also noticed that we were still\r\nusing the data plugin here instead of the data views plugin directly, so\r\nI fixed that too.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"87e88694f2ef3c32e0ace5a35704f992fcef2f0a"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146209","number":146209,"mergeCommit":{"message":"[Canvas] Fixes broken data view sort (#146209)\n\n## Summary\r\n\r\nCloses #146171.\r\n\r\nThis sorting function for the data view options was assuming that `name`\r\nwas always defined, but with some legacy data views/index patterns,\r\n`name` is not defined and only `title` is. This changes the sort\r\nfunction to use `name` or `title` when sorting, so it doesn't error out\r\nwhen `name` or `title` is missing. I also noticed that we were still\r\nusing the data plugin here instead of the data views plugin directly, so\r\nI fixed that too.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"87e88694f2ef3c32e0ace5a35704f992fcef2f0a"}}]}] BACKPORT-->