### PR TITLE
[Security Solution]: List details page fix  Linked Rules max height

### DIFF
--- a/packages/kbn-securitysolution-exception-list-components/src/header_menu/__snapshots__/header_menu.test.tsx.snap
+++ b/packages/kbn-securitysolution-exception-list-components/src/header_menu/__snapshots__/header_menu.test.tsx.snap
@@ -176,7 +176,7 @@ Object {
           </p>
           <div>
             <div
-              class="euiContextMenuPanel"
+              class="euiContextMenuPanel eui-scrollBar css-zos0rl"
               data-test-subj="MenuPanel"
               tabindex="-1"
             >

--- a/packages/kbn-securitysolution-exception-list-components/src/header_menu/index.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/header_menu/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { ButtonContentIconSide } from '@elastic/eui/src/components/button/_button_content_deprecated';
+import { css } from '@emotion/react';
 
 export interface Action {
   key: string;
@@ -42,6 +43,12 @@ interface HeaderMenuComponentProps {
   panelPaddingSize?: PanelPaddingSize;
 }
 
+const popoverHeightStyle = css`
+  max-height: 300px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
 const HeaderMenuComponent: FC<HeaderMenuComponentProps> = ({
   text,
   dataTestSubj,
@@ -114,6 +121,8 @@ const HeaderMenuComponent: FC<HeaderMenuComponentProps> = ({
       >
         {!itemActions ? null : (
           <EuiContextMenuPanel
+            css={popoverHeightStyle}
+            className="eui-scrollBar"
             data-test-subj={`${dataTestSubj || ''}MenuPanel`}
             size="s"
             items={itemActions as ReactElement[]}

--- a/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
+++ b/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
@@ -1831,7 +1831,7 @@ Object {
           </p>
           <div>
             <div
-              class="euiContextMenuPanel"
+              class="euiContextMenuPanel eui-scrollBar css-zos0rl"
               data-test-subj="RightSideMenuItemsMenuActionsMenuPanel"
               tabindex="-1"
             >

--- a/packages/kbn-securitysolution-exception-list-components/src/list_header/menu_items/__snapshots__/menu_items.test.tsx.snap
+++ b/packages/kbn-securitysolution-exception-list-components/src/list_header/menu_items/__snapshots__/menu_items.test.tsx.snap
@@ -499,7 +499,7 @@ Object {
           </p>
           <div>
             <div
-              class="euiContextMenuPanel"
+              class="euiContextMenuPanel eui-scrollBar css-zos0rl"
               data-test-subj="MenuActionsMenuPanel"
               tabindex="-1"
             >
@@ -779,7 +779,7 @@ Object {
           </p>
           <div>
             <div
-              class="euiContextMenuPanel"
+              class="euiContextMenuPanel eui-scrollBar css-zos0rl"
               data-test-subj="MenuActionsMenuPanel"
               tabindex="-1"
             >


### PR DESCRIPTION
## Summary

- Applying a max-height to the `Linked Rules` combobox in the List Shared details as well as in the Add Exception Items


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->