### PR TITLE
[Guided onboarding] Add isGuideStepReadyToComplete$ observable

### DIFF
--- a/src/plugins/guided_onboarding/README.md
+++ b/src/plugins/guided_onboarding/README.md
@@ -62,6 +62,10 @@ useEffect(() => {
 }, [guidedOnboardingApi]);
 ```
 
+### isGuideStepReadyToComplete$(guideID: string, stepID: string): Observable\<boolean\>
+Similar to `isGuideStepActive$`, the observable `isGuideStepReadyToComplete$` can be used to track the state of a step that is configured for manual completion. The observable broadcasts `true` when the manual completion popover is displayed and the user can mark the step "done". In this state the step is not in progress anymore but is not yet fully completed. 
+
+
 ### completeGuideStep(guideID: string, stepID: string): Promise\<{ state: GuidedOnboardingState } | undefined\>
 The API service exposes an async function to mark a guide step as completed. 
 If the specified guide step is not currently active, the function is a noop. The return value is `undefined` in that case, 

--- a/src/plugins/guided_onboarding/public/mocks.ts
+++ b/src/plugins/guided_onboarding/public/mocks.ts
@@ -19,6 +19,7 @@ const apiServiceMock: jest.Mocked<GuidedOnboardingPluginStart> = {
     deactivateGuide: jest.fn(),
     completeGuide: jest.fn(),
     isGuideStepActive$: () => new BehaviorSubject(false),
+    isGuideStepReadyToComplete$: () => new BehaviorSubject(false),
     startGuideStep: jest.fn(),
     completeGuideStep: jest.fn(),
     isGuidedOnboardingActiveForIntegration$: () => new BehaviorSubject(false),

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -28,6 +28,7 @@ import {
   mockPluginStateInProgress,
   mockPluginStateNotStarted,
   testGuideStep3ActiveState,
+  testGuideStep2ReadyToCompleteState,
 } from './api.mocks';
 
 describe('GuidedOnboarding ApiService', () => {
@@ -250,6 +251,7 @@ describe('GuidedOnboarding ApiService', () => {
         pluginState: { ...mockPluginStateInProgress, activeGuide: testGuideStep1InProgressState },
       });
 
+      apiService.setup(httpClient, true);
       subscription = apiService
         .isGuideStepActive$(testGuideId, testGuideFirstStep)
         .subscribe((isStepActive) => {
@@ -263,6 +265,65 @@ describe('GuidedOnboarding ApiService', () => {
     it('returns false if the step is not been started', (done) => {
       subscription = apiService
         .isGuideStepActive$(testGuideId, testGuideFirstStep)
+        .subscribe((isStepActive) => {
+          if (!isStepActive) {
+            subscription.unsubscribe();
+            done();
+          }
+        });
+    });
+  });
+
+  describe('isGuideStepReadyToComplete$', () => {
+    it('returns true if the step is ready to complete', (done) => {
+      httpClient.get.mockResolvedValueOnce({
+        pluginState: {
+          ...mockPluginStateInProgress,
+          activeGuide: testGuideStep2ReadyToCompleteState,
+        },
+      });
+      apiService.setup(httpClient, true);
+
+      subscription = apiService
+        .isGuideStepReadyToComplete$(testGuideId, testGuideManualCompletionStep)
+        .subscribe((isStepReadyToComplete) => {
+          if (isStepReadyToComplete) {
+            subscription.unsubscribe();
+            done();
+          }
+        });
+    });
+
+    it('returns false if the step has not been started', (done) => {
+      httpClient.get.mockResolvedValueOnce({
+        pluginState: {
+          ...mockPluginStateInProgress,
+          activeGuide: testGuideStep2ActiveState,
+        },
+      });
+      apiService.setup(httpClient, true);
+
+      subscription = apiService
+        .isGuideStepReadyToComplete$(testGuideId, testGuideManualCompletionStep)
+        .subscribe((isStepActive) => {
+          if (!isStepActive) {
+            subscription.unsubscribe();
+            done();
+          }
+        });
+    });
+
+    it('returns false if the step has been completed', (done) => {
+      httpClient.get.mockResolvedValueOnce({
+        pluginState: {
+          ...mockPluginStateInProgress,
+          activeGuide: testGuideStep3ActiveState,
+        },
+      });
+      apiService.setup(httpClient, true);
+
+      subscription = apiService
+        .isGuideStepReadyToComplete$(testGuideId, testGuideManualCompletionStep)
         .subscribe((isStepActive) => {
           if (!isStepActive) {
             subscription.unsubscribe();

--- a/src/plugins/guided_onboarding/public/services/api.ts
+++ b/src/plugins/guided_onboarding/public/services/api.ts
@@ -283,6 +283,23 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
+   * An observable with the boolean value if the step is ready_to_complete (i.e., user needs to click the "Mark done" button).
+   * Returns true, if the passed params identify the guide step that is currently ready_to_complete.
+   * Returns false otherwise.
+   * @param {GuideId} guideId the id of the guide (one of search, observability, security)
+   * @param {GuideStepIds} stepId the id of the step in the guide
+   * @return {Observable} an observable with the boolean value
+   */
+  public isGuideStepReadyToComplete$(guideId: GuideId, stepId: GuideStepIds): Observable<boolean> {
+    return this.fetchPluginState$().pipe(
+      map((pluginState) => {
+        if (!isGuideActive(pluginState, guideId)) return false;
+        return isStepReadyToComplete(pluginState!.activeGuide, guideId, stepId);
+      })
+    );
+  }
+
+  /**
    * Updates the selected step to 'in_progress' state.
    * This is useful for the dropdown panel, when the user clicks the "Start" button for the active step.
    * @param {GuideId} guideId the id of the guide (one of search, observability, security)

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -38,6 +38,7 @@ export interface GuidedOnboardingApi {
   deactivateGuide: (guide: GuideState) => Promise<{ pluginState: PluginState } | undefined>;
   completeGuide: (guideId: GuideId) => Promise<{ pluginState: PluginState } | undefined>;
   isGuideStepActive$: (guideId: GuideId, stepId: GuideStepIds) => Observable<boolean>;
+  isGuideStepReadyToComplete$: (guideId: GuideId, stepId: GuideStepIds) => Observable<boolean>;
   startGuideStep: (
     guideId: GuideId,
     stepId: GuideStepIds


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/146911

This PR adds an observable to track when a guide step is in `ready_to_complete` status. This can be used to hide some UI elements while the "manual completion popover" is displayed on the header button (see screenshot below).

<img width="446" alt="Screenshot 2022-12-14 at 17 20 55" src="https://user-images.githubusercontent.com/6585477/207650715-59402068-b9e8-4c1c-bbf7-0d992739b05e.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
