### PR TITLE
[Lens] Enables the tooltip on partition charts

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/partition/to_expression.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/to_expression.ts
@@ -169,7 +169,7 @@ const generateCommonArguments = (
     truncateLegend:
       layer.truncateLegend ?? getDefaultVisualValuesForLayer(state, datasourceLayers).truncateText,
     palette: generatePaletteAstArguments(paletteService, state.palette),
-    addTooltip: false,
+    addTooltip: true,
   };
 };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/146574

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/17003240/204623693-a2d17c66-cd86-450b-b50f-e2ced880e46f.png">

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->