### PR TITLE
[8.6] Added Time-series indexing (TSDB) to Integrations Experimental Indexing settings (#144974)

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
@@ -80,7 +80,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "endpoint:user-artifact": "f94c250a52b30d0a2d32635f8b4c5bdabd1e25c0",
         "endpoint:user-artifact-manifest": "8c14d49a385d5d1307d956aa743ec78de0b2be88",
         "enterprise_search_telemetry": "fafcc8318528d34f721c42d1270787c52565bad5",
-        "epm-packages": "cb22b422398a785e7e0565a19c6d4d5c7af6f2fd",
+        "epm-packages": "fe3716a54188b3c71327fa060dd6780a674d3994",
         "epm-packages-assets": "9fd3d6726ac77369249e9a973902c2cd615fc771",
         "event_loop_delays_daily": "d2ed39cf669577d90921c176499908b4943fb7bd",
         "exception-list": "fe8cc004fd2742177cdb9300f4a67689463faf9c",

--- a/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.test.ts
+++ b/x-pack/plugins/fleet/common/services/simplified_package_policy_helper.test.ts
@@ -131,6 +131,7 @@ describe('toPackagePolicy', () => {
               data_stream: 'logs-nginx.access',
               features: {
                 synthetic_source: true,
+                tsdb: false,
               },
             },
           ],
@@ -142,6 +143,7 @@ describe('toPackagePolicy', () => {
           data_stream: 'logs-nginx.access',
           features: {
             synthetic_source: true,
+            tsdb: false,
           },
         },
       ]);

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -352,6 +352,7 @@ export interface RegistryElasticsearch {
   'index_template.mappings'?: estypes.MappingTypeMapping;
   'ingest_pipeline.name'?: string;
   source_mode?: 'default' | 'synthetic';
+  index_mode?: 'time_series';
 }
 
 export interface RegistryDataStreamPrivileges {
@@ -444,7 +445,7 @@ export type PackageInfo =
   | Installable<Merge<ArchivePackage, EpmPackageAdditions>>;
 
 // TODO - Expand this with other experimental indexing types
-export type ExperimentalIndexingFeature = 'synthetic_source';
+export type ExperimentalIndexingFeature = 'synthetic_source' | 'tsdb';
 
 export interface ExperimentalDataStreamFeature {
   data_stream: string;

--- a/x-pack/plugins/fleet/common/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_policy.ts
@@ -33,6 +33,7 @@ export interface NewPackagePolicyInputStream {
       privileges?: {
         indices?: string[];
       };
+      index_mode?: string;
     };
   };
   release?: RegistryRelease;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
@@ -19,6 +19,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 
+import { getRegistryDataStreamAssetBaseName } from '../../../../../../../../../common/services';
 import type {
   NewPackagePolicy,
   NewPackagePolicyInput,
@@ -124,6 +125,41 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
           .filter((stream) => Boolean(stream.packagePolicyInputStream)),
       [packageInputStreams, packagePolicyInput.streams]
     );
+
+    // setting Indexing setting: TSDB to enabled by default, if the data stream's index_mode is set to time_series
+    let isUpdated = false;
+    inputStreams.forEach(({ packagePolicyInputStream }) => {
+      const dataStreamInfo = packageInfo.data_streams?.find(
+        (ds) => ds.dataset === packagePolicyInputStream?.data_stream.dataset
+      );
+
+      if (dataStreamInfo?.elasticsearch?.index_mode === 'time_series') {
+        if (!packagePolicy.package) return;
+        if (!packagePolicy.package?.experimental_data_stream_features)
+          packagePolicy.package!.experimental_data_stream_features = [];
+
+        const dsName = getRegistryDataStreamAssetBaseName(packagePolicyInputStream!.data_stream);
+        const match = packagePolicy.package!.experimental_data_stream_features.find(
+          (feat) => feat.data_stream === dsName
+        );
+        if (match) {
+          if (!match.features.tsdb) {
+            match.features.tsdb = true;
+            isUpdated = true;
+          }
+        } else {
+          packagePolicy.package!.experimental_data_stream_features.push({
+            data_stream: dsName,
+            features: { tsdb: true, synthetic_source: false },
+          });
+          isUpdated = true;
+        }
+      }
+    });
+
+    if (isUpdated) {
+      updatePackagePolicy(packagePolicy);
+    }
 
     return (
       <>

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -289,6 +289,7 @@ const getSavedObjectTypes = (
               type: 'nested',
               properties: {
                 synthetic_source: { type: 'boolean' },
+                tsdb: { type: 'boolean' },
               },
             },
           },

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -67,6 +67,11 @@ describe('parseDataStreamElasticsearchEntry', () => {
       source_mode: 'synthetic',
     });
   });
