### PR TITLE
[Behavioral Analytics] Add i18n text formatting for Behavioral Analytics integrate tab

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { AnalyticsCollection } from '../../../../../common/types/analytics';
 import { getEnterpriseSearchUrl } from '../../../shared/enterprise_search_url';
@@ -99,15 +100,13 @@ export const AnalyticsCollectionIntegrate: React.FC<AnalyticsCollectionIntegrate
 
       <EuiSpacer size="l" />
       <EuiText size="s">
-        <p>
-          {i18n.translate(
-            'xpack.enterpriseSearch.analytics.collections.collectionsView.integrateTab.scriptDescription',
-            {
-              defaultMessage:
-                'Track individual events, like clicks, by calling the <strong>trackEvent</strong> method.',
-            }
-          )}
-        </p>
+        <FormattedMessage
+          id="xpack.enterpriseSearch.analytics.collections.collectionsView.integrateTab.scriptDescription"
+          defaultMessage="Track individual events, like clicks, by calling the {trackEvent} method."
+          values={{
+            trackEvent: <strong>trackEvent</strong>,
+          }}
+        />
       </EuiText>
       <EuiSpacer size="s" />
       <EuiCodeBlock language="js" isCopyable>


### PR DESCRIPTION
### Description
In order to replace not rendered HTML (see the screenshot below) with the rendered one, it's required to add `FormattedMessage` to Behavioral Analytics integrate tab.

![Not rendered html example](https://user-images.githubusercontent.com/5709507/203792820-3b750b2e-9644-469c-ae12-72fa33337f9f.png)


This PR is dedicated to adding `FormattedMessage` for text formatting

### Example
<img width="497" alt="Screenshot 2022-11-24 at 14 13 25" src="https://user-images.githubusercontent.com/5709507/203792962-17c07a4b-7c4f-420b-8022-85143c42f19a.png">
