### PR TITLE
[ci] Shorten timeout for jest and ftr steps

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -389,7 +389,7 @@ export async function pickTestGroupRunOrder() {
             label: 'Jest Tests',
             command: getRequiredEnv('JEST_UNIT_SCRIPT'),
             parallelism: unit.count,
-            timeout_in_minutes: 90,
+            timeout_in_minutes: 60,
             key: 'jest',
             agents: {
               queue: 'n2-4-spot',
@@ -409,7 +409,7 @@ export async function pickTestGroupRunOrder() {
             label: 'Jest Integration Tests',
             command: getRequiredEnv('JEST_INTEGRATION_SCRIPT'),
             parallelism: integration.count,
-            timeout_in_minutes: 120,
+            timeout_in_minutes: 60,
             key: 'jest-integration',
             agents: {
               queue: 'n2-4-spot',
@@ -446,7 +446,7 @@ export async function pickTestGroupRunOrder() {
                 ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
                   label: title,
                   command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
-                  timeout_in_minutes: 150,
+                  timeout_in_minutes: 60,
                   agents: {
                     queue,
                   },


### PR DESCRIPTION
We're seeing sporadic image outages today causing test steps to reach their max timeout.  Currently we displays warnings on configurations taking >40? minutes.  This decreases the error timeout for jest and ftr configurations to 60 minutes.

https://buildkite.com/elastic/kibana-on-merge/builds/24321#0184c4b6-ae6c-4777-a637-20d34feba777 https://buildkite.com/elastic/kibana-on-merge/builds/24279#0184c3d0-5b12-4c8b-9e8c-6c7b67638661

I'll follow up with a separate issue for better error handling during test setup.

<!--ONMERGE {"backportTargets":["8.5","8.6"]} ONMERGE-->