### PR TITLE
[Index Management] Fix component template usage count sort

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_list.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/component_template_list.test.ts
@@ -46,7 +46,16 @@ describe('<ComponentTemplateList />', () => {
       isManaged: false,
     };
 
-    const componentTemplates = [componentTemplate1, componentTemplate2];
+    const componentTemplate3: ComponentTemplateListItem = {
+      name: 'test_component_template_3',
+      hasMappings: true,
+      hasAliases: true,
+      hasSettings: true,
+      usedBy: ['test_index_template_1', 'test_index_template_2'],
+      isManaged: false,
+    };
+
+    const componentTemplates = [componentTemplate1, componentTemplate2, componentTemplate3];
 
     httpRequestsMockHelpers.setLoadComponentTemplatesResponse(componentTemplates);
 
@@ -61,6 +70,26 @@ describe('<ComponentTemplateList />', () => {
 
         expect(row).toEqual(['', name, usedByText, '', '', '', 'EditDelete']);
       });
+    });
+
+    test('should sort "Usage count" column by number', async () => {
+      const { actions, table } = testBed;
+
+      // Sort ascending
+      await actions.clickTableColumnSortButton(1);
+
+      const { tableCellsValues: ascTableCellsValues } =
+        table.getMetaData('componentTemplatesTable');
+      const ascUsageCountValues = ascTableCellsValues.map((row) => row[2]);
+      expect(ascUsageCountValues).toEqual(['Not in use', '1', '2']);
+
+      // Sort descending
+      await actions.clickTableColumnSortButton(1);
+
+      const { tableCellsValues: descTableCellsValues } =
+        table.getMetaData('componentTemplatesTable');
+      const descUsageCountValues = descTableCellsValues.map((row) => row[2]);
+      expect(descUsageCountValues).toEqual(['2', '1', 'Not in use']);
     });
 
     test('should reload the component templates data', async () => {

--- a/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_list.helpers.ts
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/__jest__/client_integration/helpers/component_template_list.helpers.ts
@@ -32,7 +32,7 @@ export type ComponentTemplateListTestBed = TestBed<ComponentTemplateTestSubjects
 };
 
 const createActions = (testBed: TestBed) => {
-  const { find } = testBed;
+  const { find, component } = testBed;
 
   /**
    * User Actions
@@ -42,7 +42,7 @@ const createActions = (testBed: TestBed) => {
   };
 
   const clickComponentTemplateAt = async (index: number) => {
-    const { component, table, router } = testBed;
+    const { table, router } = testBed;
     const { rows } = table.getMetaData('componentTemplatesTable');
     const componentTemplateLink = findTestSubject(
       rows[index].reactWrapper,
@@ -55,6 +55,13 @@ const createActions = (testBed: TestBed) => {
       await nextTick();
       component.update();
     });
+  };
+
+  const clickTableColumnSortButton = async (index: number) => {
+    await act(async () => {
+      find('tableHeaderSortButton').at(index).simulate('click');
+    });
+    component.update();
   };
 
   const clickDeleteActionAt = (index: number) => {
@@ -70,6 +77,7 @@ const createActions = (testBed: TestBed) => {
     clickReloadButton,
     clickComponentTemplateAt,
     clickDeleteActionAt,
+    clickTableColumnSortButton,
   };
 };
 

--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_list/table.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_list/table.tsx
@@ -187,7 +187,7 @@ export const ComponentTable: FunctionComponent<Props> = ({
         name: i18n.translate('xpack.idxMgmt.componentTemplatesList.table.isInUseColumnTitle', {
           defaultMessage: 'Usage count',
         }),
-        sortable: true,
+        sortable: ({ usedBy }: ComponentTemplateListItem) => usedBy.length,
         render: (usedBy: string[]) => {
           if (usedBy.length) {
             return usedBy.length;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/146820

### Release note
The "Usage count" table column in the Component Templates UI can now be sorted in ascending and descending order.

![sort](https://user-images.githubusercontent.com/5226211/206080345-6ae8fe85-ce64-4fb7-8abe-463c9105234a.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->