### PR TITLE
[Security Solution][Endpoint] Fix `get-file` response action that was reporting uploaded file as Deleted

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.test.ts
@@ -95,8 +95,8 @@ describe('Action Files service', () => {
         status: 'DELETED',
       });
 
-      expect(loggerMock.debug).toHaveBeenCalledWith(
-        'File with id [123] has no data chunks. Status will be adjusted to DELETED'
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'File with id [123] has no data chunks in index [.fleet-file-data-endpoint]. File status will be adjusted to DELETED'
       );
     });
 

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
@@ -93,8 +93,8 @@ export const getFileInfo = async (
       fileHasChunks = await doesFileHaveChunks(esClient, fileId);
 
       if (!fileHasChunks) {
-        logger.debug(
-          `File with id [${fileId}] has no data chunks. Status will be adjusted to DELETED`
+        logger.warn(
+          `File with id [${fileId}] has no data chunks in index [${FILE_STORAGE_DATA_INDEX}]. File status will be adjusted to DELETED`
         );
       }
     }
@@ -118,10 +118,17 @@ const doesFileHaveChunks = async (
 ): Promise<boolean> => {
   const chunks = await esClient.search({
     index: FILE_STORAGE_DATA_INDEX,
+    size: 0,
     body: {
       query: {
-        term: {
-          bid: fileId,
+        bool: {
+          filter: [
+            {
+              term: {
+                bid: fileId,
+              },
+            },
+          ],
         },
       },
       // Setting `_source` to false - we don't need the actual document to be returned


### PR DESCRIPTION
## Summary

- Fixes the server side utility that retrieves file information to ensure it property determines if a file has chunks and does not incorrectly set the file status to `DELETED`


> **Note**
> I order to test, the following experimental feature flags must be enabled:
> 
> `xpack.fleet.enableExperimental.diagnosticFileUploadEnabled`
> `xpack.securitySolution.enableExperimental.responseActionGetFileEnabled`

