### PR TITLE
[APM] Dark mode fix for Service icon buttons

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
@@ -11,9 +11,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
 } from '@elastic/eui';
-import { rgba } from 'polished';
 import React from 'react';
-import styled from 'styled-components';
 import { PopoverItem } from '.';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 

--- a/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
@@ -27,15 +27,6 @@ interface IconPopoverProps {
   icon: PopoverItem['icon'];
 }
 
-const StyledButtonIcon = styled(EuiButtonIcon)`
-  &.serviceIcon_button {
-    box-shadow: ${({ theme }) => {
-      const shadowColor = theme.eui.euiShadowColor;
-      return `0px 0.7px 1.4px ${rgba(shadowColor, 0.07)},
-      0px 1.9px 4px ${rgba(shadowColor, 0.05)},
-      0px 4.5px 10px ${rgba(shadowColor, 0.05)} !important;`;
-    }}
-`;
 export function IconPopover({
   icon,
   title,
@@ -54,7 +45,8 @@ export function IconPopover({
       anchorPosition="downCenter"
       ownFocus={false}
       button={
-        <StyledButtonIcon
+        <EuiButtonIcon
+          display="base"
           color="text"
           onClick={onClick}
           iconType={icon.type}


### PR DESCRIPTION
## Summary

Simple fix to remove the custom styles for the service icon buttons, and use `EuiButtonIcon`. That way we easily support the dark mode and we also close an issue that was created. #127249

![image](https://user-images.githubusercontent.com/13353203/204390284-0b77cc72-bef9-48f4-ac7d-0c4413ddbed6.png)
![image](https://user-images.githubusercontent.com/13353203/204390311-aecec8fe-f9b2-4910-bd3c-562152d37c1c.png)
