### PR TITLE
[8.6] Fix: Wrong default filtering rule

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_filtering_logic.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_filtering_logic.tsx
@@ -261,7 +261,7 @@ export const ConnectorFilteringLogic = kea<
                   id: uuidv4(),
                   order: 0,
                   policy: FilteringPolicy.INCLUDE,
-                  rule: FilteringRuleRule.EQUALS,
+                  rule: FilteringRuleRule.REGEX,
                   updated_at: new Date().toISOString(),
                   value: '.*',
                 },
@@ -279,7 +279,7 @@ export const ConnectorFilteringLogic = kea<
                 id: uuidv4(),
                 order: 0,
                 policy: FilteringPolicy.INCLUDE,
-                rule: FilteringRuleRule.EQUALS,
+                rule: FilteringRuleRule.REGEX,
                 updated_at: new Date().toISOString(),
                 value: '.*',
               };


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3422

The default rule for connectors simple rule filtering should be **INCLUDE '_' REGEX '.*'** and not **INCLUDE '_' EQUALS '.*'**

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->