### PR TITLE
[Guided onboarding] Fix the kubernetes logo

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/use_case_card.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/use_case_card.tsx
@@ -38,7 +38,7 @@ const constants: UseCaseConstants = {
         defaultMessage: 'observe',
       }
     ),
-    imageUrlPrefix: '/plugins/home/assets/solution_logos/observability',
+    imageUrlPrefix: '/plugins/home/assets/solution_logos/kubernetes',
   },
   infrastructure: {
     logAltText: i18n.translate('guidedOnboardingPackage.gettingStarted.infrastructure.iconName', {


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/147443
This is a tiny fix to update the logo for the kubernetes guide card (make is separate from the infrastructure card).

### Screenshots

<img width="437" alt="Screenshot 2022-12-14 at 17 50 02" src="https://user-images.githubusercontent.com/6585477/207657819-8af3ca46-9299-49c0-90c1-acea89b340e0.png">

<img width="396" alt="Screenshot 2022-12-14 at 17 50 28" src="https://user-images.githubusercontent.com/6585477/207657827-1e64a098-ecdf-42ab-b3b6-4ddece04e8ba.png">


