### PR TITLE
[Enterprise Search] Update sync dates when canceling

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
@@ -23,6 +23,8 @@ describe('addConnector lib function', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    const now = new Date('2022-05-22T10:10:11.111Z');
+    jest.spyOn(Date, 'now').mockImplementation(() => now.getTime());
   });
 
   it('should call updateByQuery to cancel syncs', async () => {
@@ -44,7 +46,7 @@ describe('addConnector lib function', () => {
             },
             {
               terms: {
-                status: [SyncStatus.IN_PROGRESS],
+                status: [SyncStatus.PENDING, SyncStatus.SUSPENDED],
               },
             },
           ],
@@ -53,7 +55,12 @@ describe('addConnector lib function', () => {
       refresh: true,
       script: {
         lang: 'painless',
-        source: `ctx._source['status'] = '${SyncStatus.CANCELING}'`,
+        source: `
+      ctx._source['status'] = '${SyncStatus.CANCELED}';
+      ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+      ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
+      ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';
+`,
       },
     });
     expect(mockClient.asCurrentUser.updateByQuery).toHaveBeenCalledWith({
@@ -68,7 +75,7 @@ describe('addConnector lib function', () => {
             },
             {
               terms: {
-                status: [SyncStatus.PENDING, SyncStatus.SUSPENDED],
+                status: [SyncStatus.IN_PROGRESS],
               },
             },
           ],
@@ -77,7 +84,10 @@ describe('addConnector lib function', () => {
       refresh: true,
       script: {
         lang: 'painless',
-        source: `ctx._source['status'] = '${SyncStatus.CANCELED}'`,
+        source: `
+        ctx._source['status'] = '${SyncStatus.CANCELING}'
+        ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+`,
       },
     });
     await expect(mockClient.asCurrentUser.update).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
@@ -35,7 +35,12 @@ export const cancelSyncs = async (
     refresh: true,
     script: {
       lang: 'painless',
-      source: `ctx._source['status'] = '${SyncStatus.CANCELED}'`,
+      source: `
+      ctx._source['status'] = '${SyncStatus.CANCELED}';
+      ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+      ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
+      ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';
+`,
     },
   });
   await client.asCurrentUser.updateByQuery({
@@ -59,7 +64,10 @@ export const cancelSyncs = async (
     refresh: true,
     script: {
       lang: 'painless',
-      source: `ctx._source['status'] = '${SyncStatus.CANCELING}'`,
+      source: `
+        ctx._source['status'] = '${SyncStatus.CANCELING}'
+        ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+`,
     },
   });
   await client.asCurrentUser.update({


### PR DESCRIPTION
This updates relevant date fields when canceling a synchronization job.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->