### PR TITLE
[8.6] [RAM] Reactivate most tests in triggers_actions_ui #147535

### DIFF
--- a/.buildkite/disabled_jest_configs.json
+++ b/.buildkite/disabled_jest_configs.json
@@ -1,5 +1,4 @@
 [
-  "x-pack/plugins/triggers_actions_ui/jest.config.js",
   "x-pack/plugins/watcher/jest.config.js",
   "src/core/server/integration_tests/ui_settings/jest.integration.config.js"
 ]

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx
@@ -87,7 +87,7 @@ describe('ConnectorForm', () => {
     });
   });
 
-  it('calls onChange when the form is invalid', async () => {
+  it.skip('calls onChange when the form is invalid', async () => {
     const actionTypeModel = actionTypeRegistryMock.createMockActionTypeModel({
       actionConnectorFields: lazy(() => import('./connector_mock')),
     });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
@@ -261,7 +261,7 @@ describe.skip('rules_list component empty', () => {
   });
 });
 
-describe('rules_list component with props', () => {
+describe.skip('rules_list component with props', () => {
   describe('Status filter', () => {
     let wrapper: ReactWrapper<any>;
     async function setup(editable: boolean = true) {
@@ -857,7 +857,7 @@ describe('rules_list component with props', () => {
   });
 });
 
-describe('rules_list component with items', () => {
+describe.skip('rules_list component with items', () => {
   let wrapper: ReactWrapper<any>;
 
   async function setup(editable: boolean = true) {
@@ -1437,7 +1437,7 @@ describe('rules_list component with items', () => {
   });
 });
 
-describe('rules_list component empty with show only capability', () => {
+describe.skip('rules_list component empty with show only capability', () => {
   let wrapper: ReactWrapper<any>;
 
   async function setup() {
@@ -1480,7 +1480,7 @@ describe('rules_list component empty with show only capability', () => {
   });
 });
 
-describe('rules_list with show only capability', () => {
+describe.skip('rules_list with show only capability', () => {
   let wrapper: ReactWrapper<any>;
 
   async function setup(editable: boolean = true) {
@@ -1601,7 +1601,7 @@ describe('rules_list with show only capability', () => {
   });
 });
 
-describe('rules_list with disabled items', () => {
+describe.skip('rules_list with disabled items', () => {
   let wrapper: ReactWrapper<any>;
 
   async function setup() {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_bulk_edit.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_bulk_edit.test.tsx
@@ -93,7 +93,7 @@ beforeEach(() => {
   (getIsExperimentalFeatureEnabled as jest.Mock<any, any>).mockImplementation(() => false);
 });
 
-describe('Rules list bulk actions', () => {
+describe.skip('Rules list bulk actions', () => {
   let wrapper: ReactWrapper<any>;
 
   async function setup(authorized: boolean = true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[RAM] Reactivate most tests in triggers_actions_ui #147535](https://github.com/elastic/kibana/pull/147535)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2022-12-14T21:15:30Z","message":"[Security Solution] ML job enchancement: update warning message (#147550)\n\n## Summary\r\n\r\nThese changes update the wording around the ML job selection in ML rule.\r\nAs we gonna try to start selected job/s in case those are not running,\r\nwe should accordingly mention that in the callout below the job\r\nselection combobox.\r\n\r\nSlack\r\n[discussion](https://elastic.slack.com/archives/C03DXS9UZDF/p1670950300234779)\r\n\r\nMain ticket:\r\n[#1912](https://github.com/elastic/security-team/issues/1912)\r\n\r\n<img width=\"1860\" alt=\"Screenshot 2022-12-14 at 17 50 48\"\r\nsrc=\"https://user-images.githubusercontent.com/2700761/207658080-deb81240-3643-4634-aa01-0c9dee59c3b2.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b74e7f9b8227a3229b0a2b8099df776d1761fb86","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Alerts","backport:prev-minor","ci:cloud-deploy","v8.7.0"],"number":147550,"url":"https://github.com/elastic/kibana/pull/147550","mergeCommit":{"message":"[Security Solution] ML job enchancement: update warning message (#147550)\n\n## Summary\r\n\r\nThese changes update the wording around the ML job selection in ML rule.\r\nAs we gonna try to start selected job/s in case those are not running,\r\nwe should accordingly mention that in the callout below the job\r\nselection combobox.\r\n\r\nSlack\r\n[discussion](https://elastic.slack.com/archives/C03DXS9UZDF/p1670950300234779)\r\n\r\nMain ticket:\r\n[#1912](https://github.com/elastic/security-team/issues/1912)\r\n\r\n<img width=\"1860\" alt=\"Screenshot 2022-12-14 at 17 50 48\"\r\nsrc=\"https://user-images.githubusercontent.com/2700761/207658080-deb81240-3643-4634-aa01-0c9dee59c3b2.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b74e7f9b8227a3229b0a2b8099df776d1761fb86"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147550","number":147550,"mergeCommit":{"message":"[Security Solution] ML job enchancement: update warning message (#147550)\n\n## Summary\r\n\r\nThese changes update the wording around the ML job selection in ML rule.\r\nAs we gonna try to start selected job/s in case those are not running,\r\nwe should accordingly mention that in the callout below the job\r\nselection combobox.\r\n\r\nSlack\r\n[discussion](https://elastic.slack.com/archives/C03DXS9UZDF/p1670950300234779)\r\n\r\nMain ticket:\r\n[#1912](https://github.com/elastic/security-team/issues/1912)\r\n\r\n<img width=\"1860\" alt=\"Screenshot 2022-12-14 at 17 50 48\"\r\nsrc=\"https://user-images.githubusercontent.com/2700761/207658080-deb81240-3643-4634-aa01-0c9dee59c3b2.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b74e7f9b8227a3229b0a2b8099df776d1761fb86"}}]}] BACKPORT-->