### PR TITLE
[Enterprise Search] Set `enabled` connector scheduling prop when update crawler scheduling

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
@@ -27,7 +27,6 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { CrawlerIndex } from '../../../../../../../common/types/indices';
 import {
   HOURS_UNIT_LABEL,
   DAYS_UNIT_LABEL,
@@ -36,23 +35,21 @@ import {
 } from '../../../../../shared/constants';
 import { EnterpriseSearchCronEditor } from '../../../../../shared/cron_editor/enterprise_search_cron_editor';
 import { docLinks } from '../../../../../shared/doc_links/doc_links';
-import { UpdateConnectorSchedulingApiLogic } from '../../../../api/connector/update_connector_scheduling_api_logic';
 import { CrawlUnits } from '../../../../api/crawler/types';
 import { isCrawlerIndex } from '../../../../utils/indices';
-import { IndexViewLogic } from '../../index_view_logic';
 
 import { AutomaticCrawlSchedulerLogic } from './automatic_crawl_scheduler_logic';
 
 export const AutomaticCrawlScheduler: React.FC = () => {
-  const { index } = useValues(IndexViewLogic);
-  const { makeRequest } = useActions(UpdateConnectorSchedulingApiLogic);
+  const {
+    setCrawlAutomatically,
+    setCrawlFrequency,
+    setCrawlUnit,
+    setUseConnectorSchedule,
+    submitConnectorSchedule,
+  } = useActions(AutomaticCrawlSchedulerLogic);
 
-  const scheduling = (index as CrawlerIndex)?.connector?.scheduling;
-
-  const { setCrawlFrequency, setCrawlUnit, setUseConnectorSchedule, toggleCrawlAutomatically } =
-    useActions(AutomaticCrawlSchedulerLogic);
-
-  const { crawlAutomatically, crawlFrequency, crawlUnit, useConnectorSchedule } = useValues(
+  const { index, crawlAutomatically, crawlFrequency, crawlUnit, useConnectorSchedule } = useValues(
     AutomaticCrawlSchedulerLogic
   );
 
@@ -84,7 +81,7 @@ export const AutomaticCrawlScheduler: React.FC = () => {
                   defaultMessage: 'Enable recurring crawls with the following schedule',
                 }
               )}
-              onChange={toggleCrawlAutomatically}
+              onChange={(e) => setCrawlAutomatically(e.target.checked)}
               compressed
             />
           </EuiFormRow>
@@ -124,11 +121,11 @@ export const AutomaticCrawlScheduler: React.FC = () => {
               >
                 <EnterpriseSearchCronEditor
                   disabled={!crawlAutomatically || !useConnectorSchedule}
-                  scheduling={scheduling}
+                  scheduling={index.connector.scheduling}
                   onChange={(newScheduling) =>
-                    makeRequest({
-                      connectorId: index.connector.id,
-                      scheduling: { ...newScheduling },
+                    submitConnectorSchedule({
+                      ...newScheduling,
+                      enabled: true,
                     })
                   }
                 />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler_logic.ts
@@ -7,16 +7,27 @@
 
 import { kea, MakeLogicType } from 'kea';
 
+import { ConnectorScheduling } from '../../../../../../../common/types/connectors';
+
+import { CrawlerIndex } from '../../../../../../../common/types/indices';
+import { Actions } from '../../../../../shared/api_logic/create_api_logic';
+
 import { flashAPIErrors } from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
+import {
+  UpdateConnectorSchedulingApiLogic,
+  UpdateConnectorSchedulingArgs,
+} from '../../../../api/connector/update_connector_scheduling_api_logic';
 import { CrawlSchedule, CrawlScheduleFromServer, CrawlUnits } from '../../../../api/crawler/types';
 import { crawlScheduleServerToClient } from '../../../../api/crawler/utils';
 import { IndexNameLogic } from '../../index_name_logic';
+import { IndexViewLogic } from '../../index_view_logic';
 
 export interface AutomaticCrawlSchedulerLogicValues {
   crawlAutomatically: boolean;
   crawlFrequency: CrawlSchedule['frequency'];
   crawlUnit: CrawlSchedule['unit'];
+  index: CrawlerIndex;
   isSubmitting: boolean;
   useConnectorSchedule: CrawlSchedule['useConnectorSchedule'];
 }
@@ -33,7 +44,9 @@ export interface AutomaticCrawlSchedulerLogicActions {
   onDoneSubmitting(): void;
   enableCrawlAutomatically(): void;
   fetchCrawlSchedule(): void;
+  makeUpdateConnectorSchedulingRequest: Actions<{}, UpdateConnectorSchedulingArgs>['makeRequest'];
   saveChanges(): void;
+  setCrawlAutomatically(crawlAutomatically: boolean): { crawlAutomatically: boolean };
   setCrawlFrequency(crawlFrequency: CrawlSchedule['frequency']): {
     crawlFrequency: CrawlSchedule['frequency'];
   };
@@ -42,14 +55,21 @@ export interface AutomaticCrawlSchedulerLogicActions {
   setUseConnectorSchedule(useConnectorSchedule: CrawlSchedule['useConnectorSchedule']): {
     useConnectorSchedule: CrawlSchedule['useConnectorSchedule'];
   };
+  submitConnectorSchedule(scheduling: ConnectorScheduling): { scheduling: ConnectorScheduling };
   submitCrawlSchedule(): void;
-  toggleCrawlAutomatically(): void;
 }
 
 export const AutomaticCrawlSchedulerLogic = kea<
   MakeLogicType<AutomaticCrawlSchedulerLogicValues, AutomaticCrawlSchedulerLogicActions>
 >({
   path: ['enterprise_search', 'crawler', 'automatic_crawl_scheduler_logic'],
+  connect: {
+    actions: [
+      UpdateConnectorSchedulingApiLogic,
+      ['makeRequest as makeUpdateConnectorSchedulingRequest'],
+    ],
+    values: [IndexViewLogic, ['index']],
+  },
   actions: () => ({
     clearCrawlSchedule: true,
     deleteCrawlSchedule: true,
@@ -59,19 +79,20 @@ export const AutomaticCrawlSchedulerLogic = kea<
     fetchCrawlSchedule: true,
     saveChanges: true,
     setCrawlSchedule: (crawlSchedule: CrawlSchedule) => ({ crawlSchedule }),
+    submitConnectorSchedule: (scheduling) => ({ scheduling }),
     submitCrawlSchedule: true,
+    setCrawlAutomatically: (crawlAutomatically) => ({ crawlAutomatically }),
     setCrawlFrequency: (crawlFrequency: string) => ({ crawlFrequency }),
     setCrawlUnit: (crawlUnit: CrawlUnits) => ({ crawlUnit }),
     setUseConnectorSchedule: (useConnectorSchedule) => ({ useConnectorSchedule }),
-    toggleCrawlAutomatically: true,
   }),
   reducers: () => ({
     crawlAutomatically: [
       false,
       {
         clearCrawlSchedule: () => false,
+        setCrawlAutomatically: (_, { crawlAutomatically }) => crawlAutomatically,
         setCrawlSchedule: () => true,
-        toggleCrawlAutomatically: (crawlAutomatically) => !crawlAutomatically,
       },
     ],
     crawlFrequency: [
@@ -80,6 +101,9 @@ export const AutomaticCrawlSchedulerLogic = kea<
         clearCrawlSchedule: () => DEFAULT_VALUES.crawlFrequency,
         setCrawlSchedule: (_, { crawlSchedule: { frequency } }) => frequency,
         setCrawlFrequency: (_, { crawlFrequency }) => crawlFrequency,
+        // TODO Enable this reducer once BE allows
+        // setUseConnectorSchedule: (crawlFrequency) =>
+        //   crawlFrequency || DEFAULT_VALUES.crawlFrequency,
       },
     ],
     crawlUnit: [
@@ -88,6 +112,7 @@ export const AutomaticCrawlSchedulerLogic = kea<
         clearCrawlSchedule: () => DEFAULT_VALUES.crawlUnit,
         setCrawlSchedule: (_, { crawlSchedule: { unit } }) => unit,
         setCrawlUnit: (_, { crawlUnit }) => crawlUnit,
+        // setUseConnectorSchedule: (crawlUnit) => crawlUnit || DEFAULT_VALUES.crawlUnit,
       },
     ],
     isSubmitting: [
@@ -101,6 +126,8 @@ export const AutomaticCrawlSchedulerLogic = kea<
     useConnectorSchedule: [
       false,
       {
+        // setCrawlAutomatically: (useConnectorSchedule, { crawlAutomatically }) =>
+        //   crawlAutomatically || useConnectorSchedule,
         setCrawlSchedule: (_, { crawlSchedule: { useConnectorSchedule = false } }) =>
           useConnectorSchedule,
         setUseConnectorSchedule: (_, { useConnectorSchedule }) => useConnectorSchedule,
@@ -148,11 +175,25 @@ export const AutomaticCrawlSchedulerLogic = kea<
       } else {
         actions.deleteCrawlSchedule();
       }
+      actions.submitConnectorSchedule({
+        ...values.index.connector.scheduling,
+        enabled: values.crawlAutomatically && values.useConnectorSchedule,
+      });
     },
-    setCrawlUnit: actions.saveChanges,
+    setCrawlAutomatically: actions.saveChanges,
     setCrawlFrequency: actions.saveChanges,
+    setCrawlUnit: actions.saveChanges,
     setUseConnectorSchedule: actions.saveChanges,
-    toggleCrawlAutomatically: actions.saveChanges,
+    submitConnectorSchedule: async ({ scheduling }) => {
+      try {
+        await actions.makeUpdateConnectorSchedulingRequest({
+          connectorId: values.index.connector.id,
+          scheduling,
+        });
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
     submitCrawlSchedule: async () => {
       const { http } = HttpLogic.values;
       const { indexName } = IndexNameLogic.values;


### PR DESCRIPTION

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
