### PR TITLE
[Synthetics] adjust quick filers

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.test.tsx
@@ -96,36 +96,42 @@ describe('useMonitorsSortedByStatus', () => {
               allMonitorIds: [],
               monitors: [
                 {
+                  configId: 'test-monitor-1',
                   id: 'test-monitor-1',
                   name: 'Test monitor 1',
                   location: location1,
                   isEnabled: false,
                 },
                 {
+                  configId: 'test-monitor-1',
                   id: 'test-monitor-1',
                   name: 'Test monitor 1',
                   location: location2,
                   isEnabled: true,
                 },
                 {
+                  configId: 'test-monitor-2',
                   id: 'test-monitor-2',
                   name: 'Test monitor 2',
                   location: location1,
                   isEnabled: true,
                 },
                 {
+                  configId: 'test-monitor-2',
                   id: 'test-monitor-2',
                   name: 'Test monitor 2',
                   location: location2,
                   isEnabled: true,
                 },
                 {
+                  configId: 'test-monitor-3',
                   id: 'test-monitor-3',
                   name: 'Test monitor 3',
                   location: location1,
                   isEnabled: true,
                 },
                 {
+                  configId: 'test-monitor-3',
                   id: 'test-monitor-3',
                   name: 'Test monitor 3',
                   location: location2,
@@ -151,36 +157,42 @@ describe('useMonitorsSortedByStatus', () => {
     expect(result.current).toEqual({
       monitorsSortedByStatus: [
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location1,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location1,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location1,
@@ -204,36 +216,42 @@ describe('useMonitorsSortedByStatus', () => {
     expect(result.current).toEqual({
       monitorsSortedByStatus: [
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location1,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location1,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location1,
@@ -261,18 +279,21 @@ describe('useMonitorsSortedByStatus', () => {
     expect(result.current).toEqual({
       monitorsSortedByStatus: [
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location2,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location2,
@@ -300,12 +321,14 @@ describe('useMonitorsSortedByStatus', () => {
     expect(result.current).toEqual({
       monitorsSortedByStatus: [
         {
+          configId: 'test-monitor-2',
           id: 'test-monitor-2',
           name: 'Test monitor 2',
           location: location1,
           isEnabled: true,
         },
         {
+          configId: 'test-monitor-3',
           id: 'test-monitor-3',
           name: 'Test monitor 3',
           location: location1,
@@ -333,6 +356,7 @@ describe('useMonitorsSortedByStatus', () => {
     expect(result.current).toEqual({
       monitorsSortedByStatus: [
         {
+          configId: 'test-monitor-1',
           id: 'test-monitor-1',
           name: 'Test monitor 1',
           location: location1,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
@@ -34,7 +34,6 @@ export function useMonitorsSortedByStatus() {
 
     const { downConfigs } = status;
     const downMonitorMap: Record<string, string[]> = {};
-    console.warn('downConfigs', downConfigs);
     downConfigs.forEach(({ location, configId }) => {
       if (downMonitorMap[configId]) {
         downMonitorMap[configId].push(location);

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
@@ -34,6 +34,7 @@ export function useMonitorsSortedByStatus() {
 
     const { downConfigs } = status;
     const downMonitorMap: Record<string, string[]> = {};
+    console.warn('downConfigs', downConfigs);
     downConfigs.forEach(({ location, configId }) => {
       if (downMonitorMap[configId]) {
         downMonitorMap[configId].push(location);
@@ -51,8 +52,8 @@ export function useMonitorsSortedByStatus() {
       if (!monitor.isEnabled) {
         orderedDisabledMonitors.push(monitor);
       } else if (
-        monitor.id in downMonitorMap &&
-        downMonitorMap[monitor.id].includes(monitorLocation)
+        monitor.configId in downMonitorMap &&
+        downMonitorMap[monitor.configId].includes(monitorLocation)
       ) {
         orderedDownMonitors.push(monitor);
       } else {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/146824

Adjusts logic for querying down monitors to rely on `config_id` (the saved object id) rather than `id` (the monitor query id).

### Testing
1. Create at least 1 project monitor and 1 UI monitor that are consistently down
2. Navigate to Synthetics Overview page
3. Click the down filter
4. Ensure both monitors appear

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->