### PR TITLE
[APM] Removing operations tab from labs

### DIFF
--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -237,7 +237,7 @@ export const uiSettings: Record<string, UiSettings> = {
     value: true,
     requiresPageReload: true,
     type: 'boolean',
-    showInLabs: true,
+    showInLabs: false,
   },
   [apmLabsButton]: {
     category: [observabilityFeatureId],


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/145537.

Removing operations tab from Labs.


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->