### PR TITLE
[controls] complete control input builder API

### DIFF
--- a/examples/controls_example/public/app.tsx
+++ b/examples/controls_example/public/app.tsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import type { DataView } from '@kbn/data-views-plugin/public';
 import { AppMountParameters } from '@kbn/core/public';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { ControlsExampleStartDeps } from './plugin';

--- a/examples/controls_example/public/app.tsx
+++ b/examples/controls_example/public/app.tsx
@@ -15,16 +15,19 @@ import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { ControlsExampleStartDeps } from './plugin';
 import { BasicReduxExample } from './basic_redux_example';
 
-interface Props {
-  dataView: DataView;
-}
-
-const ControlsExamples = ({ dataView }: Props) => {
+const ControlsExamples = ({ dataViewId }: { dataViewId?: string }) => {
+  const examples = dataViewId
+    ? <>
+        <BasicReduxExample dataViewId={dataViewId} />
+      </>
+    : <div>
+        {"Please install e-commerce sample data to run controls examples."}
+      </div>
   return (
     <KibanaPageTemplate>
       <KibanaPageTemplate.Header pageTitle="Controls as a Building Block" />
       <KibanaPageTemplate.Section>
-        <BasicReduxExample dataView={dataView} />
+        {examples}
       </KibanaPageTemplate.Section>
     </KibanaPageTemplate>
   );
@@ -35,8 +38,7 @@ export const renderApp = async (
   { element }: AppMountParameters
 ) => {
   const dataViews = await data.dataViews.find('kibana_sample_data_ecommerce');
-  if (dataViews.length > 0) {
-    ReactDOM.render(<ControlsExamples dataView={dataViews[0]} />, element);
-  }
+  const dataViewId = dataViews.length > 0 ? dataViews[0].id : undefined;
+  ReactDOM.render(<ControlsExamples dataViewId={dataViewId} />, element);
   return () => ReactDOM.unmountComponentAtNode(element);
 };

--- a/examples/controls_example/public/app.tsx
+++ b/examples/controls_example/public/app.tsx
@@ -15,19 +15,17 @@ import { ControlsExampleStartDeps } from './plugin';
 import { BasicReduxExample } from './basic_redux_example';
 
 const ControlsExamples = ({ dataViewId }: { dataViewId?: string }) => {
-  const examples = dataViewId
-    ? <>
-        <BasicReduxExample dataViewId={dataViewId} />
-      </>
-    : <div>
-        {"Please install e-commerce sample data to run controls examples."}
-      </div>
+  const examples = dataViewId ? (
+    <>
+      <BasicReduxExample dataViewId={dataViewId} />
+    </>
+  ) : (
+    <div>{'Please install e-commerce sample data to run controls examples.'}</div>
+  );
   return (
     <KibanaPageTemplate>
       <KibanaPageTemplate.Header pageTitle="Controls as a Building Block" />
-      <KibanaPageTemplate.Section>
-        {examples}
-      </KibanaPageTemplate.Section>
+      <KibanaPageTemplate.Section>{examples}</KibanaPageTemplate.Section>
     </KibanaPageTemplate>
   );
 };

--- a/examples/controls_example/public/basic_redux_example.tsx
+++ b/examples/controls_example/public/basic_redux_example.tsx
@@ -26,20 +26,16 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { getDefaultControlGroupInput } from '@kbn/controls-plugin/common';
 
-interface Props {
-  dataView: DataView;
-}
 const ControlGroupRenderer = withSuspense(LazyControlGroupRenderer);
 
-export const BasicReduxExample = ({ dataView }: Props) => {
-  const [myControlGroup, setControlGroup] = useState<ControlGroupContainer>();
+export const BasicReduxExample = ({ dataViewId }: { dataViewId?: string }) => {
+  const [controlGroup, setControlGroup] = useState<ControlGroupContainer>();
   const [currentControlStyle, setCurrentControlStyle] = useState<ControlStyle>('oneLine');
 
   const ControlGroupReduxWrapper = useMemo(() => {
-    if (myControlGroup) return myControlGroup.getReduxEmbeddableTools().Wrapper;
-  }, [myControlGroup]);
+    if (controlGroup) return controlGroup.getReduxEmbeddableTools().Wrapper;
+  }, [controlGroup]);
 
   const ButtonControls = () => {
     const {
@@ -105,20 +101,17 @@ export const BasicReduxExample = ({ dataView }: Props) => {
         )}
 
         <ControlGroupRenderer
-          onEmbeddableLoad={async (controlGroup) => {
-            setControlGroup(controlGroup);
+          onLoadComplete={async (newControlGroup) => {
+            setControlGroup(newControlGroup);
           }}
-          getCreationOptions={async (controlGroupInputBuilder) => {
-            const initialInput: Partial<ControlGroupInput> = {
-              ...getDefaultControlGroupInput(),
-              defaultControlWidth: 'small',
-            };
-            await controlGroupInputBuilder.addDataControlFromField(initialInput, {
-              dataViewId: dataView.id ?? 'kibana_sample_data_ecommerce',
+          getInitialInput={async (initialInput, builder) => {
+            await builder.addDataControlFromField(initialInput, {
+              dataViewId,
               fieldName: 'customer_first_name.keyword',
+              width: 'small',
             });
-            await controlGroupInputBuilder.addDataControlFromField(initialInput, {
-              dataViewId: dataView.id ?? 'kibana_sample_data_ecommerce',
+            await builder.addDataControlFromField(initialInput, {
+              dataViewId,
               fieldName: 'customer_last_name.keyword',
               width: 'medium',
               grow: false,

--- a/examples/controls_example/public/basic_redux_example.tsx
+++ b/examples/controls_example/public/basic_redux_example.tsx
@@ -41,9 +41,7 @@ export const BasicReduxExample = ({ dataViewId }: { dataViewId: string }) => {
       actions: { setControlStyle },
     } = useControlGroupContainerContext();
     const dispatch = useEmbeddableDispatch();
-    const controlStyle = select((state) => {
-      return state.explicitInput.controlStyle;
-    });
+    const controlStyle = select((state) => state.explicitInput.controlStyle);
 
     return (
       <>

--- a/examples/controls_example/public/basic_redux_example.tsx
+++ b/examples/controls_example/public/basic_redux_example.tsx
@@ -11,12 +11,10 @@ import React, { useMemo, useState } from 'react';
 import {
   LazyControlGroupRenderer,
   ControlGroupContainer,
-  ControlGroupInput,
   useControlGroupContainerContext,
   ControlStyle,
 } from '@kbn/controls-plugin/public';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
-import type { DataView } from '@kbn/data-views-plugin/public';
 import {
   EuiButtonGroup,
   EuiFlexGroup,

--- a/examples/controls_example/public/basic_redux_example.tsx
+++ b/examples/controls_example/public/basic_redux_example.tsx
@@ -27,7 +27,7 @@ import {
 
 const ControlGroupRenderer = withSuspense(LazyControlGroupRenderer);
 
-export const BasicReduxExample = ({ dataViewId }: { dataViewId?: string }) => {
+export const BasicReduxExample = ({ dataViewId }: { dataViewId: string }) => {
   const [controlGroup, setControlGroup] = useState<ControlGroupContainer>();
 
   const ControlGroupReduxWrapper = useMemo(() => {

--- a/examples/controls_example/public/basic_redux_example.tsx
+++ b/examples/controls_example/public/basic_redux_example.tsx
@@ -31,7 +31,6 @@ const ControlGroupRenderer = withSuspense(LazyControlGroupRenderer);
 
 export const BasicReduxExample = ({ dataViewId }: { dataViewId?: string }) => {
   const [controlGroup, setControlGroup] = useState<ControlGroupContainer>();
-  const [currentControlStyle, setCurrentControlStyle] = useState<ControlStyle>('oneLine');
 
   const ControlGroupReduxWrapper = useMemo(() => {
     if (controlGroup) return controlGroup.getReduxEmbeddableTools().Wrapper;
@@ -40,9 +39,13 @@ export const BasicReduxExample = ({ dataViewId }: { dataViewId?: string }) => {
   const ButtonControls = () => {
     const {
       useEmbeddableDispatch,
+      useEmbeddableSelector: select,
       actions: { setControlStyle },
     } = useControlGroupContainerContext();
     const dispatch = useEmbeddableDispatch();
+    const controlStyle = select((state) => {
+      return state.explicitInput.controlStyle;
+    });
 
     return (
       <>
@@ -67,9 +70,8 @@ export const BasicReduxExample = ({ dataViewId }: { dataViewId?: string }) => {
                   value: 'twoLine' as ControlStyle,
                 },
               ]}
-              idSelected={currentControlStyle}
+              idSelected={controlStyle}
               onChange={(id, value) => {
-                setCurrentControlStyle(value);
                 dispatch(setControlStyle(value));
               }}
               type="single"

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import uuid from 'uuid';
+import { ControlPanelState, getDefaultControlGroupInput } from '../../common';
+import {
+  DEFAULT_CONTROL_GROW,
+  DEFAULT_CONTROL_WIDTH,
+} from '../../common/control_group/control_group_constants';
+import { OPTIONS_LIST_CONTROL } from '..';
+import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
+
+export type AddDataControlProps = {
+  controlId?: string;
+  dataViewId: string;
+  fieldName: string;
+  grow?: boolean;
+  title?: string;
+  width?: ControlWidth;
+}
+
+export type AddOptionsListControlProps = AddDataControlProps & {
+  selectedOptions?: string[];
+}
+
+export const controlGroupInputBuilder = {
+  addDataControlFromField: async (
+    initialInput: Partial<ControlGroupInput>,
+    controlProps: AddDataControlFromFieldProps,
+  ) => {
+    const { controlId, dataViewId, fieldName, title } = controlProps;
+    const panelId = controlId ? controlId : uuid.v4();
+    initialInput.panels = {
+      ...initialInput.panels,
+      [panelId]: {
+        order: getNextPanelOrder(initialInput),
+        type: await getCompatibleControlType({ dataViewId, fieldName }),
+        grow: getGrow(initialInput, controlProps),
+        width: getWidth(initialInput, controlProps),
+        explicitInput: {
+          id: panelId, 
+          dataViewId, 
+          fieldName, 
+          title: controlProps.title ?? fieldName,
+        },
+      } as ControlPanelState<DataControlInput>,
+    };
+  },
+  addOptionsListControl: (
+    initialInput: Partial<ControlGroupInput>,
+    controlProps: AddOptionsListControlProps,
+  ) => {
+    const { controlId, dataViewId, fieldName, selectedOptions, title } = controlProps;
+    const panelId = controlId ? controlId : uuid.v4();
+    initialInput.panels = {
+      ...initialInput.panels,
+      [panelId]: {
+        order: getNextPanelOrder(initialInput),
+        type: OPTIONS_LIST_CONTROL,
+        grow: getGrow(initialInput, controlProps),
+        width: getWidth(initialInput, controlProps),
+        explicitInput: {
+          id: panelId,
+          dataViewId, 
+          fieldName,
+          selectedOptions,
+          title: controlProps.title ?? fieldName,
+        },
+      } as ControlPanelState<DataControlInput>,
+    };
+  },
+  addRangeSliderControl: (
+    initialInput: Partial<ControlGroupInput>,
+    controlProps: AddDataControlProps,
+  ) => {
+    const { controlId, dataViewId, fieldName, selectedOptions, title } = controlProps;
+    const panelId = controlId ? controlId : uuid.v4();
+    initialInput.panels = {
+      ...initialInput.panels,
+      [panelId]: {
+        order: getNextPanelOrder(initialInput),
+        type: RANGE_SLIDER_CONTROL,
+        grow: getGrow(initialInput, controlProps),
+        width: getWidth(initialInput, controlProps),
+        explicitInput: {
+          id: panelId,
+          dataViewId, 
+          fieldName,
+          title: controlProps.title ?? fieldName,
+        },
+      } as ControlPanelState<DataControlInput>,
+    };
+  },
+  addTimeSliderControl: (initialInput: Partial<ControlGroupInput>) => {
+    const panelId = uuid.v4();
+    initialInput.panels = {
+      ...initialInput.panels,
+      [panelId]: {
+        order: getNextPanelOrder(initialInput),
+        type: TIME_SLIDER_CONTROL,
+        grow: true,
+        width: 'large',
+        explicitInput: {
+          id: panelId,
+          title: 'timeslider',
+        },
+      } as ControlPanelState<ControlInput>,
+    };
+  },
+};
+
+function getGrow(initialInput: Partial<ControlGroupInput>, controlProps: AddDataControlProps) {
+  if (typeof controlProps.grow === 'boolean') {
+    return controlProps.grow;
+  }
+
+  return typeof initialInput.defaultControlGrow === 'boolean'
+    ? initialInput.defaultControlGrow
+    : DEFAULT_CONTROL_GROW;
+}
+
+function getWidth(initialInput: Partial<ControlGroupInput>, controlProps: AddDataControlProps) {
+  if (controlProps.width) {
+    return controlProps.width;
+  }
+
+  return initialInput.defaultControlWidth
+    ? initialInput.defaultControlWidth
+    : DEFAULT_CONTROL_WIDTH;
+}

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -12,11 +12,7 @@ import {
   DEFAULT_CONTROL_GROW,
   DEFAULT_CONTROL_WIDTH,
 } from '../../common/control_group/control_group_constants';
-import {
-  OPTIONS_LIST_CONTROL,
-  RANGE_SLIDER_CONTROL,
-  TIME_SLIDER_CONTROL
-} from '..';
+import { OPTIONS_LIST_CONTROL, RANGE_SLIDER_CONTROL, TIME_SLIDER_CONTROL } from '..';
 import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
 
 export interface AddDataControlProps {

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -105,7 +105,7 @@ export const controlGroupInputBuilder = {
           dataViewId,
           fieldName,
           title: title ?? fieldName,
-          value: value ? value : ['', '']
+          value: value ? value : ['', ''],
         },
       } as ControlPanelState<DataControlInput>,
     };

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_CONTROL_GROW,
   DEFAULT_CONTROL_WIDTH,
 } from '../../common/control_group/control_group_constants';
+import { RangeValue } from '../../common/range_slider/types';
 import {
   ControlInput,
   ControlWidth,
@@ -34,6 +35,10 @@ export interface AddDataControlProps {
 
 export type AddOptionsListControlProps = AddDataControlProps & {
   selectedOptions?: string[];
+};
+
+export type AddRangeSliderControlProps = AddDataControlProps & {
+  value?: RangeValue;
 };
 
 export const controlGroupInputBuilder = {
@@ -84,9 +89,9 @@ export const controlGroupInputBuilder = {
   },
   addRangeSliderControl: (
     initialInput: Partial<ControlGroupInput>,
-    controlProps: AddDataControlProps
+    controlProps: AddRangeSliderControlProps
   ) => {
-    const { controlId, dataViewId, fieldName, title } = controlProps;
+    const { controlId, dataViewId, fieldName, title, value } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
     initialInput.panels = {
       ...initialInput.panels,
@@ -100,6 +105,7 @@ export const controlGroupInputBuilder = {
           dataViewId,
           fieldName,
           title: title ?? fieldName,
+          value: value ? value : ['', '']
         },
       } as ControlPanelState<DataControlInput>,
     };

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -7,15 +7,19 @@
  */
 
 import uuid from 'uuid';
-import { ControlPanelState, getDefaultControlGroupInput } from '../../common';
+import { ControlPanelState } from '../../common';
 import {
   DEFAULT_CONTROL_GROW,
   DEFAULT_CONTROL_WIDTH,
 } from '../../common/control_group/control_group_constants';
-import { OPTIONS_LIST_CONTROL } from '..';
+import {
+  OPTIONS_LIST_CONTROL,
+  RANGE_SLIDER_CONTROL,
+  TIME_SLIDER_CONTROL
+} from '..';
 import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
 
-export type AddDataControlProps = {
+export interface AddDataControlProps {
   controlId?: string;
   dataViewId: string;
   fieldName: string;
@@ -26,12 +30,12 @@ export type AddDataControlProps = {
 
 export type AddOptionsListControlProps = AddDataControlProps & {
   selectedOptions?: string[];
-}
+};
 
 export const controlGroupInputBuilder = {
   addDataControlFromField: async (
     initialInput: Partial<ControlGroupInput>,
-    controlProps: AddDataControlFromFieldProps,
+    controlProps: AddDataControlFromFieldProps
   ) => {
     const { controlId, dataViewId, fieldName, title } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
@@ -43,9 +47,9 @@ export const controlGroupInputBuilder = {
         grow: getGrow(initialInput, controlProps),
         width: getWidth(initialInput, controlProps),
         explicitInput: {
-          id: panelId, 
-          dataViewId, 
-          fieldName, 
+          id: panelId,
+          dataViewId,
+          fieldName,
           title: controlProps.title ?? fieldName,
         },
       } as ControlPanelState<DataControlInput>,
@@ -53,7 +57,7 @@ export const controlGroupInputBuilder = {
   },
   addOptionsListControl: (
     initialInput: Partial<ControlGroupInput>,
-    controlProps: AddOptionsListControlProps,
+    controlProps: AddOptionsListControlProps
   ) => {
     const { controlId, dataViewId, fieldName, selectedOptions, title } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
@@ -66,7 +70,7 @@ export const controlGroupInputBuilder = {
         width: getWidth(initialInput, controlProps),
         explicitInput: {
           id: panelId,
-          dataViewId, 
+          dataViewId,
           fieldName,
           selectedOptions,
           title: controlProps.title ?? fieldName,
@@ -76,7 +80,7 @@ export const controlGroupInputBuilder = {
   },
   addRangeSliderControl: (
     initialInput: Partial<ControlGroupInput>,
-    controlProps: AddDataControlProps,
+    controlProps: AddDataControlProps
   ) => {
     const { controlId, dataViewId, fieldName, selectedOptions, title } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
@@ -89,7 +93,7 @@ export const controlGroupInputBuilder = {
         width: getWidth(initialInput, controlProps),
         explicitInput: {
           id: panelId,
-          dataViewId, 
+          dataViewId,
           fieldName,
           title: controlProps.title ?? fieldName,
         },

--- a/src/plugins/controls/public/control_group/control_group_input_builder.ts
+++ b/src/plugins/controls/public/control_group/control_group_input_builder.ts
@@ -12,7 +12,15 @@ import {
   DEFAULT_CONTROL_GROW,
   DEFAULT_CONTROL_WIDTH,
 } from '../../common/control_group/control_group_constants';
-import { OPTIONS_LIST_CONTROL, RANGE_SLIDER_CONTROL, TIME_SLIDER_CONTROL } from '..';
+import {
+  ControlInput,
+  ControlWidth,
+  DataControlInput,
+  OPTIONS_LIST_CONTROL,
+  RANGE_SLIDER_CONTROL,
+  TIME_SLIDER_CONTROL,
+} from '..';
+import { ControlGroupInput } from './types';
 import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
 
 export interface AddDataControlProps {
@@ -31,7 +39,7 @@ export type AddOptionsListControlProps = AddDataControlProps & {
 export const controlGroupInputBuilder = {
   addDataControlFromField: async (
     initialInput: Partial<ControlGroupInput>,
-    controlProps: AddDataControlFromFieldProps
+    controlProps: AddDataControlProps
   ) => {
     const { controlId, dataViewId, fieldName, title } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
@@ -46,7 +54,7 @@ export const controlGroupInputBuilder = {
           id: panelId,
           dataViewId,
           fieldName,
-          title: controlProps.title ?? fieldName,
+          title: title ?? fieldName,
         },
       } as ControlPanelState<DataControlInput>,
     };
@@ -69,7 +77,7 @@ export const controlGroupInputBuilder = {
           dataViewId,
           fieldName,
           selectedOptions,
-          title: controlProps.title ?? fieldName,
+          title: title ?? fieldName,
         },
       } as ControlPanelState<DataControlInput>,
     };
@@ -78,7 +86,7 @@ export const controlGroupInputBuilder = {
     initialInput: Partial<ControlGroupInput>,
     controlProps: AddDataControlProps
   ) => {
-    const { controlId, dataViewId, fieldName, selectedOptions, title } = controlProps;
+    const { controlId, dataViewId, fieldName, title } = controlProps;
     const panelId = controlId ? controlId : uuid.v4();
     initialInput.panels = {
       ...initialInput.panels,
@@ -91,7 +99,7 @@ export const controlGroupInputBuilder = {
           id: panelId,
           dataViewId,
           fieldName,
-          title: controlProps.title ?? fieldName,
+          title: title ?? fieldName,
         },
       } as ControlPanelState<DataControlInput>,
     };

--- a/src/plugins/controls/public/control_group/control_group_renderer.tsx
+++ b/src/plugins/controls/public/control_group/control_group_renderer.tsx
@@ -14,7 +14,7 @@ import { IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { useReduxContainerContext } from '@kbn/presentation-util-plugin/public';
 
 import { pluginServices } from '../services';
-import { ControlPanelState, getDefaultControlGroupInput } from '../../common';
+import { getDefaultControlGroupInput } from '../../common';
 import {
   ControlGroupInput,
   ControlGroupOutput,
@@ -22,8 +22,6 @@ import {
   CONTROL_GROUP_TYPE,
 } from './types';
 import { ControlGroupContainer } from './embeddable/control_group_container';
-import { DataControlInput } from '../types';
-import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
 import { controlGroupReducers } from './state/control_group_reducers';
 import { controlGroupInputBuilder } from './control_group_input_builder';
 
@@ -31,7 +29,7 @@ export interface ControlGroupRendererProps {
   onLoadComplete?: (controlGroup: ControlGroupContainer) => void;
   getInitialInput: (
     initialInput: Partial<ControlGroupInput>,
-    builder: typeof controlGroupInputBuilder,
+    builder: typeof controlGroupInputBuilder
   ) => Promise<Partial<ControlGroupInput>>;
 }
 

--- a/src/plugins/controls/public/control_group/control_group_renderer.tsx
+++ b/src/plugins/controls/public/control_group/control_group_renderer.tsx
@@ -55,6 +55,7 @@ export const ControlGroupRenderer = ({
         >(CONTROL_GROUP_TYPE);
         const newControlGroup = (await factory?.create({
           id,
+          ...getDefaultControlGroupInput(),
           ...(await getInitialInput(getDefaultControlGroupInput(), controlGroupInputBuilder)),
         })) as ControlGroupContainer;
 

--- a/src/plugins/controls/public/control_group/control_group_renderer.tsx
+++ b/src/plugins/controls/public/control_group/control_group_renderer.tsx
@@ -25,57 +25,28 @@ import { ControlGroupContainer } from './embeddable/control_group_container';
 import { DataControlInput } from '../types';
 import { getCompatibleControlType, getNextPanelOrder } from './embeddable/control_group_helpers';
 import { controlGroupReducers } from './state/control_group_reducers';
-
-const ControlGroupInputBuilder = {
-  addDataControlFromField: async (
-    initialInput: Partial<ControlGroupInput>,
-    newPanelInput: {
-      title?: string;
-      panelId?: string;
-      fieldName: string;
-      dataViewId: string;
-    } & Partial<ControlPanelState>
-  ) => {
-    const { defaultControlGrow, defaultControlWidth } = getDefaultControlGroupInput();
-    const controlGrow = initialInput.defaultControlGrow ?? defaultControlGrow;
-    const controlWidth = initialInput.defaultControlWidth ?? defaultControlWidth;
-
-    const { panelId, dataViewId, fieldName, title, grow, width } = newPanelInput;
-    const newPanelId = panelId || uuid.v4();
-    const nextOrder = getNextPanelOrder(initialInput);
-    const controlType = await getCompatibleControlType({ dataViewId, fieldName });
-
-    initialInput.panels = {
-      ...initialInput.panels,
-      [newPanelId]: {
-        order: nextOrder,
-        type: controlType,
-        grow: grow ?? controlGrow,
-        width: width ?? controlWidth,
-        explicitInput: { id: newPanelId, dataViewId, fieldName, title: title ?? fieldName },
-      } as ControlPanelState<DataControlInput>,
-    };
-  },
-};
+import { controlGroupInputBuilder } from './control_group_input_builder';
 
 export interface ControlGroupRendererProps {
-  onEmbeddableLoad: (controlGroupContainer: ControlGroupContainer) => void;
-  getCreationOptions: (
-    builder: typeof ControlGroupInputBuilder
+  onLoadComplete?: (controlGroup: ControlGroupContainer) => void;
+  getInitialInput: (
+    initialInput: Partial<ControlGroupInput>,
+    builder: typeof controlGroupInputBuilder,
   ) => Promise<Partial<ControlGroupInput>>;
 }
 
 export const ControlGroupRenderer = ({
-  onEmbeddableLoad,
-  getCreationOptions,
+  onLoadComplete,
+  getInitialInput,
 }: ControlGroupRendererProps) => {
-  const controlsRoot = useRef(null);
-  const [controlGroupContainer, setControlGroupContainer] = useState<ControlGroupContainer>();
+  const controlGroupRef = useRef(null);
+  const [controlGroup, setControlGroup] = useState<ControlGroupContainer>();
   const id = useMemo(() => uuid.v4(), []);
   /**
    * Use Lifecycles to load initial control group container
    */
   useLifecycles(
+    // onMount
     () => {
       const { embeddable } = pluginServices.getServices();
       (async () => {
@@ -84,25 +55,27 @@ export const ControlGroupRenderer = ({
           ControlGroupOutput,
           IEmbeddable<ControlGroupInput, ControlGroupOutput>
         >(CONTROL_GROUP_TYPE);
-        const container = (await factory?.create({
+        const newControlGroup = (await factory?.create({
           id,
-          ...getDefaultControlGroupInput(),
-          ...(await getCreationOptions(ControlGroupInputBuilder)),
+          ...(await getInitialInput(getDefaultControlGroupInput(), controlGroupInputBuilder)),
         })) as ControlGroupContainer;
 
-        if (controlsRoot.current) {
-          container.render(controlsRoot.current);
+        if (controlGroupRef.current) {
+          newControlGroup.render(controlGroupRef.current);
         }
-        setControlGroupContainer(container);
-        onEmbeddableLoad(container);
+        setControlGroup(newControlGroup);
+        if (onLoadComplete) {
+          onLoadComplete(newControlGroup);
+        }
       })();
     },
+    // onUnmount
     () => {
-      controlGroupContainer?.destroy();
+      controlGroup?.destroy();
     }
   );
 
-  return <div ref={controlsRoot} />;
+  return <div ref={controlGroupRef} />;
 };
 
 export const useControlGroupContainerContext = () =>

--- a/src/plugins/controls/public/control_group/index.ts
+++ b/src/plugins/controls/public/control_group/index.ts
@@ -18,7 +18,7 @@ export {
   type AddDataControlProps,
   type AddOptionsListControlProps,
   controlGroupInputBuilder,
-} from './control_group_renderer';
+} from './control_group_input_builder';
 
 export {
   type ControlGroupRendererProps,

--- a/src/plugins/controls/public/control_group/index.ts
+++ b/src/plugins/controls/public/control_group/index.ts
@@ -15,6 +15,12 @@ export { CONTROL_GROUP_TYPE } from './types';
 export { ControlGroupContainerFactory } from './embeddable/control_group_container_factory';
 
 export {
+  type AddDataControlProps,
+  type AddOptionsListControlProps,
+  controlGroupInputBuilder,
+} from './control_group_renderer';
+
+export {
   type ControlGroupRendererProps,
   useControlGroupContainerContext,
 } from './control_group_renderer';

--- a/src/plugins/controls/public/index.ts
+++ b/src/plugins/controls/public/index.ts
@@ -22,6 +22,7 @@ export type {
   ControlStyle,
   ParentIgnoreSettings,
   ControlInput,
+  DataControlInput,
 } from '../common/types';
 
 export {

--- a/src/plugins/controls/public/index.ts
+++ b/src/plugins/controls/public/index.ts
@@ -32,9 +32,12 @@ export {
 } from '../common';
 
 export {
+  type AddDataControlProps,
+  type AddOptionsListControlProps,
   type ControlGroupContainer,
   ControlGroupContainerFactory,
   type ControlGroupInput,
+  controlGroupInputBuilder,
   type ControlGroupOutput,
 } from './control_group';
 

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/controls_content.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/controls_content.tsx
@@ -59,7 +59,7 @@ export const ControlsContent: React.FC<Props> = ({
 
   return (
     <LazyControlsRenderer
-      getCreationOptions={async ({ addDataControlFromField }) => ({
+      getInitialInput={async () => ({
         id: dataViewId,
         type: CONTROL_GROUP_TYPE,
         timeRange,
@@ -72,7 +72,7 @@ export const ControlsContent: React.FC<Props> = ({
         defaultControlWidth: 'small',
         panels: controlPanel,
       })}
-      onEmbeddableLoad={(newControlGroup) => {
+      onLoadComplete={(newControlGroup) => {
         setControlGroup(newControlGroup);
         newControlGroup.onFiltersPublished$.subscribe((newFilters) => {
           setPanelFilters([...newFilters]);


### PR DESCRIPTION
ControlGroupRenderer API changes
* Added parameter `initialInput: Partial<ControlGroupInput>,` to getCreationOptions method signature so consumers don't need to call `getDefaultControlGroupInput`
* Rename prop onEmbeddableLoad -> onLoadComplete
* Rename prop getCreationOptions -> getInitialInput

controlGroupInputBuilder API changes
* Added `addOptionsListControl` method that allows users to pass selectedOptions
* Added `addRangeSliderControl`
* Added `addTimeSliderControl`