### PR TITLE
Fix typos in @kbn/handlebars package

### DIFF
--- a/packages/kbn-handlebars/README.md
+++ b/packages/kbn-handlebars/README.md
@@ -69,7 +69,7 @@ The tests for `@kbn/handlebars` are integrated into the regular test suite of Ki
 node scripts/jest packages/kbn-handlebars
 ```
 
-By default each test will run both the original `handlebars` code and the modified `@kbn/handlebars` code to compare if the output of the two are identical. To isolate a test run to just one or the other, you can use the following environment variables:
+By default, each test will run both the original `handlebars` code and the modified `@kbn/handlebars` code to compare if the output of the two are identical. To isolate a test run to just one or the other, you can use the following environment variables:
 
 - `EVAL=1` - Set to only run the original `handlebars` implementation that uses `eval`.
 - `AST=1` - Set to only run the modified `@kbn/handlebars` implementation that doesn't use `eval`.
@@ -84,7 +84,7 @@ Some of the tests have been copied from the upstream `handlebars` project and mo
 
 If the script outputs a diff for a given file, it means that this file has been updated.
 
-_Note: that this will look for chanages in the `4.x` branch of the `handlebars.js` repo only. Changes in the `master` branch are ignored._
+_Note: that this will look for changes in the `4.x` branch of the `handlebars.js` repo only. Changes in the `master` branch are ignored._
 
 Once all updates have been manually merged with our versions of the files, run the following script to "lock" us into the new updates:
 

--- a/packages/kbn-handlebars/src/upstream/index.builtins.test.ts
+++ b/packages/kbn-handlebars/src/upstream/index.builtins.test.ts
@@ -276,7 +276,7 @@ describe('builtin helpers', () => {
     // TODO: This test has been added to the `4.x` branch of the handlebars.js repo along with a code-fix,
     // but a new version of the handlebars package containing this fix has not yet been published to npm.
     //
-    // Before enabling this code, a new version of handlebars needs to be released and the corrosponding
+    // Before enabling this code, a new version of handlebars needs to be released and the corresponding
     // updates needs to be applied to this implementation.
     //
     // See: https://github.com/handlebars-lang/handlebars.js/commit/30dbf0478109ded8f12bb29832135d480c17e367


### PR DESCRIPTION
As a follow up to #146174 here's a PR containing the typo-fixes found by @azasypkin.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->