### PR TITLE
[Cases] Make the audit logger required

### DIFF
--- a/x-pack/plugins/cases/server/authorization/audit_logger.test.ts
+++ b/x-pack/plugins/cases/server/authorization/audit_logger.test.ts
@@ -38,23 +38,6 @@ describe('audit_logger', () => {
       logger = new AuthorizationAuditLogger(mockLogger);
     });
 
-    it('does not throw an error when the underlying audit logger is undefined', () => {
-      const authLogger = new AuthorizationAuditLogger();
-      jest.spyOn(authLogger, 'log');
-
-      expect(() => {
-        authLogger.log({
-          operation: Operations.createCase,
-          entity: {
-            owner: 'a',
-            id: '1',
-          },
-        });
-      }).not.toThrow();
-
-      expect(authLogger.log).toHaveBeenCalledTimes(1);
-    });
-
     it('logs a message with a saved object ID in the message field', () => {
       logger.log({
         operation: Operations.createCase,

--- a/x-pack/plugins/cases/server/authorization/audit_logger.ts
+++ b/x-pack/plugins/cases/server/authorization/audit_logger.ts
@@ -21,9 +21,9 @@ interface CreateAuditMsgParams {
  * Audit logger for authorization operations
  */
 export class AuthorizationAuditLogger {
-  private readonly auditLogger?: AuditLogger;
+  private readonly auditLogger: AuditLogger;
 
-  constructor(logger?: AuditLogger) {
+  constructor(logger: AuditLogger) {
     this.auditLogger = logger;
   }
 
@@ -97,6 +97,6 @@ export class AuthorizationAuditLogger {
    * Logs an audit event based on the status of an operation.
    */
   public log(auditMsgParams: CreateAuditMsgParams) {
-    this.auditLogger?.log(AuthorizationAuditLogger.createAuditMsg(auditMsgParams));
+    this.auditLogger.log(AuthorizationAuditLogger.createAuditMsg(auditMsgParams));
   }
 }

--- a/x-pack/plugins/cases/server/authorization/authorization.test.ts
+++ b/x-pack/plugins/cases/server/authorization/authorization.test.ts
@@ -61,7 +61,7 @@ describe('authorization', () => {
         securityAuth: securityStart.authz,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 
@@ -81,7 +81,7 @@ describe('authorization', () => {
         securityAuth: securityStart.authz,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 
@@ -140,7 +140,7 @@ describe('authorization', () => {
         request,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 
@@ -266,7 +266,7 @@ describe('authorization', () => {
         securityAuth: securityStart.authz,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 
@@ -295,7 +295,7 @@ describe('authorization', () => {
         securityAuth: securityStart.authz,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 
@@ -322,7 +322,7 @@ describe('authorization', () => {
         securityAuth: securityStart.authz,
         spaces: spacesStart,
         features: featuresStart,
-        auditLogger: new AuthorizationAuditLogger(),
+        auditLogger: new AuthorizationAuditLogger(mockLogger),
         logger: loggingSystemMock.createLogger(),
       });
 


### PR DESCRIPTION
This PR makes the audit logger required for the `AuthorizationAuditLogger`. We can do this because the security plugin is not optional anymore.