### PR TITLE
[data view editor] Revalidate index pattern when 'allow hidden' changes

### DIFF
--- a/src/plugins/data_view_editor/public/components/advanced_params_content/advanced_params_content.tsx
+++ b/src/plugins/data_view_editor/public/components/advanced_params_content/advanced_params_content.tsx
@@ -29,11 +29,13 @@ const customIndexPatternIdLabel = i18n.translate(
 interface AdvancedParamsContentProps {
   disableAllowHidden: boolean;
   disableId: boolean;
+  onAllowHiddenChange?: (value: boolean) => void;
 }
 
 export const AdvancedParamsContent = ({
   disableAllowHidden,
   disableId,
+  onAllowHiddenChange,
 }: AdvancedParamsContentProps) => (
   <AdvancedParamsSection>
     <EuiFlexGroup>
@@ -48,6 +50,7 @@ export const AdvancedParamsContent = ({
               disabled: disableAllowHidden,
             },
           }}
+          onChange={onAllowHiddenChange}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -281,6 +281,9 @@ const IndexPatternEditorFlyoutContentComponent = ({
           <AdvancedParamsContent
             disableAllowHidden={type === INDEX_PATTERN_TYPE.ROLLUP}
             disableId={!!editData}
+            onAllowHiddenChange={() => {
+              form.getFields().title.validate();
+            }}
           />
         </Form>
         <Footer


### PR DESCRIPTION
## Summary

Steps to reproduce problem -

1) Open create data view flyout
2) Enter `.kibana` as index pattern
  - no indices will match, the field will display an error
3) Click on 'Advanced Options'
4) Click 'Allow Hidden'
  - the index pattern will still show an error

This PR fixes the index pattern error state after step four. It will revalidate the index pattern field and load the timestamp field list again. 

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->