### PR TITLE
[TIP] investigate in timeline - set start and end date to 7 days from indicator timestamp

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.ts
@@ -52,8 +52,13 @@ export const useInvestigateInTimeline = ({
     generateDataProvider(e, value as string)
   );
 
-  const to = unwrapValue(indicator, RawIndicatorFieldId.TimeStamp) as string;
-  const from = moment(to).subtract(10, 'm').toISOString();
+  const indicatorTimestamp: string = unwrapValue(
+    indicator,
+    RawIndicatorFieldId.TimeStamp
+  ) as string;
+
+  const from = moment(indicatorTimestamp).subtract(7, 'd').toISOString();
+  const to = moment(indicatorTimestamp).add(7, 'd').toISOString();
 
   if (!to || !from) {
     return {} as unknown as UseInvestigateInTimelineValue;


### PR DESCRIPTION
## Summary

When the user clicks on Investigate in Timeline, we want to expand the start and end dates a bit. Instead of only showing 15min around the timestamp of the indicator, we're now showing 7 days before and 7 days after.

https://user-images.githubusercontent.com/17276605/204923326-b79c2dfe-c9c9-4e60-b1ae-190ca0ed26fd.mov

https://github.com/elastic/security-team/issues/5220