### PR TITLE
[performance] add APM data set extraction pipeline

### DIFF
--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -1,22 +1,23 @@
 steps:
-  - label: '👨‍🔧 Pre-Build'
+  - label: ':male-mechanic::skin-tone-2: Pre-Build'
     command: .buildkite/scripts/lifecycle/pre_build.sh
     agents:
       queue: kibana-default
+    timeout_in_minutes: 10
 
   - wait
 
-  - label: '🧑‍🏭 Build Kibana Distribution and Plugins'
+  - label: ':building_construction: Build Kibana Distribution and Plugins'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
       queue: c2-16
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
 
-  - label: '💪 Performance Tests with Playwright config'
+  - label: ':kibana: Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
     agents:
-      queue: kb-static-ubuntu
+      queue: n2-2
     depends_on: build
     key: tests
     timeout_in_minutes: 60
@@ -27,8 +28,8 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - label: '📈 Report performance metrics to ci-stats'
-    command: .buildkite/scripts/steps/functional/report_performance_metrics.sh
+  - label: ':ship: Single user journeys dataset extraction for scalability benchmarking'
+    command: .buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
     agents:
       queue: n2-2
     depends_on: tests
@@ -36,7 +37,7 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: '🦸 Post-Build'
+  - label: ':male_superhero::skin-tone-2: Post-Build'
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
       queue: kibana-default

--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -17,7 +17,7 @@ steps:
   - label: ':kibana: Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
     agents:
-      queue: n2-2
+      queue: n2-2-spot
     depends_on: build
     key: tests
     timeout_in_minutes: 60


### PR DESCRIPTION
## Summary

Part of #140828

PR for run yml file [elastic/kibana-buildkite/pull/67](https://github.com/elastic/kibana-buildkite/pull/67) 

This PR moves data set extraction step in separate pipeline, still reporting KIbana scalability and ES Rally output in Kibana-related bucket.

Reporting ES Rally data to required bucket will be added in the follow-up PR.   