### PR TITLE
[Fleet] Ensure top-level package vars are parsed when reading archive

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -252,6 +252,11 @@ function parseAndVerifyArchive(
       semverPrerelease(parsed.version) || semverMajor(parsed.version) < 1 ? 'beta' : 'ga';
   }
 
+  // Ensure top-level variables are parsed as well
+  if (manifest.vars) {
+    parsed.vars = parseAndVerifyVars(manifest.vars, 'manifest.yml');
+  }
+
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147028

## Testing instructions

See steps to reproduce in linked issue. Verify AWS credential variables appear on this branch.

![image](https://user-images.githubusercontent.com/6766512/205719634-98bc4db8-25c4-4362-afba-5246fb5fb326.png)

I took a pass at adding tests for our `parseAndVeryArchive` method but it's sort of a recursive chain of mocked `Buffer` -> `yaml.safeLoad` operations and got pretty involved to set up from scratch. The other option would be to add an FTR API test that catches this case, but we'd need a package with top-level variables loaded into the test registry, which we may not have readily available if https://github.com/elastic/kibana/pull/146809 lands.

I would love some alternative ideas on adding test coverage for this fix, but if it's going to involved I don't want to block this fix from landing in 8.6 on tests.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->