### PR TITLE
[APM] Mark operations breakdown as beta

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/dependency_detail_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/dependency_detail_template.tsx
@@ -6,21 +6,22 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
-import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { ApmMainTemplate } from './apm_main_template';
-import { SpanIcon } from '../../shared/span_icon';
-import { useApmParams } from '../../../hooks/use_apm_params';
-import { useTimeRange } from '../../../hooks/use_time_range';
-import { useFetcher } from '../../../hooks/use_fetcher';
-import { useApmRouter } from '../../../hooks/use_apm_router';
-import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
-import { SearchBar } from '../../shared/search_bar';
+import React from 'react';
 import {
   getKueryBarBoolFilter,
   kueryBarPlaceholder,
 } from '../../../../common/dependencies';
+import { useApmParams } from '../../../hooks/use_apm_params';
+import { useApmRouter } from '../../../hooks/use_apm_router';
+import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
+import { useFetcher } from '../../../hooks/use_fetcher';
 import { useOperationBreakdownEnabledSetting } from '../../../hooks/use_operations_breakdown_enabled_setting';
+import { useTimeRange } from '../../../hooks/use_time_range';
+import { BetaBadge } from '../../shared/beta_badge';
+import { SearchBar } from '../../shared/search_bar';
+import { SpanIcon } from '../../shared/span_icon';
+import { ApmMainTemplate } from './apm_main_template';
 
 interface Props {
   children: React.ReactNode;
@@ -90,6 +91,7 @@ export function DependencyDetailTemplate({ children }: Props) {
           isSelected:
             path === '/dependencies/operations' ||
             path === '/dependencies/operation',
+          append: <BetaBadge />,
         },
       ]
     : [];

--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -30,6 +30,10 @@ import {
   enableServiceMetrics,
 } from '../common/ui_settings_keys';
 
+const betaLabel = i18n.translate('xpack.observability.uiSettings.betaLabel', {
+  defaultMessage: 'beta',
+});
+
 const technicalPreviewLabel = i18n.translate(
   'xpack.observability.uiSettings.technicalPreviewLabel',
   { defaultMessage: 'technical preview' }
@@ -239,14 +243,14 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     description: i18n.translate('xpack.observability.apmOperationsBreakdownDescription', {
       defaultMessage:
-        '{technicalPreviewLabel} Enable the APM Operations Breakdown feature, that displays aggregates for backend operations. {feedbackLink}.',
+        '{betaLabel} Enable the APM Operations Breakdown feature, that displays aggregates for backend operations. {feedbackLink}.',
       values: {
-        technicalPreviewLabel: `<em>[${technicalPreviewLabel}]</em>`,
+        betaLabel: `<em>[${betaLabel}]</em>`,
         feedbackLink: feedbackLink({ href: 'https://ela.st/feedback-operations-breakdown' }),
       },
     }),
     schema: schema.boolean(),
-    value: false,
+    value: true,
     requiresPageReload: true,
     type: 'boolean',
     showInLabs: true,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/145537.

**Before**
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/1313018/204528102-c09251c7-ba3f-4cd1-843f-3853fe199775.png">


**After**
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/1313018/204527703-92d5725c-8182-4e0c-9215-802daf2f1c47.png">


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->