### PR TITLE
[ML] Adds new screenshot to the generate anomaly alerts test suite

### DIFF
--- a/x-pack/test/functional/services/ml/alerting.ts
+++ b/x-pack/test/functional/services/ml/alerting.ts
@@ -242,5 +242,3 @@ export function MachineLearningAlertingProvider(
     },
   };
 }
-
-

--- a/x-pack/test/functional/services/ml/alerting.ts
+++ b/x-pack/test/functional/services/ml/alerting.ts
@@ -32,6 +32,13 @@ export function MachineLearningAlertingProvider(
       });
     },
 
+    async selectAnomalyDetectionJobHealthAlertType() {
+      await retry.tryForTime(5000, async () => {
+        await testSubjects.click('xpack.ml.anomaly_detection_jobs_health-SelectOption');
+        await testSubjects.existOrFail(`mlJobsHealthAlertingRuleForm`, { timeout: 1000 });
+      });
+    },
+
     async selectJobs(jobIds: string[]) {
       for (const jobId of jobIds) {
         await comboBox.set('mlAnomalyAlertJobSelection > comboBoxInput', jobId);
@@ -219,6 +226,14 @@ export function MachineLearningAlertingProvider(
       });
     },
 
+    async clickCancelSaveRuleButton() {
+      await retry.tryForTime(5000, async () => {
+        await testSubjects.click('cancelSaveRuleButton');
+        await testSubjects.existOrFail('confirmModalTitleText', { timeout: 1000 });
+        await testSubjects.click('confirmModalConfirmButton');
+      });
+    },
+
     async openAddRuleVariable() {
       await retry.tryForTime(5000, async () => {
         await testSubjects.click('messageAddVariableButton');
@@ -227,3 +242,5 @@ export function MachineLearningAlertingProvider(
     },
   };
 }
+
+

--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/generate_anomaly_alerts.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/generate_anomaly_alerts.ts
@@ -101,7 +101,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
 
     describe('overview page alert flyout controls', () => {
-      it('alert flyout screenshot', async () => {
+      it('alert flyout screenshots', async () => {
         await ml.navigation.navigateToAlertsAndAction();
         await pageObjects.triggersActionsUI.clickCreateAlertButton();
         await ml.alerting.setRuleName('test-ecommerce');
@@ -112,6 +112,19 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         // close popover
         await browser.pressKeys(browser.keys.ESCAPE);
 
+        await ml.alerting.selectAnomalyDetectionJobHealthAlertType();
+        await ml.alerting.selectJobs([testJobId]);
+        await ml.testExecution.logTestStep('take screenshot');
+        await commonScreenshots.takeScreenshot(
+          'ml-health-check-config',
+          screenshotDirectories,
+          1920,
+          1400
+        );
+        await ml.alerting.clickCancelSaveRuleButton();
+
+        await pageObjects.triggersActionsUI.clickCreateAlertButton();
+        await ml.alerting.setRuleName('test-ecommerce');
         await ml.alerting.selectAnomalyDetectionAlertType();
         await ml.testExecution.logTestStep('should have correct default values');
         await ml.alerting.assertSeverity(75);


### PR DESCRIPTION
## Summary

This PR adds the necessary code to take the `ml-health-check-config` screenshot in the generate anomaly alerts test suite.

<!--ONMERGE {"backportTargets":["8.5","8.6"]} ONMERGE-->