### PR TITLE
[Guided Onboarding] Fix isGuideStepActive$ observable

### DIFF
--- a/src/plugins/guided_onboarding/public/services/api.mocks.ts
+++ b/src/plugins/guided_onboarding/public/services/api.mocks.ts
@@ -49,6 +49,18 @@ export const testGuideStep1InProgressState: GuideState = {
   ],
 };
 
+export const testGuideStep1ReadyToCompleteState: GuideState = {
+  ...testGuideStep1ActiveState,
+  steps: [
+    {
+      id: testGuideStep1ActiveState.steps[0].id,
+      status: 'ready_to_complete',
+    },
+    testGuideStep1ActiveState.steps[1],
+    testGuideStep1ActiveState.steps[2],
+  ],
+};
+
 export const testGuideStep2ActiveState: GuideState = {
   ...testGuideStep1ActiveState,
   steps: [

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -29,6 +29,7 @@ import {
   mockPluginStateInProgress,
   mockPluginStateNotStarted,
   testGuideStep3ActiveState,
+  testGuideStep1ReadyToCompleteState,
 } from './api.mocks';
 
 describe('GuidedOnboarding ApiService', () => {
@@ -246,7 +247,7 @@ describe('GuidedOnboarding ApiService', () => {
   });
 
   describe('isGuideStepActive$', () => {
-    it('returns true if the step has been started', (done) => {
+    it('returns true if the step is in progress', (done) => {
       httpClient.get.mockResolvedValueOnce({
         pluginState: { ...mockPluginStateInProgress, activeGuide: testGuideStep1InProgressState },
       });
@@ -261,7 +262,25 @@ describe('GuidedOnboarding ApiService', () => {
         });
     });
 
-    it('returns false if the step is not been started', (done) => {
+    it('returns true if the step is ready to complete', (done) => {
+      httpClient.get.mockResolvedValueOnce({
+        pluginState: {
+          ...mockPluginStateInProgress,
+          activeGuide: testGuideStep1ReadyToCompleteState,
+        },
+      });
+
+      subscription = apiService
+        .isGuideStepActive$(testGuide, testGuideFirstStep)
+        .subscribe((isStepActive) => {
+          if (isStepActive) {
+            subscription.unsubscribe();
+            done();
+          }
+        });
+    });
+
+    it('returns false if the step has not been started', (done) => {
       subscription = apiService
         .isGuideStepActive$(testGuide, testGuideFirstStep)
         .subscribe((isStepActive) => {

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -277,7 +277,10 @@ export class ApiService implements GuidedOnboardingApi {
     return this.fetchPluginState$().pipe(
       map((pluginState) => {
         if (!isGuideActive(pluginState, guideId)) return false;
-        return isStepInProgress(pluginState!.activeGuide, guideId, stepId);
+        return (
+          isStepInProgress(pluginState!.activeGuide, guideId, stepId) ||
+          isStepReadyToComplete(pluginState!.activeGuide, guideId, stepId)
+        );
       })
     );
   }

--- a/src/plugins/guided_onboarding/public/services/helpers.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.ts
@@ -95,7 +95,6 @@ const isStepStatus = (
 ): boolean => {
   if (!guideState || !guideState.isActive || guideState.guideId !== guideId) return false;
 
-  // false if the step is not 'in_progress'
   const selectedStep = guideState.steps.find((step) => step.id === stepId);
   return selectedStep ? selectedStep.status === status : false;
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/146911

Related to https://github.com/elastic/kibana/pull/146902

### How to test
This can be tested using the existing "step 3" of the test guide.

1. Run Kibana with the example plugins enabled: `yarn start --run-examples`
2. Navigate to the example plugin: `app/guidedOnboardingExample`
3. Enable step 3 of the test guide using the form. Guide: `test guide`, Step ID: `step3`
4. Verify the tour step is hidden only **after** marking the step as done.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

