### PR TITLE
[Spacetime] [Docs] Add docs search to global nav bar

### DIFF
--- a/packages/core/application/core-application-browser-internal/src/application_service.tsx
+++ b/packages/core/application/core-application-browser-internal/src/application_service.tsx
@@ -319,14 +319,28 @@ export class ApplicationService {
       navigateToApp,
       navigateToUrl: async (
         url: string,
-        { skipAppLeave = false, forceRedirect = false, state }: NavigateToUrlOptions = {}
+        {
+          forceRedirect = false,
+          skipAppLeave = false,
+          openInNewTab = false,
+          externalLink = false,
+          state,
+        }: NavigateToUrlOptions = {}
       ) => {
+        if (externalLink && openInNewTab) {
+          window.open(url, '_blank');
+          return;
+        }
         const appInfo = parseAppUrl(url, http.basePath, this.apps);
         if ((forceRedirect || !appInfo) === true) {
           if (skipAppLeave) {
             window.removeEventListener('beforeunload', this.onBeforeUnload);
           }
-          return this.redirectTo!(url);
+          if (openInNewTab) {
+            this.openInNewTab!(url);
+          } else {
+            this.redirectTo!(url);
+          }
         }
         if (appInfo) {
           return navigateToApp(appInfo.app, { path: appInfo.path, skipAppLeave, state });

--- a/packages/core/application/core-application-browser/src/contracts.ts
+++ b/packages/core/application/core-application-browser/src/contracts.ts
@@ -188,4 +188,7 @@ export interface NavigateToUrlOptions {
    * optional state to forward to the application
    */
   state?: unknown;
+
+  externalLink?: boolean;
+  openInNewTab?: boolean;
 }

--- a/x-pack/plugins/global_search/common/types.ts
+++ b/x-pack/plugins/global_search/common/types.ts
@@ -107,6 +107,7 @@ export interface GlobalSearchFindParams {
    * The tag ids to filter search by.
    */
   tags?: string[];
+  docs?: string[];
 }
 
 /**

--- a/x-pack/plugins/global_search/public/services/search_service.ts
+++ b/x-pack/plugins/global_search/public/services/search_service.ts
@@ -187,10 +187,13 @@ export class SearchService {
         map((results) => results.map((r) => processResult(r)))
       )
     );
+
     return merge(...providersResults$, serverResults$).pipe(
-      map((results) => ({
-        results,
-      }))
+      map((results) => {
+        return {
+          results,
+        };
+      })
     );
   }
 }

--- a/x-pack/plugins/global_search/server/routes/find.ts
+++ b/x-pack/plugins/global_search/server/routes/find.ts
@@ -20,6 +20,7 @@ export const registerInternalFindRoute = (router: GlobalSearchRouter) => {
             term: schema.maybe(schema.string()),
             types: schema.maybe(schema.arrayOf(schema.string())),
             tags: schema.maybe(schema.arrayOf(schema.string())),
+            docs: schema.maybe(schema.arrayOf(schema.string())),
           }),
           options: schema.maybe(
             schema.object({

--- a/x-pack/plugins/global_search/server/services/search_service.ts
+++ b/x-pack/plugins/global_search/server/services/search_service.ts
@@ -177,7 +177,9 @@ export class SearchService {
         catchError(() => EMPTY),
         takeInArray(this.maxProviderResults),
         takeUntil(aborted$),
-        map((results) => results.map((r) => processResult(r)))
+        map((results) => {
+          return results.map((r) => processResult(r));
+        })
       );
     });
 

--- a/x-pack/plugins/global_search/server/services/search_service.ts
+++ b/x-pack/plugins/global_search/server/services/search_service.ts
@@ -172,19 +172,21 @@ export class SearchService {
     const processResult = (result: GlobalSearchProviderResult) =>
       processProviderResult(result, basePath);
 
-    const providersResults$ = [...this.providers.values()].map((provider) =>
-      provider.find(params, findOptions, context).pipe(
+    const providersResults$ = [...this.providers.values()].map((provider) => {
+      return provider.find(params, findOptions, context).pipe(
         catchError(() => EMPTY),
         takeInArray(this.maxProviderResults),
         takeUntil(aborted$),
         map((results) => results.map((r) => processResult(r)))
-      )
-    );
+      );
+    });
 
     return merge(...providersResults$).pipe(
-      map((results) => ({
-        results,
-      }))
+      map((results) => {
+        return {
+          results,
+        };
+      })
     );
   }
 }

--- a/x-pack/plugins/global_search_bar/public/components/popover_footer.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/popover_footer.tsx
@@ -31,12 +31,13 @@ export const PopoverFooter: FC<PopoverFooterProps> = ({ isMac }) => {
             />
             &nbsp;
             <EuiCode>type:</EuiCode>&nbsp;
+            <EuiCode>tag:</EuiCode>&nbsp;
             <FormattedMessage
               id="xpack.globalSearchBar.searchBar.helpText.helpTextConjunction"
               defaultMessage="or"
             />
             &nbsp;
-            <EuiCode>tag:</EuiCode>
+            <EuiCode>docs:</EuiCode>
           </p>
         </EuiText>
       </EuiFlexItem>

--- a/x-pack/plugins/global_search_bar/public/components/popover_placeholder.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/popover_placeholder.tsx
@@ -48,7 +48,7 @@ export const PopoverPlaceholder: FC<PopoverPlaceholderProps> = ({ basePath, dark
         <p>
           <FormattedMessage
             id="xpack.globalSearchBar.searchBar.noResults"
-            defaultMessage="Try searching for applications, dashboards, visualizations, and more."
+            defaultMessage="Try searching for applications, dashboards, visualizations, docs, and more."
           />
         </p>
       </EuiFlexItem>

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -31,7 +31,7 @@ import type {
   GlobalSearchFindParams,
 } from '@kbn/global-search-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
-import { FilterValues, parseSearchParams } from '../search_syntax';
+import { parseSearchParams } from '../search_syntax';
 import { getSuggestions, SearchSuggestion } from '../suggestions';
 import { resultToOption, suggestionToOption } from '../lib';
 import { PopoverFooter } from './popover_footer';
@@ -247,7 +247,10 @@ export const SearchBar: FC<SearchBarProps> = ({
         console.log('Error trying to track searchbar metrics', e);
       }
 
-      navigateToUrl(url);
+      navigateToUrl(
+        url,
+        type === 'documentation' ? { openInNewTab: true, externalLink: true } : {}
+      );
 
       (document.activeElement as HTMLElement).blur();
       if (searchRef) {

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -31,7 +31,7 @@ import type {
   GlobalSearchFindParams,
 } from '@kbn/global-search-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
-import { parseSearchParams } from '../search_syntax';
+import { FilterValues, parseSearchParams } from '../search_syntax';
 import { getSuggestions, SearchSuggestion } from '../suggestions';
 import { resultToOption, suggestionToOption } from '../lib';
 import { PopoverFooter } from './popover_footer';
@@ -99,11 +99,12 @@ export const SearchBar: FC<SearchBarProps> = ({
   }, [globalSearch, initialLoad]);
 
   const loadSuggestions = useCallback(
-    (term: string) => {
+    (term: string, docs?: FilterValues<string>) => {
       return getSuggestions({
         searchTerm: term,
         searchableTypes,
         tagCache: taggingApi?.cache,
+        docs,
       });
     },
     [taggingApi, searchableTypes]
@@ -118,7 +119,6 @@ export const SearchBar: FC<SearchBarProps> = ({
       if (!isMounted()) {
         return;
       }
-
       _setOptions([
         ...suggestions.map(suggestionToOption),
         ..._options.map((option) =>
@@ -143,6 +143,7 @@ export const SearchBar: FC<SearchBarProps> = ({
         }
 
         const suggestions = loadSuggestions(searchValue);
+        // console.log('seachValue', searchValue);
 
         let aggregatedResults: GlobalSearchResult[] = [];
         if (searchValue.length !== 0) {
@@ -157,8 +158,9 @@ export const SearchBar: FC<SearchBarProps> = ({
               )
             : undefined;
         const searchParams: GlobalSearchFindParams = {
-          term: rawParams.term,
           types: rawParams.filters.types,
+          docs: rawParams.filters.docs,
+          term: rawParams.term,
           tags: tagIds,
         };
         // TODO technically a subtle bug here

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -275,7 +275,7 @@ export const SearchBar: FC<SearchBarProps> = ({
   );
 
   const placeholderText = i18n.translate('xpack.globalSearchBar.searchBar.placeholder', {
-    defaultMessage: 'Find apps, content, and more.',
+    defaultMessage: 'Find apps, content, docs, and more.',
   });
   const keyboardShortcutTooltip = `${i18n.translate(
     'xpack.globalSearchBar.searchBar.shortcutTooltip.description',

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -144,7 +144,6 @@ export const SearchBar: FC<SearchBarProps> = ({
         }
 
         const suggestions = loadSuggestions(searchValue);
-        // console.log('seachValue', searchValue);
 
         let aggregatedResults: GlobalSearchResult[] = [];
         if (searchValue.length !== 0) {

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -99,12 +99,11 @@ export const SearchBar: FC<SearchBarProps> = ({
   }, [globalSearch, initialLoad]);
 
   const loadSuggestions = useCallback(
-    (term: string, docs?: FilterValues<string>) => {
+    (term: string) => {
       return getSuggestions({
         searchTerm: term,
         searchableTypes,
         tagCache: taggingApi?.cache,
-        docs,
       });
     },
     [taggingApi, searchableTypes]

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -21,6 +21,8 @@ import {
   EuiLoadingSpinner,
   EuiFlexGroup,
   EuiFlexItem,
+  toSentenceCase,
+  EuiLink,
 } from '@elastic/eui';
 import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
@@ -303,7 +305,22 @@ export const SearchBar: FC<SearchBarProps> = ({
       className="kbnSearchBar"
       popoverButtonBreakpoints={['xs', 's']}
       singleSelection={true}
-      renderOption={(option) => euiSelectableTemplateSitewideRenderOptions(option, searchTerm)}
+      renderOption={(option) => {
+        return option.type === 'documentation' ? (
+          <span className="euiSelectableListItem__text">
+            <EuiLink href="" external={true}>
+              <span className="euiSelectableTemplateSitewide__listItemTitle">{option.label}</span>
+            </EuiLink>
+            <span className="euiSelectableTemplateSitewide__optionMetasList">
+              <span className="euiSelectableTemplateSitewide__optionMeta">
+                {toSentenceCase(option.type)}
+              </span>
+            </span>
+          </span>
+        ) : (
+          euiSelectableTemplateSitewideRenderOptions(option, searchTerm)
+        );
+      }}
       searchProps={{
         value: searchValue,
         onInput: (e: React.UIEvent<HTMLInputElement>) => setSearchValue(e.currentTarget.value),

--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -43,17 +43,16 @@ export const resultToOption = (
       <ResultTagList tags={tagIds.map(getTag) as Tag[]} searchTagIds={searchTagIds} />
     );
   }
-
-  if (type === 'documentation') {
-    // Did the following in the application service instead
-    /*
+  // Did the following in the application service instead
+  /*
+    if (type === 'documentation') {
         option.onClick = (x) => {
           window.open(url, '_blank', 'noopener,noreferrer');
         };
-    */
-
-    option.append = <EuiIcon type="popout" />;
-  }
+        
+        option.append = <EuiIcon type="popout" />;
+    }
+  */
 
   return option;
 };

