### PR TITLE
[Enterprise Search] Show custom connector config without refresh

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.test.ts
@@ -8,6 +8,8 @@
 import { LogicMounter, mockFlashMessageHelpers } from '../../../../__mocks__/kea_logic';
 import { connectorIndex } from '../../../__mocks__/view_index.mock';
 
+import { ConnectorStatus } from '../../../../../../common/types/connectors';
+
 import { ConnectorConfigurationApiLogic } from '../../../api/connector/update_connector_configuration_api_logic';
 import { CachedFetchIndexApiLogic } from '../../../api/index/cached_fetch_index_api_logic';
 
@@ -23,6 +25,7 @@ const DEFAULT_VALUES = {
   isEditing: false,
   localConfigState: {},
   localConfigView: [],
+  shouldStartInEditMode: false,
 };
 
 describe('ConnectorConfigurationLogic', () => {
@@ -145,6 +148,26 @@ describe('ConnectorConfigurationLogic', () => {
           ...DEFAULT_VALUES,
           index: connectorIndex,
           isEditing: true,
+        });
+      });
+      it('should set isEditing if connector has a config definition and shouldStartInEditMode is true', () => {
+        ConnectorConfigurationLogic.actions.setShouldStartInEditMode(true);
+        ConnectorConfigurationLogic.actions.fetchIndexApiSuccess({
+          ...connectorIndex,
+          connector: { ...connectorIndex.connector, status: ConnectorStatus.NEEDS_CONFIGURATION },
+        });
+        expect(ConnectorConfigurationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          configState: connectorIndex.connector.configuration,
+          configView: [{ key: 'foo', label: 'bar', value: 'barbar' }],
+          index: {
+            ...connectorIndex,
+            connector: { ...connectorIndex.connector, status: ConnectorStatus.NEEDS_CONFIGURATION },
+          },
+          isEditing: true,
+          localConfigState: connectorIndex.connector.configuration,
+          localConfigView: [{ key: 'foo', label: 'bar', value: 'barbar' }],
+          shouldStartInEditMode: true,
         });
       });
     });


### PR DESCRIPTION
This fixes a bug where the configuration for a custom connector wouldn't show up until a manual page refresh.

https://user-images.githubusercontent.com/94373878/204558351-d35a4c06-afd7-48ca-9fb7-0ed930f7d3ee.mov



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->