### PR TITLE
[8.6] [APM] Switching service groups from grid to flex layout (#147448)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
+  useIsWithinBreakpoints,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -34,8 +35,10 @@ export function ServiceGroupsCard({
   href,
   servicesCount,
 }: Props) {
+  const isMobile = useIsWithinBreakpoints(['xs', 's']);
+
   const cardProps: EuiCardProps = {
-    style: { width: 286 },
+    style: { width: isMobile ? '100%' : 286 },
     icon: (
       <EuiAvatar
         name={serviceGroup.groupName}
@@ -80,8 +83,12 @@ export function ServiceGroupsCard({
   };
 
   return (
-    <EuiFlexItem key={serviceGroup.groupName}>
-      <EuiCard layout="vertical" {...cardProps} />
+    <EuiFlexItem key={serviceGroup.groupName} grow={false}>
+      <EuiCard
+        layout="vertical"
+        {...cardProps}
+        data-test-subj="serviceGroupCard"
+      />
     </EuiFlexItem>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_groups_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_groups_list.tsx
@@ -4,13 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiFlexGrid } from '@elastic/eui';
+import { EuiFlexGroup } from '@elastic/eui';
 import React from 'react';
 import { SavedServiceGroup } from '../../../../../common/service_groups';
-import { ServiceGroupsCard } from './service_group_card';
-import { useApmRouter } from '../../../../hooks/use_apm_router';
 import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useApmRouter } from '../../../../hooks/use_apm_router';
 import { useDefaultEnvironment } from '../../../../hooks/use_default_environment';
+import { ServiceGroupsCard } from './service_group_card';
 
 interface Props {
   items: SavedServiceGroup[];
@@ -25,7 +25,7 @@ export function ServiceGroupsListItems({ items, servicesCounts }: Props) {
   const environment = useDefaultEnvironment();
 
   return (
-    <EuiFlexGrid gutterSize="m">
+    <EuiFlexGroup gutterSize="m" wrap>
       {items.map((item) => (
         <ServiceGroupsCard
           serviceGroup={item}
@@ -40,6 +40,6 @@ export function ServiceGroupsListItems({ items, servicesCounts }: Props) {
           })}
         />
       ))}
-    </EuiFlexGrid>
+    </EuiFlexGroup>
   );
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[APM] Switching service groups from grid to flex layout (#147448)](https://github.com/elastic/kibana/pull/147448)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2022-12-14T11:03:32Z","message":"[APM] Switching service groups from grid to flex layout (#147448)\n\nCloses https://github.com/elastic/kibana/issues/147435.\r\n\r\n### Changes\r\n- `ServiceGroupList` is now using `EuiFlexGroup`. Grid is not suitable\r\nfor this case since the `ServiceGroupCard` has a fixed width.\r\n- `ServiceGroupCard` width is changed to `100%` when we are in mobile\r\nresolutions.\r\n\r\n**Before**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371784-60dbb1e3-7295-4d33-a62d-d051d652a2b0.mov\r\n\r\n\r\n**After**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371298-fc970def-332f-4cfe-9603-efdf68f1ce8e.mov","sha":"d53a159405dd90e8f70c18d137ce5997d6403cd8","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","Team:APM","release_note:skip","v8.6.0","v8.7.0"],"number":147448,"url":"https://github.com/elastic/kibana/pull/147448","mergeCommit":{"message":"[APM] Switching service groups from grid to flex layout (#147448)\n\nCloses https://github.com/elastic/kibana/issues/147435.\r\n\r\n### Changes\r\n- `ServiceGroupList` is now using `EuiFlexGroup`. Grid is not suitable\r\nfor this case since the `ServiceGroupCard` has a fixed width.\r\n- `ServiceGroupCard` width is changed to `100%` when we are in mobile\r\nresolutions.\r\n\r\n**Before**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371784-60dbb1e3-7295-4d33-a62d-d051d652a2b0.mov\r\n\r\n\r\n**After**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371298-fc970def-332f-4cfe-9603-efdf68f1ce8e.mov","sha":"d53a159405dd90e8f70c18d137ce5997d6403cd8"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147448","number":147448,"mergeCommit":{"message":"[APM] Switching service groups from grid to flex layout (#147448)\n\nCloses https://github.com/elastic/kibana/issues/147435.\r\n\r\n### Changes\r\n- `ServiceGroupList` is now using `EuiFlexGroup`. Grid is not suitable\r\nfor this case since the `ServiceGroupCard` has a fixed width.\r\n- `ServiceGroupCard` width is changed to `100%` when we are in mobile\r\nresolutions.\r\n\r\n**Before**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371784-60dbb1e3-7295-4d33-a62d-d051d652a2b0.mov\r\n\r\n\r\n**After**\r\n\r\n\r\nhttps://user-images.githubusercontent.com/1313018/207371298-fc970def-332f-4cfe-9603-efdf68f1ce8e.mov","sha":"d53a159405dd90e8f70c18d137ce5997d6403cd8"}}]}] BACKPORT-->