### PR TITLE
[Visualize] Fixes the display of the modal viz creation wizard titles

### DIFF
--- a/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
@@ -57,10 +57,12 @@ class AggBasedSelection extends React.Component<AggBasedSelectionProps, AggBased
       <>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="visualizations.newVisWizard.title"
-              defaultMessage="New visualization"
-            />
+            <h1>
+              <FormattedMessage
+                id="visualizations.newVisWizard.title"
+                defaultMessage="New visualization"
+              />
+            </h1>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -67,10 +67,12 @@ function GroupSelection(props: GroupSelectionProps) {
     <>
       <EuiModalHeader>
         <EuiModalHeaderTitle data-test-subj="groupModalHeader">
-          <FormattedMessage
-            id="visualizations.newVisWizard.title"
-            defaultMessage="New visualization"
-          />
+          <h1>
+            <FormattedMessage
+              id="visualizations.newVisWizard.title"
+              defaultMessage="New visualization"
+            />
+          </h1>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody className="visNewVisDialogGroupSelection__body">

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -33,16 +33,18 @@ export class SearchSelection extends React.Component<SearchSelectionProps> {
       <React.Fragment>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="visualizations.newVisWizard.newVisTypeTitle"
-              defaultMessage="New {visTypeName}"
-              values={{ visTypeName: this.props.visType.title }}
-            />{' '}
-            /{' '}
-            <FormattedMessage
-              id="visualizations.newVisWizard.chooseSourceTitle"
-              defaultMessage="Choose a source"
-            />
+            <h1>
+              <FormattedMessage
+                id="visualizations.newVisWizard.newVisTypeTitle"
+                defaultMessage="New {visTypeName}"
+                values={{ visTypeName: this.props.visType.title }}
+              />{' '}
+              /{' '}
+              <FormattedMessage
+                id="visualizations.newVisWizard.chooseSourceTitle"
+                defaultMessage="Choose a source"
+              />
+            </h1>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>


### PR DESCRIPTION
## Summary

Fixes the way that the modal title is being displayed. It must have been broken with the new EUI upgrade.
<img width="847" alt="image" src="https://user-images.githubusercontent.com/17003240/205611399-6f927bd1-f1de-4f0e-8932-fb46b5f41bd1.png">


Before the fix
<img width="842" alt="image" src="https://user-images.githubusercontent.com/17003240/205611852-84c2adef-10a8-4e2c-992c-6d36a84f7df9.png">
