### PR TITLE
[Security Solution] Reduce load on Kibana generated by Cypress tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/changing_alert_status.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/changing_alert_status.cy.ts
@@ -151,7 +151,7 @@ describe('Changing alert status', () => {
   context('Closing alerts', () => {
     beforeEach(() => {
       deleteAlertsAndRules();
-      createCustomRuleEnabled(getNewRule(), '1', '100m', 100);
+      createCustomRuleEnabled(getNewRule(), '1', 100);
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
       selectCountTable();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_actions.cy.ts
@@ -99,7 +99,6 @@ describe('Detection rules, bulk edit of rule actions', () => {
           name: ruleNameToAssert,
         },
         '1',
-        '100m',
         500,
         actions
       );

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
@@ -253,9 +253,13 @@ describe('Add/edit exception from rule details', () => {
           ...getNewRule(),
           customQuery: 'agent.name:*',
           dataSource: { index: ['exceptions*'], type: 'indexPatterns' },
+          runsEvery: {
+            interval: '1',
+            timeType: 'Seconds',
+            type: 's',
+          },
         },
-        'rule_testing',
-        '1s'
+        'rule_testing'
       );
       visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
       goToRuleDetails();

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
@@ -65,9 +65,13 @@ describe('Add exception using data views from rule details', () => {
         ...getNewRule(),
         customQuery: 'agent.name:*',
         dataSource: { dataView: 'exceptions-*', type: 'dataView' },
+        runsEvery: {
+          interval: '1',
+          timeType: 'Seconds',
+          type: 's',
+        },
       },
-      'rule_testing',
-      '1s'
+      'rule_testing'
     );
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
     goToRuleDetails();

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -49,7 +49,6 @@ export interface CustomRule {
   name: string;
   description: string;
   dataSource: RuleDataSource;
-  interval?: string;
   severity?: string;
   riskScore?: string;
   tags?: string[];
@@ -59,6 +58,7 @@ export interface CustomRule {
   mitre?: Mitre[];
   note?: string;
   runsEvery?: Interval;
+  interval?: string;
   lookBack?: Interval;
   timeline?: CompleteTimeline;
   maxSignals?: number;
@@ -180,16 +180,8 @@ const getSeverityOverride4 = (): SeverityOverride => ({
   sourceValue: 'auditbeat',
 });
 
-// Default interval is 1m, our tests config overwrite this to 1s
-// See https://github.com/elastic/kibana/pull/125396 for details
 const getRunsEvery = (): Interval => ({
-  interval: '1',
-  timeType: 'Seconds',
-  type: 's',
-});
-
-const getRunsEveryFiveMinutes = (): Interval => ({
-  interval: '5',
+  interval: '100',
   timeType: 'Minutes',
   type: 'm',
 });
@@ -212,7 +204,7 @@ export const getDataViewRule = (): CustomRule => ({
   falsePositivesExamples: ['False1', 'False2'],
   mitre: [getMitre1(), getMitre2()],
   note: '# test markdown',
-  runsEvery: getRunsEveryFiveMinutes(),
+  runsEvery: getRunsEvery(),
   lookBack: getLookBack(),
   timeline: getTimeline(),
   maxSignals: 100,
@@ -305,7 +297,6 @@ export const getExistingRule = (): CustomRule => ({
   name: 'Rule 1',
   description: 'Description for Rule 1',
   dataSource: { index: ['auditbeat-*'], type: 'indexPatterns' },
-  interval: '100m',
   severity: 'High',
   riskScore: '19',
   tags: ['rule1'],
@@ -314,6 +305,7 @@ export const getExistingRule = (): CustomRule => ({
   mitre: [],
   note: 'This is my note',
   runsEvery: getRunsEvery(),
+  interval: '100m',
   lookBack: getLookBack(),
   timeline: getTimeline(),
   // Please do not change, or if you do, needs

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -31,6 +31,6 @@ export const waitTillPrebuiltRulesReadyToInstall = () => {
         return availablePrebuiltRulesCount > 0;
       });
     },
-    { interval: 100, timeout: 60000 }
+    { interval: 2000, timeout: 60000 }
   );
 };

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
@@ -40,12 +40,12 @@ export const createMachineLearningRule = (rule: MachineLearningRule, ruleId = 'm
 
 export const createCustomRule = (
   rule: CustomRule,
-  ruleId = 'rule_testing',
-  interval = '100m'
+  ruleId = 'rule_testing'
 ): Cypress.Chainable<Cypress.Response<unknown>> => {
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
   const timeline = rule.timeline != null ? rule.timeline : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   return cy.request({
     method: 'POST',
@@ -82,6 +82,7 @@ export const createCustomRule = (
 export const createEventCorrelationRule = (rule: CustomRule, ruleId = 'rule_testing') => {
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLowerCase() : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   cy.request({
     method: 'POST',
@@ -90,7 +91,7 @@ export const createEventCorrelationRule = (rule: CustomRule, ruleId = 'rule_test
       rule_id: ruleId,
       risk_score: riskScore,
       description: rule.description,
-      interval: `${rule.runsEvery?.interval}${rule.runsEvery?.type}`,
+      interval,
       from: `now-${rule.lookBack?.interval}${rule.lookBack?.type}`,
       name: rule.name,
       severity,
@@ -109,6 +110,7 @@ export const createEventCorrelationRule = (rule: CustomRule, ruleId = 'rule_test
 export const createThresholdRule = (rule: ThresholdRule, ruleId = 'rule_testing') => {
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   cy.request({
     method: 'POST',
@@ -117,7 +119,7 @@ export const createThresholdRule = (rule: ThresholdRule, ruleId = 'rule_testing'
       rule_id: ruleId,
       risk_score: riskScore,
       description: rule.description,
-      interval: `${rule.runsEvery?.interval}${rule.runsEvery?.type}`,
+      interval,
       from: `now-${rule.lookBack?.interval}${rule.lookBack?.type}`,
       name: rule.name,
       severity,
@@ -140,6 +142,7 @@ export const createThresholdRule = (rule: ThresholdRule, ruleId = 'rule_testing'
 export const createNewTermsRule = (rule: NewTermsRule, ruleId = 'rule_testing') => {
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   cy.request({
     method: 'POST',
@@ -148,7 +151,7 @@ export const createNewTermsRule = (rule: NewTermsRule, ruleId = 'rule_testing') 
       rule_id: ruleId,
       risk_score: riskScore,
       description: rule.description,
-      interval: `${rule.runsEvery?.interval}${rule.runsEvery?.type}`,
+      interval,
       from: `now-${rule.lookBack?.interval}${rule.lookBack?.type}`,
       name: rule.name,
       severity,
@@ -172,6 +175,7 @@ export const createSavedQueryRule = (
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
   const timeline = rule.timeline != null ? rule.timeline : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   return cy.request({
     method: 'POST',
@@ -180,7 +184,7 @@ export const createSavedQueryRule = (
       rule_id: ruleId,
       risk_score: riskScore,
       description: rule.description,
-      interval: rule.interval,
+      interval,
       name: rule.name,
       severity,
       type: 'saved_query',
@@ -208,6 +212,7 @@ export const createCustomIndicatorRule = (rule: ThreatIndicatorRule, ruleId = 'r
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
   const timeline = rule.timeline != null ? rule.timeline : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   cy.request({
     method: 'POST',
@@ -216,9 +221,7 @@ export const createCustomIndicatorRule = (rule: ThreatIndicatorRule, ruleId = 'r
       rule_id: ruleId,
       risk_score: riskScore,
       description: rule.description,
-      // Default interval is 1m, our tests config overwrite this to 1s
-      // See https://github.com/elastic/kibana/pull/125396 for details
-      interval: '10s',
+      interval,
       name: rule.name,
       severity,
       type: 'threat_match',
@@ -256,12 +259,12 @@ export const createCustomIndicatorRule = (rule: ThreatIndicatorRule, ruleId = 'r
 export const createCustomRuleEnabled = (
   rule: CustomRule,
   ruleId = '1',
-  interval = '100m',
   maxSignals = 500,
   actions?: RuleActionArray
 ) => {
   const riskScore = rule.riskScore != null ? parseInt(rule.riskScore, 10) : undefined;
   const severity = rule.severity != null ? rule.severity.toLocaleLowerCase() : undefined;
+  const interval = rule.runsEvery ? `${rule.runsEvery.interval}${rule.runsEvery.type}` : '100m';
 
   if (rule.dataSource.type === 'indexPatterns') {
     cy.request({

--- a/x-pack/plugins/security_solution/cypress/tasks/sourcerer.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/sourcerer.ts
@@ -148,6 +148,6 @@ const refreshUntilAlertsIndexExists = async () => {
 };
 
 export const waitForAlertsIndexToExist = () => {
-  createCustomRuleEnabled(getNewRule(), '1', '100m', 100);
+  createCustomRuleEnabled(getNewRule(), '1', 100);
   refreshUntilAlertsIndexExists();
 };


### PR DESCRIPTION
## Summary

This PR makes the following adjustments in the Cypress tests:

- Increases the default rule interval from 1 second to 100 minutes.
- Increases the long-polling interval for the `api/detection_engine/rules/prepackaged/_status` endpoint from 0.1 to 2 seconds.

This should hopefully reduce the load that Cypress tests generate on CI on Kibana which makes the tests themselves slower.

In the next episodes:

- https://github.com/elastic/kibana/issues/147377

## Background

With the recent issues related to installing the prebuilt rules package, 

> @dhurley14 did some initial research and found that there are some bulk_edit cypress tests that are going into an infinitely loop. Looks like the infinite loops can be reproduced locally and are happening here [https://github.com/elastic/kibana/blob/3e56eba64d51aa98ef5d9ed8d7d6cdcfc1f3cd5d/x-[…]rity_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts](https://github.com/elastic/kibana/blob/3e56eba64d51aa98ef5d9ed8d7d6cdcfc1f3cd5d/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts#L166)

@xcrzx @maximpn and I reproduced the issue locally and found that:

- There's no infinite loop in the `bulk_edit_rules.cy.ts` tests, but it took more than 1 hour to run 3 attempts of a single test: `Only prebuilt rules selected`.
- 6 rules that this test created were enabled and were executing every 1 second each.
- The `api/detection_engine/rules/prepackaged/_status` endpoint was being called 600 times per minute until the timeout. It looks like it took _way_ more than a few minutes to run each attempt.

We were able to reproduce this locally with the exception that the attempts didn't take much time to fail.

The hypothesis is that on CI where we have less computing power our Cypress tests overload the Kibana server by creating enabled rules that execute way too frequently. We shouldn't need rules to be enabled in many of the tests; we should be able to set a very long rule interval where rules have to be enabled. Finally, we shouldn't be spamming the API with highly frequent requests where we implement long-polling and wait for something to happen on the BE side.
