### PR TITLE
Fix flaky test for Observability > Rules Page

### DIFF
--- a/x-pack/test/observability_functional/apps/observability/pages/rules_page.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/rules_page.ts
@@ -65,13 +65,16 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/146450
-    describe.skip('Create rule button', () => {
+    describe('Create rule button', () => {
       it('Show Create Rule flyout when Create Rule button is clicked', async () => {
         await observability.alerts.common.navigateToRulesPage();
         await retry.waitFor(
           'Create Rule button is visible',
           async () => await testSubjects.exists('createRuleButton')
+        );
+        await retry.waitFor(
+          'Create Rule button is enabled',
+          async () => await testSubjects.isEnabled('createRuleButton')
         );
         await observability.alerts.rulesPage.clickCreateRuleButton();
         await retry.waitFor(


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/146450.

## Summary

Check if Create Rule button not only exists, but also is enabled. 

- [X] Ran the Flaky Test Runner on this branch with 50 iterations: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1634#0184ec8a-d86a-40a9-9e04-47936d9ec9f9 ✅