### PR TITLE
[Telemetry] Cache the report generation promise

### DIFF
--- a/src/plugins/telemetry_collection_manager/server/plugin.test.ts
+++ b/src/plugins/telemetry_collection_manager/server/plugin.test.ts
@@ -136,6 +136,15 @@ describe('Telemetry Collection Manager', () => {
             ).toBeInstanceOf(TelemetrySavedObjectsClient);
           });
 
+          test('caches the promise calling `getStats` for concurrent requests', async () => {
+            collectionStrategy.clusterDetailsGetter.mockResolvedValue([
+              { clusterUuid: 'clusterUuid' },
+            ]);
+            collectionStrategy.statsGetter.mockResolvedValue([basicStats]);
+            await Promise.all([setupApi.getStats(config), setupApi.getStats(config)]);
+            expect(collectionStrategy.statsGetter).toHaveBeenCalledTimes(1);
+          });
+
           it('calls getStats with passed refreshCache config', async () => {
             const getStatsCollectionConfig: jest.SpyInstance<
               TelemetryCollectionManagerPlugin['getStatsCollectionConfig']
@@ -269,6 +278,15 @@ describe('Telemetry Collection Manager', () => {
             );
 
             getStatsCollectionConfig.mockRestore();
+          });
+
+          test('does not cache the promise calling `getStats` for concurrent requests', async () => {
+            collectionStrategy.clusterDetailsGetter.mockResolvedValue([
+              { clusterUuid: 'clusterUuid' },
+            ]);
+            collectionStrategy.statsGetter.mockResolvedValue([basicStats]);
+            await Promise.all([setupApi.getStats(config), setupApi.getStats(config)]);
+            expect(collectionStrategy.statsGetter).toHaveBeenCalledTimes(2);
           });
         });
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/146676

The caching mechanism of the telemetry report generation now caches the promise instead of the end stats to make sure we don't call the generation multiple times concurrently.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| When there are multiple Kibana instances, the report might be generated once per instance. | High | Low | Most of the performance issues we've noticed are on the Kibana end because it accumulated many concurrent generation requests. Elasticsearch was fine with the load. |


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->