### PR TITLE
[Synthetics] Add field filtering to status endpoint to reduce memory footprint

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/status/current_status.ts
+++ b/x-pack/plugins/synthetics/server/routes/status/current_status.ts
@@ -171,6 +171,12 @@ export async function getStatus(
         sortField: 'name.keyword',
         sortOrder: 'asc',
         query,
+        fields: [
+          ConfigKey.ENABLED,
+          ConfigKey.LOCATIONS,
+          ConfigKey.MONITOR_QUERY_ID,
+          ConfigKey.SCHEDULE,
+        ],
       },
       syntheticsMonitorClient.syntheticsService,
       savedObjectsClient
@@ -181,8 +187,8 @@ export async function getStatus(
         disabledCount += monitor.attributes[ConfigKey.LOCATIONS].length;
       } else {
         enabledIds.push(monitor.attributes[ConfigKey.MONITOR_QUERY_ID]);
-        maxLocations = Math.max(maxLocations, monitor.attributes.locations.length);
-        maxPeriod = Math.max(maxPeriod, periodToMs(monitor.attributes.schedule));
+        maxLocations = Math.max(maxLocations, monitor.attributes[ConfigKey.LOCATIONS].length);
+        maxPeriod = Math.max(maxPeriod, periodToMs(monitor.attributes[ConfigKey.SCHEDULE]));
       }
     });
   } while (monitors.saved_objects.length === monitors.per_page);


### PR DESCRIPTION
## Summary

Not related to an issue, this simply filters out unneeded fields for status counting. The status count endpoint could end up needing lots of memory, and it will run frequently, so this is a low-effort way to help reduce load on the Kibana server.

## Testing this PR

There should be no noticeable impact on the Kibana server or client performance, except maybe for very large deployments.

Ensure you can create and see monitors in the overview page/flyout, and that the stats at the top of the page continue working as they do on current `main`.