### PR TITLE
Lower the alert summary limit from 1000 alerts to 100 alerts per group

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_get_summarized_alerts_fn.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_get_summarized_alerts_fn.test.ts
@@ -161,7 +161,7 @@ describe('createGetSummarizedAlertsFn', () => {
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledTimes(3);
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(1, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -188,7 +188,7 @@ describe('createGetSummarizedAlertsFn', () => {
     });
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(2, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -215,7 +215,7 @@ describe('createGetSummarizedAlertsFn', () => {
     });
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(3, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -410,7 +410,7 @@ describe('createGetSummarizedAlertsFn', () => {
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledTimes(3);
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(1, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -442,7 +442,7 @@ describe('createGetSummarizedAlertsFn', () => {
     });
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(2, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -483,7 +483,7 @@ describe('createGetSummarizedAlertsFn', () => {
     });
     expect(ruleDataClientMock.getReader().search).toHaveBeenNthCalledWith(3, {
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -660,7 +660,7 @@ describe('createGetSummarizedAlertsFn', () => {
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledTimes(1);
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledWith({
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {
@@ -812,7 +812,7 @@ describe('createGetSummarizedAlertsFn', () => {
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledTimes(1);
     expect(ruleDataClientMock.getReader().search).toHaveBeenCalledWith({
       body: {
-        size: 1000,
+        size: 100,
         track_total_hits: true,
         query: {
           bool: {

--- a/x-pack/plugins/rule_registry/server/utils/create_get_summarized_alerts_fn.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_get_summarized_alerts_fn.ts
@@ -24,7 +24,7 @@ import { ParsedTechnicalFields } from '../../common';
 import { ParsedExperimentalFields } from '../../common/parse_experimental_fields';
 import { IRuleDataClient, IRuleDataReader } from '../rule_data_client';
 
-const MAX_ALERT_DOCS_TO_RETURN = 1000;
+const MAX_ALERT_DOCS_TO_RETURN = 100;
 type AlertDocument = Partial<ParsedTechnicalFields & ParsedExperimentalFields>;
 
 interface CreateGetSummarizedAlertsFnOpts {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/147440.

In this PR, I'm lowering the max number of alerts that get summarized per group (new, ongoing, recovered) from 1000 to 100.