### PR TITLE
[8.6] [Security Solution] Use default time range if one can't be determined from query (#145651)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/investigate_in_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/investigate_in_timeline_button.tsx
@@ -23,14 +23,18 @@ import { useCreateTimeline } from '../../../../timelines/components/timeline/pro
 import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../detections/components/alerts_table/translations';
 import { useDeepEqualSelector } from '../../../hooks/use_selector';
 
-export const InvestigateInTimelineButton: React.FunctionComponent<{
+export interface InvestigateInTimelineButtonProps {
   asEmptyButton: boolean;
   dataProviders: DataProvider[] | null;
   filters?: Filter[] | null;
   timeRange?: TimeRange;
   keepDataView?: boolean;
   isDisabled?: boolean;
-}> = ({ asEmptyButton, children, dataProviders, filters, timeRange, keepDataView, ...rest }) => {
+}
+
+export const InvestigateInTimelineButton: React.FunctionComponent<
+  InvestigateInTimelineButtonProps
+> = ({ asEmptyButton, children, dataProviders, filters, timeRange, keepDataView, ...rest }) => {
   const dispatch = useDispatch();
 
   const getDataViewsSelector = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import moment from 'moment';
+import { TestProviders } from '../../../../mock';
+import {
+  DEFAULT_FROM,
+  DEFAULT_APP_TIME_RANGE,
+  DEFAULT_TO,
+} from '../../../../../../common/constants';
+import { KibanaServices } from '../../../../lib/kibana';
+import type { DefaultTimeRangeSetting } from '../../../../utils/default_date_settings';
+import { renderer as Renderer } from '.';
+import type { InvestigateInTimelineButtonProps } from '../../../event_details/table/investigate_in_timeline_button';
+
+jest.mock('../../../../lib/kibana');
+const mockGetServices = KibanaServices.get as jest.Mock;
+
+jest.mock('../../../event_details/table/investigate_in_timeline_button', () => {
+  const originalModule = jest.requireActual(
+    '../../../event_details/table/investigate_in_timeline_button'
+  );
+  return {
+    ...originalModule,
+    InvestigateInTimelineButton: function InvestigateInTimelineButton(
+      props: InvestigateInTimelineButtonProps
+    ) {
+      return (
+        <div
+          data-test-subj="insight-investigate-in-timeline-button"
+          data-timerange-from={props.timeRange?.from}
+          data-timerange-to={props.timeRange?.to}
+          data-timerange-kind={props.timeRange?.kind}
+        />
+      );
+    },
+  };
+});
+const mockTimeRange = (
+  timeRange: DefaultTimeRangeSetting = { from: DEFAULT_FROM, to: DEFAULT_TO }
+) => {
+  mockGetServices.mockImplementation(() => ({
+    uiSettings: {
+      get: (key: string) => {
+        switch (key) {
+          case DEFAULT_APP_TIME_RANGE:
+            return timeRange;
+          default:
+            throw new Error(`Unexpected config key: ${key}`);
+        }
+      },
+    },
+  }));
+};
+
+describe('insight component renderer', () => {
+  beforeEach(() => {
+    mockTimeRange(null);
+  });
+  it('renders correctly with valid date strings with no timestamp from results', () => {
+    render(
+      <TestProviders>
+        <Renderer
+          label={'test label'}
+          description={'test description'}
+          providers={
+            '[[{"field":"event.id","value":"kibana.alert.original_event.id","type":"parameter"}],[{"field":"event.category","value":"network","type":"literal"},{"field":"process.pid","value":"process.pid","type":"parameter"}]]'
+          }
+        />
+      </TestProviders>
+    );
+    const timelineButton = screen.getByTestId('insight-investigate-in-timeline-button');
+    const relativeTo = timelineButton.getAttribute('data-timerange-to') || '';
+    const relativeFrom = timelineButton.getAttribute('data-timerange-from') || '';
+    expect(timelineButton).toHaveAttribute('data-timerange-kind', 'relative');
+    try {
+      const toDate = new Date(relativeTo);
+      const fromDate = new Date(relativeFrom);
+      expect(moment(toDate).isValid()).toBe(true);
+      expect(moment(fromDate).isValid()).toBe(true);
+    } catch {
+      expect(false).toBe(true);
+    }
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -15,7 +15,8 @@ import { useInsightQuery } from './use_insight_query';
 import { useInsightDataProviders } from './use_insight_data_providers';
 import { BasicAlertDataContext } from '../../../event_details/investigation_guide_view';
 import { InvestigateInTimelineButton } from '../../../event_details/table/investigate_in_timeline_button';
-import type { AbsoluteTimeRange } from '../../../../store/inputs/model';
+import { getTimeRangeSettings } from '../../../../utils/default_date_settings';
+import type { TimeRange } from '../../../../store/inputs/model';
 
 interface InsightComponentProps {
   label?: string;
@@ -117,12 +118,23 @@ const InsightComponent = ({ label, description, providers }: InsightComponentPro
   const { totalCount, isQueryLoading, oldestTimestamp, hasError } = useInsightQuery({
     dataProviders,
   });
-  const timerange: AbsoluteTimeRange = useMemo(() => {
-    return {
-      kind: 'absolute',
-      from: oldestTimestamp ?? '',
-      to: new Date().toISOString(),
-    };
+  const timerange: TimeRange = useMemo(() => {
+    if (oldestTimestamp != null) {
+      return {
+        kind: 'absolute',
+        from: oldestTimestamp,
+        to: new Date().toISOString(),
+      };
+    } else {
+      const { to, from, fromStr, toStr } = getTimeRangeSettings();
+      return {
+        kind: 'relative',
+        to,
+        from,
+        fromStr,
+        toStr,
+      };
+    }
   }, [oldestTimestamp]);
   if (isQueryLoading) {
     return <EuiLoadingSpinner size="l" />;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution] Use default time range if one can't be determined from query (#145651)](https://github.com/elastic/kibana/pull/145651)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-11-29T16:10:09Z","message":"[Security Solution] Use default time range if one can't be determined from query (#145651)\n\n## Summary\r\n\r\nCurrently if an investigation guide contains markup providers that do\r\nnot match any events, an empty string is used as a date, resulting in\r\nhttps://github.com/elastic/kibana/issues/145521 . This pr fixes that\r\nissue by falling back to the users default settings in any case where a\r\ntime range cannot be determined.\r\n\r\n<img width=\"1020\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/56408403/202581667-b64dc388-f329-4913-a475-429470f8a2d1.png\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"73e9386247f4ce1772b3d8a5fabc2781fb3aee16","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","v8.6.0","v8.7.0"],"number":145651,"url":"https://github.com/elastic/kibana/pull/145651","mergeCommit":{"message":"[Security Solution] Use default time range if one can't be determined from query (#145651)\n\n## Summary\r\n\r\nCurrently if an investigation guide contains markup providers that do\r\nnot match any events, an empty string is used as a date, resulting in\r\nhttps://github.com/elastic/kibana/issues/145521 . This pr fixes that\r\nissue by falling back to the users default settings in any case where a\r\ntime range cannot be determined.\r\n\r\n<img width=\"1020\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/56408403/202581667-b64dc388-f329-4913-a475-429470f8a2d1.png\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"73e9386247f4ce1772b3d8a5fabc2781fb3aee16"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145651","number":145651,"mergeCommit":{"message":"[Security Solution] Use default time range if one can't be determined from query (#145651)\n\n## Summary\r\n\r\nCurrently if an investigation guide contains markup providers that do\r\nnot match any events, an empty string is used as a date, resulting in\r\nhttps://github.com/elastic/kibana/issues/145521 . This pr fixes that\r\nissue by falling back to the users default settings in any case where a\r\ntime range cannot be determined.\r\n\r\n<img width=\"1020\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/56408403/202581667-b64dc388-f329-4913-a475-429470f8a2d1.png\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"73e9386247f4ce1772b3d8a5fabc2781fb3aee16"}}]}] BACKPORT-->