### PR TITLE
[DOCS] Removes tag from 7.17.8 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -81,8 +81,6 @@ Review important information about the {kib} 7.17.x releases.
 [[release-notes-7.17.8]]
 == {kib} 7.17.8
 
-coming::[7.17.8]
-
 Review the following information about the 7.17.8 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 7.17.8 release notes.

