### PR TITLE
[8.6] [ML] Transforms/Data Visualizer: Fix handling of aggregate_metric_double field types. (#147711)

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/util/field_types_utils.ts
+++ b/x-pack/plugins/data_visualizer/public/application/common/util/field_types_utils.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { DataViewField } from '@kbn/data-views-plugin/public';
-import { KBN_FIELD_TYPES } from '@kbn/data-plugin/common';
+import { ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/field-types';
 import { SupportedFieldType } from '../../../../common/types';
 import { SUPPORTED_FIELD_TYPES } from '../../../../common/constants';
 
@@ -127,6 +127,9 @@ export function kbnTypeToJobType(field: DataViewField) {
       }
       break;
     case KBN_FIELD_TYPES.NUMBER:
+      if (field.esTypes?.some((d) => d === ES_FIELD_TYPES.AGGREGATE_METRIC_DOUBLE)) {
+        break;
+      }
       type = SUPPORTED_FIELD_TYPES.NUMBER;
       break;
     case KBN_FIELD_TYPES.DATE:

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/use_data_visualizer_grid_data.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/use_data_visualizer_grid_data.ts
@@ -10,7 +10,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { merge } from 'rxjs';
 import type { EuiTableActionsColumnType } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { DataViewField, KBN_FIELD_TYPES, UI_SETTINGS } from '@kbn/data-plugin/common';
+import {
+  DataViewField,
+  ES_FIELD_TYPES,
+  KBN_FIELD_TYPES,
+  UI_SETTINGS,
+} from '@kbn/data-plugin/common';
 import seedrandom from 'seedrandom';
 import type { SamplingOption } from '@kbn/discover-plugin/public/application/main/components/field_stats_table/field_stats_table';
 import type { RandomSamplerOption } from '../constants/random_sampler';
@@ -205,7 +210,11 @@ export const useDataVisualizerGridData = (
         }
         const fieldName = field.displayName !== undefined ? field.displayName : field.name;
         if (!OMIT_FIELDS.includes(fieldName)) {
-          if (field.aggregatable === true && !NON_AGGREGATABLE_FIELD_TYPES.has(field.type)) {
+          if (
+            field.aggregatable === true &&
+            !NON_AGGREGATABLE_FIELD_TYPES.has(field.type) &&
+            !field.esTypes?.some((d) => d === ES_FIELD_TYPES.AGGREGATE_METRIC_DOUBLE)
+          ) {
             aggregatableFields.push(field.name);
           } else {
             nonAggregatableFields.push(field.name);

--- a/x-pack/plugins/ml/public/application/components/data_grid/common.test.ts
+++ b/x-pack/plugins/ml/public/application/components/data_grid/common.test.ts
@@ -5,54 +5,146 @@
  * 2.0.
  */
 
-import { MultiColumnSorter, multiColumnSortFactory } from './common';
+import type { DataViewField } from '@kbn/data-views-plugin/common';
+
+import {
+  getDataGridSchemaFromKibanaFieldType,
+  MultiColumnSorter,
+  multiColumnSortFactory,
+} from './common';
+
+const data = [
+  { s: 'a', n: 1 },
+  { s: 'a', n: 2 },
+  { s: 'b', n: 3 },
+  { s: 'b', n: 4 },
+];
 
 describe('Data Frame Analytics: Data Grid Common', () => {
-  test('multiColumnSortFactory()', () => {
-    const data = [
-      { s: 'a', n: 1 },
-      { s: 'a', n: 2 },
-      { s: 'b', n: 3 },
-      { s: 'b', n: 4 },
-    ];
+  describe('multiColumnSortFactory', () => {
+    it('returns desc sorted by one column', () => {
+      const sortingColumns1: MultiColumnSorter[] = [{ id: 's', direction: 'desc', type: 'number' }];
+      const multiColumnSort1 = multiColumnSortFactory(sortingColumns1);
+      data.sort(multiColumnSort1);
 
-    const sortingColumns1: MultiColumnSorter[] = [{ id: 's', direction: 'desc', type: 'number' }];
-    const multiColumnSort1 = multiColumnSortFactory(sortingColumns1);
-    data.sort(multiColumnSort1);
+      expect(data).toStrictEqual([
+        { s: 'b', n: 3 },
+        { s: 'b', n: 4 },
+        { s: 'a', n: 1 },
+        { s: 'a', n: 2 },
+      ]);
+    });
 
-    expect(data).toStrictEqual([
-      { s: 'b', n: 3 },
-      { s: 'b', n: 4 },
-      { s: 'a', n: 1 },
-      { s: 'a', n: 2 },
-    ]);
+    it('returns asc/desc sorted by two columns', () => {
+      const sortingColumns2: MultiColumnSorter[] = [
+        { id: 's', direction: 'asc', type: 'number' },
+        { id: 'n', direction: 'desc', type: 'number' },
+      ];
+      const multiColumnSort2 = multiColumnSortFactory(sortingColumns2);
+      data.sort(multiColumnSort2);
 
-    const sortingColumns2: MultiColumnSorter[] = [
-      { id: 's', direction: 'asc', type: 'number' },
-      { id: 'n', direction: 'desc', type: 'number' },
-    ];
-    const multiColumnSort2 = multiColumnSortFactory(sortingColumns2);
-    data.sort(multiColumnSort2);
+      expect(data).toStrictEqual([
+        { s: 'a', n: 2 },
+        { s: 'a', n: 1 },
+        { s: 'b', n: 4 },
+        { s: 'b', n: 3 },
+      ]);
+    });
 
-    expect(data).toStrictEqual([
-      { s: 'a', n: 2 },
-      { s: 'a', n: 1 },
-      { s: 'b', n: 4 },
-      { s: 'b', n: 3 },
-    ]);
+    it('returns desc/desc sorted by two column', () => {
+      const sortingColumns3: MultiColumnSorter[] = [
+        { id: 'n', direction: 'desc', type: 'number' },
+        { id: 's', direction: 'desc', type: 'number' },
+      ];
+      const multiColumnSort3 = multiColumnSortFactory(sortingColumns3);
+      data.sort(multiColumnSort3);
 
-    const sortingColumns3: MultiColumnSorter[] = [
-      { id: 'n', direction: 'desc', type: 'number' },
-      { id: 's', direction: 'desc', type: 'number' },
-    ];
-    const multiColumnSort3 = multiColumnSortFactory(sortingColumns3);
-    data.sort(multiColumnSort3);
+      expect(data).toStrictEqual([
+        { s: 'b', n: 4 },
+        { s: 'b', n: 3 },
+        { s: 'a', n: 2 },
+        { s: 'a', n: 1 },
+      ]);
+    });
+  });
 
-    expect(data).toStrictEqual([
-      { s: 'b', n: 4 },
-      { s: 'b', n: 3 },
-      { s: 'a', n: 2 },
-      { s: 'a', n: 1 },
-    ]);
+  describe('getDataGridSchemaFromKibanaFieldType', () => {
+    it('returns undefined for an undefined field', () => {
+      expect(getDataGridSchemaFromKibanaFieldType(undefined)).toBe(undefined);
+    });
+
+    it(`returns 'boolean' for a 'boolean' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'boolean',
+        } as DataViewField)
+      ).toBe('boolean');
+    });
+
+    it(`returns 'datetime' for a 'date' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'date',
+        } as DataViewField)
+      ).toBe('datetime');
+    });
+
+    it(`returns 'json' for a 'geo_point' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'geo_point',
+        } as DataViewField)
+      ).toBe('json');
+    });
+
+    it(`returns 'json' for a 'geo_shape' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'geo_point',
+        } as DataViewField)
+      ).toBe('json');
+    });
+
+    it(`returns 'numeric' for a 'number' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'number',
+        } as DataViewField)
+      ).toBe('numeric');
+    });
+
+    it(`returns 'json' for a 'nested' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'nested',
+        } as DataViewField)
+      ).toBe('json');
+    });
+
+    it(`returns 'non-aggregatable' for a 'number' kibana field with 'aggregate_metric_double' estype field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'number',
+          esTypes: ['aggregate_metric_double'],
+        } as DataViewField)
+      ).toBe('non-aggregatable');
+    });
+
+    it(`returns undefined for a 'string' kibana field`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'string',
+        } as DataViewField)
+      ).toBe(undefined);
+    });
+
+    it(`returns 'non-aggregatable' for a 'string' kibana field that is not aggregatable`, () => {
+      expect(
+        getDataGridSchemaFromKibanaFieldType({
+          type: 'string',
+          aggregatable: false,
+        } as DataViewField)
+      ).toBe('non-aggregatable');
+    });
   });
 });

--- a/x-pack/plugins/ml/public/application/components/data_grid/common.ts
+++ b/x-pack/plugins/ml/public/application/components/data_grid/common.ts
@@ -239,7 +239,11 @@ export const getDataGridSchemaFromKibanaFieldType = (
       break;
   }
 
-  if (schema === undefined && field?.aggregatable === false) {
+  if (
+    (schema === undefined && field?.aggregatable === false) ||
+    (schema === 'numeric' &&
+      field?.esTypes?.some((d) => d === ES_FIELD_TYPES.AGGREGATE_METRIC_DOUBLE))
+  ) {
     return NON_AGGREGATABLE;
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[ML] Transforms/Data Visualizer: Fix handling of aggregate_metric_double field types. (#147711)](https://github.com/elastic/kibana/pull/147711)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Walter Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2022-12-20T19:29:47Z","message":"[ML] Transforms/Data Visualizer: Fix handling of aggregate_metric_double field types. (#147711)\n\nFix to avoid aggregating on `aggregate_metric_double` field types.","sha":"087fec38f93362a52cbacb3fa73a4e05607ae4ac","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","Feature:Transforms","v8.6.0","v8.7.0"],"number":147711,"url":"https://github.com/elastic/kibana/pull/147711","mergeCommit":{"message":"[ML] Transforms/Data Visualizer: Fix handling of aggregate_metric_double field types. (#147711)\n\nFix to avoid aggregating on `aggregate_metric_double` field types.","sha":"087fec38f93362a52cbacb3fa73a4e05607ae4ac"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147711","number":147711,"mergeCommit":{"message":"[ML] Transforms/Data Visualizer: Fix handling of aggregate_metric_double field types. (#147711)\n\nFix to avoid aggregating on `aggregate_metric_double` field types.","sha":"087fec38f93362a52cbacb3fa73a4e05607ae4ac"}}]}] BACKPORT-->