### PR TITLE
fix Exception lists are shared between different spaces

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_table/use_add_to_lists_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_table/use_add_to_lists_table.tsx
@@ -47,7 +47,6 @@ export const useAddToSharedListTable = ({
   onListSelectionChange,
 }: ExceptionsAddToListsComponentProps) => {
   const [listsToDisplay, setListsToDisplay] = useState<ExceptionListRuleReferencesSchema[]>([]);
-  const [exceptionListReferences, setExceptionListReferences] = useState<RuleReferences>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const listsToFetch = useMemo(() => {
@@ -68,7 +67,7 @@ export const useAddToSharedListTable = ({
   const getReferences = useCallback(async () => {
     try {
       setIsLoading(true);
-      return await getExceptionItemsReferences(
+      return getExceptionItemsReferences(
         (!listsToFetch.length
           ? [{ namespace_type: 'single' }]
           : listsToFetch) as ExceptionListSchema[]
@@ -83,9 +82,9 @@ export const useAddToSharedListTable = ({
     if (!result) {
       return setIsLoading(false);
     }
-    setExceptionListReferences(result as RuleReferences);
     const lists: ExceptionListRuleReferencesSchema[] = [];
-    for (const [_, value] of Object.entries(result))
+
+    for (const value of Object.values(result))
       if (value.type === ExceptionListTypeEnum.DETECTION) lists.push(value);
 
     setListsToDisplay(lists);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_table/use_add_to_lists_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_lists_table/use_add_to_lists_table.tsx
@@ -47,7 +47,7 @@ export const useAddToSharedListTable = ({
   onListSelectionChange,
 }: ExceptionsAddToListsComponentProps) => {
   const [listsToDisplay, setListsToDisplay] = useState<ExceptionListRuleReferencesSchema[]>([]);
-  const [exceptionListReferences, setExceptionListReferences] = useState<RuleReferences>({});
+  const [exceptionListReferences, setExceptionListReferences] = useState<RuleReferences>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const listsToFetch = useMemo(() => {
@@ -68,28 +68,29 @@ export const useAddToSharedListTable = ({
   const getReferences = useCallback(async () => {
     try {
       setIsLoading(true);
-      const result = await getExceptionItemsReferences(
+      return await getExceptionItemsReferences(
         (!listsToFetch.length
-          ? [{ namespace_type: 'single' }, { namespace_type: 'agnostic' }] // TODO remove 'agnostic' when using `single` only
+          ? [{ namespace_type: 'single' }]
           : listsToFetch) as ExceptionListSchema[]
       );
-      setExceptionListReferences(result as RuleReferences);
     } catch (err) {
       setError(i18n.REFERENCES_FETCH_ERROR);
     }
   }, [listsToFetch]);
 
   const fillListsToDisplay = useCallback(async () => {
-    await getReferences();
-    if (exceptionListReferences) {
-      const lists: ExceptionListRuleReferencesSchema[] = [];
-      for (const [_, value] of Object.entries(exceptionListReferences))
-        if (value.type === ExceptionListTypeEnum.DETECTION) lists.push(value);
-
-      setListsToDisplay(lists);
-      setIsLoading(false);
+    const result = (await getReferences()) as RuleReferences;
+    if (!result) {
+      return setIsLoading(false);
     }
-  }, [exceptionListReferences, getReferences]);
+    setExceptionListReferences(result as RuleReferences);
+    const lists: ExceptionListRuleReferencesSchema[] = [];
+    for (const [_, value] of Object.entries(result))
+      if (value.type === ExceptionListTypeEnum.DETECTION) lists.push(value);
+
+    setListsToDisplay(lists);
+    setIsLoading(false);
+  }, [getReferences]);
 
   useEffect(() => {
     fillListsToDisplay();

--- a/x-pack/plugins/security_solution/server/lib/exceptions/api/manage_exceptions/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/exceptions/api/manage_exceptions/route.ts
@@ -60,7 +60,7 @@ export const createSharedExceptionListRoute = (router: SecuritySolutionPluginRou
           listId: uuid.v4(),
           meta: undefined,
           name,
-          namespaceType: 'agnostic',
+          namespaceType: 'single',
           tags: [],
           type: 'detection',
           version: 1,


### PR DESCRIPTION

## Summary

- Addresses https://github.com/elastic/kibana/issues/146461 
- Fix transition state when `Add to shared list is loading`

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->