### PR TITLE
adds time_series bucket aggregation

### DIFF
--- a/src/plugins/data/common/search/aggs/agg_types.ts
+++ b/src/plugins/data/common/search/aggs/agg_types.ts
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import {FieldFormatsStartCommon} from '@kbn/field-formats-plugin/common';
+import { FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
 
 import * as buckets from './buckets';
-import {BUCKET_TYPES, CalculateBoundsFn} from './buckets';
+import { BUCKET_TYPES, CalculateBoundsFn } from './buckets';
 import * as metrics from './metrics';
-import {METRIC_TYPES} from './metrics';
+import { METRIC_TYPES } from './metrics';
 
 export interface AggTypesDependencies {
   calculateBounds: CalculateBoundsFn;

--- a/src/plugins/data/common/search/aggs/agg_types.ts
+++ b/src/plugins/data/common/search/aggs/agg_types.ts
@@ -6,13 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
+import {FieldFormatsStartCommon} from '@kbn/field-formats-plugin/common';
 
 import * as buckets from './buckets';
+import {BUCKET_TYPES, CalculateBoundsFn} from './buckets';
 import * as metrics from './metrics';
-
-import { BUCKET_TYPES, CalculateBoundsFn } from './buckets';
-import { METRIC_TYPES } from './metrics';
+import {METRIC_TYPES} from './metrics';
 
 export interface AggTypesDependencies {
   calculateBounds: CalculateBoundsFn;
@@ -71,6 +70,7 @@ export const getAggTypes = () => ({
     { name: BUCKET_TYPES.GEOTILE_GRID, fn: buckets.getGeoTitleBucketAgg },
     { name: BUCKET_TYPES.SAMPLER, fn: buckets.getSamplerBucketAgg },
     { name: BUCKET_TYPES.DIVERSIFIED_SAMPLER, fn: buckets.getDiversifiedSamplerBucketAgg },
+    { name: BUCKET_TYPES.TIME_SERIES, fn: buckets.getTimeSeriesBucketAgg },
   ],
 });
 
@@ -88,6 +88,7 @@ export const getAggTypesFunctions = () => [
   buckets.aggHistogram,
   buckets.aggDateHistogram,
   buckets.aggTerms,
+  buckets.aggTimeSeries,
   buckets.aggMultiTerms,
   buckets.aggRareTerms,
   buckets.aggSampler,

--- a/src/plugins/data/common/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/common/search/aggs/aggs_service.test.ts
@@ -69,6 +69,7 @@ describe('Aggs service', () => {
           "geotile_grid",
           "sampler",
           "diversified_sampler",
+          "time_series",
           "foo",
         ]
       `);
@@ -124,6 +125,7 @@ describe('Aggs service', () => {
           "geotile_grid",
           "sampler",
           "diversified_sampler",
+          "time_series",
         ]
       `);
       expect(bStart.types.getAll().metrics.map((t) => t.name)).toMatchInlineSnapshot(`

--- a/src/plugins/data/common/search/aggs/buckets/bucket_agg_types.ts
+++ b/src/plugins/data/common/search/aggs/buckets/bucket_agg_types.ts
@@ -23,4 +23,5 @@ export enum BUCKET_TYPES {
   DATE_HISTOGRAM = 'date_histogram',
   SAMPLER = 'sampler',
   DIVERSIFIED_SAMPLER = 'diversified_sampler',
+  TIME_SERIES = 'time_series',
 }

--- a/src/plugins/data/common/search/aggs/buckets/index.ts
+++ b/src/plugins/data/common/search/aggs/buckets/index.ts
@@ -48,4 +48,6 @@ export * from './sampler_fn';
 export * from './sampler';
 export * from './diversified_sampler_fn';
 export * from './diversified_sampler';
+export * from './time_series';
+export * from './time_series_fn';
 export { SHARD_DELAY_AGG_NAME } from './shard_delay';

--- a/src/plugins/data/common/search/aggs/buckets/time_series.ts
+++ b/src/plugins/data/common/search/aggs/buckets/time_series.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+import { BucketAggType } from './bucket_agg_type';
+import { BUCKET_TYPES } from './bucket_agg_types';
+import { createFilterTerms } from './create_filter/terms';
+import { aggTimeSeriesFnName } from './time_series_fn';
+import { BaseAggParams } from '../types';
+
+export { termsAggFilter } from './_terms_order_helper';
+
+const timeSeriesTitle = i18n.translate('data.search.aggs.buckets.timeSeriesTitle', {
+  defaultMessage: 'Time Series',
+});
+
+export type AggParamsTimeSeries = BaseAggParams;
+
+export const getTimeSeriesBucketAgg = () =>
+  new BucketAggType({
+    name: BUCKET_TYPES.TIME_SERIES,
+    expressionName: aggTimeSeriesFnName,
+    title: timeSeriesTitle,
+    makeLabel(agg) {
+      return 'rate';
+    },
+    createFilter: createFilterTerms,
+    params: [],
+  });

--- a/src/plugins/data/common/search/aggs/buckets/time_series.ts
+++ b/src/plugins/data/common/search/aggs/buckets/time_series.ts
@@ -10,7 +10,6 @@ import { i18n } from '@kbn/i18n';
 
 import { BucketAggType } from './bucket_agg_type';
 import { BUCKET_TYPES } from './bucket_agg_types';
-import { createFilterTerms } from './create_filter/terms';
 import { aggTimeSeriesFnName } from './time_series_fn';
 import { BaseAggParams } from '../types';
 

--- a/src/plugins/data/common/search/aggs/buckets/time_series.ts
+++ b/src/plugins/data/common/search/aggs/buckets/time_series.ts
@@ -27,9 +27,5 @@ export const getTimeSeriesBucketAgg = () =>
     name: BUCKET_TYPES.TIME_SERIES,
     expressionName: aggTimeSeriesFnName,
     title: timeSeriesTitle,
-    makeLabel(agg) {
-      return 'rate';
-    },
-    createFilter: createFilterTerms,
     params: [],
   });

--- a/src/plugins/data/common/search/aggs/buckets/time_series_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/time_series_fn.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { functionWrapper } from '../test_helpers';
+import { aggTimeSeries } from './time_series_fn';
+
+describe('agg_expression_functions', () => {
+  describe('timeSeries', () => {
+    const fn = functionWrapper(aggTimeSeries());
+
+    test('fills in defaults when only required args are provided', () => {
+      const actual = fn({});
+      expect(actual).toMatchInlineSnapshot(`
+        Object {
+          "type": "agg_type",
+          "value": Object {
+            "enabled": true,
+            "id": undefined,
+            "params": Object {
+              "customLabel": undefined,
+            },
+            "schema": undefined,
+            "type": "time_series",
+          },
+        }
+      `);
+    });
+  });
+});

--- a/src/plugins/data/common/search/aggs/buckets/time_series_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/time_series_fn.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
+import { AggExpressionType, AggExpressionFunctionArgs, BUCKET_TYPES } from '..';
+
+export const aggTimeSeriesFnName = 'aggTimeSeries';
+
+type Input = any;
+type Output = AggExpressionType;
+type AggArgs = AggExpressionFunctionArgs<typeof BUCKET_TYPES.TIME_SERIES>;
+
+type FunctionDefinition = ExpressionFunctionDefinition<
+  typeof aggTimeSeriesFnName,
+  Input,
+  AggArgs,
+  Output
+>;
+
+export const aggTimeSeries = (): FunctionDefinition => ({
+  name: aggTimeSeriesFnName,
+  help: i18n.translate('data.search.aggs.function.buckets.timeSeries.help', {
+    defaultMessage: 'Generates a serialized agg config for a Time Series agg',
+  }),
+  type: 'agg_type',
+  args: {
+    id: {
+      types: ['string'],
+      help: i18n.translate('data.search.aggs.buckets.timeSeries.id.help', {
+        defaultMessage: 'ID for this aggregation',
+      }),
+    },
+    enabled: {
+      types: ['boolean'],
+      default: true,
+      help: i18n.translate('data.search.aggs.buckets.timeSeries.enabled.help', {
+        defaultMessage: 'Specifies whether this aggregation should be enabled',
+      }),
+    },
+    schema: {
+      types: ['string'],
+      help: i18n.translate('data.search.aggs.buckets.timeSeries.schema.help', {
+        defaultMessage: 'Schema to use for this aggregation',
+      }),
+    },
+    customLabel: {
+      types: ['string'],
+      help: i18n.translate('data.search.aggs.buckets.terms.customLabel.help', {
+        defaultMessage: 'Represents a custom label for this aggregation',
+      }),
+    },
+  },
+  fn: (input, args) => {
+    const { id, enabled, schema, ...rest } = args;
+
+    return {
+      type: 'agg_type',
+      value: {
+        id,
+        enabled,
+        schema,
+        type: BUCKET_TYPES.TIME_SERIES,
+        params: {
+          ...rest,
+        },
+      },
+    };
+  },
+});

--- a/src/plugins/data/common/search/aggs/types.ts
+++ b/src/plugins/data/common/search/aggs/types.ts
@@ -8,6 +8,7 @@
 
 import { Assign } from '@kbn/utility-types';
 import type { DataView } from '@kbn/data-views-plugin/common';
+import { aggTimeSeries } from './buckets/time_series_fn';
 import {
   aggAvg,
   aggBucketAvg,
@@ -116,7 +117,6 @@ import { AggParamsSampler } from './buckets/sampler';
 import { AggParamsDiversifiedSampler } from './buckets/diversified_sampler';
 import { AggParamsSignificantText } from './buckets/significant_text';
 import { aggTopMetrics } from './metrics/top_metrics_fn';
-import {aggTimeSeries} from "@kbn/data-plugin/common/search/aggs/buckets/time_series_fn";
 
 export type { IAggConfig, AggConfigSerialized } from './agg_config';
 export type { CreateAggConfigParams, IAggConfigs, AggConfigsOptions } from './agg_configs';

--- a/src/plugins/data/common/search/aggs/types.ts
+++ b/src/plugins/data/common/search/aggs/types.ts
@@ -110,11 +110,13 @@ import {
   AggParamsMovingAvgSerialized,
   AggParamsSerialDiffSerialized,
   AggParamsTopHitSerialized,
+  AggParamsTimeSeries,
 } from '.';
 import { AggParamsSampler } from './buckets/sampler';
 import { AggParamsDiversifiedSampler } from './buckets/diversified_sampler';
 import { AggParamsSignificantText } from './buckets/significant_text';
 import { aggTopMetrics } from './metrics/top_metrics_fn';
+import {aggTimeSeries} from "@kbn/data-plugin/common/search/aggs/buckets/time_series_fn";
 
 export type { IAggConfig, AggConfigSerialized } from './agg_config';
 export type { CreateAggConfigParams, IAggConfigs, AggConfigsOptions } from './agg_configs';
@@ -183,6 +185,7 @@ interface SerializedAggParamsMapping {
   [BUCKET_TYPES.HISTOGRAM]: AggParamsHistogram;
   [BUCKET_TYPES.DATE_HISTOGRAM]: AggParamsDateHistogram;
   [BUCKET_TYPES.TERMS]: AggParamsTermsSerialized;
+  [BUCKET_TYPES.TIME_SERIES]: AggParamsTimeSeries;
   [BUCKET_TYPES.MULTI_TERMS]: AggParamsMultiTermsSerialized;
   [BUCKET_TYPES.RARE_TERMS]: AggParamsRareTerms;
   [BUCKET_TYPES.SAMPLER]: AggParamsSampler;
@@ -229,6 +232,7 @@ export interface AggParamsMapping {
   [BUCKET_TYPES.HISTOGRAM]: AggParamsHistogram;
   [BUCKET_TYPES.DATE_HISTOGRAM]: AggParamsDateHistogram;
   [BUCKET_TYPES.TERMS]: AggParamsTerms;
+  [BUCKET_TYPES.TIME_SERIES]: AggParamsTimeSeries;
   [BUCKET_TYPES.MULTI_TERMS]: AggParamsMultiTerms;
   [BUCKET_TYPES.RARE_TERMS]: AggParamsRareTerms;
   [BUCKET_TYPES.SAMPLER]: AggParamsSampler;
@@ -276,6 +280,7 @@ export interface AggFunctionsMapping {
   aggHistogram: ReturnType<typeof aggHistogram>;
   aggDateHistogram: ReturnType<typeof aggDateHistogram>;
   aggTerms: ReturnType<typeof aggTerms>;
+  aggTimeSeries: ReturnType<typeof aggTimeSeries>;
   aggMultiTerms: ReturnType<typeof aggMultiTerms>;
   aggRareTerms: ReturnType<typeof aggRareTerms>;
   aggAvg: ReturnType<typeof aggAvg>;

--- a/src/plugins/data/public/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/public/search/aggs/aggs_service.test.ts
@@ -52,7 +52,7 @@ describe('AggsService - public', () => {
     test('registers default agg types', () => {
       service.setup(setupDeps);
       const start = service.start(startDeps);
-      expect(start.types.getAll().buckets.length).toBe(16);
+      expect(start.types.getAll().buckets.length).toBe(17);
       expect(start.types.getAll().metrics.length).toBe(27);
     });
 
@@ -68,7 +68,7 @@ describe('AggsService - public', () => {
       );
 
       const start = service.start(startDeps);
-      expect(start.types.getAll().buckets.length).toBe(17);
+      expect(start.types.getAll().buckets.length).toBe(18);
       expect(start.types.getAll().buckets.some(({ name }) => name === 'foo')).toBe(true);
       expect(start.types.getAll().metrics.length).toBe(28);
       expect(start.types.getAll().metrics.some(({ name }) => name === 'bar')).toBe(true);

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/calculations/counter_rate.tsx
@@ -53,7 +53,7 @@ export const counterRateOperation: OperationDefinition<
   requiredReferences: [
     {
       input: ['field', 'managedReference'],
-      specificOperations: ['max'],
+      specificOperations: ['max', 'min', 'avg'],
       validateMetadata: (meta) => meta.dataType === 'number' && !meta.isBucketed,
     },
   ],

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/calculations/counter_rate.tsx
@@ -53,7 +53,7 @@ export const counterRateOperation: OperationDefinition<
   requiredReferences: [
     {
       input: ['field', 'managedReference'],
-      specificOperations: ['max', 'min', 'avg'],
+      specificOperations: ['max'],
       validateMetadata: (meta) => meta.dataType === 'number' && !meta.isBucketed,
     },
   ],


### PR DESCRIPTION
## Summary

Adds time_series bucket aggregation support to AggConfigs

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
