### PR TITLE
[Discover] Fix crash when navigating from saved search with time field to saved search without time field

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.ts
@@ -33,6 +33,7 @@ import {
 } from './use_discover_histogram';
 import { setTimeout } from 'timers/promises';
 import { calculateBounds } from '@kbn/data-plugin/public';
+import { buildChartData } from '@kbn/unified-histogram-plugin/public';
 
 const mockData = dataPluginMock.createStartContract();
 
@@ -59,6 +60,16 @@ jest.mock('@kbn/unified-field-list-plugin/public', () => {
   return {
     ...originalModule,
     getVisualizeInformation: jest.fn(() => Promise.resolve(mockCanVisualize)),
+  };
+});
+
+const mockBuildChartData = buildChartData as jest.MockedFunction<typeof buildChartData>;
+
+jest.mock('@kbn/unified-histogram-plugin/public', () => {
+  const originalModule = jest.requireActual('@kbn/unified-histogram-plugin/public');
+  return {
+    ...originalModule,
+    buildChartData: jest.fn(originalModule.buildChartData),
   };
 });
 
@@ -292,6 +303,26 @@ describe('useDiscoverHistogram', () => {
         result.current.onTimeIntervalChange('auto');
       });
       expect(stateContainer.setAppState).toHaveBeenCalledWith({ interval: 'auto' });
+    });
+  });
+
+  describe('buildChartData', () => {
+    it('should call buildChartData when isPlainRecord is false and isTimeBased is true', async () => {
+      mockBuildChartData.mockClear();
+      await renderUseDiscoverHistogram();
+      expect(mockBuildChartData).toHaveBeenCalled();
+    });
+
+    it('should not call buildChartData when isPlainRecord is true', async () => {
+      mockBuildChartData.mockClear();
+      await renderUseDiscoverHistogram({ isPlainRecord: true });
+      expect(mockBuildChartData).not.toHaveBeenCalled();
+    });
+
+    it('should not call buildChartData when isTimeBased is false', async () => {
+      mockBuildChartData.mockClear();
+      await renderUseDiscoverHistogram({ isTimeBased: false });
+      expect(mockBuildChartData).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -137,13 +137,15 @@ export const useDiscoverHistogram = ({
 
   const { bucketInterval, chartData } = useMemo(
     () =>
-      buildChartData({
-        data,
-        dataView,
-        timeInterval: state.interval,
-        response,
-      }),
-    [data, dataView, response, state.interval]
+      isPlainRecord || !isTimeBased
+        ? { bucketInterval: undefined, chartData: undefined }
+        : buildChartData({
+            data,
+            dataView,
+            timeInterval: state.interval,
+            response,
+          }),
+    [data, dataView, isPlainRecord, isTimeBased, response, state.interval]
   );
 
   const chart = useMemo(

--- a/test/functional/apps/discover/group2/_indexpattern_without_timefield.ts
+++ b/test/functional/apps/discover/group2/_indexpattern_without_timefield.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
   const testSubjects = getService('testSubjects');
-  const PageObjects = getPageObjects(['common', 'timePicker', 'discover']);
+  const PageObjects = getPageObjects(['common', 'timePicker', 'discover', 'header']);
 
   describe('indexpattern without timefield', () => {
     before(async () => {
@@ -113,6 +113,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.selectIndexPattern('without-timefield');
       url = await browser.getCurrentUrl();
       expect(url).to.contain(`refreshInterval:(pause:!t,value:${autoRefreshInterval * 1000})`);
+    });
+
+    it('should allow switching from a saved search with a time field to a saved search without a time field', async () => {
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.selectIndexPattern('with-timefield');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.saveSearch('with-timefield');
+      await PageObjects.discover.selectIndexPattern('without-timefield');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.saveSearch('without-timefield', true);
+      await PageObjects.discover.loadSavedSearch('with-timefield');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.loadSavedSearch('without-timefield');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.assertHitCount('1');
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where loading a saved search with a time field and then loading a saved search without a time field would cause Discover to crash.

Fixes #146464.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->