### PR TITLE
[ML] Functional tests - stabilize index data visualizer tests

### DIFF
--- a/x-pack/test/functional/services/ml/data_visualizer_table.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_table.ts
@@ -13,9 +13,10 @@ import { MlCommonUI } from './common_ui';
 export type MlDataVisualizerTable = ProvidedType<typeof MachineLearningDataVisualizerTableProvider>;
 
 export function MachineLearningDataVisualizerTableProvider(
-  { getService }: FtrProviderContext,
+  { getPageObject, getService }: FtrProviderContext,
   mlCommonUI: MlCommonUI
 ) {
+  const headerPage = getPageObject('header');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const find = getService('find');
@@ -391,6 +392,7 @@ export function MachineLearningDataVisualizerTableProvider(
       hasActionMenu = false,
       checkDistributionPreviewExist = true
     ) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
       await this.ensureDetailsOpen(fieldName);
@@ -421,6 +423,7 @@ export function MachineLearningDataVisualizerTableProvider(
     }
 
     public async assertDateFieldContents(fieldName: string, docCountFormatted: string) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
       await this.ensureDetailsOpen(fieldName);
@@ -437,6 +440,7 @@ export function MachineLearningDataVisualizerTableProvider(
       topValuesCount: number,
       exampleContent?: string[]
     ) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
       await this.ensureDetailsOpen(fieldName);
@@ -467,6 +471,7 @@ export function MachineLearningDataVisualizerTableProvider(
       docCountFormatted: string,
       expectedExamplesCount: number
     ) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
 
@@ -481,6 +486,7 @@ export function MachineLearningDataVisualizerTableProvider(
       docCountFormatted: string,
       expectedExamplesCount: number
     ) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
 
@@ -496,6 +502,7 @@ export function MachineLearningDataVisualizerTableProvider(
     }
 
     public async assertUnknownFieldContents(fieldName: string, docCountFormatted: string) {
+      await headerPage.waitUntilLoadingHasFinished();
       await this.assertRowExists(fieldName);
       await this.assertFieldDocCount(fieldName, docCountFormatted);
 


### PR DESCRIPTION
## Summary

This PR stabilizes the index data visualizer tests.

### Details

We occasionally see data visualizer test failures like this:
`Error: Expected field geo.coordinates's document count to be '408 (100%)' (got '')`
with a failure screnshot like this:
![image](https://user-images.githubusercontent.com/1945390/203787765-6b32a7a6-d734-4659-9610-51288f88a78f.png)

The screenshot shows that global loading is not finished yet and as a result, the field details are not displayed as expected.
Stabilized by adding waits for the global loading to all data viz field content assertion service methods.

Closes #118472


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->