### PR TITLE
[Synthetics] Fix infinite loading of Monitor Details page

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -6,15 +6,7 @@
  */
 
 import React from 'react';
-import {
-  EuiTitle,
-  EuiPanel,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiSpacer,
-  EuiLoadingSpinner,
-} from '@elastic/eui';
+import { EuiTitle, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { LoadWhenInView } from '@kbn/observability-plugin/public';
 
@@ -35,16 +27,12 @@ import { MonitorErrorsCount } from './monitor_errors_count';
 import { useAbsoluteDate } from '../../../hooks';
 
 export const MonitorSummary = () => {
-  const { from: fromRelative, loading } = useEarliestStartDate();
+  const { from: fromRelative } = useEarliestStartDate();
   const toRelative = 'now';
 
   const { from, to } = useAbsoluteDate({ from: fromRelative, to: toRelative });
 
   const monitorId = useMonitorQueryId();
-
-  if (loading) {
-    return <LoadingState />;
-  }
 
   const dateLabel = from === 'now-30d/d' ? LAST_30_DAYS_LABEL : TO_DATE_LABEL;
 
@@ -68,7 +56,6 @@ export const MonitorSummary = () => {
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
-
             <EuiFlexGroup gutterSize="s">
               <EuiFlexItem>
                 <AvailabilityPanel from={from} to={to} />
@@ -137,16 +124,6 @@ export const MonitorSummary = () => {
     </>
   );
 };
-
-function LoadingState({ height }: { height?: string }) {
-  return (
-    <EuiFlexGroup alignItems="center" justifyContent="center" style={{ height: height ?? '100%' }}>
-      <EuiFlexItem grow={false}>
-        <EuiLoadingSpinner size="xl" />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-}
 
 const SUMMARY_LABEL = i18n.translate('xpack.synthetics.detailsPanel.summary', {
   defaultMessage: 'Summary',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_list.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_list.test.tsx
@@ -51,6 +51,10 @@ describe('useMonitorList', () => {
     };
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('returns expected initial state', () => {
     const {
       result: { current: hookResult },
@@ -62,6 +66,8 @@ describe('useMonitorList', () => {
   it('dispatches correct action for query url param', async () => {
     const query = 'xyz';
     const url = `/monitor/1?query=${query}`;
+
+    jest.useFakeTimers().setSystemTime(Date.now());
     const WrapperWithState = ({ children }: { children: React.ReactElement }) => {
       return (
         <WrappedHelper url={url} path={MONITOR_ROUTE}>
@@ -85,6 +91,8 @@ describe('useMonitorList', () => {
     const url = `/monitor/1?tags=${JSON.stringify(tags)}&locations=${JSON.stringify(
       locations
     )}&monitorType=${JSON.stringify(monitorType)}`;
+
+    jest.useFakeTimers().setSystemTime(Date.now());
     const WrapperWithState = ({ children }: { children: React.ReactElement }) => {
       return (
         <WrappedHelper url={url} path={MONITOR_ROUTE}>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
@@ -9,11 +9,15 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 
 interface SyntheticsRefreshContext {
   lastRefresh: number;
+  refreshInterval: number;
   refreshApp: () => void;
 }
 
+export const APP_DEFAULT_REFRESH_INTERVAL = 1000 * 30;
+
 const defaultContext: SyntheticsRefreshContext = {
   lastRefresh: 0,
+  refreshInterval: APP_DEFAULT_REFRESH_INTERVAL,
   refreshApp: () => {
     throw new Error('App refresh was not initialized, set it when you invoke the context');
   },
@@ -30,15 +34,15 @@ export const SyntheticsRefreshContextProvider: React.FC = ({ children }) => {
   }, [setLastRefresh]);
 
   const value = useMemo(() => {
-    return { lastRefresh, refreshApp };
+    return { lastRefresh, refreshApp, refreshInterval: APP_DEFAULT_REFRESH_INTERVAL };
   }, [lastRefresh, refreshApp]);
 
   useEffect(() => {
     const interval = setInterval(() => {
       refreshApp();
-    }, 1000 * 30);
+    }, value.refreshInterval);
     return () => clearInterval(interval);
-  }, [refreshApp]);
+  }, [refreshApp, value.refreshInterval]);
 
   return <SyntheticsRefreshContext.Provider value={value} children={children} />;
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_url_params.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_url_params.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from '../utils/testing';
 import React, { useState, Fragment } from 'react';
 import { useUrlParams, SyntheticsUrlParamsHook } from './use_url_params';
-import { SyntheticsRefreshContext } from '../contexts';
+import { APP_DEFAULT_REFRESH_INTERVAL, SyntheticsRefreshContext } from '../contexts';
 
 interface MockUrlParamsComponentProps {
   hook: SyntheticsUrlParamsHook;
@@ -53,7 +53,13 @@ describe('useUrlParams', () => {
 
   it('accepts router props, updates URL params, and returns the current params', async () => {
     const { findByText, history } = render(
-      <SyntheticsRefreshContext.Provider value={{ lastRefresh: 123, refreshApp: jest.fn() }}>
+      <SyntheticsRefreshContext.Provider
+        value={{
+          lastRefresh: 123,
+          refreshApp: jest.fn(),
+          refreshInterval: APP_DEFAULT_REFRESH_INTERVAL,
+        }}
+      >
         <UseUrlParamsTestComponent hook={useUrlParams} />
       </SyntheticsRefreshContext.Provider>
     );
@@ -71,7 +77,13 @@ describe('useUrlParams', () => {
 
   it('clears search when null is passed to params', async () => {
     const { findByText, history } = render(
-      <SyntheticsRefreshContext.Provider value={{ lastRefresh: 123, refreshApp: jest.fn() }}>
+      <SyntheticsRefreshContext.Provider
+        value={{
+          lastRefresh: 123,
+          refreshApp: jest.fn(),
+          refreshInterval: APP_DEFAULT_REFRESH_INTERVAL,
+        }}
+      >
         <UseUrlParamsTestComponent hook={useUrlParams} updateParams={null} />
       </SyntheticsRefreshContext.Provider>
     );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
@@ -11,14 +11,11 @@ import {
   PingsResponse,
   EncryptedSyntheticsSavedMonitor,
 } from '../../../../../common/runtime_types';
-import { QueryParams } from './api';
 import { createAsyncAction } from '../utils/actions';
 
 export const setMonitorDetailsLocationAction = createAction<string>(
   '[MONITOR SUMMARY] SET LOCATION'
 );
-
-export const getMonitorStatusAction = createAsyncAction<QueryParams, Ping>('[MONITOR DETAILS] GET');
 
 export const getMonitorAction = createAsyncAction<
   { monitorId: string },
@@ -29,6 +26,10 @@ export const getMonitorLastRunAction = createAsyncAction<
   { monitorId: string; locationId: string },
   PingsResponse
 >('[MONITOR DETAILS] GET LAST RUN');
+
+export const updateMonitorLastRunAction = createAction<{ data: Ping }>(
+  '[MONITOR DETAILS] UPdATE LAST RUN'
+);
 
 export const getMonitorRecentPingsAction = createAsyncAction<
   {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
@@ -15,12 +15,6 @@ import {
 } from '../../../../../common/runtime_types';
 import { API_URLS, SYNTHETICS_API_URLS } from '../../../../../common/constants';
 
-export interface QueryParams {
-  monitorId: string;
-  dateStart: string;
-  dateEnd: string;
-}
-
 export const fetchMonitorLastRun = async ({
   monitorId,
   locationId,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
@@ -5,10 +5,19 @@
  * 2.0.
  */
 
-import { takeLeading } from 'redux-saga/effects';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { takeLeading, takeEvery, select, put } from 'redux-saga/effects';
+
+import { ConfigKey, Ping, PingsResponse } from '../../../../../common/runtime_types';
 import { fetchEffectFactory } from '../utils/fetch_effect';
-import { getMonitorLastRunAction, getMonitorRecentPingsAction, getMonitorAction } from './actions';
+import {
+  getMonitorLastRunAction,
+  getMonitorRecentPingsAction,
+  getMonitorAction,
+  updateMonitorLastRunAction,
+} from './actions';
 import { fetchSyntheticsMonitor, fetchMonitorRecentPings, fetchMonitorLastRun } from './api';
+import { selectLastRunMetadata } from './selectors';
 
 export function* fetchSyntheticsMonitorEffect() {
   yield takeLeading(
@@ -28,6 +37,31 @@ export function* fetchSyntheticsMonitorEffect() {
       getMonitorLastRunAction.fail
     )
   );
+
+  // Additional listener on `getMonitorRecentPingsAction.success` to possibly update the `lastRun` as well
+  yield takeEvery(
+    getMonitorRecentPingsAction.success,
+    function* (action: PayloadAction<PingsResponse>): Generator {
+      // If `lastRun` and pings from `getMonitorRecentPingsAction` are of the same monitor and location AND
+      // `getMonitorRecentPingsAction` fetched the latest pings than `lastRun`, update `lastRun` as well
+      const lastRun = yield select(selectLastRunMetadata);
+      const lastRunPing = (lastRun as { data?: Ping })?.data;
+      const recentPingFromList = action.payload?.pings[0];
+
+      if (
+        lastRunPing &&
+        recentPingFromList &&
+        lastRunPing?.[ConfigKey.CONFIG_ID] &&
+        recentPingFromList?.[ConfigKey.CONFIG_ID] &&
+        lastRunPing?.[ConfigKey.CONFIG_ID] === recentPingFromList?.[ConfigKey.CONFIG_ID] &&
+        lastRunPing?.observer?.geo?.name === recentPingFromList?.observer?.geo?.name &&
+        new Date(lastRunPing?.timestamp) < new Date(recentPingFromList?.timestamp)
+      ) {
+        yield put(updateMonitorLastRunAction({ data: recentPingFromList }));
+      }
+    }
+  );
+
   yield takeLeading(
     getMonitorAction.get,
     fetchEffectFactory(fetchSyntheticsMonitor, getMonitorAction.success, getMonitorAction.fail)

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -81,7 +81,7 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
     })
 
     .addCase(getMonitorAction.get, (state, action) => {
-      state.syntheticsMonitorDispatchedAt = action.meta.timestamp;
+      state.syntheticsMonitorDispatchedAt = action.meta.dispatchedAt;
       state.syntheticsMonitorLoading = true;
     })
     .addCase(getMonitorAction.success, (state, action) => {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -30,6 +30,7 @@ export interface MonitorDetailsState {
   };
   syntheticsMonitorLoading: boolean;
   syntheticsMonitor: EncryptedSyntheticsSavedMonitor | null;
+  syntheticsMonitorDispatchedAt: number;
   error: IHttpSerializedFetchError | null;
   selectedLocationId: string | null;
 }
@@ -39,6 +40,7 @@ const initialState: MonitorDetailsState = {
   lastRun: { loading: false },
   syntheticsMonitor: null,
   syntheticsMonitorLoading: false,
+  syntheticsMonitorDispatchedAt: 0,
   error: null,
   selectedLocationId: null,
 };
@@ -78,7 +80,8 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       state.pings.loading = false;
     })
 
-    .addCase(getMonitorAction.get, (state) => {
+    .addCase(getMonitorAction.get, (state, action) => {
+      state.syntheticsMonitorDispatchedAt = action.meta.timestamp;
       state.syntheticsMonitorLoading = true;
     })
     .addCase(getMonitorAction.success, (state, action) => {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -13,6 +13,7 @@ import { IHttpSerializedFetchError } from '../utils/http_error';
 
 import {
   getMonitorLastRunAction,
+  updateMonitorLastRunAction,
   getMonitorRecentPingsAction,
   setMonitorDetailsLocationAction,
   getMonitorAction,
@@ -63,6 +64,9 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
     .addCase(getMonitorLastRunAction.fail, (state, action) => {
       state.lastRun.loading = false;
       state.error = action.payload;
+    })
+    .addCase(updateMonitorLastRunAction, (state, action) => {
+      state.lastRun.data = action.payload.data;
     })
     .addCase(getMonitorRecentPingsAction.get, (state, action) => {
       state.pings.loading = true;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/effects.ts
@@ -34,6 +34,6 @@ export function* fetchOverviewStatusEffect() {
       fetchOverviewStatus,
       fetchOverviewStatusAction.success,
       fetchOverviewStatusAction.fail
-    )
+    ) as ReturnType<typeof fetchEffectFactory>
   );
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
@@ -5,11 +5,19 @@
  * 2.0.
  */
 
+import { PayloadAction } from '@reduxjs/toolkit';
 import { takeEvery } from 'redux-saga/effects';
 import { fetchEffectFactory } from '../utils/fetch_effect';
 import { fetchMonitorPingStatuses } from './api';
 
 import { getMonitorPingStatusesAction } from './actions';
+
+export function* fetchPingStatusesEffect2() {
+  yield takeEvery(
+    getMonitorPingStatusesAction.get,
+    function* (action: PayloadAction<any>): Generator {}
+  );
+}
 
 export function* fetchPingStatusesEffect() {
   yield takeEvery(
@@ -18,6 +26,6 @@ export function* fetchPingStatusesEffect() {
       fetchMonitorPingStatuses,
       getMonitorPingStatusesAction.success,
       getMonitorPingStatusesAction.fail
-    )
+    ) as ReturnType<typeof fetchEffectFactory>
   );
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/ping_status/effects.ts
@@ -5,19 +5,11 @@
  * 2.0.
  */
 
-import { PayloadAction } from '@reduxjs/toolkit';
 import { takeEvery } from 'redux-saga/effects';
 import { fetchEffectFactory } from '../utils/fetch_effect';
 import { fetchMonitorPingStatuses } from './api';
 
 import { getMonitorPingStatusesAction } from './actions';
-
-export function* fetchPingStatusesEffect2() {
-  yield takeEvery(
-    getMonitorPingStatusesAction.get,
-    function* (action: PayloadAction<any>): Generator {}
-  );
-}
 
 export function* fetchPingStatusesEffect() {
   yield takeEvery(

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
@@ -22,7 +22,7 @@ function prepareForTimestamp<Payload>(payload: Payload) {
   return {
     payload,
     meta: {
-      timestamp: Date.now(),
+      dispatchedAt: Date.now(),
     },
   };
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
@@ -18,6 +18,7 @@ export function createAsyncAction<Payload, SuccessPayload>(actionStr: string) {
 
 export type Nullable<T> = T | null;
 
+// Action prepare function which adds meta.dispatchedAt timestamp to the action
 function prepareForTimestamp<Payload>(payload: Payload) {
   return {
     payload,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
@@ -10,10 +10,19 @@ import type { IHttpSerializedFetchError } from './http_error';
 
 export function createAsyncAction<Payload, SuccessPayload>(actionStr: string) {
   return {
-    get: createAction<Payload>(actionStr),
+    get: createAction(actionStr, (payload: Payload) => prepareForTimestamp(payload)),
     success: createAction<SuccessPayload>(`${actionStr}_SUCCESS`),
     fail: createAction<IHttpSerializedFetchError>(`${actionStr}_FAIL`),
   };
 }
 
 export type Nullable<T> = T | null;
+
+function prepareForTimestamp<Payload>(payload: Payload) {
+  return {
+    payload,
+    meta: {
+      timestamp: Date.now(),
+    },
+  };
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -419,6 +419,7 @@ function getMonitorDetailsMockSlice() {
       created_at: '2022-05-24T13:20:49.322Z',
     },
     syntheticsMonitorLoading: false,
+    syntheticsMonitorDispatchedAt: 0,
     error: null,
     selectedLocationId: 'us_central',
   };


### PR DESCRIPTION
## Summary

With the `SyntheticsRefreshContext` now refreshing itself periodically, hooks which are called from multiple child components in parallel and which load data when initialized, may cause multiple redundant, or based on the flow, unending back to back calls to server. This is because a hook called multiple times in parallel, will dispatch the same action the number of times it is initialized.

The PR solves one such case on Monitor details page, which was loading itself over and over.

The PR also fixes the issue where **Last test run** panel on Monitor Details page stays out of date when data is auto refreshed.

Before:

https://user-images.githubusercontent.com/2748376/203871355-afdbb9aa-77ce-4459-a98f-9077fbed83e8.mov


After:

https://user-images.githubusercontent.com/2748376/203871360-2ac584e4-73d6-4698-b137-119284f27144.mov



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->