### PR TITLE
[Cloud Posture] Add test for filtering findings by evaluation

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
@@ -24,7 +24,11 @@ const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
 };
 
 export const CspEvaluationBadge = ({ type }: Props) => (
-  <EuiBadge color={getColor(type)} style={{ width: BADGE_WIDTH, textAlign: 'center' }}>
+  <EuiBadge
+    color={getColor(type)}
+    style={{ width: BADGE_WIDTH, textAlign: 'center' }}
+    data-test-subj={`${type}_finding`}
+  >
     {type === 'failed' ? (
       <FormattedMessage id="xpack.csp.cspEvaluationBadge.failLabel" defaultMessage="Fail" />
     ) : (

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_distribution_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_distribution_bar.tsx
@@ -126,6 +126,7 @@ const DistributionBar: React.FC<Omit<Props, 'pageEnd' | 'pageStart'>> = ({
         distributionOnClick={() => {
           distributionOnClick(RULE_PASSED);
         }}
+        data-test-subj="distribution_bar_passed"
       />
       <DistributionBarPart
         value={failed}
@@ -133,6 +134,7 @@ const DistributionBar: React.FC<Omit<Props, 'pageEnd' | 'pageStart'>> = ({
         distributionOnClick={() => {
           distributionOnClick(RULE_FAILED);
         }}
+        data-test-subj="distribution_bar_failed"
       />
     </EuiFlexGroup>
   );
@@ -142,12 +144,15 @@ const DistributionBarPart = ({
   value,
   color,
   distributionOnClick,
+  ...rest
 }: {
   value: number;
   color: string;
   distributionOnClick: () => void;
+  ['data-test-subj']: string;
 }) => (
   <button
+    data-test-subj={rest['data-test-subj']}
     onClick={distributionOnClick}
     css={css`
       flex: ${value};

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -47,6 +47,14 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     },
   };
 
+  const distributionBar = {
+    filterBy: async (type: 'passed' | 'failed') => {
+      await testSubjects.click(
+        type === 'failed' ? 'distribution_bar_failed' : 'distribution_bar_passed'
+      );
+    },
+  };
+
   const table = {
     getElement: () => testSubjects.find('findings_table'),
 
@@ -160,5 +168,6 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     navigateToFindingsPage,
     table,
     index,
+    distributionBar,
   };
 }

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -48,11 +48,8 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
   };
 
   const distributionBar = {
-    filterBy: async (type: 'passed' | 'failed') => {
-      await testSubjects.click(
-        type === 'failed' ? 'distribution_bar_failed' : 'distribution_bar_passed'
-      );
-    },
+    filterBy: async (type: 'passed' | 'failed') =>
+      testSubjects.click(type === 'failed' ? 'distribution_bar_failed' : 'distribution_bar_passed'),
   };
 
   const table = {
@@ -82,6 +79,12 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
       const element = await table.getElement();
       const rows = await element.findAllByCssSelector('tbody tr');
       return rows.length;
+    },
+
+    getFindingsCount: async (type: 'passed' | 'failed') => {
+      const element = await table.getElement();
+      const items = await element.findAllByCssSelector(`span[data-test-subj="${type}_finding"]`);
+      return items.length;
     },
 
     getRowIndexForValue: async (columnName: string, value: string) => {

--- a/x-pack/test/cloud_security_posture_functional/pages/findings.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings.ts
@@ -112,28 +112,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     describe('DistributionBar', () => {
-      it('filters by passed findings', async () => {
-        await distributionBar.filterBy('passed');
+      (['passed', 'failed'] as const).forEach((type) => {
+        it(`filters by ${type} findings`, async () => {
+          await distributionBar.filterBy(type);
 
-        const passed = data
-          .filter(({ result }) => result.evaluation === 'passed')
-          .map(() => 'Pass');
+          const items = data.filter(({ result }) => result.evaluation === type);
+          expect(await table.getFindingsCount(type)).to.eql(items.length);
 
-        expect(await table.getColumnValues('Result')).to.eql(passed);
-
-        await filterBar.removeFilter('result.evaluation');
-      });
-
-      it('filters by failed findings', async () => {
-        await distributionBar.filterBy('failed');
-
-        const failed = data
-          .filter(({ result }) => result.evaluation === 'failed')
-          .map(() => 'Fail');
-
-        expect(await table.getColumnValues('Result')).to.eql(failed);
-
-        await filterBar.removeFilter('result.evaluation');
+          await filterBar.removeFilter('result.evaluation');
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

adds tests for filtering by `passed` / `failed` using the distribution bar. 





 