### PR TITLE
[Unified search] Fixes the styling of the filters modal

### DIFF
--- a/src/plugins/unified_search/public/apply_filters/apply_filter_popover_content.tsx
+++ b/src/plugins/unified_search/public/apply_filters/apply_filter_popover_content.tsx
@@ -87,10 +87,12 @@ export default class ApplyFiltersPopoverContent extends Component<Props, State> 
       <React.Fragment>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="unifiedSearch.filter.applyFilters.popupHeader"
-              defaultMessage="Select filters to apply"
-            />
+            <h1>
+              <FormattedMessage
+                id="unifiedSearch.filter.applyFilters.popupHeader"
+                defaultMessage="Select filters to apply"
+              />
+            </h1>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 


### PR DESCRIPTION
## Summary

Created by the latest EUI update. Some modal headers are not displayed with the correct styling. 

<img width="591" alt="Screenshot 2022-12-14 at 1 38 37 PM" src="https://user-images.githubusercontent.com/17003240/207585800-094028d2-f90d-43ea-a415-8567f3e72db6.png">

<img width="625" alt="image" src="https://user-images.githubusercontent.com/17003240/207585977-e92f332b-30f1-4aad-b995-d067e386ae42.png">
