### PR TITLE
[ML] Explain Log Rate Spikes: Fix item set post processing.

### DIFF
--- a/x-pack/test/api_integration/apis/aiops/test_data.ts
+++ b/x-pack/test/api_integration/apis/aiops/test_data.ts
@@ -138,7 +138,6 @@ export const explainLogRateSpikesTestData: TestData[] = [
           group: [
             { fieldName: 'response_code', fieldValue: '500', duplicate: false },
             { fieldName: 'url', fieldValue: 'home.php', duplicate: false },
-            { fieldName: 'url', fieldValue: 'home.php', duplicate: false },
             { fieldName: 'url', fieldValue: 'login.php', duplicate: false },
           ],
           docCount: 792,


### PR DESCRIPTION
## Summary

Part of #146162.

Fixes cases where the item set post processing would end up with duplicate entries.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->