### PR TITLE
[core-http] `net.socket.timeout` is now documented

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -176,9 +176,8 @@ export class CoreKibanaRequest<
       timeout: payloadTimeout,
     } = request.route.settings.payload || {};
 
-    // net.Socket#timeout isn't documented, yet, and isn't part of the types... https://github.com/nodejs/node/pull/34543
-    // the socket is also undefined when using @hapi/shot, or when a "fake request" is used
-    const socketTimeout = (request.raw.req.socket as any)?.timeout;
+    // the socket is undefined when using @hapi/shot, or when a "fake request" is used
+    const socketTimeout = request.raw.req.socket?.timeout;
     const options = {
       authRequired: this.getAuthRequired(request),
       // TypeScript note: Casting to `RouterOptions` to fix the following error:


### PR DESCRIPTION
## Summary

Removing the cast to `any` because `socket.timeout` is now documented 🎉 


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
