### PR TITLE
[8.5] Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780)

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -59,6 +59,16 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables the detection response actions in rule + alerts
    */
   responseActionsEnabled: true,
+
+  /**
+   * Keep DEPRECATED experimental flags that are documented to prevent failed upgrades.
+   * https://www.elastic.co/guide/en/security/current/user-risk-score.html
+   * https://www.elastic.co/guide/en/security/current/host-risk-score.html
+   *
+   * Issue: https://github.com/elastic/kibana/issues/146777
+   */
+     riskyHostsEnabled: false, // DEPRECATED
+     riskyUsersEnabled: false, // DEPRECATED
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -67,8 +67,8 @@ export const allowedExperimentalValues = Object.freeze({
    *
    * Issue: https://github.com/elastic/kibana/issues/146777
    */
-     riskyHostsEnabled: false, // DEPRECATED
-     riskyUsersEnabled: false, // DEPRECATED
+  riskyHostsEnabled: false, // DEPRECATED
+  riskyUsersEnabled: false, // DEPRECATED
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780)](https://github.com/elastic/kibana/pull/146780)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2022-12-01T17:25:46Z","message":"Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780)\n\nUsers can't upgrade their clusters when an old experimental feature is\r\nenabled.\r\n\r\nWhile we don't have a final solution for this issue, I am adding the\r\nexperimental flag configuration back to prevent users from having this\r\nfrustrating experience.\r\n\r\nQuick-fix for: https://github.com/elastic/kibana/issues/146777\r\nOriginal report:\r\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\r\n\r\nFix\r\n```\r\nFATAL Error: [config validation of [xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not allowed. Allowed values are: tGridEnabled, tGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled, kubernetesEnabled, disableIsolationUIPendingStatuses, pendingActionResponsesWithAck, policyListEnabled, policyResponseInFleetEnabled, previewTelemetryUrlEnabled, responseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry, extendedRuleExecutionLoggingEnabled, socTrendsEnabled, responseActionsEnabled\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","v8.6.0","v8.7.0","v8.6.1"],"number":146780,"url":"https://github.com/elastic/kibana/pull/146780","mergeCommit":{"message":"Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780)\n\nUsers can't upgrade their clusters when an old experimental feature is\r\nenabled.\r\n\r\nWhile we don't have a final solution for this issue, I am adding the\r\nexperimental flag configuration back to prevent users from having this\r\nfrustrating experience.\r\n\r\nQuick-fix for: https://github.com/elastic/kibana/issues/146777\r\nOriginal report:\r\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\r\n\r\nFix\r\n```\r\nFATAL Error: [config validation of [xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not allowed. Allowed values are: tGridEnabled, tGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled, kubernetesEnabled, disableIsolationUIPendingStatuses, pendingActionResponsesWithAck, policyListEnabled, policyResponseInFleetEnabled, previewTelemetryUrlEnabled, responseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry, extendedRuleExecutionLoggingEnabled, socTrendsEnabled, responseActionsEnabled\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/146813","number":146813,"state":"MERGED","mergeCommit":{"sha":"acede4b442ca8e1eac9246316796d98bcf27e6c8","message":"[8.6] Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780) (#146813)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.6`:\n- [Quick-fix Users can’t upgrade their clusters when `riskScore`\nexperimental feature is enabled\n(#146780)](https://github.com/elastic/kibana/pull/146780)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Pablo\nMachado\",\"email\":\"pablo.nevesmachado@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2022-12-01T17:25:46Z\",\"message\":\"Quick-fix\nUsers can’t upgrade their clusters when `riskScore` experimental feature\nis enabled (#146780)\\n\\nUsers can't upgrade their clusters when an old\nexperimental feature is\\r\\nenabled.\\r\\n\\r\\nWhile we don't have a final\nsolution for this issue, I am adding the\\r\\nexperimental flag\nconfiguration back to prevent users from having this\\r\\nfrustrating\nexperience.\\r\\n\\r\\nQuick-fix for:\nhttps://github.com/elastic/kibana/issues/146777\\r\\nOriginal\nreport:\\r\\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\\r\\n\\r\\nFix\\r\\n```\\r\\nFATAL\nError: [config validation of\n[xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not\nallowed. Allowed values are: tGridEnabled,\ntGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled,\nkubernetesEnabled, disableIsolationUIPendingStatuses,\npendingActionResponsesWithAck, policyListEnabled,\npolicyResponseInFleetEnabled, previewTelemetryUrlEnabled,\nresponseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry,\nextendedRuleExecutionLoggingEnabled, socTrendsEnabled,\nresponseActionsEnabled\\r\\n```\\r\\n\\r\\nCo-authored-by: Kibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e\",\"branchLabelMapping\":{\"^v8.7.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"Team:Threat\nHunting\",\"Team: SecuritySolution\",\"Team:Threat\nHunting:Explore\",\"v8.6.0\",\"v8.7.0\",\"v8.6.1\"],\"number\":146780,\"url\":\"https://github.com/elastic/kibana/pull/146780\",\"mergeCommit\":{\"message\":\"Quick-fix\nUsers can’t upgrade their clusters when `riskScore` experimental feature\nis enabled (#146780)\\n\\nUsers can't upgrade their clusters when an old\nexperimental feature is\\r\\nenabled.\\r\\n\\r\\nWhile we don't have a final\nsolution for this issue, I am adding the\\r\\nexperimental flag\nconfiguration back to prevent users from having this\\r\\nfrustrating\nexperience.\\r\\n\\r\\nQuick-fix for:\nhttps://github.com/elastic/kibana/issues/146777\\r\\nOriginal\nreport:\\r\\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\\r\\n\\r\\nFix\\r\\n```\\r\\nFATAL\nError: [config validation of\n[xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not\nallowed. Allowed values are: tGridEnabled,\ntGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled,\nkubernetesEnabled, disableIsolationUIPendingStatuses,\npendingActionResponsesWithAck, policyListEnabled,\npolicyResponseInFleetEnabled, previewTelemetryUrlEnabled,\nresponseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry,\nextendedRuleExecutionLoggingEnabled, socTrendsEnabled,\nresponseActionsEnabled\\r\\n```\\r\\n\\r\\nCo-authored-by: Kibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.6\"],\"targetPullRequestStates\":[{\"branch\":\"8.6\",\"label\":\"v8.6.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.7.0\",\"labelRegex\":\"^v8.7.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/146780\",\"number\":146780,\"mergeCommit\":{\"message\":\"Quick-fix\nUsers can’t upgrade their clusters when `riskScore` experimental feature\nis enabled (#146780)\\n\\nUsers can't upgrade their clusters when an old\nexperimental feature is\\r\\nenabled.\\r\\n\\r\\nWhile we don't have a final\nsolution for this issue, I am adding the\\r\\nexperimental flag\nconfiguration back to prevent users from having this\\r\\nfrustrating\nexperience.\\r\\n\\r\\nQuick-fix for:\nhttps://github.com/elastic/kibana/issues/146777\\r\\nOriginal\nreport:\\r\\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\\r\\n\\r\\nFix\\r\\n```\\r\\nFATAL\nError: [config validation of\n[xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not\nallowed. Allowed values are: tGridEnabled,\ntGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled,\nkubernetesEnabled, disableIsolationUIPendingStatuses,\npendingActionResponsesWithAck, policyListEnabled,\npolicyResponseInFleetEnabled, previewTelemetryUrlEnabled,\nresponseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry,\nextendedRuleExecutionLoggingEnabled, socTrendsEnabled,\nresponseActionsEnabled\\r\\n```\\r\\n\\r\\nCo-authored-by: Kibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>"}},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146780","number":146780,"mergeCommit":{"message":"Quick-fix Users can’t upgrade their clusters when `riskScore` experimental feature is enabled (#146780)\n\nUsers can't upgrade their clusters when an old experimental feature is\r\nenabled.\r\n\r\nWhile we don't have a final solution for this issue, I am adding the\r\nexperimental flag configuration back to prevent users from having this\r\nfrustrating experience.\r\n\r\nQuick-fix for: https://github.com/elastic/kibana/issues/146777\r\nOriginal report:\r\nhttps://elastic.slack.com/archives/C6E3MTCD7/p1669236299374339\r\n\r\nFix\r\n```\r\nFATAL Error: [config validation of [xpack.securitySolution].enableExperimental]: [riskyUsersEnabled] is not allowed. Allowed values are: tGridEnabled, tGridEventRenderedViewEnabled, excludePoliciesInFilterEnabled, kubernetesEnabled, disableIsolationUIPendingStatuses, pendingActionResponsesWithAck, policyListEnabled, policyResponseInFleetEnabled, previewTelemetryUrlEnabled, responseActionsConsoleEnabled, insightsRelatedAlertsByProcessAncestry, extendedRuleExecutionLoggingEnabled, socTrendsEnabled, responseActionsEnabled\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"c3d1d9ec284f81f3c5d713010e52cd9d4f09c39e"}}]}] BACKPORT-->