### PR TITLE
Fixes the bad alignment issue on the missing dataview text

### DIFF
--- a/src/plugins/visualizations/public/components/visualization_missed_saved_object_error.tsx
+++ b/src/plugins/visualizations/public/components/visualization_missed_saved_object_error.tsx
@@ -48,6 +48,7 @@ export const VisualizationMissedSavedObjectError = ({
                 path: '/kibana/indexPatterns/create',
               })}
               data-test-subj="configuration-failure-reconfigure-indexpatterns"
+              style={{ width: '100%' }}
             >
               {i18n.translate('visualizations.missedDataView.dataViewReconfigure', {
                 defaultMessage: `Recreate it in the data view management page`,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -824,6 +824,7 @@ export const VisualizationWrapper = ({
                     href={core.application.getUrlForApp('management', {
                       path: '/kibana/indexPatterns/create',
                     })}
+                    style={{ width: '100%' }}
                     data-test-subj="configuration-failure-reconfigure-indexpatterns"
                   >
                     {i18n.translate('xpack.lens.editorFrame.dataViewReconfigure', {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147392

Fixes the link alignment issue in both Visualize and Lens.
<img width="902" alt="Screenshot 2022-12-13 at 2 11 24 PM" src="https://user-images.githubusercontent.com/17003240/207315694-96cde72e-10b1-4680-90bb-426cdf1956bd.png">

This has been caused due to an update on the EUI and the fact that the `<RedirectAppLinks/>` component adds its own style (flex which makes the link to be aligned on the left), This component is used in many places so I decided to not make css changes there as it might affect other places.
