### PR TITLE
[Security Solution] Global query string functionality improvements

### DIFF
--- a/packages/kbn-rison/kbn_rison.test.ts
+++ b/packages/kbn-rison/kbn_rison.test.ts
@@ -21,7 +21,7 @@ describe('encoding', () => {
   });
   it('throws if it received undefined', () => {
     expect(() => Rison.encode(undefined)).toThrowErrorMatchingInlineSnapshot(
-      `"unable to encode value into rison, expected a primative value array or object"`
+      `"unable to encode value into rison, expected a primitive value array or object"`
     );
   });
   it('encodes a complex object', () => {

--- a/packages/kbn-rison/kbn_rison.ts
+++ b/packages/kbn-rison/kbn_rison.ts
@@ -38,7 +38,7 @@ export function encode(obj: any) {
 /**
  * parse a rison string into a javascript structure.
  */
-export function decode<T>(rison: string): T | null {
+export function decode<T = RisonValue>(rison: string): T | null {
   // Rison is unable to handle an empty string
   if (rison.length === 0) {
     return null;

--- a/packages/kbn-rison/kbn_rison.ts
+++ b/packages/kbn-rison/kbn_rison.ts
@@ -39,12 +39,18 @@ export function encode(obj: any) {
  * parse a rison string into a javascript structure.
  */
 export function decode<T = RisonValue>(rison: string): T | null {
-  // Rison is unable to handle an empty string
-  if (rison.length === 0) {
+  return Rison.decode(rison);
+}
+
+/**
+ * safely parse a rison string into a javascript structure, never throws
+ */
+export function safeDecode<T = RisonValue>(rison: string): T | null {
+  try {
+    return decode(rison);
+  } catch {
     return null;
   }
-
-  return Rison.decode(rison);
 }
 
 /**

--- a/packages/kbn-rison/kbn_rison.ts
+++ b/packages/kbn-rison/kbn_rison.ts
@@ -29,7 +29,7 @@ export function encode(obj: any) {
   const rison = encodeUnknown(obj);
   if (rison === undefined) {
     throw new Error(
-      'unable to encode value into rison, expected a primative value array or object'
+      'unable to encode value into rison, expected a primitive value array or object'
     );
   }
   return rison;
@@ -38,7 +38,12 @@ export function encode(obj: any) {
 /**
  * parse a rison string into a javascript structure.
  */
-export function decode(rison: string): RisonValue {
+export function decode<T>(rison: string): T | null {
+  // Rison is unable to handle an empty string
+  if (rison.length === 0) {
+    return null;
+  }
+
   return Rison.decode(rison);
 }
 

--- a/packages/kbn-rison/kbn_rison.ts
+++ b/packages/kbn-rison/kbn_rison.ts
@@ -38,14 +38,14 @@ export function encode(obj: any) {
 /**
  * parse a rison string into a javascript structure.
  */
-export function decode<T = RisonValue>(rison: string): T | null {
+export function decode(rison: string): RisonValue {
   return Rison.decode(rison);
 }
 
 /**
  * safely parse a rison string into a javascript structure, never throws
  */
-export function safeDecode<T = RisonValue>(rison: string): T | null {
+export function safeDecode(rison: string): RisonValue {
   try {
     return decode(rison);
   } catch {

--- a/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.ts
+++ b/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.ts
@@ -5,16 +5,14 @@
  * 2.0.
  */
 
-import rison from '@kbn/rison';
 import type { FilterItemObj } from '../../public/common/components/filter_group/types';
 
 export const formatPageFilterSearchParam = (filters: FilterItemObj[]) => {
-  const modifiedFilters = filters.map((filter) => ({
+  return filters.map((filter) => ({
     title: filter.title ?? filter.fieldName,
     selectedOptions: filter.selectedOptions ?? [],
     fieldName: filter.fieldName,
     existsSelected: filter.existsSelected ?? false,
     exclude: filter.exclude ?? false,
   }));
-  return rison.encode(modifiedFilters);
 };

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { encode } from '@kbn/rison';
 import { getNewRule } from '../../objects/rule';
 import {
   CONTROL_FRAMES,
@@ -83,7 +84,7 @@ describe('Detections : Page Filters', () => {
     cy.url().then((url) => {
       const currURL = new URL(url);
 
-      currURL.searchParams.set('pageFilters', formatPageFilterSearchParam(NEW_FILTERS));
+      currURL.searchParams.set('pageFilters', encode(formatPageFilterSearchParam(NEW_FILTERS)));
       cy.visit(currURL.toString());
       waitForAlerts();
       assertFilterControlsWithFilterObject(NEW_FILTERS);
@@ -104,7 +105,7 @@ describe('Detections : Page Filters', () => {
     cy.url().then((url) => {
       const currURL = new URL(url);
 
-      currURL.searchParams.set('pageFilters', pageFilterUrlString);
+      currURL.searchParams.set('pageFilters', encode(pageFilterUrlString));
       cy.visit(currURL.toString());
 
       waitForAlerts();

--- a/x-pack/plugins/security_solution/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/cypress/tsconfig.json
@@ -26,6 +26,7 @@
     {
       "path": "../tsconfig.json",
       "force": true
-    }
+    },
+    "@kbn/rison"
   ]
 }

--- a/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
@@ -218,12 +218,9 @@ const useExternalAlertsInitialUrlState = () => {
   useEffect(() => {
     // Only called on component unmount
     return () => {
-      replaceUrlParams([
-        {
-          key: EXTERNAL_ALERTS_URL_PARAM,
-          value: null,
-        },
-      ]);
+      replaceUrlParams({
+        [EXTERNAL_ALERTS_URL_PARAM]: null,
+      });
     };
   }, [replaceUrlParams]);
 
@@ -236,11 +233,8 @@ const useExternalAlertsInitialUrlState = () => {
 const useSyncExternalAlertsUrlState = (showExternalAlerts: boolean) => {
   const replaceUrlParams = useReplaceUrlParams();
   useEffect(() => {
-    replaceUrlParams([
-      {
-        key: EXTERNAL_ALERTS_URL_PARAM,
-        value: showExternalAlerts ? true : null,
-      },
-    ]);
+    replaceUrlParams({
+      [EXTERNAL_ALERTS_URL_PARAM]: showExternalAlerts ? true : null,
+    });
   }, [showExternalAlerts, replaceUrlParams]);
 };

--- a/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
@@ -210,7 +210,7 @@ const useExternalAlertsInitialUrlState = () => {
 
   const getInitialUrlParamValue = useGetInitialUrlParamValue<boolean>(EXTERNAL_ALERTS_URL_PARAM);
 
-  const { decodedParam: showExternalAlertsInitialUrlState } = useMemo(
+  const showExternalAlertsInitialUrlState = useMemo(
     () => getInitialUrlParamValue(),
     [getInitialUrlParamValue]
   );
@@ -239,7 +239,7 @@ const useSyncExternalAlertsUrlState = (showExternalAlerts: boolean) => {
     replaceUrlParams([
       {
         key: EXTERNAL_ALERTS_URL_PARAM,
-        value: showExternalAlerts ? 'true' : null,
+        value: showExternalAlerts ? true : null,
       },
     ]);
   }, [showExternalAlerts, replaceUrlParams]);

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
@@ -7,7 +7,7 @@
 
 import type { Plugin } from 'unified';
 import type { RemarkTokenizer } from '@elastic/eui';
-import { decode } from '@kbn/rison';
+import { safeDecode } from '@kbn/rison';
 import { parse } from 'query-string';
 
 import { ID, PREFIX } from './constants';
@@ -73,9 +73,10 @@ export const TimelineParser: Plugin = function () {
     try {
       const timelineSearch = timelineUrl.split('?');
       const parseTimelineUrlSearch = parse(timelineSearch[1]) as { timeline: string };
-      const { id: timelineId = '', graphEventId = '' } = decode(
-        parseTimelineUrlSearch.timeline ?? ''
-      ) ?? { id: null, graphEventId: '' };
+      const { id: timelineId = '', graphEventId = '' } = safeDecode<{
+        id: string;
+        graphEventId: string;
+      }>(parseTimelineUrlSearch.timeline ?? '') ?? { id: null, graphEventId: '' };
 
       if (!timelineId) {
         this.file.info(i18n.NO_TIMELINE_ID_FOUND, {

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
@@ -73,10 +73,14 @@ export const TimelineParser: Plugin = function () {
     try {
       const timelineSearch = timelineUrl.split('?');
       const parseTimelineUrlSearch = parse(timelineSearch[1]) as { timeline: string };
-      const { id: timelineId = '', graphEventId = '' } = safeDecode<{
-        id: string;
-        graphEventId: string;
-      }>(parseTimelineUrlSearch.timeline ?? '') ?? { id: null, graphEventId: '' };
+      const decodedTimeline = safeDecode(parseTimelineUrlSearch.timeline ?? '') as {
+        id?: string;
+        graphEventId?: string;
+      } | null;
+      const { id: timelineId = '', graphEventId = '' } = decodedTimeline ?? {
+        id: null,
+        graphEventId: '',
+      };
 
       if (!timelineId) {
         this.file.info(i18n.NO_TIMELINE_ID_FOUND, {

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/parser.ts
@@ -7,8 +7,8 @@
 
 import type { Plugin } from 'unified';
 import type { RemarkTokenizer } from '@elastic/eui';
+import { decode } from '@kbn/rison';
 import { parse } from 'query-string';
-import { decodeRisonUrlState } from '../../../../utils/global_query_string/helpers';
 
 import { ID, PREFIX } from './constants';
 import * as i18n from './translations';
@@ -73,7 +73,7 @@ export const TimelineParser: Plugin = function () {
     try {
       const timelineSearch = timelineUrl.split('?');
       const parseTimelineUrlSearch = parse(timelineSearch[1]) as { timeline: string };
-      const { id: timelineId = '', graphEventId = '' } = decodeRisonUrlState(
+      const { id: timelineId = '', graphEventId = '' } = decode(
         parseTimelineUrlSearch.timeline ?? ''
       ) ?? { id: null, graphEventId: '' };
 

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.test.ts
@@ -93,7 +93,7 @@ describe('queryTimelineByIdOnUrlChange', () => {
       mockUseLocation.mockReturnValue({ search: oldTimelineRisonSearchString });
 
       const { rerender } = renderHook(() => useQueryTimelineByIdOnUrlChange());
-      mockUseLocation.mockReturnValue({ search: '?timeline=!invalid' });
+      mockUseLocation.mockReturnValue({ search: '?foo=bar' });
 
       rerender();
 

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.test.ts
@@ -7,7 +7,6 @@
 
 import { queryTimelineById } from '../../../timelines/components/open_timeline/helpers';
 import { useQueryTimelineByIdOnUrlChange } from './use_query_timeline_by_id_on_url_change';
-import * as urlHelpers from '../../utils/global_query_string/helpers';
 import { renderHook } from '@testing-library/react-hooks';
 import { timelineDefaults } from '../../../timelines/store/timeline/defaults';
 
@@ -91,15 +90,11 @@ describe('queryTimelineByIdOnUrlChange', () => {
 
   describe('when decode rison fails', () => {
     it('should not call queryTimelineById', () => {
-      jest.spyOn(urlHelpers, 'decodeRisonUrlState').mockImplementationOnce(() => {
-        throw new Error('Unable to decode');
-      });
-
       mockUseLocation.mockReturnValue({ search: oldTimelineRisonSearchString });
 
       const { rerender } = renderHook(() => useQueryTimelineByIdOnUrlChange());
-      mockUseLocation.mockReturnValue({ search: newTimelineRisonSearchString });
-      jest.clearAllMocks();
+      mockUseLocation.mockReturnValue({ search: '?timeline=!invalid' });
+
       rerender();
 
       expect(queryTimelineById).not.toBeCalled();

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
@@ -54,7 +54,10 @@ export const useQueryTimelineByIdOnUrlChange = () => {
     const newUrlStateString = getQueryStringKeyValue({ urlKey: URL_PARAM_KEY.timeline, search });
 
     return oldUrlStateString != null && newUrlStateString != null
-      ? [safeDecode<TimelineUrl>(oldUrlStateString), safeDecode<TimelineUrl>(newUrlStateString)]
+      ? [
+          safeDecode(oldUrlStateString) as TimelineUrl | null,
+          safeDecode(newUrlStateString) as TimelineUrl | null,
+        ]
       : [null, null];
   }, [oldSearch, search]);
 

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
@@ -10,6 +10,7 @@ import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import usePrevious from 'react-use/lib/usePrevious';
 import { useDispatch } from 'react-redux';
+import { decode } from '@kbn/rison';
 import type { TimelineUrl } from '../../../timelines/store/timeline/model';
 import { timelineActions, timelineSelectors } from '../../../timelines/store/timeline';
 import { TimelineId, TimelineTabs } from '../../../../common/types';
@@ -20,7 +21,6 @@ import {
   queryTimelineById,
 } from '../../../timelines/components/open_timeline/helpers';
 import {
-  decodeRisonUrlState,
   getParamFromQueryString,
   getQueryStringFromLocation,
 } from '../../utils/global_query_string/helpers';
@@ -55,17 +55,17 @@ export const useQueryTimelineByIdOnUrlChange = () => {
     const newUrlStateString = getQueryStringKeyValue({ urlKey: URL_PARAM_KEY.timeline, search });
 
     if (oldUrlStateString != null && newUrlStateString != null) {
-      let newTimeline = null;
-      let oldTimeline = null;
+      let newTimeline: TimelineUrl | null = null;
+      let oldTimeline: TimelineUrl | null = null;
 
       try {
-        newTimeline = decodeRisonUrlState<TimelineUrl>(newUrlStateString);
+        newTimeline = decode(newUrlStateString);
       } catch (error) {
         // do nothing as timeline is defaulted to null
       }
 
       try {
-        oldTimeline = decodeRisonUrlState<TimelineUrl>(oldUrlStateString);
+        oldTimeline = decode(oldUrlStateString);
       } catch (error) {
         // do nothing as timeline is defaulted to null
       }

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
@@ -10,7 +10,7 @@ import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import usePrevious from 'react-use/lib/usePrevious';
 import { useDispatch } from 'react-redux';
-import { decode } from '@kbn/rison';
+import { safeDecode } from '@kbn/rison';
 import type { TimelineUrl } from '../../../timelines/store/timeline/model';
 import { timelineActions, timelineSelectors } from '../../../timelines/store/timeline';
 import { TimelineId, TimelineTabs } from '../../../../common/types';
@@ -51,29 +51,11 @@ export const useQueryTimelineByIdOnUrlChange = () => {
       urlKey: URL_PARAM_KEY.timeline,
       search: oldSearch ?? '',
     });
-
     const newUrlStateString = getQueryStringKeyValue({ urlKey: URL_PARAM_KEY.timeline, search });
 
-    if (oldUrlStateString != null && newUrlStateString != null) {
-      let newTimeline: TimelineUrl | null = null;
-      let oldTimeline: TimelineUrl | null = null;
-
-      try {
-        newTimeline = decode(newUrlStateString);
-      } catch (error) {
-        // do nothing as timeline is defaulted to null
-      }
-
-      try {
-        oldTimeline = decode(oldUrlStateString);
-      } catch (error) {
-        // do nothing as timeline is defaulted to null
-      }
-
-      return [oldTimeline, newTimeline];
-    }
-
-    return [null, null];
+    return oldUrlStateString != null && newUrlStateString != null
+      ? [safeDecode<TimelineUrl>(oldUrlStateString), safeDecode<TimelineUrl>(newUrlStateString)]
+      : [null, null];
   }, [oldSearch, search]);
 
   const oldId = previousTimeline?.id;

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.test.tsx
@@ -9,7 +9,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useDeepEqualSelector } from './use_selector';
 import { useKibana } from '../lib/kibana';
 import { useResolveConflict } from './use_resolve_conflict';
-import * as urlHelpers from '../utils/global_query_string/helpers';
 
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
@@ -127,9 +126,6 @@ describe('useResolveConflict', () => {
 
     describe('rison is unable to be decoded', () => {
       it('should use timeline values from redux to create the otherObjectPath', async () => {
-        jest.spyOn(urlHelpers, 'decodeRisonUrlState').mockImplementation(() => {
-          throw new Error('Unable to decode');
-        });
         (useLocation as jest.Mock).mockReturnValue({
           pathname: 'my/cool/path',
           search: '?foo=bar',

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
@@ -8,12 +8,12 @@
 import React, { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { EuiSpacer } from '@elastic/eui';
+import { decode, encode } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';
 import type { TimelineUrl } from '../../timelines/store/timeline/model';
 import { timelineDefaults } from '../../timelines/store/timeline/defaults';
-import { decodeRisonUrlState, encodeRisonUrlState } from '../utils/global_query_string/helpers';
 import { useKibana } from '../lib/kibana';
 import { URL_PARAM_KEY } from './use_url_state';
 
@@ -55,7 +55,7 @@ export const useResolveConflict = () => {
     };
     let timelineSearch: TimelineUrl = currentTimelineState;
     try {
-      timelineSearch = decodeRisonUrlState(timelineRison) ?? currentTimelineState;
+      timelineSearch = decode(timelineRison ?? '') ?? currentTimelineState;
     } catch (error) {
       // do nothing as it's already defaulted on line 77
     }
@@ -68,7 +68,7 @@ export const useResolveConflict = () => {
       ...timelineSearch,
       id: newSavedObjectId,
     };
-    const newTimelineRison = encodeRisonUrlState(newTimelineSearch);
+    const newTimelineRison = encode(newTimelineSearch);
     searchQuery.set(URL_PARAM_KEY.timeline, newTimelineRison);
 
     const newPath = `${pathname}?${searchQuery.toString()}${window.location.hash}`;

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { EuiSpacer } from '@elastic/eui';
-import { safeDecode, encode, RisonValue } from '@kbn/rison';
+import { safeDecode, encode } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { EuiSpacer } from '@elastic/eui';
-import { decode, encode } from '@kbn/rison';
+import { safeDecode, encode } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';
@@ -53,12 +53,8 @@ export const useResolveConflict = () => {
       activeTab,
       graphEventId,
     };
-    let timelineSearch: TimelineUrl = currentTimelineState;
-    try {
-      timelineSearch = decode(timelineRison ?? '') ?? currentTimelineState;
-    } catch (error) {
-      // do nothing as it's already defaulted on line 77
-    }
+    const timelineSearch = safeDecode<TimelineUrl>(timelineRison ?? '') ?? currentTimelineState;
+
     // We have resolved to one object, but another object has a legacy URL alias associated with this ID/page. We should display a
     // callout with a warning for the user, and provide a way for them to navigate to the other object.
     const currentObjectId = timelineSearch?.id;

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { EuiSpacer } from '@elastic/eui';
-import { safeDecode, encode } from '@kbn/rison';
+import { safeDecode, encode, RisonValue } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';
@@ -53,7 +53,8 @@ export const useResolveConflict = () => {
       activeTab,
       graphEventId,
     };
-    const timelineSearch = safeDecode<TimelineUrl>(timelineRison ?? '') ?? currentTimelineState;
+    const timelineSearch =
+      (safeDecode(timelineRison ?? '') as TimelineUrl | null) ?? currentTimelineState;
 
     // We have resolved to one object, but another object has a legacy URL alias associated with this ID/page. We should display a
     // callout with a warning for the user, and provide a way for them to navigate to the other object.

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.test.ts
@@ -10,7 +10,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useDeepEqualSelector } from './use_selector';
 import { useKibana } from '../lib/kibana';
 import { useResolveRedirect } from './use_resolve_redirect';
-import * as urlHelpers from '../utils/global_query_string/helpers';
 
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
@@ -20,6 +19,7 @@ jest.mock('react-router-dom', () => {
     useLocation: jest.fn(),
   };
 });
+// jest.mock('@kbn/rison');
 jest.mock('../lib/kibana');
 jest.mock('./use_selector');
 jest.mock('../../timelines/store/timeline', () => ({
@@ -101,9 +101,6 @@ describe('useResolveRedirect', () => {
 
     describe('rison is unable to be decoded', () => {
       it('should use timeline values from redux to create the redirect path', async () => {
-        jest.spyOn(urlHelpers, 'decodeRisonUrlState').mockImplementation(() => {
-          throw new Error('Unable to decode');
-        });
         (useLocation as jest.Mock).mockReturnValue({
           pathname: 'my/cool/path',
           search: '?foo=bar',

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.test.ts
@@ -19,7 +19,6 @@ jest.mock('react-router-dom', () => {
     useLocation: jest.fn(),
   };
 });
-// jest.mock('@kbn/rison');
 jest.mock('../lib/kibana');
 jest.mock('./use_selector');
 jest.mock('../../timelines/store/timeline', () => ({

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
@@ -42,7 +42,8 @@ export const useResolveRedirect = () => {
       activeTab,
       graphEventId,
     };
-    const timelineSearch = safeDecode<TimelineUrl>(timelineRison ?? '') ?? currentTimelineState;
+    const timelineSearch =
+      (safeDecode(timelineRison ?? '') as TimelineUrl | null) ?? currentTimelineState;
 
     if (
       hasRedirected ||

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { decode, encode } from '@kbn/rison';
+import { safeDecode, encode } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';
@@ -42,12 +42,7 @@ export const useResolveRedirect = () => {
       activeTab,
       graphEventId,
     };
-    let timelineSearch: TimelineUrl = currentTimelineState;
-    try {
-      timelineSearch = decode(timelineRison ?? '') ?? currentTimelineState;
-    } catch (error) {
-      // do nothing as it's already defaulted on line 77
-    }
+    const timelineSearch = safeDecode<TimelineUrl>(timelineRison ?? '') ?? currentTimelineState;
 
     if (
       hasRedirected ||

--- a/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_resolve_redirect.ts
@@ -7,11 +7,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { decode, encode } from '@kbn/rison';
 import { useDeepEqualSelector } from './use_selector';
 import { TimelineId } from '../../../common/types/timeline';
 import { timelineSelectors } from '../../timelines/store/timeline';
 import { timelineDefaults } from '../../timelines/store/timeline/defaults';
-import { decodeRisonUrlState, encodeRisonUrlState } from '../utils/global_query_string/helpers';
 import { useKibana } from '../lib/kibana';
 import type { TimelineUrl } from '../../timelines/store/timeline/model';
 import { URL_PARAM_KEY } from './use_url_state';
@@ -44,7 +44,7 @@ export const useResolveRedirect = () => {
     };
     let timelineSearch: TimelineUrl = currentTimelineState;
     try {
-      timelineSearch = decodeRisonUrlState(timelineRison) ?? currentTimelineState;
+      timelineSearch = decode(timelineRison ?? '') ?? currentTimelineState;
     } catch (error) {
       // do nothing as it's already defaulted on line 77
     }
@@ -64,7 +64,7 @@ export const useResolveRedirect = () => {
       ...timelineSearch,
       id: newObjectId,
     };
-    const newTimelineRison = encodeRisonUrlState(newTimelineSearch);
+    const newTimelineRison = encode(newTimelineSearch);
     searchQuery.set(URL_PARAM_KEY.timeline, newTimelineRison);
     const newPath = `${pathname}?${searchQuery.toString()}`;
     spaces.ui.redirectLegacyUrl({

--- a/x-pack/plugins/security_solution/public/common/store/global_url_param/actions.ts
+++ b/x-pack/plugins/security_solution/public/common/store/global_url_param/actions.ts
@@ -5,16 +5,17 @@
  * 2.0.
  */
 
+import type { RisonValue } from '@kbn/rison';
 import actionCreatorFactory from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory('x-pack/security_solution/local/global_url_param');
 
-export const registerUrlParam = actionCreator<{ key: string; initialValue: string | null }>(
+export const registerUrlParam = actionCreator<{ key: string; initialValue: RisonValue | null }>(
   'REGISTER_URL_PARAM'
 );
 
 export const deregisterUrlParam = actionCreator<{ key: string }>('DEREGISTER_URL_PARAM');
 
-export const updateUrlParam = actionCreator<{ key: string; value: string | null }>(
+export const updateUrlParam = actionCreator<{ key: string; value: RisonValue | null }>(
   'UPDATE_URL_PARAM'
 );

--- a/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import type { RisonValue } from '@kbn/rison';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { registerUrlParam, updateUrlParam, deregisterUrlParam } from './actions';
 
-export type GlobalUrlParam = Record<string, string | null>;
+export type GlobalUrlParam = Record<string, RisonValue | null>;
 
 export const initialGlobalUrlParam: GlobalUrlParam = {};
 

--- a/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
@@ -6,6 +6,7 @@
  */
 
 import type { RisonValue } from '@kbn/rison';
+import deepEqual from 'fast-deep-equal';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { registerUrlParam, updateUrlParam, deregisterUrlParam } from './actions';
 
@@ -35,6 +36,10 @@ export const globalUrlParamReducer = reducerWithInitialState(initialGlobalUrlPar
     return nextState;
   })
   .case(updateUrlParam, (state, { key, value }) => {
+    if (state[key] === undefined || deepEqual(state[key], value)) {
+      return state;
+    }
+
     return {
       ...state,
       [key]: value,

--- a/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/global_url_param/reducer.ts
@@ -35,11 +35,6 @@ export const globalUrlParamReducer = reducerWithInitialState(initialGlobalUrlPar
     return nextState;
   })
   .case(updateUrlParam, (state, { key, value }) => {
-    // Only update the URL after the query param is registered and if the current value is different than the previous value
-    if (state[key] === undefined || state[key] === value) {
-      return state;
-    }
-
     return {
       ...state,
       [key]: value,

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
@@ -48,7 +48,7 @@ export const useGetInitialUrlParamValue = <State extends RisonValue>(
       getQueryStringFromLocation(window.location.search),
       urlParamKey
     );
-    const paramValue = safeDecode<State>(rawParamValue ?? '');
+    const paramValue = safeDecode(rawParamValue ?? '') as State | null;
 
     return paramValue;
   }, [urlParamKey]);

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { decode, encode } from '@kbn/rison';
+import { decode } from '@kbn/rison';
 import type { ParsedQuery } from 'query-string';
 import { parse, stringify } from 'query-string';
 import { url } from '@kbn/kibana-utils-plugin/public';
@@ -18,20 +18,6 @@ export const isDetectionsPages = (pageName: string) =>
   pageName === SecurityPageName.rules ||
   pageName === SecurityPageName.rulesCreate ||
   pageName === SecurityPageName.exceptions;
-
-export const decodeRisonUrlState = <T>(value: string | undefined): T | null => {
-  try {
-    return value ? (decode(value) as unknown as T) : null;
-  } catch (error) {
-    if (error instanceof Error && error.message.startsWith('rison decoder error')) {
-      return null;
-    }
-    throw error;
-  }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const encodeRisonUrlState = (state: any) => encode(state);
 
 export const getQueryStringFromLocation = (search: string) => search.substring(1);
 
@@ -60,7 +46,7 @@ export const useGetInitialUrlParamValue = <State>(urlParamKey: string) => {
       urlParamKey
     );
 
-    const decodedParam = decodeRisonUrlState<State>(param ?? undefined);
+    const decodedParam = decode<State>(param ?? '');
 
     return { param, decodedParam };
   }, [urlParamKey]);

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
@@ -59,20 +59,20 @@ export const useGetInitialUrlParamValue = <State extends RisonValue>(
 export const encodeQueryString = (urlParams: ParsedQuery<string>): string =>
   stringify(url.encodeQuery(urlParams), { sort: false, encode: false });
 
-export const useReplaceUrlParams = (): ((
-  params: Array<{ key: string; value: RisonValue | null }>
-) => void) => {
+export const useReplaceUrlParams = (): ((params: Record<string, RisonValue | null>) => void) => {
   const history = useHistory();
 
   const replaceUrlParams = useCallback(
-    (params: Array<{ key: string; value: RisonValue | null }>): void => {
+    (params: Record<string, RisonValue | null>): void => {
       // window.location.search provides the most updated representation of the url search.
       // It prevents unnecessary re-renders which useLocation would create because 'replaceUrlParams' does update the location.
       // window.location.search also guarantees that we don't overwrite URL param managed outside react-router.
       const search = window.location.search;
       const urlParams = parse(search, { sort: false });
 
-      params.forEach(({ key, value }) => {
+      Object.keys(params).forEach((key) => {
+        const value = params[key];
+
         if (value == null || value === '') {
           delete urlParams[key];
           return;

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import type { RisonValue } from '@kbn/rison';
-import { decode, encode } from '@kbn/rison';
+import { safeDecode, encode } from '@kbn/rison';
 import type { ParsedQuery } from 'query-string';
 import { parse, stringify } from 'query-string';
 import { url } from '@kbn/kibana-utils-plugin/public';
@@ -48,7 +48,7 @@ export const useGetInitialUrlParamValue = <State extends RisonValue>(
       getQueryStringFromLocation(window.location.search),
       urlParamKey
     );
-    const paramValue = decode<State>(rawParamValue ?? '');
+    const paramValue = safeDecode<State>(rawParamValue ?? '');
 
     return paramValue;
   }, [urlParamKey]);

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
@@ -187,6 +187,8 @@ describe('global query string', () => {
           globalUrlParam: {
             testNumber: 123,
             testObject: { testKey: 321 },
+            testEmptyObject: {},
+            testEmptyArray: [],
             testNull: null,
             testEmptyString: '',
           },
@@ -201,9 +203,7 @@ describe('global query string', () => {
 
       const { result } = renderHook(() => useGlobalQueryString(), { wrapper });
 
-      expect(result.current).toEqual(
-        `testNumber=123&testObject=(testKey:321)&testNull=!n&testEmptyString=''`
-      );
+      expect(result.current).toEqual(`testNumber=123&testObject=(testKey:321)`);
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
@@ -130,7 +130,7 @@ describe('global query string', () => {
       expect(mockDispatch).toBeCalledWith(
         globalUrlParamActions.registerUrlParam({
           key: urlParamKey,
-          initialValue: initialValue.toString(),
+          initialValue: initialValue,
         })
       );
     });
@@ -140,7 +140,6 @@ describe('global query string', () => {
     it('dispatch updateUrlParam action', () => {
       const urlParamKey = 'testKey';
       const value = { test: 123 };
-      const encodedVaue = '(test:123)';
 
       const globalUrlParam = {
         [urlParamKey]: 'oldValue',
@@ -156,7 +155,7 @@ describe('global query string', () => {
       expect(mockDispatch).toBeCalledWith(
         globalUrlParamActions.updateUrlParam({
           key: urlParamKey,
-          value: encodedVaue,
+          value,
         })
       );
     });
@@ -186,10 +185,10 @@ describe('global query string', () => {
         {
           ...mockGlobalState,
           globalUrlParam: {
-            testNumber: '123',
-            testObject: '(test:321)',
+            testNumber: 123,
+            testObject: { testKey: 321 },
             testNull: null,
-            testEmpty: '',
+            testEmptyString: '',
           },
         },
         SUB_PLUGINS_REDUCER,
@@ -202,7 +201,9 @@ describe('global query string', () => {
 
       const { result } = renderHook(() => useGlobalQueryString(), { wrapper });
 
-      expect(result.current).toEqual('testNumber=123&testObject=(test:321)');
+      expect(result.current).toEqual(
+        `testNumber=123&testObject=(testKey:321)&testNull=!n&testEmptyString=''`
+      );
     });
   });
 
@@ -218,7 +219,7 @@ describe('global query string', () => {
       renderHook(() => useSyncGlobalQueryString(), { wrapper: makeWrapper(globalUrlParam) });
 
       expect(mockHistory.replace).toHaveBeenCalledWith({
-        search: `firstKey=111&${urlParamKey}=${value}&lastKey=999`,
+        search: `firstKey=111&${urlParamKey}='${value}'&lastKey=999`,
       });
     });
 
@@ -236,7 +237,7 @@ describe('global query string', () => {
       renderHook(() => useSyncGlobalQueryString(), { wrapper: makeWrapper(globalUrlParam) });
 
       expect(mockHistory.replace).toHaveBeenCalledWith({
-        search: `${urlParamKey1}=${value1}&${urlParamKey2}=${value2}`,
+        search: `${urlParamKey1}='${value1}'&${urlParamKey2}='${value2}'`,
       });
     });
 

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
@@ -130,7 +130,7 @@ describe('global query string', () => {
       expect(mockDispatch).toBeCalledWith(
         globalUrlParamActions.registerUrlParam({
           key: urlParamKey,
-          initialValue: initialValue,
+          initialValue,
         })
       );
     });

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -107,12 +107,6 @@ export const useSyncGlobalQueryString = () => {
   const previousGlobalUrlParams = usePrevious(globalUrlParam);
   const replaceUrlParams = useReplaceUrlParams();
 
-  // Url params that got deleted from GlobalUrlParams
-  const unregisteredKeys = useMemo(
-    () => difference(Object.keys(previousGlobalUrlParams ?? {}), Object.keys(globalUrlParam)),
-    [previousGlobalUrlParams, globalUrlParam]
-  );
-
   useEffect(() => {
     const linkInfo = getLinkInfo(pageName) ?? { skipUrlState: true };
     const paramsToUpdate = { ...globalUrlParam };
@@ -123,6 +117,12 @@ export const useSyncGlobalQueryString = () => {
       });
     }
 
+    // Url params that got deleted from GlobalUrlParams
+    const unregisteredKeys = difference(
+      Object.keys(previousGlobalUrlParams ?? {}),
+      Object.keys(globalUrlParam)
+    );
+
     // Delete unregistered Url params
     unregisteredKeys.forEach((key) => {
       paramsToUpdate[key] = null;
@@ -131,5 +131,5 @@ export const useSyncGlobalQueryString = () => {
     if (Object.keys(paramsToUpdate).length > 0) {
       replaceUrlParams(paramsToUpdate);
     }
-  }, [globalUrlParam, pageName, unregisteredKeys, replaceUrlParams]);
+  }, [previousGlobalUrlParams, globalUrlParam, pageName, replaceUrlParams]);
 };

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -84,8 +84,14 @@ export const useGlobalQueryString = (): string => {
     }
 
     Object.keys(globalUrlParam).forEach((paramName) => {
+      const value = globalUrlParam[paramName];
+
+      if (isEmpty(value)) {
+        return;
+      }
+
       try {
-        encodedGlobalUrlParam[paramName] = encode(globalUrlParam[paramName]);
+        encodedGlobalUrlParam[paramName] = encode(value);
       } catch {
         // Just ignore parameters which unable to encode
       }

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -80,6 +80,10 @@ export const useGlobalQueryString = (): string => {
   const globalQueryString = useMemo(() => {
     const encodedGlobalUrlParam: Record<string, string> = {};
 
+    if (!globalUrlParam) {
+      return '';
+    }
+
     Object.keys(globalUrlParam).forEach((paramName) => {
       try {
         encodedGlobalUrlParam[paramName] = encode(globalUrlParam[paramName]);

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -9,12 +9,8 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { difference, isEmpty, pickBy } from 'lodash/fp';
 import { useDispatch } from 'react-redux';
 import usePrevious from 'react-use/lib/usePrevious';
-import {
-  encodeQueryString,
-  encodeRisonUrlState,
-  useGetInitialUrlParamValue,
-  useReplaceUrlParams,
-} from './helpers';
+import { encode } from '@kbn/rison';
+import { encodeQueryString, useGetInitialUrlParamValue, useReplaceUrlParams } from './helpers';
 import { useShallowEqualSelector } from '../../hooks/use_selector';
 import { globalUrlParamActions, globalUrlParamSelectors } from '../../store/global_url_param';
 import { useRouteSpy } from '../route/use_route_spy';
@@ -70,7 +66,7 @@ export const useUpdateUrlParam = <State>(urlParamKey: string) => {
 
   const updateUrlParam = useCallback(
     (value: State | null) => {
-      const encodedValue = value !== null ? encodeRisonUrlState(value) : null;
+      const encodedValue = value !== null ? encode(value) : null;
       dispatch(globalUrlParamActions.updateUrlParam({ key: urlParamKey, value: encodedValue }));
     },
     [dispatch, urlParamKey]

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -86,7 +86,7 @@ export const useGlobalQueryString = (): string => {
     Object.keys(globalUrlParam).forEach((paramName) => {
       const value = globalUrlParam[paramName];
 
-      if (isEmpty(value)) {
+      if (!value || (typeof value === 'object' && isEmpty(value))) {
         return;
       }
 

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -26,7 +26,7 @@ import { getLinkInfo } from '../../links';
  * @param urlParamKey Must not change.
  * @param onInitialize Called once when initializing. It must not change.
  */
-export const useInitializeUrlParam = <State extends RisonValue>(
+export const useInitializeUrlParam = <State extends {}>(
   urlParamKey: string,
   /**
    * @param state Decoded URL param value.
@@ -35,7 +35,7 @@ export const useInitializeUrlParam = <State extends RisonValue>(
 ) => {
   const dispatch = useDispatch();
 
-  const getInitialUrlParamValue = useGetInitialUrlParamValue<State>(urlParamKey);
+  const getInitialUrlParamValue = useGetInitialUrlParamValue(urlParamKey);
 
   useEffect(() => {
     const value = getInitialUrlParamValue();
@@ -48,7 +48,7 @@ export const useInitializeUrlParam = <State extends RisonValue>(
     );
 
     // execute consumer initialization
-    onInitialize(value);
+    onInitialize(value as State);
 
     return () => {
       dispatch(globalUrlParamActions.deregisterUrlParam({ key: urlParamKey }));
@@ -62,7 +62,7 @@ export const useInitializeUrlParam = <State extends RisonValue>(
  *
  * Make sure to call `useInitializeUrlParam` before calling this function.
  */
-export const useUpdateUrlParam = <State extends RisonValue>(urlParamKey: string) => {
+export const useUpdateUrlParam = <State extends {}>(urlParamKey: string) => {
   const dispatch = useDispatch();
 
   const updateUrlParam = useCallback(

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -112,21 +112,21 @@ export const useSyncGlobalQueryString = () => {
 
   useEffect(() => {
     const linkInfo = getLinkInfo(pageName) ?? { skipUrlState: true };
-    const params = Object.entries(globalUrlParam).map(([key, value]) => ({
-      key,
-      value: linkInfo.skipUrlState ? null : value,
-    }));
+    const paramsToUpdate = { ...globalUrlParam };
+
+    if (linkInfo.skipUrlState) {
+      Object.keys(paramsToUpdate).forEach((key) => {
+        paramsToUpdate[key] = null;
+      });
+    }
 
     // Delete unregistered Url params
     unregisteredKeys.forEach((key) => {
-      params.push({
-        key,
-        value: null,
-      });
+      paramsToUpdate[key] = null;
     });
 
-    if (params.length > 0) {
-      replaceUrlParams(params);
+    if (Object.keys(paramsToUpdate).length > 0) {
+      replaceUrlParams(paramsToUpdate);
     }
   }, [globalUrlParam, pageName, unregisteredKeys, replaceUrlParams]);
 };

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { difference, isEmpty, pickBy } from 'lodash/fp';
 import { useDispatch } from 'react-redux';
 import usePrevious from 'react-use/lib/usePrevious';
-import type { RisonValue } from '@kbn/rison';
 import { encode } from '@kbn/rison';
 import { encodeQueryString, useGetInitialUrlParamValue, useReplaceUrlParams } from './helpers';
 import { useShallowEqualSelector } from '../../hooks/use_selector';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/__mocks__/mock_rules_table_persistent_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/__mocks__/mock_rules_table_persistent_state.ts
@@ -19,9 +19,7 @@ export function mockRulesTablePersistedState({
   urlState: RulesTableUrlSavedState | null;
   storageState: RulesTableStorageSavedState | null;
 }): void {
-  (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(
-    jest.fn().mockReturnValue({ decodedParam: urlState })
-  );
+  (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(jest.fn().mockReturnValue(urlState));
   (useKibana as jest.Mock).mockReturnValue({
     services: { sessionStorage: { get: jest.fn().mockReturnValue(storageState) } },
   });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.ts
@@ -62,7 +62,7 @@ export function useInitializeRulesTableSavedState(): void {
   } = useKibana();
 
   useEffect(() => {
-    const { decodedParam: urlState } = getUrlParam();
+    const urlState = getUrlParam();
     const storageState = readStorageState(sessionStorage);
 
     if (!urlState && !storageState) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.test.tsx
@@ -55,12 +55,9 @@ describe('useSyncRulesTableSavedState', () => {
 
     renderHook(() => useSyncRulesTableSavedState());
 
-    expect(replaceUrlParams).toHaveBeenCalledWith([
-      {
-        key: URL_PARAM_KEY.rulesTable,
-        value: expectedUrlState,
-      },
-    ]);
+    expect(replaceUrlParams).toHaveBeenCalledWith({
+      [URL_PARAM_KEY.rulesTable]: expectedUrlState,
+    });
   };
 
   const expectStateToSyncWithStorage = (
@@ -96,7 +93,7 @@ describe('useSyncRulesTableSavedState', () => {
 
     renderHook(() => useSyncRulesTableSavedState());
 
-    expect(replaceUrlParams).toHaveBeenCalledWith([{ key: URL_PARAM_KEY.rulesTable, value: null }]);
+    expect(replaceUrlParams).toHaveBeenCalledWith({ [URL_PARAM_KEY.rulesTable]: null });
     expect(setStorage).not.toHaveBeenCalled();
     expect(removeStorage).toHaveBeenCalledWith(RULES_TABLE_STATE_STORAGE_KEY);
   });
@@ -136,9 +133,7 @@ describe('useSyncRulesTableSavedState', () => {
 
     renderHook(() => useSyncRulesTableSavedState());
 
-    expect(replaceUrlParams).toHaveBeenCalledWith([
-      { key: URL_PARAM_KEY.rulesTable, value: expectedUrlState },
-    ]);
+    expect(replaceUrlParams).toHaveBeenCalledWith({ [URL_PARAM_KEY.rulesTable]: expectedUrlState });
     expect(setStorage).toHaveBeenCalledWith(RULES_TABLE_STATE_STORAGE_KEY, expectedStorageState);
   });
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
@@ -6,10 +6,7 @@
  */
 
 import { useEffect } from 'react';
-import {
-  encodeRisonUrlState,
-  useReplaceUrlParams,
-} from '../../../../../common/utils/global_query_string/helpers';
+import { useReplaceUrlParams } from '../../../../../common/utils/global_query_string/helpers';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { URL_PARAM_KEY } from '../../../../../common/hooks/use_url_state';
 import { RULES_TABLE_STATE_STORAGE_KEY } from '../constants';
@@ -76,7 +73,7 @@ export function useSyncRulesTableSavedState(): void {
     const hasStorageStateToSave = Object.keys(storageStateToSave).length > 0;
 
     if (!hasUrlStateToSave) {
-      replaceUrlParams([{ key: URL_PARAM_KEY.rulesTable, value: null }]);
+      replaceUrlParams({ [URL_PARAM_KEY.rulesTable]: null });
     }
 
     if (!hasStorageStateToSave) {
@@ -87,9 +84,7 @@ export function useSyncRulesTableSavedState(): void {
       return;
     }
 
-    replaceUrlParams([
-      { key: URL_PARAM_KEY.rulesTable, value: encodeRisonUrlState(urlStateToSave) },
-    ]);
+    replaceUrlParams({ [URL_PARAM_KEY.rulesTable]: urlStateToSave });
     sessionStorage.set(RULES_TABLE_STATE_STORAGE_KEY, storageStateToSave);
   }, [replaceUrlParams, sessionStorage, state]);
 }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.test.ts
@@ -100,9 +100,7 @@ describe('useRuleFromTimeline', () => {
     jest.clearAllMocks();
     appToastsMock = useAppToastsMock.create();
     (useAppToasts as jest.Mock).mockReturnValue(appToastsMock);
-    (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => ({
-      decodedParam: timelineId,
-    }));
+    (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => timelineId);
     (resolveTimeline as jest.Mock).mockResolvedValue(selectedTimeline);
   });
 
@@ -139,9 +137,7 @@ describe('useRuleFromTimeline', () => {
         });
     });
     it('if no timeline id in URL, loading: false and query not set', async () => {
-      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => ({
-        decodedParam: undefined,
-      }));
+      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => undefined);
       const { result } = renderHook(() => useRuleFromTimeline(setRuleQuery));
 
       expect(result.current.loading).toEqual(false);
@@ -227,9 +223,7 @@ describe('useRuleFromTimeline', () => {
     });
 
     it('Sets rule from timeline query via callback', async () => {
-      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => ({
-        decodedParam: undefined,
-      }));
+      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => undefined);
       const { result } = renderHook(() => useRuleFromTimeline(setRuleQuery));
       expect(result.current.loading).toEqual(false);
       await act(async () => {
@@ -280,9 +274,7 @@ describe('useRuleFromTimeline', () => {
     });
 
     it('Handles error when query is malformed', async () => {
-      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => ({
-        decodedParam: undefined,
-      }));
+      (useGetInitialUrlParamValue as jest.Mock).mockReturnValue(() => undefined);
       const { result } = renderHook(() => useRuleFromTimeline(setRuleQuery));
       expect(result.current.loading).toEqual(false);
       const tl = {

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.tsx
@@ -181,9 +181,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
 
   // start handle set rule from timeline id
   const getInitialUrlParamValue = useGetInitialUrlParamValue<string>(RULE_FROM_TIMELINE_URL_PARAM);
-  const { decodedParam: timelineIdFromUrl } = useMemo(getInitialUrlParamValue, [
-    getInitialUrlParamValue,
-  ]);
+  const timelineIdFromUrl = useMemo(getInitialUrlParamValue, [getInitialUrlParamValue]);
 
   const getTimelineById = useCallback(
     (timelineId: string) => {

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -7,9 +7,9 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
+import { encode } from '@kbn/rison';
 
 import { RULE_FROM_TIMELINE_URL_PARAM } from '../../../detections/containers/detection_engine/rules/use_rule_from_timeline';
-import { encodeRisonUrlState } from '../../../common/utils/global_query_string/helpers';
 import { useNavigation } from '../../../common/lib/kibana';
 import { SecurityPageName } from '../../../../common/constants';
 import { useShallowEqualSelector } from '../../../common/hooks/use_selector';
@@ -283,7 +283,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
       (savedObjectId) =>
         navigateTo({
           deepLinkId: SecurityPageName.rulesCreate,
-          path: `?${RULE_FROM_TIMELINE_URL_PARAM}=${encodeRisonUrlState(savedObjectId)}`,
+          path: `?${RULE_FROM_TIMELINE_URL_PARAM}=${encode(savedObjectId)}`,
         }),
       [navigateTo]
     );


### PR DESCRIPTION
Addresses: https://github.com/elastic/kibana/issues/140263

This PR was inspired by https://github.com/elastic/kibana/pull/146649 and while working on persistent rules table state https://github.com/elastic/kibana/pull/145111.

## Summary

It includes improvements for url search parameters manipulation functionality. In particular `useGetInitialUrlParamValue` and `useReplaceUrlParams` hooks.

The main idea is to isolate the encoding layer ([rison](https://github.com/Nanonid/rison)) as an implementation detail so `useGetInitialUrlParamValue` and `useReplaceUrlParams` consumers can just provide types they wish and the hooks serialize/desirealize the data into appropriate format under the hood.

On top of that after `@kbn/rison` was added in https://github.com/elastic/kibana/pull/146649 it's possible to use this package directly to encode and decode parameters whenever necessary.

The improvements include
- store unserialized url parameters state in the redux store
- encode and decode data by using functions from `@kbn/rison` directly
- let `useReplaceUrlParams` accept an updater object

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

