### PR TITLE
[8.6] [Enterprise Search] Replace long-running jobs with stuck jobs (#146419)

### DIFF
--- a/x-pack/plugins/enterprise_search/common/stats.ts
+++ b/x-pack/plugins/enterprise_search/common/stats.ts
@@ -10,6 +10,6 @@ export interface SyncJobsStats {
   errors: number;
   in_progress: number;
   incomplete: number;
-  long_running: number;
   orphaned_jobs: number;
+  stuck: number;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
@@ -85,20 +85,16 @@ export const IndicesStats: React.FC = () => {
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiPanel
-              color={data?.long_running ? 'warning' : 'subdued'}
-              hasShadow={false}
-              paddingSize="l"
-            >
+            <EuiPanel color={data?.stuck ? 'warning' : 'subdued'} hasShadow={false} paddingSize="l">
               <EuiStat
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.longRunningSyncs',
                   {
-                    defaultMessage: 'Long running syncs',
+                    defaultMessage: 'Stuck syncs',
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.long_running}
+                title={data?.stuck}
               />
             </EuiPanel>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
@@ -45,7 +45,7 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
     },
   });
 
-  const longRunningProgressJobsCountResponse = await client.asCurrentUser.count({
+  const stuckJobsCountResponse = await client.asCurrentUser.count({
     index: CONNECTORS_JOBS_INDEX,
     query: {
       bool: {
@@ -57,8 +57,8 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
           },
           {
             range: {
-              started_at: {
-                lt: moment().subtract(1, 'day').toISOString(),
+              last_seen: {
+                lt: moment().subtract(1, 'minute').toISOString(),
               },
             },
           },
@@ -129,8 +129,8 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
     errors: errorResponse.count,
     in_progress: inProgressJobsCountResponse.count,
     incomplete: incompleteResponse.count,
-    long_running: longRunningProgressJobsCountResponse.count,
     orphaned_jobs: orphanedJobsCountResponse.count,
+    stuck: stuckJobsCountResponse.count,
   };
 
   return response;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Enterprise Search] Replace long-running jobs with stuck jobs (#146419)](https://github.com/elastic/kibana/pull/146419)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-11-28T16:25:59Z","message":"[Enterprise Search] Replace long-running jobs with stuck jobs (#146419)\n\nThis replaces the long-running syncs view with stuck syncs.","sha":"1e5f7034cc324182641dcbeb5d37730ed3c3fd02","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.6.0","v8.7.0"],"number":146419,"url":"https://github.com/elastic/kibana/pull/146419","mergeCommit":{"message":"[Enterprise Search] Replace long-running jobs with stuck jobs (#146419)\n\nThis replaces the long-running syncs view with stuck syncs.","sha":"1e5f7034cc324182641dcbeb5d37730ed3c3fd02"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146419","number":146419,"mergeCommit":{"message":"[Enterprise Search] Replace long-running jobs with stuck jobs (#146419)\n\nThis replaces the long-running syncs view with stuck syncs.","sha":"1e5f7034cc324182641dcbeb5d37730ed3c3fd02"}}]}] BACKPORT-->