### PR TITLE
[8.6] [Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/alternative_tour/tour.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/alternative_tour/tour.tsx
@@ -6,6 +6,8 @@
  */
 
 import { EuiText, EuiTourStep } from '@elastic/eui';
+import useObservable from 'react-use/lib/useObservable';
+import { of } from 'rxjs';
 import React, { useCallback, useEffect, useState } from 'react';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '../../../../../../common/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -22,7 +24,15 @@ export const RulesPageTourComponent: React.FC<Props> = ({ children }) => {
     tourPopoverWidth: 300,
   };
 
-  const { storage } = useKibana().services;
+  const {
+    storage,
+    guidedOnboarding: { guidedOnboardingApi },
+  } = useKibana().services;
+
+  const isGuidedOnboardingActive = useObservable(
+    guidedOnboardingApi?.isGuideStepActive$('security', 'rules') ?? of(false),
+    true
+  );
 
   const [tourState, setTourState] = useState(() => {
     const restoredTourState = storage.get(NEW_FEATURES_TOUR_STORAGE_KEYS.RULE_MANAGEMENT_PAGE);
@@ -54,7 +64,9 @@ export const RulesPageTourComponent: React.FC<Props> = ({ children }) => {
   return (
     <EuiTourStep
       content={demoTourSteps[0].content}
-      isStepOpen={tourState.currentTourStep === 1 && tourState.isTourActive}
+      isStepOpen={
+        tourState.currentTourStep === 1 && tourState.isTourActive && !isGuidedOnboardingActive
+      }
       minWidth={tourState.tourPopoverWidth}
       onFinish={finishTour}
       step={1}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)](https://github.com/elastic/kibana/pull/146902)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marshall Main","email":"55718608+marshallmain@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-12-06T09:34:42Z","message":"[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)\n\nDue to the location of the guided onboarding tour, it can overlap with\r\nthe new features tour when a user is doing guided onboarding. This PR\r\ndisables the new features tour if the user is in the middle of guided\r\nonboarding.\r\n\r\nThere is still a remaining issue where after the user completes the 3\r\nsteps of the guided onboarding on the rules page, the\r\n`isGuideStepActive# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)](https://github.com/elastic/kibana/pull/146902)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  API returns `false` even though there is still a\r\ntooltip open for the `Continue with the guide` option. The new features\r\ntour overlaps with this option.\r\n\r\n![image](https://user-images.githubusercontent.com/55718608/205739417-fd19930d-a9c5-41ea-8f78-3adb4451ca16.png)","sha":"6d12ced52b554c8e6297372a4daf52ef26f134ac","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Detection Alerts","v8.6.0","v8.7.0"],"number":146902,"url":"https://github.com/elastic/kibana/pull/146902","mergeCommit":{"message":"[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)\n\nDue to the location of the guided onboarding tour, it can overlap with\r\nthe new features tour when a user is doing guided onboarding. This PR\r\ndisables the new features tour if the user is in the middle of guided\r\nonboarding.\r\n\r\nThere is still a remaining issue where after the user completes the 3\r\nsteps of the guided onboarding on the rules page, the\r\n`isGuideStepActive# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)](https://github.com/elastic/kibana/pull/146902)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  API returns `false` even though there is still a\r\ntooltip open for the `Continue with the guide` option. The new features\r\ntour overlaps with this option.\r\n\r\n![image](https://user-images.githubusercontent.com/55718608/205739417-fd19930d-a9c5-41ea-8f78-3adb4451ca16.png)","sha":"6d12ced52b554c8e6297372a4daf52ef26f134ac"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/146902","number":146902,"mergeCommit":{"message":"[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)\n\nDue to the location of the guided onboarding tour, it can overlap with\r\nthe new features tour when a user is doing guided onboarding. This PR\r\ndisables the new features tour if the user is in the middle of guided\r\nonboarding.\r\n\r\nThere is still a remaining issue where after the user completes the 3\r\nsteps of the guided onboarding on the rules page, the\r\n`isGuideStepActive# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Rules] Don't display new features tour if guided onboarding is active (#146902)](https://github.com/elastic/kibana/pull/146902)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  API returns `false` even though there is still a\r\ntooltip open for the `Continue with the guide` option. The new features\r\ntour overlaps with this option.\r\n\r\n![image](https://user-images.githubusercontent.com/55718608/205739417-fd19930d-a9c5-41ea-8f78-3adb4451ca16.png)","sha":"6d12ced52b554c8e6297372a4daf52ef26f134ac"}}]}] BACKPORT-->