### PR TITLE
[Security Solution] Reintroduce loading spinner while bulk deleting rules

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
@@ -287,12 +287,25 @@ describe('Custom query rules', () => {
             deleteSelectedRules();
 
             cy.get(RULES_TABLE)
+              .get(RULES_ROW)
+              .first()
+              .within(() => {
+                cy.get(RULE_SWITCH).should('not.exist');
+              });
+
+            cy.get(RULES_TABLE)
               .find(RULES_ROW)
               .should('have.length', expectedNumberOfRulesAfterDeletion);
             cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
               const numberOfRules = body.data.length;
               expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
             });
+            cy.get(RULES_TABLE)
+              .get(RULES_ROW)
+              .first()
+              .within(() => {
+                cy.get(RULE_SWITCH).should('exist');
+              });
             cy.get(CUSTOM_RULES_BTN).should(
               'have.text',
               `Custom rules (${expectedNumberOfRulesAfterDeletion})`

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -65,7 +65,10 @@ const useEnabledColumn = ({ hasCRUDPermissions, startMlJobs }: ColumnsProps): Ta
   const { loadingRulesAction, loadingRuleIds } = useRulesTableContext().state;
 
   const loadingIds = useMemo(
-    () => (['disable', 'enable', 'edit'].includes(loadingRulesAction ?? '') ? loadingRuleIds : []),
+    () =>
+      ['disable', 'enable', 'edit', 'delete'].includes(loadingRulesAction ?? '')
+        ? loadingRuleIds
+        : [],
     [loadingRuleIds, loadingRulesAction]
   );
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/147564

## Summary

https://github.com/elastic/kibana/pull/145905 changed the behaviour of the Rules Table, so that the table was fully disabled (with an overlay loading spinner) during preflight requests. In the other requests types, `enable`ing, `disable`ing and actual `edit` requests, each rule would be disabled individually.

This however did not include **deletion**, so we incorrectly still allowed the user to enable and disable rules while they were being bulk deleted.

This PR fixes that by disabling the switch while a delete action is in progress.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->