### PR TITLE
[APM] Disable service metrics and remove the option to enable it in settings

### DIFF
--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -7,7 +7,6 @@
 
 import Boom from '@hapi/boom';
 import { isoToEpochRt, jsonRt, toNumberRt } from '@kbn/io-ts-utils';
-import { enableServiceMetrics } from '@kbn/observability-plugin/common';
 import * as t from 'io-ts';
 import { uniq, mergeWith } from 'lodash';
 import {
@@ -126,7 +125,6 @@ const servicesRoute = createApmServerRoute({
       probability,
     } = params.query;
     const savedObjectsClient = (await context.core).savedObjects.client;
-    const coreContext = await resources.context.core;
 
     const [mlClient, apmEventClient, serviceGroup, randomSampler] =
       await Promise.all([
@@ -138,12 +136,9 @@ const servicesRoute = createApmServerRoute({
         getRandomSampler({ security, request, probability }),
       ]);
 
-    const serviceMetricsEnabled =
-      await coreContext.uiSettings.client.get<boolean>(enableServiceMetrics);
-
     const { searchAggregatedTransactions, searchAggregatedServiceMetrics } =
       await getServiceInventorySearchSource({
-        serviceMetricsEnabled,
+        serviceMetricsEnabled: false, // Disable serviceMetrics for 8.5 & 8.6
         config,
         apmEventClient,
         kuery,
@@ -220,7 +215,6 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
       request,
       plugins: { security },
     } = resources;
-    const coreContext = await resources.context.core;
 
     const { environment, kuery, offset, start, end, probability } =
       params.query;
@@ -232,12 +226,9 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
       getRandomSampler({ security, request, probability }),
     ]);
 
-    const serviceMetricsEnabled =
-      await coreContext.uiSettings.client.get<boolean>(enableServiceMetrics);
-
     const { searchAggregatedTransactions, searchAggregatedServiceMetrics } =
       await getServiceInventorySearchSource({
-        serviceMetricsEnabled,
+        serviceMetricsEnabled: false, // Disable serviceMetrics for 8.5 & 8.6
         config,
         apmEventClient,
         kuery,

--- a/x-pack/plugins/observability/common/index.ts
+++ b/x-pack/plugins/observability/common/index.ts
@@ -24,7 +24,6 @@ export {
   apmOperationsTab,
   apmLabsButton,
   enableInfrastructureHostsView,
-  enableServiceMetrics,
   enableAwsLambdaMetrics,
   enableAgentExplorerView,
   apmAWSLambdaPriceFactor,

--- a/x-pack/plugins/observability/common/ui_settings_keys.ts
+++ b/x-pack/plugins/observability/common/ui_settings_keys.ts
@@ -20,7 +20,6 @@ export const apmOperationsTab = 'observability:apmOperationsTab';
 export const apmLabsButton = 'observability:apmLabsButton';
 export const enableInfrastructureHostsView = 'observability:enableInfrastructureHostsView';
 export const enableAwsLambdaMetrics = 'observability:enableAwsLambdaMetrics';
-export const enableServiceMetrics = 'observability:apmEnableServiceMetrics';
 export const enableAgentExplorerView = 'observability:apmAgentExplorerView';
 export const apmAWSLambdaPriceFactor = 'observability:apmAWSLambdaPriceFactor';
 export const apmAWSLambdaRequestCostPerMillion = 'observability:apmAWSLambdaRequestCostPerMillion';

--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -27,7 +27,6 @@ import {
   apmAWSLambdaRequestCostPerMillion,
   enableCriticalPath,
   enableInfrastructureHostsView,
-  enableServiceMetrics,
 } from '../common/ui_settings_keys';
 
 const technicalPreviewLabel = i18n.translate(
@@ -163,21 +162,6 @@ export const uiSettings: Record<string, UiSettings> = {
         }
       ),
     },
-    showInLabs: true,
-  },
-  [enableServiceMetrics]: {
-    category: [observabilityFeatureId],
-    name: i18n.translate('xpack.observability.apmEnableServiceMetrics', {
-      defaultMessage: 'Service metrics',
-    }),
-    value: false,
-    description: i18n.translate('xpack.observability.apmEnableServiceMetricsGroupsDescription', {
-      defaultMessage:
-        '{technicalPreviewLabel} Enables Service metrics. When is enabled, additional configuration in APM Server is required.',
-      values: { technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>` },
-    }),
-    schema: schema.boolean(),
-    requiresPageReload: true,
     showInLabs: true,
   },
   [apmServiceInventoryOptimizedSorting]: {


### PR DESCRIPTION

## Summary
closes https://github.com/elastic/kibana/issues/145745 

The feature Service Metrics was released and marked as a technical preview in 8.5 and it was disabled by default. 

As we expect to have some breaking changes in the following releases, we disable and remove the feature so it would simplify the backward compatibility. 


The PR includes:
1. Disable service metrics
2. Remove the option to enable it from labs and advanced settings. 


 



<!--ONMERGE {"backportTargets":["8.5","8.6"]} ONMERGE-->