### PR TITLE
Fix default exception validation

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -101,7 +101,8 @@ export const bulkCreateRulesRoute = (
               await validateRuleDefaultExceptionList({
                 exceptionsList: payloadRule.exceptions_list,
                 rulesClient,
-                ruleId: payloadRule.rule_id,
+                ruleRuleId: payloadRule.rule_id,
+                ruleId: undefined,
               });
 
               const validationErrors = validateCreateRuleProps(payloadRule);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -95,6 +95,7 @@ export const bulkPatchRulesRoute = (
             await validateRuleDefaultExceptionList({
               exceptionsList: payloadRule.exceptions_list,
               rulesClient,
+              ruleRuleId: payloadRule.rule_id,
               ruleId: payloadRule.id,
             });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -100,6 +100,7 @@ export const bulkUpdateRulesRoute = (
             await validateRuleDefaultExceptionList({
               exceptionsList: payloadRule.exceptions_list,
               rulesClient,
+              ruleRuleId: payloadRule.rule_id,
               ruleId: payloadRule.id,
             });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
@@ -90,6 +90,7 @@ export const createRuleRoute = (
         await validateRuleDefaultExceptionList({
           exceptionsList: request.body.exceptions_list,
           rulesClient,
+          ruleRuleId: undefined,
           ruleId: undefined,
         });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
@@ -80,6 +80,7 @@ export const patchRuleRoute = (router: SecuritySolutionPluginRouter, ml: SetupPl
         await validateRuleDefaultExceptionList({
           exceptionsList: params.exceptions_list,
           rulesClient,
+          ruleRuleId: params.rule_id,
           ruleId: params.id,
         });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
@@ -62,6 +62,7 @@ export const updateRuleRoute = (router: SecuritySolutionPluginRouter, ml: SetupP
         await validateRuleDefaultExceptionList({
           exceptionsList: request.body.exceptions_list,
           rulesClient,
+          ruleRuleId: request.body.rule_id,
           ruleId: request.body.id,
         });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/exceptions/validate_rule_default_exception_list.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/exceptions/validate_rule_default_exception_list.test.ts
@@ -39,6 +39,7 @@ describe('validateRuleDefaultExceptionList', () => {
   it('is valid if there no exceptionsList', async () => {
     const result = await validateRuleDefaultExceptionList({
       ruleId: '1',
+      ruleRuleId: undefined,
       exceptionsList: undefined,
       rulesClient: clients.rulesClient,
     });
@@ -48,6 +49,7 @@ describe('validateRuleDefaultExceptionList', () => {
   it('is valid if there default exceptions list', async () => {
     const result = await validateRuleDefaultExceptionList({
       ruleId: '1',
+      ruleRuleId: undefined,
       exceptionsList: [notDefaultExceptionList],
       rulesClient: clients.rulesClient,
     });
@@ -58,6 +60,7 @@ describe('validateRuleDefaultExceptionList', () => {
     await expect(
       validateRuleDefaultExceptionList({
         ruleId: '1',
+        ruleRuleId: undefined,
         exceptionsList: [defaultExceptionList, defaultExceptionList],
         rulesClient: clients.rulesClient,
       })
@@ -67,6 +70,7 @@ describe('validateRuleDefaultExceptionList', () => {
   it('is valid if there no rules with this exceptions', async () => {
     const result = await validateRuleDefaultExceptionList({
       ruleId: '1',
+      ruleRuleId: undefined,
       exceptionsList: [defaultExceptionList],
       rulesClient: clients.rulesClient,
     });
@@ -93,6 +97,7 @@ describe('validateRuleDefaultExceptionList', () => {
     await expect(
       validateRuleDefaultExceptionList({
         ruleId: '1',
+        ruleRuleId: undefined,
         exceptionsList: [defaultExceptionList],
         rulesClient: clients.rulesClient,
       })
@@ -116,6 +121,7 @@ describe('validateRuleDefaultExceptionList', () => {
 
     const result = await validateRuleDefaultExceptionList({
       ruleId: '1',
+      ruleRuleId: undefined,
       exceptionsList: [defaultExceptionList],
       rulesClient: clients.rulesClient,
     });
@@ -137,6 +143,7 @@ describe('validateRuleDefaultExceptionList', () => {
     await expect(
       validateRuleDefaultExceptionList({
         ruleId: '1',
+        ruleRuleId: undefined,
         exceptionsList: [defaultExceptionList],
         rulesClient: clients.rulesClient,
       })
@@ -160,11 +167,36 @@ describe('validateRuleDefaultExceptionList', () => {
     await expect(
       validateRuleDefaultExceptionList({
         ruleId: undefined,
+        ruleRuleId: undefined,
         exceptionsList: [defaultExceptionList],
         rulesClient: clients.rulesClient,
       })
     ).rejects.toThrow(
       'default exception list already exists in rule(s): 04128c15-0d1b-4716-a4c5-46997ac7f3bd'
+    );
+  });
+
+  it('throw error if there rule default list in other rule and ruleID undefined but ruleRuleId defined', async () => {
+    clients.rulesClient.find.mockResolvedValue({
+      ...getFindResultWithSingleHit(),
+      data: [
+        {
+          ...getRuleMock({
+            ...getQueryRuleParams(),
+          }),
+        },
+      ],
+    });
+
+    await expect(
+      validateRuleDefaultExceptionList({
+        ruleId: undefined,
+        ruleRuleId: '2',
+        exceptionsList: [defaultExceptionList],
+        rulesClient: clients.rulesClient,
+      })
+    ).rejects.toThrow(
+      'default exception list for rule: 2 already exists in rule(s): 04128c15-0d1b-4716-a4c5-46997ac7f3bd'
     );
   });
 });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
@@ -299,7 +299,7 @@ export default ({ getService }: FtrProviderContext) => {
           status_code: 409,
         });
       });
-      
+
       it('should not update a rule if trying to add default rule exception list which attached to another using rule.id', async () => {
         const ruleWithException = await createRule(supertest, log, {
           ...getSimpleRule('rule-1'),

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
@@ -299,6 +299,42 @@ export default ({ getService }: FtrProviderContext) => {
           status_code: 409,
         });
       });
+      
+      it('should not update a rule if trying to add default rule exception list which attached to another using rule.id', async () => {
+        const ruleWithException = await createRule(supertest, log, {
+          ...getSimpleRule('rule-1'),
+          exceptions_list: [
+            {
+              id: '2',
+              list_id: '123',
+              namespace_type: 'single',
+              type: ExceptionListTypeEnum.RULE_DEFAULT,
+            },
+          ],
+        });
+        const createdBody = await createRule(supertest, log, getSimpleRule('rule-2'));
+
+        const { body } = await supertest
+          .patch(DETECTION_ENGINE_RULES_URL)
+          .set('kbn-xsrf', 'true')
+          .send({
+            id: createdBody.id,
+            exceptions_list: [
+              {
+                id: '2',
+                list_id: '123',
+                namespace_type: 'single',
+                type: ExceptionListTypeEnum.RULE_DEFAULT,
+              },
+            ],
+          })
+          .expect(409);
+
+        expect(body).to.eql({
+          message: `default exception list for rule: ${createdBody.id} already exists in rule(s): ${ruleWithException.id}`,
+          status_code: 409,
+        });
+      });
 
       it('should return the rule with migrated actions after the enable patch', async () => {
         const [connector, rule] = await Promise.all([

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
@@ -295,7 +295,7 @@ export default ({ getService }: FtrProviderContext) => {
           .expect(409);
 
         expect(body).to.eql({
-          message: `default exception list already exists in rule(s): ${ruleWithException.id}`,
+          message: `default exception list for rule: rule-2 already exists in rule(s): ${ruleWithException.id}`,
           status_code: 409,
         });
       });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules_bulk.ts
@@ -407,7 +407,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(body).to.eql([
           {
             error: {
-              message: `default exception list already exists in rule(s): ${ruleWithException.id}`,
+              message: `default exception list for rule: rule-1 already exists in rule(s): ${ruleWithException.id}`,
               status_code: 409,
             },
             rule_id: 'rule-1',

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
@@ -459,7 +459,7 @@ export default ({ getService }: FtrProviderContext) => {
           .expect(409);
 
         expect(body).to.eql({
-          message: `default exception list already exists in rule(s): ${ruleWithException.id}`,
+          message: `default exception list for rule: rule-2 already exists in rule(s): ${ruleWithException.id}`,
           status_code: 409,
         });
       });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
@@ -464,6 +464,47 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
+      it('should not update a rule if trying to add default rule exception list which attached to another using rule.id', async () => {
+        const ruleWithException = await createRule(supertest, log, {
+          ...getSimpleRule('rule-1'),
+          exceptions_list: [
+            {
+              id: '2',
+              list_id: '123',
+              namespace_type: 'single',
+              type: ExceptionListTypeEnum.RULE_DEFAULT,
+            },
+          ],
+        });
+        const createdBody = await createRule(supertest, log, getSimpleRule('rule-2'));
+
+        // update a simple rule's name
+        const updatedRule = getSimpleRuleUpdate('rule-2');
+        updatedRule.id = createdBody.id;
+        delete updatedRule.rule_id;
+
+        const { body } = await supertest
+          .put(DETECTION_ENGINE_RULES_URL)
+          .set('kbn-xsrf', 'true')
+          .send({
+            ...updatedRule,
+            exceptions_list: [
+              {
+                id: '2',
+                list_id: '123',
+                namespace_type: 'single',
+                type: ExceptionListTypeEnum.RULE_DEFAULT,
+              },
+            ],
+          })
+          .expect(409);
+
+        expect(body).to.eql({
+          message: `default exception list for rule: ${updatedRule.id} already exists in rule(s): ${ruleWithException.id}`,
+          status_code: 409,
+        });
+      });
+
       describe('threshold validation', () => {
         it('should result in 400 error if no threshold-specific fields are provided', async () => {
           const existingRule = getThresholdRuleForSignalTesting(['*']);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules_bulk.ts
@@ -523,7 +523,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(body).to.eql([
           {
             error: {
-              message: `default exception list already exists in rule(s): ${ruleWithException.id}`,
+              message: `default exception list for rule: rule-1 already exists in rule(s): ${ruleWithException.id}`,
               status_code: 409,
             },
             rule_id: 'rule-1',


### PR DESCRIPTION
## Summary
Validation of default exception list for rule mutation works with id or rule_id property

Related: https://github.com/elastic/kibana/issues/146980


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->