### PR TITLE
[Guided onboarding] Address design feedback

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card_footer.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card_footer.test.tsx.snap
@@ -4,6 +4,19 @@ exports[`guide card footer snapshots should render the footer when the guide has
 <Fragment>
   <EuiProgress
     label="Completed"
+    labelProps={
+      Object {
+        "css": Object {
+          "map": undefined,
+          "name": "x46p4t",
+          "next": undefined,
+          "styles": "
+  text-align: 'left';
+",
+          "toString": [Function],
+        },
+      }
+    }
     max={2}
     size="s"
     value={1}

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_card_footer.test.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_card_footer.test.tsx
@@ -23,7 +23,7 @@ const searchGuideState: GuideState = {
   status: 'not_started',
   steps: [
     { id: 'add_data', status: 'complete' },
-    { id: 'browse_docs', status: 'in_progress' },
+    { id: 'search_experience', status: 'in_progress' },
   ],
   isActive: true,
 };

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_card_footer.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_card_footer.tsx
@@ -90,6 +90,9 @@ export const GuideCardFooter = ({ guides, useCase, activateGuide }: GuideCardFoo
           max={numberSteps}
           size="s"
           label={completedLabel}
+          labelProps={{
+            css: progressBarLabelCss,
+          }}
         />
         <EuiSpacer size="l" />
         {viewGuideButton}

--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -17,11 +17,14 @@ import { css } from '@emotion/react';
  * See https://github.com/elastic/eui/issues/6241 for more details
  */
 export const getGuidePanelStyles = (euiTheme: EuiThemeComputed) => ({
+  setupButton: css`
+    margin-right: ${euiTheme.size.m};
+  `,
   flyoutOverrides: {
     flyoutContainer: css`
       top: 55px !important;
       bottom: 25px !important;
-      right: 128px;
+      right: calc(${euiTheme.size.s} + 128px); // Accounting for margin on button
       border-radius: 6px;
       inline-size: 480px !important;
       height: auto;

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -181,12 +181,14 @@ export const GuidePanel = ({ api, application, notifications }: GuidePanelProps)
 
   return (
     <>
-      <GuideButton
-        pluginState={pluginState}
-        toggleGuidePanel={toggleGuide}
-        isGuidePanelOpen={isGuideOpen}
-        navigateToLandingPage={navigateToLandingPage}
-      />
+      <div css={styles.setupButton}>
+        <GuideButton
+          pluginState={pluginState}
+          toggleGuidePanel={toggleGuide}
+          isGuidePanelOpen={isGuideOpen}
+          navigateToLandingPage={navigateToLandingPage}
+        />
+      </div>
 
       {isGuideOpen && (
         <EuiFlyout


### PR DESCRIPTION
Partially addresses https://github.com/elastic/kibana/issues/145941

This PR addresses some design polish items:
1. Fixes the alignment of the "Completed" text on the progress bar.
2. Adds margin to the "Setup guide" button in the header

### Screenshots
// Before
<img width="578" alt="Screen Shot 2022-11-28 at 1 22 51 PM" src="https://user-images.githubusercontent.com/5226211/204369195-2aef4e03-29de-41a1-b2f8-b91eaf25038f.png">

// After
<img width="575" alt="Screen Shot 2022-11-28 at 1 23 13 PM" src="https://user-images.githubusercontent.com/5226211/204369199-a8adf2d8-ab90-4a3d-81f6-07e67fb87f13.png">

// Before
<img width="340" alt="Screen Shot 2022-11-28 at 2 59 00 PM" src="https://user-images.githubusercontent.com/5226211/204369400-5cea31b9-0725-40b0-8ee7-c7accd3d3be1.png">


// After
<img width="429" alt="Screen Shot 2022-11-28 at 2 53 43 PM" src="https://user-images.githubusercontent.com/5226211/204369312-f472dc6c-0e00-4566-843f-6ce7f265a83f.png">
<img width="681" alt="Screen Shot 2022-11-28 at 2 54 16 PM" src="https://user-images.githubusercontent.com/5226211/204369313-e3113242-050a-42fa-a8f3-9e565cdf51fc.png">



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->