### PR TITLE
[Canvas] Fix expression editor test

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/editor.tsx
+++ b/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/editor.tsx
@@ -52,7 +52,7 @@ const EditorArg: FC<EditorArgProps> = ({ argValue, typeInstance, onValueChange, 
   const { language } = typeInstance?.options ?? {};
 
   return (
-    <EuiFormRow display="rowCompressed">
+    <EuiFormRow display="rowCompressed" data-test-subj="canvasCodeEditorField">
       <CodeEditorField
         languageId={language ?? ''}
         value={value}

--- a/x-pack/plugins/canvas/public/components/expression_input/expression_input.tsx
+++ b/x-pack/plugins/canvas/public/components/expression_input/expression_input.tsx
@@ -23,7 +23,7 @@ const Input = withSuspense(LazyExpressionInput);
 
 export const ExpressionInput = ({ error, ...rest }: Props) => {
   return (
-    <div className="canvasExpressionInput">
+    <div className="canvasExpressionInput" data-test-subj="canvasExpressionInput">
       <EuiFormRow
         className="canvasExpressionInput__inner"
         fullWidth

--- a/x-pack/test/functional/apps/canvas/expression.ts
+++ b/x-pack/test/functional/apps/canvas/expression.ts
@@ -12,8 +12,8 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function canvasExpressionTest({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
+  const monacoEditor = getService('monacoEditor');
   const PageObjects = getPageObjects(['canvas', 'common']);
-  const find = getService('find');
   const kibanaServer = getService('kibanaServer');
   const archive = 'x-pack/test/functional/fixtures/kbn_archiver/canvas/default';
 
@@ -43,31 +43,31 @@ export default function canvasExpressionTest({ getService, getPageObjects }: Ftr
         expect(elements).to.have.length(4);
       });
 
+      const codeEditorSubj = 'canvasCodeEditorField';
+
       // find the first workpad element (a markdown element) and click it to select it
       await testSubjects.click('canvasWorkpadPage > canvasWorkpadPageElementContent', 20000);
+      await monacoEditor.waitCodeEditorReady(codeEditorSubj);
 
       // open the expression editor
       await PageObjects.canvas.openExpressionEditor();
+      await monacoEditor.waitCodeEditorReady('canvasExpressionInput');
 
       // select markdown content and clear it
-      const mdBox = await find.byCssSelector('.canvasSidebar__panel .canvasTextArea__code');
-      const oldMd = await mdBox.getVisibleText();
-      await mdBox.clearValueWithKeyboard();
+      const oldMd = await monacoEditor.getCodeEditorValue(0);
+      await monacoEditor.setCodeEditorValue('', 0);
 
       // type the new text
       const newMd = `${oldMd} and this is a test`;
-      await mdBox.type(newMd);
-      await find.clickByCssSelector('.canvasArg--controls .euiButton');
+      await monacoEditor.setCodeEditorValue(newMd, 0);
+      await PageObjects.common.sleep(300);
 
       // make sure the open expression editor also has the changes
-      const editor = await find.byCssSelector('.monaco-editor .view-lines');
-      const editorText = await editor.getVisibleText();
+      const editorText = await monacoEditor.getCodeEditorValue(1);
       expect(editorText).to.contain('Orange: Timelion, Server function and this is a test');
 
       // reset the markdown
-      await mdBox.clearValueWithKeyboard();
-      await mdBox.type(oldMd);
-      await find.clickByCssSelector('.canvasArg--controls .euiButton');
+      await monacoEditor.setCodeEditorValue(oldMd, 0);
     });
   });
 }

--- a/x-pack/test/functional/apps/canvas/expression.ts
+++ b/x-pack/test/functional/apps/canvas/expression.ts
@@ -60,12 +60,12 @@ export default function canvasExpressionTest({ getService, getPageObjects }: Ftr
       // type the new text
       const newMd = `${oldMd} and this is a test`;
       await monacoEditor.setCodeEditorValue(newMd, 0);
-      await PageObjects.common.sleep(300);
 
       // make sure the open expression editor also has the changes
-      const editorText = await monacoEditor.getCodeEditorValue(1);
-      expect(editorText).to.contain('Orange: Timelion, Server function and this is a test');
-
+      await retry.try(async () => {
+        const editorText = await monacoEditor.getCodeEditorValue(1);
+        expect(editorText).to.contain('Orange: Timelion, Server function and this is a test');
+      });
       // reset the markdown
       await monacoEditor.setCodeEditorValue(oldMd, 0);
     });

--- a/x-pack/test/functional/apps/canvas/expression.ts
+++ b/x-pack/test/functional/apps/canvas/expression.ts
@@ -17,8 +17,7 @@ export default function canvasExpressionTest({ getService, getPageObjects }: Ftr
   const kibanaServer = getService('kibanaServer');
   const archive = 'x-pack/test/functional/fixtures/kbn_archiver/canvas/default';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/115883
-  describe.skip('expression editor', function () {
+  describe('expression editor', function () {
     // there is an issue with FF not properly clicking on workpad elements
     this.tags('skipFirefox');
 


### PR DESCRIPTION
Fixes a skipped flaky test for the expression editor.

The test was skipped before the expression editor was changed to use Monaco in https://github.com/elastic/kibana/pull/133318. I refactored the test to use the Monaco service which should also address https://github.com/elastic/kibana/pull/133318#issuecomment-1208330199. 

[Flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1606)