### PR TITLE
[Fleet] Fix agent status computation to support agent v2 uppercase

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -33,10 +33,10 @@ export function getAgentStatus(agent: Agent | FleetServerAgent): AgentStatus {
     return 'unenrolling';
   }
 
-  if (agent.last_checkin_status === 'error') {
+  if (agent.last_checkin_status?.toLowerCase() === 'error') {
     return 'error';
   }
-  if (agent.last_checkin_status === 'degraded') {
+  if (agent.last_checkin_status?.toLowerCase() === 'degraded') {
     return 'degraded';
   }
 
@@ -61,10 +61,10 @@ export function getPreviousAgentStatusForOfflineAgents(
     return 'unenrolling';
   }
 
-  if (agent.last_checkin_status === 'error') {
+  if (agent.last_checkin_status?.toLowerCase() === 'error') {
     return 'error';
   }
-  if (agent.last_checkin_status === 'degraded') {
+  if (agent.last_checkin_status?.toLowerCase() === 'degraded') {
     return 'degraded';
   }
 
@@ -96,7 +96,7 @@ export function buildKueryForOnlineAgents(path: string = ''): string {
 }
 
 export function buildKueryForErrorAgents(path: string = ''): string {
-  return `(${path}last_checkin_status:error or ${path}last_checkin_status:degraded) ${addExclusiveKueryFilter(
+  return `(${path}last_checkin_status:error or ${path}last_checkin_status:degraded or ${path}last_checkin_status:DEGRADED or ${path}last_checkin_status:ERROR) ${addExclusiveKueryFilter(
     [buildKueryForOfflineAgents, buildKueryForUnenrollingAgents],
     path
   )}`;

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -372,6 +372,30 @@ describe('test endpoint routes', () => {
                                               minimum_should_match: 1,
                                             },
                                           },
+                                          {
+                                            bool: {
+                                              should: [
+                                                {
+                                                  match: {
+                                                    'united.agent.last_checkin_status': 'DEGRADED',
+                                                  },
+                                                },
+                                              ],
+                                              minimum_should_match: 1,
+                                            },
+                                          },
+                                          {
+                                            bool: {
+                                              should: [
+                                                {
+                                                  match: {
+                                                    'united.agent.last_checkin_status': 'ERROR',
+                                                  },
+                                                },
+                                              ],
+                                              minimum_should_match: 1,
+                                            },
+                                          },
                                         ],
                                         minimum_should_match: 1,
                                       },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.fixtures.ts
@@ -170,6 +170,32 @@ export const expectedCompleteUnitedIndexQuery = {
                                                       minimum_should_match: 1,
                                                     },
                                                   },
+                                                  {
+                                                    bool: {
+                                                      should: [
+                                                        {
+                                                          match: {
+                                                            'united.agent.last_checkin_status':
+                                                              'DEGRADED',
+                                                          },
+                                                        },
+                                                      ],
+                                                      minimum_should_match: 1,
+                                                    },
+                                                  },
+                                                  {
+                                                    bool: {
+                                                      should: [
+                                                        {
+                                                          match: {
+                                                            'united.agent.last_checkin_status':
+                                                              'ERROR',
+                                                          },
+                                                        },
+                                                      ],
+                                                      minimum_should_match: 1,
+                                                    },
+                                                  },
                                                 ],
                                                 minimum_should_match: 1,
                                               },
@@ -244,6 +270,24 @@ export const expectedCompleteUnitedIndexQuery = {
                                         {
                                           match: { 'united.agent.last_checkin_status': 'degraded' },
                                         },
+                                      ],
+                                      minimum_should_match: 1,
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      should: [
+                                        {
+                                          match: { 'united.agent.last_checkin_status': 'DEGRADED' },
+                                        },
+                                      ],
+                                      minimum_should_match: 1,
+                                    },
+                                  },
+                                  {
+                                    bool: {
+                                      should: [
+                                        { match: { 'united.agent.last_checkin_status': 'ERROR' } },
                                       ],
                                       minimum_should_match: 1,
                                     },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
@@ -93,7 +93,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const status = ['healthy'];
       const kuery = buildStatusesKuery(status);
       expect(kuery).toMatchInlineSnapshot(
-        `"(united.agent.last_checkin:*  AND not ((united.agent.last_checkin < now-300s) or ((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*))))) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+        `"(united.agent.last_checkin:*  AND not ((united.agent.last_checkin < now-300s) or ((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded or united.agent.last_checkin_status:DEGRADED or united.agent.last_checkin_status:ERROR)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*))))) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded or united.agent.last_checkin_status:DEGRADED or united.agent.last_checkin_status:ERROR)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
       );
     });
 
@@ -107,7 +107,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const status = ['unhealthy'];
       const kuery = buildStatusesKuery(status);
       expect(kuery).toMatchInlineSnapshot(
-        `"((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
+        `"((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded or united.agent.last_checkin_status:DEGRADED or united.agent.last_checkin_status:ERROR)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
       );
     });
 
@@ -115,7 +115,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const status = ['updating'];
       const kuery = buildStatusesKuery(status);
       expect(kuery).toMatchInlineSnapshot(
-        `"((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
+        `"((((united.agent.upgrade_started_at:*) and not (united.agent.upgraded_at:*)) or (not (united.agent.last_checkin:*)) or (united.agent.unenrollment_started_at:*) or (not united.agent.policy_revision_idx:*))  AND not ((united.agent.last_checkin < now-300s) or ((united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded or united.agent.last_checkin_status:DEGRADED or united.agent.last_checkin_status:ERROR)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))))"`
       );
     });
 
@@ -130,7 +130,7 @@ describe('test filtering endpoint hosts by agent status', () => {
       const statuses = ['offline', 'unhealthy'];
       const kuery = buildStatusesKuery(statuses);
       expect(kuery).toMatchInlineSnapshot(
-        `"(united.agent.last_checkin < now-300s OR (united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
+        `"(united.agent.last_checkin < now-300s OR (united.agent.last_checkin_status:error or united.agent.last_checkin_status:degraded or united.agent.last_checkin_status:DEGRADED or united.agent.last_checkin_status:ERROR)  AND not ((united.agent.last_checkin < now-300s) or (united.agent.unenrollment_started_at:*)))"`
       );
     });
   });


### PR DESCRIPTION
## Description 

Resolve #146755

Agent used to store their last checkin status (`last_checkin_status`) in lower case but they now return it uppercase (`DEGRADED` instead of `DEGRADED`)

That PR allow to support both in the service that compute and create the KQL for agent status.



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->