### PR TITLE
[Guided onboarding] Fix an error in the guide panel

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -188,7 +188,7 @@ export const GuidePanel = ({ api, application, notifications }: GuidePanelProps)
         navigateToLandingPage={navigateToLandingPage}
       />
 
-      {isGuideOpen && (
+      {isGuideOpen && guideConfig && (
         <EuiFlyout
           ownFocus
           onClose={toggleGuide}


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/146418

When a guide is completed, the guide panel would throw an error. The error was caused by the missing guide config value because of a missing guide in the plugin state. 

Error in the console 
<img width="537" alt="Screenshot 2022-11-29 at 11 22 21" src="https://user-images.githubusercontent.com/6585477/204503816-57c47c48-06fc-431b-a37b-594d1ce629ef.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
