### PR TITLE
[Enterprise Search] updated simulate endpoints to return error from simulate

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -596,8 +596,12 @@ export function registerIndexRoutes({
           headers: { 'content-type': 'application/json' },
         });
       } catch (e) {
-        log.error(`Error simulating inference pipeline: ${JSON.stringify(e)}`);
-        throw e;
+        return createError({
+          errorCode: ErrorCode.UNCAUGHT_EXCEPTION,
+          message: e.message,
+          response,
+          statusCode: 400,
+        });
       }
     })
   );
@@ -673,8 +677,12 @@ export function registerIndexRoutes({
           headers: { 'content-type': 'application/json' },
         });
       } catch (e) {
-        log.error(`Error simulating inference pipeline: ${JSON.stringify(e)}`);
-        throw e;
+        return createError({
+          errorCode: ErrorCode.UNCAUGHT_EXCEPTION,
+          message: e.message,
+          response,
+          statusCode: 400,
+        });
       }
     })
   );


### PR DESCRIPTION
## Summary

Updated the two simulate endpoints to return an error with the underlying simulate error instead of throwing the error up to the default handler.

<img width="1839" alt="image" src="https://user-images.githubusercontent.com/1972968/208780111-c9315897-adc8-40af-bbcf-7a67a997381e.png">



