### PR TITLE
[Security Solution] Adding security solution packages as a dependency

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -56,6 +56,7 @@ const uploadPipeline = (pipelineContent: string | object) => {
 
     if (
       (await doAnyChangesMatch([
+        /^packages\/kbn-securitysolution-.*/,
         /^x-pack\/plugins\/lists/,
         /^x-pack\/plugins\/security_solution/,
         /^x-pack\/plugins\/timelines/,


### PR DESCRIPTION
## Summary

Changes in the Security Solution packages may break our application, we are adding them as a dependency to execute our Cypress tests when a change is made in order to minimise the risk of introducing new issues.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->