### PR TITLE
Update Elastic Package Registry distribution docker image for V2

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "endpoint",
-    "version": "8.5.0"
+    "version": "8.6.0"
   },
   {
     "name": "fleet_server",

--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "endpoint",
-    "version": "8.6.0"
+    "version": "8.5.0"
   },
   {
     "name": "fleet_server",

--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -18,7 +18,7 @@ import pRetry from 'p-retry';
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
 const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:production-v2-experimental`;
+const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:production`;
 
 function firstWithTimeout(source$: Rx.Observable<any>, errorMsg: string, ms = 30 * 1000) {
   return Rx.race(

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -15,11 +15,11 @@ import {
 
 const getFullPath = (relativePath: string) => path.join(path.dirname(__filename), relativePath);
 // Docker image to use for Fleet API integration tests.
-// This hash comes from the latest successful build of the Snapshot Distribution of the Package Registry, for
-// example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
-// It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
+// This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
+// example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
+// It should be updated any time there is a new package published.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production-v2-experimental';
+  'docker.elastic.co/package-registry/distribution:production';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -18,8 +18,7 @@ const getFullPath = (relativePath: string) => path.join(path.dirname(__filename)
 // This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
 // example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
 // It should be updated any time there is a new package published.
-export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production';
+export const dockerImage = 'docker.elastic.co/package-registry/distribution:production';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -11,11 +11,11 @@ import { services } from './services';
 import { pageObjects } from './page_objects';
 
 // Docker image to use for Fleet API integration tests.
-// This hash comes from the latest successful build of the Snapshot Distribution of the Package Registry, for
-// example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
-// It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
+// This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
+// example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
+// It should be updated any time there is a new package published.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production-v2-experimental';
+  'docker.elastic.co/package-registry/distribution:production';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -14,8 +14,7 @@ import { pageObjects } from './page_objects';
 // This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
 // example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
 // It should be updated any time there is a new package published.
-export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production';
+export const dockerImage = 'docker.elastic.co/package-registry/distribution:production';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values


### PR DESCRIPTION
## Summary

Update the docker image used as Elastic Package Registry distribution for Package Storage V2, so it contains the latest packages published.

Tested updating fleet_packages.json to use endpoint version 8.6.0 (and reverted).


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->