### PR TITLE
Backport Fixing upgrade dashboard smoke test render error #147037 to 8.5

### DIFF
--- a/x-pack/test/upgrade/apps/dashboard/dashboard_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/dashboard/dashboard_smoke_tests.ts
@@ -54,6 +54,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         it('should render visualizations', async () => {
           await PageObjects.home.launchSampleDashboard('flights');
           await PageObjects.header.waitUntilLoadingHasFinished();
+          await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
           await renderable.waitForRender();
           log.debug('Checking saved searches rendered');
           await dashboardExpect.savedSearchRowCount(49);


### PR DESCRIPTION
Backport Fixing upgrade dashboard smoke test render error #[147037 ](https://github.com/elastic/kibana/pull/147037) to 8.5