### PR TITLE
Properly re-expose `close` method from the `createPointInTimeFinderDecryptedAsInternalUser` API.

### DIFF
--- a/x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts
@@ -177,7 +177,7 @@ export function setupSavedObjects({
           }
         }
 
-        return { ...finder, find: () => encryptedFinder() };
+        return { find: () => encryptedFinder(), close: finder.close.bind(finder) };
       },
     };
   };

--- a/x-pack/test/encrypted_saved_objects_api_integration/fixtures/api_consumer_plugin/server/hidden_saved_object_routes.ts
+++ b/x-pack/test/encrypted_saved_objects_api_integration/fixtures/api_consumer_plugin/server/hidden_saved_object_routes.ts
@@ -68,6 +68,8 @@ export function registerHiddenSORoutes(
         savedObjects = [...savedObjects, ...result.saved_objects];
       }
 
+      await finder.close();
+
       try {
         return response.ok({
           body: { saved_objects: savedObjects },


### PR DESCRIPTION
## Summary

Encrypted Saved Objects plugin exposes a `createPointInTimeFinderDecryptedAsInternalUser` API that's supposed to provide a custom wrapper around ordinary saved objects point in time finder. The API overrides `find` method internally so that we can decrypt secrets before returning saved object to consumer. It also re-exposes `close` method as is, but does it incorrectly:
```ts
const finder = internalRepository.createPointInTimeFinder(...);
...
return { ...finder, find: () => encryptedFinder() };
# ^-- `finder` is an instance of a JavaScript class, spread operator doesn't work
# like it would have worked for object literals, leading to a missing `close` method.
...
const wrappedFinder = createPointInTimeFinderDecryptedAsInternalUser();
await wrappedFinder.close(); --> TypeError: wrappedFinder.close is not a function
```

In this PR we properly re-expose `close` method and adjust unit and integration tests accordingly.

cc @shahzad31 

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->