### PR TITLE
fix cyclic imports in core packages

### DIFF
--- a/packages/core/metrics/core-metrics-collectors-server-internal/src/elasticsearch_client.test.ts
+++ b/packages/core/metrics/core-metrics-collectors-server-internal/src/elasticsearch_client.test.ts
@@ -8,13 +8,19 @@
 
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
-import { sampleEsClientMetrics } from '@kbn/core-metrics-server-mocks';
+import type { ElasticsearchClientsMetrics } from '@kbn/core-metrics-server';
 import { createAgentStoreMock } from '@kbn/core-elasticsearch-client-server-mocks';
 import { getAgentsSocketsStatsMock } from './get_agents_sockets_stats.test.mocks';
 import { ElasticsearchClientsMetricsCollector } from './elasticsearch_client';
 import { getAgentsSocketsStats } from './get_agents_sockets_stats';
 
 jest.mock('@kbn/core-elasticsearch-client-server-internal');
+
+export const sampleEsClientMetrics: ElasticsearchClientsMetrics = {
+  totalActiveSockets: 25,
+  totalIdleSockets: 2,
+  totalQueuedRequests: 0,
+};
 
 describe('ElasticsearchClientsMetricsCollector', () => {
   test('#collect calls getAgentsSocketsStats with the Agents managed by the provided AgentManager', async () => {

--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/src/utils/get_index_for_type.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/src/utils/get_index_for_type.test.ts
@@ -6,16 +6,22 @@
  * Side Public License, v 1.
  */
 
-import { typeRegistryMock } from '@kbn/core-saved-objects-base-server-mocks';
+import { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
 import { getIndexForType } from './get_index_for_type';
+
+const createTypeRegistry = () => {
+  return {
+    getIndex: jest.fn(),
+  } as unknown as jest.Mocked<ISavedObjectTypeRegistry>;
+};
 
 describe('getIndexForType', () => {
   const kibanaVersion = '8.0.0';
   const defaultIndex = '.kibana';
-  let typeRegistry: ReturnType<typeof typeRegistryMock.create>;
+  let typeRegistry: ReturnType<typeof createTypeRegistry>;
 
   beforeEach(() => {
-    typeRegistry = typeRegistryMock.create();
+    typeRegistry = createTypeRegistry();
   });
 
   it('returns the correct index for a type specifying a custom index', () => {


### PR DESCRIPTION
## Summary

Fix cyclic imports causes by `-impl` packages importing their mock counterparts
