### PR TITLE
[Lens][Visualize2Lens] Do not show warning modal if changed viz has been saved in Lens

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -492,6 +492,7 @@ export function App({
           })}
           buttonColor="danger"
           defaultFocusedButton="confirm"
+          data-test-subj="lnsApp_discardChangesModalOrigin"
         >
           {i18n.translate('xpack.lens.app.goBackModalMessage', {
             defaultMessage:

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -336,13 +336,13 @@ export function App({
       'vizEditorOriginatingAppUrl' in initialContext &&
       initialContext.vizEditorOriginatingAppUrl
     ) {
-      const initialDocFromContextHasChanged = !isLensEqual(
+      const [initialDocFromContextUnchanged, currentDocHasBeenSavedInLens] = [
         initialDocFromContext,
-        lastKnownDoc,
-        data.query.filterManager.inject,
-        datasourceMap
+        persistedDoc,
+      ].map((refDoc) =>
+        isLensEqual(refDoc, lastKnownDoc, data.query.filterManager.inject, datasourceMap)
       );
-      if (!initialDocFromContextHasChanged) {
+      if (initialDocFromContextUnchanged || currentDocHasBeenSavedInLens) {
         onAppLeave((actions) => {
           return actions.default();
         });
@@ -359,6 +359,7 @@ export function App({
     initialDocFromContext,
     lastKnownDoc,
     onAppLeave,
+    persistedDoc,
   ]);
 
   const navigateToVizEditor = useCallback(() => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/index.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/index.ts
@@ -76,5 +76,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     loadTestFile(require.resolve('./goal'));
     loadTestFile(require.resolve('./table'));
     loadTestFile(require.resolve('./heatmap'));
+    loadTestFile(require.resolve('./navigation'));
   });
 }

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/navigation.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/navigation.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { visualize, lens, timePicker } = getPageObjects(['visualize', 'lens', 'timePicker']);
+
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+
+  describe('Visualize to Lens and back', function describeIndexTests() {
+    before(async () => {
+      await visualize.initTests();
+    });
+
+    before(async () => {
+      await visualize.navigateToNewAggBasedVisualization();
+      await visualize.clickLineChart();
+      await visualize.clickNewSearch();
+      await timePicker.setDefaultAbsoluteRange();
+    });
+
+    it('should let the user return back to Visualize if no changes were made', async () => {
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('xyVisChart');
+
+      await retry.try(async () => {
+        expect(await lens.getLayerCount()).to.be(1);
+      });
+
+      await testSubjects.click('lnsApp_goBackToAppButton');
+
+      // it should be back to visualize now
+      await retry.try(async () => {
+        expect(await visualize.hasNavigateToLensButton()).to.eql(true);
+      });
+    });
+
+    it('should let the user return back to Visualize but show a warning modal if changes happened in Lens', async () => {
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('xyVisChart');
+
+      await retry.try(async () => {
+        expect(await lens.getLayerCount()).to.be(1);
+      });
+
+      // Make a change in Lens
+      await lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await testSubjects.click('lnsApp_goBackToAppButton');
+
+      // check that there's a modal
+      await retry.try(async () => {
+        await testSubjects.existOrFail('lnsApp_discardChangesModalOrigin');
+      });
+      // click on discard
+      await testSubjects.click('confirmModalConfirmButton');
+
+      await retry.try(async () => {
+        expect(await visualize.hasNavigateToLensButton()).to.eql(true);
+      });
+    });
+
+    it('should let the user return back to Visualize with no modal if changes have been saved in Lens', async () => {
+      await visualize.navigateToLensFromAnotherVisulization();
+      await lens.waitForVisualization('xyVisChart');
+
+      await retry.try(async () => {
+        expect(await lens.getLayerCount()).to.be(1);
+      });
+
+      // Make a change in Lens
+      await lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      // save in Lens new changes
+      await lens.save('Migrated Viz saved in Lens');
+
+      await testSubjects.click('lnsApp_goBackToAppButton');
+      await retry.try(async () => {
+        expect(await visualize.hasNavigateToLensButton()).to.eql(true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #146161 

This PR checks the current saveable state of the Lens visualization before prompting the "Discard changes" modal on navigating back to agg-based editor.
A new functional test suite has been added to test this route in different combinations.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
