### PR TITLE
[TableListView] Fix url state when Router context missing

### DIFF
--- a/packages/content-management/table_list/src/table_list_view.tsx
+++ b/packages/content-management/table_list/src/table_list_view.tsx
@@ -41,7 +41,7 @@ import type { SavedObjectsReference, SavedObjectsFindOptionsReference } from './
 import { getReducer } from './reducer';
 import type { SortColumnField } from './components';
 import { useTags } from './use_tags';
-import { useUrlState } from './use_url_state';
+import { useInRouterContext, useUrlState } from './use_url_state';
 
 interface ContentEditorConfig
   extends Pick<OpenContentEditorParams, 'isReadonly' | 'onSave' | 'customValidators'> {
@@ -273,6 +273,14 @@ function TableListViewComp<T extends UserContentCommonSchema>({
   } = useServices();
 
   const openContentEditor = useOpenContentEditor();
+
+  const isInRouterContext = useInRouterContext();
+
+  if (!isInRouterContext) {
+    throw new Error(
+      `<TableListView/> requires a React Router context. Ensure your component or React root is being rendered in the context of a <Router>.`
+    );
+  }
 
   const [urlState, setUrlState] = useUrlState<URLState, URLQueryParams>({
     queryParamsDeserializer: urlStateDeserializer,

--- a/packages/content-management/table_list/src/use_url_state.ts
+++ b/packages/content-management/table_list/src/use_url_state.ts
@@ -9,6 +9,15 @@ import queryString from 'query-string';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
+export function useInRouterContext() {
+  try {
+    useLocation();
+    return true;
+  } catch (e: unknown) {
+    return false;
+  }
+}
+
 function useQuery<T extends Record<string, unknown> = {}>() {
   const { search } = useLocation();
   return useMemo<T>(() => queryString.parse(search) as T, [search]);

--- a/src/plugins/files_management/public/app.tsx
+++ b/src/plugins/files_management/public/app.tsx
@@ -27,7 +27,7 @@ export const App: FunctionComponent = () => {
   const [showDiagnosticsFlyout, setShowDiagnosticsFlyout] = useState<boolean>(false);
   const [selectedFile, setSelectedFile] = useState<undefined | FileJSON>(undefined);
   return (
-    <>
+    <div data-test-subj="filesManagementApp">
       <TableListView<FilesUserContentSchema>
         tableListTitle={i18nTexts.tableListTitle}
         tableListDescription={i18nTexts.tableListDescription}
@@ -78,6 +78,6 @@ export const App: FunctionComponent = () => {
       {Boolean(selectedFile) && (
         <FileFlyout file={selectedFile!} onClose={() => setSelectedFile(undefined)} />
       )}
-    </>
+    </div>
   );
 };

--- a/src/plugins/files_management/public/mount_management_section.tsx
+++ b/src/plugins/files_management/public/mount_management_section.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Router, Route } from 'react-router-dom';
 import { toMountPoint } from '@kbn/kibana-react-plugin/public';
 import { I18nProvider, FormattedRelative } from '@kbn/i18n-react';
 import type { CoreStart } from '@kbn/core/public';
@@ -26,7 +27,7 @@ const queryClient = new QueryClient();
 export const mountManagementSection = (
   coreStart: CoreStart,
   startDeps: StartDependencies,
-  { element }: ManagementAppMountParams
+  { element, history }: ManagementAppMountParams
 ) => {
   ReactDOM.render(
     <I18nProvider>
@@ -41,7 +42,9 @@ export const mountManagementSection = (
           <FilesManagementAppContextProvider
             filesClient={startDeps.files.filesClientFactory.asUnscoped()}
           >
-            <App />
+            <Router history={history}>
+              <Route path="/" component={App} />
+            </Router>
           </FilesManagementAppContextProvider>
         </TableListViewKibanaProvider>
       </QueryClientProvider>

--- a/test/functional/apps/management/_files.ts
+++ b/test/functional/apps/management/_files.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import expect from '@kbn/expect/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'filesManagement']);
+  const testSubjects = getService('testSubjects');
+
+  describe('Files management', () => {
+    before(async () => {
+      await PageObjects.filesManagement.navigateTo();
+    });
+
+    it(`should render an empty prompt`, async () => {
+      await testSubjects.existOrFail('filesManagementApp');
+
+      const pageText = await (await testSubjects.find('filesManagementApp')).getVisibleText();
+
+      expect(pageText).to.contain('No files found');
+    });
+  });
+}

--- a/test/functional/apps/management/index.ts
+++ b/test/functional/apps/management/index.ts
@@ -45,5 +45,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./_handle_not_found'));
     loadTestFile(require.resolve('./_data_view_relationships'));
     loadTestFile(require.resolve('./_edit_field'));
+    loadTestFile(require.resolve('./_files'));
   });
 }

--- a/test/functional/config.base.js
+++ b/test/functional/config.base.js
@@ -69,6 +69,9 @@ export default async function ({ readConfigFile }) {
       management: {
         pathname: '/app/management',
       },
+      filesManagement: {
+        pathname: '/app/management/kibana/filesManagement',
+      },
       /** @obsolete "management" should be instead of "settings" **/
       settings: {
         pathname: '/app/management',

--- a/test/functional/page_objects/files_management.ts
+++ b/test/functional/page_objects/files_management.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { FtrService } from '../ftr_provider_context';
+
+export class FilesManagementPageObject extends FtrService {
+  private readonly common = this.ctx.getPageObject('common');
+
+  async navigateTo() {
+    await this.common.navigateToApp('filesManagement');
+  }
+}

--- a/test/functional/page_objects/index.ts
+++ b/test/functional/page_objects/index.ts
@@ -32,6 +32,7 @@ import { LegacyDataTableVisPageObject } from './legacy/data_table_vis';
 import { IndexPatternFieldEditorPageObject } from './management/indexpattern_field_editor_page';
 import { DashboardPageControls } from './dashboard_page_controls';
 import { UnifiedSearchPageObject } from './unified_search_page';
+import { FilesManagementPageObject } from './files_management';
 
 export const pageObjects = {
   common: CommonPageObject,
@@ -60,4 +61,5 @@ export const pageObjects = {
   savedObjects: SavedObjectsPageObject,
   indexPatternFieldEditorObjects: IndexPatternFieldEditorPageObject,
   unifiedSearch: UnifiedSearchPageObject,
+  filesManagement: FilesManagementPageObject,
 };


### PR DESCRIPTION
This PR fixes an issue found by @Dosant in the TableListView when the component is not wrapped by a react router context. 

Files management which consume this component was not using a router and it caused the app to crash. I've wrapped the app in a `<Router /> --- <Route />` and added a clearer error message for consumers if they haven't wrapped the component in a Router context.

<img width="686" alt="Screenshot 2022-12-20 at 11 11 52" src="https://user-images.githubusercontent.com/2854616/208641909-be9965e7-7b80-49e9-83e6-a00e8a9ec864.png">

