### PR TITLE
[Stack Monitoring] Remove visible semicolon from LoadingPage

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/loading_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/loading_page.tsx
@@ -24,7 +24,7 @@ export const LoadingPage = ({ staticLoadingState }: { staticLoadingState?: boole
   if (staticLoadingState) {
     return (
       <PageTemplate title={title}>
-        <PageLoading />;
+        <PageLoading />
       </PageTemplate>
     );
   }


### PR DESCRIPTION
Fixes #146342

There was a semicolon added to the JSX markup which would show on slower devices where loading takes longer.
Please refer to the issue for a screenshot of that.

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->