### PR TITLE
[Cloud Posture] add tests for findings flyout interactions

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -112,7 +112,7 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
   const [tab, setTab] = useState<FindingsTab>(tabs[0]);
 
   return (
-    <EuiFlyout onClose={onClose}>
+    <EuiFlyout onClose={onClose} data-test-subj="findings_flyout">
       <EuiFlyoutHeader>
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -51,6 +51,7 @@ export const getExpandColumn = <T extends unknown>({
   width: '40px',
   actions: [
     {
+      ['data-test-subj']: 'findings_table_expand_column',
       name: i18n.translate('xpack.csp.expandColumnNameLabel', { defaultMessage: 'Expand' }),
       description: i18n.translate('xpack.csp.expandColumnDescriptionLabel', {
         defaultMessage: 'Expand',

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -18,6 +18,7 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
+  const flyoutService = getService('flyout');
 
   /**
    * required before indexing findings
@@ -44,6 +45,26 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
           })
         )
       );
+    },
+  };
+
+  const flyout = {
+    isFlyoutOpen: () => retry.try(() => testSubjects.exists('findings_flyout')),
+    closeFlyout: () => flyoutService.close('findings_flyout'),
+    navigateToJSONTab: () => testSubjects.click('findings_flyout_tab_json'),
+    copyJSONToClipboard: async () => {
+      const element = await testSubjects.find('findings_flyout');
+      const copyButton = await element.findByCssSelector('button[aria-label="Copy"]');
+      await copyButton.click();
+    },
+    openRowIndexFlyout: async (rowIndex: number) => {
+      const element = await table.getElement();
+      const buttons = await element.findAllByCssSelector(
+        'button[data-test-subj="findings_table_expand_column"]'
+      );
+      const button = buttons[rowIndex - 1];
+      expect(button).to.not.be(undefined);
+      await button.click();
     },
   };
 
@@ -160,5 +181,6 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     navigateToFindingsPage,
     table,
     index,
+    flyout,
   };
 }

--- a/x-pack/test/cloud_security_posture_functional/pages/findings.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings.ts
@@ -117,7 +117,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    describe.only('Flyout', () => {
+    describe('Flyout', () => {
       it('opens flyout', async () => {
         await flyout.openRowIndexFlyout(1);
 


### PR DESCRIPTION
## Summary

adds tests for opening / closing the flyout and copying JSON value. 

technically, triggering es/kibana services isn't required for this test, but it's in the happy-path, as in - really common. 

i also wasn't able to render the JSON editor in unit test. we should revisit this, but for now i think it's a good test to have in general. 

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

