### PR TITLE
[8.6] Retrieve endpoint package from package storage v2 (#146513)

### DIFF
--- a/src/dev/build/tasks/bundle_fleet_packages.ts
+++ b/src/dev/build/tasks/bundle_fleet_packages.ts
@@ -70,8 +70,8 @@ export const BundleFleetPackages: Task = {
         const archivePath = `${fleetPackage.name}-${versionToWrite}.zip`;
         let archiveUrl = `${eprUrl}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
 
-        // Point APM to package storage v2
-        if (fleetPackage.name === 'apm') {
+        // Point APM and Endpoint packages to package storage v2
+        if (fleetPackage.name === 'apm' || fleetPackage.name === 'endpoint') {
           archiveUrl = `${PACKAGE_STORAGE_V2_URL}/epr/${fleetPackage.name}/${fleetPackage.name}-${fleetPackage.version}.zip`;
         }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Retrieve endpoint package from package storage v2 (#146513)](https://github.com/elastic/kibana/pull/146513)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mario Rodriguez Molins","email":"mario.rodriguez@elastic.co"},"sourceCommit":{"committedDate":"2022-11-29T17:33:44Z","message":"Retrieve endpoint package from package storage v2 (#146513)\n\n## Summary\r\n\r\nEndpoint package is just published into package storage v2, so it\r\nrequires to add an exception as it was done for the APM package.","sha":"998c5b21a1d8934a3f5a978848985df7db7d15b0","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","v8.7.0"],"number":146513,"url":"https://github.com/elastic/kibana/pull/146513","mergeCommit":{"message":"Retrieve endpoint package from package storage v2 (#146513)\n\n## Summary\r\n\r\nEndpoint package is just published into package storage v2, so it\r\nrequires to add an exception as it was done for the APM package.","sha":"998c5b21a1d8934a3f5a978848985df7db7d15b0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146513","number":146513,"mergeCommit":{"message":"Retrieve endpoint package from package storage v2 (#146513)\n\n## Summary\r\n\r\nEndpoint package is just published into package storage v2, so it\r\nrequires to add an exception as it was done for the APM package.","sha":"998c5b21a1d8934a3f5a978848985df7db7d15b0"}}]}] BACKPORT-->