### PR TITLE
[ci] Omit kibana-buildkite dev dependencies

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -23,7 +23,7 @@ if ! ts-node --version; then
 fi
 
 cd '.buildkite'
-retry 5 15 npm ci
+retry 5 15 npm ci -omit=dev
 cd ..
 
 echo '--- Agent Debug/SSH Info'


### PR DESCRIPTION
Drops the installed package count from 164 to 54.  If we want to run the test suites it probably makes more sense to setup a dedicated step than install on every step.