### PR TITLE
[8.6] [Cloud Posture] UI for insufficient ES privileges (#145794)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -54,11 +54,23 @@ export interface ComplianceDashboardData {
 export type CspStatusCode =
   | 'indexed' // latest findings index exists and has results
   | 'indexing' // index timeout was not surpassed since installation, assumes data is being indexed
+  | 'unprivileged' // user lacks privileges for the latest findings index
   | 'index-timeout' // index timeout was surpassed since installation
   | 'not-deployed' // no healthy agents were deployed
   | 'not-installed'; // number of installed csp integrations is 0;
 
+export type IndexStatus =
+  | 'not-empty' // Index contains documents
+  | 'empty' // Index doesn't contain documents (or doesn't exist)
+  | 'unprivileged'; // User doesn't have access to query the index
+
+export interface IndexDetails {
+  index: string;
+  status: IndexStatus;
+}
+
 interface BaseCspSetupStatus {
+  indicesDetails: IndexDetails[];
   latestPackageVersion: string;
   installedPackagePolicies: number;
   healthyAgents: number;

--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -6,14 +6,23 @@
  */
 
 import React from 'react';
-import { EuiLoadingLogo, EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import {
+  EuiLoadingLogo,
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiIcon,
+  EuiMarkdownFormat,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import { FullSizeCenteredPage } from './full_size_centered_page';
 import { useCspBenchmarkIntegrations } from '../pages/benchmarks/use_csp_benchmark_integrations';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
 import { NO_FINDINGS_STATUS_TEST_SUBJ } from './test_subjects';
 import { CloudPosturePage } from './cloud_posture_page';
 import { useCspSetupStatusApi } from '../common/api/use_setup_status_api';
+import type { IndexDetails } from '../../common/types';
 
 const REFETCH_INTERVAL_MS = 20000;
 
@@ -116,6 +125,43 @@ const IndexTimeout = () => (
   />
 );
 
+const Unprivileged = ({ unprivilegedIndices }: { unprivilegedIndices: string[] }) => (
+  <EuiEmptyPrompt
+    data-test-subj={NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED}
+    color="plain"
+    icon={<EuiIcon type="logoSecurity" size="xl" />}
+    title={
+      <h2>
+        <FormattedMessage
+          id="xpack.csp.noFindingsStates.unprivileged.unprivilegedTitle"
+          defaultMessage="Privileges required"
+        />
+      </h2>
+    }
+    body={
+      <p>
+        <FormattedMessage
+          id="xpack.csp.noFindingsStates.unprivileged.unprivilegedDescription"
+          defaultMessage="To view cloud posture data, you must update privileges. For more information, contact your Kibana administrator."
+        />
+      </p>
+    }
+    footer={
+      <EuiMarkdownFormat
+        css={css`
+          text-align: initial;
+        `}
+        children={
+          i18n.translate('xpack.csp.noFindingsStates.unprivileged.unprivilegedFooterMarkdown', {
+            defaultMessage:
+              'Required Elasticsearch index privilege `read` for the following indices:',
+          }) + unprivilegedIndices.map((idx) => `\n- \`${idx}\``)
+        }
+      />
+    }
+  />
+);
+
 /**
  * This component will return the render states based on cloud posture setup status API
  * since 'not-installed' is being checked globally by CloudPosturePage and 'indexed' is the pass condition, those states won't be handled here
@@ -125,11 +171,20 @@ export const NoFindingsStates = () => {
     options: { refetchInterval: REFETCH_INTERVAL_MS },
   });
   const status = getSetupStatus.data?.status;
+  const indicesStatus = getSetupStatus.data?.indicesDetails;
+  const unprivilegedIndices =
+    indicesStatus &&
+    indicesStatus
+      .filter((idxDetails) => idxDetails.status === 'unprivileged')
+      .map((idxDetails: IndexDetails) => idxDetails.index)
+      .sort((a, b) => a.localeCompare(b));
 
   const render = () => {
     if (status === 'not-deployed') return <NotDeployed />; // integration installed, but no agents added
     if (status === 'indexing') return <Indexing />; // agent added, index timeout hasn't passed since installation
     if (status === 'index-timeout') return <IndexTimeout />; // agent added, index timeout has passed
+    if (status === 'unprivileged')
+      return <Unprivileged unprivilegedIndices={unprivilegedIndices || []} />; // user has no privileges for our indices
   };
 
   return (

--- a/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
@@ -16,4 +16,5 @@ export const NO_FINDINGS_STATUS_TEST_SUBJ = {
   NO_AGENTS_DEPLOYED: 'status-api-no-agent-deployed',
   INDEXING: 'status-api-indexing',
   INDEX_TIMEOUT: 'status-api-index-timeout',
+  UNPRIVILEGED: 'status-api-unprivileged',
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
@@ -247,6 +247,7 @@ describe('<ComplianceDashboard />', () => {
         DASHBOARD_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });
@@ -268,6 +269,7 @@ describe('<ComplianceDashboard />', () => {
         DASHBOARD_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });
@@ -289,6 +291,29 @@ describe('<ComplianceDashboard />', () => {
         DASHBOARD_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
+      ],
+    });
+  });
+
+  it('no findings state: unprivileged - shows Unprivileged instead of dashboard', () => {
+    (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
+      createReactQueryResponse({
+        status: 'success',
+        data: { status: 'unprivileged' },
+      })
+    );
+    (useCISIntegrationLink as jest.Mock).mockImplementation(() => chance.url());
+
+    renderComplianceDashboardPage();
+
+    expectIdsInDoc({
+      be: [NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED],
+      notToBe: [
+        DASHBOARD_CONTAINER,
+        NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
+        NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
       ],
     });
   });
@@ -308,6 +333,7 @@ describe('<ComplianceDashboard />', () => {
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
@@ -94,6 +94,7 @@ describe('<Findings />', () => {
         TEST_SUBJECTS.FINDINGS_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });
@@ -115,6 +116,7 @@ describe('<Findings />', () => {
         TEST_SUBJECTS.FINDINGS_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });
@@ -136,6 +138,29 @@ describe('<Findings />', () => {
         TEST_SUBJECTS.FINDINGS_CONTAINER,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
+      ],
+    });
+  });
+
+  it('no findings state: unprivileged - shows Unprivileged instead of findings', () => {
+    (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
+      createReactQueryResponse({
+        status: 'success',
+        data: { status: 'unprivileged' },
+      })
+    );
+    (useCISIntegrationLink as jest.Mock).mockImplementation(() => chance.url());
+
+    renderFindingsPage();
+
+    expectIdsInDoc({
+      be: [NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED],
+      notToBe: [
+        TEST_SUBJECTS.FINDINGS_CONTAINER,
+        NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
+        NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
       ],
     });
   });
@@ -166,6 +191,7 @@ describe('<Findings />', () => {
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEX_TIMEOUT,
         NO_FINDINGS_STATUS_TEST_SUBJ.NO_AGENTS_DEPLOYED,
         NO_FINDINGS_STATUS_TEST_SUBJ.INDEXING,
+        NO_FINDINGS_STATUS_TEST_SUBJ.UNPRIVILEGED,
       ],
     });
   });

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@kbn/fleet-plugin/common';
 import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
 import { createCspRequestHandlerContextMock } from '../../mocks';
+import { errors } from '@elastic/elasticsearch';
 
 const mockCspPackageInfo: Installation = {
   verification_status: 'verified',
@@ -85,6 +86,77 @@ describe('CspSetupStatus route', () => {
     expect(config.path).toEqual('/internal/cloud_security_posture/status');
   });
 
+  const indices = [
+    {
+      index: 'logs-cloud_security_posture.findings-default*',
+      expected_status: 'not-installed',
+    },
+    {
+      index: 'logs-cloud_security_posture.findings_latest-default',
+      expected_status: 'unprivileged',
+    },
+    {
+      index: 'logs-cloud_security_posture.scores-default',
+      expected_status: 'unprivileged',
+    },
+  ];
+
+  indices.forEach((idxTestCase) => {
+    it(
+      'Verify the API result when there are no permissions to index: ' + idxTestCase.index,
+      async () => {
+        mockContext.core.elasticsearch.client.asCurrentUser.search.mockResponseImplementation(
+          (req) => {
+            if (req?.index === idxTestCase.index) {
+              throw new errors.ResponseError({
+                body: {
+                  error: {
+                    type: 'security_exception',
+                  },
+                },
+                statusCode: 503,
+                headers: {},
+                warnings: [],
+                meta: {} as any,
+              });
+            }
+
+            return {
+              hits: {
+                hits: [{}],
+              },
+            } as any;
+          }
+        );
+        mockPackageClient.fetchFindLatestPackage.mockResolvedValueOnce(mockLatestCspPackageInfo);
+
+        mockPackagePolicyService.list.mockResolvedValueOnce({
+          items: [],
+          total: 0,
+          page: 1,
+          perPage: 100,
+        });
+
+        // Act
+        defineGetCspStatusRoute(router);
+        const [_, handler] = router.get.mock.calls[0];
+
+        const mockResponse = httpServerMock.createResponseFactory();
+        const mockRequest = httpServerMock.createKibanaRequest();
+        await handler(mockContext, mockRequest, mockResponse);
+
+        // Assert
+        const [call] = mockResponse.ok.mock.calls;
+        const body = call[0]?.body;
+        expect(mockResponse.ok).toHaveBeenCalledTimes(1);
+
+        await expect(body).toMatchObject({
+          status: idxTestCase.expected_status,
+        });
+      }
+    );
+  });
+
   it('Verify the API result when there are findings and no installed policies', async () => {
     mockContext.core.elasticsearch.client.asCurrentUser.search.mockResponseOnce({
       hits: {
@@ -113,7 +185,7 @@ describe('CspSetupStatus route', () => {
     const body = call[0]?.body;
     expect(mockResponse.ok).toHaveBeenCalledTimes(1);
 
-    await expect(body).toEqual({
+    await expect(body).toMatchObject({
       status: 'indexed',
       latestPackageVersion: '0.0.14',
       installedPackagePolicies: 0,
@@ -153,7 +225,7 @@ describe('CspSetupStatus route', () => {
 
     expect(mockResponse.ok).toHaveBeenCalledTimes(1);
 
-    await expect(body).toEqual({
+    await expect(body).toMatchObject({
       status: 'indexed',
       latestPackageVersion: '0.0.14',
       installedPackagePolicies: 3,
@@ -202,7 +274,7 @@ describe('CspSetupStatus route', () => {
 
     expect(mockResponse.ok).toHaveBeenCalledTimes(1);
 
-    await expect(body).toEqual({
+    await expect(body).toMatchObject({
       status: 'indexed',
       latestPackageVersion: '0.0.14',
       installedPackagePolicies: 3,

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
@@ -10,15 +10,21 @@ import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { AgentPolicyServiceInterface, AgentService } from '@kbn/fleet-plugin/server';
 import moment from 'moment';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
-import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME, STATUS_ROUTE_PATH } from '../../../common/constants';
+import {
+  CLOUD_SECURITY_POSTURE_PACKAGE_NAME,
+  STATUS_ROUTE_PATH,
+  LATEST_FINDINGS_INDEX_DEFAULT_NS,
+  FINDINGS_INDEX_PATTERN,
+  BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+} from '../../../common/constants';
 import type { CspApiRequestHandlerContext, CspRouter } from '../../types';
-import type { CspSetupStatus, CspStatusCode } from '../../../common/types';
+import type { CspSetupStatus, CspStatusCode, IndexStatus } from '../../../common/types';
 import {
   getAgentStatusesByAgentPolicies,
   getCspAgentPolicies,
   getCspPackagePolicies,
 } from '../../lib/fleet_util';
-import { checkForFindings } from '../../lib/check_for_findings';
+import { checkIndexStatus } from '../../lib/check_index_status';
 
 export const INDEX_TIMEOUT_IN_MINUTES = 10;
 
@@ -51,18 +57,34 @@ const getHealthyAgents = async (
 };
 
 const calculateCspStatusCode = (
-  hasFindings: boolean,
+  indicesStatus: {
+    findingsLatest: IndexStatus;
+    findings: IndexStatus;
+    score: IndexStatus;
+  },
   installedCspPackagePolicies: number,
   healthyAgents: number,
   timeSinceInstallationInMinutes: number
 ): CspStatusCode => {
-  if (hasFindings) return 'indexed';
+  // We check privileges only for the relevant indices for our pages to appear
+  if (indicesStatus.findingsLatest === 'unprivileged' || indicesStatus.score === 'unprivileged')
+    return 'unprivileged';
+  if (indicesStatus.findingsLatest === 'not-empty') return 'indexed';
   if (installedCspPackagePolicies === 0) return 'not-installed';
   if (healthyAgents === 0) return 'not-deployed';
   if (timeSinceInstallationInMinutes <= INDEX_TIMEOUT_IN_MINUTES) return 'indexing';
   if (timeSinceInstallationInMinutes > INDEX_TIMEOUT_IN_MINUTES) return 'index-timeout';
 
   throw new Error('Could not determine csp status');
+};
+
+const assertResponse = (resp: CspSetupStatus, logger: CspApiRequestHandlerContext['logger']) => {
+  if (
+    resp.status === 'unprivileged' &&
+    !resp.indicesDetails.some((idxDetails) => idxDetails.status === 'unprivileged')
+  ) {
+    logger.warn('Returned status in `unprivileged` but response is missing the unprivileged index');
+  }
 };
 
 const getCspStatus = async ({
@@ -74,16 +96,23 @@ const getCspStatus = async ({
   agentPolicyService,
   agentService,
 }: CspApiRequestHandlerContext): Promise<CspSetupStatus> => {
-  const [hasFindings, installation, latestCspPackage, installedPackagePolicies] = await Promise.all(
-    [
-      checkForFindings(esClient.asCurrentUser, true, logger),
-      packageService.asInternalUser.getInstallation(CLOUD_SECURITY_POSTURE_PACKAGE_NAME),
-      packageService.asInternalUser.fetchFindLatestPackage(CLOUD_SECURITY_POSTURE_PACKAGE_NAME),
-      getCspPackagePolicies(soClient, packagePolicyService, CLOUD_SECURITY_POSTURE_PACKAGE_NAME, {
-        per_page: 10000,
-      }),
-    ]
-  );
+  const [
+    findingsLatestIndexStatus,
+    findingsIndexStatus,
+    scoreIndexStatus,
+    installation,
+    latestCspPackage,
+    installedPackagePolicies,
+  ] = await Promise.all([
+    checkIndexStatus(esClient.asCurrentUser, LATEST_FINDINGS_INDEX_DEFAULT_NS, logger),
+    checkIndexStatus(esClient.asCurrentUser, FINDINGS_INDEX_PATTERN, logger),
+    checkIndexStatus(esClient.asCurrentUser, BENCHMARK_SCORE_INDEX_DEFAULT_NS, logger),
+    packageService.asInternalUser.getInstallation(CLOUD_SECURITY_POSTURE_PACKAGE_NAME),
+    packageService.asInternalUser.fetchFindLatestPackage(CLOUD_SECURITY_POSTURE_PACKAGE_NAME),
+    getCspPackagePolicies(soClient, packagePolicyService, CLOUD_SECURITY_POSTURE_PACKAGE_NAME, {
+      per_page: 10000,
+    }),
+  ]);
 
   const healthyAgents = await getHealthyAgents(
     soClient,
@@ -96,8 +125,27 @@ const getCspStatus = async ({
   const latestCspPackageVersion = latestCspPackage.version;
 
   const MIN_DATE = 0;
+  const indicesDetails = [
+    {
+      index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
+      status: findingsLatestIndexStatus,
+    },
+    {
+      index: FINDINGS_INDEX_PATTERN,
+      status: findingsIndexStatus,
+    },
+    {
+      index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+      status: scoreIndexStatus,
+    },
+  ];
+
   const status = calculateCspStatusCode(
-    hasFindings,
+    {
+      findingsLatest: findingsLatestIndexStatus,
+      findings: findingsIndexStatus,
+      score: scoreIndexStatus,
+    },
     installedPackagePoliciesTotal,
     healthyAgents,
     calculateDiffFromNowInMinutes(installation?.install_started_at || MIN_DATE)
@@ -106,18 +154,23 @@ const getCspStatus = async ({
   if (status === 'not-installed')
     return {
       status,
+      indicesDetails,
       latestPackageVersion: latestCspPackageVersion,
       healthyAgents,
       installedPackagePolicies: installedPackagePoliciesTotal,
     };
 
-  return {
+  const response = {
     status,
+    indicesDetails,
     latestPackageVersion: latestCspPackageVersion,
     healthyAgents,
     installedPackagePolicies: installedPackagePoliciesTotal,
     installedPackageVersion: installation?.install_version,
   };
+
+  assertResponse(response, logger);
+  return response;
 };
 
 export const defineGetCspStatusRoute = (router: CspRouter): void =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Cloud Posture] UI for insufficient ES privileges (#145794)](https://github.com/elastic/kibana/pull/145794)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ari Aviran","email":"ari.aviran@elastic.co"},"sourceCommit":{"committedDate":"2022-11-28T19:14:32Z","message":"[Cloud Posture] UI for insufficient ES privileges (#145794)\n\nCo-authored-by: Kfir Peled <kfir.peled@elastic.co>","sha":"55b59722f7b1445ae6be1084c0ac3d804f524692","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security Posture","ci:cloud-deploy","ci:cloud-redeploy","v8.6.0","v8.7.0","v8.5.3"],"number":145794,"url":"https://github.com/elastic/kibana/pull/145794","mergeCommit":{"message":"[Cloud Posture] UI for insufficient ES privileges (#145794)\n\nCo-authored-by: Kfir Peled <kfir.peled@elastic.co>","sha":"55b59722f7b1445ae6be1084c0ac3d804f524692"}},"sourceBranch":"main","suggestedTargetBranches":["8.6","8.5"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145794","number":145794,"mergeCommit":{"message":"[Cloud Posture] UI for insufficient ES privileges (#145794)\n\nCo-authored-by: Kfir Peled <kfir.peled@elastic.co>","sha":"55b59722f7b1445ae6be1084c0ac3d804f524692"}},{"branch":"8.5","label":"v8.5.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->