### PR TITLE
[Lens] missing field validation as warnings

### DIFF
--- a/src/plugins/data/common/search/aggs/param_types/field.ts
+++ b/src/plugins/data/common/search/aggs/param_types/field.ts
@@ -7,7 +7,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { SavedFieldNotFound, SavedFieldTypeInvalidForAgg } from '@kbn/kibana-utils-plugin/common';
+import { SavedFieldTypeInvalidForAgg } from '@kbn/kibana-utils-plugin/common';
 import { isNestedField, DataViewField } from '@kbn/data-views-plugin/common';
 import { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
@@ -43,6 +43,7 @@ export class FieldParamType extends BaseParamType {
     this.scriptable = config.scriptable !== false;
     this.filterField = config.filterField;
 
+    // TODO - are there any custom write methods that do a missing check?
     if (!config.write) {
       this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
         const field = aggConfig.getField();
@@ -58,24 +59,10 @@ export class FieldParamType extends BaseParamType {
           );
         }
 
-        if (field.type === KBN_FIELD_TYPES.MISSING) {
-          throw new SavedFieldNotFound(
-            i18n.translate(
-              'data.search.aggs.paramTypes.field.notFoundSavedFieldParameterErrorMessage',
-              {
-                defaultMessage:
-                  'The field "{fieldParameter}" associated with this object no longer exists in the data view. Please use another field.',
-                values: {
-                  fieldParameter: field.name,
-                },
-              }
-            )
-          );
-        }
-
-        const validField = this.getAvailableFields(aggConfig).find(
-          (f: any) => f.name === field.name
-        );
+        const validField =
+          field.type === KBN_FIELD_TYPES.MISSING // we always let missing fields through because there may be good reasons they are missing
+            ? field
+            : this.getAvailableFields(aggConfig).find((f: any) => f.name === field.name);
 
         if (!validField) {
           throw new SavedFieldTypeInvalidForAgg(

--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_panel.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_panel.tsx
@@ -15,7 +15,7 @@ import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { DatasourceDimensionTriggerProps, DatasourceDimensionEditorProps } from '../../../types';
 import { GenericIndexPatternColumn } from '../form_based';
-import { isColumnInvalid } from '../utils';
+import { columnHasWarnings, isColumnInvalid } from '../utils';
 import { FormBasedPrivateState } from '../types';
 import { DimensionEditor } from './dimension_editor';
 import { DateRange } from '../../../../common';
@@ -62,6 +62,11 @@ export const FormBasedDimensionTriggerComponent = function FormBasedDimensionTri
     [layer, columnId, currentIndexPattern, invalid]
   );
 
+  const currentColumnHasWarnings = useMemo(
+    () => columnHasWarnings(layer, columnId, currentIndexPattern),
+    [layer, columnId, currentIndexPattern]
+  );
+
   const selectedColumn: GenericIndexPatternColumn | null = layer.columns[props.columnId] ?? null;
 
   if (!selectedColumn) {
@@ -73,9 +78,11 @@ export const FormBasedDimensionTriggerComponent = function FormBasedDimensionTri
     <DimensionTrigger
       id={columnId}
       label={!currentColumnHasErrors ? formattedLabel : selectedColumn.label}
-      isInvalid={Boolean(currentColumnHasErrors)}
+      problemSeverity={
+        currentColumnHasErrors ? 'error' : currentColumnHasWarnings ? 'warning' : undefined
+      }
       hideTooltip={hideTooltip}
-      invalidMessage={invalidMessage}
+      problemMessage={invalidMessage}
     />
   );
 };

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
@@ -87,6 +87,7 @@ import {
   copyColumn,
   getColumnOrder,
   getReferenceRoot,
+  getWarningMessages,
   reorderByGroups,
 } from './operations/layer_helpers';
 import { FormBasedPrivateState, FormBasedPersistedState, DataViewDragDropOperation } from './types';
@@ -872,7 +873,16 @@ export function getFormBasedDatasource({
       return messages.length ? messages : undefined;
     },
     getWarningMessages: (state, frame, adapters, setState) => {
+      const layerWarnings = Object.values(state.layers)
+        .filter((layer) => !!frame.dataViews.indexPatterns[layer.indexPatternId])
+        .map(
+          (layer) =>
+            getWarningMessages(layer, frame.dataViews.indexPatterns[layer.indexPatternId]) ?? []
+        )
+        .flat();
+
       return [
+        ...layerWarnings,
         ...(getStateTimeShiftWarningMessages(data.datatableUtilities, state, frame) || []),
         ...getPrecisionErrorWarningMessages(
           data.datatableUtilities,

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
@@ -92,10 +92,14 @@ export const cardinalityOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
-      getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   isTransferable: (column, newIndexPattern) => {
     const newField = newIndexPattern.getFieldByName(column.sourceField);
 

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/cardinality.tsx
@@ -16,11 +16,12 @@ import { FieldBasedIndexPatternColumn, ValueFormatConfig } from './column_types'
 
 import {
   getFormatFromPreviousColumn,
-  getInvalidFieldMessage,
   getSafeName,
   getFilter,
   combineErrorMessages,
   isColumnOfType,
+  getWrongFieldTypeMessage,
+  getMissingFieldMessage,
 } from './helpers';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
 import { getDisallowedPreviousShiftMessage } from '../../time_shift_utils';
@@ -92,11 +93,15 @@ export const cardinalityOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/count.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/count.tsx
@@ -16,11 +16,12 @@ import { OperationDefinition, ParamEditorProps } from '.';
 import { FieldBasedIndexPatternColumn, ValueFormatConfig } from './column_types';
 import type { IndexPatternField } from '../../../../types';
 import {
-  getInvalidFieldMessage,
   getFilter,
   combineErrorMessages,
   getFormatFromPreviousColumn,
   isColumnOfType,
+  getWrongFieldTypeMessage,
+  getMissingFieldMessage,
 } from './helpers';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
 import { getDisallowedPreviousShiftMessage } from '../../time_shift_utils';
@@ -91,11 +92,15 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
   input: 'field',
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/count.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/count.tsx
@@ -91,10 +91,14 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
   input: 'field',
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
-      getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   allowAsReference: true,
   onFieldChange: (oldColumn, field) => {
     return {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/date_histogram.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/date_histogram.tsx
@@ -85,13 +85,12 @@ export const dateHistogramOperation: OperationDefinition<
   priority: 5, // Highest priority level used
   operationParams: [{ name: 'interval', type: 'string', required: false }],
   getErrorMessage: (layer, columnId, indexPattern) =>
-    [
-      ...(getInvalidFieldMessage(
-        layer.columns[columnId] as FieldBasedIndexPatternColumn,
-        indexPattern
-      ) || []),
-      getMultipleDateHistogramsErrorMessage(layer, columnId) || '',
-    ].filter(Boolean),
+    [getMultipleDateHistogramsErrorMessage(layer, columnId) || ''].filter(Boolean),
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   getPossibleOperationForField: ({ aggregationRestrictions, aggregatable, type }) => {
     if (
       (type === 'date' || type === 'date_range') &&

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/date_histogram.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/date_histogram.tsx
@@ -32,7 +32,7 @@ import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { updateColumnParam } from '../layer_helpers';
 import { OperationDefinition, ParamEditorProps } from '.';
 import { FieldBasedIndexPatternColumn } from './column_types';
-import { getInvalidFieldMessage, getSafeName } from './helpers';
+import { getMissingFieldMessage, getSafeName, getWrongFieldTypeMessage } from './helpers';
 import { FormBasedLayer } from '../../types';
 import { TooltipWrapper } from '../../../../shared_components';
 
@@ -85,9 +85,15 @@ export const dateHistogramOperation: OperationDefinition<
   priority: 5, // Highest priority level used
   operationParams: [{ name: 'interval', type: 'string', required: false }],
   getErrorMessage: (layer, columnId, indexPattern) =>
-    [getMultipleDateHistogramsErrorMessage(layer, columnId) || ''].filter(Boolean),
+    [
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
+      getMultipleDateHistogramsErrorMessage(layer, columnId) || '',
+    ].filter(Boolean),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -19,7 +19,17 @@ import { hasField } from '../../pure_utils';
 export function getInvalidFieldMessage(
   column: FieldBasedIndexPatternColumn,
   indexPattern?: IndexPattern
-) {
+): string[] | undefined {
+  return [
+    i18n.translate('xpack.lens.indexPattern.fieldsNotFound', {
+      defaultMessage:
+        '{count, plural, one {Field} other {Fields}} {missingFields} {count, plural, one {was} other {were}} not found',
+      values: {
+        count: 1,
+        missingFields: 'lolz',
+      },
+    }),
+  ];
   if (!indexPattern) {
     return;
   }

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
@@ -329,6 +329,12 @@ interface BaseOperationDefinitionProps<
       >
     | undefined;
 
+  getWarningMessages?: (
+    layer: FormBasedLayer,
+    columnId: string,
+    indexPattern: IndexPattern
+  ) => React.ReactNode[] | undefined;
+
   /*
    * Flag whether this operation can be scaled by time unit if a date histogram is available.
    * If set to mandatory or optional, a UI element is shown in the config flyout to configure the time unit

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/metrics.tsx
@@ -13,11 +13,12 @@ import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { OperationDefinition, ParamEditorProps } from '.';
 import {
   getFormatFromPreviousColumn,
-  getInvalidFieldMessage,
   getSafeName,
   getFilter,
   combineErrorMessages,
   isColumnOfType,
+  getWrongFieldTypeMessage,
+  getMissingFieldMessage,
 } from './helpers';
 import {
   FieldBasedIndexPatternColumn,
@@ -211,11 +212,15 @@ function buildMetricOperation<T extends MetricColumn<string>>({
 
     getErrorMessage: (layer, columnId, indexPattern) =>
       combineErrorMessages([
+        getWrongFieldTypeMessage(
+          layer.columns[columnId] as FieldBasedIndexPatternColumn,
+          indexPattern
+        ),
         getDisallowedPreviousShiftMessage(layer, columnId),
         getColumnReducedTimeRangeError(layer, columnId, indexPattern),
       ]),
     getWarningMessages: (layer, columnId, indexPattern) =>
-      getInvalidFieldMessage(
+      getMissingFieldMessage(
         layer.columns[columnId] as FieldBasedIndexPatternColumn,
         indexPattern
       )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/metrics.tsx
@@ -211,13 +211,14 @@ function buildMetricOperation<T extends MetricColumn<string>>({
 
     getErrorMessage: (layer, columnId, indexPattern) =>
       combineErrorMessages([
-        getInvalidFieldMessage(
-          layer.columns[columnId] as FieldBasedIndexPatternColumn,
-          indexPattern
-        ),
         getDisallowedPreviousShiftMessage(layer, columnId),
         getColumnReducedTimeRangeError(layer, columnId, indexPattern),
       ]),
+    getWarningMessages: (layer, columnId, indexPattern) =>
+      getInvalidFieldMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      )?.map((msg) => <div>{msg}</div>),
     filterable: true,
     canReduceTimeRange: true,
     documentation: {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
@@ -289,11 +289,14 @@ export const percentileOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
-      getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
-  getWarningMessages: (layer, columnId, indexPattern) => [<div>hey dude</div>],
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   paramEditor: function PercentileParamEditor({
     paramEditorUpdater,
     currentColumn,

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
@@ -18,12 +18,13 @@ import {
 import { OperationDefinition } from '.';
 import {
   getFormatFromPreviousColumn,
-  getInvalidFieldMessage,
   getSafeName,
   isValidNumber,
   getFilter,
   isColumnOfType,
   combineErrorMessages,
+  getWrongFieldTypeMessage,
+  getMissingFieldMessage,
 } from './helpers';
 import { FieldBasedIndexPatternColumn } from './column_types';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
@@ -289,11 +290,15 @@ export const percentileOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile.tsx
@@ -293,6 +293,7 @@ export const percentileOperation: OperationDefinition<
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
+  getWarningMessages: (layer, columnId, indexPattern) => [<div>hey dude</div>],
   paramEditor: function PercentileParamEditor({
     paramEditorUpdater,
     currentColumn,

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
@@ -167,10 +167,14 @@ export const percentileRanksOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
-      getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   paramEditor: function PercentileParamEditor({
     paramEditorUpdater,
     currentColumn,

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
@@ -13,12 +13,13 @@ import { buildExpressionFunction } from '@kbn/expressions-plugin/public';
 import { OperationDefinition } from '.';
 import {
   getFormatFromPreviousColumn,
-  getInvalidFieldMessage,
   getSafeName,
   isValidNumber,
   getFilter,
   isColumnOfType,
   combineErrorMessages,
+  getWrongFieldTypeMessage,
+  getMissingFieldMessage,
 } from './helpers';
 import { FieldBasedIndexPatternColumn } from './column_types';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
@@ -167,11 +168,15 @@ export const percentileRanksOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) =>
     combineErrorMessages([
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
       getDisallowedPreviousShiftMessage(layer, columnId),
       getColumnReducedTimeRangeError(layer, columnId, indexPattern),
     ]),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
@@ -18,7 +18,7 @@ import { updateColumnParam } from '../../layer_helpers';
 import { supportedFormats } from '../../../../../../common/expressions/format_column/supported_formats';
 import { MODES, AUTO_BARS, DEFAULT_INTERVAL, MIN_HISTOGRAM_BARS, SLICES } from './constants';
 import { IndexPattern, IndexPatternField } from '../../../../../types';
-import { getInvalidFieldMessage, isValidNumber } from '../helpers';
+import { getWrongFieldTypeMessage, getMissingFieldMessage, isValidNumber } from '../helpers';
 
 type RangeType = Omit<Range, 'type'>;
 // Try to cover all possible serialized states for ranges
@@ -82,8 +82,10 @@ export const rangeOperation: OperationDefinition<
   }),
   priority: 4, // Higher than terms, so numbers get histogram
   input: 'field',
+  getErrorMessage: (layer, columnId, indexPattern) =>
+    getWrongFieldTypeMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.tsx
@@ -82,8 +82,11 @@ export const rangeOperation: OperationDefinition<
   }),
   priority: 4, // Higher than terms, so numbers get histogram
   input: 'field',
-  getErrorMessage: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   getPossibleOperationForField: ({ aggregationRestrictions, aggregatable, type }) => {
     if (
       type === 'number' &&

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
@@ -35,7 +35,7 @@ import {
   IncompleteColumn,
 } from '../column_types';
 import { ValuesInput } from './values_input';
-import { getInvalidFieldMessage, isColumn } from '../helpers';
+import { getMissingFieldMessage, getWrongFieldTypeMessage, isColumn } from '../helpers';
 import { FieldInputs, getInputFieldErrorMessage, MAX_MULTI_FIELDS_SIZE } from './field_inputs';
 import {
   FieldInput as FieldInputBase,
@@ -187,13 +187,17 @@ export const termsOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) => {
     const messages = [
+      getWrongFieldTypeMessage(
+        layer.columns[columnId] as FieldBasedIndexPatternColumn,
+        indexPattern
+      ),
       getDisallowedTermsMessage(layer, columnId, indexPattern) || '',
       getMultiTermsScriptedFieldErrorMessage(layer, columnId, indexPattern) || '',
     ].filter(Boolean);
     return messages.length ? messages : undefined;
   },
   getWarningMessages: (layer, columnId, indexPattern) =>
-    getInvalidFieldMessage(
+    getMissingFieldMessage(
       layer.columns[columnId] as FieldBasedIndexPatternColumn,
       indexPattern
     )?.map((msg) => <div>{msg}</div>),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/index.tsx
@@ -187,15 +187,16 @@ export const termsOperation: OperationDefinition<
   },
   getErrorMessage: (layer, columnId, indexPattern) => {
     const messages = [
-      ...(getInvalidFieldMessage(
-        layer.columns[columnId] as FieldBasedIndexPatternColumn,
-        indexPattern
-      ) || []),
       getDisallowedTermsMessage(layer, columnId, indexPattern) || '',
       getMultiTermsScriptedFieldErrorMessage(layer, columnId, indexPattern) || '',
     ].filter(Boolean);
     return messages.length ? messages : undefined;
   },
+  getWarningMessages: (layer, columnId, indexPattern) =>
+    getInvalidFieldMessage(
+      layer.columns[columnId] as FieldBasedIndexPatternColumn,
+      indexPattern
+    )?.map((msg) => <div>{msg}</div>),
   getNonTransferableFields: (column, newIndexPattern) => {
     return getFieldsByValidationState(newIndexPattern, column).invalidFields;
   },

--- a/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
@@ -234,6 +234,7 @@ export function getShardFailuresWarningMessages(
   return [];
 }
 
+// TODO move to terms op?
 export function getPrecisionErrorWarningMessages(
   datatableUtilities: DatatableUtilitiesService,
   state: FormBasedPrivateState,

--- a/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
@@ -42,7 +42,7 @@ import {
   getReferencedColumnIds,
 } from './operations';
 
-import { getInvalidFieldMessage, isColumnOfType } from './operations/definitions/helpers';
+import { getWrongFieldTypeMessage, isColumnOfType } from './operations/definitions/helpers';
 import { FiltersIndexPatternColumn } from './operations/definitions/filters';
 import { hasField } from './pure_utils';
 import { mergeLayer } from './state_helpers';
@@ -129,7 +129,7 @@ export function fieldIsInvalid(
   if (!column || !hasField(column)) {
     return false;
   }
-  return !!getInvalidFieldMessage(column, indexPattern)?.length;
+  return !!getWrongFieldTypeMessage(column, indexPattern)?.length;
 }
 
 const accuracyModeDisabledWarning = (

--- a/x-pack/plugins/lens/public/shared_components/dimension_trigger/index.tsx
+++ b/x-pack/plugins/lens/public/shared_components/dimension_trigger/index.tsx
@@ -23,22 +23,22 @@ export const defaultDimensionTriggerTooltip = (
 export const DimensionTrigger = ({
   id,
   label,
-  isInvalid,
   hideTooltip,
-  invalidMessage = defaultDimensionTriggerTooltip,
+  problemSeverity,
+  problemMessage = defaultDimensionTriggerTooltip,
 }: {
   label: string;
   id: string;
-  isInvalid?: boolean;
   hideTooltip?: boolean;
-  invalidMessage?: string | JSX.Element;
+  problemSeverity?: 'warning' | 'error';
+  problemMessage?: string | JSX.Element;
 }) => {
-  if (isInvalid) {
+  if (problemSeverity) {
     return (
-      <EuiToolTip content={!hideTooltip ? invalidMessage : null} anchorClassName="eui-displayBlock">
+      <EuiToolTip content={!hideTooltip ? problemMessage : null} anchorClassName="eui-displayBlock">
         <EuiText
           size="s"
-          color="danger"
+          color={problemSeverity === 'warning' ? 'warning' : 'danger'}
           id={id}
           className="lnsLayerPanel__triggerText"
           data-test-subj="lns-dimensionTrigger"

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -870,8 +870,8 @@ export const getXyVisualization = ({
         <DimensionTrigger
           id={columnId}
           hideTooltip={hideTooltip}
-          isInvalid={invalid}
-          invalidMessage={invalidMessage}
+          problemSeverity={invalid ? 'error' : undefined}
+          problemMessage={invalidMessage}
           label={label || defaultAnnotationLabel}
         />
       );


### PR DESCRIPTION
## Summary

resolve https://github.com/elastic/kibana/issues/143673

### TODO
- [ ] change toast message?
<img width="428" alt="Screen Shot 2022-12-12 at 2 57 41 PM" src="https://user-images.githubusercontent.com/315764/207153121-c5413713-8aff-45f7-8084-00034a389f99.png">

- [ ] Do we still want a field warning?
- [ ] Surface errors on dashboard
- [ ] Is this warning now too strong?
<img width="300" alt="Screen Shot 2022-12-12 at 3 00 52 PM" src="https://user-images.githubusercontent.com/315764/207153530-64315657-b094-403c-ad6f-b1d6be726f3f.png">
- [ ] Functional test??

### Test
- [ ] data view that doesn't have any matching indices
- [ ] deleted runtime field
- [ ] conflict fields as warnings



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
