### PR TITLE
[Fleet] Honor source_mode defined in a package datastream when installing it

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -88,4 +88,38 @@ describe('EPM index template install', () => {
     expect(indexTemplate.priority).toBe(templatePriorityDatasetIsPrefixTrue);
     expect(indexTemplate.index_patterns).toEqual([templateIndexPatternDatasetIsPrefixTrue]);
   });
+
+  it('tests prepareTemplate to set source mode to synthetics if specified', async () => {
+    const dataStreamDatasetIsPrefixTrue = {
+      type: 'metrics',
+      dataset: 'package.dataset',
+      title: 'test data stream',
+      release: 'experimental',
+      package: 'package',
+      path: 'path',
+      ingest_pipeline: 'default',
+      dataset_is_prefix: true,
+      elasticsearch: {
+        source_mode: 'synthetic',
+      },
+    } as RegistryDataStream;
+    const pkg = {
+      name: 'package',
+      version: '0.0.1',
+    };
+
+    const { componentTemplates } = prepareTemplate({
+      pkg,
+      dataStream: dataStreamDatasetIsPrefixTrue,
+    });
+
+    const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
+
+    if (!('mappings' in packageTemplate)) {
+      throw new Error('no mappings on package template');
+    }
+
+    expect(packageTemplate.mappings).toHaveProperty('_source');
+    expect(packageTemplate.mappings._source).toEqual({ mode: 'synthetic' });
+  });
 });

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -290,7 +290,17 @@ export function buildComponentTemplates(params: {
       mappings: {
         properties: mappingsProperties,
         dynamic_templates: mappingsDynamicTemplates.length ? mappingsDynamicTemplates : undefined,
-        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates'),
+        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates', '_source'),
+        ...(indexTemplateMappings?._source || registryElasticsearch?.source_mode
+          ? {
+              _source: {
+                ...indexTemplateMappings?._source,
+                ...(registryElasticsearch?.source_mode === 'synthetic'
+                  ? { mode: 'synthetic' }
+                  : {}),
+              },
+            }
+          : {}),
       },
     },
     _meta,


### PR DESCRIPTION
## Description 

Closes #141211

When installing a package we should honor the value of source_mode if a package datastream define it.

That PR does that.


The experiment datastream UI in the package policy editor need to be udpated too, this will come in a following PR.


## Testing

I added some unit test to validate how generate the mappings, and you can test locally by adding this to a datastream manifest, I tested it with nginx stubstatus and it seems to work well
```
elasticsearch:
  source_mode: "synthetic"
```
