### PR TITLE
[Security Solution] Add CellActions (alpha version) component to ui_actions plugin

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -41,6 +41,7 @@ const STORYBOOKS = [
   'security_solution',
   'shared_ux',
   'triggers_actions_ui',
+  'ui_actions',
   'ui_actions_enhanced',
   'language_documentation_popover',
   'unified_search',

--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -45,5 +45,6 @@ export const storybookAliases = {
   threat_intelligence: 'x-pack/plugins/threat_intelligence/.storybook',
   triggers_actions_ui: 'x-pack/plugins/triggers_actions_ui/.storybook',
   ui_actions_enhanced: 'src/plugins/ui_actions_enhanced/.storybook',
+  ui_actions: 'src/plugins/ui_actions/.storybook',
   unified_search: 'src/plugins/unified_search/.storybook',
 };

--- a/src/plugins/ui_actions/.storybook/main.js
+++ b/src/plugins/ui_actions/.storybook/main.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const defaultConfig = require('@kbn/storybook').defaultConfig;
+
+module.exports = {
+  ...defaultConfig,
+  stories: ['../**/*.stories.tsx'],
+  reactOptions: {
+    strictMode: true,
+  },
+};

--- a/src/plugins/ui_actions/public/cell_actions/README.md
+++ b/src/plugins/ui_actions/public/cell_actions/README.md
@@ -1,0 +1,17 @@
+This package provides a uniform interface for displaying UI actions for a cell.
+For the `CellActions` component to work, it must be wrapped by `CellActionsContextProvider`. Ideally, the wrapper should stay on the top of the rendering tree.
+
+Example:
+```JSX
+<CellActionsContextProvider
+    // call uiActions.getTriggerCompatibleActions(triggerId, data)
+    getCompatibleActions={getCompatibleActions}>
+    ...
+    <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={MY_TRIGGER_ID} config={{ field: 'fieldName', value: 'fieldValue', fieldType: 'text' }}>
+        Hover me
+    </CellActions>
+</CellActionsContextProvider>
+
+```
+
+`CellActions` component will display all compatible actions registered for the trigger id.

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_action_item.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_action_item.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { makeAction } from '../mocks/helpers';
+import { CellActionExecutionContext } from './cell_actions';
+import { ActionItem } from './cell_action_item';
+
+describe('ActionItem', () => {
+  it('renders', () => {
+    const action = makeAction('test-action');
+    const actionContext = {} as CellActionExecutionContext;
+    const { queryByTestId } = render(
+      <ActionItem action={action} actionContext={actionContext} showTooltip={false} />
+    );
+    expect(queryByTestId('actionItem-test-action')).toBeInTheDocument();
+  });
+
+  it('renders tooltip when showTooltip=true is received', () => {
+    const action = makeAction('test-action');
+    const actionContext = {} as CellActionExecutionContext;
+    const { container } = render(
+      <ActionItem action={action} actionContext={actionContext} showTooltip />
+    );
+
+    expect(container.querySelector('.euiToolTipAnchor')).not.toBeNull();
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_action_item.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_action_item.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useMemo } from 'react';
+
+import { EuiButtonIcon, EuiToolTip, IconType } from '@elastic/eui';
+import type { Action } from '../../actions';
+import { CellActionExecutionContext } from './cell_actions';
+
+export const ActionItem = ({
+  action,
+  actionContext,
+  showTooltip,
+}: {
+  action: Action;
+  actionContext: CellActionExecutionContext;
+  showTooltip: boolean;
+}) => {
+  const actionProps = useMemo(
+    () => ({
+      iconType: action.getIconType(actionContext) as IconType,
+      onClick: () => action.execute(actionContext),
+      'data-test-subj': `actionItem-${action.id}`,
+      'aria-label': action.getDisplayName(actionContext),
+    }),
+    [action, actionContext]
+  );
+
+  if (!actionProps.iconType) return null;
+
+  return showTooltip ? (
+    <EuiToolTip
+      content={action.getDisplayNameTooltip ? action.getDisplayNameTooltip(actionContext) : ''}
+    >
+      <EuiButtonIcon {...actionProps} iconSize="s" />
+    </EuiToolTip>
+  ) : (
+    <EuiButtonIcon {...actionProps} iconSize="s" />
+  );
+};

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
@@ -31,7 +31,7 @@ export default {
     (storyFn: Function) => (
       <CellActionsContextProvider
         // call uiActions getTriggerCompatibleActions(triggerId, data)
-        getCompatibleActions={getCompatibleActions}
+        getTriggerCompatibleActions={getCompatibleActions}
       >
         <div style={{ paddingTop: '70px' }} />
         {storyFn()}

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
@@ -14,7 +14,7 @@ import { CellActions, CellActionsMode, CellActionsProps } from './cell_actions';
 
 const TRIGGER_ID = 'testTriggerId';
 
-const CONFIG = { field: 'name', value: '123', fieldType: 'text' };
+const FIELD = { name: 'name', value: '123', type: 'text' };
 
 const getCompatibleActions = () =>
   Promise.resolve([
@@ -60,18 +60,18 @@ DefaultWithControls.args = {
   showTooltip: true,
   mode: CellActionsMode.ALWAYS_VISIBLE,
   triggerId: TRIGGER_ID,
-  config: CONFIG,
+  field: FIELD,
   showMoreActionsFrom: 3,
 };
 
 export const CellActionInline = ({}: {}) => (
-  <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+  <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} field={FIELD}>
     Field value
   </CellActions>
 );
 
 export const CellActionHoverPopup = ({}: {}) => (
-  <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} config={CONFIG}>
+  <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} field={FIELD}>
     Hover me
   </CellActions>
 );

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
@@ -57,11 +57,11 @@ DefaultWithControls.argTypes = {
 };
 
 DefaultWithControls.args = {
-  showTooltip: true,
+  showActionTooltips: true,
   mode: CellActionsMode.ALWAYS_VISIBLE,
   triggerId: TRIGGER_ID,
   field: FIELD,
-  showMoreActionsFrom: 3,
+  visibleCellActions: 3,
 };
 
 export const CellActionInline = ({}: {}) => (

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.stories.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import { CellActionsContextProvider } from './cell_actions_context';
+import { makeAction } from '../mocks/helpers';
+import { CellActions, CellActionsMode, CellActionsProps } from './cell_actions';
+
+const TRIGGER_ID = 'testTriggerId';
+
+const CONFIG = { field: 'name', value: '123', fieldType: 'text' };
+
+const getCompatibleActions = () =>
+  Promise.resolve([
+    makeAction('Filter in', 'plusInCircle', 2),
+    makeAction('Filter out', 'minusInCircle', 3),
+    makeAction('Minimize', 'minimize', 1),
+    makeAction('Send email', 'email', 4),
+    makeAction('Pin field', 'pin', 5),
+  ]);
+
+export default {
+  title: 'CellAction',
+  decorators: [
+    (storyFn: Function) => (
+      <CellActionsContextProvider
+        // call uiActions getTriggerCompatibleActions(triggerId, data)
+        getCompatibleActions={getCompatibleActions}
+      >
+        <div style={{ paddingTop: '70px' }} />
+        {storyFn()}
+      </CellActionsContextProvider>
+    ),
+  ],
+};
+
+const CellActionsTemplate: ComponentStory<React.FC<CellActionsProps>> = (args) => (
+  <CellActions {...args}>Field value</CellActions>
+);
+
+export const DefaultWithControls = CellActionsTemplate.bind({});
+
+DefaultWithControls.argTypes = {
+  mode: {
+    options: [CellActionsMode.HOVER_POPOVER, CellActionsMode.ALWAYS_VISIBLE],
+    defaultValue: CellActionsMode.HOVER_POPOVER,
+    control: {
+      type: 'radio',
+    },
+  },
+};
+
+DefaultWithControls.args = {
+  showTooltip: true,
+  mode: CellActionsMode.ALWAYS_VISIBLE,
+  triggerId: TRIGGER_ID,
+  config: CONFIG,
+  showMoreActionsFrom: 3,
+};
+
+export const CellActionInline = ({}: {}) => (
+  <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+    Field value
+  </CellActions>
+);
+
+export const CellActionHoverPopup = ({}: {}) => (
+  <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} config={CONFIG}>
+    Hover me
+  </CellActions>
+);

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
@@ -20,7 +20,7 @@ describe('CellActions', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>
@@ -39,7 +39,7 @@ describe('CellActions', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>
@@ -58,7 +58,7 @@ describe('CellActions', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
@@ -12,7 +12,7 @@ import { CellActions, CellActionsMode } from './cell_actions';
 import { CellActionsContextProvider } from './cell_actions_context';
 
 const TRIGGER_ID = 'test-trigger-id';
-const CONFIG = { field: 'name', value: '123', fieldType: 'text' };
+const FIELD = { name: 'name', value: '123', type: 'text' };
 
 describe('CellActions', () => {
   it('renders', async () => {
@@ -21,7 +21,7 @@ describe('CellActions', () => {
 
     const { queryByTestId } = render(
       <CellActionsContextProvider getCompatibleActions={getActions}>
-        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>
       </CellActionsContextProvider>
@@ -40,7 +40,7 @@ describe('CellActions', () => {
 
     const { queryByTestId } = render(
       <CellActionsContextProvider getCompatibleActions={getActions}>
-        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>
       </CellActionsContextProvider>
@@ -59,7 +59,7 @@ describe('CellActions', () => {
 
     const { queryByTestId } = render(
       <CellActionsContextProvider getCompatibleActions={getActions}>
-        <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} config={CONFIG}>
+        <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} field={FIELD}>
           Field value
         </CellActions>
       </CellActionsContextProvider>

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { CellActions, CellActionsMode } from './cell_actions';
+import { makeAction } from '../mocks/helpers';
+import { CellActionsContextProvider } from './cell_actions_context';
+
+const TRIGGER_ID = 'test-trigger-id';
+const CONFIG = { field: 'name', value: '123', fieldType: 'text' };
+
+describe('CellActions', () => {
+  it('renders', async () => {
+    const getActionsPromise = Promise.resolve([]);
+    const getActions = () => getActionsPromise;
+
+    const { queryByTestId } = render(
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+          Field value
+        </CellActions>
+      </CellActionsContextProvider>
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(queryByTestId('cellActions')).toBeInTheDocument();
+  });
+
+  it('renders InlineActions when mode is ALWAYS_VISIBLE', async () => {
+    const getActionsPromise = Promise.resolve([]);
+    const getActions = () => getActionsPromise;
+
+    const { queryByTestId } = render(
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+          Field value
+        </CellActions>
+      </CellActionsContextProvider>
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(queryByTestId('inlineActions')).toBeInTheDocument();
+  });
+
+  it('renders HoverActionsPopover when mode is HOVER_POPOVER', async () => {
+    const getActionsPromise = Promise.resolve([]);
+    const getActions = () => getActionsPromise;
+
+    const { queryByTestId } = render(
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={TRIGGER_ID} config={CONFIG}>
+          Field value
+        </CellActions>
+      </CellActionsContextProvider>
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(queryByTestId('hoverActionsPopover')).toBeInTheDocument();
+  });
+
+  it('sorts actions', async () => {
+    const getActionsPromise = Promise.resolve([
+      makeAction('action-2', 'icon', 2),
+      makeAction('action-1', 'icon', 1),
+    ]);
+    const getActions = () => getActionsPromise;
+
+    const { getAllByRole } = render(
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
+          Field value
+        </CellActions>
+      </CellActionsContextProvider>
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(getAllByRole('button').map((e) => e.getAttribute('aria-label'))).toEqual([
+      'action-1',
+      'action-2',
+    ]);
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.test.tsx
@@ -9,7 +9,6 @@
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { CellActions, CellActionsMode } from './cell_actions';
-import { makeAction } from '../mocks/helpers';
 import { CellActionsContextProvider } from './cell_actions_context';
 
 const TRIGGER_ID = 'test-trigger-id';
@@ -71,30 +70,5 @@ describe('CellActions', () => {
     });
 
     expect(queryByTestId('hoverActionsPopover')).toBeInTheDocument();
-  });
-
-  it('sorts actions', async () => {
-    const getActionsPromise = Promise.resolve([
-      makeAction('action-2', 'icon', 2),
-      makeAction('action-1', 'icon', 1),
-    ]);
-    const getActions = () => getActionsPromise;
-
-    const { getAllByRole } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
-        <CellActions mode={CellActionsMode.ALWAYS_VISIBLE} triggerId={TRIGGER_ID} config={CONFIG}>
-          Field value
-        </CellActions>
-      </CellActionsContextProvider>
-    );
-
-    await act(async () => {
-      await getActionsPromise;
-    });
-
-    expect(getAllByRole('button').map((e) => e.getAttribute('aria-label'))).toEqual([
-      'action-1',
-      'action-2',
-    ]);
   });
 });

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -96,11 +96,11 @@ export const CellActions: React.FC<CellActionsProps> = ({
         'No CellActionsContext found. Please wrap the application with CellActionsContextProvider'
       );
       return Promise.resolve([]);
-    } else {
-      return context
-        .getCompatibleActions(triggerId, actionContext)
-        .then((actions) => orderBy(['order', 'id'], ['asc', 'asc'], actions));
     }
+
+    return context
+      .getCompatibleActions(triggerId, actionContext)
+      .then((actions) => orderBy(['order', 'id'], ['asc', 'asc'], actions));
   }, [context, triggerId, actionContext]);
 
   if (mode === CellActionsMode.HOVER_POPOVER) {
@@ -118,22 +118,20 @@ export const CellActions: React.FC<CellActionsProps> = ({
         <div ref={extraContentNodeRef} />
       </div>
     );
-  } else if (mode === CellActionsMode.ALWAYS_VISIBLE) {
-    return (
-      <div ref={nodeRef} data-test-subj={'cellActions'}>
-        {children}
-        <InlineActions
-          getActions={getActions}
-          actionContext={actionContext}
-          showTooltip={showTooltip}
-          showMoreActionsFrom={showMoreActionsFrom}
-        />
-        <div ref={extraContentNodeRef} />
-      </div>
-    );
-  } else {
-    return <>Not implemented</>;
   }
+
+  return (
+    <div ref={nodeRef} data-test-subj={'cellActions'}>
+      {children}
+      <InlineActions
+        getActions={getActions}
+        actionContext={actionContext}
+        showTooltip={showTooltip}
+        showMoreActionsFrom={showMoreActionsFrom}
+      />
+      <div ref={extraContentNodeRef} />
+    </div>
+  );
 };
 
 CellActions.displayName = 'CellActions';

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -80,7 +80,6 @@ export const CellActions: React.FC<CellActionsProps> = ({
   showMoreActionsFrom = 3,
   metadata,
 }) => {
-  const context = useContext(CellActionsContext);
   const extraContentNodeRef = useRef<HTMLDivElement | null>(null);
   const nodeRef = useRef<HTMLDivElement | null>(null);
 
@@ -89,25 +88,10 @@ export const CellActions: React.FC<CellActionsProps> = ({
     [config, triggerId, metadata]
   );
 
-  const getActions = useCallback(() => {
-    if (!context.getCompatibleActions) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'No CellActionsContext found. Please wrap the application with CellActionsContextProvider'
-      );
-      return Promise.resolve([]);
-    }
-
-    return context
-      .getCompatibleActions(triggerId, actionContext)
-      .then((actions) => orderBy(['order', 'id'], ['asc', 'asc'], actions));
-  }, [context, triggerId, actionContext]);
-
   if (mode === CellActionsMode.HOVER_POPOVER) {
     return (
       <div ref={nodeRef} data-test-subj={'cellActions'}>
         <HoverActionsPopover
-          getActions={getActions}
           actionContext={actionContext}
           showTooltip={showTooltip}
           showMoreActionsFrom={showMoreActionsFrom}
@@ -124,7 +108,6 @@ export const CellActions: React.FC<CellActionsProps> = ({
     <div ref={nodeRef} data-test-subj={'cellActions'}>
       {children}
       <InlineActions
-        getActions={getActions}
         actionContext={actionContext}
         showTooltip={showTooltip}
         showMoreActionsFrom={showMoreActionsFrom}

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -6,20 +6,30 @@
  * Side Public License, v 1.
  */
 
-import { orderBy } from 'lodash/fp';
-import React, { useCallback, useContext, useMemo, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import type { ActionExecutionContext } from '../../actions';
-import { CellActionsContext } from './cell_actions_context';
 import { InlineActions } from './inline_actions';
 import { HoverActionsPopover } from './hover_actions_popover';
 
-export interface CellActionConfig {
-  field: string;
-  fieldType: string;
+export interface CellActionField {
+  /**
+   * Field name.
+   * Example: 'host.name'
+   */
+  name: string;
+  /**
+   * Field type.
+   * Example: 'keyword'
+   */
+  type: string;
+  /**
+   * Field value.
+   * Example: 'My-Laptop'
+   */
   value: string;
 }
 
-export interface CellActionExecutionContext extends CellActionConfig, ActionExecutionContext {
+export interface CellActionExecutionContext extends ActionExecutionContext {
   /**
    * Ref to a DOM node where the action can add custom HTML.
    */
@@ -34,6 +44,8 @@ export interface CellActionExecutionContext extends CellActionConfig, ActionExec
    * Extra configurations for actions.
    */
   metadata?: Record<string, unknown>;
+
+  field: CellActionField;
 }
 
 export enum CellActionsMode {
@@ -45,7 +57,7 @@ export interface CellActionsProps {
   /**
    * Common set of properties used by most actions.
    */
-  config: CellActionConfig;
+  field: CellActionField;
   /**
    * The trigger in which the actions are registered.
    */
@@ -72,7 +84,7 @@ export interface CellActionsProps {
 }
 
 export const CellActions: React.FC<CellActionsProps> = ({
-  config,
+  field,
   triggerId,
   children,
   mode,
@@ -84,8 +96,14 @@ export const CellActions: React.FC<CellActionsProps> = ({
   const nodeRef = useRef<HTMLDivElement | null>(null);
 
   const actionContext: CellActionExecutionContext = useMemo(
-    () => ({ ...config, trigger: { id: triggerId }, extraContentNodeRef, nodeRef, metadata }),
-    [config, triggerId, metadata]
+    () => ({
+      field,
+      trigger: { id: triggerId },
+      extraContentNodeRef,
+      nodeRef,
+      metadata,
+    }),
+    [field, triggerId, metadata]
   );
 
   if (mode === CellActionsMode.HOVER_POPOVER) {

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { orderBy } from 'lodash/fp';
+import React, { useCallback, useContext, useMemo, useRef } from 'react';
+import type { ActionExecutionContext } from '../../actions';
+import { CellActionsContext } from './cell_actions_context';
+import { InlineActions } from './inline_actions';
+import { HoverActionsPopover } from './hover_actions_popover';
+
+export interface CellActionConfig {
+  field: string;
+  fieldType: string;
+  value: string;
+}
+
+export interface CellActionExecutionContext extends CellActionConfig, ActionExecutionContext {
+  /**
+   * Ref to a DOM node where the action can add custom HTML.
+   */
+  extraContentNodeRef: React.MutableRefObject<HTMLDivElement | null>;
+
+  /**
+   * Ref to the node where the cell action are rendered.
+   */
+  nodeRef: React.MutableRefObject<HTMLDivElement | null>;
+
+  /**
+   * Extra configurations for actions.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export enum CellActionsMode {
+  HOVER_POPOVER = 'hover-popover',
+  ALWAYS_VISIBLE = 'always-visible',
+}
+
+export interface CellActionsProps {
+  /**
+   * Common set of properties used by most actions.
+   */
+  config: CellActionConfig;
+  /**
+   * The trigger in which the actions are registered.
+   */
+  triggerId: string;
+  /**
+   * UI configuration. Possible options are `HOVER_POPOVER` and `ALWAYS_VISIBLE`.
+   *
+   * `HOVER_POPOVER` shows the actions when the children component is hovered.
+   *
+   * `ALWAYS_VISIBLE` always shows the actions.
+   */
+  mode: CellActionsMode;
+  showTooltip?: boolean;
+  /**
+   * It shows 'more actions' button when the number of actions is bigger than this parameter.
+   */
+  showMoreActionsFrom?: number;
+  /**
+   * Custom set of properties used by some actions.
+   * An action might require a specific set of metadata properties to render.
+   * This data is sent directly to actions.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export const CellActions: React.FC<CellActionsProps> = ({
+  config,
+  triggerId,
+  children,
+  mode,
+  showTooltip = true,
+  showMoreActionsFrom = 3,
+  metadata,
+}) => {
+  const context = useContext(CellActionsContext);
+  const extraContentNodeRef = useRef<HTMLDivElement | null>(null);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  const actionContext: CellActionExecutionContext = useMemo(
+    () => ({ ...config, trigger: { id: triggerId }, extraContentNodeRef, nodeRef, metadata }),
+    [config, triggerId, metadata]
+  );
+
+  const getActions = useCallback(() => {
+    if (!context.getCompatibleActions) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'No CellActionsContext found. Please wrap the application with CellActionsContextProvider'
+      );
+      return Promise.resolve([]);
+    } else {
+      return context
+        .getCompatibleActions(triggerId, actionContext)
+        .then((actions) => orderBy(['order', 'id'], ['asc', 'asc'], actions));
+    }
+  }, [context, triggerId, actionContext]);
+
+  if (mode === CellActionsMode.HOVER_POPOVER) {
+    return (
+      <div ref={nodeRef} data-test-subj={'cellActions'}>
+        <HoverActionsPopover
+          getActions={getActions}
+          actionContext={actionContext}
+          showTooltip={showTooltip}
+          showMoreActionsFrom={showMoreActionsFrom}
+        >
+          {children}
+        </HoverActionsPopover>
+
+        <div ref={extraContentNodeRef} />
+      </div>
+    );
+  } else if (mode === CellActionsMode.ALWAYS_VISIBLE) {
+    return (
+      <div ref={nodeRef} data-test-subj={'cellActions'}>
+        {children}
+        <InlineActions
+          getActions={getActions}
+          actionContext={actionContext}
+          showTooltip={showTooltip}
+          showMoreActionsFrom={showMoreActionsFrom}
+        />
+        <div ref={extraContentNodeRef} />
+      </div>
+    );
+  } else {
+    return <>Not implemented</>;
+  }
+};
+
+CellActions.displayName = 'CellActions';

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -134,5 +134,3 @@ export const CellActions: React.FC<CellActionsProps> = ({
     </div>
   );
 };
-
-CellActions.displayName = 'CellActions';

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions.tsx
@@ -70,11 +70,15 @@ export interface CellActionsProps {
    * `ALWAYS_VISIBLE` always shows the actions.
    */
   mode: CellActionsMode;
-  showTooltip?: boolean;
+
+  /**
+   * It displays a tooltip for every action button when `true`.
+   */
+  showActionTooltips?: boolean;
   /**
    * It shows 'more actions' button when the number of actions is bigger than this parameter.
    */
-  showMoreActionsFrom?: number;
+  visibleCellActions?: number;
   /**
    * Custom set of properties used by some actions.
    * An action might require a specific set of metadata properties to render.
@@ -88,8 +92,8 @@ export const CellActions: React.FC<CellActionsProps> = ({
   triggerId,
   children,
   mode,
-  showTooltip = true,
-  showMoreActionsFrom = 3,
+  showActionTooltips = true,
+  visibleCellActions = 3,
   metadata,
 }) => {
   const extraContentNodeRef = useRef<HTMLDivElement | null>(null);
@@ -111,8 +115,8 @@ export const CellActions: React.FC<CellActionsProps> = ({
       <div ref={nodeRef} data-test-subj={'cellActions'}>
         <HoverActionsPopover
           actionContext={actionContext}
-          showTooltip={showTooltip}
-          showMoreActionsFrom={showMoreActionsFrom}
+          showActionTooltips={showActionTooltips}
+          visibleCellActions={visibleCellActions}
         >
           {children}
         </HoverActionsPopover>
@@ -127,8 +131,8 @@ export const CellActions: React.FC<CellActionsProps> = ({
       {children}
       <InlineActions
         actionContext={actionContext}
-        showTooltip={showTooltip}
-        showMoreActionsFrom={showMoreActionsFrom}
+        showActionTooltips={showActionTooltips}
+        visibleCellActions={visibleCellActions}
       />
       <div ref={extraContentNodeRef} />
     </div>

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
@@ -99,4 +99,30 @@ describe('CellActionsContextProvider', () => {
 
     expect(result.current.value).toEqual([firstAction, secondAction]);
   });
+
+  it('sorts actions by id when order is undefined', async () => {
+    const firstAction = makeAction('action-1');
+    const secondAction = makeAction('action-2');
+
+    const getActionsPromise = Promise.resolve([secondAction, firstAction]);
+    const getActions = () => getActionsPromise;
+
+    const { result } = renderHook(
+      () => useLoadActions(actionContext),
+
+      {
+        wrapper: ({ children }) => (
+          <CellActionsContextProvider getCompatibleActions={getActions}>
+            {children}
+          </CellActionsContextProvider>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(result.current.value).toEqual([firstAction, secondAction]);
+  });
 });

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
@@ -29,7 +29,7 @@ describe('CellActionsContextProvider', () => {
 
       {
         wrapper: ({ children }) => (
-          <CellActionsContextProvider getCompatibleActions={getActions}>
+          <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
             {children}
           </CellActionsContextProvider>
         ),
@@ -61,7 +61,7 @@ describe('CellActionsContextProvider', () => {
 
       {
         wrapper: ({ children }) => (
-          <CellActionsContextProvider getCompatibleActions={getActions}>
+          <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
             {children}
           </CellActionsContextProvider>
         ),
@@ -86,7 +86,7 @@ describe('CellActionsContextProvider', () => {
 
       {
         wrapper: ({ children }) => (
-          <CellActionsContextProvider getCompatibleActions={getActions}>
+          <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
             {children}
           </CellActionsContextProvider>
         ),
@@ -112,7 +112,7 @@ describe('CellActionsContextProvider', () => {
 
       {
         wrapper: ({ children }) => (
-          <CellActionsContextProvider getCompatibleActions={getActions}>
+          <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
             {children}
           </CellActionsContextProvider>
         ),

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { makeAction } from '../mocks/helpers';
+import { CellActionExecutionContext } from './cell_actions';
+import {
+  CellActionsContextProvider,
+  useLoadActions,
+  useLoadActionsFn,
+} from './cell_actions_context';
+
+describe('CellActionsContextProvider', () => {
+  const actionContext = { trigger: { id: 'triggerId' } } as CellActionExecutionContext;
+
+  it('loads actions when useLoadActionsFn callback is called', async () => {
+    const action = makeAction('action-1', 'icon', 1);
+    const getActionsPromise = Promise.resolve([action]);
+    const getActions = () => getActionsPromise;
+
+    const { result } = renderHook(
+      () => useLoadActionsFn(),
+
+      {
+        wrapper: ({ children }) => (
+          <CellActionsContextProvider getCompatibleActions={getActions}>
+            {children}
+          </CellActionsContextProvider>
+        ),
+      }
+    );
+
+    const [{ value: valueBeforeFnCalled }, loadActions] = result.current;
+
+    // value is undefined before loadActions is called
+    expect(valueBeforeFnCalled).toBeUndefined();
+
+    await act(async () => {
+      loadActions(actionContext);
+      await getActionsPromise;
+    });
+
+    const [{ value: valueAfterFnCalled }] = result.current;
+
+    expect(valueAfterFnCalled).toEqual([action]);
+  });
+
+  it('loads actions when useLoadActions called', async () => {
+    const action = makeAction('action-1', 'icon', 1);
+    const getActionsPromise = Promise.resolve([action]);
+    const getActions = () => getActionsPromise;
+
+    const { result } = renderHook(
+      () => useLoadActions(actionContext),
+
+      {
+        wrapper: ({ children }) => (
+          <CellActionsContextProvider getCompatibleActions={getActions}>
+            {children}
+          </CellActionsContextProvider>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(result.current.value).toEqual([action]);
+  });
+
+  it('sorts actions', async () => {
+    const firstAction = makeAction('action-1', 'icon', 1);
+    const secondAction = makeAction('action-2', 'icon', 2);
+    const getActionsPromise = Promise.resolve([secondAction, firstAction]);
+    const getActions = () => getActionsPromise;
+
+    const { result } = renderHook(
+      () => useLoadActions(actionContext),
+
+      {
+        wrapper: ({ children }) => (
+          <CellActionsContextProvider getCompatibleActions={getActions}>
+            {children}
+          </CellActionsContextProvider>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(result.current.value).toEqual([firstAction, secondAction]);
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.test.tsx
@@ -75,7 +75,7 @@ describe('CellActionsContextProvider', () => {
     expect(result.current.value).toEqual([action]);
   });
 
-  it('sorts actions', async () => {
+  it('sorts actions by order', async () => {
     const firstAction = makeAction('action-1', 'icon', 1);
     const secondAction = makeAction('action-2', 'icon', 2);
     const getActionsPromise = Promise.resolve([secondAction, firstAction]);
@@ -124,5 +124,32 @@ describe('CellActionsContextProvider', () => {
     });
 
     expect(result.current.value).toEqual([firstAction, secondAction]);
+  });
+
+  it('sorts actions by id and order', async () => {
+    const actionWithoutOrder = makeAction('action-1-no-order');
+    const secondAction = makeAction('action-2', 'icon', 2);
+    const thirdAction = makeAction('action-3', 'icon', 3);
+
+    const getActionsPromise = Promise.resolve([secondAction, actionWithoutOrder, thirdAction]);
+    const getActions = () => getActionsPromise;
+
+    const { result } = renderHook(
+      () => useLoadActions(actionContext),
+
+      {
+        wrapper: ({ children }) => (
+          <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
+            {children}
+          </CellActionsContextProvider>
+        ),
+      }
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(result.current.value).toEqual([secondAction, thirdAction, actionWithoutOrder]);
   });
 });

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.tsx
@@ -6,22 +6,27 @@
  * Side Public License, v 1.
  */
 
-import React, { createContext, FC } from 'react';
+import { orderBy } from 'lodash/fp';
+import React, { createContext, FC, useContext, useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
 import type { Action } from '../../actions';
+import { CellActionExecutionContext } from './cell_actions';
 
-type GetActionsType = undefined | ((trigger: string, context: object) => Promise<Action[]>);
+type GetActionsType = (trigger: string, context: object) => Promise<Action[]>;
 
 const initialContext = {
   getCompatibleActions: undefined,
 };
 
-export const CellActionsContext = createContext<{ getCompatibleActions: GetActionsType }>(
-  initialContext
-);
+const CellActionsContext = createContext<{
+  getCompatibleActions: GetActionsType | undefined;
+}>(initialContext);
 
 interface CellActionsContextProviderProps {
   /**
    * Please assign `uiActions.getTriggerCompatibleActions` function.
+   * This function should return a list of actions for a triggerId that are compatible with the provided context.
    */
   getCompatibleActions: GetActionsType;
 }
@@ -29,8 +34,42 @@ interface CellActionsContextProviderProps {
 export const CellActionsContextProvider: FC<CellActionsContextProviderProps> = ({
   children,
   getCompatibleActions,
-}) => (
-  <CellActionsContext.Provider value={{ getCompatibleActions }}>
-    {children}
-  </CellActionsContext.Provider>
-);
+}) => {
+  const getSortedCompatibleActions = useMemo<GetActionsType>(() => {
+    return (trigger, context) =>
+      getCompatibleActions(trigger, context).then((actions) =>
+        orderBy(['order', 'id'], ['asc', 'asc'], actions)
+      );
+  }, [getCompatibleActions]);
+
+  return (
+    <CellActionsContext.Provider value={{ getCompatibleActions: getSortedCompatibleActions }}>
+      {children}
+    </CellActionsContext.Provider>
+  );
+};
+
+const useGetCompatibleActions = () => {
+  const context = useContext(CellActionsContext);
+  if (context.getCompatibleActions === undefined) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'No CellActionsContext found. Please wrap the application with CellActionsContextProvider'
+    );
+  }
+
+  return (cellActionContext: CellActionExecutionContext) =>
+    context.getCompatibleActions
+      ? context.getCompatibleActions(cellActionContext.trigger.id, cellActionContext)
+      : Promise.resolve([]);
+};
+
+export const useLoadActions = (context: CellActionExecutionContext) => {
+  const getCompatibleActions = useGetCompatibleActions();
+  return useAsync(() => getCompatibleActions(context), []);
+};
+
+export const useLoadActionsFn = () => {
+  const getCompatibleActions = useGetCompatibleActions();
+  return useAsyncFn(getCompatibleActions, []);
+};

--- a/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/cell_actions_context.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { createContext, FC } from 'react';
+import type { Action } from '../../actions';
+
+type GetActionsType = undefined | ((trigger: string, context: object) => Promise<Action[]>);
+
+const initialContext = {
+  getCompatibleActions: undefined,
+};
+
+export const CellActionsContext = createContext<{ getCompatibleActions: GetActionsType }>(
+  initialContext
+);
+
+interface CellActionsContextProviderProps {
+  /**
+   * Please assign `uiActions.getTriggerCompatibleActions` function.
+   */
+  getCompatibleActions: GetActionsType;
+}
+
+export const CellActionsContextProvider: FC<CellActionsContextProviderProps> = ({
+  children,
+  getCompatibleActions,
+}) => (
+  <CellActionsContext.Provider value={{ getCompatibleActions }}>
+    {children}
+  </CellActionsContext.Provider>
+);

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { ExtraActionsButton } from './extra_actions_button';
+
+describe('ExtraActionsButton', () => {
+  it('renders', () => {
+    const { queryByTestId } = render(<ExtraActionsButton onClick={() => {}} showTooltip={false} />);
+
+    expect(queryByTestId('showExtraActionsButton')).toBeInTheDocument();
+  });
+
+  it('renders tooltip when showTooltip=true is received', () => {
+    const { container } = render(<ExtraActionsButton onClick={() => {}} showTooltip />);
+    expect(container.querySelector('.euiToolTipAnchor')).not.toBeNull();
+  });
+
+  it('calls onClick when button is clicked', () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(<ExtraActionsButton onClick={onClick} showTooltip />);
+
+    fireEvent.click(getByTestId('showExtraActionsButton'));
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
@@ -8,16 +8,12 @@
 
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+import { SHOW_MORE_ACTIONS } from './translations';
 
 interface ExtraActionsButtonProps {
   onClick: () => void;
   showTooltip: boolean;
 }
-
-export const SHOW_MORE_ACTIONS = i18n.translate('uiActions.showMoreActionsLabel', {
-  defaultMessage: 'More actions',
-});
 
 export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({ onClick, showTooltip }) =>
   showTooltip ? (

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+
+interface ExtraActionsButtonProps {
+  onClick: () => void;
+  showTooltip: boolean;
+}
+
+export const SHOW_MORE_ACTIONS = i18n.translate('uiActions.showMoreActionsLabel', {
+  defaultMessage: 'More actions',
+});
+
+export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({ onClick, showTooltip }) =>
+  showTooltip ? (
+    <EuiToolTip content={SHOW_MORE_ACTIONS}>
+      <EuiButtonIcon
+        data-test-subj="showExtraActionsButton"
+        aria-label={SHOW_MORE_ACTIONS}
+        iconType="boxesHorizontal"
+        onClick={onClick}
+      />
+    </EuiToolTip>
+  ) : (
+    <EuiButtonIcon
+      data-test-subj="showExtraActionsButton"
+      aria-label={SHOW_MORE_ACTIONS}
+      iconType="boxesHorizontal"
+      onClick={onClick}
+    />
+  );
+
+ExtraActionsButton.displayName = 'ExtraActionsButton';

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_button.tsx
@@ -33,5 +33,3 @@ export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({ onClick,
       onClick={onClick}
     />
   );
-
-ExtraActionsButton.displayName = 'ExtraActionsButton';

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { CellActionExecutionContext } from './cell_actions';
+import { makeAction } from '../mocks/helpers';
+import { ExtraActionsPopOver, ExtraActionsPopOverWithAnchor } from './extra_actions_popover';
+
+describe('ExtraActionsPopOver', () => {
+  it('renders', () => {
+    const { queryByTestId } = render(
+      <ExtraActionsPopOver
+        actionContext={{} as CellActionExecutionContext}
+        isOpen={false}
+        closePopOver={() => {}}
+        actions={[]}
+        button={<span />}
+      />
+    );
+
+    expect(queryByTestId('extraActionsPopOver')).toBeInTheDocument();
+  });
+
+  it('executes action and close popover when menu item is clicked', async () => {
+    const executeAction = jest.fn();
+    const closePopOver = jest.fn();
+    const action = { ...makeAction('test-action'), execute: executeAction };
+    const { getByLabelText } = render(
+      <ExtraActionsPopOver
+        actionContext={{} as CellActionExecutionContext}
+        isOpen={true}
+        closePopOver={closePopOver}
+        actions={[action]}
+        button={<span />}
+      />
+    );
+
+    await act(async () => {
+      await fireEvent.click(getByLabelText('test-action'));
+    });
+
+    expect(executeAction).toHaveBeenCalled();
+    expect(closePopOver).toHaveBeenCalled();
+  });
+});
+
+describe('ExtraActionsPopOverWithAnchor', () => {
+  const anchorElement = document.createElement('span');
+  document.body.appendChild(anchorElement);
+
+  it('renders', () => {
+    const { queryByTestId } = render(
+      <ExtraActionsPopOverWithAnchor
+        actionContext={{} as CellActionExecutionContext}
+        isOpen={false}
+        closePopOver={() => {}}
+        actions={[]}
+        anchorRef={{ current: anchorElement }}
+      />
+    );
+
+    expect(queryByTestId('extraActionsPopOverWithAnchor')).toBeInTheDocument();
+  });
+
+  it('executes action and close popover when menu item is clicked', () => {
+    const executeAction = jest.fn();
+    const closePopOver = jest.fn();
+    const action = { ...makeAction('test-action'), execute: executeAction };
+    const { getByLabelText } = render(
+      <ExtraActionsPopOverWithAnchor
+        actionContext={{} as CellActionExecutionContext}
+        isOpen={true}
+        closePopOver={closePopOver}
+        actions={[action]}
+        anchorRef={{ current: anchorElement }}
+      />
+    );
+
+    fireEvent.click(getByLabelText('test-action'));
+
+    expect(executeAction).toHaveBeenCalled();
+    expect(closePopOver).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.test.tsx
@@ -12,11 +12,12 @@ import { CellActionExecutionContext } from './cell_actions';
 import { makeAction } from '../mocks/helpers';
 import { ExtraActionsPopOver, ExtraActionsPopOverWithAnchor } from './extra_actions_popover';
 
+const actionContext = { field: { name: 'fieldName' } } as CellActionExecutionContext;
 describe('ExtraActionsPopOver', () => {
   it('renders', () => {
     const { queryByTestId } = render(
       <ExtraActionsPopOver
-        actionContext={{} as CellActionExecutionContext}
+        actionContext={actionContext}
         isOpen={false}
         closePopOver={() => {}}
         actions={[]}
@@ -33,7 +34,7 @@ describe('ExtraActionsPopOver', () => {
     const action = { ...makeAction('test-action'), execute: executeAction };
     const { getByLabelText } = render(
       <ExtraActionsPopOver
-        actionContext={{} as CellActionExecutionContext}
+        actionContext={actionContext}
         isOpen={true}
         closePopOver={closePopOver}
         actions={[action]}
@@ -57,7 +58,7 @@ describe('ExtraActionsPopOverWithAnchor', () => {
   it('renders', () => {
     const { queryByTestId } = render(
       <ExtraActionsPopOverWithAnchor
-        actionContext={{} as CellActionExecutionContext}
+        actionContext={actionContext}
         isOpen={false}
         closePopOver={() => {}}
         actions={[]}
@@ -74,7 +75,7 @@ describe('ExtraActionsPopOverWithAnchor', () => {
     const action = { ...makeAction('test-action'), execute: executeAction };
     const { getByLabelText } = render(
       <ExtraActionsPopOverWithAnchor
-        actionContext={{} as CellActionExecutionContext}
+        actionContext={actionContext}
         isOpen={true}
         closePopOver={closePopOver}
         actions={[action]}

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
@@ -94,8 +94,6 @@ export const ExtraActionsPopOverWithAnchor = ({
   ) : null;
 };
 
-ExtraActionsPopOverWithAnchor.displayName = 'ExtraActionsPopOverWithAnchor';
-
 type ExtraActionsPopOverContentProps = Pick<
   ActionsPopOverProps,
   'actionContext' | 'closePopOver' | 'actions'
@@ -133,5 +131,3 @@ const ExtraActionsPopOverContent: React.FC<ExtraActionsPopOverContentProps> = ({
     </>
   );
 };
-
-ExtraActionsPopOverContent.displayName = 'ExtraActionsPopOverContent';

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
@@ -16,6 +16,7 @@ import {
 import React, { useMemo } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { Action } from '../../actions';
 import { YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
 import { CellActionExecutionContext } from './cell_actions';
@@ -23,6 +24,10 @@ import { CellActionExecutionContext } from './cell_actions';
 const euiContextMenuItemCSS = css`
   color: ${euiThemeVars.euiColorPrimaryText};
 `;
+
+const EXTRA_ACTIONS_ARIA_LABEL = i18n.translate('uiActions.cellActions.extraActionsAriaLabel', {
+  defaultMessage: 'Extra actions',
+});
 
 interface ActionsPopOverProps {
   actionContext: CellActionExecutionContext;
@@ -49,6 +54,7 @@ export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
     repositionOnScroll
     ownFocus
     data-test-subj="extraActionsPopOver"
+    aria-label={EXTRA_ACTIONS_ARIA_LABEL}
   >
     <ExtraActionsPopOverContent
       actions={actions}
@@ -72,6 +78,7 @@ export const ExtraActionsPopOverWithAnchor = ({
 }: ExtraActionsPopOverWithAnchorProps) => {
   return anchorRef.current ? (
     <EuiWrappingPopover
+      aria-label={EXTRA_ACTIONS_ARIA_LABEL}
       button={anchorRef.current}
       isOpen={isOpen}
       closePopover={closePopOver}

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
@@ -127,7 +127,7 @@ const ExtraActionsPopOverContent: React.FC<ExtraActionsPopOverContentProps> = ({
   return (
     <>
       <EuiScreenReaderOnly>
-        <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field)}</p>
+        <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field.name)}</p>
       </EuiScreenReaderOnly>
       <EuiContextMenuPanel size="s" items={items} />
     </>

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
@@ -16,18 +16,13 @@ import {
 import React, { useMemo } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
-import { i18n } from '@kbn/i18n';
 import type { Action } from '../../actions';
-import { YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
+import { EXTRA_ACTIONS_ARIA_LABEL, YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
 import { CellActionExecutionContext } from './cell_actions';
 
 const euiContextMenuItemCSS = css`
   color: ${euiThemeVars.euiColorPrimaryText};
 `;
-
-const EXTRA_ACTIONS_ARIA_LABEL = i18n.translate('uiActions.cellActions.extraActionsAriaLabel', {
-  defaultMessage: 'Extra actions',
-});
 
 interface ActionsPopOverProps {
   actionContext: CellActionExecutionContext;
@@ -50,7 +45,7 @@ export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
     closePopover={closePopOver}
     panelPaddingSize="xs"
     anchorPosition={'downCenter'}
-    hasArrow={true}
+    hasArrow
     repositionOnScroll
     ownFocus
     data-test-subj="extraActionsPopOver"

--- a/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/extra_actions_popover.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiPopover,
+  EuiScreenReaderOnly,
+  EuiWrappingPopover,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { euiThemeVars } from '@kbn/ui-theme';
+import { css } from '@emotion/react';
+import type { Action } from '../../actions';
+import { YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
+import { CellActionExecutionContext } from './cell_actions';
+
+const euiContextMenuItemCSS = css`
+  color: ${euiThemeVars.euiColorPrimaryText};
+`;
+
+interface ActionsPopOverProps {
+  actionContext: CellActionExecutionContext;
+  isOpen: boolean;
+  closePopOver: () => void;
+  actions: Action[];
+  button: JSX.Element;
+}
+
+export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
+  actions,
+  actionContext,
+  isOpen,
+  closePopOver,
+  button,
+}) => (
+  <EuiPopover
+    button={button}
+    isOpen={isOpen}
+    closePopover={closePopOver}
+    panelPaddingSize="xs"
+    anchorPosition={'downCenter'}
+    hasArrow={true}
+    repositionOnScroll
+    ownFocus
+    data-test-subj="extraActionsPopOver"
+  >
+    <ExtraActionsPopOverContent
+      actions={actions}
+      actionContext={actionContext}
+      closePopOver={closePopOver}
+    />
+  </EuiPopover>
+);
+
+interface ExtraActionsPopOverWithAnchorProps
+  extends Pick<ActionsPopOverProps, 'actionContext' | 'closePopOver' | 'isOpen' | 'actions'> {
+  anchorRef: React.RefObject<HTMLElement>;
+}
+
+export const ExtraActionsPopOverWithAnchor = ({
+  anchorRef,
+  actionContext,
+  isOpen,
+  closePopOver,
+  actions,
+}: ExtraActionsPopOverWithAnchorProps) => {
+  return anchorRef.current ? (
+    <EuiWrappingPopover
+      button={anchorRef.current}
+      isOpen={isOpen}
+      closePopover={closePopOver}
+      panelPaddingSize="xs"
+      anchorPosition={'downCenter'}
+      hasArrow={false}
+      repositionOnScroll
+      ownFocus
+      attachToAnchor={false}
+      data-test-subj="extraActionsPopOverWithAnchor"
+    >
+      <ExtraActionsPopOverContent
+        actions={actions}
+        actionContext={actionContext}
+        closePopOver={closePopOver}
+      />
+    </EuiWrappingPopover>
+  ) : null;
+};
+
+ExtraActionsPopOverWithAnchor.displayName = 'ExtraActionsPopOverWithAnchor';
+
+type ExtraActionsPopOverContentProps = Pick<
+  ActionsPopOverProps,
+  'actionContext' | 'closePopOver' | 'actions'
+>;
+
+const ExtraActionsPopOverContent: React.FC<ExtraActionsPopOverContentProps> = ({
+  actionContext,
+  actions,
+  closePopOver,
+}) => {
+  const items = useMemo(
+    () =>
+      actions.map((action) => (
+        <EuiContextMenuItem
+          css={euiContextMenuItemCSS}
+          key={action.id}
+          icon={action.getIconType(actionContext)}
+          aria-label={action.getDisplayName(actionContext)}
+          onClick={() => {
+            closePopOver();
+            action.execute(actionContext);
+          }}
+        >
+          {action.getDisplayName(actionContext)}
+        </EuiContextMenuItem>
+      )),
+    [actionContext, actions, closePopOver]
+  );
+  return (
+    <>
+      <EuiScreenReaderOnly>
+        <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field)}</p>
+      </EuiScreenReaderOnly>
+      <EuiContextMenuPanel size="s" items={items} />
+    </>
+  );
+};
+
+ExtraActionsPopOverContent.displayName = 'ExtraActionsPopOverContent';

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -27,9 +27,9 @@ describe('HoverActionsPopover', () => {
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           children={null}
-          showMoreActionsFrom={4}
+          visibleCellActions={4}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         />
       </CellActionsContextProvider>
     );
@@ -44,9 +44,9 @@ describe('HoverActionsPopover', () => {
     const { queryByLabelText, getByTestId } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
-          showMoreActionsFrom={4}
+          visibleCellActions={4}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         >
           <TestComponent />
         </HoverActionsPopover>
@@ -69,9 +69,9 @@ describe('HoverActionsPopover', () => {
     const { queryByLabelText, getByTestId } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
-          showMoreActionsFrom={4}
+          visibleCellActions={4}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         >
           <TestComponent />
         </HoverActionsPopover>
@@ -99,9 +99,9 @@ describe('HoverActionsPopover', () => {
     const { getByTestId } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
-          showMoreActionsFrom={1}
+          visibleCellActions={1}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         >
           <TestComponent />
         </HoverActionsPopover>
@@ -124,9 +124,9 @@ describe('HoverActionsPopover', () => {
     const { getByTestId, getByLabelText } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
-          showMoreActionsFrom={1}
+          visibleCellActions={1}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         >
           <TestComponent />
         </HoverActionsPopover>
@@ -158,9 +158,9 @@ describe('HoverActionsPopover', () => {
     const { getByTestId, queryByLabelText } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
-          showMoreActionsFrom={2}
+          visibleCellActions={2}
           actionContext={actionContext}
-          showTooltip={false}
+          showActionTooltips={false}
         >
           <TestComponent />
         </HoverActionsPopover>

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -24,7 +24,7 @@ describe('HoverActionsPopover', () => {
   it('renders', () => {
     const getActions = () => Promise.resolve([]);
     const { queryByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           children={null}
           showMoreActionsFrom={4}
@@ -42,7 +42,7 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByLabelText, getByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           showMoreActionsFrom={4}
           actionContext={actionContext}
@@ -67,7 +67,7 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByLabelText, getByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           showMoreActionsFrom={4}
           actionContext={actionContext}
@@ -97,7 +97,7 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           showMoreActionsFrom={1}
           actionContext={actionContext}
@@ -122,7 +122,7 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId, getByLabelText } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           showMoreActionsFrom={1}
           actionContext={actionContext}
@@ -156,7 +156,7 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId, queryByLabelText } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <HoverActionsPopover
           showMoreActionsFrom={2}
           actionContext={actionContext}

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { CellActionExecutionContext } from './cell_actions';
+import { makeAction } from '../mocks/helpers';
+import { HoverActionsPopover } from './hover_actions_popover';
+
+describe('HoverActionsPopover', () => {
+  const TestComponent = () => <span data-test-subj="test-component" />;
+  jest.useFakeTimers();
+
+  it('renders', () => {
+    const getActions = () => Promise.resolve([]);
+    const { queryByTestId } = render(
+      <HoverActionsPopover
+        children={null}
+        getActions={getActions}
+        showMoreActionsFrom={4}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      />
+    );
+    expect(queryByTestId('hoverActionsPopover')).toBeInTheDocument();
+  });
+
+  it('renders actions when hovered', async () => {
+    const action = makeAction('test-action');
+    const getActionsPromise = Promise.resolve([action]);
+    const getActions = () => getActionsPromise;
+
+    const { queryByLabelText, getByTestId } = render(
+      <HoverActionsPopover
+        getActions={getActions}
+        showMoreActionsFrom={4}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      >
+        <TestComponent />
+      </HoverActionsPopover>
+    );
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    expect(queryByLabelText('test-action')).toBeInTheDocument();
+  });
+
+  it('hide actions when mouse stops hovering', async () => {
+    const action = makeAction('test-action');
+    const getActionsPromise = Promise.resolve([action]);
+    const getActions = () => getActionsPromise;
+
+    const { queryByLabelText, getByTestId } = render(
+      <HoverActionsPopover
+        getActions={getActions}
+        showMoreActionsFrom={4}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      >
+        <TestComponent />
+      </HoverActionsPopover>
+    );
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    // Mouse leaves hover state
+    await act(async () => {
+      fireEvent.mouseLeave(getByTestId('test-component'));
+    });
+
+    expect(queryByLabelText('test-action')).not.toBeInTheDocument();
+  });
+
+  it('renders extra actions button', async () => {
+    const actions = [makeAction('test-action-1'), makeAction('test-action-2')];
+    const getActionsPromise = Promise.resolve(actions);
+    const getActions = () => getActionsPromise;
+
+    const { getByTestId } = render(
+      <HoverActionsPopover
+        getActions={getActions}
+        showMoreActionsFrom={1}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      >
+        <TestComponent />
+      </HoverActionsPopover>
+    );
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    expect(getByTestId('showExtraActionsButton')).toBeInTheDocument();
+  });
+
+  it('shows extra actions when extra actions button is clicked', async () => {
+    const actions = [makeAction('test-action-1'), makeAction('test-action-2')];
+    const getActionsPromise = Promise.resolve(actions);
+    const getActions = () => getActionsPromise;
+
+    const { getByTestId, getByLabelText } = render(
+      <HoverActionsPopover
+        getActions={getActions}
+        showMoreActionsFrom={1}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      >
+        <TestComponent />
+      </HoverActionsPopover>
+    );
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    act(() => {
+      fireEvent.click(getByTestId('showExtraActionsButton'));
+    });
+
+    expect(getByLabelText('test-action-2')).toBeInTheDocument();
+  });
+});
+
+const hoverElement = async (element: Element, waitForChange: () => Promise<unknown>) => {
+  await act(async () => {
+    fireEvent.mouseEnter(element);
+    await waitForChange();
+  });
+};

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -14,7 +14,10 @@ import { HoverActionsPopover } from './hover_actions_popover';
 import { CellActionsContextProvider } from './cell_actions_context';
 
 describe('HoverActionsPopover', () => {
-  const actionContext = { trigger: { id: 'triggerId' } } as CellActionExecutionContext;
+  const actionContext = {
+    trigger: { id: 'triggerId' },
+    field: { name: 'fieldName' },
+  } as CellActionExecutionContext;
   const TestComponent = () => <span data-test-subj="test-component" />;
   jest.useFakeTimers();
 

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -11,21 +11,24 @@ import React from 'react';
 import { CellActionExecutionContext } from './cell_actions';
 import { makeAction } from '../mocks/helpers';
 import { HoverActionsPopover } from './hover_actions_popover';
+import { CellActionsContextProvider } from './cell_actions_context';
 
 describe('HoverActionsPopover', () => {
+  const actionContext = { trigger: { id: 'triggerId' } } as CellActionExecutionContext;
   const TestComponent = () => <span data-test-subj="test-component" />;
   jest.useFakeTimers();
 
   it('renders', () => {
     const getActions = () => Promise.resolve([]);
     const { queryByTestId } = render(
-      <HoverActionsPopover
-        children={null}
-        getActions={getActions}
-        showMoreActionsFrom={4}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      />
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          children={null}
+          showMoreActionsFrom={4}
+          actionContext={actionContext}
+          showTooltip={false}
+        />
+      </CellActionsContextProvider>
     );
     expect(queryByTestId('hoverActionsPopover')).toBeInTheDocument();
   });
@@ -36,14 +39,15 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByLabelText, getByTestId } = render(
-      <HoverActionsPopover
-        getActions={getActions}
-        showMoreActionsFrom={4}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      >
-        <TestComponent />
-      </HoverActionsPopover>
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          showMoreActionsFrom={4}
+          actionContext={actionContext}
+          showTooltip={false}
+        >
+          <TestComponent />
+        </HoverActionsPopover>
+      </CellActionsContextProvider>
     );
 
     await hoverElement(getByTestId('test-component'), async () => {
@@ -60,14 +64,15 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { queryByLabelText, getByTestId } = render(
-      <HoverActionsPopover
-        getActions={getActions}
-        showMoreActionsFrom={4}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      >
-        <TestComponent />
-      </HoverActionsPopover>
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          showMoreActionsFrom={4}
+          actionContext={actionContext}
+          showTooltip={false}
+        >
+          <TestComponent />
+        </HoverActionsPopover>
+      </CellActionsContextProvider>
     );
 
     await hoverElement(getByTestId('test-component'), async () => {
@@ -89,14 +94,15 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId } = render(
-      <HoverActionsPopover
-        getActions={getActions}
-        showMoreActionsFrom={1}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      >
-        <TestComponent />
-      </HoverActionsPopover>
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          showMoreActionsFrom={1}
+          actionContext={actionContext}
+          showTooltip={false}
+        >
+          <TestComponent />
+        </HoverActionsPopover>
+      </CellActionsContextProvider>
     );
 
     await hoverElement(getByTestId('test-component'), async () => {
@@ -113,14 +119,15 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId, getByLabelText } = render(
-      <HoverActionsPopover
-        getActions={getActions}
-        showMoreActionsFrom={1}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      >
-        <TestComponent />
-      </HoverActionsPopover>
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          showMoreActionsFrom={1}
+          actionContext={actionContext}
+          showTooltip={false}
+        >
+          <TestComponent />
+        </HoverActionsPopover>
+      </CellActionsContextProvider>
     );
 
     await hoverElement(getByTestId('test-component'), async () => {
@@ -146,14 +153,15 @@ describe('HoverActionsPopover', () => {
     const getActions = () => getActionsPromise;
 
     const { getByTestId, queryByLabelText } = render(
-      <HoverActionsPopover
-        getActions={getActions}
-        showMoreActionsFrom={2}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      >
-        <TestComponent />
-      </HoverActionsPopover>
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <HoverActionsPopover
+          showMoreActionsFrom={2}
+          actionContext={actionContext}
+          showTooltip={false}
+        >
+          <TestComponent />
+        </HoverActionsPopover>
+      </CellActionsContextProvider>
     );
 
     await hoverElement(getByTestId('test-component'), async () => {

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.test.tsx
@@ -134,6 +134,46 @@ describe('HoverActionsPopover', () => {
 
     expect(getByLabelText('test-action-2')).toBeInTheDocument();
   });
+
+  it('does not render visible actions if extra actions are already rendered', async () => {
+    const actions = [
+      makeAction('test-action-1'),
+      // extra actions
+      makeAction('test-action-2'),
+      makeAction('test-action-3'),
+    ];
+    const getActionsPromise = Promise.resolve(actions);
+    const getActions = () => getActionsPromise;
+
+    const { getByTestId, queryByLabelText } = render(
+      <HoverActionsPopover
+        getActions={getActions}
+        showMoreActionsFrom={2}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      >
+        <TestComponent />
+      </HoverActionsPopover>
+    );
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    act(() => {
+      fireEvent.click(getByTestId('showExtraActionsButton'));
+    });
+
+    await hoverElement(getByTestId('test-component'), async () => {
+      await getActionsPromise;
+      jest.runAllTimers();
+    });
+
+    expect(queryByLabelText('test-action-1')).not.toBeInTheDocument();
+    expect(queryByLabelText('test-action-2')).toBeInTheDocument();
+    expect(queryByLabelText('test-action-3')).toBeInTheDocument();
+  });
 });
 
 const hoverElement = async (element: Element, waitForChange: () => Promise<unknown>) => {

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -11,6 +11,7 @@ import { EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { Action } from '../../actions';
 import { ActionItem } from './cell_action_item';
 import { ExtraActionsButton } from './extra_actions_button';
@@ -124,6 +125,9 @@ export const HoverActionsPopover = React.memo<Props>(
             repositionOnScroll
             ownFocus={false}
             data-test-subj={'hoverActionsPopover'}
+            aria-label={i18n.translate('uiActions.cellActions.actionsAriaLabel', {
+              defaultMessage: 'Actions',
+            })}
           >
             {showHoverContent ? (
               <div css={hoverContentWrapperCSS}>

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -75,7 +75,8 @@ export const HoverActionsPopover = React.memo<Props>(
     }, [closePopover, setIsExtraActionsPopoverOpen]);
 
     const onMouseEnter = useCallback(async () => {
-      closeExtraActions(); // Closed extra actions when opening hover actions
+      // Do not open actions with extra action popover is open
+      if (isExtraActionsPopoverOpen) return;
 
       // memoize actions after the first call
       if (actions === null) {
@@ -94,7 +95,7 @@ export const HoverActionsPopover = React.memo<Props>(
           }, HOVER_INTENT_DELAY)
         )
       );
-    }, [closeExtraActions, getActions, actions]);
+    }, [isExtraActionsPopoverOpen, actions, getActions]);
 
     const onMouseLeave = useCallback(() => {
       closePopover();

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -37,13 +37,13 @@ const HOVER_INTENT_DELAY = 100; // ms
 
 interface Props {
   children: React.ReactNode;
-  showMoreActionsFrom: number;
+  visibleCellActions: number;
   actionContext: CellActionExecutionContext;
-  showTooltip: boolean;
+  showActionTooltips: boolean;
 }
 
 export const HoverActionsPopover = React.memo<Props>(
-  ({ children, showMoreActionsFrom, actionContext, showTooltip }) => {
+  ({ children, visibleCellActions, actionContext, showActionTooltips }) => {
     const contentRef = useRef<HTMLDivElement>(null);
     const [isExtraActionsPopoverOpen, setIsExtraActionsPopoverOpen] = useState(false);
     const [showHoverContent, setShowHoverContent] = useState(false);
@@ -52,8 +52,8 @@ export const HoverActionsPopover = React.memo<Props>(
     const [{ value: actions }, loadActions] = useLoadActionsFn();
 
     const { visibleActions, extraActions } = useMemo(
-      () => partitionActions(actions ?? [], showMoreActionsFrom),
-      [actions, showMoreActionsFrom]
+      () => partitionActions(actions ?? [], visibleCellActions),
+      [actions, visibleCellActions]
     );
 
     const closePopover = useCallback(() => {
@@ -139,11 +139,14 @@ export const HoverActionsPopover = React.memo<Props>(
                     key={action.id}
                     action={action}
                     actionContext={actionContext}
-                    showTooltip={showTooltip}
+                    showTooltip={showActionTooltips}
                   />
                 ))}
                 {extraActions.length > 0 ? (
-                  <ExtraActionsButton onClick={onShowExtraActionsClick} showTooltip={showTooltip} />
+                  <ExtraActionsButton
+                    onClick={onShowExtraActionsClick}
+                    showTooltip={showActionTooltips}
+                  />
                 ) : null}
               </div>
             ) : null}

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -160,5 +160,3 @@ export const HoverActionsPopover = React.memo<Props>(
     );
   }
 );
-
-HoverActionsPopover.displayName = 'HoverActionsPopover';

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -11,6 +11,7 @@ import { EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
 import type { Action } from '../../actions';
 import { ActionItem } from './cell_action_item';
 import { ExtraActionsButton } from './extra_actions_button';
@@ -49,7 +50,7 @@ export const HoverActionsPopover = React.memo<Props>(
     const [showHoverContent, setShowHoverContent] = useState(false);
     const [, setHoverTimeout] = useState<number | undefined>(undefined);
     const popoverRef = useRef<EuiPopover>(null);
-    const [actions, setActions] = useState<Action[] | null>(null);
+    const [{ value: actions }, loadActions] = useAsyncFn(getActions, [getActions]);
 
     const { visibleActions, extraActions } = useMemo(
       () => partitionActions(actions ?? [], showMoreActionsFrom),
@@ -79,8 +80,8 @@ export const HoverActionsPopover = React.memo<Props>(
       if (isExtraActionsPopoverOpen) return;
 
       // memoize actions after the first call
-      if (actions === null) {
-        getActions().then((newActions) => setActions(newActions));
+      if (actions === undefined) {
+        loadActions();
       }
 
       setHoverTimeout(
@@ -95,7 +96,7 @@ export const HoverActionsPopover = React.memo<Props>(
           }, HOVER_INTENT_DELAY)
         )
       );
-    }, [isExtraActionsPopoverOpen, actions, getActions]);
+    }, [isExtraActionsPopoverOpen, actions, loadActions]);
 
     const onMouseLeave = useCallback(() => {
       closePopover();

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -130,7 +130,7 @@ export const HoverActionsPopover = React.memo<Props>(
             {showHoverContent ? (
               <div css={hoverContentWrapperCSS}>
                 <EuiScreenReaderOnly>
-                  <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field)}</p>
+                  <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field.name)}</p>
                 </EuiScreenReaderOnly>
                 {visibleActions.map((action) => (
                   <ActionItem

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
+
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { euiThemeVars } from '@kbn/ui-theme';
+import { css } from '@emotion/react';
+import type { Action } from '../../actions';
+import { ActionItem } from './cell_action_item';
+import { ExtraActionsButton } from './extra_actions_button';
+import { YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
+import { partitionActions } from '../hooks/actions';
+import { ExtraActionsPopOverWithAnchor } from './extra_actions_popover';
+import { CellActionExecutionContext } from './cell_actions';
+
+/** This class is added to the document body while dragging */
+export const IS_DRAGGING_CLASS_NAME = 'is-dragging';
+
+// Overwrite Popover default minWidth to avoid displaying empty space
+const PANEL_STYLE = { minWidth: `24px` };
+
+const hoverContentWrapperCSS = css`
+  padding: 0 ${euiThemeVars.euiSizeS};
+`;
+
+/**
+ * To avoid expensive changes to the DOM, delay showing the popover menu
+ */
+const HOVER_INTENT_DELAY = 100; // ms
+
+interface Props {
+  children: React.ReactNode;
+  getActions: () => Promise<Action[]>;
+  showMoreActionsFrom: number;
+  actionContext: CellActionExecutionContext;
+  showTooltip: boolean;
+}
+
+export const HoverActionsPopover = React.memo<Props>(
+  ({ children, getActions, showMoreActionsFrom, actionContext, showTooltip }) => {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [isExtraActionsPopoverOpen, setIsExtraActionsPopoverOpen] = useState(false);
+    const [showHoverContent, setShowHoverContent] = useState(false);
+    const [, setHoverTimeout] = useState<number | undefined>(undefined);
+    const popoverRef = useRef<EuiPopover>(null);
+    const [actions, setActions] = useState<Action[] | null>(null);
+
+    const { visibleActions, extraActions } = useMemo(
+      () => partitionActions(actions ?? [], showMoreActionsFrom),
+      [actions, showMoreActionsFrom]
+    );
+
+    const closePopover = useCallback(() => {
+      setHoverTimeout((prevHoverTimeout) => {
+        clearTimeout(prevHoverTimeout);
+        return undefined;
+      });
+      setShowHoverContent(false);
+    }, []);
+
+    const closeExtraActions = useCallback(
+      () => setIsExtraActionsPopoverOpen(false),
+      [setIsExtraActionsPopoverOpen]
+    );
+
+    const onShowExtraActionsClick = useCallback(() => {
+      setIsExtraActionsPopoverOpen(true);
+      closePopover();
+    }, [closePopover, setIsExtraActionsPopoverOpen]);
+
+    const onMouseEnter = useCallback(async () => {
+      closeExtraActions(); // Closed extra actions when opening hover actions
+
+      // memoize actions after the first call
+      if (actions === null) {
+        getActions().then((newActions) => setActions(newActions));
+      }
+
+      setHoverTimeout(
+        Number(
+          setTimeout(() => {
+            // NOTE: the following read from the DOM is expensive, but not as
+            // expensive as the default behavior, which adds a div to the body,
+            // which-in turn performs a more expensive change to the layout
+            if (!document.body.classList.contains(IS_DRAGGING_CLASS_NAME)) {
+              setShowHoverContent(true);
+            }
+          }, HOVER_INTENT_DELAY)
+        )
+      );
+    }, [closeExtraActions, getActions, actions]);
+
+    const onMouseLeave = useCallback(() => {
+      closePopover();
+    }, [closePopover]);
+
+    const content = useMemo(
+      () => (
+        <div ref={contentRef} onMouseEnter={onMouseEnter}>
+          {children}
+        </div>
+      ),
+      [children, onMouseEnter]
+    );
+
+    return (
+      <>
+        <div onMouseLeave={onMouseLeave}>
+          <EuiPopover
+            panelStyle={PANEL_STYLE}
+            ref={popoverRef}
+            anchorPosition={'downCenter'}
+            button={content}
+            closePopover={closePopover}
+            hasArrow={false}
+            isOpen={showHoverContent}
+            panelPaddingSize="none"
+            repositionOnScroll
+            ownFocus={false}
+            data-test-subj={'hoverActionsPopover'}
+          >
+            {showHoverContent ? (
+              <div css={hoverContentWrapperCSS}>
+                <EuiScreenReaderOnly>
+                  <p>{YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS(actionContext.field)}</p>
+                </EuiScreenReaderOnly>
+                {visibleActions.map((action) => (
+                  <ActionItem
+                    key={action.id}
+                    action={action}
+                    actionContext={actionContext}
+                    showTooltip={showTooltip}
+                  />
+                ))}
+                {extraActions.length > 0 ? (
+                  <ExtraActionsButton onClick={onShowExtraActionsClick} showTooltip={showTooltip} />
+                ) : null}
+              </div>
+            ) : null}
+          </EuiPopover>
+        </div>
+        <ExtraActionsPopOverWithAnchor
+          actions={extraActions}
+          anchorRef={contentRef}
+          actionContext={actionContext}
+          closePopOver={closeExtraActions}
+          isOpen={isExtraActionsPopoverOpen}
+        />
+      </>
+    );
+  }
+);
+
+HoverActionsPopover.displayName = 'HoverActionsPopover';

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -11,11 +11,10 @@ import { EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
-import { i18n } from '@kbn/i18n';
 import type { Action } from '../../actions';
 import { ActionItem } from './cell_action_item';
 import { ExtraActionsButton } from './extra_actions_button';
-import { YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
+import { ACTIONS_AREA_LABEL, YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
 import { partitionActions } from '../hooks/actions';
 import { ExtraActionsPopOverWithAnchor } from './extra_actions_popover';
 import { CellActionExecutionContext } from './cell_actions';
@@ -125,9 +124,7 @@ export const HoverActionsPopover = React.memo<Props>(
             repositionOnScroll
             ownFocus={false}
             data-test-subj={'hoverActionsPopover'}
-            aria-label={i18n.translate('uiActions.cellActions.actionsAriaLabel', {
-              defaultMessage: 'Actions',
-            })}
+            aria-label={ACTIONS_AREA_LABEL}
           >
             {showHoverContent ? (
               <div css={hoverContentWrapperCSS}>

--- a/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/hover_actions_popover.tsx
@@ -103,14 +103,17 @@ export const HoverActionsPopover = React.memo<Props>(
       closePopover();
     }, [closePopover]);
 
-    const content = useMemo(
-      () => (
-        <div ref={contentRef} onMouseEnter={onMouseEnter}>
+    const content = useMemo(() => {
+      return (
+        // Hack - Forces extra actions popover to close when hover content is clicked.
+        // This hack is required because we anchor the popover to the hover content instead
+        // of anchoring it to the button that triggers the popover.
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+        <div ref={contentRef} onMouseEnter={onMouseEnter} onClick={closeExtraActions}>
           {children}
         </div>
-      ),
-      [children, onMouseEnter]
-    );
+      );
+    }, [onMouseEnter, closeExtraActions, children]);
 
     return (
       <>

--- a/src/plugins/ui_actions/public/cell_actions/components/index.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/index.tsx
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { CellActions, CellActionsMode } from './cell_actions';
+export { CellActionsContextProvider } from './cell_actions_context';

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
@@ -20,7 +20,11 @@ describe('InlineActions', () => {
     const getActions = () => getActionsPromise;
     const { queryByTestId } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
-        <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
+        <InlineActions
+          visibleCellActions={5}
+          actionContext={actionContext}
+          showActionTooltips={false}
+        />
       </CellActionsContextProvider>
     );
 
@@ -42,7 +46,11 @@ describe('InlineActions', () => {
     const getActions = () => getActionsPromise;
     const { queryAllByRole } = render(
       <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
-        <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
+        <InlineActions
+          visibleCellActions={5}
+          actionContext={actionContext}
+          showActionTooltips={false}
+        />
       </CellActionsContextProvider>
     );
 

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
@@ -11,18 +11,17 @@ import React from 'react';
 import { CellActionExecutionContext } from './cell_actions';
 import { makeAction } from '../mocks/helpers';
 import { InlineActions } from './inline_actions';
+import { CellActionsContextProvider } from '.';
 
 describe('InlineActions', () => {
+  const actionContext = { trigger: { id: 'triggerId' } } as CellActionExecutionContext;
   it('renders', async () => {
     const getActionsPromise = Promise.resolve([]);
     const getActions = () => getActionsPromise;
     const { queryByTestId } = render(
-      <InlineActions
-        getActions={getActions}
-        showMoreActionsFrom={5}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      />
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
+      </CellActionsContextProvider>
     );
 
     await act(async () => {
@@ -42,12 +41,9 @@ describe('InlineActions', () => {
     ]);
     const getActions = () => getActionsPromise;
     const { queryAllByRole } = render(
-      <InlineActions
-        getActions={getActions}
-        showMoreActionsFrom={5}
-        actionContext={{} as CellActionExecutionContext}
-        showTooltip={false}
-      />
+      <CellActionsContextProvider getCompatibleActions={getActions}>
+        <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
+      </CellActionsContextProvider>
     );
 
     await act(async () => {

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
@@ -19,7 +19,7 @@ describe('InlineActions', () => {
     const getActionsPromise = Promise.resolve([]);
     const getActions = () => getActionsPromise;
     const { queryByTestId } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
       </CellActionsContextProvider>
     );
@@ -41,7 +41,7 @@ describe('InlineActions', () => {
     ]);
     const getActions = () => getActionsPromise;
     const { queryAllByRole } = render(
-      <CellActionsContextProvider getCompatibleActions={getActions}>
+      <CellActionsContextProvider getTriggerCompatibleActions={getActions}>
         <InlineActions showMoreActionsFrom={5} actionContext={actionContext} showTooltip={false} />
       </CellActionsContextProvider>
     );

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { CellActionExecutionContext } from './cell_actions';
+import { makeAction } from '../mocks/helpers';
+import { InlineActions } from './inline_actions';
+
+describe('InlineActions', () => {
+  it('renders', async () => {
+    const getActionsPromise = Promise.resolve([]);
+    const getActions = () => getActionsPromise;
+    const { queryByTestId } = render(
+      <InlineActions
+        getActions={getActions}
+        showMoreActionsFrom={5}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      />
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(queryByTestId('inlineActions')).toBeInTheDocument();
+  });
+
+  it('renders all actions', async () => {
+    const getActionsPromise = Promise.resolve([
+      makeAction('action-1'),
+      makeAction('action-2'),
+      makeAction('action-3'),
+      makeAction('action-4'),
+      makeAction('action-5'),
+    ]);
+    const getActions = () => getActionsPromise;
+    const { queryAllByRole } = render(
+      <InlineActions
+        getActions={getActions}
+        showMoreActionsFrom={5}
+        actionContext={{} as CellActionExecutionContext}
+        showTooltip={false}
+      />
+    );
+
+    await act(async () => {
+      await getActionsPromise;
+    });
+
+    expect(queryAllByRole('button').length).toBe(5);
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { Action } from '../../actions';
+import { ActionItem } from './cell_action_item';
+import { usePartitionActions } from '../hooks/actions';
+import { ExtraActionsPopOver } from './extra_actions_popover';
+import { ExtraActionsButton } from './extra_actions_button';
+import { CellActionExecutionContext } from './cell_actions';
+
+interface InlineActionsProps {
+  getActions: () => Promise<Action[]>;
+  actionContext: CellActionExecutionContext;
+  showTooltip: boolean;
+  showMoreActionsFrom: number;
+}
+
+export const InlineActions: React.FC<InlineActionsProps> = ({
+  getActions,
+  actionContext,
+  showTooltip,
+  showMoreActionsFrom,
+}) => {
+  const { extraActions, visibleActions } = usePartitionActions(getActions, showMoreActionsFrom);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const togglePopOver = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
+  const closePopOver = useCallback(() => setIsPopoverOpen(false), []);
+  const button = useMemo(
+    () => <ExtraActionsButton onClick={togglePopOver} showTooltip={showTooltip} />,
+    [togglePopOver, showTooltip]
+  );
+
+  return (
+    <span data-test-subj="inlineActions">
+      {visibleActions.map((action, index) => (
+        <ActionItem
+          key={`action-item-${index}`}
+          action={action}
+          actionContext={actionContext}
+          showTooltip={showTooltip}
+        />
+      ))}
+      {extraActions.length > 0 ? (
+        <ExtraActionsPopOver
+          actions={extraActions}
+          actionContext={actionContext}
+          button={button}
+          closePopOver={closePopOver}
+          isOpen={isPopoverOpen}
+        />
+      ) : null}
+    </span>
+  );
+};
+
+InlineActions.displayName = 'InlineActions';

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
@@ -7,27 +7,29 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import type { Action } from '../../actions';
 import { ActionItem } from './cell_action_item';
 import { usePartitionActions } from '../hooks/actions';
 import { ExtraActionsPopOver } from './extra_actions_popover';
 import { ExtraActionsButton } from './extra_actions_button';
 import { CellActionExecutionContext } from './cell_actions';
+import { useLoadActions } from './cell_actions_context';
 
 interface InlineActionsProps {
-  getActions: () => Promise<Action[]>;
   actionContext: CellActionExecutionContext;
   showTooltip: boolean;
   showMoreActionsFrom: number;
 }
 
 export const InlineActions: React.FC<InlineActionsProps> = ({
-  getActions,
   actionContext,
   showTooltip,
   showMoreActionsFrom,
 }) => {
-  const { extraActions, visibleActions } = usePartitionActions(getActions, showMoreActionsFrom);
+  const { value: allActions } = useLoadActions(actionContext);
+  const { extraActions, visibleActions } = usePartitionActions(
+    allActions ?? [],
+    showMoreActionsFrom
+  );
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const togglePopOver = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
   const closePopOver = useCallback(() => setIsPopoverOpen(false), []);

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
@@ -16,26 +16,26 @@ import { useLoadActions } from './cell_actions_context';
 
 interface InlineActionsProps {
   actionContext: CellActionExecutionContext;
-  showTooltip: boolean;
-  showMoreActionsFrom: number;
+  showActionTooltips: boolean;
+  visibleCellActions: number;
 }
 
 export const InlineActions: React.FC<InlineActionsProps> = ({
   actionContext,
-  showTooltip,
-  showMoreActionsFrom,
+  showActionTooltips,
+  visibleCellActions,
 }) => {
   const { value: allActions } = useLoadActions(actionContext);
   const { extraActions, visibleActions } = usePartitionActions(
     allActions ?? [],
-    showMoreActionsFrom
+    visibleCellActions
   );
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const togglePopOver = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
   const closePopOver = useCallback(() => setIsPopoverOpen(false), []);
   const button = useMemo(
-    () => <ExtraActionsButton onClick={togglePopOver} showTooltip={showTooltip} />,
-    [togglePopOver, showTooltip]
+    () => <ExtraActionsButton onClick={togglePopOver} showTooltip={showActionTooltips} />,
+    [togglePopOver, showActionTooltips]
   );
 
   return (
@@ -45,7 +45,7 @@ export const InlineActions: React.FC<InlineActionsProps> = ({
           key={`action-item-${index}`}
           action={action}
           actionContext={actionContext}
-          showTooltip={showTooltip}
+          showTooltip={showActionTooltips}
         />
       ))}
       {extraActions.length > 0 ? (

--- a/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
+++ b/src/plugins/ui_actions/public/cell_actions/components/inline_actions.tsx
@@ -60,5 +60,3 @@ export const InlineActions: React.FC<InlineActionsProps> = ({
     </span>
   );
 };
-
-InlineActions.displayName = 'InlineActions';

--- a/src/plugins/ui_actions/public/cell_actions/components/translations.ts
+++ b/src/plugins/ui_actions/public/cell_actions/components/translations.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { i18n } from '@kbn/i18n';
+
+export const YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS = (fieldName: string) =>
+  i18n.translate('uiActions.cellActions.youAreInADialogContainingOptionsScreenReaderOnly', {
+    values: { fieldName },
+    defaultMessage: `You are in a dialog, containing options for field {fieldName}. Press tab to navigate options. Press escape to exit.`,
+  });

--- a/src/plugins/ui_actions/public/cell_actions/components/translations.ts
+++ b/src/plugins/ui_actions/public/cell_actions/components/translations.ts
@@ -12,3 +12,18 @@ export const YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS = (fieldName: string) =>
     values: { fieldName },
     defaultMessage: `You are in a dialog, containing options for field {fieldName}. Press tab to navigate options. Press escape to exit.`,
   });
+
+export const EXTRA_ACTIONS_ARIA_LABEL = i18n.translate(
+  'uiActions.cellActions.extraActionsAriaLabel',
+  {
+    defaultMessage: 'Extra actions',
+  }
+);
+
+export const SHOW_MORE_ACTIONS = i18n.translate('uiActions.showMoreActionsLabel', {
+  defaultMessage: 'More actions',
+});
+
+export const ACTIONS_AREA_LABEL = i18n.translate('uiActions.cellActions.actionsAriaLabel', {
+  defaultMessage: 'Actions',
+});

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.test.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.test.ts
@@ -17,7 +17,7 @@ describe('InlineActions', () => {
     expect(extraActions).toEqual([]);
   });
 
-  it('returns only visible actions when showMoreActionsFrom > actions.length', async () => {
+  it('returns only visible actions when visibleCellActions > actions.length', async () => {
     const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
     const { extraActions, visibleActions } = partitionActions(actions, 4);
 
@@ -25,7 +25,7 @@ describe('InlineActions', () => {
     expect(extraActions).toEqual([]);
   });
 
-  it('returns only extra actions when showMoreActionsFrom is 1', async () => {
+  it('returns only extra actions when visibleCellActions is 1', async () => {
     const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
     const { extraActions, visibleActions } = partitionActions(actions, 1);
 
@@ -33,7 +33,7 @@ describe('InlineActions', () => {
     expect(extraActions.length).toEqual(actions.length);
   });
 
-  it('returns only extra actions when showMoreActionsFrom is 0', async () => {
+  it('returns only extra actions when visibleCellActions is 0', async () => {
     const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
     const { extraActions, visibleActions } = partitionActions(actions, 0);
 
@@ -41,7 +41,7 @@ describe('InlineActions', () => {
     expect(extraActions.length).toEqual(actions.length);
   });
 
-  it('returns only extra actions when showMoreActionsFrom is negative', async () => {
+  it('returns only extra actions when visibleCellActions is negative', async () => {
     const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
     const { extraActions, visibleActions } = partitionActions(actions, -6);
 
@@ -49,7 +49,7 @@ describe('InlineActions', () => {
     expect(extraActions.length).toEqual(actions.length);
   });
 
-  it('returns only one visible action when showMoreActionsFrom is 2 and action.length is 3', async () => {
+  it('returns only one visible action when visibleCellActionss 2 and action.length is 3', async () => {
     const { extraActions, visibleActions } = partitionActions(
       [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')],
       2
@@ -59,7 +59,7 @@ describe('InlineActions', () => {
     expect(extraActions.length).toEqual(2);
   });
 
-  it('returns two visible actions when showMoreActionsFrom is 3 and action.length is 5', async () => {
+  it('returns two visible actions when visibleCellActions is 3 and action.length is 5', async () => {
     const { extraActions, visibleActions } = partitionActions(
       [
         makeAction('action-1'),
@@ -74,7 +74,7 @@ describe('InlineActions', () => {
     expect(extraActions.length).toEqual(3);
   });
 
-  it('returns three visible actions when showMoreActionsFrom is 3 and action.length is 3', async () => {
+  it('returns three visible actions when visibleCellActions is 3 and action.length is 3', async () => {
     const { extraActions, visibleActions } = partitionActions(
       [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')],
       3

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.test.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { makeAction } from '../mocks/helpers';
+import { partitionActions } from './actions';
+
+describe('InlineActions', () => {
+  it('returns an empty array when actions is an empty array', async () => {
+    const { extraActions, visibleActions } = partitionActions([], 5);
+
+    expect(visibleActions).toEqual([]);
+    expect(extraActions).toEqual([]);
+  });
+
+  it('returns only visible actions when showMoreActionsFrom > actions.length', async () => {
+    const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
+    const { extraActions, visibleActions } = partitionActions(actions, 4);
+
+    expect(visibleActions.length).toEqual(actions.length);
+    expect(extraActions).toEqual([]);
+  });
+
+  it('returns only extra actions when showMoreActionsFrom is 1', async () => {
+    const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
+    const { extraActions, visibleActions } = partitionActions(actions, 1);
+
+    expect(visibleActions).toEqual([]);
+    expect(extraActions.length).toEqual(actions.length);
+  });
+
+  it('returns only extra actions when showMoreActionsFrom is 0', async () => {
+    const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
+    const { extraActions, visibleActions } = partitionActions(actions, 0);
+
+    expect(visibleActions).toEqual([]);
+    expect(extraActions.length).toEqual(actions.length);
+  });
+
+  it('returns only extra actions when showMoreActionsFrom is negative', async () => {
+    const actions = [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')];
+    const { extraActions, visibleActions } = partitionActions(actions, -6);
+
+    expect(visibleActions).toEqual([]);
+    expect(extraActions.length).toEqual(actions.length);
+  });
+
+  it('returns only one visible action when showMoreActionsFrom is 2 and action.length is 3', async () => {
+    const { extraActions, visibleActions } = partitionActions(
+      [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')],
+      2
+    );
+
+    expect(visibleActions.length).toEqual(1);
+    expect(extraActions.length).toEqual(2);
+  });
+
+  it('returns two visible actions when showMoreActionsFrom is 3 and action.length is 5', async () => {
+    const { extraActions, visibleActions } = partitionActions(
+      [
+        makeAction('action-1'),
+        makeAction('action-2'),
+        makeAction('action-3'),
+        makeAction('action-4'),
+        makeAction('action-5'),
+      ],
+      3
+    );
+    expect(visibleActions.length).toEqual(2);
+    expect(extraActions.length).toEqual(3);
+  });
+
+  it('returns three visible actions when showMoreActionsFrom is 3 and action.length is 3', async () => {
+    const { extraActions, visibleActions } = partitionActions(
+      [makeAction('action-1'), makeAction('action-2'), makeAction('action-3')],
+      3
+    );
+    expect(visibleActions.length).toEqual(3);
+    expect(extraActions.length).toEqual(0);
+  });
+});

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
@@ -9,13 +9,13 @@
 import { useMemo } from 'react';
 import { Action } from '../../actions';
 
-export const partitionActions = (actions: Action[], showMoreActionsFrom: number) => {
-  if (showMoreActionsFrom <= 1) return { extraActions: actions, visibleActions: [] };
-  if (actions.length <= showMoreActionsFrom) return { extraActions: [], visibleActions: actions };
+export const partitionActions = (actions: Action[], visibleCellActions: number) => {
+  if (visibleCellActions <= 1) return { extraActions: actions, visibleActions: [] };
+  if (actions.length <= visibleCellActions) return { extraActions: [], visibleActions: actions };
 
   return {
-    visibleActions: actions.slice(0, showMoreActionsFrom - 1),
-    extraActions: actions.slice(showMoreActionsFrom - 1, actions.length),
+    visibleActions: actions.slice(0, visibleCellActions - 1),
+    extraActions: actions.slice(visibleCellActions - 1, actions.length),
   };
 };
 
@@ -26,9 +26,9 @@ export interface PartitionedActions {
 
 export const usePartitionActions = (
   allActions: Action[],
-  showMoreActionsFrom: number
+  visibleCellActions: number
 ): PartitionedActions => {
   return useMemo(() => {
-    return partitionActions(allActions ?? [], showMoreActionsFrom);
-  }, [allActions, showMoreActionsFrom]);
+    return partitionActions(allActions ?? [], visibleCellActions);
+  }, [allActions, visibleCellActions]);
 };

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
@@ -7,7 +7,6 @@
  */
 
 import { useMemo } from 'react';
-import useAsync from 'react-use/lib/useAsync';
 import { Action } from '../../actions';
 
 export const partitionActions = (actions: Action[], showMoreActionsFrom: number) => {
@@ -26,15 +25,10 @@ export interface PartitionedActions {
 }
 
 export const usePartitionActions = (
-  getActions: () => Promise<Action[]>,
+  allActions: Action[],
   showMoreActionsFrom: number
-): PartitionedActions & { loading: boolean } => {
-  const { value: allActions, loading } = useAsync(getActions, []);
-
+): PartitionedActions => {
   return useMemo(() => {
-    if (loading) {
-      return { extraActions: [], visibleActions: [], loading };
-    }
-    return { ...partitionActions(allActions ?? [], showMoreActionsFrom), loading };
-  }, [loading, allActions, showMoreActionsFrom]);
+    return partitionActions(allActions ?? [], showMoreActionsFrom);
+  }, [allActions, showMoreActionsFrom]);
 };

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
@@ -29,7 +29,7 @@ export const usePartitionActions = (
   getActions: () => Promise<Action[]>,
   showMoreActionsFrom: number
 ): PartitionedActions & { loading: boolean } => {
-  const { value: allActions, loading } = useAsync(() => getActions(), []);
+  const { value: allActions, loading } = useAsync(getActions, []);
 
   return useMemo(() => {
     if (loading) {

--- a/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
+++ b/src/plugins/ui_actions/public/cell_actions/hooks/actions.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { Action } from '../../actions';
+
+export const partitionActions = (actions: Action[], showMoreActionsFrom: number) => {
+  if (showMoreActionsFrom <= 1) return { extraActions: actions, visibleActions: [] };
+  if (actions.length <= showMoreActionsFrom) return { extraActions: [], visibleActions: actions };
+
+  return {
+    visibleActions: actions.slice(0, showMoreActionsFrom - 1),
+    extraActions: actions.slice(showMoreActionsFrom - 1, actions.length),
+  };
+};
+
+export interface PartitionedActions {
+  extraActions: Array<Action<object>>;
+  visibleActions: Array<Action<object>>;
+}
+
+export const usePartitionActions = (
+  getActions: () => Promise<Action[]>,
+  showMoreActionsFrom: number
+): PartitionedActions & { loading: boolean } => {
+  const { value: allActions, loading } = useAsync(() => getActions(), []);
+
+  return useMemo(() => {
+    if (loading) {
+      return { extraActions: [], visibleActions: [], loading };
+    }
+    return { ...partitionActions(allActions ?? [], showMoreActionsFrom), loading };
+  }, [loading, allActions, showMoreActionsFrom]);
+};

--- a/src/plugins/ui_actions/public/cell_actions/mocks/helpers.ts
+++ b/src/plugins/ui_actions/public/cell_actions/mocks/helpers.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const makeAction = (actionsName: string, icon: string = 'icon', order: number = 0) => ({
+  id: actionsName,
+  type: actionsName,
+  order,
+  getIconType: () => icon,
+  getDisplayName: () => actionsName,
+  getDisplayNameTooltip: () => actionsName,
+  isCompatible: () => Promise.resolve(true),
+  execute: () => {
+    alert(actionsName);
+    return Promise.resolve();
+  },
+});

--- a/src/plugins/ui_actions/public/cell_actions/mocks/helpers.ts
+++ b/src/plugins/ui_actions/public/cell_actions/mocks/helpers.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export const makeAction = (actionsName: string, icon: string = 'icon', order: number = 0) => ({
+export const makeAction = (actionsName: string, icon: string = 'icon', order?: number) => ({
   id: actionsName,
   type: actionsName,
   order,

--- a/src/plugins/ui_actions/public/index.ts
+++ b/src/plugins/ui_actions/public/index.ts
@@ -39,3 +39,8 @@ export {
   ACTION_VISUALIZE_LENS_FIELD,
 } from './types';
 export type { ActionExecutionContext, ActionExecutionMeta, ActionMenuItemProps } from './actions';
+export {
+  CellActions,
+  CellActionsMode,
+  CellActionsContextProvider,
+} from './cell_actions/components';


### PR DESCRIPTION
## Summary

Create a `CellActions` component. It hooks into a UI-Actions trigger and displays all available actions.
It has two modes, Hover_Actions and Always_Visible. 

You can run the storybook and take a look at the component: `yarn storybook ui_actions` or access https://ci-artifacts.kibana.dev/storybooks/pr-147434/226993c612bbe1719de6374219009bc69b0378d8/ui_actions/index.html

*** This component is still not in use.

<img width="117" alt="Screenshot 2022-12-13 at 13 13 46" src="https://user-images.githubusercontent.com/1490444/207316029-26c7bad8-ae39-48ba-8059-cbacf01a98aa.png">


<img width="224" alt="Screenshot 2022-12-13 at 13 13 30" src="https://user-images.githubusercontent.com/1490444/207316024-0d7706c8-bd59-42e8-bf6d-b5648fc818fd.png">


#### Why?
The security Solution team is creating a generic UI component to allow teams to share actions between different plugins.
Initially, only the Security solution plugin will use this component and deprecate the Security solution custom implementation. Some actions that will be shared are: "copy to clipboard", "filter in", "filter out" and "add to timeline".



#### How to use it:
This package provides a uniform interface for displaying UI actions for a cell.
For the `CellActions` component to work, it must be wrapped by `CellActionsContextProvider`. Ideally, the wrapper should stay on the top of the rendering tree.

Example:
```JSX
<CellActionsContextProvider
    // call uiActions.getTriggerCompatibleActions(triggerId, data)
    getCompatibleActions={getCompatibleActions}>
    ...
    <CellActions mode={CellActionsMode.HOVER_POPOVER} triggerId={MY_TRIGGER_ID} config={{ field: 'fieldName', value: 'fieldValue', fieldType: 'text' }}>
        Hover me
    </CellActions>
</CellActionsContextProvider>

```

`CellActions` component will display all compatible actions registered for the trigger id.



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


