### PR TITLE
[Fleet] publish `agents_per_version` telemetry as separate docs

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -28,6 +28,22 @@ export interface Usage {
   fleet_server: FleetServerUsage;
 }
 
+export interface FleetUsage extends Usage {
+  fleet_server_config: { policies: Array<{ input_config: any }> };
+  agent_policies: { count: number; output_types: string[] };
+  agents_per_version: Array<{
+    version: string;
+    count: number;
+  }>;
+  agent_checkin_status: {
+    error: number;
+    degraded: number;
+  };
+  agents_per_policy: number[];
+  agent_logs_top_errors: string[];
+  fleet_server_logs_top_errors: string[];
+}
+
 export const fetchFleetUsage = async (
   core: CoreSetup,
   config: FleetConfigType,

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -7,6 +7,25 @@
 
 import type { RootSchema } from '@kbn/analytics-client';
 
+export const fleetAgentsSchema: RootSchema<any> = {
+  agents_per_version: {
+    properties: {
+      version: {
+        type: 'keyword',
+        _meta: {
+          description: 'Agent version enrolled to this kibana',
+        },
+      },
+      count: {
+        type: 'long',
+        _meta: {
+          description: 'Number of agents enrolled that use this version',
+        },
+      },
+    },
+  },
+};
+
 export const fleetUsagesSchema: RootSchema<any> = {
   agents_enabled: { type: 'boolean', _meta: { description: 'agents enabled' } },
   agents: {
@@ -103,15 +122,6 @@ export const fleetUsagesSchema: RootSchema<any> = {
         name: { type: 'keyword' },
         version: { type: 'keyword' },
         enabled: { type: 'boolean' },
-      },
-    },
-  },
-  agents_per_version: {
-    type: 'array',
-    items: {
-      properties: {
-        version: { type: 'keyword' },
-        count: { type: 'long' },
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147543

Sending `agents_per_version` telemetry as separate docs with a new type `fleet_agents`.
This docs then can be indexed to a new index in telemetry.

E.g. having 2 versions of agents enrolled to kibana, will result in 2 documents sent
```
{ "agents_per_version": {"version":"8.2.0","count":2000}}
{ "agents_per_version": {"version":"8.6.0","count":1}}

```

the new data is visible in staging, under `ebt-kibana-server` index pattern, I'll add a new indexer to have proper data types: https://telemetry-v2-staging.elastic.dev/s/kibana-core/app/r/s/QbN5e
<img width="605" alt="image" src="https://user-images.githubusercontent.com/90178898/207886931-6d3e7922-9b18-45f5-8002-ff109b62310b.png">


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->