### PR TITLE
[PresentationUtil] Fix Canvas expression autocomplete

### DIFF
--- a/src/plugins/presentation_util/public/components/expression_input/language.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/language.ts
@@ -116,7 +116,7 @@ export function registerExpressionsLanguage(functions: ExpressionFunction[]) {
   expressionsLanguage.keywords = functions.map((fn) => fn.name);
   expressionsLanguage.deprecated = functions.filter((fn) => fn.deprecated).map((fn) => fn.name);
   monaco.languages.onLanguage(EXPRESSIONS_LANGUAGE_ID, () => {
-    monaco.languages.register({ id: EXPRESSIONS_LANGUAGE_ID });
     monaco.languages.setMonarchTokensProvider(EXPRESSIONS_LANGUAGE_ID, expressionsLanguage);
   });
+  monaco.languages.register({ id: EXPRESSIONS_LANGUAGE_ID });
 }


### PR DESCRIPTION
Fixes #146243 

## Summary

Fixes Canvas expression autocomplete

https://github.com/elastic/kibana/pull/143739 upgraded the monaco-editor dependency which uses a callback to the  `onLanguage` method to initialize the expressions. The PR moved the `monaco.languages.register` command inside this callback and which was never triggered.

Moving the `monaco.languages.register` command outside the callback appears to fix the issue. 


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->