### PR TITLE
changed agent versions to agents per version telemetry

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
@@ -49,7 +49,10 @@ export const getAgentUsage = async (
 };
 
 export interface AgentData {
-  agent_versions: string[];
+  agents_per_version: Array<{
+    version: string;
+    count: number;
+  }>;
   agent_checkin_status: {
     error: number;
     degraded: number;
@@ -58,9 +61,9 @@ export interface AgentData {
 }
 
 const DEFAULT_AGENT_DATA = {
-  agent_versions: [],
   agent_checkin_status: { error: 0, degraded: 0 },
   agents_per_policy: [],
+  agents_per_version: [],
 };
 
 export const getAgentData = async (
@@ -105,8 +108,8 @@ export const getAgentData = async (
       },
       { signal: abortController.signal }
     );
-    const versions = ((response?.aggregations?.versions as any).buckets ?? []).map(
-      (bucket: any) => bucket.key
+    const agentsPerVersion = ((response?.aggregations?.versions as any).buckets ?? []).map(
+      (bucket: any) => ({ version: bucket.key, count: bucket.doc_count })
     );
     const statuses = transformLastCheckinStatusBuckets(response);
 
@@ -115,9 +118,9 @@ export const getAgentData = async (
     );
 
     return {
-      agent_versions: versions,
       agent_checkin_status: statuses,
       agents_per_policy: agentsPerPolicy,
+      agents_per_version: agentsPerVersion,
     };
   } catch (error) {
     if (error.statusCode === 404) {

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -265,7 +265,10 @@ describe('fleet usage telemetry', () => {
           num_host_urls: 0,
         },
         packages: [],
-        agent_versions: ['8.5.1', '8.6.0'],
+        agents_per_version: [
+          { version: '8.5.1', count: 1 },
+          { version: '8.6.0', count: 1 },
+        ],
         agent_checkin_status: { error: 1, degraded: 1 },
         agents_per_policy: [2],
         fleet_server_config: {

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -106,11 +106,13 @@ export const fleetUsagesSchema: RootSchema<any> = {
       },
     },
   },
-  agent_versions: {
+  agents_per_version: {
     type: 'array',
     items: {
-      type: 'keyword',
-      _meta: { description: 'The agent versions enrolled in this deployment.' },
+      properties: {
+        version: { type: 'keyword' },
+        count: { type: 'long' },
+      },
     },
   },
   agents_per_policy: {


### PR DESCRIPTION
## Summary

Changed the list of agent versions to agent count per version in fleet-usages telemetry as requested [here](https://github.com/elastic/kibana/pull/145353#issuecomment-1331783758).


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->