### PR TITLE
[SecuritySolution] Inspect modal styling

### DIFF
--- a/x-pack/plugins/timelines/public/components/inspect/modal.tsx
+++ b/x-pack/plugins/timelines/public/components/inspect/modal.tsx
@@ -67,6 +67,8 @@ interface Response {
 }
 
 const MyEuiModal = styled(EuiModal)`
+  width: min(768px, calc(100vw - 16px));
+  min-height: 41vh;
   .euiModal__flex {
     width: 60vw;
   }


### PR DESCRIPTION
## Summary

Original issue: https://github.com/elastic/kibana/issues/145800
Previous fix: https://github.com/elastic/kibana/pull/146015
Previous fix missed to update the styles for x-pack/plugins/timelines/public/components/inspect/modal.tsx, so some of the inspect modal did not apply the same styling.

Steps to verify:
- Please check the inspect panels for hosts page - events table, users page - events table and alerts page - alerts table. Please check the modals' hight and width are the same as rest of the inspect modals on the page.
