### PR TITLE
[Enterprise Search] Allow empty config values to be saved

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -7,7 +7,7 @@
 
 export interface KeyValuePair {
   label: string;
-  value: string;
+  value: string | null;
 }
 
 export type ConnectorConfiguration = Record<string, KeyValuePair | null>;

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -100,7 +100,7 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
       validate: {
         body: schema.recordOf(
           schema.string(),
-          schema.object({ label: schema.string(), value: schema.string() })
+          schema.object({ label: schema.string(), value: schema.nullable(schema.string()) })
         ),
         params: schema.object({
           connectorId: schema.string(),


### PR DESCRIPTION
This allows null values for connector configuration values, which was initially breaking some configuration setting.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->