### PR TITLE
[TIP] Extend preselected categories list

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.test.tsx
@@ -37,7 +37,7 @@ describe('<IndicatorsFieldBrowser />', () => {
         onResetColumns: stub,
         onToggleColumn: stub,
         options: {
-          preselectedCategoryIds: ['threat'],
+          preselectedCategoryIds: ['threat', 'base', 'event', 'agent'],
         },
       })
     );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/field_browser/field_browser.tsx
@@ -30,7 +30,7 @@ export const IndicatorsFieldBrowser: VFC<IndicatorsFieldBrowserProps> = ({
     onResetColumns,
     onToggleColumn,
     options: {
-      preselectedCategoryIds: ['threat'],
+      preselectedCategoryIds: ['threat', 'base', 'event', 'agent'],
     },
   });
 };


### PR DESCRIPTION
## Summary

Preselected categories list is now extended with `agent`, `base` and `event` fields.

![preselected](https://user-images.githubusercontent.com/11671118/204263661-f2add53d-6d47-4b94-a1b3-5e105aa81e8a.png)

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
