### PR TITLE
[Synthetics] do not show api key error unless there are monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -294,7 +294,6 @@ export class SyntheticsService {
   async pushConfigs() {
     const service = this;
     const subject = new Subject<SyntheticsMonitorWithId[]>();
-    const output = await this.getOutput();
 
     subject.subscribe(async (monitorConfigs) => {
       try {
@@ -304,6 +303,8 @@ export class SyntheticsService {
           this.logger.debug('No monitor found which can be pushed to service.');
           return null;
         }
+
+        const output = await this.getOutput();
 
         if (!output) {
           sendErrorTelemetryEvents(service.logger, service.server.telemetry, {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/147586

Do not show errors related to missing synthetics api key unless there are synthetics monitors present.

### Testing
1. Create a brand new cluster via `oblt-cli`
2. Add that cluster details to your `kibana.dev.yml` file
3. Monitor your Kibana logs. Ensure there is not an error log complaining about the api key. For example:
```
[2022-12-14T20:19:43.516-05:00][ERROR][plugins.synthetics] API key is not valid. Cannot push monitor configuration to synthetics public testing locations
```


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->