### PR TITLE
[8.6] Reduce startup time by skipping update mappings step when possible (#145604)

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/index.ts
@@ -24,6 +24,7 @@ export {
   cloneIndex,
   waitForTask,
   updateAndPickupMappings,
+  updateTargetMappingsMeta,
   updateAliases,
   transformDocs,
   setWriteBlock,

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/check_target_mappings.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/check_target_mappings.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import * as Either from 'fp-ts/lib/Either';
+import type { IndexMapping } from '@kbn/core-saved-objects-base-server-internal';
+import { checkTargetMappings } from './check_target_mappings';
+import { diffMappings } from '../core/build_active_mappings';
+
+jest.mock('../core/build_active_mappings');
+
+const diffMappingsMock = diffMappings as jest.MockedFn<typeof diffMappings>;
+
+const sourceIndexMappings: IndexMapping = {
+  properties: {
+    field: { type: 'integer' },
+  },
+};
+
+const targetIndexMappings: IndexMapping = {
+  properties: {
+    field: { type: 'long' },
+  },
+};
+
+describe('checkTargetMappings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns match=false if source mappings are not defined', async () => {
+    const task = checkTargetMappings({
+      targetIndexMappings,
+    });
+
+    const result = await task();
+    expect(diffMappings).not.toHaveBeenCalled();
+    expect(result).toEqual(Either.right({ match: false }));
+  });
+
+  it('calls diffMappings() with the source and target mappings', async () => {
+    const task = checkTargetMappings({
+      sourceIndexMappings,
+      targetIndexMappings,
+    });
+
+    await task();
+    expect(diffMappings).toHaveBeenCalledTimes(1);
+    expect(diffMappings).toHaveBeenCalledWith(sourceIndexMappings, targetIndexMappings);
+  });
+
+  it('returns match=true if diffMappings() match', async () => {
+    diffMappingsMock.mockReturnValueOnce(undefined);
+
+    const task = checkTargetMappings({
+      sourceIndexMappings,
+      targetIndexMappings,
+    });
+
+    const result = await task();
+    expect(result).toEqual(Either.right({ match: true }));
+  });
+
+  it('returns match=false if diffMappings() finds differences', async () => {
+    diffMappingsMock.mockReturnValueOnce({ changedProp: 'field' });
+
+    const task = checkTargetMappings({
+      sourceIndexMappings,
+      targetIndexMappings,
+    });
+
+    const result = await task();
+    expect(result).toEqual(Either.right({ match: false }));
+  });
+});

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/check_target_mappings.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/check_target_mappings.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import * as Either from 'fp-ts/lib/Either';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
+
+import { IndexMapping } from '@kbn/core-saved-objects-base-server-internal';
+import { diffMappings } from '../core/build_active_mappings';
+
+/** @internal */
+export interface CheckTargetMappingsParams {
+  sourceIndexMappings?: IndexMapping;
+  targetIndexMappings: IndexMapping;
+}
+
+/** @internal */
+export interface TargetMappingsCompareResult {
+  match: boolean;
+}
+
+export const checkTargetMappings =
+  ({
+    sourceIndexMappings,
+    targetIndexMappings,
+  }: CheckTargetMappingsParams): TaskEither.TaskEither<never, TargetMappingsCompareResult> =>
+  async () => {
+    if (!sourceIndexMappings) {
+      return Either.right({ match: false });
+    }
+    const diff = diffMappings(sourceIndexMappings, targetIndexMappings);
+    return Either.right({ match: !diff });
+  };

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
@@ -6,8 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { RetryableEsClientError } from './catch_retryable_es_client_errors';
-import { DocumentsTransformFailed } from '../core/migrate_raw_docs';
+import { type Either, right } from 'fp-ts/lib/Either';
+import type { RetryableEsClientError } from './catch_retryable_es_client_errors';
+import type { DocumentsTransformFailed } from '../core/migrate_raw_docs';
 
 export {
   BATCH_SIZE,
@@ -77,6 +78,12 @@ export { updateAliases } from './update_aliases';
 
 export type { CreateIndexParams } from './create_index';
 export { createIndex } from './create_index';
+
+export { checkTargetMappings } from './check_target_mappings';
+
+export { updateTargetMappingsMeta } from './update_target_mappings_meta';
+
+export const noop = async (): Promise<Either<never, 'noop'>> => right('noop' as const);
 
 export type {
   UpdateAndPickupMappingsResponse,

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_and_pickup_mappings.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_and_pickup_mappings.ts
@@ -45,11 +45,13 @@ export const updateAndPickupMappings = ({
     RetryableEsClientError,
     'update_mappings_succeeded'
   > = () => {
+    // ._meta property will be updated on a later step
+    const { _meta, ...mappingsWithoutMeta } = mappings;
     return client.indices
       .putMapping({
         index,
         timeout: DEFAULT_TIMEOUT,
-        ...mappings,
+        ...mappingsWithoutMeta,
       })
       .then(() => {
         // Ignore `acknowledged: false`. When the coordinating node accepts

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_target_mappings_meta.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_target_mappings_meta.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { catchRetryableEsClientErrors } from './catch_retryable_es_client_errors';
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { updateTargetMappingsMeta } from './update_target_mappings_meta';
+import { DEFAULT_TIMEOUT } from './constants';
+
+jest.mock('./catch_retryable_es_client_errors');
+
+describe('updateTargetMappingsMeta', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Create a mock client that rejects all methods with a 503 status code
+  // response.
+  const retryableError = new EsErrors.ResponseError(
+    elasticsearchClientMock.createApiResponse({
+      statusCode: 503,
+      body: { error: { type: 'es_type', reason: 'es_reason' } },
+    })
+  );
+  const client = elasticsearchClientMock.createInternalClient(
+    elasticsearchClientMock.createErrorTransportRequestPromise(retryableError)
+  );
+
+  it('calls catchRetryableEsClientErrors when the promise rejects', async () => {
+    const task = updateTargetMappingsMeta({
+      client,
+      index: 'new_index',
+      meta: {},
+    });
+    try {
+      await task();
+    } catch (e) {
+      /** ignore */
+    }
+
+    expect(catchRetryableEsClientErrors).toHaveBeenCalledWith(retryableError);
+  });
+
+  it('updates the _meta information of the desired index', async () => {
+    const task = updateTargetMappingsMeta({
+      client,
+      index: 'new_index',
+      meta: {
+        migrationMappingPropertyHashes: {
+          references: '7997cf5a56cc02bdc9c93361bde732b0',
+          'epm-packages': '860e23f4404fa1c33f430e6dad5d8fa2',
+          'cases-connector-mappings': '17d2e9e0e170a21a471285a5d845353c',
+        },
+      },
+    });
+    try {
+      await task();
+    } catch (e) {
+      /** ignore */
+    }
+
+    expect(client.indices.putMapping).toHaveBeenCalledTimes(1);
+    expect(client.indices.putMapping).toHaveBeenCalledWith({
+      index: 'new_index',
+      timeout: DEFAULT_TIMEOUT,
+      _meta: {
+        migrationMappingPropertyHashes: {
+          references: '7997cf5a56cc02bdc9c93361bde732b0',
+          'epm-packages': '860e23f4404fa1c33f430e6dad5d8fa2',
+          'cases-connector-mappings': '17d2e9e0e170a21a471285a5d845353c',
+        },
+      },
+    });
+  });
+});

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_target_mappings_meta.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_target_mappings_meta.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import * as Either from 'fp-ts/lib/Either';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { IndexMappingMeta } from '@kbn/core-saved-objects-base-server-internal';
+
+import {
+  catchRetryableEsClientErrors,
+  RetryableEsClientError,
+} from './catch_retryable_es_client_errors';
+import { DEFAULT_TIMEOUT } from './constants';
+
+/** @internal */
+export interface UpdateTargetMappingsMetaParams {
+  client: ElasticsearchClient;
+  index: string;
+  meta?: IndexMappingMeta;
+}
+/**
+ * Updates an index's mappings _meta information
+ */
+export const updateTargetMappingsMeta =
+  ({
+    client,
+    index,
+    meta,
+  }: UpdateTargetMappingsMetaParams): TaskEither.TaskEither<
+    RetryableEsClientError,
+    'update_mappings_meta_succeeded'
+  > =>
+  () => {
+    return client.indices
+      .putMapping({
+        index,
+        timeout: DEFAULT_TIMEOUT,
+        _meta: meta || {},
+      })
+      .then(() => {
+        // Ignore `acknowledged: false`. When the coordinating node accepts
+        // the new cluster state update but not all nodes have applied the
+        // update within the timeout `acknowledged` will be false. However,
+        // retrying this update will always immediately result in `acknowledged:
+        // true` even if there are still nodes which are falling behind with
+        // cluster state updates.
+        return Either.right('update_mappings_meta_succeeded' as const);
+      })
+      .catch(catchRetryableEsClientErrors);
+  };

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
@@ -41,6 +41,10 @@ import type {
   ReindexSourceToTempIndexBulk,
   CheckUnknownDocumentsState,
   CalculateExcludeFiltersState,
+  PostInitState,
+  CheckVersionIndexReadyActions,
+  UpdateTargetMappingsMeta,
+  CheckTargetMappingsState,
 } from '../state';
 import { TransformErrorObjects, TransformSavedObjectDocumentError } from '../core';
 import { AliasAction, RetryableEsClientError } from '../actions';
@@ -2041,12 +2045,34 @@ describe('migrations v2 model', () => {
         hasTransformedDocs: false,
       };
 
-      it('OUTDATED_DOCUMENTS_SEARCH_CLOSE_PIT -> UPDATE_TARGET_MAPPINGS if action succeeded', () => {
+      it('OUTDATED_DOCUMENTS_SEARCH_CLOSE_PIT -> CHECK_TARGET_MAPPINGS if action succeeded', () => {
         const res: ResponseType<'OUTDATED_DOCUMENTS_SEARCH_CLOSE_PIT'> = Either.right({});
-        const newState = model(state, res) as UpdateTargetMappingsState;
-        expect(newState.controlState).toBe('UPDATE_TARGET_MAPPINGS');
+        const newState = model(state, res) as CheckTargetMappingsState;
+        expect(newState.controlState).toBe('CHECK_TARGET_MAPPINGS');
         // @ts-expect-error pitId shouldn't leak outside
         expect(newState.pitId).toBe(undefined);
+      });
+    });
+
+    describe('CHECK_TARGET_MAPPINGS', () => {
+      const checkTargetMappingsState: CheckTargetMappingsState = {
+        ...baseState,
+        controlState: 'CHECK_TARGET_MAPPINGS',
+        versionIndexReadyActions: Option.none,
+        sourceIndex: Option.some('.kibana') as Option.Some<string>,
+        targetIndex: '.kibana_7.11.0_001',
+      };
+
+      it('CHECK_TARGET_MAPPINGS -> UPDATE_TARGET_MAPPINGS if mappings do not match', () => {
+        const res: ResponseType<'CHECK_TARGET_MAPPINGS'> = Either.right({ match: false });
+        const newState = model(checkTargetMappingsState, res) as UpdateTargetMappingsState;
+        expect(newState.controlState).toBe('UPDATE_TARGET_MAPPINGS');
+      });
+
+      it('CHECK_TARGET_MAPPINGS -> CHECK_VERSION_INDEX_READY_ACTIONS if mappings match', () => {
+        const res: ResponseType<'CHECK_TARGET_MAPPINGS'> = Either.right({ match: true });
+        const newState = model(checkTargetMappingsState, res) as CheckVersionIndexReadyActions;
+        expect(newState.controlState).toBe('CHECK_VERSION_INDEX_READY_ACTIONS');
       });
     });
 
@@ -2310,35 +2336,21 @@ describe('migrations v2 model', () => {
         targetIndex: '.kibana_7.11.0_001',
         updateTargetMappingsTaskId: 'update target mappings task',
       };
-      test('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> MARK_VERSION_INDEX_READY if some versionIndexReadyActions', () => {
+
+      test('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> UPDATE_TARGET_MAPPINGS_META if response is right', () => {
         const res: ResponseType<'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK'> = Either.right(
           'pickup_updated_mappings_succeeded'
         );
-        const newState = model(
-          {
-            ...updateTargetMappingsWaitForTaskState,
-            versionIndexReadyActions: Option.some([
-              { add: { index: 'kibana-index', alias: 'my-alias' } },
-            ]),
-          },
-          res
-        ) as UpdateTargetMappingsWaitForTaskState;
-        expect(newState.controlState).toEqual('MARK_VERSION_INDEX_READY');
-        expect(newState.retryCount).toEqual(0);
-        expect(newState.retryDelay).toEqual(0);
-      });
-      test('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> DONE if none versionIndexReadyActions', () => {
-        const res: ResponseType<'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK'> = Either.right(
-          'pickup_updated_mappings_succeeded'
-        );
+
         const newState = model(
           updateTargetMappingsWaitForTaskState,
           res
-        ) as UpdateTargetMappingsWaitForTaskState;
-        expect(newState.controlState).toEqual('DONE');
+        ) as UpdateTargetMappingsMeta;
+        expect(newState.controlState).toEqual('UPDATE_TARGET_MAPPINGS_META');
         expect(newState.retryCount).toEqual(0);
         expect(newState.retryDelay).toEqual(0);
       });
+
       test('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK when response is left wait_for_task_completion_timeout', () => {
         const res: ResponseType<'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK'> = Either.left({
           message: '[timeout_exception] Timeout waiting for ...',
@@ -2352,6 +2364,7 @@ describe('migrations v2 model', () => {
         expect(newState.retryCount).toEqual(1);
         expect(newState.retryDelay).toEqual(2000);
       });
+
       test('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK with incremented retry count when response is left wait_for_task_completion_timeout a second time', () => {
         const state = Object.assign({}, updateTargetMappingsWaitForTaskState, { retryCount: 1 });
         const res: ResponseType<'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK'> = Either.left({
@@ -2362,6 +2375,60 @@ describe('migrations v2 model', () => {
         expect(newState.controlState).toEqual('UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK');
         expect(newState.retryCount).toEqual(2);
         expect(newState.retryDelay).toEqual(4000);
+      });
+    });
+
+    describe('UPDATE_TARGET_MAPPINGS_META', () => {
+      const updateTargetMappingsMetaState: UpdateTargetMappingsMeta = {
+        ...baseState,
+        controlState: 'UPDATE_TARGET_MAPPINGS_META',
+        versionIndexReadyActions: Option.none,
+        sourceIndex: Option.some('.kibana') as Option.Some<string>,
+        targetIndex: '.kibana_7.11.0_001',
+      };
+
+      test('UPDATE_TARGET_MAPPINGS_META -> CHECK_VERSION_INDEX_READY_ACTIONS if the mapping _meta information is successfully updated', () => {
+        const res: ResponseType<'UPDATE_TARGET_MAPPINGS_META'> = Either.right(
+          'update_mappings_meta_succeeded'
+        );
+        const newState = model(updateTargetMappingsMetaState, res) as CheckVersionIndexReadyActions;
+        expect(newState.controlState).toBe('CHECK_VERSION_INDEX_READY_ACTIONS');
+      });
+    });
+
+    describe('CHECK_VERSION_INDEX_READY_ACTIONS', () => {
+      const res: ResponseType<'CHECK_VERSION_INDEX_READY_ACTIONS'> = Either.right('noop');
+
+      const postInitState: CheckVersionIndexReadyActions = {
+        ...baseState,
+        controlState: 'CHECK_VERSION_INDEX_READY_ACTIONS',
+        versionIndexReadyActions: Option.none,
+        sourceIndex: Option.some('.kibana') as Option.Some<string>,
+        targetIndex: '.kibana_7.11.0_001',
+      };
+
+      test('CHECK_VERSION_INDEX_READY_ACTIONS -> MARK_VERSION_INDEX_READY if some versionIndexReadyActions', () => {
+        const versionIndexReadyActions = Option.some([
+          { add: { index: 'kibana-index', alias: 'my-alias' } },
+        ]);
+
+        const newState = model(
+          {
+            ...postInitState,
+            versionIndexReadyActions,
+          },
+          res
+        ) as PostInitState;
+        expect(newState.controlState).toEqual('MARK_VERSION_INDEX_READY');
+        expect(newState.retryCount).toEqual(0);
+        expect(newState.retryDelay).toEqual(0);
+      });
+
+      test('CHECK_VERSION_INDEX_READY_ACTIONS -> DONE if none versionIndexReadyActions', () => {
+        const newState = model(postInitState, res) as PostInitState;
+        expect(newState.controlState).toEqual('DONE');
+        expect(newState.retryCount).toEqual(0);
+        expect(newState.retryDelay).toEqual(0);
       });
     });
 

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.ts
@@ -41,6 +41,7 @@ import type {
   CheckUnknownDocumentsState,
   CalculateExcludeFiltersState,
   WaitForMigrationCompletionState,
+  CheckTargetMappingsState,
 } from './state';
 import type { TransformRawDocs } from './types';
 import * as Actions from './actions';
@@ -129,6 +130,11 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
       Actions.cloneIndex({ client, source: state.tempIndex, target: state.targetIndex }),
     REFRESH_TARGET: (state: RefreshTarget) =>
       Actions.refreshIndex({ client, targetIndex: state.targetIndex }),
+    CHECK_TARGET_MAPPINGS: (state: CheckTargetMappingsState) =>
+      Actions.checkTargetMappings({
+        sourceIndexMappings: state.sourceIndexMappings,
+        targetIndexMappings: state.targetIndexMappings,
+      }),
     UPDATE_TARGET_MAPPINGS: (state: UpdateTargetMappingsState) =>
       Actions.updateAndPickupMappings({
         client,
@@ -141,6 +147,13 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
         taskId: state.updateTargetMappingsTaskId,
         timeout: '60s',
       }),
+    UPDATE_TARGET_MAPPINGS_META: (state: UpdateTargetMappingsState) =>
+      Actions.updateTargetMappingsMeta({
+        client,
+        index: state.targetIndex,
+        meta: state.targetIndexMappings._meta,
+      }),
+    CHECK_VERSION_INDEX_READY_ACTIONS: () => Actions.noop,
     OUTDATED_DOCUMENTS_SEARCH_OPEN_PIT: (state: OutdatedDocumentsSearchOpenPit) =>
       Actions.openPit({ client, index: state.targetIndex }),
     OUTDATED_DOCUMENTS_SEARCH_READ: (state: OutdatedDocumentsSearchRead) =>

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/state.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/state.ts
@@ -286,6 +286,11 @@ export interface RefreshTarget extends PostInitState {
   readonly targetIndex: string;
 }
 
+export interface CheckTargetMappingsState extends PostInitState {
+  readonly controlState: 'CHECK_TARGET_MAPPINGS';
+  readonly sourceIndexMappings?: IndexMapping;
+}
+
 export interface UpdateTargetMappingsState extends PostInitState {
   /** Update the mappings of the target index */
   readonly controlState: 'UPDATE_TARGET_MAPPINGS';
@@ -297,9 +302,19 @@ export interface UpdateTargetMappingsWaitForTaskState extends PostInitState {
   readonly updateTargetMappingsTaskId: string;
 }
 
+export interface UpdateTargetMappingsMeta extends PostInitState {
+  /** Update the mapping _meta information with the hashes of the mappings for each plugin */
+  readonly controlState: 'UPDATE_TARGET_MAPPINGS_META';
+}
+
+export interface CheckVersionIndexReadyActions extends PostInitState {
+  readonly controlState: 'CHECK_VERSION_INDEX_READY_ACTIONS';
+}
+
 export interface OutdatedDocumentsSearchOpenPit extends PostInitState {
   /** Open PiT for target index to search for outdated documents */
   readonly controlState: 'OUTDATED_DOCUMENTS_SEARCH_OPEN_PIT';
+  readonly sourceIndexMappings?: IndexMapping;
 }
 
 export interface OutdatedDocumentsSearchRead extends PostInitState {
@@ -451,8 +466,11 @@ export type State = Readonly<
   | ReindexSourceToTempIndexBulk
   | SetTempWriteBlock
   | CloneTempToSource
+  | CheckTargetMappingsState
   | UpdateTargetMappingsState
   | UpdateTargetMappingsWaitForTaskState
+  | UpdateTargetMappingsMeta
+  | CheckVersionIndexReadyActions
   | OutdatedDocumentsSearchOpenPit
   | OutdatedDocumentsSearchRead
   | OutdatedDocumentsSearchClosePit

--- a/src/core/server/integration_tests/saved_objects/migrations/check_target_mappings.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_target_mappings.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+import fs from 'fs/promises';
+import JSON5 from 'json5';
+import { Env } from '@kbn/config';
+import { REPO_ROOT } from '@kbn/utils';
+import { getEnvOptions } from '@kbn/config-mocks';
+import { Root } from '@kbn/core-root-server-internal';
+import { LogRecord } from '@kbn/logging';
+import {
+  createRootWithCorePlugins,
+  createTestServers,
+  type TestElasticsearchUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+
+const logFilePath = Path.join(__dirname, 'check_target_mappings.log');
+
+const delay = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+
+async function removeLogFile() {
+  // ignore errors if it doesn't exist
+  await fs.unlink(logFilePath).catch(() => void 0);
+}
+
+async function parseLogFile() {
+  const logFileContent = await fs.readFile(logFilePath, 'utf-8');
+
+  return logFileContent
+    .split('\n')
+    .filter(Boolean)
+    .map((str) => JSON5.parse(str)) as LogRecord[];
+}
+
+function logIncludes(logs: LogRecord[], message: string): boolean {
+  return Boolean(logs?.find((rec) => rec.message.includes(message)));
+}
+
+describe('migration v2 - CHECK_TARGET_MAPPINGS', () => {
+  let esServer: TestElasticsearchUtils;
+  let root: Root;
+  let logs: LogRecord[];
+
+  beforeEach(async () => await removeLogFile());
+
+  afterEach(async () => {
+    await root?.shutdown();
+    await esServer?.stop();
+    await delay(10);
+  });
+
+  it('is not run for new installations', async () => {
+    const { startES } = createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+      settings: {
+        es: {
+          license: 'basic',
+        },
+      },
+    });
+
+    root = createRoot();
+    esServer = await startES();
+    await root.preboot();
+    await root.setup();
+    await root.start();
+
+    // Check for migration steps present in the logs
+    logs = await parseLogFile();
+    expect(logIncludes(logs, 'CREATE_NEW_TARGET')).toEqual(true);
+    expect(logIncludes(logs, 'CHECK_TARGET_MAPPINGS')).toEqual(false);
+  });
+
+  it('skips UPDATE_TARGET_MAPPINGS for up-to-date deployments, when there are no changes in the mappings', async () => {
+    const { startES } = createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+      settings: {
+        es: {
+          license: 'basic',
+        },
+      },
+    });
+
+    esServer = await startES();
+
+    // start Kibana a first time to create the system indices
+    root = createRoot();
+    await root.preboot();
+    await root.setup();
+    await root.start();
+
+    // stop Kibana and remove logs
+    await root.shutdown();
+    await delay(10);
+    await removeLogFile();
+
+    root = createRoot();
+    await root.preboot();
+    await root.setup();
+    await root.start();
+
+    // Check for migration steps present in the logs
+    logs = await parseLogFile();
+    expect(logIncludes(logs, 'CREATE_NEW_TARGET')).toEqual(false);
+    expect(logIncludes(logs, 'CHECK_TARGET_MAPPINGS -> CHECK_VERSION_INDEX_READY_ACTIONS')).toEqual(
+      true
+    );
+    expect(logIncludes(logs, 'UPDATE_TARGET_MAPPINGS')).toEqual(false);
+    expect(logIncludes(logs, 'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK')).toEqual(false);
+    expect(logIncludes(logs, 'UPDATE_TARGET_MAPPINGS_META')).toEqual(false);
+  });
+
+  it('runs UPDATE_TARGET_MAPPINGS when mappings have changed', async () => {
+    const currentVersion = Env.createDefault(REPO_ROOT, getEnvOptions()).packageInfo.version;
+
+    const { startES } = createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+      settings: {
+        es: {
+          license: 'basic',
+          dataArchive: Path.join(__dirname, 'archives', '8.4.0_with_sample_data_logs.zip'),
+        },
+      },
+    });
+
+    esServer = await startES();
+
+    // start Kibana a first time to create the system indices
+    root = createRoot(currentVersion); // we discard a bunch of SO that have become unknown since 8.4.0
+    await root.preboot();
+    await root.setup();
+    await root.start();
+
+    // Check for migration steps present in the logs
+    logs = await parseLogFile();
+    expect(logIncludes(logs, 'CREATE_NEW_TARGET')).toEqual(false);
+    expect(logIncludes(logs, 'CHECK_TARGET_MAPPINGS -> UPDATE_TARGET_MAPPINGS')).toEqual(true);
+    expect(
+      logIncludes(logs, 'UPDATE_TARGET_MAPPINGS -> UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK')
+    ).toEqual(true);
+    expect(
+      logIncludes(logs, 'UPDATE_TARGET_MAPPINGS_WAIT_FOR_TASK -> UPDATE_TARGET_MAPPINGS_META')
+    ).toEqual(true);
+    expect(
+      logIncludes(logs, 'UPDATE_TARGET_MAPPINGS_META -> CHECK_VERSION_INDEX_READY_ACTIONS')
+    ).toEqual(true);
+    expect(
+      logIncludes(logs, 'CHECK_VERSION_INDEX_READY_ACTIONS -> MARK_VERSION_INDEX_READY')
+    ).toEqual(true);
+    expect(logIncludes(logs, 'MARK_VERSION_INDEX_READY -> DONE')).toEqual(true);
+    expect(logIncludes(logs, 'Migration completed')).toEqual(true);
+  });
+});
+
+function createRoot(discardUnknownObjects?: string) {
+  return createRootWithCorePlugins(
+    {
+      migrations: {
+        discardUnknownObjects,
+      },
+      logging: {
+        appenders: {
+          file: {
+            type: 'file',
+            fileName: logFilePath,
+            layout: {
+              type: 'json',
+            },
+          },
+        },
+        loggers: [
+          {
+            name: 'root',
+            level: 'info',
+            appenders: ['file'],
+          },
+        ],
+      },
+    },
+    {
+      oss: true,
+    }
+  );
+}

--- a/src/core/server/integration_tests/saved_objects/migrations/check_target_mappings.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_target_mappings.test.ts
@@ -18,7 +18,7 @@ import {
   createRootWithCorePlugins,
   createTestServers,
   type TestElasticsearchUtils,
-} from '@kbn/core-test-helpers-kbn-server';
+} from '../../../../test_helpers/kbn_server';
 
 const logFilePath = Path.join(__dirname, 'check_target_mappings.log');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Reduce startup time by skipping update mappings step when possible (#145604)](https://github.com/elastic/kibana/pull/145604)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2022-11-28T14:34:58Z","message":"Reduce startup time by skipping update mappings step when possible (#145604)\n\nThe goal of this PR is to reduce the startup times of Kibana server by\r\nimproving the migration logic.\r\n\r\nFixes https://github.com/elastic/kibana/issues/145743\r\nRelated https://github.com/elastic/kibana/issues/144035)\r\n\r\nThe migration logic is run systematically at startup, whether the\r\ncustomers are upgrading or not.\r\nHistorically, these steps have been very quick, but we recently found\r\nout about some customers that have more than **one million** Saved\r\nObjects stored, making the overall startup process slow, even when there\r\nare no migrations to perform.\r\n\r\nThis PR specifically targets the case where there are no migrations to\r\nperform, aka a Kibana node is started against an ES cluster that is\r\nalready up to date wrt stack version and list of plugins.\r\n\r\nIn this scenario, we aim at skipping the `UPDATE_TARGET_MAPPINGS` step\r\nof the migration logic, which internally runs the\r\n`updateAndPickupMappings` method, which turns out to be expensive if the\r\nsystem indices contain lots of SO.\r\n\r\n\r\nI locally tested the following scenarios too:\r\n\r\n- **Fresh install.** The step is not even run, as the `.kibana` index\r\ndid not exist ✅\r\n- **Stack version + list of plugins up to date.** Simply restarting\r\nKibana after the fresh install. The step is run and leads to `DONE`, as\r\nthe md5 hashes match those stored in `.kibana._mapping._meta` ✅\r\n- **Faking re-enabling an old plugin.** I manually removed one of the\r\nMD5 hashes from the stored .kibana._mapping._meta through `curl`, and\r\nthen restarted Kibana. The step is run and leads to\r\n`UPDATE_TARGET_MAPPINGS` as it used to before the PR ✅\r\n- **Faking updating a plugin.** Same as the previous one, but altering\r\nan existing md5 stored in the metas. ✅\r\n\r\nAnd that is the curl command used to tamper with the stored _meta:\r\n```bash\r\ncurl -X PUT \"kibana:changeme@localhost:9200/.kibana/_mapping?pretty\" -H 'Content-Type: application/json' -d'\r\n{\r\n  \"_meta\": {\r\n      \"migrationMappingPropertyHashes\": {\r\n        \"references\": \"7997cf5a56cc02bdc9c93361bde732b0\",\r\n      }\r\n  }\r\n}\r\n'\r\n```","sha":"b1e18a0414ed99456706119d15173b687c6e7366","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","enhancement","release_note:skip","Feature:Migrations","backport:prev-minor","v8.7.0"],"number":145604,"url":"https://github.com/elastic/kibana/pull/145604","mergeCommit":{"message":"Reduce startup time by skipping update mappings step when possible (#145604)\n\nThe goal of this PR is to reduce the startup times of Kibana server by\r\nimproving the migration logic.\r\n\r\nFixes https://github.com/elastic/kibana/issues/145743\r\nRelated https://github.com/elastic/kibana/issues/144035)\r\n\r\nThe migration logic is run systematically at startup, whether the\r\ncustomers are upgrading or not.\r\nHistorically, these steps have been very quick, but we recently found\r\nout about some customers that have more than **one million** Saved\r\nObjects stored, making the overall startup process slow, even when there\r\nare no migrations to perform.\r\n\r\nThis PR specifically targets the case where there are no migrations to\r\nperform, aka a Kibana node is started against an ES cluster that is\r\nalready up to date wrt stack version and list of plugins.\r\n\r\nIn this scenario, we aim at skipping the `UPDATE_TARGET_MAPPINGS` step\r\nof the migration logic, which internally runs the\r\n`updateAndPickupMappings` method, which turns out to be expensive if the\r\nsystem indices contain lots of SO.\r\n\r\n\r\nI locally tested the following scenarios too:\r\n\r\n- **Fresh install.** The step is not even run, as the `.kibana` index\r\ndid not exist ✅\r\n- **Stack version + list of plugins up to date.** Simply restarting\r\nKibana after the fresh install. The step is run and leads to `DONE`, as\r\nthe md5 hashes match those stored in `.kibana._mapping._meta` ✅\r\n- **Faking re-enabling an old plugin.** I manually removed one of the\r\nMD5 hashes from the stored .kibana._mapping._meta through `curl`, and\r\nthen restarted Kibana. The step is run and leads to\r\n`UPDATE_TARGET_MAPPINGS` as it used to before the PR ✅\r\n- **Faking updating a plugin.** Same as the previous one, but altering\r\nan existing md5 stored in the metas. ✅\r\n\r\nAnd that is the curl command used to tamper with the stored _meta:\r\n```bash\r\ncurl -X PUT \"kibana:changeme@localhost:9200/.kibana/_mapping?pretty\" -H 'Content-Type: application/json' -d'\r\n{\r\n  \"_meta\": {\r\n      \"migrationMappingPropertyHashes\": {\r\n        \"references\": \"7997cf5a56cc02bdc9c93361bde732b0\",\r\n      }\r\n  }\r\n}\r\n'\r\n```","sha":"b1e18a0414ed99456706119d15173b687c6e7366"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/145604","number":145604,"mergeCommit":{"message":"Reduce startup time by skipping update mappings step when possible (#145604)\n\nThe goal of this PR is to reduce the startup times of Kibana server by\r\nimproving the migration logic.\r\n\r\nFixes https://github.com/elastic/kibana/issues/145743\r\nRelated https://github.com/elastic/kibana/issues/144035)\r\n\r\nThe migration logic is run systematically at startup, whether the\r\ncustomers are upgrading or not.\r\nHistorically, these steps have been very quick, but we recently found\r\nout about some customers that have more than **one million** Saved\r\nObjects stored, making the overall startup process slow, even when there\r\nare no migrations to perform.\r\n\r\nThis PR specifically targets the case where there are no migrations to\r\nperform, aka a Kibana node is started against an ES cluster that is\r\nalready up to date wrt stack version and list of plugins.\r\n\r\nIn this scenario, we aim at skipping the `UPDATE_TARGET_MAPPINGS` step\r\nof the migration logic, which internally runs the\r\n`updateAndPickupMappings` method, which turns out to be expensive if the\r\nsystem indices contain lots of SO.\r\n\r\n\r\nI locally tested the following scenarios too:\r\n\r\n- **Fresh install.** The step is not even run, as the `.kibana` index\r\ndid not exist ✅\r\n- **Stack version + list of plugins up to date.** Simply restarting\r\nKibana after the fresh install. The step is run and leads to `DONE`, as\r\nthe md5 hashes match those stored in `.kibana._mapping._meta` ✅\r\n- **Faking re-enabling an old plugin.** I manually removed one of the\r\nMD5 hashes from the stored .kibana._mapping._meta through `curl`, and\r\nthen restarted Kibana. The step is run and leads to\r\n`UPDATE_TARGET_MAPPINGS` as it used to before the PR ✅\r\n- **Faking updating a plugin.** Same as the previous one, but altering\r\nan existing md5 stored in the metas. ✅\r\n\r\nAnd that is the curl command used to tamper with the stored _meta:\r\n```bash\r\ncurl -X PUT \"kibana:changeme@localhost:9200/.kibana/_mapping?pretty\" -H 'Content-Type: application/json' -d'\r\n{\r\n  \"_meta\": {\r\n      \"migrationMappingPropertyHashes\": {\r\n        \"references\": \"7997cf5a56cc02bdc9c93361bde732b0\",\r\n      }\r\n  }\r\n}\r\n'\r\n```","sha":"b1e18a0414ed99456706119d15173b687c6e7366"}}]}] BACKPORT-->