### PR TITLE
[Lens] Table shows extra rows when embedded on a dashboard

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -90,19 +90,15 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
   }, [props]);
 
   useEffect(() => {
-    setPagination((pag) => {
-      if (pag && pag.pageSize === props.args.pageSize) {
-        return pag;
-      }
-
-      return props.args.pageSize && props.args.pageSize < firstLocalTable.rows.length
+    setPagination(
+      props.args.pageSize
         ? {
             pageIndex: 0,
             pageSize: props.args.pageSize ?? DEFAULT_PAGE_SIZE,
           }
-        : undefined;
-    });
-  }, [props.args.pageSize, firstLocalTable]);
+        : undefined
+    );
+  }, [props.args.pageSize]);
 
   useDeepCompareEffect(() => {
     setColumnConfig({
@@ -121,7 +117,9 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
 
   useEffect(() => {
     if (!pagination?.pageIndex && !pagination?.pageSize) return;
-    const lastPageIndex = Math.ceil(firstLocalTable.rows.length / pagination.pageSize) - 1;
+    const lastPageIndex = firstLocalTable.rows.length
+      ? Math.ceil(firstLocalTable.rows.length / pagination.pageSize) - 1
+      : 0;
     /**
      * When the underlying data changes, there might be a case when actual pagination page
      * doesn't exist anymore - if the number of rows has decreased.

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -91,14 +91,14 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
 
   useEffect(() => {
     setPagination(
-      props.args.pageSize
+      props.args.pageSize && props.args.pageSize < firstLocalTable.rows.length
         ? {
             pageIndex: 0,
             pageSize: props.args.pageSize ?? DEFAULT_PAGE_SIZE,
           }
         : undefined
     );
-  }, [props.args.pageSize]);
+  }, [props.args.pageSize, firstLocalTable]);
 
   useDeepCompareEffect(() => {
     setColumnConfig({

--- a/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/components/table_basic.tsx
@@ -90,14 +90,18 @@ export const DatatableComponent = (props: DatatableRenderProps) => {
   }, [props]);
 
   useEffect(() => {
-    setPagination(
-      props.args.pageSize && props.args.pageSize < firstLocalTable.rows.length
+    setPagination((pag) => {
+      if (pag && pag.pageSize === props.args.pageSize) {
+        return pag;
+      }
+
+      return props.args.pageSize && props.args.pageSize < firstLocalTable.rows.length
         ? {
             pageIndex: 0,
             pageSize: props.args.pageSize ?? DEFAULT_PAGE_SIZE,
           }
-        : undefined
-    );
+        : undefined;
+    });
   }, [props.args.pageSize, firstLocalTable]);
 
   useDeepCompareEffect(() => {


### PR DESCRIPTION
## Summary

Fixes: #147922

previously we set `-1` as `pageIndex` if we have empty data, but in this case it should be `0`.