### PR TITLE
[Enterprise Search] Replace long-running jobs with stuck jobs

### DIFF
--- a/x-pack/plugins/enterprise_search/common/stats.ts
+++ b/x-pack/plugins/enterprise_search/common/stats.ts
@@ -10,6 +10,6 @@ export interface SyncJobsStats {
   errors: number;
   in_progress: number;
   incomplete: number;
-  long_running: number;
   orphaned_jobs: number;
+  stuck: number;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
@@ -85,20 +85,16 @@ export const IndicesStats: React.FC = () => {
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiPanel
-              color={data?.long_running ? 'warning' : 'subdued'}
-              hasShadow={false}
-              paddingSize="l"
-            >
+            <EuiPanel color={data?.stuck ? 'warning' : 'subdued'} hasShadow={false} paddingSize="l">
               <EuiStat
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.longRunningSyncs',
                   {
-                    defaultMessage: 'Long running syncs',
+                    defaultMessage: 'Stuck syncs',
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.long_running}
+                title={data?.stuck}
               />
             </EuiPanel>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
@@ -45,7 +45,7 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
     },
   });
 
-  const longRunningProgressJobsCountResponse = await client.asCurrentUser.count({
+  const stuckJobsCountResponse = await client.asCurrentUser.count({
     index: CONNECTORS_JOBS_INDEX,
     query: {
       bool: {
@@ -57,8 +57,8 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
           },
           {
             range: {
-              started_at: {
-                lt: moment().subtract(1, 'day').toISOString(),
+              last_seen: {
+                lt: moment().subtract(1, 'minute').toISOString(),
               },
             },
           },
@@ -129,8 +129,8 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
     errors: errorResponse.count,
     in_progress: inProgressJobsCountResponse.count,
     incomplete: incompleteResponse.count,
-    long_running: longRunningProgressJobsCountResponse.count,
     orphaned_jobs: orphanedJobsCountResponse.count,
+    stuck: stuckJobsCountResponse.count,
   };
 
   return response;


### PR DESCRIPTION
This replaces the long-running syncs view with stuck syncs.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->