### PR TITLE
[Lens][Inspector] Show annotations queries as "Annotations" in the inspector panel

### DIFF
--- a/src/plugins/data/common/search/expressions/esaggs/request_handler.test.ts
+++ b/src/plugins/data/common/search/expressions/esaggs/request_handler.test.ts
@@ -143,6 +143,26 @@ describe('esaggs expression function - public', () => {
     });
   });
 
+  test('calls searchSource.fetch with custom inspector params', async () => {
+    await handleRequest({
+      ...mockParams,
+      title: 'MyTitle',
+      description: 'MyDescription',
+    }).toPromise();
+    const searchSource = await mockParams.searchSourceService.create();
+
+    expect(searchSource.fetch$).toHaveBeenCalledWith({
+      abortSignal: mockParams.abortSignal,
+      sessionId: mockParams.searchSessionId,
+      inspector: {
+        title: 'MyTitle',
+        description: 'MyDescription',
+        adapter: undefined,
+      },
+      disableShardFailureWarning: false,
+    });
+  });
+
   test('tabifies response data', async () => {
     await handleRequest(mockParams).toPromise();
     expect(tabifyAggResponse).toHaveBeenCalledWith(

--- a/src/plugins/data/common/search/expressions/esaggs/request_handler.ts
+++ b/src/plugins/data/common/search/expressions/esaggs/request_handler.ts
@@ -33,6 +33,8 @@ export interface RequestHandlerParams {
   disableShardWarnings?: boolean;
   getNow?: () => Date;
   executionContext?: KibanaExecutionContext;
+  title?: string;
+  description?: string;
 }
 
 export const handleRequest = ({
@@ -49,6 +51,8 @@ export const handleRequest = ({
   disableShardWarnings,
   getNow,
   executionContext,
+  title,
+  description,
 }: RequestHandlerParams) => {
   return defer(async () => {
     const forceNow = getNow?.();
@@ -117,13 +121,17 @@ export const handleRequest = ({
           sessionId: searchSessionId,
           inspector: {
             adapter: inspectorAdapters.requests,
-            title: i18n.translate('data.functions.esaggs.inspector.dataRequest.title', {
-              defaultMessage: 'Data',
-            }),
-            description: i18n.translate('data.functions.esaggs.inspector.dataRequest.description', {
-              defaultMessage:
-                'This request queries Elasticsearch to fetch the data for the visualization.',
-            }),
+            title:
+              title ??
+              i18n.translate('data.functions.esaggs.inspector.dataRequest.title', {
+                defaultMessage: 'Data',
+              }),
+            description:
+              description ??
+              i18n.translate('data.functions.esaggs.inspector.dataRequest.description', {
+                defaultMessage:
+                  'This request queries Elasticsearch to fetch the data for the visualization.',
+              }),
           },
           executionContext,
         })

--- a/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
@@ -23,6 +23,7 @@ import { ESCalendarInterval, ESFixedInterval, roundDateToESInterval } from '@ela
 import { Adapters } from '@kbn/inspector-plugin/common';
 import { SerializableRecord } from '@kbn/utility-types';
 import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+import { i18n } from '@kbn/i18n';
 import { handleRequest } from './handle_request';
 import {
   ANNOTATIONS_PER_BUCKET,
@@ -134,6 +135,19 @@ export const requestEventAnnotations = (
           searchSourceService: searchSource,
           getNow,
           executionContext: getExecutionContext(),
+          title: i18n.translate(
+            'eventAnnotation.fetchEventAnnotations.inspector.dataRequest.title',
+            {
+              defaultMessage: 'Annotations',
+            }
+          ),
+          description: i18n.translate(
+            'eventAnnotation.fetchEventAnnotations.inspector.dataRequest.description',
+            {
+              defaultMessage:
+                'This request queries Elasticsearch to fetch the data for the annotations.',
+            }
+          ),
         })
       );
 


### PR DESCRIPTION
## Summary

Fixes #141199 

Extends the `fetch$` method in the `handleRequest` to accept a custom title+description params to be used on the inspector request log method. In case params are not passed the old behaviour is kept as fallback.

The annotation expression can now pass the request meta information about the Annotation request type, that will show up in the panel:

<img width="709" alt="Screenshot 2022-12-05 at 18 40 14" src="https://user-images.githubusercontent.com/924948/205705862-45ae1070-d635-4519-9e4e-7d769d05b8d7.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
