### PR TITLE
[Security solution][Endpoint] Uses new search strategy in endpoints list

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -90,3 +90,5 @@ export const ENDPOINT_DEFAULT_PAGE_SIZE = 10;
 export const ENDPOINT_ERROR_CODES: Record<string, number> = {
   ES_CONNECTION_ERROR: -272,
 };
+
+export const ENDPOINT_FIELDS_SEARCH_STRATEGY = 'endpointFields';

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { firstValueFrom } from 'rxjs';
 import type { CoreStart, HttpSetup } from '@kbn/core/public';
 import type { Store } from 'redux';
 import { applyMiddleware, createStore } from 'redux';
@@ -56,11 +57,13 @@ jest.mock('../../../services/policies/ingest', () => ({
 }));
 
 jest.mock('../../../../common/lib/kibana');
+jest.mock('rxjs');
 
 type EndpointListStore = Store<Immutable<EndpointState>, Immutable<AppAction>>;
 
 describe('endpoint list middleware', () => {
   const getKibanaServicesMock = KibanaServices.get as jest.Mock;
+  const firstValueFromMock = firstValueFrom as jest.Mock;
   let fakeCoreStart: jest.Mocked<CoreStart>;
   let depsStart: DepsStartMock;
   let fakeHttpServices: jest.Mocked<HttpSetup>;
@@ -120,6 +123,7 @@ describe('endpoint list middleware', () => {
   });
 
   it('handles `appRequestedEndpointList`', async () => {
+    firstValueFromMock.mockResolvedValue({ indexFields: [] });
     endpointPageHttpMock(fakeHttpServices);
     const apiResponse = getEndpointListApiResponse();
     fakeHttpServices.get.mockResolvedValue(apiResponse);

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/integration_tests/search_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/integration_tests/search_bar.test.tsx
@@ -16,6 +16,14 @@ import { fireEvent } from '@testing-library/dom';
 import { uiQueryParams } from '../../../store/selectors';
 import type { EndpointIndexUIQueryParams } from '../../../types';
 
+jest.mock('rxjs', () => {
+  const actual = jest.requireActual('rxjs');
+  return {
+    ...actual,
+    firstValueFrom: async () => ({ indexFields: [] }),
+  };
+});
+
 describe('when rendering the endpoint list `AdminSearchBar`', () => {
   let render: (
     urlParams?: EndpointIndexUIQueryParams

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
@@ -28,7 +28,10 @@ import { OperatingSystem } from '@kbn/securitysolution-utils';
 import { getExceptionBuilderComponentLazy } from '@kbn/lists-plugin/public';
 import type { OnChangeProps } from '@kbn/lists-plugin/public';
 import type { ValueSuggestionsGetFn } from '@kbn/unified-search-plugin/public/autocomplete/providers/value_suggestion_provider';
-import { eventsIndexPattern } from '../../../../../../common/endpoint/constants';
+import {
+  ENDPOINT_FIELDS_SEARCH_STRATEGY,
+  eventsIndexPattern,
+} from '../../../../../../common/endpoint/constants';
 import { useSuggestions } from '../../../../hooks/use_suggestions';
 import { useTestIdGenerator } from '../../../../hooks/use_test_id_generator';
 import type { PolicyData } from '../../../../../../common/endpoint/types';
@@ -146,7 +149,7 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
     const [isIndexPatternLoading, { indexPatterns }] = useFetchIndex(
       indexNames,
       undefined,
-      'eventFiltersFields'
+      ENDPOINT_FIELDS_SEARCH_STRATEGY
     );
 
     const [areConditionsValid, setAreConditionsValid] = useState(

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -103,7 +103,8 @@ import { EndpointFleetServicesFactory } from './endpoint/services/fleet';
 import { featureUsageService } from './endpoint/services/feature_usage';
 import { setIsElasticCloudDeployment } from './lib/telemetry/helpers';
 import { artifactService } from './lib/telemetry/artifact';
-import { eventFiltersFieldsProvider } from './search_strategy/event_filters_fields';
+import { endpointFieldsProvider } from './search_strategy/endpoint_fields';
+import { ENDPOINT_FIELDS_SEARCH_STRATEGY } from '../common/endpoint/constants';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 
@@ -357,11 +358,14 @@ export class Plugin implements ISecuritySolutionPlugin {
         config,
       });
 
-      const eventFiltersFieldsStrategy = eventFiltersFieldsProvider(
+      const endpointFieldsStrategy = endpointFieldsProvider(
         this.endpointAppContextService,
         depsStart.data.indexPatterns
       );
-      plugins.data.search.registerSearchStrategy('eventFiltersFields', eventFiltersFieldsStrategy);
+      plugins.data.search.registerSearchStrategy(
+        ENDPOINT_FIELDS_SEARCH_STRATEGY,
+        endpointFieldsStrategy
+      );
 
       const securitySolutionSearchStrategy = securitySolutionSearchStrategyProvider(
         depsStart.data,

--- a/x-pack/plugins/security_solution/server/search_strategy/endpoint_fields/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/endpoint_fields/index.ts
@@ -51,16 +51,16 @@ export const requestEndpointFieldsSearch = async (
   beatFields: BeatFields,
   indexPatterns: DataViewsServerPluginStart
 ): Promise<IndexFieldsStrategyResponse> => {
-  const { canWriteEventFilters, canReadEndpointList } = await context.getEndpointAuthz(
-    deps.request
-  );
-
   if (
     request.indices.length > 1 ||
     (request.indices[0] !== eventsIndexPattern && request.indices[0] !== METADATA_UNITED_INDEX)
   ) {
     throw new Error(`Invalid indices request ${request.indices.join(', ')}`);
   }
+
+  const { canWriteEventFilters, canReadEndpointList } = await context.getEndpointAuthz(
+    deps.request
+  );
 
   if (
     (!canWriteEventFilters && request.indices[0] === eventsIndexPattern) ||

--- a/x-pack/plugins/security_solution/server/search_strategy/endpoint_fields/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/endpoint_fields/index.ts
@@ -14,7 +14,7 @@ import type {
 
 import { requestIndexFieldSearch } from '@kbn/timelines-plugin/server/search_strategy/index_fields';
 
-import { eventsIndexPattern } from '../../../common/endpoint/constants';
+import { eventsIndexPattern, METADATA_UNITED_INDEX } from '../../../common/endpoint/constants';
 import type {
   BeatFields,
   IndexFieldsStrategyRequest,
@@ -24,11 +24,11 @@ import type { EndpointAppContextService } from '../../endpoint/endpoint_app_cont
 import { EndpointAuthorizationError } from '../../endpoint/errors';
 
 /**
- * EventFiltersFieldProvider mimics indexField provider from timeline plugin: x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
+ * EndpointFieldProvider mimics indexField provider from timeline plugin: x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
  * but it uses ES internalUser instead to avoid adding extra index privileges for users with event filters permissions.
  * It is used to retrieve index patterns for event filters form.
  */
-export const eventFiltersFieldsProvider = (
+export const endpointFieldsProvider = (
   context: EndpointAppContextService,
   indexPatterns: DataViewsServerPluginStart
 ): ISearchStrategy<IndexFieldsStrategyRequest<'indices'>, IndexFieldsStrategyResponse> => {
@@ -40,25 +40,34 @@ export const eventFiltersFieldsProvider = (
 
   return {
     search: (request, _, deps) =>
-      from(requestEventFiltersFieldsSearch(context, request, deps, beatFields, indexPatterns)),
+      from(requestEndpointFieldsSearch(context, request, deps, beatFields, indexPatterns)),
   };
 };
 
-export const requestEventFiltersFieldsSearch = async (
+export const requestEndpointFieldsSearch = async (
   context: EndpointAppContextService,
   request: IndexFieldsStrategyRequest<'indices'>,
   deps: SearchStrategyDependencies,
   beatFields: BeatFields,
   indexPatterns: DataViewsServerPluginStart
 ): Promise<IndexFieldsStrategyResponse> => {
-  const { canWriteEventFilters } = await context.getEndpointAuthz(deps.request);
+  const { canWriteEventFilters, canReadEndpointList } = await context.getEndpointAuthz(
+    deps.request
+  );
 
-  if (!canWriteEventFilters) {
+  if (
+    request.indices.length > 1 ||
+    (request.indices[0] !== eventsIndexPattern && request.indices[0] !== METADATA_UNITED_INDEX)
+  ) {
+    throw new Error(`Invalid indices request ${request.indices.join(', ')}`);
+  }
+
+  if (
+    (!canWriteEventFilters && request.indices[0] === eventsIndexPattern) ||
+    (!canReadEndpointList && request.indices[0] === METADATA_UNITED_INDEX)
+  ) {
     throw new EndpointAuthorizationError();
   }
 
-  if (request.indices.length > 1 || request.indices[0] !== eventsIndexPattern) {
-    throw new Error(`Invalid indices request ${request.indices.join(', ')}`);
-  }
   return requestIndexFieldSearch(request, deps, beatFields, indexPatterns, true);
 };


### PR DESCRIPTION
## Summary

- Uses new search strategy in endpoints list.
- Uses endpoints list RBAC privileges in search strategy.
- Renamed search strategy to be more generic.
- Adds test cases.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
