### PR TITLE
[Behavioral Analytics] Change Analytics DNS path

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate.test.tsx
@@ -44,7 +44,7 @@ describe('AnalyticsCollectionIntegrate', () => {
       <AnalyticsCollectionIntegrate collection={analyticsCollections} />
     );
     expect(wrapper.find(EuiCodeBlock).at(0).text()).toContain(
-      'data-dsn="/analytics/api/collections/1"'
+      'data-dsn="/api/analytics/collections/1"'
     );
     expect(wrapper.find(EuiCodeBlock).at(0).text()).toContain('src="/analytics.js"');
   });

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate.tsx
@@ -28,7 +28,7 @@ export type TabKey = 'javascriptEmbed' | 'searchuiEmbed' | 'javascriptClientEmbe
 export const AnalyticsCollectionIntegrate: React.FC<AnalyticsCollectionIntegrateProps> = ({
   collection,
 }) => {
-  const analyticsDNSUrl = getEnterpriseSearchUrl(`/analytics/api/collections/${collection.id}`);
+  const analyticsDNSUrl = getEnterpriseSearchUrl(`/api/analytics/collections/${collection.id}`);
   const webClientSrc = getEnterpriseSearchUrl('/analytics.js');
 
   const [selectedTab, setSelectedTab] = React.useState<TabKey>('javascriptEmbed');


### PR DESCRIPTION
### Description
Recently it was discovered that our initial path to analytics brings some inconsistency into Enterprise Search routes, so it was decided to replace the `analytics/api` path with `api/analytics`.

This PR is dedicated to changing Analytics DNS path from `analytics/api` to `api/analytics`