### PR TITLE
[Fleet] Display callout when user has inactive or unenrolled agents

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -8,6 +8,7 @@
 import React, { useState } from 'react';
 import {
   EuiButton,
+  EuiCallOut,
   EuiFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
@@ -15,6 +16,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiIcon,
+  EuiLink,
   EuiPopover,
   EuiToolTip,
 } from '@elastic/eui';
@@ -78,6 +80,37 @@ const ClearAllTagsFilterItem = styled(EuiFilterSelectItem)`
 const FlexEndEuiFlexItem = styled(EuiFlexItem)`
   align-self: flex-end;
 `;
+
+const InactiveAgentsCallout: React.FC<{
+  onShowInactiveClick: () => void;
+}> = ({ onShowInactiveClick }) => {
+  return (
+    <EuiCallOut
+      size="m"
+      title={
+        <FormattedMessage
+          id="xpack.fleet.agentList.inactiveAgentsCalloutText"
+          defaultMessage="Some agents are inactive or unenrolled"
+        />
+      }
+      iconType="iInCircle"
+    >
+      <FormattedMessage
+        id="xpack.fleet.agentList.inactiveAgentsCalloutText"
+        defaultMessage="These are not displayed by default. Use status filters to show inactive or unenrolled agents. {clickToShow}"
+        values={{
+          clickToShow: (
+            <EuiLink onClick={onShowInactiveClick}>
+              {i18n.translate('xpack.fleet.agentList.inactiveAgentsCalloutClickToShowText', {
+                defaultMessage: 'Click to add these filters',
+              })}
+            </EuiLink>
+          ),
+        }}
+      />
+    </EuiCallOut>
+  );
+};
 
 export const SearchAndFilterBar: React.FunctionComponent<{
   agentPolicies: AgentPolicy[];
@@ -158,10 +191,24 @@ export const SearchAndFilterBar: React.FunctionComponent<{
     onSelectedTagsChange(selectedTags.filter((t) => t !== tag));
   };
 
+  const inactiveAgentsNotVisible =
+    totalInactiveAgents > 0 &&
+    !(selectedStatus.includes('unenrolled') || selectedStatus.includes('inactive'));
   return (
     <>
       {/* Search and filter bar */}
       <EuiFlexGroup direction="column">
+        {inactiveAgentsNotVisible && (
+          <EuiFlexItem grow={4}>
+            <InactiveAgentsCallout
+              onShowInactiveClick={() =>
+                onSelectedStatusChange(
+                  Array.from(new Set([...selectedStatus, 'unenrolled', 'inactive']))
+                )
+              }
+            />
+          </EuiFlexItem>
+        )}
         <FlexEndEuiFlexItem>
           <EuiFlexGroup gutterSize="s">
             <EuiFlexItem>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -89,14 +89,14 @@ const InactiveAgentsCallout: React.FC<{
       size="m"
       title={
         <FormattedMessage
-          id="xpack.fleet.agentList.inactiveAgentsCalloutText"
+          id="xpack.fleet.agentList.inactiveAgentsCalloutTitle"
           defaultMessage="Some agents are inactive or unenrolled"
         />
       }
       iconType="iInCircle"
     >
       <FormattedMessage
-        id="xpack.fleet.agentList.inactiveAgentsCalloutText"
+        id="xpack.fleet.agentList.inactiveAgentsCalloutBody"
         defaultMessage="These are not displayed by default. Use status filters to show inactive or unenrolled agents. {clickToShow}"
         values={{
           clickToShow: (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -193,7 +193,9 @@ export const SearchAndFilterBar: React.FunctionComponent<{
 
   const inactiveAgentsNotVisible =
     totalInactiveAgents > 0 &&
-    !(selectedStatus.includes('unenrolled') || selectedStatus.includes('inactive'));
+    !selectedStatus.includes('unenrolled') &&
+    !selectedStatus.includes('inactive');
+
   return (
     <>
       {/* Search and filter bar */}


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/143455

Let the user know they have inactive or unenrolled agents that aren't visible with the current filters. There is a link in the callout which adds the inactive and unenrolled status filters.

https://user-images.githubusercontent.com/3315046/209006569-f8c68314-7881-455e-ad06-f79d350e6256.mov

