### PR TITLE
[Discover] Fixes the transition from Discover to Lens for the Visualize button

### DIFF
--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -473,6 +473,27 @@ describe('Textbased Data Source', () => {
         layerId: 'newid',
       });
     });
+
+    it('should not return suggestions if no query is given', () => {
+      const state = {
+        layers: {},
+        initialContext: {
+          contextualFields: ['bytes', 'dest'],
+          dataViewSpec: {
+            title: 'foo',
+            id: '1',
+            name: 'Foo',
+          },
+        },
+      } as unknown as TextBasedPrivateState;
+      const suggestions = TextBasedDatasource.getDatasourceSuggestionsForVisualizeField(
+        state,
+        '1',
+        '',
+        indexPatterns
+      );
+      expect(suggestions).toEqual([]);
+    });
   });
 
   describe('#getErrorMessages', () => {

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -92,7 +92,9 @@ export function getTextBasedDatasource({
     indexPatterns: IndexPatternMap
   ) => {
     const context = state.initialContext;
-    if (context && 'dataViewSpec' in context && context.dataViewSpec.title) {
+    // on text based mode we offer suggestions for the query and not for a specific field
+    if (fieldName) return [];
+    if (context && 'dataViewSpec' in context && context.dataViewSpec.title && context.query) {
       const newLayerId = generateId();
       const indexPattern = indexPatterns[indexPatternId];
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147479

This is a regression that exists on 8.6.0 when the users are trying to Visualize a field and have selected columns in Discover.

The problem is that the text based datasource is also providing some suggestions while it shouldn't. This PR adds 2 extra checks:

- if the context has the fieldname it returns empty suggestions (in the text based mode we suggest based on the query and not the field
- If there is no aggregate query we also return empty suggestions

![discover](https://user-images.githubusercontent.com/17003240/207583040-fb58d5d8-bb26-48bb-b809-fe8091b93619.gif)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->