### PR TITLE
[ML] Fix caret direction for expanded state of table rows

### DIFF
--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -223,7 +223,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
                   }
                 )
           }
-          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
+          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowDown' : 'arrowRight'}
         />
       ),
       valign: 'top',

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/expandable_section/expandable_section.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/expandable_section/expandable_section.tsx
@@ -86,7 +86,7 @@ export const ExpandableSection: FC<ExpandableSectionProps> = ({
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
               onClick={toggleExpanded}
-              iconType={isExpanded ? 'arrowUp' : 'arrowDown'}
+              iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
               iconSide="right"
               flush="left"
               data-test-subj={`mlDFExpandableSection-${dataTestId}-toggle-button`}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
@@ -198,7 +198,7 @@ export const useColumns = (
                   values: { analyticsId: item.config.id },
                 })
           }
-          iconType={expandedRowItemIds.includes(item.config.id) ? 'arrowUp' : 'arrowDown'}
+          iconType={expandedRowItemIds.includes(item.config.id) ? 'arrowDown' : 'arrowRight'}
         />
       ),
       'data-test-subj': 'mlAnalyticsTableRowDetailsToggle',

--- a/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/models_management/models_list.tsx
@@ -297,7 +297,7 @@ export const ModelsList: FC<Props> = ({
                   defaultMessage: 'Expand',
                 })
           }
-          iconType={itemIdToExpandedRowMap[item.model_id] ? 'arrowUp' : 'arrowDown'}
+          iconType={itemIdToExpandedRowMap[item.model_id] ? 'arrowDown' : 'arrowRight'}
         />
       ),
       'data-test-subj': 'mlModelsTableRowDetailsToggle',

--- a/x-pack/plugins/ml/public/application/trained_models/nodes_overview/nodes_list.tsx
+++ b/x-pack/plugins/ml/public/application/trained_models/nodes_overview/nodes_list.tsx
@@ -114,7 +114,7 @@ export const NodesList: FC<NodesListProps> = ({ compactView = false }) => {
                   defaultMessage: 'Expand',
                 })
           }
-          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
+          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowDown' : 'arrowRight'}
         />
       ),
       'data-test-subj': 'mlNodesTableRowDetailsToggle',

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -133,7 +133,7 @@ export const useColumns = (
                   values: { transformId: item.config.id },
                 })
           }
-          iconType={expandedRowItemIds.includes(item.config.id) ? 'arrowUp' : 'arrowDown'}
+          iconType={expandedRowItemIds.includes(item.config.id) ? 'arrowDown' : 'arrowRight'}
           data-test-subj="transformListRowDetailsToggle"
         />
       ),


### PR DESCRIPTION
## Summary

Fixes the icons used to indicate the collapsed / expanded state of table rows in the Data Frame Analytics, Trained Models and Explain Log Rate Spikes pages in the ML plugin, and the Transforms list page. They are now consistent with other tables, with a **right caret** to indicate a **closed section** and a **down caret** for **open sections**. 

### Data frame analytics jobs list
<img width="689" alt="image" src="https://user-images.githubusercontent.com/7405507/204346940-e56436e1-2e21-4f4d-a618-2b243438a55f.png">

### Data frame analytics results
<img width="730" alt="image" src="https://user-images.githubusercontent.com/7405507/204346993-32c600d1-f94c-4cb3-8740-e5344ecd6b4e.png">

### Trained models list
<img width="788" alt="image" src="https://user-images.githubusercontent.com/7405507/204347063-2a50ac16-456c-4ca0-a446-b8535f5ba5cb.png">

### Nodes list
<img width="506" alt="image" src="https://user-images.githubusercontent.com/7405507/204347215-970a07fe-062c-4c6f-bdfc-ed0f473e9681.png">

### Explain Log Rate Spikes grouped results
<img width="809" alt="image" src="https://user-images.githubusercontent.com/7405507/204347302-10975598-5e88-42ac-a648-eae64976ed84.png">

### Transform management
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/7405507/204347393-124a366e-f5a9-44ba-8bfc-94788f334ba9.png">



Fixes #142898


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->