### PR TITLE
[ML] Removing duplicate tooltip text

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
@@ -487,7 +487,7 @@ export const AnomalyExplanationDetails: FC<{ anomaly: AnomaliesTableRecord }> = 
             'xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationDetails.incompleteBucketTooltip',
             {
               defaultMessage:
-                'If the bucket contains fewer samples than expected, the score is reduced. If the bucket contains fewer samples than expected, the score is reduced.',
+                'If the bucket contains fewer samples than expected, the score is reduced.',
             }
           )}
         >


### PR DESCRIPTION
Tooltip sentence was mistakenly repeated.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->