### PR TITLE
[Security Solution] Clean connectors before custom query rule test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
@@ -79,7 +79,7 @@ import {
 } from '../../tasks/alerts_detection_rules';
 import { createCustomRuleEnabled } from '../../tasks/api_calls/rules';
 import { createTimeline } from '../../tasks/api_calls/timelines';
-import { cleanKibana, deleteAlertsAndRules } from '../../tasks/common';
+import { cleanKibana, deleteAlertsAndRules, deleteConnectors } from '../../tasks/common';
 import { addEmailConnectorAndRuleAction } from '../../tasks/common/rule_actions';
 import {
   continueWithNextSection,
@@ -356,6 +356,7 @@ describe('Custom query rules', () => {
 
       before(() => {
         deleteAlertsAndRules();
+        deleteConnectors();
         createCustomRuleEnabled(getExistingRule(), 'rule1');
       });
       beforeEach(() => {


### PR DESCRIPTION
## Summary

Connector list is not cleaned up currently which prevents running `custom_query_rule.cy.ts` more than once after bootstrap (manually from the cypress UI). This PR ensures that the connector list is cleaned up properly.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

