### PR TITLE
[Enterprise Search] Show only connector error on config page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
@@ -26,7 +26,7 @@ import { ConnectorConfigurationForm } from './connector_configuration_form';
 import { ConnectorConfigurationLogic } from './connector_configuration_logic';
 
 export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
-  const { error } = useValues(IndexViewLogic);
+  const { connectorError } = useValues(IndexViewLogic);
   const { configView, isEditing } = useValues(ConnectorConfigurationLogic);
   const { setIsEditing } = useActions(ConnectorConfigurationLogic);
 
@@ -68,7 +68,7 @@ export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
           )
         )}
       </EuiFlexItem>
-      {!!error && (
+      {!!connectorError && (
         <EuiFlexItem>
           <EuiCallOut
             color="danger"
@@ -79,7 +79,7 @@ export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
               }
             )}
           >
-            <EuiText size="s">{error}</EuiText>
+            <EuiText size="s">{connectorError}</EuiText>
           </EuiCallOut>
         </EuiFlexItem>
       )}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -68,6 +68,7 @@ export interface IndexViewActions {
 
 export interface IndexViewValues {
   connector: Connector | undefined;
+  connectorError: string | undefined;
   connectorId: string | null;
   error: string | undefined;
   fetchIndexApiData: typeof CachedFetchIndexApiLogic.values.fetchIndexApiData;
@@ -204,16 +205,17 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
           ? index.connector
           : undefined,
     ],
+    connectorError: [
+      () => [selectors.connector],
+      (connector: Connector | undefined) => connector?.error,
+    ],
     connectorId: [
       () => [selectors.indexData],
       (index) => (isConnectorViewIndex(index) ? index.connector.id : null),
     ],
     error: [
-      () => [selectors.indexData],
-      (index: ElasticsearchViewIndex) =>
-        isConnectorViewIndex(index)
-          ? index.connector.error || index.connector.last_sync_error
-          : null,
+      () => [selectors.connector],
+      (connector: Connector | undefined) => connector?.error || connector?.last_sync_error || null,
     ],
     hasAdvancedFilteringFeature: [
       () => [selectors.connector],


### PR DESCRIPTION
This removes synchronization errors from the connector configuration screen, showing only connector errors.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->