### PR TITLE
Revert "Include client IP address in audit log"

### DIFF
--- a/docs/user/security/audit-logging.asciidoc
+++ b/docs/user/security/audit-logging.asciidoc
@@ -407,18 +407,10 @@ Example: `[marketing]`
 | *Field*
 | *Description*
 
-| `client.ip`
-| Client IP address.
-
 | `http.request.method`
 | HTTP request method.
 
 Example: `get`, `post`, `put`, `delete`
-
-| `http.request.headers.x-forwarded-for`
-| `X-Forwarded-For` request header used to identify the originating client IP address when connecting through proxy servers.
-
-Example: `161.66.20.177, 236.198.214.101`
 
 | `url.domain`
 | Domain of the URL.

--- a/packages/core/http/core-http-router-server-internal/src/socket.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/socket.test.ts
@@ -152,11 +152,4 @@ describe('KibanaSocket', () => {
       expect(socket.authorizationError).toBe(authorizationError);
     });
   });
-
-  describe('remoteAddress', () => {
-    it('mirrors the value of net.Socket instance', () => {
-      const socket = new KibanaSocket({ remoteAddress: '1.1.1.1' } as Socket);
-      expect(socket.remoteAddress).toBe('1.1.1.1');
-    });
-  });
 });

--- a/packages/core/http/core-http-router-server-internal/src/socket.ts
+++ b/packages/core/http/core-http-router-server-internal/src/socket.ts
@@ -20,10 +20,6 @@ export class KibanaSocket implements IKibanaSocket {
     return this.socket instanceof TLSSocket ? this.socket.authorizationError : undefined;
   }
 
-  public get remoteAddress() {
-    return this.socket.remoteAddress;
-  }
-
   constructor(private readonly socket: Socket) {}
 
   getPeerCertificate(detailed: true): DetailedPeerCertificate | null;

--- a/packages/core/http/core-http-server/src/router/socket.ts
+++ b/packages/core/http/core-http-server/src/router/socket.ts
@@ -51,11 +51,4 @@ export interface IKibanaSocket {
    * only when `authorized` is `false`.
    */
   readonly authorizationError?: Error;
-
-  /**
-   * The string representation of the remote IP address. For example,`'74.125.127.100'` or
-   * `'2001:4860:a005::68'`. Value may be `undefined` if the socket is destroyed (for example, if
-   * the client disconnected).
-   */
-  readonly remoteAddress?: string;
 }

--- a/x-pack/plugins/security/server/audit/audit_events.ts
+++ b/x-pack/plugins/security/server/audit/audit_events.ts
@@ -15,71 +15,6 @@ import type { AuthenticationProvider } from '../../common/model';
 import type { AuthenticationResult } from '../authentication/authentication_result';
 
 /**
- * Audit kibana schema using ECS format
- */
-export interface AuditKibana {
-  /**
-   * The ID of the space associated with this event.
-   */
-  space_id?: string;
-  /**
-   * The ID of the user session associated with this event. Each login attempt
-   * results in a unique session id.
-   */
-  session_id?: string;
-  /**
-   * Saved object that was created, changed, deleted or accessed as part of this event.
-   */
-  saved_object?: {
-    type: string;
-    id: string;
-  };
-  /**
-   * Name of authentication provider associated with a login event.
-   */
-  authentication_provider?: string;
-  /**
-   * Type of authentication provider associated with a login event.
-   */
-  authentication_type?: string;
-  /**
-   * Name of Elasticsearch realm that has authenticated the user.
-   */
-  authentication_realm?: string;
-  /**
-   * Name of Elasticsearch realm where the user details were retrieved from.
-   */
-  lookup_realm?: string;
-  /**
-   * Set of space IDs that a saved object was shared to.
-   */
-  add_to_spaces?: readonly string[];
-  /**
-   * Set of space IDs that a saved object was removed from.
-   */
-  delete_from_spaces?: readonly string[];
-}
-
-type EcsHttp = Required<LogMeta>['http'];
-type EcsRequest = Required<EcsHttp>['request'];
-
-/**
- * Audit request schema using ECS format
- */
-export interface AuditRequest extends EcsRequest {
-  headers?: {
-    'x-forwarded-for'?: string;
-  };
-}
-
-/**
- * Audit http schema using ECS format
- */
-export interface AuditHttp extends EcsHttp {
-  request?: AuditRequest;
-}
-
-/**
  * Audit event schema using ECS format: https://www.elastic.co/guide/en/ecs/1.12/index.html
  *
  * If you add additional fields to the schema ensure you update the Kibana Filebeat module:
@@ -89,8 +24,48 @@ export interface AuditHttp extends EcsHttp {
  */
 export interface AuditEvent extends LogMeta {
   message: string;
-  kibana?: AuditKibana;
-  http?: AuditHttp;
+  kibana?: {
+    /**
+     * The ID of the space associated with this event.
+     */
+    space_id?: string;
+    /**
+     * The ID of the user session associated with this event. Each login attempt
+     * results in a unique session id.
+     */
+    session_id?: string;
+    /**
+     * Saved object that was created, changed, deleted or accessed as part of this event.
+     */
+    saved_object?: {
+      type: string;
+      id: string;
+    };
+    /**
+     * Name of authentication provider associated with a login event.
+     */
+    authentication_provider?: string;
+    /**
+     * Type of authentication provider associated with a login event.
+     */
+    authentication_type?: string;
+    /**
+     * Name of Elasticsearch realm that has authenticated the user.
+     */
+    authentication_realm?: string;
+    /**
+     * Name of Elasticsearch realm where the user details were retrieved from.
+     */
+    lookup_realm?: string;
+    /**
+     * Set of space IDs that a saved object was shared to.
+     */
+    add_to_spaces?: readonly string[];
+    /**
+     * Set of space IDs that a saved object was removed from.
+     */
+    delete_from_spaces?: readonly string[];
+  };
 }
 
 export interface HttpRequestParams {

--- a/x-pack/plugins/security/server/audit/audit_service.ts
+++ b/x-pack/plugins/security/server/audit/audit_service.ts
@@ -162,8 +162,6 @@ export class AuditService {
         const spaceId = getSpaceId(request);
         const user = getCurrentUser(request);
         const sessionId = await getSID(request);
-        const forwardedFor = getForwardedFor(request);
-
         log({
           ...event,
           user:
@@ -179,18 +177,6 @@ export class AuditService {
             ...event.kibana,
           },
           trace: { id: request.id },
-          client: { ip: request.socket.remoteAddress },
-          http: forwardedFor
-            ? {
-                ...event.http,
-                request: {
-                  ...event.http?.request,
-                  headers: {
-                    'x-forwarded-for': forwardedFor,
-                  },
-                },
-              }
-            : event.http,
         });
       },
       enabled,
@@ -256,17 +242,4 @@ export function filterEvent(
     );
   }
   return true;
