### PR TITLE
[8.5] Update Elastic Package Registry distribution docker image for V2 (#146673)

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -18,7 +18,7 @@ import pRetry from 'p-retry';
 const BEFORE_SETUP_TIMEOUT = 30 * 60 * 1000; // 30 minutes;
 
 const DOCKER_START_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:production-v2-experimental`;
+const DOCKER_IMAGE = `docker.elastic.co/package-registry/distribution:production`;
 
 function firstWithTimeout(source$: Rx.Observable<any>, errorMsg: string, ms = 30 * 1000) {
   return Rx.race(

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -15,11 +15,10 @@ import {
 
 const getFullPath = (relativePath: string) => path.join(path.dirname(__filename), relativePath);
 // Docker image to use for Fleet API integration tests.
-// This hash comes from the latest successful build of the Snapshot Distribution of the Package Registry, for
-// example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
-// It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
-export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production-v2-experimental';
+// This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
+// example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
+// It should be updated any time there is a new package published.
+export const dockerImage = 'docker.elastic.co/package-registry/distribution:production';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -11,11 +11,10 @@ import { services } from './services';
 import { pageObjects } from './page_objects';
 
 // Docker image to use for Fleet API integration tests.
-// This hash comes from the latest successful build of the Snapshot Distribution of the Package Registry, for
-// example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
-// It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
-export const dockerImage =
-  'docker.elastic.co/package-registry/distribution:production-v2-experimental';
+// This hash comes from the latest successful build of the Production Distribution of the Package Registry, for
+// example: https://internal-ci.elastic.co/blue/organizations/jenkins/package_storage%2Findexing-job/detail/main/1884/pipeline/147.
+// It should be updated any time there is a new package published.
+export const dockerImage = 'docker.elastic.co/package-registry/distribution:production';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Update Elastic Package Registry distribution docker image for V2 (#146673)](https://github.com/elastic/kibana/pull/146673)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mario Rodriguez Molins","email":"mario.rodriguez@elastic.co"},"sourceCommit":{"committedDate":"2022-11-30T13:19:32Z","message":"Update Elastic Package Registry distribution docker image for V2 (#146673)\n\n## Summary\r\n\r\nUpdate the docker image used as Elastic Package Registry distribution\r\nfor Package Storage V2, so it contains the latest packages published.\r\n\r\nTested updating fleet_packages.json to use endpoint version 8.6.0 (and\r\nreverted).","sha":"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-minor","v8.6.0","v8.7.0"],"number":146673,"url":"https://github.com/elastic/kibana/pull/146673","mergeCommit":{"message":"Update Elastic Package Registry distribution docker image for V2 (#146673)\n\n## Summary\r\n\r\nUpdate the docker image used as Elastic Package Registry distribution\r\nfor Package Storage V2, so it contains the latest packages published.\r\n\r\nTested updating fleet_packages.json to use endpoint version 8.6.0 (and\r\nreverted).","sha":"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/146684","number":146684,"state":"MERGED","mergeCommit":{"sha":"e5e68c6c169185555747a673f8cfff43175ff466","message":"[8.6] Update Elastic Package Registry distribution docker image for V2 (#146673) (#146684)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.6`:\n- [Update Elastic Package Registry distribution docker image for V2\n(#146673)](https://github.com/elastic/kibana/pull/146673)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Mario Rodriguez\nMolins\",\"email\":\"mario.rodriguez@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2022-11-30T13:19:32Z\",\"message\":\"Update\nElastic Package Registry distribution docker image for V2\n(#146673)\\n\\n## Summary\\r\\n\\r\\nUpdate the docker image used as Elastic\nPackage Registry distribution\\r\\nfor Package Storage V2, so it contains\nthe latest packages published.\\r\\n\\r\\nTested updating\nfleet_packages.json to use endpoint version 8.6.0\n(and\\r\\nreverted).\",\"sha\":\"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe\",\"branchLabelMapping\":{\"^v8.7.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:Fleet\",\"backport:prev-minor\",\"v8.7.0\"],\"number\":146673,\"url\":\"https://github.com/elastic/kibana/pull/146673\",\"mergeCommit\":{\"message\":\"Update\nElastic Package Registry distribution docker image for V2\n(#146673)\\n\\n## Summary\\r\\n\\r\\nUpdate the docker image used as Elastic\nPackage Registry distribution\\r\\nfor Package Storage V2, so it contains\nthe latest packages published.\\r\\n\\r\\nTested updating\nfleet_packages.json to use endpoint version 8.6.0\n(and\\r\\nreverted).\",\"sha\":\"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.7.0\",\"labelRegex\":\"^v8.7.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/146673\",\"number\":146673,\"mergeCommit\":{\"message\":\"Update\nElastic Package Registry distribution docker image for V2\n(#146673)\\n\\n## Summary\\r\\n\\r\\nUpdate the docker image used as Elastic\nPackage Registry distribution\\r\\nfor Package Storage V2, so it contains\nthe latest packages published.\\r\\n\\r\\nTested updating\nfleet_packages.json to use endpoint version 8.6.0\n(and\\r\\nreverted).\",\"sha\":\"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Mario Rodriguez Molins <mario.rodriguez@elastic.co>"}},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146673","number":146673,"mergeCommit":{"message":"Update Elastic Package Registry distribution docker image for V2 (#146673)\n\n## Summary\r\n\r\nUpdate the docker image used as Elastic Package Registry distribution\r\nfor Package Storage V2, so it contains the latest packages published.\r\n\r\nTested updating fleet_packages.json to use endpoint version 8.6.0 (and\r\nreverted).","sha":"c6c612ef81ed7c11d3b0a39ea6d3579e7bd6cabe"}}]}] BACKPORT-->