### PR TITLE
[8.5] [Console] Fix issue with bulk requests (#147596)

### DIFF
--- a/src/plugins/console/public/lib/row_parser.test.ts
+++ b/src/plugins/console/public/lib/row_parser.test.ts
@@ -82,10 +82,25 @@ describe('RowParser', () => {
       expect(parser?.getRowParseMode()).toBe(MODE.REQUEST_START | MODE.REQUEST_END);
     });
 
-    it('should return MODE.REQUEST_END | MODE.MULTI_DOC_CUR_DOC_END for a request that ends with a curly closing brace', () => {
+    it('should return MODE.REQUEST_START | MODE.REQUEST_END if a single request line ends with a closing curly brace', () => {
       editor?.getCoreEditor().setValue('DELETE <foo>/_bar/_baz%{test}', forceRetokenize);
       // eslint-disable-next-line no-bitwise
-      expect(parser?.getRowParseMode()).toBe(MODE.REQUEST_END | MODE.MULTI_DOC_CUR_DOC_END);
+      expect(parser?.getRowParseMode()).toBe(MODE.REQUEST_START | MODE.REQUEST_END);
+    });
+
+    it('should return correct modes for multiple bulk requests', () => {
+      editor
+        ?.getCoreEditor()
+        .setValue('POST _bulk\n{"index": {"_index": "test"}}\n{"foo": "bar"}\n', forceRetokenize);
+      expect(parser?.getRowParseMode(0)).toBe(MODE.BETWEEN_REQUESTS);
+      editor
+        ?.getCoreEditor()
+        .setValue('POST _bulk\n{"index": {"_index": "test"}}\n{"foo": "bar"}\n', forceRetokenize);
+      const lineNumber = editor?.getCoreEditor().getLineCount()! - 1;
+      expect(parser?.getRowParseMode(lineNumber)).toBe(
+        // eslint-disable-next-line no-bitwise
+        MODE.REQUEST_END | MODE.MULTI_DOC_CUR_DOC_END
+      );
     });
   });
 });

--- a/src/plugins/console/public/lib/row_parser.ts
+++ b/src/plugins/console/public/lib/row_parser.ts
@@ -29,8 +29,6 @@ export default class RowParser {
       return MODE.BETWEEN_REQUESTS;
     }
     const mode = this.editor.getLineState(lineNumber);
-    const pos = this.editor.getCurrentPosition();
-    const token = this.editor.getTokenAt(pos);
 
     if (!mode) {
       return MODE.BETWEEN_REQUESTS;
@@ -59,9 +57,8 @@ export default class RowParser {
       return MODE.BETWEEN_REQUESTS;
     } // empty line or a comment waiting for a new req to start
 
-    // If the line ends with a closing curly brace, it's the end of a request,
-    // and we should also check if the current token is not an url token
-    if (line.indexOf('}', line.length - 1) >= 0 && token?.type !== 'url.part') {
+    // Check for multi doc requests
+    if (line.endsWith('}') && !this.isRequestLine(line)) {
       // check for a multi doc request must start a new json doc immediately after this one end.
       lineNumber++;
       if (lineNumber < linesCount + 1) {
@@ -166,5 +163,10 @@ export default class RowParser {
         token.type === 'comment.line' ||
         token.type === 'comment.block')
     );
+  }
+
+  isRequestLine(line: string) {
+    const methods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS'];
+    return methods.some((m) => line.startsWith(m));
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[Console] Fix issue with bulk requests (#147596)](https://github.com/elastic/kibana/pull/147596)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Muhammad Ibragimov","email":"53621505+mibragimov@users.noreply.github.com"},"sourceCommit":{"committedDate":"2022-12-16T10:01:50Z","message":"[Console] Fix issue with bulk requests (#147596)\n\nFixes https://github.com/elastic/kibana/issues/146366\r\n\r\n\r\n### Summary\r\n\r\nThe issue was that the parser was not able to detect the end of a bulk\r\nrequest correctly when multiple requests were sent. This PR fixes that\r\nissue.\r\n\r\n### How to test\r\n\r\n1. Go to Console\r\n2. Send a bulk request with multiple requests. For example the following\r\nrequests:\r\n\r\n```\r\nPUT /metrics-hello-world/_bulk?refresh\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:49:00Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:45:50Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:44:50Z\",\"namespace\":\"namespace26\"}\r\n\r\n\r\nGET _alias\r\n\r\nPUT <foo>/_bar/_baz%{test}\r\n```\r\n\r\n3. Send the request by pressing `CMD ⌘ + A` and `ENTER`\r\n4. The response should be displayed correctly\r\n\r\nCo-authored-by: Muhammad Ibragimov <muhammad.ibragimov@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fa9094366c63aa371b7010a19e5ba5eb99b74236","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Deployment Management","release_note:skip","backport:skip","v8.7.0"],"number":147596,"url":"https://github.com/elastic/kibana/pull/147596","mergeCommit":{"message":"[Console] Fix issue with bulk requests (#147596)\n\nFixes https://github.com/elastic/kibana/issues/146366\r\n\r\n\r\n### Summary\r\n\r\nThe issue was that the parser was not able to detect the end of a bulk\r\nrequest correctly when multiple requests were sent. This PR fixes that\r\nissue.\r\n\r\n### How to test\r\n\r\n1. Go to Console\r\n2. Send a bulk request with multiple requests. For example the following\r\nrequests:\r\n\r\n```\r\nPUT /metrics-hello-world/_bulk?refresh\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:49:00Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:45:50Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:44:50Z\",\"namespace\":\"namespace26\"}\r\n\r\n\r\nGET _alias\r\n\r\nPUT <foo>/_bar/_baz%{test}\r\n```\r\n\r\n3. Send the request by pressing `CMD ⌘ + A` and `ENTER`\r\n4. The response should be displayed correctly\r\n\r\nCo-authored-by: Muhammad Ibragimov <muhammad.ibragimov@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fa9094366c63aa371b7010a19e5ba5eb99b74236"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147596","number":147596,"mergeCommit":{"message":"[Console] Fix issue with bulk requests (#147596)\n\nFixes https://github.com/elastic/kibana/issues/146366\r\n\r\n\r\n### Summary\r\n\r\nThe issue was that the parser was not able to detect the end of a bulk\r\nrequest correctly when multiple requests were sent. This PR fixes that\r\nissue.\r\n\r\n### How to test\r\n\r\n1. Go to Console\r\n2. Send a bulk request with multiple requests. For example the following\r\nrequests:\r\n\r\n```\r\nPUT /metrics-hello-world/_bulk?refresh\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:49:00Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:45:50Z\",\"namespace\":\"namespace26\"}\r\n{\"create\":{}}\r\n{\"@timestamp\":\"2022-06-21T15:44:50Z\",\"namespace\":\"namespace26\"}\r\n\r\n\r\nGET _alias\r\n\r\nPUT <foo>/_bar/_baz%{test}\r\n```\r\n\r\n3. Send the request by pressing `CMD ⌘ + A` and `ENTER`\r\n4. The response should be displayed correctly\r\n\r\nCo-authored-by: Muhammad Ibragimov <muhammad.ibragimov@elastic.co>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fa9094366c63aa371b7010a19e5ba5eb99b74236"}}]}] BACKPORT-->