### PR TITLE
[8.6] [Fix] scheduling multiple recovered alert actions (#147617)

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/execution_handler.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/execution_handler.test.ts
@@ -732,6 +732,109 @@ describe('Execution Handler', () => {
     );
   });
 
+  test('schedules alerts with multiple recovered actions', async () => {
+    const actions = [
+      {
+        id: '1',
+        group: 'recovered',
+        actionTypeId: 'test',
+        params: {
+          foo: true,
+          contextVal: 'My {{context.value}} goes here',
+          stateVal: 'My {{state.value}} goes here',
+          alertVal:
+            'My {{alertId}} {{alertName}} {{spaceId}} {{tags}} {{alertInstanceId}} goes here',
+        },
+      },
+      {
+        id: '2',
+        group: 'recovered',
+        actionTypeId: 'test',
+        params: {
+          foo: true,
+          contextVal: 'My {{context.value}} goes here',
+          stateVal: 'My {{state.value}} goes here',
+          alertVal:
+            'My {{alertId}} {{alertName}} {{spaceId}} {{tags}} {{alertInstanceId}} goes here',
+        },
+      },
+    ];
+    const executionHandler = new ExecutionHandler(
+      generateExecutionParams({
+        ...defaultExecutionParams,
+        rule: {
+          ...defaultExecutionParams.rule,
+          actions,
+        },
+      })
+    );
+    await executionHandler.run(generateAlert({ id: 1, scheduleActions: false }), true);
+
+    expect(actionsClient.bulkEnqueueExecution).toHaveBeenCalledTimes(1);
+    expect(actionsClient.bulkEnqueueExecution.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "apiKey": "MTIzOmFiYw==",
+                "consumer": "rule-consumer",
+                "executionId": "5f6aa57d-3e22-484e-bae8-cbed868f4d28",
+                "id": "1",
+                "params": Object {
+                  "alertVal": "My 1 name-of-alert test1 tag-A,tag-B 1 goes here",
+                  "contextVal": "My  goes here",
+                  "foo": true,
+                  "stateVal": "My  goes here",
+                },
+                "relatedSavedObjects": Array [
+                  Object {
+                    "id": "1",
+                    "namespace": "test1",
+                    "type": "alert",
+                    "typeId": "test",
+                  },
+                ],
+                "source": Object {
+                  "source": Object {
+                    "id": "1",
+                    "type": "alert",
+                  },
+                  "type": "SAVED_OBJECT",
+                },
+                "spaceId": "test1",
+              },
+              Object {
+                "apiKey": "MTIzOmFiYw==",
+                "consumer": "rule-consumer",
+                "executionId": "5f6aa57d-3e22-484e-bae8-cbed868f4d28",
+                "id": "2",
+                "params": Object {
+                  "alertVal": "My 1 name-of-alert test1 tag-A,tag-B 1 goes here",
+                  "contextVal": "My  goes here",
+                  "foo": true,
+                  "stateVal": "My  goes here",
+                },
+                "relatedSavedObjects": Array [
+                  Object {
+                    "id": "1",
+                    "namespace": "test1",
+                    "type": "alert",
+                    "typeId": "test",
+                  },
+                ],
+                "source": Object {
+                  "source": Object {
+                    "id": "1",
+                    "type": "alert",
+                  },
+                  "type": "SAVED_OBJECT",
+                },
+                "spaceId": "test1",
+              },
+            ],
+          ]
+      `);
+  });
+
   describe('rule url', () => {
     const ruleWithUrl = {
       ...rule,

--- a/x-pack/plugins/alerting/server/task_runner/execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/execution_handler.ts
@@ -225,10 +225,6 @@ export class ExecutionHandler<
           alertId,
           alertGroup: action.group,
         });
-
-        if (recovered) {
-          alert.scheduleActions(action.group as ActionGroupIds);
-        }
       }
 
       if (!!bulkActions.length) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Fix] scheduling multiple recovered alert actions (#147617)](https://github.com/elastic/kibana/pull/147617)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-12-16T18:04:36Z","message":"[Fix] scheduling multiple recovered alert actions (#147617)\n\nRemoves the code that blocks running multiple recovered actions of an\r\nalert.","sha":"5145f8d246ec3fa0ea05e0c975bed344457c2e1d","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","ci:cloud-deploy","v8.7.0","v8.6.1"],"number":147617,"url":"https://github.com/elastic/kibana/pull/147617","mergeCommit":{"message":"[Fix] scheduling multiple recovered alert actions (#147617)\n\nRemoves the code that blocks running multiple recovered actions of an\r\nalert.","sha":"5145f8d246ec3fa0ea05e0c975bed344457c2e1d"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147617","number":147617,"mergeCommit":{"message":"[Fix] scheduling multiple recovered alert actions (#147617)\n\nRemoves the code that blocks running multiple recovered actions of an\r\nalert.","sha":"5145f8d246ec3fa0ea05e0c975bed344457c2e1d"}},{"branch":"8.6","label":"v8.6.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->