### PR TITLE
[Security Solution] Stop Job should show when ml job toggle is on

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/ml_job_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/ml_job_description.tsx
@@ -93,6 +93,7 @@ const MlJobDescriptionComponent: React.FC<{
   });
 
   const jobIdSpan = <span data-test-subj="machineLearningJobId">{jobId}</span>;
+  const isStarted = isJobStarted(job.jobState, job.datafeedState);
 
   const handleJobStateChange = useCallback(
     async (_, latestTimestampMs: number, enable: boolean) => {
@@ -102,7 +103,7 @@ const MlJobDescriptionComponent: React.FC<{
     [enableDatafeed, job, refreshJob]
   );
 
-  return job != null ? (
+  return (
     <Wrapper>
       <div>
         <JobLink href={jobUrl} target="_blank">
@@ -122,12 +123,10 @@ const MlJobDescriptionComponent: React.FC<{
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false} style={{ marginLeft: '0' }}>
-          {i18n.ML_RUN_JOB_LABEL}
+          {isStarted ? i18n.ML_STOP_JOB_LABEL : i18n.ML_RUN_JOB_LABEL}
         </EuiFlexItem>
       </EuiFlexGroup>
     </Wrapper>
-  ) : (
-    jobIdSpan
   );
 };
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/translations.tsx
@@ -98,6 +98,13 @@ export const ML_RUN_JOB_LABEL = i18n.translate(
   }
 );
 
+export const ML_STOP_JOB_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDescription.mlStopJobLabel',
+  {
+    defaultMessage: 'Stop job',
+  }
+);
+
 export const ML_JOB_STARTED = i18n.translate(
   'xpack.securitySolution.detectionEngine.ruleDescription.mlJobStartedDescription',
   {


### PR DESCRIPTION
## Summary

This PR fixes incorrect wording of the ML Job run/stop status label. Right now we always show "Run job" label even when job has been started already. With this fix we will show "Stop job" in case of running job.

Job is not running state:

<img width="782" alt="Screenshot 2022-11-28 at 15 55 37" src="https://user-images.githubusercontent.com/2700761/204308912-b53fa125-715a-4240-b6a3-e75be68d4251.png">

Job is running state:

<img width="785" alt="Screenshot 2022-11-28 at 15 55 29" src="https://user-images.githubusercontent.com/2700761/204308956-c0fb7cae-8c95-4f26-8bae-ddff3e44a214.png">

Ticket: #145324


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->