### PR TITLE
feat(slo): rename kql indicator parameters

### DIFF
--- a/x-pack/plugins/observability/dev_docs/slo.md
+++ b/x-pack/plugins/observability/dev_docs/slo.md
@@ -288,7 +288,7 @@ curl --request POST \
 			"index": "high-cardinality-data-fake_logs*",
 			"good": "latency < 300",
 			"total": "",
-			"query_filter": "labels.groupId: group-0"
+			"filter": "labels.groupId: group-0"
 		}
 	},
 	"time_window": {

--- a/x-pack/plugins/observability/dev_docs/slo.md
+++ b/x-pack/plugins/observability/dev_docs/slo.md
@@ -286,8 +286,8 @@ curl --request POST \
 		"type": "sli.kql.custom",
 		"params": {
 			"index": "high-cardinality-data-fake_logs*",
-			"numerator": "latency < 300",
-			"denominator": "",
+			"good": "latency < 300",
+			"total": "",
 			"query_filter": "labels.groupId: group-0"
 		}
 	},

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -61,8 +61,8 @@ export const createKQLCustomIndicator = (
   params: {
     index: 'my-index*',
     query_filter: 'labels.groupId: group-3',
-    numerator: 'latency < 300',
-    denominator: '',
+    good: 'latency < 300',
+    total: '',
     ...params,
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -60,7 +60,7 @@ export const createKQLCustomIndicator = (
   type: 'sli.kql.custom',
   params: {
     index: 'my-index*',
-    query_filter: 'labels.groupId: group-3',
+    filter: 'labels.groupId: group-3',
     good: 'latency < 300',
     total: '',
     ...params,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
@@ -26,7 +26,7 @@ describe('KQL Custom Transform Generator', () => {
     });
     it('throws when the KQL query_filter is invalid', () => {
       const anSLO = createSLO({
-        indicator: createKQLCustomIndicator({ query_filter: '{ kql.query: invalid' }),
+        indicator: createKQLCustomIndicator({ filter: '{ kql.query: invalid' }),
       });
       expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
     });
@@ -51,7 +51,7 @@ describe('KQL Custom Transform Generator', () => {
 
   it('filters the source using the kql query', async () => {
     const anSLO = createSLO({
-      indicator: createKQLCustomIndicator({ query_filter: 'labels.groupId: group-4' }),
+      indicator: createKQLCustomIndicator({ filter: 'labels.groupId: group-4' }),
     });
     const transform = generator.getTransformParams(anSLO);
 

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.test.ts
@@ -14,13 +14,13 @@ describe('KQL Custom Transform Generator', () => {
   describe('validation', () => {
     it('throws when the KQL numerator is invalid', () => {
       const anSLO = createSLO({
-        indicator: createKQLCustomIndicator({ numerator: '{ kql.query: invalid' }),
+        indicator: createKQLCustomIndicator({ good: '{ kql.query: invalid' }),
       });
       expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
     });
     it('throws when the KQL denominator is invalid', () => {
       const anSLO = createSLO({
-        indicator: createKQLCustomIndicator({ denominator: '{ kql.query: invalid' }),
+        indicator: createKQLCustomIndicator({ total: '{ kql.query: invalid' }),
       });
       expect(() => generator.getTransformParams(anSLO)).toThrow(/Invalid KQL/);
     });
@@ -70,8 +70,7 @@ describe('KQL Custom Transform Generator', () => {
   it('aggregates using the numerator kql', async () => {
     const anSLO = createSLO({
       indicator: createKQLCustomIndicator({
-        numerator:
-          'latency < 400 and (http.status_code: 2xx or http.status_code: 3xx or http.status_code: 4xx)',
+        good: 'latency < 400 and (http.status_code: 2xx or http.status_code: 3xx or http.status_code: 4xx)',
       }),
     });
     const transform = generator.getTransformParams(anSLO);
@@ -82,7 +81,7 @@ describe('KQL Custom Transform Generator', () => {
   it('aggregates using the denominator kql', async () => {
     const anSLO = createSLO({
       indicator: createKQLCustomIndicator({
-        denominator: 'http.status_code: *',
+        total: 'http.status_code: *',
       }),
     });
     const transform = generator.getTransformParams(anSLO);

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -56,8 +56,8 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
   }
 
   private buildAggregations(slo: SLO, indicator: KQLCustomIndicator) {
-    const numerator = getElastichsearchQueryOrThrow(indicator.params.numerator);
-    const denominator = getElastichsearchQueryOrThrow(indicator.params.denominator);
+    const numerator = getElastichsearchQueryOrThrow(indicator.params.good);
+    const denominator = getElastichsearchQueryOrThrow(indicator.params.total);
     return {
       'slo.numerator': {
         filter: numerator,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -40,7 +40,7 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
   }
 
   private buildSource(slo: SLO, indicator: KQLCustomIndicator) {
-    const filter = getElastichsearchQueryOrThrow(indicator.params.query_filter);
+    const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
       index: indicator.params.index,
       runtime_mappings: this.buildCommonRuntimeMappings(slo),

--- a/x-pack/plugins/observability/server/types/schema/indicators.ts
+++ b/x-pack/plugins/observability/server/types/schema/indicators.ts
@@ -43,7 +43,7 @@ const kqlCustomIndicatorSchema = t.type({
   type: kqlCustomIndicatorTypeSchema,
   params: t.type({
     index: t.string,
-    query_filter: t.string,
+    filter: t.string,
     good: t.string,
     total: t.string,
   }),

--- a/x-pack/plugins/observability/server/types/schema/indicators.ts
+++ b/x-pack/plugins/observability/server/types/schema/indicators.ts
@@ -44,8 +44,8 @@ const kqlCustomIndicatorSchema = t.type({
   params: t.type({
     index: t.string,
     query_filter: t.string,
-    numerator: t.string,
-    denominator: t.string,
+    good: t.string,
+    total: t.string,
   }),
 });
 


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/146460

Rename the KQL indicator parameters to be more self-explanatory. 

## 🥼 Manual testing

<details>
<summary>Create a SLO with KQL indicator using the new parameters</summary>

```
curl --request POST \
  --url http://localhost:5601/kibana/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "SLO latency service log",
	"description": "latency from logs",
	"indicator": {
		"type": "sli.kql.custom",
		"params": {
			"index": "high-cardinality-data-fake_logs*",
			"good": "latency < 300",
			"total": "",
			"filter": "labels.groupId: group-0"
		}
	},
	"time_window": {
		"duration": "30d",
		"is_rolling": true
	},
	"budgeting_method": "occurrences",
	"objective": {
		"target": 0.98
	}
}'
```
</details>


<details>
<summary>Fetch all SLO</summary>

```
curl --request GET \
  --url 'http://localhost:5601/kibana/api/observability/slos?per_page=10&page=1' \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'kbn-xsrf: oui'
```
</details>