-}
-
-/**
- * Extracts `X-Forwarded-For` header(s) from `KibanaRequest`.
- */
-export function getForwardedFor(request: KibanaRequest) {
-  const forwardedFor = request.headers['x-forwarded-for'];
-
-  if (Array.isArray(forwardedFor)) {
-    return forwardedFor.join(', ');
-  }
-
-  return forwardedFor;
 }

--- a/x-pack/test/security_api_integration/tests/audit/audit_log.ts
+++ b/x-pack/test/security_api_integration/tests/audit/audit_log.ts
@@ -55,7 +55,6 @@ export default function ({ getService }: FtrProviderContext) {
       await supertest
         .post('/internal/security/login')
         .set('kbn-xsrf', 'xxx')
-        .set('X-Forwarded-For', '1.1.1.1, 2.2.2.2')
         .send({
           providerType: 'basic',
           providerName: 'basic',
@@ -72,15 +71,12 @@ export default function ({ getService }: FtrProviderContext) {
       expect(loginEvent.event.outcome).to.be('success');
       expect(loginEvent.trace.id).to.be.ok();
       expect(loginEvent.user.name).to.be(username);
-      expect(loginEvent.client.ip).to.be.ok();
-      expect(loginEvent.http.request.headers['x-forwarded-for']).to.be('1.1.1.1, 2.2.2.2');
     });
 
     it('logs audit events when failing to log in', async () => {
       await supertest
         .post('/internal/security/login')
         .set('kbn-xsrf', 'xxx')
-        .set('X-Forwarded-For', '1.1.1.1, 2.2.2.2')
         .send({
           providerType: 'basic',
           providerName: 'basic',
@@ -97,8 +93,6 @@ export default function ({ getService }: FtrProviderContext) {
       expect(loginEvent.event.outcome).to.be('failure');
       expect(loginEvent.trace.id).to.be.ok();
       expect(loginEvent.user).not.to.be.ok();
-      expect(loginEvent.client.ip).to.be.ok();
-      expect(loginEvent.http.request.headers['x-forwarded-for']).to.be('1.1.1.1, 2.2.2.2');
     });
   });
 }


### PR DESCRIPTION
Reverts elastic/kibana#147526

Reverting due to errors when using `FakeRequest`:

```
TypeError: Cannot read properties of undefined (reading 'remoteAddress')
    at KibanaSocket.get remoteAddress [as remoteAddress] (/Users/shahzad-16/elastic/kibana/node_modules/@kbn/core-http-router-server-internal/target_node/src/socket.js:25:24)
    at Object.log (/Users/shahzad-16/elastic/kibana/x-pack/plugins/security/server/audit/audit_service.ts:95:32)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Terminating process...
 server crashed  with status code 1
```