### PR TITLE
[Behavorial Analytics] Update the name of behavorial analytics

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -44,7 +44,7 @@ export const ENTERPRISE_SEARCH_CONTENT_PLUGIN = {
 export const ANALYTICS_PLUGIN = {
   ID: 'enterpriseSearchAnalytics',
   NAME: i18n.translate('xpack.enterpriseSearch.analytics.productName', {
-    defaultMessage: 'Analytics',
+    defaultMessage: 'Behavorial Analytics',
   }),
   DESCRIPTION: i18n.translate('xpack.enterpriseSearch.analytics.productDescription', {
     defaultMessage:

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate_javascript_client_embed.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate_javascript_client_embed.tsx
@@ -97,7 +97,7 @@ trackEvent,
           </p>
           <EuiCodeBlock language="javascript" isCopyable>
             {`createTracker({
-dsn: "${analyticsDNSUrl}",
+  dsn: "${analyticsDNSUrl}",
 });`}
           </EuiCodeBlock>
         </EuiText>
@@ -136,16 +136,15 @@ dsn: "${analyticsDNSUrl}",
             {`// track a page view in React
 
 const SearchPage = (props) => {
-useEffect(() => {
-trackPageView();
-}, []);
+  useEffect(() => {
+    trackPageView();
+  }, []);
 
-return (
-<div>
-  <h1>Search Page</h1>
-  <
-</div>
-);
+  return (
+    <div>
+      <h1>Search Page</h1>
+    </div>
+  );
 };`}
           </EuiCodeBlock>
           <EuiSpacer size="m" />
@@ -164,20 +163,21 @@ import { trackEvent } from '@elastic/behavioural-analytics-javascript-tracker';
 
 const ProductDetailPage = (props) => {
 
-return (
-<div>
-  <h1>Product detail page</h1>
-  <input type="button" onClick={() => {
-    trackEvent("click", {
-      category: "product",
-      action: "add_to_cart",
-      label: "product_id",
-      value: "123"
-    })
-  }} />
-  }}>Add to Basket</input>
-</div>
-)
+  return (
+    <div>
+      <h1>Product detail page</h1>
+      <input type="button" onClick={() => {
+        trackEvent("click", {
+          category: "product",
+          action: "add_to_cart",
+          label: "product_id",
+          value: "123"
+        })
+      }} />
+      }}>Add to Basket</input>
+    </div>
+    )
+  }
 }`}
           </EuiCodeBlock>
         </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -67,7 +67,7 @@ describe('useEnterpriseSearchContentNav', () => {
             name: 'Collections',
           },
         ],
-        name: 'Analytics',
+        name: 'Behavorial Analytics',
       },
       {
         id: 'search',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -106,7 +106,7 @@ export const useEnterpriseSearchNav = () => {
         },
       ],
       name: i18n.translate('xpack.enterpriseSearch.nav.analyticsTitle', {
-        defaultMessage: 'Analytics',
+        defaultMessage: 'Behavorial Analytics',
       }),
     },
     {


### PR DESCRIPTION
Update the name within the nav and search from "Analytics" to "Behavorial Analytics"

Also some slight updates to the code indenting for the onboarding documentation.

![Screenshot 2022-12-13 at 15 24 49](https://user-images.githubusercontent.com/49480/207620922-62467208-86e0-4019-a9d8-aeef06b4c72e.png)

