### PR TITLE
[TIP] fix add integrations link not working in cloud

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/global_header/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/global_header/index.tsx
@@ -64,7 +64,7 @@ export const GlobalHeader = React.memo(
     useVariation(
       cloudExperiments,
       'security-solutions.add-integrations-url',
-      ADD_DATA_PATH,
+      integrationsUrl,
       setAddIntegrationsUrl
     );
 


### PR DESCRIPTION
## Summary

This [previous PR](https://github.com/elastic/kibana/pull/142538) updated the Add Integrations logic when the user is clicking from the Threat Intelligence view. We want to navigate to the Integrations screen with the Threat Intelligence category already selected.

Although this was working locally, I had forgotten to modify the code logic when the `cloudExperiments` plugin is enabled (see [here](https://github.com/elastic/kibana/pull/142538/files#diff-8b700725072994c477c478744ab1e35a8420606b50a3ad9f6b112a98c0a05f90R65)).

https://github.com/elastic/security-team/issues/5008