### PR TITLE
[Fleet] show dataset combo box for input packages

### DIFF
--- a/x-pack/plugins/fleet/cypress/e2e/integrations_real.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/integrations_real.cy.ts
@@ -177,7 +177,7 @@ describe('Add Integration - Real API', () => {
     cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length.greaterThan', 29);
 
     cy.getBySel(INTEGRATIONS_SEARCHBAR.INPUT).clear().type('Cloud');
-    cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length', 3);
+    cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length.greaterThan', 3);
     cy.getBySel(INTEGRATIONS_SEARCHBAR.REMOVE_BADGE_BUTTON).click();
     cy.getBySel(INTEGRATIONS_SEARCHBAR.BADGE).should('not.exist');
   });

--- a/x-pack/plugins/fleet/cypress/e2e/integrations_real.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/integrations_real.cy.ts
@@ -174,7 +174,7 @@ describe('Add Integration - Real API', () => {
     setupIntegrations();
     cy.getBySel(getIntegrationCategories('aws')).click();
     cy.getBySel(INTEGRATIONS_SEARCHBAR.BADGE).contains('AWS').should('exist');
-    cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length', 29);
+    cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length.greaterThan', 29);
 
     cy.getBySel(INTEGRATIONS_SEARCHBAR.INPUT).clear().type('Cloud');
     cy.getBySel(INTEGRATION_LIST).find('.euiCard').should('have.length', 3);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 export const DatasetComboBox: React.FC<{
   value: any;
@@ -43,14 +44,21 @@ export const DatasetComboBox: React.FC<{
 
   return (
     <EuiComboBox
-      aria-label="Dataset combo box"
-      placeholder="Select a dataset"
+      aria-label={i18n.translate('xpack.fleet.datasetCombo.ariaLabel', {
+        defaultMessage: 'Dataset combo box',
+      })}
+      placeholder={i18n.translate('xpack.fleet.datasetCombo.placeholder', {
+        defaultMessage: 'Select a dataset',
+      })}
       singleSelection={{ asPlainText: true }}
       options={datasetOptions}
       selectedOptions={selectedOptions}
       onCreateOption={onCreateOption}
       onChange={onDatasetChange}
-      customOptionText="Add {searchValue} as a custom option"
+      customOptionText={i18n.translate('xpack.fleet.datasetCombo.customOptionText', {
+        defaultMessage: 'Add {searchValue} as a custom option',
+        values: { searchValue: '{searchValue}' },
+      })}
     />
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
@@ -15,15 +15,14 @@ export const DatasetComboBox: React.FC<{
   datasets: string[];
 }> = ({ value, onChange, datasets }) => {
   const datasetOptions = datasets.map((dataset: string) => ({ label: dataset })) ?? [];
-  const [selectedOptions, setSelectedOptions] = useState<Array<{ label: string }>>(
-    value
-      ? [
-          {
-            label: value,
-          },
-        ]
-      : []
-  );
+  const defaultOption = 'generic';
+  const [selectedOptions, setSelectedOptions] = useState<Array<{ label: string }>>([
+    {
+      label: value ?? defaultOption,
+    },
+  ]);
+
+  if (!value) onChange(defaultOption);
 
   const onDatasetChange = (newSelectedOptions: Array<{ label: string }>) => {
     setSelectedOptions(newSelectedOptions);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -22,7 +22,9 @@ export const DatasetComboBox: React.FC<{
     },
   ]);
 
-  if (!value) onChange(defaultOption);
+  useEffect(() => {
+    if (!value) onChange(defaultOption);
+  }, [value, defaultOption, onChange]);
 
   const onDatasetChange = (newSelectedOptions: Array<{ label: string }>) => {
     setSelectedOptions(newSelectedOptions);
@@ -58,6 +60,7 @@ export const DatasetComboBox: React.FC<{
         defaultMessage: 'Add {searchValue} as a custom option',
         values: { searchValue: '{searchValue}' },
       })}
+      isClearable={false}
     />
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiComboBox } from '@elastic/eui';
+
+export const DatasetComboBox: React.FC<{
+  value: any;
+  onChange: (newValue: any) => void;
+  datasets: string[];
+}> = ({ value, onChange, datasets }) => {
+  const datasetOptions = datasets.map((dataset: string) => ({ label: dataset })) ?? [];
+  const [selectedOptions, setSelectedOptions] = useState<Array<{ label: string }>>(
+    value
+      ? [
+          {
+            label: value,
+          },
+        ]
+      : []
+  );
+
+  const onDatasetChange = (newSelectedOptions: Array<{ label: string }>) => {
+    setSelectedOptions(newSelectedOptions);
+    onChange(newSelectedOptions[0]?.label);
+  };
+
+  const onCreateOption = (searchValue: string = '') => {
+    const normalizedSearchValue = searchValue.trim().toLowerCase();
+    if (!normalizedSearchValue) {
+      return;
+    }
+    const newOption = {
+      label: searchValue,
+    };
+    setSelectedOptions([newOption]);
+    onChange(searchValue);
+  };
+
+  return (
+    <EuiComboBox
+      aria-label="Dataset combo box"
+      placeholder="Select a dataset"
+      singleSelection={{ asPlainText: true }}
+      options={datasetOptions}
+      selectedOptions={selectedOptions}
+      onCreateOption={onCreateOption}
+      onChange={onDatasetChange}
+      customOptionText="Add {searchValue} as a custom option"
+    />
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/order_datasets.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/order_datasets.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { orderDatasets } from './order_datasets';
+
+describe('orderDatasets', () => {
+  it('should move datasets up that match name', () => {
+    const datasets = orderDatasets(
+      ['system.memory', 'elastic_agent', 'elastic_agent.filebeat', 'system.cpu'],
+      'elastic_agent'
+    );
+
+    expect(datasets).toEqual([
+      'elastic_agent',
+      'elastic_agent.filebeat',
+      'system.cpu',
+      'system.memory',
+    ]);
+  });
+
+  it('should order alphabetically if name does not match', () => {
+    const datasets = orderDatasets(['system.memory', 'elastic_agent'], 'nginx');
+
+    expect(datasets).toEqual(['elastic_agent', 'system.memory']);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/order_datasets.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/order_datasets.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { partition } from 'lodash';
+
+export function orderDatasets(datasetList: string[], name: string): string[] {
+  const [relevantDatasets, otherDatasets] = partition(datasetList.sort(), (record) =>
+    record.startsWith(name)
+  );
+  const datasets = relevantDatasets.concat(otherDatasets);
+  return datasets;
+}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -8,6 +8,7 @@
 import React, { useState, Fragment, memo, useMemo, useEffect, useRef, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
+import { uniq } from 'lodash';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiFlexGrid,
@@ -43,6 +44,7 @@ import { PackagePolicyEditorDatastreamMappings } from '../../datastream_mappings
 
 import { PackagePolicyInputVarField } from './package_policy_input_var_field';
 import { useDataStreamId } from './hooks';
+import { orderDatasets } from './order_datasets';
 
 const ScrollAnchor = styled.div`
   display: none;
@@ -178,7 +180,9 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     };
 
     const { data: dataStreamsData } = useGetDataStreams();
-    const datasets = dataStreamsData?.data_streams.map((dataStream) => dataStream.dataset) ?? [];
+    const datasetList =
+      uniq(dataStreamsData?.data_streams.map((dataStream) => dataStream.dataset)) ?? [];
+    const datasets = orderDatasets(datasetList, packageInfo.name);
 
     return (
       <>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -22,6 +22,8 @@ import {
 } from '@elastic/eui';
 import { useRouteMatch } from 'react-router-dom';
 
+import { useGetDataStreams } from '../../../../../../../../hooks';
+
 import { mapPackageReleaseToIntegrationCardRelease } from '../../../../../../../../services/package_prerelease';
 
 import { getRegistryDataStreamAssetBaseName } from '../../../../../../../../../common/services';
@@ -175,6 +177,9 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
       });
     };
 
+    const { data: dataStreamsData } = useGetDataStreams();
+    const datasets = dataStreamsData?.data_streams.map((dataStream) => dataStream.dataset) ?? [];
+
     return (
       <>
         <EuiFlexGrid columns={2}>
@@ -252,6 +257,8 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                       }}
                       errors={inputStreamValidationResults?.vars![varName]}
                       forceShowErrors={forceShowErrors}
+                      packageType={packageInfo.type}
+                      datasets={datasets}
                     />
                   </EuiFlexItem>
                 );
@@ -311,6 +318,8 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                             }}
                             errors={inputStreamValidationResults?.vars![varName]}
                             forceShowErrors={forceShowErrors}
+                            packageType={packageInfo.type}
+                            datasets={datasets}
                           />
                         </EuiFlexItem>
                       );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -25,6 +25,7 @@ import { CodeEditor } from '@kbn/kibana-react-plugin/public';
 import type { RegistryVarsEntry } from '../../../../../../types';
 
 import { MultiTextInput } from './multi_text_input';
+import { DatasetComboBox } from './dataset_combo';
 
 const FixedHeightDiv = styled.div`
   height: 300px;
@@ -37,127 +38,144 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
   errors?: string[] | null;
   forceShowErrors?: boolean;
   frozen?: boolean;
-}> = memo(({ varDef, value, onChange, errors: varErrors, forceShowErrors, frozen }) => {
-  const [isDirty, setIsDirty] = useState<boolean>(false);
-  const { multi, required, type, title, name, description } = varDef;
-  const isInvalid = (isDirty || forceShowErrors) && !!varErrors;
-  const errors = isInvalid ? varErrors : null;
-  const fieldLabel = title || name;
+  packageType?: string;
+  datasets?: string[];
+}> = memo(
+  ({
+    varDef,
+    value,
+    onChange,
+    errors: varErrors,
+    forceShowErrors,
+    frozen,
+    packageType,
+    datasets = [],
+  }) => {
+    const [isDirty, setIsDirty] = useState<boolean>(false);
+    const { multi, required, type, title, name, description } = varDef;
+    const isInvalid = (isDirty || forceShowErrors) && !!varErrors;
+    const errors = isInvalid ? varErrors : null;
+    const fieldLabel = title || name;
 
-  const field = useMemo(() => {
-    if (multi) {
-      return (
-        <MultiTextInput
-          value={value ?? []}
-          onChange={onChange}
-          onBlur={() => setIsDirty(true)}
-          isDisabled={frozen}
-        />
-      );
-    }
-    switch (type) {
-      case 'textarea':
+    const field = useMemo(() => {
+      if (multi) {
         return (
-          <EuiTextArea
-            isInvalid={isInvalid}
-            value={value === undefined ? '' : value}
-            onChange={(e) => onChange(e.target.value)}
+          <MultiTextInput
+            value={value ?? []}
+            onChange={onChange}
             onBlur={() => setIsDirty(true)}
-            disabled={frozen}
-            resize="vertical"
+            isDisabled={frozen}
           />
         );
-      case 'yaml':
-        return frozen ? (
-          <EuiCodeBlock language="yaml" isCopyable={false} paddingSize="s">
-            <pre>{value}</pre>
-          </EuiCodeBlock>
-        ) : (
-          <FixedHeightDiv>
-            <CodeEditor
-              languageId="yaml"
-              width="100%"
-              height="300px"
-              value={value}
-              onChange={onChange}
-              options={{
-                minimap: {
-                  enabled: false,
-                },
-                ariaLabel: i18n.translate('xpack.fleet.packagePolicyField.yamlCodeEditor', {
-                  defaultMessage: 'YAML Code Editor',
-                }),
-                scrollBeyondLastLine: false,
-                wordWrap: 'off',
-                wrappingIndent: 'indent',
-                tabSize: 2,
-                // To avoid left margin
-                lineNumbers: 'off',
-                lineNumbersMinChars: 0,
-                glyphMargin: false,
-                folding: false,
-                lineDecorationsWidth: 0,
-                overviewRulerBorder: false,
-              }}
-            />
-          </FixedHeightDiv>
-        );
-      case 'bool':
-        return (
-          <EuiSwitch
-            label={fieldLabel}
-            checked={value}
-            showLabel={false}
-            onChange={(e) => onChange(e.target.checked)}
-            onBlur={() => setIsDirty(true)}
-            disabled={frozen}
-          />
-        );
-      case 'password':
-        return (
-          <EuiFieldPassword
-            type="dual"
-            isInvalid={isInvalid}
-            value={value === undefined ? '' : value}
-            onChange={(e) => onChange(e.target.value)}
-            onBlur={() => setIsDirty(true)}
-            disabled={frozen}
-          />
-        );
-      default:
-        return (
-          <EuiFieldText
-            isInvalid={isInvalid}
-            value={value === undefined ? '' : value}
-            onChange={(e) => onChange(e.target.value)}
-            onBlur={() => setIsDirty(true)}
-            disabled={frozen}
-          />
-        );
-    }
-  }, [isInvalid, multi, onChange, type, value, fieldLabel, frozen]);
-
-  // Boolean cannot be optional by default set to false
-  const isOptional = useMemo(() => type !== 'bool' && !required, [required, type]);
-
-  return (
-    <EuiFormRow
-      isInvalid={isInvalid}
-      error={errors}
-      label={fieldLabel}
-      labelAppend={
-        isOptional ? (
-          <EuiText size="xs" color="subdued">
-            <FormattedMessage
-              id="xpack.fleet.createPackagePolicy.stepConfigure.inputVarFieldOptionalLabel"
-              defaultMessage="Optional"
-            />
-          </EuiText>
-        ) : null
       }
-      helpText={description && <ReactMarkdown children={description} />}
-    >
-      {field}
-    </EuiFormRow>
-  );
-});
+
+      if (name === 'data_stream.dataset' && packageType === 'input') {
+        return <DatasetComboBox datasets={datasets} value={value} onChange={onChange} />;
+      }
+      switch (type) {
+        case 'textarea':
+          return (
+            <EuiTextArea
+              isInvalid={isInvalid}
+              value={value === undefined ? '' : value}
+              onChange={(e) => onChange(e.target.value)}
+              onBlur={() => setIsDirty(true)}
+              disabled={frozen}
+              resize="vertical"
+            />
+          );
+        case 'yaml':
+          return frozen ? (
+            <EuiCodeBlock language="yaml" isCopyable={false} paddingSize="s">
+              <pre>{value}</pre>
+            </EuiCodeBlock>
+          ) : (
+            <FixedHeightDiv>
+              <CodeEditor
+                languageId="yaml"
+                width="100%"
+                height="300px"
+                value={value}
+                onChange={onChange}
+                options={{
+                  minimap: {
+                    enabled: false,
+                  },
+                  ariaLabel: i18n.translate('xpack.fleet.packagePolicyField.yamlCodeEditor', {
+                    defaultMessage: 'YAML Code Editor',
+                  }),
+                  scrollBeyondLastLine: false,
+                  wordWrap: 'off',
+                  wrappingIndent: 'indent',
+                  tabSize: 2,
+                  // To avoid left margin
+                  lineNumbers: 'off',
+                  lineNumbersMinChars: 0,
+                  glyphMargin: false,
+                  folding: false,
+                  lineDecorationsWidth: 0,
+                  overviewRulerBorder: false,
+                }}
+              />
+            </FixedHeightDiv>
+          );
+        case 'bool':
+          return (
+            <EuiSwitch
+              label={fieldLabel}
+              checked={value}
+              showLabel={false}
+              onChange={(e) => onChange(e.target.checked)}
+              onBlur={() => setIsDirty(true)}
+              disabled={frozen}
+            />
+          );
+        case 'password':
+          return (
+            <EuiFieldPassword
+              type="dual"
+              isInvalid={isInvalid}
+              value={value === undefined ? '' : value}
+              onChange={(e) => onChange(e.target.value)}
+              onBlur={() => setIsDirty(true)}
+              disabled={frozen}
+            />
+          );
+        default:
+          return (
+            <EuiFieldText
+              isInvalid={isInvalid}
+              value={value === undefined ? '' : value}
+              onChange={(e) => onChange(e.target.value)}
+              onBlur={() => setIsDirty(true)}
+              disabled={frozen}
+            />
+          );
+      }
+    }, [isInvalid, multi, onChange, type, value, fieldLabel, frozen, datasets, name, packageType]);
+
+    // Boolean cannot be optional by default set to false
+    const isOptional = useMemo(() => type !== 'bool' && !required, [required, type]);
+
+    return (
+      <EuiFormRow
+        isInvalid={isInvalid}
+        error={errors}
+        label={fieldLabel}
+        labelAppend={
+          isOptional ? (
+            <EuiText size="xs" color="subdued">
+              <FormattedMessage
+                id="xpack.fleet.createPackagePolicy.stepConfigure.inputVarFieldOptionalLabel"
+                defaultMessage="Optional"
+              />
+            </EuiText>
+          ) : null
+        }
+        helpText={description && <ReactMarkdown children={description} />}
+      >
+        {field}
+      </EuiFormRow>
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/145903

Added datasets combo box to input type packages `Dataset name` variable with the option of creating a new one.

Using the existing `/data_streams` API to show the list of all datasets.

Package policy create/edit API already supports setting the value of `data_stream.dataset` (input packages should have this variable as described in https://github.com/elastic/kibana/issues/133296)

To verify:
- Start local EPR with input type packages as described [here](https://github.com/elastic/kibana/pull/140035#issue-1362132163)
- Add `Custom Logs` integration
- Verify that Dataset name displays a dropdown and the selected value is persisted.
- Verify that a new value can be entered in Dataset name
- Verify that Edit integration policy displays the existing value and allows selecting/creating another one.

<img width="924" alt="image" src="https://user-images.githubusercontent.com/90178898/205680787-3ef7da08-f5f0-4f05-b8d7-3a1c0a6a3d56.png">
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/90178898/205679497-935fe450-ce78-4f0b-943e-58e7f851f44b.png">
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/90178898/205679589-fedbbe0e-2c4d-4c00-986f-34ec5c2eb2f6.png">

Added ordering of datasets to move up those that start with the package name e.g. `system*` datasets come first if adding a `system` integration. Other than that ordering datasets alphabetically.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/90178898/205924837-a9807c92-2fe4-431a-88c6-f161d00812fb.png">

The rest of the requirements seem to be already implemented, see [comments](https://github.com/elastic/kibana/issues/145903#issuecomment-1339109189)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
