### PR TITLE
[8.6] [ML] Explain Log Rate Spikes: Fix client side code to transform groups into table rows. (#147592)

### DIFF
--- a/x-pack/plugins/aiops/public/application/utils/query_utils.test.ts
+++ b/x-pack/plugins/aiops/public/application/utils/query_utils.test.ts
@@ -27,16 +27,16 @@ const selectedGroupMock: GroupTableItem = {
   id: '21289599',
   docCount: 20468,
   pValue: 2.2250738585072626e-308,
-  group: {
-    'error.message': 'rate limit exceeded',
-    message: 'too many requests',
-    'user_agent.original.keyword': 'Mozilla/5.0',
-  },
-  repeatedValues: {
-    'beat.hostname.keyword': 'ip-192-168-1-1',
-    'beat.name.keyword': 'i-1234',
-    'docker.container.id.keyword': 'asdf',
-  },
+  group: [
+    { fieldName: 'error.message', fieldValue: 'rate limit exceeded' },
+    { fieldName: 'message', fieldValue: 'too many requests' },
+    { fieldName: 'user_agent.original.keyword', fieldValue: 'Mozilla/5.0' },
+  ],
+  repeatedValues: [
+    { fieldName: 'beat.hostname.keyword', fieldValue: 'ip-192-168-1-1' },
+    { fieldName: 'beat.name.keyword', fieldValue: 'i-1234' },
+    { fieldName: 'docker.container.id.keyword', fieldValue: 'asdf' },
+  ],
   histogram: [],
 };
 

--- a/x-pack/plugins/aiops/public/application/utils/query_utils.ts
+++ b/x-pack/plugins/aiops/public/application/utils/query_utils.ts
@@ -15,7 +15,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import { Query } from '@kbn/es-query';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
-import type { ChangePoint } from '@kbn/ml-agg-utils';
+import type { ChangePoint, FieldValuePair } from '@kbn/ml-agg-utils';
 import type { GroupTableItem } from '../../components/spike_analysis_table/spike_analysis_table_groups';
 
 /*
@@ -52,11 +52,10 @@ export function buildBaseFilterCriteria(
 
   const groupFilter = [];
   if (selectedGroup) {
-    const allItems = { ...selectedGroup.group, ...selectedGroup.repeatedValues };
-    for (const fieldName in allItems) {
-      if (allItems.hasOwnProperty(fieldName)) {
-        groupFilter.push({ term: { [fieldName]: allItems[fieldName] } });
-      }
+    const allItems: FieldValuePair[] = [...selectedGroup.group, ...selectedGroup.repeatedValues];
+    for (const item of allItems) {
+      const { fieldName, fieldValue } = item;
+      groupFilter.push({ term: { [fieldName]: fieldValue } });
     }
   }
 

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -25,6 +25,7 @@ import type { WindowParameters } from '@kbn/aiops-utils';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { Query } from '@kbn/es-query';
+import type { FieldValuePair } from '@kbn/ml-agg-utils';
 
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import { initialState, streamReducer } from '../../../common/api/stream_reducer';
@@ -163,15 +164,15 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
       const sortedGroup = group.sort((a, b) =>
         a.fieldName > b.fieldName ? 1 : b.fieldName > a.fieldName ? -1 : 0
       );
-      const dedupedGroup: Record<string, any> = {};
-      const repeatedValues: Record<string, any> = {};
+      const dedupedGroup: FieldValuePair[] = [];
+      const repeatedValues: FieldValuePair[] = [];
 
       sortedGroup.forEach((pair) => {
         const { fieldName, fieldValue } = pair;
         if (pair.duplicate === false) {
-          dedupedGroup[fieldName] = fieldValue;
+          dedupedGroup.push({ fieldName, fieldValue });
         } else {
-          repeatedValues[fieldName] = fieldValue;
+          repeatedValues.push({ fieldName, fieldValue });
         }
       });
 
@@ -197,7 +198,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
 
   const showSpikeAnalysisTable = data?.changePoints.length > 0;
   const groupItemCount = groupTableItems.reduce((p, c) => {
-    return p + Object.keys(c.group).length;
+    return p + c.group.length;
   }, 0);
   const foundGroups = groupTableItems.length > 0 && groupItemCount > 0;
 

--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -55,7 +55,7 @@ export const artificialLogDataViewTestData: TestData = {
     totalDocCountFormatted: '8,400',
     analysisGroupsTable: [
       { group: 'user: Peter', docCount: '1981' },
-      { group: 'response_code: 500url: login.php', docCount: '792' },
+      { group: 'response_code: 500url: home.phpurl: login.php', docCount: '792' },
     ],
     analysisTable: [
       {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[ML] Explain Log Rate Spikes: Fix client side code to transform groups into table rows. (#147592)](https://github.com/elastic/kibana/pull/147592)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Walter Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2022-12-20T08:19:11Z","message":"[ML] Explain Log Rate Spikes: Fix client side code to transform groups into table rows. (#147592)\n\nFixes client side code to transform groups into table rows. Because the\r\ntransformation used a dictionary like structure with field names as\r\nkeys, we missed if there were multiple values for a field. This changes\r\nthe structure to an array of field/value pairs so we can support\r\nmultiple values per field.","sha":"92ffe2764f01a67658db854506bbd5003f0adcb8","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","Feature:ML/AIOps","v8.6.0","v8.7.0"],"number":147592,"url":"https://github.com/elastic/kibana/pull/147592","mergeCommit":{"message":"[ML] Explain Log Rate Spikes: Fix client side code to transform groups into table rows. (#147592)\n\nFixes client side code to transform groups into table rows. Because the\r\ntransformation used a dictionary like structure with field names as\r\nkeys, we missed if there were multiple values for a field. This changes\r\nthe structure to an array of field/value pairs so we can support\r\nmultiple values per field.","sha":"92ffe2764f01a67658db854506bbd5003f0adcb8"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147592","number":147592,"mergeCommit":{"message":"[ML] Explain Log Rate Spikes: Fix client side code to transform groups into table rows. (#147592)\n\nFixes client side code to transform groups into table rows. Because the\r\ntransformation used a dictionary like structure with field names as\r\nkeys, we missed if there were multiple values for a field. This changes\r\nthe structure to an array of field/value pairs so we can support\r\nmultiple values per field.","sha":"92ffe2764f01a67658db854506bbd5003f0adcb8"}}]}] BACKPORT-->