### PR TITLE
[DOCS] Removes 8.5.3 tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,8 +42,6 @@ Review important information about the {kib} 8.5.x releases.
 [[release-notes-8.5.3]]
 == {kib} 8.5.3
 
-coming::[8.5.3]
-
 Review the following information about the {kib} 8.5.3 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.5.3 release notes.
