### PR TITLE
 [Security Solution] Fix filtering on searching for lists

### DIFF
--- a/x-pack/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
@@ -94,9 +94,7 @@ export const SharedLists = React.memo(() => {
   const [referenceModalState, setReferenceModalState] = useState<ReferenceModalState>(
     exceptionReferenceModalInitialState
   );
-  const [filters, setFilters] = useState<ExceptionListFilter | undefined>({
-    types: [ExceptionListTypeEnum.DETECTION, ExceptionListTypeEnum.ENDPOINT],
-  });
+  const [filters, setFilters] = useState<ExceptionListFilter | undefined>();
 
   const [
     loadingExceptions,
@@ -108,7 +106,10 @@ export const SharedLists = React.memo(() => {
     setSort,
   ] = useExceptionLists({
     errorMessage: i18n.ERROR_EXCEPTION_LISTS,
-    filterOptions: filters,
+    filterOptions: {
+      ...filters,
+      types: [ExceptionListTypeEnum.DETECTION, ExceptionListTypeEnum.ENDPOINT],
+    },
     http,
     namespaceTypes: ['single', 'agnostic'],
     notifications,


### PR DESCRIPTION
## Summary

- Addresses https://github.com/elastic/kibana/issues/145677
- Use the filter of the list type every time we call the fetch list.
     - On search we need to append the ` types: [ExceptionListTypeEnum.DETECTION, ExceptionListTypeEnum.ENDPOINT],` to the users' filters, to filter out the other list type that should not be displayed on `Rule Exceptions` page



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->