+  it('Should add index_mode', () => {
+    expect(parseDataStreamElasticsearchEntry({ index_mode: 'time_series' })).toEqual({
+      index_mode: 'time_series',
+    });
+  });
   it('Should add index_template mappings and expand dots', () => {
     expect(
       parseDataStreamElasticsearchEntry({

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -539,6 +539,10 @@ export function parseDataStreamElasticsearchEntry(
     );
   }
 
+  if (expandedElasticsearch?.index_mode) {
+    parsedElasticsearchEntry.index_mode = expandedElasticsearch.index_mode;
+  }
+
   return parsedElasticsearchEntry;
 }
 

--- a/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
@@ -10,12 +10,17 @@ import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks
 
 import type { NewPackagePolicy, PackagePolicy } from '../../types';
 
-import { handleExperimentalDatastreamFeatureOptIn } from './experimental_datastream_features';
+import {
+  builRoutingPath,
+  handleExperimentalDatastreamFeatureOptIn,
+} from './experimental_datastream_features';
 
 function getNewTestPackagePolicy({
   isSyntheticSourceEnabled,
+  isTSDBEnabled,
 }: {
   isSyntheticSourceEnabled: boolean;
+  isTSDBEnabled: boolean;
 }): NewPackagePolicy {
   const packagePolicy: NewPackagePolicy = {
     name: 'Test policy',
@@ -33,6 +38,7 @@ function getNewTestPackagePolicy({
           data_stream: 'metrics-test.test',
           features: {
             synthetic_source: isSyntheticSourceEnabled,
+            tsdb: isTSDBEnabled,
           },
         },
       ],
@@ -44,8 +50,10 @@ function getNewTestPackagePolicy({
 
 function getExistingTestPackagePolicy({
   isSyntheticSourceEnabled,
+  isTSDBEnabled,
 }: {
   isSyntheticSourceEnabled: boolean;
+  isTSDBEnabled: boolean;
 }): PackagePolicy {
   const packagePolicy: PackagePolicy = {
     id: 'test-policy',
@@ -64,6 +72,7 @@ function getExistingTestPackagePolicy({
           data_stream: 'metrics-test.test',
           features: {
             synthetic_source: isSyntheticSourceEnabled,
+            tsdb: isTSDBEnabled,
           },
         },
       ],
@@ -83,43 +92,56 @@ describe('experimental_datastream_features', () => {
     soClient.get.mockClear();
     esClient.cluster.getComponentTemplate.mockClear();
     esClient.cluster.putComponentTemplate.mockClear();
+
+    esClient.cluster.getComponentTemplate.mockResolvedValueOnce({
+      component_templates: [
+        {
+          name: 'metrics-test.test@package',
+          component_template: {
+            template: {
+              settings: {},
+              mappings: {
+                _source: {
+                  // @ts-expect-error
+                  mode: 'stored',
+                },
+                properties: {
+                  test_dimension: {
+                    type: 'keyword',
+                    time_series_dimension: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
   });
 
   const soClient = savedObjectsClientMock.create();
   const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
   describe('when package policy does not exist (create)', () => {
-    it('updates component template', async () => {
-      const packagePolicy = getNewTestPackagePolicy({ isSyntheticSourceEnabled: true });
-
+    beforeEach(() => {
       soClient.get.mockResolvedValueOnce({
         attributes: {
           experimental_data_stream_features: [
-            { data_stream: 'metrics-test.test', features: { synthetic_source: false } },
+            {
+              data_stream: 'metrics-test.test',
+              features: { synthetic_source: false, tsdb: false },
+            },
           ],
         },
         id: 'mocked',
         type: 'mocked',
         references: [],
       });
-
-      esClient.cluster.getComponentTemplate.mockResolvedValueOnce({
-        component_templates: [
-          {
-            name: 'metrics-test.test@package',
-            component_template: {
-              template: {
-                settings: {},
-                mappings: {
-                  _source: {
-                    // @ts-expect-error
-                    mode: 'stored',
-                  },
-                },
-              },
-            },
-          },
-        ],
+    });
+    it('updates component template', async () => {
+      const packagePolicy = getNewTestPackagePolicy({
+        isSyntheticSourceEnabled: true,
+        isTSDBEnabled: false,
       });
 
       await handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy });
@@ -135,17 +157,61 @@ describe('experimental_datastream_features', () => {
         })
       );
     });
+
+    it('should update index template', async () => {
+      const packagePolicy = getNewTestPackagePolicy({
+        isSyntheticSourceEnabled: false,
+        isTSDBEnabled: true,
+      });
+
+      esClient.indices.getIndexTemplate.mockResolvedValueOnce({
+        index_templates: [
+          {
+            name: 'metrics-test.test',
+            index_template: {
+              template: {
+                settings: {},
+                mappings: {},
+              },
+              composed_of: [],
+              index_patterns: '',
+            },
+          },
+        ],
+      });
+
+      await handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy });
+
+      expect(esClient.indices.getIndexTemplate).toHaveBeenCalled();
+      expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            template: expect.objectContaining({
+              settings: expect.objectContaining({
+                index: { mode: 'time_series', routing_path: ['test_dimension'] },
+              }),
+            }),
+          }),
+        })
+      );
+    });
   });
 
   describe('when package policy exists (update)', () => {
     describe('when opt in status in unchanged', () => {
       it('does not update component template', async () => {
-        const packagePolicy = getExistingTestPackagePolicy({ isSyntheticSourceEnabled: true });
+        const packagePolicy = getExistingTestPackagePolicy({
+          isSyntheticSourceEnabled: true,
+          isTSDBEnabled: false,
+        });
 
         soClient.get.mockResolvedValueOnce({
           attributes: {
             experimental_data_stream_features: [
-              { data_stream: 'metrics-test.test', features: { synthetic_source: true } },
+              {
+                data_stream: 'metrics-test.test',
+                features: { synthetic_source: true, tsdb: false },
+              },
             ],
           },
           id: 'mocked',
@@ -161,37 +227,25 @@ describe('experimental_datastream_features', () => {
     });
 
     describe('when opt in status is changed', () => {
-      it('updates component template', async () => {
-        const packagePolicy = getExistingTestPackagePolicy({ isSyntheticSourceEnabled: true });
-
+      beforeEach(() => {
         soClient.get.mockResolvedValueOnce({
           attributes: {
             experimental_data_stream_features: [
-              { data_stream: 'metrics-test.test', features: { synthetic_source: false } },
+              {
+                data_stream: 'metrics-test.test',
+                features: { synthetic_source: false, tsdb: false },
+              },
             ],
           },
           id: 'mocked',
           type: 'mocked',
           references: [],
         });
-
-        esClient.cluster.getComponentTemplate.mockResolvedValueOnce({
-          component_templates: [
-            {
-              name: 'metrics-test.test@package',
-              component_template: {
-                template: {
-                  settings: {},
-                  mappings: {
-                    _source: {
-                      // @ts-expect-error
-                      mode: 'stored',
-                    },
-                  },
-                },
-              },
-            },
-          ],
+      });
+      it('updates component template', async () => {
+        const packagePolicy = getExistingTestPackagePolicy({
+          isSyntheticSourceEnabled: true,
+          isTSDBEnabled: false,
         });
 
         await handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy });
@@ -207,6 +261,104 @@ describe('experimental_datastream_features', () => {
           })
         );
       });
+
+      it('should update index template', async () => {
+        const packagePolicy = getExistingTestPackagePolicy({
+          isSyntheticSourceEnabled: false,
+          isTSDBEnabled: true,
+        });
+
+        esClient.indices.getIndexTemplate.mockResolvedValueOnce({
+          index_templates: [
+            {
+              name: 'metrics-test.test',
+              index_template: {
+                template: {
+                  settings: {},
+                  mappings: {},
+                },
+                composed_of: [],
+                index_patterns: '',
+              },
+            },
+          ],
+        });
+
+        await handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy });
+
+        expect(esClient.indices.getIndexTemplate).toHaveBeenCalled();
+        expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              template: expect.objectContaining({
+                settings: expect.objectContaining({
+                  index: { mode: 'time_series', routing_path: ['test_dimension'] },
+                }),
+              }),
+            }),
+          })
+        );
+      });
     });
+  });
+  it('should build routing path', () => {
+    const mappingProperties = {
+      cloud: {
+        properties: {
+          availability_zone: {
+            ignore_above: 1024,
+            type: 'keyword',
+          },
+          image: {
+            properties: {
+              id: {
+                ignore_above: 1024,
+                type: 'keyword',
+              },
+            },
+          },
+        },
+      },
+      test_dimension: {
+        time_series_dimension: true,
+        type: 'keyword',
+      },
+      '@timestamp': {
+        type: 'date',
+      },
+    };
+    const routingPath = builRoutingPath(mappingProperties as any);
+    expect(routingPath).toEqual(['test_dimension']);
+  });
+
+  it('should build routing path from nested properties', () => {
+    const mappingProperties = {
+      cloud: {
+        properties: {
+          availability_zone: {
+            ignore_above: 1024,
+            type: 'keyword',
+          },
+          image: {
+            properties: {
+              id: {
+                ignore_above: 1024,
+                type: 'keyword',
+                time_series_dimension: true,
+              },
+            },
+          },
+        },
+      },
+      test_dimension: {
+        time_series_dimension: true,
+        type: 'keyword',
+      },
+      '@timestamp': {
+        type: 'date',
+      },
+    };
+    const routingPath = builRoutingPath(mappingProperties as any);
+    expect(routingPath).toEqual(['cloud.image.id', 'test_dimension']);
   });
 });

--- a/x-pack/plugins/fleet/server/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/package_policy.ts
@@ -84,6 +84,7 @@ const ExperimentalDataStreamFeatures = schema.arrayOf(
     data_stream: schema.string(),
     features: schema.object({
       synthetic_source: schema.boolean(),
+      tsdb: schema.boolean(),
     }),
   })
 );
@@ -128,7 +129,7 @@ const CreatePackagePolicyProps = {
         schema.arrayOf(
           schema.object({
             data_stream: schema.string(),
-            features: schema.object({ synthetic_source: schema.boolean() }),
+            features: schema.object({ synthetic_source: schema.boolean(), tsdb: schema.boolean() }),
           })
         )
       ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Added Time-series indexing (TSDB) to Integrations Experimental Indexing settings (#144974)](https://github.com/elastic/kibana/pull/144974)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Bardi","email":"90178898+juliaElastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-11-17T09:13:20Z","message":"Added Time-series indexing (TSDB) to Integrations Experimental Indexing settings (#144974)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/144530\r\n\r\nAdded a new option under integration / data streams / Index settings\r\n(experimental) / TSDB\r\n\r\n- [x] Add a toggle to the \"Experimental indexing features\" data streams\r\nUI for TSDB\r\n- Enabling this toggle adds `index.mode: time_series` to the data\r\nstream's index template settings.\r\n- Note: `index.routing_path` value was not needed to be added in this\r\nlogic, because there is an existing elasticsearch automation that\r\ngenerates it from dimension fields, see test instructions.\r\n- [x] If the current package's manifest contains `index_mode:\r\ntime_series` for a given data stream, the toggle should be in an\r\n\"enabled + readonly\" state, e.g. it cannot be disabled\r\n- Note: currently there is no package that has this setting enabled, I\r\ntested locally by manually modifying the package info response. Will\r\nneed to figure out a way to create a mock package to test this.\r\n- [x] Once the toggle is enabled and the policy is saved, the toggle\r\nshould _not_ be disable-able. Enabling TSDB for a data stream is an\r\nirreversible operation\r\n- [x] Add a tooltip to make the irreversible nature of this operation\r\nclear\r\n\r\nTSDB setting in System package:\r\n<img width=\"915\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656513-78bbe993-a900-4633-ad66-886f56ce2cf0.png\">\r\n<img width=\"632\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656559-e0c90ae2-4b21-4ee9-9bfc-a69c4ffaf708.png\">\r\n\r\nTooltip:\r\n<img width=\"509\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657054-11daeac3-cab2-45e4-8794-17a74b6c4300.png\">\r\n\r\n\r\n## Test instructions\r\n\r\n### Setup local registry\r\n\r\n- For testing, I created a new version of `System` package, that has a\r\n`dimension` field called `test_dimension`. This is needed so that the\r\nelasticsearch automation runs to generate the `routing_path` setting.\r\n\r\n- Download the test data zip:\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10004220/registry-packages.zip)\r\n\r\n\r\n- Start a registry:\r\n```\r\ndocker run -p 8080:8080 -v <path to unzipped dir>/input-packages/packages:/packages/test-packages -v <path to unzipped dir>/input-packages/package_registry_config.yml:/package-registry/config.yml docker.elastic.co/package-registry/package-registry:main\r\n```\r\n- Add this to your kibana config:\r\n```\r\nxpack.fleet.registryUrl: http://localhost:8080\r\n```\r\n\r\n- Open kibana, open Add System integration page (should be version\r\n`1.20.5` coming from local registry)\r\n- Enable only `Collect metrics from System instances / System cpu\r\nmetrics` stream, and enable `Time-series indexing (TSDB)` switch under\r\n`Advanced options`\r\n- Click on save integration. The integration should be added\r\nsuccessfully to an agent policy.\r\n- Start a fleet server and enroll an agent to the previously created\r\nagent policy. Wait for the agent to be healthy, this should trigger\r\nsystem metrics flowing in, this way triggering the creation of the data\r\nstream.\r\n- Go to `Stack Management / Index Management / Index Templates`, and\r\nopen the details of `metrics-system.cpu`, check that it has this in\r\n`Settings` tab: `index.mode: time_series`\r\n\r\n<img width=\"2013\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657409-1754d5a4-98fa-4646-9ccf-e47981404018.png\">\r\n\r\n- Go to `Indices` tab and look for\r\n`data_stream=\"metrics-system.cpu-default\"` including hidden indices. You\r\nshould see `routing_path` populated in Settings, and `test_dimension` in\r\nMappings.\r\n\r\n<img width=\"1792\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659788-845fbca8-2cdb-4d1b-8af6-efc24b71f1d3.png\">\r\n<img width=\"774\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659882-e9cba197-d354-494c-974a-3c580d4d98a5.png\">\r\n\r\n### Testing scenario of enabling TSDB in package spec by default\r\n\r\n- Prepared a newer version of `system` package `v1.20.9` that has\r\n`index_mode: \"time_series\"` in `system.cpu` data stream in package\r\nmanifest.\r\n- Download and extract the below zip and restart the local epr container\r\nto read from this folder.\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10011702/registry-packages.zip)\r\n- Open add system integration page\r\n- Check that `tsdb:true` is set in `Preview API request` for\r\n`system.cpu` data stream\r\n\r\n<img width=\"1033\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897480-f9a79526-776f-4d9f-b168-474b44e0aa53.png\">\r\n\r\n- Open the system cpu metrics stream on the policy editor, and check\r\nthat the TSDB switch is turned on.\r\n<img width=\"1093\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897787-f5a34aa6-c150-4c90-af97-bda6df92e0c4.png\">\r\n<img width=\"1051\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897943-85157b6b-caca-492d-8933-46ebe19b6930.png\">\r\n\r\n### Update 11/16:\r\n\r\n- After latest changes, expect `routing_path` with dimension fields to\r\nbe generated in Index Template when enabling TSDB:\r\n\r\n<img width=\"1163\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202123899-388d3f74-014a-492c-91ad-8afc9e454186.png\">\r\n\r\nThis was added to fix the issue mentioned here\r\nhttps://github.com/elastic/kibana/pull/144974#issuecomment-1315270890\r\n\r\n- After adding TSDB, modifying the parent component template should be\r\nsuccessful.\r\n\r\n<img width=\"555\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202124250-14bcc310-0dd9-4246-8461-ef66c1f7ac43.png\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"4608af41da7dc98403bbdbfba8a3ac02475277e4","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport:skip","Team:Fleet","release_note:feature","v8.7.0"],"number":144974,"url":"https://github.com/elastic/kibana/pull/144974","mergeCommit":{"message":"Added Time-series indexing (TSDB) to Integrations Experimental Indexing settings (#144974)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/144530\r\n\r\nAdded a new option under integration / data streams / Index settings\r\n(experimental) / TSDB\r\n\r\n- [x] Add a toggle to the \"Experimental indexing features\" data streams\r\nUI for TSDB\r\n- Enabling this toggle adds `index.mode: time_series` to the data\r\nstream's index template settings.\r\n- Note: `index.routing_path` value was not needed to be added in this\r\nlogic, because there is an existing elasticsearch automation that\r\ngenerates it from dimension fields, see test instructions.\r\n- [x] If the current package's manifest contains `index_mode:\r\ntime_series` for a given data stream, the toggle should be in an\r\n\"enabled + readonly\" state, e.g. it cannot be disabled\r\n- Note: currently there is no package that has this setting enabled, I\r\ntested locally by manually modifying the package info response. Will\r\nneed to figure out a way to create a mock package to test this.\r\n- [x] Once the toggle is enabled and the policy is saved, the toggle\r\nshould _not_ be disable-able. Enabling TSDB for a data stream is an\r\nirreversible operation\r\n- [x] Add a tooltip to make the irreversible nature of this operation\r\nclear\r\n\r\nTSDB setting in System package:\r\n<img width=\"915\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656513-78bbe993-a900-4633-ad66-886f56ce2cf0.png\">\r\n<img width=\"632\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656559-e0c90ae2-4b21-4ee9-9bfc-a69c4ffaf708.png\">\r\n\r\nTooltip:\r\n<img width=\"509\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657054-11daeac3-cab2-45e4-8794-17a74b6c4300.png\">\r\n\r\n\r\n## Test instructions\r\n\r\n### Setup local registry\r\n\r\n- For testing, I created a new version of `System` package, that has a\r\n`dimension` field called `test_dimension`. This is needed so that the\r\nelasticsearch automation runs to generate the `routing_path` setting.\r\n\r\n- Download the test data zip:\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10004220/registry-packages.zip)\r\n\r\n\r\n- Start a registry:\r\n```\r\ndocker run -p 8080:8080 -v <path to unzipped dir>/input-packages/packages:/packages/test-packages -v <path to unzipped dir>/input-packages/package_registry_config.yml:/package-registry/config.yml docker.elastic.co/package-registry/package-registry:main\r\n```\r\n- Add this to your kibana config:\r\n```\r\nxpack.fleet.registryUrl: http://localhost:8080\r\n```\r\n\r\n- Open kibana, open Add System integration page (should be version\r\n`1.20.5` coming from local registry)\r\n- Enable only `Collect metrics from System instances / System cpu\r\nmetrics` stream, and enable `Time-series indexing (TSDB)` switch under\r\n`Advanced options`\r\n- Click on save integration. The integration should be added\r\nsuccessfully to an agent policy.\r\n- Start a fleet server and enroll an agent to the previously created\r\nagent policy. Wait for the agent to be healthy, this should trigger\r\nsystem metrics flowing in, this way triggering the creation of the data\r\nstream.\r\n- Go to `Stack Management / Index Management / Index Templates`, and\r\nopen the details of `metrics-system.cpu`, check that it has this in\r\n`Settings` tab: `index.mode: time_series`\r\n\r\n<img width=\"2013\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657409-1754d5a4-98fa-4646-9ccf-e47981404018.png\">\r\n\r\n- Go to `Indices` tab and look for\r\n`data_stream=\"metrics-system.cpu-default\"` including hidden indices. You\r\nshould see `routing_path` populated in Settings, and `test_dimension` in\r\nMappings.\r\n\r\n<img width=\"1792\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659788-845fbca8-2cdb-4d1b-8af6-efc24b71f1d3.png\">\r\n<img width=\"774\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659882-e9cba197-d354-494c-974a-3c580d4d98a5.png\">\r\n\r\n### Testing scenario of enabling TSDB in package spec by default\r\n\r\n- Prepared a newer version of `system` package `v1.20.9` that has\r\n`index_mode: \"time_series\"` in `system.cpu` data stream in package\r\nmanifest.\r\n- Download and extract the below zip and restart the local epr container\r\nto read from this folder.\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10011702/registry-packages.zip)\r\n- Open add system integration page\r\n- Check that `tsdb:true` is set in `Preview API request` for\r\n`system.cpu` data stream\r\n\r\n<img width=\"1033\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897480-f9a79526-776f-4d9f-b168-474b44e0aa53.png\">\r\n\r\n- Open the system cpu metrics stream on the policy editor, and check\r\nthat the TSDB switch is turned on.\r\n<img width=\"1093\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897787-f5a34aa6-c150-4c90-af97-bda6df92e0c4.png\">\r\n<img width=\"1051\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897943-85157b6b-caca-492d-8933-46ebe19b6930.png\">\r\n\r\n### Update 11/16:\r\n\r\n- After latest changes, expect `routing_path` with dimension fields to\r\nbe generated in Index Template when enabling TSDB:\r\n\r\n<img width=\"1163\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202123899-388d3f74-014a-492c-91ad-8afc9e454186.png\">\r\n\r\nThis was added to fix the issue mentioned here\r\nhttps://github.com/elastic/kibana/pull/144974#issuecomment-1315270890\r\n\r\n- After adding TSDB, modifying the parent component template should be\r\nsuccessful.\r\n\r\n<img width=\"555\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202124250-14bcc310-0dd9-4246-8461-ef66c1f7ac43.png\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"4608af41da7dc98403bbdbfba8a3ac02475277e4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/144974","number":144974,"mergeCommit":{"message":"Added Time-series indexing (TSDB) to Integrations Experimental Indexing settings (#144974)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/144530\r\n\r\nAdded a new option under integration / data streams / Index settings\r\n(experimental) / TSDB\r\n\r\n- [x] Add a toggle to the \"Experimental indexing features\" data streams\r\nUI for TSDB\r\n- Enabling this toggle adds `index.mode: time_series` to the data\r\nstream's index template settings.\r\n- Note: `index.routing_path` value was not needed to be added in this\r\nlogic, because there is an existing elasticsearch automation that\r\ngenerates it from dimension fields, see test instructions.\r\n- [x] If the current package's manifest contains `index_mode:\r\ntime_series` for a given data stream, the toggle should be in an\r\n\"enabled + readonly\" state, e.g. it cannot be disabled\r\n- Note: currently there is no package that has this setting enabled, I\r\ntested locally by manually modifying the package info response. Will\r\nneed to figure out a way to create a mock package to test this.\r\n- [x] Once the toggle is enabled and the policy is saved, the toggle\r\nshould _not_ be disable-able. Enabling TSDB for a data stream is an\r\nirreversible operation\r\n- [x] Add a tooltip to make the irreversible nature of this operation\r\nclear\r\n\r\nTSDB setting in System package:\r\n<img width=\"915\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656513-78bbe993-a900-4633-ad66-886f56ce2cf0.png\">\r\n<img width=\"632\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201656559-e0c90ae2-4b21-4ee9-9bfc-a69c4ffaf708.png\">\r\n\r\nTooltip:\r\n<img width=\"509\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657054-11daeac3-cab2-45e4-8794-17a74b6c4300.png\">\r\n\r\n\r\n## Test instructions\r\n\r\n### Setup local registry\r\n\r\n- For testing, I created a new version of `System` package, that has a\r\n`dimension` field called `test_dimension`. This is needed so that the\r\nelasticsearch automation runs to generate the `routing_path` setting.\r\n\r\n- Download the test data zip:\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10004220/registry-packages.zip)\r\n\r\n\r\n- Start a registry:\r\n```\r\ndocker run -p 8080:8080 -v <path to unzipped dir>/input-packages/packages:/packages/test-packages -v <path to unzipped dir>/input-packages/package_registry_config.yml:/package-registry/config.yml docker.elastic.co/package-registry/package-registry:main\r\n```\r\n- Add this to your kibana config:\r\n```\r\nxpack.fleet.registryUrl: http://localhost:8080\r\n```\r\n\r\n- Open kibana, open Add System integration page (should be version\r\n`1.20.5` coming from local registry)\r\n- Enable only `Collect metrics from System instances / System cpu\r\nmetrics` stream, and enable `Time-series indexing (TSDB)` switch under\r\n`Advanced options`\r\n- Click on save integration. The integration should be added\r\nsuccessfully to an agent policy.\r\n- Start a fleet server and enroll an agent to the previously created\r\nagent policy. Wait for the agent to be healthy, this should trigger\r\nsystem metrics flowing in, this way triggering the creation of the data\r\nstream.\r\n- Go to `Stack Management / Index Management / Index Templates`, and\r\nopen the details of `metrics-system.cpu`, check that it has this in\r\n`Settings` tab: `index.mode: time_series`\r\n\r\n<img width=\"2013\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201657409-1754d5a4-98fa-4646-9ccf-e47981404018.png\">\r\n\r\n- Go to `Indices` tab and look for\r\n`data_stream=\"metrics-system.cpu-default\"` including hidden indices. You\r\nshould see `routing_path` populated in Settings, and `test_dimension` in\r\nMappings.\r\n\r\n<img width=\"1792\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659788-845fbca8-2cdb-4d1b-8af6-efc24b71f1d3.png\">\r\n<img width=\"774\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201659882-e9cba197-d354-494c-974a-3c580d4d98a5.png\">\r\n\r\n### Testing scenario of enabling TSDB in package spec by default\r\n\r\n- Prepared a newer version of `system` package `v1.20.9` that has\r\n`index_mode: \"time_series\"` in `system.cpu` data stream in package\r\nmanifest.\r\n- Download and extract the below zip and restart the local epr container\r\nto read from this folder.\r\n\r\n[registry-packages.zip](https://github.com/elastic/kibana/files/10011702/registry-packages.zip)\r\n- Open add system integration page\r\n- Check that `tsdb:true` is set in `Preview API request` for\r\n`system.cpu` data stream\r\n\r\n<img width=\"1033\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897480-f9a79526-776f-4d9f-b168-474b44e0aa53.png\">\r\n\r\n- Open the system cpu metrics stream on the policy editor, and check\r\nthat the TSDB switch is turned on.\r\n<img width=\"1093\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897787-f5a34aa6-c150-4c90-af97-bda6df92e0c4.png\">\r\n<img width=\"1051\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/201897943-85157b6b-caca-492d-8933-46ebe19b6930.png\">\r\n\r\n### Update 11/16:\r\n\r\n- After latest changes, expect `routing_path` with dimension fields to\r\nbe generated in Index Template when enabling TSDB:\r\n\r\n<img width=\"1163\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202123899-388d3f74-014a-492c-91ad-8afc9e454186.png\">\r\n\r\nThis was added to fix the issue mentioned here\r\nhttps://github.com/elastic/kibana/pull/144974#issuecomment-1315270890\r\n\r\n- After adding TSDB, modifying the parent component template should be\r\nsuccessful.\r\n\r\n<img width=\"555\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/90178898/202124250-14bcc310-0dd9-4246-8461-ef66c1f7ac43.png\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"4608af41da7dc98403bbdbfba8a3ac02475277e4"}}]}] BACKPORT-->