### PR TITLE
[Enterprise Search] Fix styling for reorderable tables

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -112,7 +112,7 @@ export const SearchIndex: React.FC = () => {
       content: <SearchIndexIndexMappings />,
       id: SearchIndexTabId.INDEX_MAPPINGS,
       name: i18n.translate('xpack.enterpriseSearch.content.searchIndex.indexMappingsTabLabel', {
-        defaultMessage: 'Index Mappings',
+        defaultMessage: 'Index mappings',
       }),
     },
   ];

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.scss
@@ -1,5 +1,11 @@
 .reorderableTable {
 
+  &Header {
+    > .euiFlexGroup {
+      margin: $euiSizeXS 0;
+    }
+  }
+
   &NoItems {
     border-top: $euiBorderThin;
     background-color: $euiColorEmptyShade;
@@ -9,18 +15,8 @@
     border-top: $euiBorderThin;
     background-color: $euiColorEmptyShade;
 
-    > .euiFlexGroup {
-      margin: 0;
-    }
-
-    > .euiFlexGroup:nth-child(2) > .euiFlexItem {
-      margin-top: 0;
-    }
-  }
-
-  &Header {
-    > .euiFlexGroup {
-      margin: ($euiSizeM * -1) 0;
+    > .euiFlexGroup > .euiFlexItem {
+      margin: $euiSizeM 0;
     }
   }
 


### PR DESCRIPTION
This updates Enterprise Search table styling to match what it was before recent EUI updates.

Before:
<img width="1244" alt="Screenshot 2022-12-21 at 16 29 58" src="https://user-images.githubusercontent.com/94373878/208943146-4a17ca9b-6328-4dc5-b3f5-730aa7a5be88.png">

After:
<img width="1254" alt="Screenshot 2022-12-21 at 16 33 29" src="https://user-images.githubusercontent.com/94373878/208943165-9d56ae7d-58ee-4bea-a6dd-ae2e32b4d9f4.png">
