### PR TITLE
[APM] Update default refresh interval to 60 seconds

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/date_picker/apm_date_picker.tsx
+++ b/x-pack/plugins/apm/public/components/shared/date_picker/apm_date_picker.tsx
@@ -7,13 +7,14 @@
 
 import React from 'react';
 import { useApmParams } from '../../../hooks/use_apm_params';
-
 import { DatePicker } from '.';
 import { useTimeRangeId } from '../../../context/time_range_id/use_time_range_id';
 import {
   toBoolean,
   toNumber,
 } from '../../../context/url_params_context/helpers';
+
+export const DEFAULT_REFRESH_INTERVAL = 60000;
 
 export function ApmDatePicker() {
   const { query } = useApmParams('/*');
@@ -26,11 +27,12 @@ export function ApmDatePicker() {
     rangeFrom,
     rangeTo,
     refreshPaused: refreshPausedFromUrl = 'true',
-    refreshInterval: refreshIntervalFromUrl = '60000',
+    refreshInterval: refreshIntervalFromUrl,
   } = query;
 
   const refreshPaused = toBoolean(refreshPausedFromUrl);
-  const refreshInterval = toNumber(refreshIntervalFromUrl);
+  const refreshInterval =
+    toNumber(refreshIntervalFromUrl) ?? DEFAULT_REFRESH_INTERVAL;
 
   const { incrementTimeRangeId } = useTimeRangeId();
 

--- a/x-pack/plugins/apm/public/components/shared/date_picker/apm_date_picker.tsx
+++ b/x-pack/plugins/apm/public/components/shared/date_picker/apm_date_picker.tsx
@@ -26,11 +26,10 @@ export function ApmDatePicker() {
     rangeFrom,
     rangeTo,
     refreshPaused: refreshPausedFromUrl = 'true',
-    refreshInterval: refreshIntervalFromUrl = '0',
+    refreshInterval: refreshIntervalFromUrl = '60000',
   } = query;
 
   const refreshPaused = toBoolean(refreshPausedFromUrl);
-
   const refreshInterval = toNumber(refreshIntervalFromUrl);
 
   const { incrementTimeRangeId } = useTimeRangeId();

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.test.tsx
@@ -23,7 +23,7 @@ describe('MLExplorerLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/explorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
+      `"/app/ml/explorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fw,to:now-4h))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
     );
   });
 
@@ -34,12 +34,12 @@ describe('MLExplorerLink', () => {
       ),
       {
         search:
-          '?rangeFrom=2020-07-29T17:27:29.000Z&rangeTo=2020-07-29T18:45:00.000Z&refreshInterval=10000&refreshPaused=true',
+          '?rangeFrom=2020-07-29T17:27:29.000Z&rangeTo=2020-07-29T18:45:00.000Z&refreshInterval=60000&refreshPaused=true',
       } as Location
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/explorer?_g=(ml:(jobIds:!(apm-production-485b-high_mean_transaction_duration)),refreshInterval:(pause:!t,value:10000),time:(from:'2020-07-29T17:27:29.000Z',to:'2020-07-29T18:45:00.000Z'))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
+      `"/app/ml/explorer?_g=(ml:(jobIds:!(apm-production-485b-high_mean_transaction_duration)),refreshInterval:(pause:!t,value:60000),time:(from:'2020-07-29T17:27:29.000Z',to:'2020-07-29T18:45:00.000Z'))&_a=(explorer:(mlExplorerFilter:(),mlExplorerSwimlane:()))"`
     );
   });
 });

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
@@ -10,6 +10,7 @@ import { EuiLink } from '@elastic/eui';
 import { useMlHref, ML_PAGES } from '@kbn/ml-plugin/public';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { DEFAULT_REFRESH_INTERVAL } from '../../date_picker/apm_date_picker';
 
 interface Props {
   children?: ReactNode;
@@ -48,7 +49,7 @@ export function useExplorerHref({ jobId }: { jobId: string }) {
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: true, value: 60000 },
+      refreshInterval: { pause: true, value: DEFAULT_REFRESH_INTERVAL },
     },
   });
 

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlexplorer_link.tsx
@@ -48,7 +48,7 @@ export function useExplorerHref({ jobId }: { jobId: string }) {
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: true, value: 10000 },
+      refreshInterval: { pause: true, value: 60000 },
     },
   });
 

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.test.tsx
@@ -23,7 +23,7 @@ describe('MLSingleMetricLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:()))"`
+      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:()))"`
     );
   });
   it('should produce the correct URL with jobId, serviceName, and transactionType', async () => {
@@ -42,7 +42,7 @@ describe('MLSingleMetricLink', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:10000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-test,transaction.type:request))))"`
+      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:!t,value:60000),time:(from:now%2Fw,to:now-4h))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-test,transaction.type:request))))"`
     );
   });
 
@@ -57,12 +57,12 @@ describe('MLSingleMetricLink', () => {
       ),
       {
         search:
-          '?rangeFrom=2020-07-29T17:27:29.000Z&rangeTo=2020-07-29T18:45:00.000Z&refreshInterval=10000&refreshPaused=true',
+          '?rangeFrom=2020-07-29T17:27:29.000Z&rangeTo=2020-07-29T18:45:00.000Z&refreshInterval=60000&refreshPaused=true',
       } as Location
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(apm-production-485b-high_mean_transaction_duration)),refreshInterval:(pause:!t,value:10000),time:(from:'2020-07-29T17:27:29.000Z',to:'2020-07-29T18:45:00.000Z'))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-java,transaction.type:request))))"`
+      `"/app/ml/timeseriesexplorer?_g=(ml:(jobIds:!(apm-production-485b-high_mean_transaction_duration)),refreshInterval:(pause:!t,value:60000),time:(from:'2020-07-29T17:27:29.000Z',to:'2020-07-29T18:45:00.000Z'))&_a=(timeseriesexplorer:(mlTimeSeriesExplorer:(entities:(service.name:opbeans-java,transaction.type:request))))"`
     );
   });
 });

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
@@ -10,6 +10,7 @@ import { EuiLink } from '@elastic/eui';
 import { useMlHref, ML_PAGES } from '@kbn/ml-plugin/public';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { DEFAULT_REFRESH_INTERVAL } from '../../date_picker/apm_date_picker';
 
 interface Props {
   children?: ReactNode;
@@ -74,7 +75,7 @@ function useSingleMetricHref({
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: true, value: 60000 },
+      refreshInterval: { pause: true, value: DEFAULT_REFRESH_INTERVAL },
       ...entities,
     },
   });

--- a/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/machine_learning_links/mlsingle_metric_link.tsx
@@ -74,7 +74,7 @@ function useSingleMetricHref({
     pageState: {
       jobIds: [jobId],
       timeRange: { from: rangeFrom, to: rangeTo },
-      refreshInterval: { pause: true, value: 10000 },
+      refreshInterval: { pause: true, value: 60000 },
       ...entities,
     },
   });


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/144389 the default refresh interval across Kibana was changed from 0 to 60 seconds. 

A while ago we opted to not follow the Kibana defaults because they were non-sensical. This has now been fixed so we may want to start following them again. However, that's a bigger change. For now I suggest we simply update the hardcoded default value specified in APM.