### PR TITLE
Invalidate cache for rules, after add shared exception

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.test.tsx
@@ -49,6 +49,7 @@ jest.mock('@kbn/securitysolution-hook-utils', () => ({
 jest.mock('../../../rule_management/logic/use_rule');
 jest.mock('@kbn/lists-plugin/public');
 jest.mock('../../../rule_management/logic/use_find_rules');
+jest.mock('../../../rule_management/api/hooks/use_fetch_rule_by_id_query');
 
 const mockGetExceptionBuilderComponentLazy = getExceptionBuilderComponentLazy as jest.Mock<
   ReturnType<typeof getExceptionBuilderComponentLazy>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
@@ -362,7 +362,6 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
         await closeAlerts(ruleStaticIds, addedItems, alertIdToClose, bulkCloseIndex);
       }
 
-      
       invalidateFetchRuleByIdQuery();
       // Rule only would have been updated if we had to create a rule default list
       // to attach to it, all shared lists would already be referenced on the rule
@@ -389,7 +388,7 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
     onConfirm,
     bulkCloseIndex,
     setErrorSubmitting,
-    invalidateFetchRuleByIdQuery
+    invalidateFetchRuleByIdQuery,
   ]);
 
   const isSubmitButtonDisabled = useMemo(

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
@@ -53,6 +53,7 @@ import { useAddNewExceptionItems } from './use_add_new_exceptions';
 import { enrichNewExceptionItems } from '../flyout_components/utils';
 import { useCloseAlertsFromExceptions } from '../../logic/use_close_alerts';
 import { ruleTypesThatAllowLargeValueLists } from '../../utils/constants';
+import { useInvalidateFetchRuleByIdQuery } from '../../../rule_management/api/hooks/use_fetch_rule_by_id_query';
 
 const SectionHeader = styled(EuiTitle)`
   ${() => css`
@@ -114,6 +115,7 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
   const { isLoading, indexPatterns } = useFetchIndexPatterns(rules);
   const [isSubmitting, submitNewExceptionItems] = useAddNewExceptionItems();
   const [isClosingAlerts, closeAlerts] = useCloseAlertsFromExceptions();
+  const invalidateFetchRuleByIdQuery = useInvalidateFetchRuleByIdQuery();
   const allowLargeValueLists = useMemo((): boolean => {
     if (rules != null && rules.length === 1) {
       // We'll only block this when we know what rule we're dealing with.
@@ -360,6 +362,8 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
         await closeAlerts(ruleStaticIds, addedItems, alertIdToClose, bulkCloseIndex);
       }
 
+      
+      invalidateFetchRuleByIdQuery();
       // Rule only would have been updated if we had to create a rule default list
       // to attach to it, all shared lists would already be referenced on the rule
       onConfirm(true, closeSingleAlert, bulkCloseAlerts);
@@ -385,6 +389,7 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
     onConfirm,
     bulkCloseIndex,
     setErrorSubmitting,
+    invalidateFetchRuleByIdQuery
   ]);
 
   const isSubmitButtonDisabled = useMemo(

--- a/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
@@ -28,6 +28,7 @@ import {
 } from '../../api';
 import { checkIfListCannotBeEdited, isAnExceptionListItem } from '../../utils/list.utils';
 import * as i18n from '../../translations';
+import { useInvalidateFetchRuleByIdQuery } from '../../../detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query';
 
 interface ReferenceModalState {
   contentText: string;
@@ -74,6 +75,7 @@ export const useListDetailsView = () => {
   );
   const [disableManageButton, setDisableManageButton] = useState(true);
   const [refreshExceptions, setRefreshExceptions] = useState(false);
+  const invalidateFetchRuleByIdQuery = useInvalidateFetchRuleByIdQuery();
 
   const headerBackOptions: BackOptions = useMemo(
     () => ({
@@ -310,7 +312,8 @@ export const useListDetailsView = () => {
           setRefreshExceptions(true);
           resetManageRulesAfterSaving();
         })
-        .then(() => setRefreshExceptions(false));
+        .then(() => setRefreshExceptions(false))
+        .then(() => invalidateFetchRuleByIdQuery());
     } catch (err) {
       handleErrorStatus(err);
     }
@@ -321,6 +324,7 @@ export const useListDetailsView = () => {
     exceptionListId,
     resetManageRulesAfterSaving,
     handleErrorStatus,
+    invalidateFetchRuleByIdQuery,
   ]);
   const onCancelManageRules = useCallback(() => {
     setShowManageRulesFlyout(false);


### PR DESCRIPTION
## Invalidate cache for rules, after adding shared exception

Related:
https://github.com/elastic/kibana/issues/146962

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->