--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import type { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
+import { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
 import type { GlobalSearchResult } from '@kbn/global-search-plugin/common/types';
 import type { SavedObjectTaggingPluginStart, Tag } from '@kbn/saved-objects-tagging-plugin/public';
 import { ResultTagList } from '../components/result_tag_list';
@@ -21,7 +21,7 @@ export const resultToOption = (
   const { id, title, url, icon, type, meta = {} } = result;
   const { tagIds = [], categoryLabel = '' } = meta as { tagIds: string[]; categoryLabel: string };
   // only displaying icons for applications and integrations
-  const useIcon = type === 'application' || type === 'integration';
+  const useIcon = type === 'application' || type === 'integration' || type === 'documentation';
   const option: EuiSelectableTemplateSitewideOption = {
     key: id,
     label: title,

--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiIcon, EuiSelectableTemplateSitewideOption } from '@elastic/eui';
+import { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
 import type { GlobalSearchResult } from '@kbn/global-search-plugin/common/types';
 import type { SavedObjectTaggingPluginStart, Tag } from '@kbn/saved-objects-tagging-plugin/public';
 import { ResultTagList } from '../components/result_tag_list';

--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
+import { EuiIcon, EuiSelectableTemplateSitewideOption } from '@elastic/eui';
 import type { GlobalSearchResult } from '@kbn/global-search-plugin/common/types';
 import type { SavedObjectTaggingPluginStart, Tag } from '@kbn/saved-objects-tagging-plugin/public';
 import { ResultTagList } from '../components/result_tag_list';
@@ -42,6 +42,17 @@ export const resultToOption = (
     option.append = (
       <ResultTagList tags={tagIds.map(getTag) as Tag[]} searchTagIds={searchTagIds} />
     );
+  }
+
+  if (type === 'documentation') {
+    // Did the following in the application service instead
+    /*
+        option.onClick = (x) => {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        };
+    */
+
+    option.append = <EuiIcon type="popout" />;
   }
 
   return option;

--- a/x-pack/plugins/global_search_bar/public/search_syntax/parse_search_params.ts
+++ b/x-pack/plugins/global_search_bar/public/search_syntax/parse_search_params.ts
@@ -45,12 +45,14 @@ export const parseSearchParams = (term: string): ParsedSearchParams => {
 
   const tags = filterValues.get('tag');
   const types = filterValues.get('type');
+  const docs = filterValues.get('docs');
 
   return {
     term: searchTerm,
     filters: {
       tags: tags ? valuesToString(tags) : undefined,
       types: types ? valuesToString(types) : undefined,
+      docs: docs ? valuesToString(docs) : undefined,
       unknowns: unknownFilters,
     },
   };

--- a/x-pack/plugins/global_search_bar/public/search_syntax/types.ts
+++ b/x-pack/plugins/global_search_bar/public/search_syntax/types.ts
@@ -30,6 +30,7 @@ export interface ParsedSearchParams {
     /**
      * All unknown field clauses
      */
+    docs?: FilterValues<string>;
     unknowns: Record<string, FilterValues>;
   };
 }

--- a/x-pack/plugins/global_search_bar/public/suggestions/get_suggestions.ts
+++ b/x-pack/plugins/global_search_bar/public/suggestions/get_suggestions.ts
@@ -7,11 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import { ITagsCache } from '@kbn/saved-objects-tagging-oss-plugin/public';
+import { FilterValues } from '../search_syntax';
 
 interface GetSuggestionOptions {
   searchTerm: string;
   searchableTypes: string[];
   tagCache?: ITagsCache;
+  docs?: FilterValues<string>;
 }
 
 export interface SearchSuggestion {

--- a/x-pack/plugins/global_search_bar/public/suggestions/get_suggestions.ts
+++ b/x-pack/plugins/global_search_bar/public/suggestions/get_suggestions.ts
@@ -31,7 +31,6 @@ export const getSuggestions = ({
 }: GetSuggestionOptions): SearchSuggestion[] => {
   const results: SearchSuggestion[] = [];
   const suggestionTerm = searchTerm.trim();
-
   const matchingType = findIgnoreCase(searchableTypes, suggestionTerm);
   if (matchingType) {
     const suggestedSearch = escapeIfWhiteSpaces(matchingType);
@@ -44,6 +43,18 @@ export const getSuggestions = ({
       }),
       suggestedSearch: `type:${suggestedSearch}`,
     });
+
+    if (matchingType === 'dashboard' || matchingType === 'lens') {
+      results.push({
+        key: '__doc__suggestion__',
+        label: `docs: ${suggestedSearch}`,
+        icon: 'documentation',
+        description: i18n.translate('xpack.globalSearchBar.suggestions.searchForDocsLabel', {
+          defaultMessage: 'Search for docs',
+        }),
+        suggestedSearch: `docs:${suggestedSearch}`,
+      });
+    }
   }
 
   if (tagCache && searchTerm) {

--- a/x-pack/plugins/global_search_providers/public/providers/application.ts
+++ b/x-pack/plugins/global_search_providers/public/providers/application.ts
@@ -29,8 +29,8 @@ export const createApplicationResultProvider = (
 
   return {
     id: 'application',
-    find: ({ term, types, tags }, { aborted$, maxResults }) => {
-      if (tags || (types && !types.includes(applicationType))) {
+    find: ({ term, types, tags, docs }, { aborted$, maxResults }) => {
+      if (tags || docs || (types && !types.includes(applicationType))) {
         return of([]);
       }
       return searchableApps$.pipe(

--- a/x-pack/plugins/global_search_providers/server/plugin.ts
+++ b/x-pack/plugins/global_search_providers/server/plugin.ts
@@ -7,7 +7,7 @@
 
 import { CoreSetup, Plugin } from '@kbn/core/server';
 import { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/server';
-import { createSavedObjectsResultProvider } from './providers';
+import { createDocsResultProvider, createSavedObjectsResultProvider } from './providers';
 
 export interface GlobalSearchProvidersPluginSetupDeps {
   globalSearch: GlobalSearchPluginSetup;
@@ -21,6 +21,8 @@ export class GlobalSearchProvidersPlugin
     { globalSearch }: GlobalSearchProvidersPluginSetupDeps
   ) {
     globalSearch.registerResultProvider(createSavedObjectsResultProvider());
+    globalSearch.registerResultProvider(createDocsResultProvider());
+
     return {};
   }
 

--- a/x-pack/plugins/global_search_providers/server/providers/docs/index.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export { createSavedObjectsResultProvider } from './saved_objects';
-export { createDocsResultProvider } from './docs';
+export { createDocsResultProvider } from './provider';

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -5,18 +5,20 @@
  * 2.0.
  */
 
+import { toSentenceCase } from '@elastic/eui';
 import { GlobalSearchProviderResult } from '@kbn/global-search-plugin/server';
 import uuid from 'uuid';
 
 export const mapToResults = (term: string, response: Response): GlobalSearchProviderResult[] => {
+  const isKibanaDoc = response.url.startsWith('https://www.elastic.co/guide/en/kibana/');
   return [
     {
       id: uuid.v4(),
-      title: `Search for "${term}" in the docs`,
+      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" in the docs`,
       type: 'documentation',
-      icon: 'document',
+      icon: isKibanaDoc ? 'documentation' : 'search',
       url: response.url,
-      score: 100,
+      score: isKibanaDoc ? 100 : 99,
     },
   ];
 };

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -14,9 +14,9 @@ export const mapToResults = (term: string, response: Response): GlobalSearchProv
   return [
     {
       id: uuid.v4(),
-      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" on elastic.co`,
+      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" in the docs`,
       type: 'documentation',
-      icon: isKibanaDoc ? 'documentation' : 'search',
+      icon: 'documentation',
       url: response.url,
       score: isKibanaDoc ? 100 : 99,
     },

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -14,7 +14,7 @@ export const mapToResults = (term: string, response: Response): GlobalSearchProv
   return [
     {
       id: uuid.v4(),
-      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" in the docs`,
+      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" on elastic.co`,
       type: 'documentation',
       icon: isKibanaDoc ? 'documentation' : 'search',
       url: response.url,

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GlobalSearchProviderResult } from '@kbn/global-search-plugin/server';
+import { toSentenceCase } from '@elastic/eui';
+import uuid from 'uuid';
+
+export const mapToResults = (term: string, response: Response): GlobalSearchProviderResult[] => {
+  return [
+    {
+      id: uuid.v4(),
+      title: `${toSentenceCase(term)}`,
+      type: 'documentation',
+      icon: 'document',
+      url: response.url,
+      score: 100,
+    },
+  ];
+};

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -9,12 +9,21 @@ import { toSentenceCase } from '@elastic/eui';
 import { GlobalSearchProviderResult } from '@kbn/global-search-plugin/server';
 import uuid from 'uuid';
 
-export const mapToResults = (term: string, response: Response): GlobalSearchProviderResult[] => {
-  const isKibanaDoc = response.url.startsWith('https://www.elastic.co/guide/en/kibana/');
+export const mapToResults = (
+  type: 'kibana' | 'search' | 'default',
+  term: string,
+  response: Response
+): GlobalSearchProviderResult[] => {
+  const isGenericSearch = type === 'default';
+  const isKibanaDoc = type === 'kibana';
   return [
     {
       id: uuid.v4(),
-      title: isKibanaDoc ? `${toSentenceCase(term)} docs` : `Search for "${term}" in the docs`,
+      title: isGenericSearch
+        ? `Elastic docs`
+        : isKibanaDoc
+        ? `${toSentenceCase(term)} docs`
+        : `Search for "${term}" in the docs`,
       type: 'documentation',
       icon: 'documentation',
       url: response.url,

--- a/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/map_doc_to_result.ts
@@ -6,14 +6,13 @@
  */
 
 import { GlobalSearchProviderResult } from '@kbn/global-search-plugin/server';
-import { toSentenceCase } from '@elastic/eui';
 import uuid from 'uuid';
 
 export const mapToResults = (term: string, response: Response): GlobalSearchProviderResult[] => {
   return [
     {
       id: uuid.v4(),
-      title: `${toSentenceCase(term)}`,
+      title: `Search for "${term}" in the docs`,
       type: 'documentation',
       icon: 'document',
       url: response.url,

--- a/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
@@ -6,7 +6,7 @@
  */
 
 import fetch from 'node-fetch';
-import { from, of, zip } from 'rxjs';
+import { from, of, zip, filter } from 'rxjs';
 import { URLSearchParams } from 'url';
 import { map, takeUntil } from 'rxjs/operators';
 
@@ -17,27 +17,43 @@ import { mapToResults } from './map_doc_to_result';
 export const createDocsResultProvider = (): GlobalSearchResultProvider => {
   return {
     id: 'docsLink',
-    find: ({ docs }, { aborted$ }) => {
-      if (!docs || docs.length <= 0) return of([]);
-      const term = docs[0];
+    find: ({ docs, term }, { aborted$ }) => {
+      if (docs && docs.length > 0) {
+        const searchTerm = docs[0];
 
-      const kibanaDocsUrl = `https://www.elastic.co/guide/en/kibana/current/${term}.html`;
-      const kibanaDocsResponsePromise = fetch(kibanaDocsUrl);
+        const kibanaDocsUrl = `https://www.elastic.co/guide/en/kibana/current/${searchTerm}.html`;
+        const kibanaDocsResponsePromise = fetch(kibanaDocsUrl);
 
-      const searchUrl = new URL('https://www.elastic.co/search');
-      searchUrl.search = new URLSearchParams([
-        ['q', term],
-        ['filters[0][field]', 'website_area'],
-        ['filters[0][values][0]', 'documentation'],
-      ]).toString();
-      const searchResponsePromise = fetch(searchUrl);
+        const searchUrl = new URL('https://www.elastic.co/search');
+        searchUrl.search = new URLSearchParams([
+          ['q', searchTerm],
+          ['filters[0][field]', 'website_area'],
+          ['filters[0][values][0]', 'documentation'],
+        ]).toString();
+        const searchResponsePromise = fetch(searchUrl);
 
-      return zip(from(kibanaDocsResponsePromise), from(searchResponsePromise)).pipe(
-        takeUntil(aborted$),
-        map(([res1, res2]) =>
-          res1.status === 200 ? mapToResults(term ?? '', res1) : mapToResults(term ?? '', res2)
-        )
-      );
+        return zip(from(kibanaDocsResponsePromise), from(searchResponsePromise)).pipe(
+          takeUntil(aborted$),
+          map(([res1, res2]) =>
+            res1.status === 200
+              ? mapToResults('kibana', searchTerm ?? '', res1)
+              : mapToResults('search', searchTerm ?? '', res2)
+          )
+        );
+      }
+
+      if (term && term.toLowerCase().includes('doc')) {
+        const mainDocsUrl = new URL('https://www.elastic.co/guide/index.html');
+        const mainDocsResponsePromise = fetch(mainDocsUrl);
+
+        return from(mainDocsResponsePromise).pipe(
+          takeUntil(aborted$),
+          filter((res) => res.status === 200),
+          map((res) => mapToResults('default', term ?? '', res))
+        );
+      }
+
+      return of([]);
     },
     getSearchableTypes: () => [],
   };

--- a/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import { from, of, merge, zip } from 'rxjs';
 import fetch from 'node-fetch';
+import { from, of, zip } from 'rxjs';
 import { URLSearchParams } from 'url';
+import { map, takeUntil } from 'rxjs/operators';
 
-import { map, takeUntil, filter, first, take } from 'rxjs/operators';
 import { GlobalSearchResultProvider } from '@kbn/global-search-plugin/server';
+
 import { mapToResults } from './map_doc_to_result';
 
 export const createDocsResultProvider = (): GlobalSearchResultProvider => {

--- a/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { from } from 'rxjs';
+import fetch from 'node-fetch';
+import { map, takeUntil, filter } from 'rxjs/operators';
+import { GlobalSearchResultProvider } from '@kbn/global-search-plugin/server';
+import { mapToResults } from './map_doc_to_result';
+
+export const createDocsResultProvider = (): GlobalSearchResultProvider => {
+  return {
+    id: 'docsLink',
+    find: ({ docs }, { aborted$ }) => {
+      if (!docs || docs.length <= 0) return from([]);
+      const term = docs[0].toLowerCase();
+
+      const responsePromise = fetch(`https://www.elastic.co/guide/en/kibana/current/${term}.html`);
+
+      return from(responsePromise).pipe(
+        takeUntil(aborted$),
+        filter((res) => res.status === 200),
+        map((res) => mapToResults(term ?? '', res))
+      );
+    },
+    getSearchableTypes: () => ['docs'],
+  };
+};

--- a/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { from } from 'rxjs';
+import { from, of } from 'rxjs';
 import fetch from 'node-fetch';
 import { map, takeUntil, filter } from 'rxjs/operators';
 import { GlobalSearchResultProvider } from '@kbn/global-search-plugin/server';
@@ -15,7 +15,7 @@ export const createDocsResultProvider = (): GlobalSearchResultProvider => {
   return {
     id: 'docsLink',
     find: ({ docs }, { aborted$ }) => {
-      if (!docs || docs.length <= 0) return from([]);
+      if (!docs || docs.length <= 0) return of([]);
       const term = docs[0].toLowerCase();
 
       const responsePromise = fetch(`https://www.elastic.co/guide/en/kibana/current/${term}.html`);
@@ -26,6 +26,6 @@ export const createDocsResultProvider = (): GlobalSearchResultProvider => {
         map((res) => mapToResults(term ?? '', res))
       );
     },
-    getSearchableTypes: () => ['docs'],
+    getSearchableTypes: () => [],
   };
 };

--- a/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
+++ b/x-pack/plugins/global_search_providers/server/providers/docs/provider.ts
@@ -7,6 +7,8 @@
 
 import { from, of } from 'rxjs';
 import fetch from 'node-fetch';
+import { URLSearchParams } from 'url';
+
 import { map, takeUntil, filter } from 'rxjs/operators';
 import { GlobalSearchResultProvider } from '@kbn/global-search-plugin/server';
 import { mapToResults } from './map_doc_to_result';
@@ -16,9 +18,15 @@ export const createDocsResultProvider = (): GlobalSearchResultProvider => {
     id: 'docsLink',
     find: ({ docs }, { aborted$ }) => {
       if (!docs || docs.length <= 0) return of([]);
-      const term = docs[0].toLowerCase();
+      const term = docs[0];
 
-      const responsePromise = fetch(`https://www.elastic.co/guide/en/kibana/current/${term}.html`);
+      const url = new URL('https://www.elastic.co/search');
+      url.search = new URLSearchParams([
+        ['q', term],
+        ['filters[0][field]', 'website_area'],
+        ['filters[0][values][0]', 'documentation'],
+      ]).toString();
+      const responsePromise = fetch(url);
 
       return from(responsePromise).pipe(
         takeUntil(aborted$),

--- a/x-pack/plugins/lens/public/search_provider.ts
+++ b/x-pack/plugins/lens/public/search_provider.ts
@@ -26,8 +26,8 @@ export const getSearchProvider: (
   uiCapabilities: Promise<ApplicationStart['capabilities']>
 ) => GlobalSearchResultProvider = (uiCapabilities) => ({
   id: 'lens',
-  find: ({ term = '', types, tags }) => {
-    if (tags || (types && !types.includes('application'))) {
+  find: ({ term = '', types, tags, docs }) => {
+    if (tags || docs || (types && !types.includes('application'))) {
       return of([]);
     }
     return from(


### PR DESCRIPTION
## ⚠️ This PR serves as a demo *only* - it contains unmergeable code.

Related to https://github.com/elastic/kibana/issues/106329

## Summary

This PR introduces a way to search the docs from within Kibana using the `docs:` prefix in the global search bar:



https://user-images.githubusercontent.com/8698078/204926395-b7119e05-05e9-4441-a0f1-5f4d5fab24d3.mov


For the sake of visibility of the docs in general, this PR also adds an option to send users off to the general Elastic docs when searching for anything containing the keyword `"doc"`

### Notes
Searching for `"docs:<search term>"` will fire requests to both `https://www.elastic.co/search?q=<search term>&filters[0][field]=website_area&filters[0][values][0]=documentation` and `https://www.elastic.co/guide/en/kibana/current/<search term>.html` - if the latter URL gives a status of  `200` (i.e. that page exists in the Kibana docs), then the user will have the option of being directed to the Kibana docs directly.
Otherwise, if this page does not exist, then the option for navigating to `https://www.elastic.co/search?q=<search term>&filters[0][field]=website_area&filters[0][values][0]=documentation` will show up, instead. 

As an example, `"docs:dashboard"` will show the option to navigate to `https://www.elastic.co/guide/en/kibana/current/dashboard.html`, since this page exists. On the other hand, `"docs:test"` will only show the generic search because `https://www.elastic.co/guide/en/kibana/current/test.html` does **not** exist.

Rather than having an option that redirects them to the generic "search results" page, it would be incredible if the Kibana search popover could instead be populated with the results on the documentation search page. However, this would require the docs website to set up some sort of API endpoint that would return these results as JSON that we could then parse on the Kibana side. That way, there would no longer be this "in between" step where the user has to click a link  to be taken to the documentation search **before** they can actually find a specific article that interests them.

If this API layer was added, this opens up many other in-product help opportunities, as well! For example, [showing a preview of the documentation](https://github.com/elastic/kibana/pull/131174) on hover.

### Collaborators
@Heenawter 
@gchaps 