### PR TITLE
[7.17] [Telemetry] Cache the report generation promise (#146679)

### DIFF
--- a/src/plugins/telemetry_collection_manager/server/plugin.ts
+++ b/src/plugins/telemetry_collection_manager/server/plugin.ts
@@ -324,20 +324,47 @@ export class TelemetryCollectionManagerPlugin
     }
 
     const cacheKey = this.createCacheKey(collectionSource, clustersDetails);
-    const cachedUsageStatsPayload = this.cacheManager.getFromCache<UsageStatsPayload[]>(cacheKey);
-    if (cachedUsageStatsPayload) {
-      return this.updateFetchedAt(cachedUsageStatsPayload);
+    const cachedUsageStatsPromise =
+      this.cacheManager.getFromCache<Promise<UsageStatsPayload[]>>(cacheKey);
+    if (cachedUsageStatsPromise) {
+      return this.updateFetchedAt(await cachedUsageStatsPromise);
     }
 
+    const statsFromCollectionPromise = this.getStatsFromCollection(
+      clustersDetails,
+      collection,
+      statsCollectionConfig
+    );
+    this.cacheManager.setCache(cacheKey, statsFromCollectionPromise);
+
+    try {
+      const stats = await statsFromCollectionPromise;
+      return this.updateFetchedAt(stats);
+    } catch (err) {
+      this.logger.debug(
+        `Failed to generate the telemetry report (${err.message}). Resetting the cache...`
+      );
+      this.cacheManager.resetCache();
+      throw err;
+    }
+  }
+
+  private async getStatsFromCollection(
+    clustersDetails: ClusterDetails[],
+    collection: CollectionStrategy,
+    statsCollectionConfig: StatsCollectionConfig
+  ) {
+    const context: StatsCollectionContext = {
+      logger: this.logger.get(collection.title),
+      version: this.version,
+    };
+    const { title: collectionSource } = collection;
     const now = new Date().toISOString();
     const stats = await collection.statsGetter(clustersDetails, statsCollectionConfig, context);
-    const usageStatsPayload = stats.map((stat) => ({
+    return stats.map((stat) => ({
       collectionSource,
       cacheDetails: { updatedAt: now, fetchedAt: now },
       ...stat,
     }));
-    this.cacheManager.setCache(cacheKey, usageStatsPayload);
-
-    return this.updateFetchedAt(usageStatsPayload);
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Telemetry] Cache the report generation promise (#146679)](https://github.com/elastic/kibana/pull/146679)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2022-12-01T15:14:46Z","message":"[Telemetry] Cache the report generation promise (#146679)\n\nResolves https://github.com/elastic/kibana/issues/146676","sha":"24de7178ed2785244f93f2e92031a921b7268f3d","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","performance","Feature:Telemetry","release_note:skip","backport:all-open","v8.7.0"],"number":146679,"url":"https://github.com/elastic/kibana/pull/146679","mergeCommit":{"message":"[Telemetry] Cache the report generation promise (#146679)\n\nResolves https://github.com/elastic/kibana/issues/146676","sha":"24de7178ed2785244f93f2e92031a921b7268f3d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146679","number":146679,"mergeCommit":{"message":"[Telemetry] Cache the report generation promise (#146679)\n\nResolves https://github.com/elastic/kibana/issues/146676","sha":"24de7178ed2785244f93f2e92031a921b7268f3d"}},{"url":"https://github.com/elastic/kibana/pull/146794","number":146794,"branch":"8.5","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/146795","number":146795,"branch":"8.6","state":"OPEN"}]}] BACKPORT-->