### PR TITLE
[Visualize] Fixes the case with existing saved search and absent dataview

### DIFF
--- a/src/plugins/vis_default_editor/public/components/agg_group.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group.tsx
@@ -65,7 +65,7 @@ function DefaultEditorAggGroup({
   const schemaNames = schemas.map((s) => s.name);
   const group: IAggConfig[] = useMemo(
     () =>
-      state.data.aggs!.aggs.filter(
+      state.data.aggs?.aggs.filter(
         (agg: IAggConfig) => agg.schema && schemaNames.includes(agg.schema)
       ) || [],
     [state.data.aggs, schemaNames]

--- a/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
@@ -167,11 +167,11 @@ function SidebarTitle({ savedSearch, vis, isLinkedSearch, eventEmitter }: Sideba
         title={i18n.translate('visDefaultEditor.sidebar.indexPatternAriaLabel', {
           defaultMessage: 'Index pattern: {title}',
           values: {
-            title: vis.data.indexPattern!.getName(),
+            title: vis.data?.indexPattern?.getName(),
           },
         })}
       >
-        {vis.data.indexPattern!.getName()}
+        {vis.data?.indexPattern?.getName()}
       </h2>
     </EuiTitle>
   ) : (

--- a/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
@@ -274,9 +274,9 @@ export const getConfiguration = (
       ? Boolean(vis.params.addTimeMarker ?? vis.type.visConfig.defaults.addTimeMarker)
       : undefined,
     curveType: getCurveType(
-      series[0].interpolate === InterpolationMode.StepAfter
+      series[0]?.interpolate === InterpolationMode.StepAfter
         ? InterpolationMode.Linear
-        : series[0].interpolate
+        : series[0]?.interpolate
     ),
   };
 };

--- a/src/plugins/vis_types/xy/public/editor/components/options/metrics_axes/index.tsx
+++ b/src/plugins/vis_types/xy/public/editor/components/options/metrics_axes/index.tsx
@@ -97,14 +97,14 @@ function MetricsAxisOptions(props: ValidationVisOptionsProps<VisParams>) {
 
         series.forEach((serie, seriesIndex) => {
           if ((axisNumber === 0 && !serie.valueAxis) || serie.valueAxis === axis.id) {
-            const aggByIndex = aggs.bySchemaName('metric')[seriesIndex];
+            const aggByIndex = aggs?.bySchemaName('metric')[seriesIndex];
             matchingSeries.push(aggByIndex);
           }
         });
 
         if (matchingSeries.length === 1) {
           // if several series matches to the axis, axis title is set according to the first serie.
-          newCustomLabel = matchingSeries[0].makeLabel();
+          newCustomLabel = matchingSeries[0]?.makeLabel();
         }
 
         if (lastCustomLabels[axis.id] !== newCustomLabel && newCustomLabel !== '') {
@@ -290,7 +290,7 @@ function MetricsAxisOptions(props: ValidationVisOptionsProps<VisParams>) {
     updateAxisTitle(updatedSeries);
   }, [firstValueAxesId, setValue, stateParams.seriesParams, updateAxisTitle, aggs, schemaName]);
 
-  const isTimeViz = aggs.aggs.some(
+  const isTimeViz = aggs?.aggs.some(
     (agg) =>
       agg.schema === 'segment' && agg.enabled && agg.type?.name === BUCKET_TYPES.DATE_HISTOGRAM
   );

--- a/src/plugins/vis_types/xy/public/editor/components/options/point_series/elastic_charts_options.tsx
+++ b/src/plugins/vis_types/xy/public/editor/components/options/point_series/elastic_charts_options.tsx
@@ -26,12 +26,12 @@ export function ElasticChartsOptions(props: ValidationVisOptionsProps<VisParams>
 
   const isLineChart = stateParams.seriesParams.some(
     ({ type, data: { id: paramId } }) =>
-      type === ChartType.Line && aggs.aggs.find(({ id }) => id === paramId)?.enabled
+      type === ChartType.Line && aggs?.aggs.find(({ id }) => id === paramId)?.enabled
   );
 
   const isAreaChart = stateParams.seriesParams.some(
     ({ type, data: { id: paramId } }) =>
-      type === ChartType.Area && aggs.aggs.find(({ id }) => id === paramId)?.enabled
+      type === ChartType.Area && aggs?.aggs.find(({ id }) => id === paramId)?.enabled
   );
 
   useEffect(() => {

--- a/src/plugins/vis_types/xy/public/editor/components/options/point_series/point_series.tsx
+++ b/src/plugins/vis_types/xy/public/editor/components/options/point_series/point_series.tsx
@@ -37,9 +37,9 @@ export function PointSeriesOptions(props: ValidationVisOptionsProps<VisParams>) 
     () =>
       stateParams.seriesParams.some(
         ({ type, data: { id: paramId } }) =>
-          type === ChartType.Histogram && aggs.aggs.find(({ id }) => id === paramId)?.enabled
+          type === ChartType.Histogram && aggs?.aggs.find(({ id }) => id === paramId)?.enabled
       ),
-    [stateParams.seriesParams, aggs.aggs]
+    [stateParams.seriesParams, aggs?.aggs]
   );
 
   const legendSize = stateParams.legendSize;
@@ -78,7 +78,7 @@ export function PointSeriesOptions(props: ValidationVisOptionsProps<VisParams>) 
           showAutoOption={hadAutoLegendSize}
         />
 
-        {vis.data.aggs!.aggs.some(
+        {vis.data?.aggs?.aggs.some(
           (agg) => agg.schema === 'segment' && agg.type.name === BUCKET_TYPES.DATE_HISTOGRAM
         ) ? (
           <SwitchOption

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -270,7 +270,8 @@ const TopNav = ({
   const shouldShowDataViewPicker = Boolean(
     vis.type.editorConfig?.enableDataViewChange &&
       ((vis.data.indexPattern && !vis.data.savedSearchId) ||
-        isFallbackDataView(vis.data.indexPattern)) &&
+        isFallbackDataView(vis.data.indexPattern) ||
+        (vis.data.searchSource && !vis.data.indexPattern)) &&
       indexPatterns.length
   );
 
@@ -283,7 +284,8 @@ const TopNav = ({
     [stateContainer.transitions]
   );
 
-  const isMissingCurrentDataView = isFallbackDataView(vis.data.indexPattern);
+  const isMissingCurrentDataView =
+    isFallbackDataView(vis.data.indexPattern) || (vis.data.searchSource && !vis.data.indexPattern);
 
   return isChromeVisible ? (
     /**
@@ -309,9 +311,9 @@ const TopNav = ({
       showQueryInput={showQueryInput}
       showSaveQuery={Boolean(services.visualizeCapabilities.saveQuery)}
       dataViewPickerComponentProps={
-        shouldShowDataViewPicker && vis.data.indexPattern
+        shouldShowDataViewPicker
           ? {
-              currentDataViewId: vis.data.indexPattern.id,
+              currentDataViewId: vis.data?.indexPattern?.id,
               trigger: {
                 label: isMissingCurrentDataView
                   ? i18n.translate('visualizations.fallbackDataView.label', {
@@ -326,7 +328,7 @@ const TopNav = ({
                             }),
                       },
                     })
-                  : vis.data.indexPattern.getName(),
+                  : vis.data?.indexPattern?.getName(),
               },
               isMissingCurrent: isMissingCurrentDataView,
               onChangeDataView,

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -309,9 +309,9 @@ const TopNav = ({
       showQueryInput={showQueryInput}
       showSaveQuery={Boolean(services.visualizeCapabilities.saveQuery)}
       dataViewPickerComponentProps={
-        shouldShowDataViewPicker
+        shouldShowDataViewPicker && vis.data.indexPattern
           ? {
-              currentDataViewId: vis.data?.indexPattern?.id,
+              currentDataViewId: vis.data.indexPattern.id,
               trigger: {
                 label: isMissingCurrentDataView
                   ? i18n.translate('visualizations.fallbackDataView.label', {
@@ -326,7 +326,7 @@ const TopNav = ({
                             }),
                       },
                     })
-                  : vis.data?.indexPattern?.getName(),
+                  : vis.data.indexPattern.getName(),
               },
               isMissingCurrent: isMissingCurrentDataView,
               onChangeDataView,

--- a/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/visualize_top_nav.tsx
@@ -270,8 +270,7 @@ const TopNav = ({
   const shouldShowDataViewPicker = Boolean(
     vis.type.editorConfig?.enableDataViewChange &&
       ((vis.data.indexPattern && !vis.data.savedSearchId) ||
-        isFallbackDataView(vis.data.indexPattern) ||
-        (vis.data.searchSource && !vis.data.indexPattern)) &&
+        isFallbackDataView(vis.data.indexPattern)) &&
       indexPatterns.length
   );
 
@@ -284,8 +283,7 @@ const TopNav = ({
     [stateContainer.transitions]
   );
 
-  const isMissingCurrentDataView =
-    isFallbackDataView(vis.data.indexPattern) || (vis.data.searchSource && !vis.data.indexPattern);
+  const isMissingCurrentDataView = isFallbackDataView(vis.data.indexPattern);
 
   return isChromeVisible ? (
     /**


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147285

It fixes the bug that is described in the issue. If you create a saved search with an index pattern and then delete the index pattern. now it won't break the entire kibana but will navigate to to the following screen that indicates that there is no index.

<img width="1858" alt="image" src="https://user-images.githubusercontent.com/17003240/206996776-aa595932-0670-4ecc-aaca-344642ec02cd.png">

This is an edge case on my point of view, ideally if there are saved searches that correspond to a non-existent dataview should not be on the list but the current architecture doesn't allow to quickly solve this. I think it is fine for now.
