### PR TITLE
[Fleet] Add active filter count to agent status filter

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -225,6 +225,8 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                       onClick={() => setIsStatusFilterOpen(!isStatusFilterOpen)}
                       isSelected={isStatusFilterOpen}
                       hasActiveFilters={selectedStatus.length > 0}
+                      numActiveFilters={selectedStatus.length}
+                      numFilters={statusFilters.length}
                       disabled={agentPolicies.length === 0}
                       data-test-subj="agentList.statusFilter"
                     >


### PR DESCRIPTION
## Summary

The agent status filter previously did not have the badge with the number of available or active filter on it. Here it is now with the badge:

<img width="1254" alt="Screenshot 2022-12-19 at 22 51 52" src="https://user-images.githubusercontent.com/3315046/208542579-4a8d8ea0-e2db-495f-9cb2-baf34aca822b.png">
<img width="1251" alt="Screenshot 2022-12-19 at 22 53 33" src="https://user-images.githubusercontent.com/3315046/208542581-48b474fd-73bb-4647-b809-8703b05d1f6c.png">
