### PR TITLE
[Fleet] update get package info API to support package level permissions

### DIFF
--- a/x-pack/plugins/fleet/common/authz.test.ts
+++ b/x-pack/plugins/fleet/common/authz.test.ts
@@ -15,11 +15,8 @@ import { ENDPOINT_PRIVILEGES } from './constants';
 
 const SECURITY_SOLUTION_ID = DEFAULT_APP_CATEGORIES.security.id;
 
-function generateActions(
-  privileges: typeof ENDPOINT_PRIVILEGES,
-  overrides: Record<string, boolean> = {}
-) {
-  return privileges.reduce((acc, privilege) => {
+function generateActions<T>(privileges: T, overrides: Record<string, boolean> = {}) {
+  return Object.keys(privileges).reduce((acc, privilege) => {
     const executePackageAction = overrides[privilege] || false;
 
     return {

--- a/x-pack/plugins/fleet/common/constants/authz.ts
+++ b/x-pack/plugins/fleet/common/constants/authz.ts
@@ -5,22 +5,137 @@
  * 2.0.
  */
 
-export const ENDPOINT_PRIVILEGES = [
-  'writeEndpointList',
-  'readEndpointList',
-  'writeTrustedApplications',
-  'readTrustedApplications',
-  'writeHostIsolationExceptions',
-  'readHostIsolationExceptions',
-  'writeBlocklist',
-  'readBlocklist',
-  'writeEventFilters',
-  'readEventFilters',
-  'writePolicyManagement',
-  'readPolicyManagement',
-  'writeActionsLogManagement',
-  'readActionsLogManagement',
-  'writeHostIsolation',
-  'writeProcessOperations',
-  'writeFileOperations',
-] as const;
+import { deepFreeze } from '@kbn/std';
+import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
+
+const SECURITY_SOLUTION_APP_ID = 'siem';
+
+interface PrivilegeMapObject {
+  appId: string;
+  privilegeSplit: string;
+  privilegeType: 'ui' | 'api';
+  privilegeName: string;
+}
+
+/**
+ * defines endpoint package privileges
+ * the key is the name of the packagePrivilege (ie. 'readSecuritySolution')
+ * the value object is for mapping kibana privileges and capabilities
+ * see x-pack/plugins/fleet/server/services/security/security.ts for example of how object values are used
+ */
+export const ENDPOINT_PRIVILEGES: Record<string, PrivilegeMapObject> = deepFreeze({
+  readSecuritySolution: {
+    appId: SECURITY_SOLUTION_APP_ID,
+    privilegeSplit: '/',
+    privilegeType: 'ui',
+    privilegeName: 'show',
+  },
+  writeSecuritySolution: {
+    appId: SECURITY_SOLUTION_APP_ID,
+    privilegeSplit: '/',
+    privilegeType: 'ui',
+    privilegeName: 'crud',
+  },
+  writeEndpointList: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeEndpointList',
+  },
+  readEndpointList: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readEndpointList',
+  },
+  writeTrustedApplications: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeTrustedApplications',
+  },
+  readTrustedApplications: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readTrustedApplications',
+  },
+  writeHostIsolationExceptions: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeHostIsolationExceptions',
+  },
+  readHostIsolationExceptions: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readHostIsolationExceptions',
+  },
+  writeBlocklist: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeBlocklist',
+  },
+  readBlocklist: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readBlocklist',
+  },
+  writeEventFilters: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeEventFilters',
+  },
+  readEventFilters: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readEventFilters',
+  },
+  writePolicyManagement: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writePolicyManagement',
+  },
+  readPolicyManagement: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readPolicyManagement',
+  },
+  writeActionsLogManagement: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeActionsLogManagement',
+  },
+  readActionsLogManagement: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'readActionsLogManagement',
+  },
+  writeHostIsolation: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeHostIsolation',
+  },
+  writeProcessOperations: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeProcessOperations',
+  },
+  writeFileOperations: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeFileOperations',
+  },
+});

--- a/x-pack/plugins/fleet/common/index.ts
+++ b/x-pack/plugins/fleet/common/index.ts
@@ -147,6 +147,7 @@ export type {
   KibanaAssetReference,
   KibanaSavedObjectType,
   EsAssetReference,
+  AssetsGroupedByServiceByType,
   KibanaAssetTypeToParts,
   KibanaAssetParts,
   KibanaAssetType,

--- a/x-pack/plugins/fleet/common/mocks.ts
+++ b/x-pack/plugins/fleet/common/mocks.ts
@@ -62,7 +62,7 @@ export const deletePackagePolicyMock = (): DeletePackagePoliciesResponse => {
  * Creates mock `authz` object
  */
 export const createFleetAuthzMock = (): FleetAuthz => {
-  const endpointActions = ENDPOINT_PRIVILEGES.reduce((acc, privilege) => {
+  const endpointActions = Object.keys(ENDPOINT_PRIVILEGES).reduce((acc, privilege) => {
     return {
       ...acc,
       [privilege]: {

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -7,7 +7,13 @@
 
 import type { IKibanaResponse } from '@kbn/core/server';
 
-import type { FleetAuthzRouter } from '../../services/security';
+import type { FleetAuthz } from '../../../common';
+
+import {
+  calculateRouteAuthz,
+  type FleetAuthzRouter,
+  getRouteRequiredAuthz,
+} from '../../services/security';
 
 import type {
   DeletePackageResponse,
@@ -111,9 +117,9 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     {
       path: EPM_API_ROUTES.INFO_PATTERN,
       validate: GetInfoRequestSchema,
-      fleetAuthz: {
-        integrations: { readPackageInfo: true },
-      },
+      fleetAuthz: (fleetAuthz: FleetAuthz): boolean =>
+        calculateRouteAuthz(fleetAuthz, getRouteRequiredAuthz('get', EPM_API_ROUTES.INFO_PATTERN))
+          .granted,
     },
     getInfoHandler
   );
@@ -186,9 +192,11 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     {
       path: EPM_API_ROUTES.INFO_PATTERN_DEPRECATED,
       validate: GetInfoRequestSchemaDeprecated,
-      fleetAuthz: {
-        integrations: { readPackageInfo: true },
-      },
+      fleetAuthz: (fleetAuthz: FleetAuthz): boolean =>
+        calculateRouteAuthz(
+          fleetAuthz,
+          getRouteRequiredAuthz('get', EPM_API_ROUTES.INFO_PATTERN_DEPRECATED)
+        ).granted,
     },
     async (context, request, response) => {
       const newRequest = { ...request, params: splitPkgKey(request.params.pkgkey) } as any;

--- a/x-pack/plugins/fleet/server/services/check_allowed_packages.test.ts
+++ b/x-pack/plugins/fleet/server/services/check_allowed_packages.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FleetUnauthorizedError } from '../errors';
+
+import { checkAllowedPackages } from './check_allowed_packages';
+
+describe('#checkAllowedPackages', () => {
+  it('does not throw if no packages', () => {
+    expect(() => checkAllowedPackages([], [])).not.toThrowError(FleetUnauthorizedError);
+  });
+
+  it('does not throw if allowedPackages is undefined', () => {
+    expect(() => checkAllowedPackages([])).not.toThrowError(FleetUnauthorizedError);
+  });
+
+  it('throws if allowedPackages is empty array', () => {
+    expect(() => checkAllowedPackages([{ name: 'packageA' }], [], 'name')).toThrowError(
+      new FleetUnauthorizedError(
+        'Authorization denied due to lack of integration package privileges'
+      )
+    );
+  });
+
+  it('does not throw if all packages allowed', () => {
+    const packages = ['packageA', 'packageB', 'packageC'];
+    const allowedPackages = ['packageA', 'packageB', 'packageC'];
+    expect(() => checkAllowedPackages(packages, allowedPackages)).not.toThrowError(
+      FleetUnauthorizedError
+    );
+  });
+
+  it('throws if contains unresolved package', () => {
+    const packages = [{ name: 'packageA' }, { name: 'packageB' }, { name: undefined }];
+    const allowedPackages = ['packageA', 'packageB', 'packageC'];
+    expect(() => checkAllowedPackages(packages, allowedPackages, 'name')).toThrowError(
+      new FleetUnauthorizedError(
+        'Authorization denied. Allowed package(s): packageA, packageB, packageC.'
+      )
+    );
+  });
+
+  it('throws if contains restricted packages', () => {
+    const packages = [{ name: 'packageA' }, { name: 'packageB' }, { name: 'packageC' }];
+    const allowedPackages = ['packageA', 'packageB'];
+    expect(() => checkAllowedPackages(packages, allowedPackages, 'name')).toThrowError(
+      new FleetUnauthorizedError(
+        'Authorization denied to package: packageC. Allowed package(s): packageA, packageB'
+      )
+    );
+  });
+});

--- a/x-pack/plugins/fleet/server/services/check_allowed_packages.ts
+++ b/x-pack/plugins/fleet/server/services/check_allowed_packages.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { get } from 'lodash';
+
+import { FleetUnauthorizedError } from '../errors';
+
+export function checkAllowedPackages<T>(
+  packages: T[],
+  allowedPackages?: string[],
+  keyPath: string = ''
+) {
+  // allowedPackages is undefined when user has privileges from fleet
+  if (!packages.length || !allowedPackages) {
+    return;
+  }
+
+  if (!allowedPackages.length) {
+    throw new FleetUnauthorizedError(
+      'Authorization denied due to lack of integration package privileges'
+    );
+  }
+
+  const allowedPackagedSet = new Set(allowedPackages);
+  const allowedPackagesStr = allowedPackages.join(', ');
+
+  packages.some((pkg) => {
+    const pkgName = typeof pkg === 'string' ? pkg : get(pkg, keyPath, undefined);
+    if (!pkgName) {
+      throw new FleetUnauthorizedError(
+        `Authorization denied. Allowed package(s): ${allowedPackagesStr}.`
+      );
+    }
+
+    const isRestricted = !allowedPackagedSet.has(pkgName);
+    if (isRestricted) {
+      throw new FleetUnauthorizedError(
+        `Authorization denied to package: ${pkgName}. Allowed package(s): ${allowedPackagesStr}`
+      );
+    }
+
+    return false;
+  });
+}

--- a/x-pack/plugins/fleet/server/services/index.ts
+++ b/x-pack/plugins/fleet/server/services/index.ts
@@ -64,3 +64,5 @@ export type { PackageService, PackageClient } from './epm';
 export { migrateSettingsToFleetServerHost } from './fleet_server_host';
 
 export { FleetUsageSender } from './telemetry/fleet_usage_sender';
+
+export { checkAllowedPackages } from './check_allowed_packages';

--- a/x-pack/plugins/fleet/server/services/security/fleet_router.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/fleet_router.test.ts
@@ -71,6 +71,8 @@ describe('FleetAuthzRouter', () => {
     const mockContext = createAppContextStartContractMock();
     // @ts-expect-error type doesn't properly respect deeply mocked keys
     mockContext.securityStart.authz.actions.api.get.mockImplementation((priv) => `api:${priv}`);
+    // @ts-expect-error type doesn't properly respect deeply mocked keys
+    mockContext.securityStart.authz.actions.ui.get.mockImplementation((priv) => `ui:${priv}`);
 
     mockContext.securityStart.authc.getCurrentUser.mockReturnValue({
       username: 'foo',

--- a/x-pack/plugins/fleet/server/services/security/route_required_authz.ts
+++ b/x-pack/plugins/fleet/server/services/security/route_required_authz.ts
@@ -11,6 +11,8 @@ import type { RouteMethod } from '@kbn/core-http-server';
 
 import { PACKAGE_POLICY_API_ROUTES, AGENT_API_ROUTES } from '../../../common';
 
+import { EPM_API_ROUTES } from '../../constants';
+
 import type { FleetRouteRequiredAuthz } from './types';
 
 /**
@@ -137,6 +139,40 @@ const ROUTE_AUTHZ_REQUIREMENTS = deepFreeze<Record<string, FleetRouteRequiredAut
         endpoint: {
           actions: {
             readPolicyManagement: {
+              executePackageAction: true,
+            },
+          },
+        },
+      },
+    },
+  },
+
+  // EPM Package Info API
+  [`get:${EPM_API_ROUTES.INFO_PATTERN}`]: {
+    any: {
+      integrations: {
+        readPackageInfo: true,
+      },
+      packagePrivileges: {
+        endpoint: {
+          actions: {
+            readSecuritySolution: {
+              executePackageAction: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  [`get:${EPM_API_ROUTES.INFO_PATTERN_DEPRECATED}`]: {
+    any: {
+      integrations: {
+        readPackageInfo: true,
+      },
+      packagePrivileges: {
+        endpoint: {
+          actions: {
+            readSecuritySolution: {
               executePackageAction: true,
             },
           },

--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_endpoint_hosts.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_endpoint_hosts.ts
@@ -11,11 +11,7 @@ import type { AxiosResponse } from 'axios';
 import uuid from 'uuid';
 import type { KbnClient } from '@kbn/test';
 import type { DeleteByQueryResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import type {
-  Agent,
-  CreatePackagePolicyResponse,
-  GetPackagesResponse,
-} from '@kbn/fleet-plugin/common';
+import type { Agent, CreatePackagePolicyResponse, GetInfoResponse } from '@kbn/fleet-plugin/common';
 import { EndpointDocGenerator } from '../generate_data';
 import type { HostMetadata, HostPolicyResponse } from '../types';
 import type {
@@ -95,7 +91,7 @@ export async function indexEndpointHostDocs({
   client: Client;
   kbnClient: KbnClient;
   realPolicies: Record<string, CreatePackagePolicyResponse['item']>;
-  epmEndpointPackage: GetPackagesResponse['items'][0];
+  epmEndpointPackage: GetInfoResponse['item'];
   metadataIndex: string;
   policyResponseIndex: string;
   enrollFleet: boolean;

--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -10,8 +10,10 @@ import { assertNever } from '@kbn/std';
 import type {
   GetAgentPoliciesResponseItem,
   GetPackagesResponse,
+  GetInfoResponse,
   EsAssetReference,
   KibanaAssetReference,
+  AssetsGroupedByServiceByType,
 } from '@kbn/fleet-plugin/common';
 import { agentPolicyStatuses } from '@kbn/fleet-plugin/common';
 import { EndpointMetadataGenerator } from './data_generators/endpoint_metadata_generator';
@@ -1589,6 +1591,90 @@ export class EndpointDocGenerator extends BaseDataGenerator {
       type: 'integration',
       download: '/epr/endpoint/endpoint-0.5.0.tar.gz',
       path: '/package/endpoint/0.5.0',
+      icons: [
+        {
+          path: '/package/endpoint/0.5.0/img/logo-endpoint-64-color.svg',
+          src: '/img/logo-endpoint-64-color.svg',
+          size: '16x16',
+          type: 'image/svg+xml',
+        },
+      ],
+      status: 'installed',
+      release: 'ga',
+      savedObject: {
+        type: 'epm-packages',
+        id: 'endpoint',
+        attributes: {
+          installed_kibana: [
+            { id: '826759f0-7074-11ea-9bc8-6b38f4d29a16', type: 'dashboard' },
+            { id: '1cfceda0-728b-11ea-9bc8-6b38f4d29a16', type: 'visualization' },
+            { id: '1e525190-7074-11ea-9bc8-6b38f4d29a16', type: 'visualization' },
+            { id: '55387750-729c-11ea-9bc8-6b38f4d29a16', type: 'visualization' },
+            { id: '92b1edc0-706a-11ea-9bc8-6b38f4d29a16', type: 'visualization' },
+            { id: 'a3a3bd10-706b-11ea-9bc8-6b38f4d29a16', type: 'map' },
+          ] as KibanaAssetReference[],
+          installed_es: [
+            { id: 'logs-endpoint.alerts', type: 'index_template' },
+            { id: 'events-endpoint', type: 'index_template' },
+            { id: 'logs-endpoint.events.file', type: 'index_template' },
+            { id: 'logs-endpoint.events.library', type: 'index_template' },
+            { id: 'metrics-endpoint.metadata', type: 'index_template' },
+            { id: 'metrics-endpoint.metadata_mirror', type: 'index_template' },
+            { id: 'logs-endpoint.events.network', type: 'index_template' },
+            { id: 'metrics-endpoint.policy', type: 'index_template' },
+            { id: 'logs-endpoint.events.process', type: 'index_template' },
+            { id: 'logs-endpoint.events.registry', type: 'index_template' },
+            { id: 'logs-endpoint.events.security', type: 'index_template' },
+            { id: 'metrics-endpoint.telemetry', type: 'index_template' },
+          ] as EsAssetReference[],
+          package_assets: [],
+          es_index_patterns: {
+            alerts: 'logs-endpoint.alerts-*',
+            events: 'events-endpoint-*',
+            file: 'logs-endpoint.events.file-*',
+            library: 'logs-endpoint.events.library-*',
+            metadata: 'metrics-endpoint.metadata-*',
+            metadata_mirror: 'metrics-endpoint.metadata_mirror-*',
+            network: 'logs-endpoint.events.network-*',
+            policy: 'metrics-endpoint.policy-*',
+            process: 'logs-endpoint.events.process-*',
+            registry: 'logs-endpoint.events.registry-*',
+            security: 'logs-endpoint.events.security-*',
+            telemetry: 'metrics-endpoint.telemetry-*',
+          },
+          name: 'endpoint',
+          version: '0.5.0',
+          internal: false,
+          install_version: '0.5.0',
+          install_status: 'installed',
+          install_started_at: '2020-06-24T14:41:23.098Z',
+          install_source: 'registry',
+          keep_policies_up_to_date: false,
+          verification_status: 'unknown',
+        },
+        references: [],
+        updated_at: '2020-06-24T14:41:23.098Z',
+        version: 'Wzc0LDFd',
+      },
+    };
+  }
+
+  /**
+   * Generate a Fleet EPM Package for Endpoint
+   */
+  public generateEpmPackageInfo(): GetInfoResponse['item'] {
+    return {
+      name: 'endpoint',
+      title: 'Elastic Endpoint',
+      version: '0.5.0',
+      description: 'This is the Elastic Endpoint package.',
+      type: 'integration',
+      download: '/epr/endpoint/endpoint-0.5.0.tar.gz',
+      path: '/package/endpoint/0.5.0',
+      format_version: '',
+      owner: { github: '' },
+      latestVersion: '',
+      assets: {} as AssetsGroupedByServiceByType,
       icons: [
         {
           path: '/package/endpoint/0.5.0/img/logo-endpoint-64-color.svg',

--- a/x-pack/plugins/security_solution/common/endpoint/index_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/index_data.ts
@@ -9,8 +9,8 @@ import type { Client } from '@elastic/elasticsearch';
 import seedrandom from 'seedrandom';
 import type { KbnClient } from '@kbn/test';
 import type { AxiosResponse } from 'axios';
-import type { CreatePackagePolicyResponse, GetPackagesResponse } from '@kbn/fleet-plugin/common';
-import { EPM_API_ROUTES } from '@kbn/fleet-plugin/common';
+import type { CreatePackagePolicyResponse, GetInfoResponse } from '@kbn/fleet-plugin/common';
+import { epmRouteService } from '@kbn/fleet-plugin/common';
 import type { TreeOptions } from './generate_data';
 import { EndpointDocGenerator } from './generate_data';
 import type {
@@ -121,15 +121,16 @@ export async function indexHostsAndAlerts(
   return response;
 }
 
-const getEndpointPackageInfo = async (
+export const getEndpointPackageInfo = async (
   kbnClient: KbnClient
-): Promise<GetPackagesResponse['items'][0]> => {
+): Promise<GetInfoResponse['item']> => {
+  const path = epmRouteService.getInfoPath('endpoint');
   const endpointPackage = (
     (await kbnClient.request({
-      path: `${EPM_API_ROUTES.LIST_PATTERN}?category=security`,
+      path,
       method: 'GET',
-    })) as AxiosResponse<GetPackagesResponse>
-  ).data.items.find((epmPackage) => epmPackage.name === 'endpoint');
+    })) as AxiosResponse<GetInfoResponse>
+  ).data.item;
 
   if (!endpointPackage) {
     throw new Error('EPM Endpoint package was not found!');

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
@@ -5,13 +5,7 @@
  * 2.0.
  */
 
-import {
-  calculateEndpointAuthz,
-  calculatePermissionsFromCapabilities,
-  calculatePermissionsFromPrivileges,
-  defaultEndpointPermissions,
-  getEndpointAuthzInitialState,
-} from './authz';
+import { calculateEndpointAuthz, getEndpointAuthzInitialState } from './authz';
 import type { FleetAuthz } from '@kbn/fleet-plugin/common';
 import { createFleetAuthzMock } from '@kbn/fleet-plugin/common';
 import { createLicenseServiceMock } from '../../../license/mocks';
@@ -87,9 +81,7 @@ describe('Endpoint Authz service', () => {
       it(`should allow Host Isolation Exception read/delete when license is not Platinum+, but entries exist`, () => {
         licenseService.isPlatinumPlus.mockReturnValue(false);
 
-        expect(
-          calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, false, undefined, true)
-        ).toEqual(
+        expect(calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, false, true)).toEqual(
           expect.objectContaining({
             canWriteHostIsolationExceptions: false,
             canReadHostIsolationExceptions: true,
@@ -197,24 +189,6 @@ describe('Endpoint Authz service', () => {
         expect(authz[auth]).toBe(false);
       });
     });
-
-    it('correctly handles permissions', () => {
-      const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles, true, {
-        canWriteSecuritySolution: false,
-        canReadSecuritySolution: true,
-      });
-      expect(authz.canWriteSecuritySolution).toBe(false);
-      expect(authz.canReadSecuritySolution).toBe(true);
-    });
-  });
-
-  describe('defaultEndpointPermissions', () => {
-    it('returns expected permissions', () => {
-      expect(defaultEndpointPermissions()).toEqual({
-        canWriteSecuritySolution: false,
-        canReadSecuritySolution: false,
-      });
-    });
   });
 
   describe('getEndpointAuthzInitialState()', () => {
@@ -248,51 +222,6 @@ describe('Endpoint Authz service', () => {
         canReadBlocklist: false,
         canWriteEventFilters: false,
         canReadEventFilters: false,
-      });
-    });
-  });
-
-  describe('calculatePermissionsFromPrivileges', () => {
-    it('returns default permissions if no privileges', () => {
-      const permissions = calculatePermissionsFromPrivileges(undefined);
-      expect(permissions).toEqual(defaultEndpointPermissions());
-    });
-
-    it('returns expected permissions from privileges', () => {
-      const privileges = [
-        { privilege: 'ui:8.6.0:siem/crud', authorized: false },
-        { privilege: 'ui:8.6.0:siem/show', authorized: true },
-        { privilege: 'ui:8.6.0:siem/foobar', authorized: true },
-      ];
-      const permissions = calculatePermissionsFromPrivileges(privileges);
-      expect(permissions).toEqual({
-        canWriteSecuritySolution: false,
-        canReadSecuritySolution: true,
-      });
-    });
-  });
-
-  describe('calculatePermissionsFromCapabilities', () => {
-    it('returns default permissions if no capabilities', () => {
-      const permissions = calculatePermissionsFromCapabilities(undefined);
-      expect(permissions).toEqual(defaultEndpointPermissions());
-    });
-
-    it('returns expected permissions from capabilities', () => {
-      const capabilities = {
-        navLinks: {},
-        management: {},
-        catalogue: {},
-        siem: {
-          crud: false,
-          show: true,
-          foobar: true,
-        },
-      };
-      const permissions = calculatePermissionsFromCapabilities(capabilities);
-      expect(permissions).toEqual({
-        canWriteSecuritySolution: false,
-        canReadSecuritySolution: true,
       });
     });
   });

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts
@@ -6,18 +6,10 @@
  */
 
 import type { ENDPOINT_PRIVILEGES, FleetAuthz } from '@kbn/fleet-plugin/common';
-import type { Capabilities } from '@kbn/core-capabilities-common';
 
 import type { LicenseService } from '../../../license';
-import type { EndpointPermissions, EndpointAuthz } from '../../types/authz';
+import type { EndpointAuthz } from '../../types/authz';
 import type { MaybeImmutable } from '../../types';
-
-export function defaultEndpointPermissions(): EndpointPermissions {
-  return {
-    canWriteSecuritySolution: false,
-    canReadSecuritySolution: false,
-  };
-}
 
 /**
  * Checks to see if a given Kibana privilege was granted.
@@ -35,7 +27,7 @@ export function hasKibanaPrivilege(
   fleetAuthz: FleetAuthz,
   isEndpointRbacEnabled: boolean,
   isSuperuser: boolean,
-  privilege: typeof ENDPOINT_PRIVILEGES[number]
+  privilege: keyof typeof ENDPOINT_PRIVILEGES
 ): boolean {
   // user is superuser, always return true
   if (isSuperuser) {
@@ -70,13 +62,21 @@ export const calculateEndpointAuthz = (
   fleetAuthz: FleetAuthz,
   userRoles: MaybeImmutable<string[]>,
   isEndpointRbacEnabled: boolean = false,
-  permissions: Partial<EndpointPermissions> = defaultEndpointPermissions(),
   hasHostIsolationExceptionsItems: boolean = false
 ): EndpointAuthz => {
   const isPlatinumPlusLicense = licenseService.isPlatinumPlus();
   const isEnterpriseLicense = licenseService.isEnterprise();
   const hasEndpointManagementAccess = userRoles.includes('superuser');
-  const { canWriteSecuritySolution = false, canReadSecuritySolution = false } = permissions;
+
+  const canWriteSecuritySolution = hasKibanaPrivilege(
+    fleetAuthz,
+    true,
+    hasEndpointManagementAccess,
+    'writeSecuritySolution'
+  );
+  const canReadSecuritySolution =
+    canWriteSecuritySolution ||
+    hasKibanaPrivilege(fleetAuthz, true, hasEndpointManagementAccess, 'readSecuritySolution');
   const canWriteEndpointList = hasKibanaPrivilege(
     fleetAuthz,
     isEndpointRbacEnabled,
@@ -251,7 +251,8 @@ export const calculateEndpointAuthz = (
 
 export const getEndpointAuthzInitialState = (): EndpointAuthz => {
   return {
-    ...defaultEndpointPermissions(),
+    canWriteSecuritySolution: false,
+    canReadSecuritySolution: false,
     canAccessFleet: false,
     canAccessEndpointActionsLogManagement: false,
     canAccessEndpointManagement: false,
@@ -280,66 +281,3 @@ export const getEndpointAuthzInitialState = (): EndpointAuthz => {
     canReadEventFilters: false,
   };
 };
-
-const SIEM_PERMISSIONS = [
-  { permission: 'canWriteSecuritySolution', privilege: 'crud' },
-  { permission: 'canReadSecuritySolution', privilege: 'show' },
-] as const;
-
-function hasPrivilege(
-  kibanaPrivileges: Array<{
-    resource?: string;
-    privilege: string;
-    authorized: boolean;
-  }>,
-  prefix: string,
-  searchPrivilege: string
-): boolean {
-  const privilege = kibanaPrivileges.find((p) =>
-    p.privilege.endsWith(`${prefix}${searchPrivilege}`)
-  );
-  return privilege?.authorized || false;
-}
-
-export function calculatePermissionsFromPrivileges(
-  kibanaPrivileges:
-    | Array<{
-        resource?: string;
-        privilege: string;
-        authorized: boolean;
-      }>
-    | undefined
-): EndpointPermissions {
-  if (!kibanaPrivileges || !kibanaPrivileges.length) {
-    return defaultEndpointPermissions();
-  }
-
-  const siemPermissions: EndpointPermissions = SIEM_PERMISSIONS.reduce(
-    (acc, { permission, privilege }) => {
-      return {
-        ...acc,
-        [permission]: hasPrivilege(kibanaPrivileges, 'siem/', privilege),
-      };
-    },
-    {} as EndpointPermissions
-  );
-
-  return {
-    ...siemPermissions,
-  };
-}
-
-export function calculatePermissionsFromCapabilities(
-  capabilities: Capabilities | undefined
-): EndpointPermissions {
-  if (!capabilities || !capabilities.siem) {
-    return defaultEndpointPermissions();
-  }
-
-  return SIEM_PERMISSIONS.reduce((acc, { permission, privilege }) => {
-    return {
-      ...acc,
-      [permission]: capabilities.siem[privilege] || false,
-    };
-  }, {} as EndpointPermissions);
-}

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/index.ts
@@ -5,10 +5,4 @@
  * 2.0.
  */
 
-export {
-  getEndpointAuthzInitialState,
-  calculateEndpointAuthz,
-  calculatePermissionsFromPrivileges,
-  calculatePermissionsFromCapabilities,
-  defaultEndpointPermissions,
-} from './authz';
+export { getEndpointAuthzInitialState, calculateEndpointAuthz } from './authz';

--- a/x-pack/plugins/security_solution/common/endpoint/types/authz.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/authz.ts
@@ -6,20 +6,14 @@
  */
 
 /**
- * Endpoint permissions derived from Kibana capabilities and privileges
+ * Set of Endpoint Specific privileges that control application authorization. This interface is
+ * used both on the client and server for consistency
  */
-export interface EndpointPermissions {
+export interface EndpointAuthz {
   /** if user has write permissions to the security solution app */
   canWriteSecuritySolution: boolean;
   /** if user has read permissions to the security solution app */
   canReadSecuritySolution: boolean;
-}
-
-/**
- * Set of Endpoint Specific privileges that control application authorization. This interface is
- * used both on the client and server for consistency
- */
-export interface EndpointAuthz extends EndpointPermissions {
   /** If user has permissions to access Fleet */
   canAccessFleet: boolean;
   /** If user has permissions to access Endpoint management (includes check to ensure they also have access to fleet) */

--- a/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
+++ b/x-pack/plugins/security_solution/public/common/components/user_privileges/endpoint/use_endpoint_privileges.ts
@@ -19,7 +19,6 @@ import type {
 import {
   calculateEndpointAuthz,
   getEndpointAuthzInitialState,
-  calculatePermissionsFromCapabilities,
 } from '../../../../../common/endpoint/service/authz';
 import { useSecuritySolutionStartDependencies } from './security_solution_start_dependencies';
 import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
@@ -57,11 +56,6 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
   const [hasHostIsolationExceptionsItems, setHasHostIsolationExceptionsItems] =
     useState<boolean>(false);
 
-  const securitySolutionPermissions = useMemo(
-    () => calculatePermissionsFromCapabilities(kibanaServices.application.capabilities),
-    [kibanaServices.application.capabilities]
-  );
-
   const privileges = useMemo(() => {
     const loading = !userRolesCheckDone || !user || !checkHostIsolationExceptionsDone;
 
@@ -73,7 +67,6 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
             fleetAuthz,
             userRoles,
             isEndpointRbacEnabled || isEndpointRbacV1Enabled,
-            securitySolutionPermissions,
             hasHostIsolationExceptionsItems
           )
         : getEndpointAuthzInitialState()),
@@ -89,7 +82,6 @@ export const useEndpointPrivileges = (): Immutable<EndpointPrivileges> => {
     userRoles,
     isEndpointRbacEnabled,
     isEndpointRbacV1Enabled,
-    securitySolutionPermissions,
     hasHostIsolationExceptionsItems,
   ]);
 

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
@@ -40,7 +40,7 @@ import type { ExperimentalFeatures } from '../../../../common/experimental_featu
 import { APP_UI_ID, APP_PATH } from '../../../../common/constants';
 import { KibanaContextProvider, KibanaServices } from '../../lib/kibana';
 import { getDeepLinks } from '../../../app/deep_links';
-import { fleetGetPackageListHttpMock } from '../../../management/mocks';
+import { fleetGetPackageHttpMock } from '../../../management/mocks';
 
 const REAL_REACT_DOM_CREATE_PORTAL = ReactDOM.createPortal;
 
@@ -373,5 +373,5 @@ const applyDefaultCoreHttpMocks = (http: AppContextTestRender['coreStart']['http
   // Need to mock getting the endpoint package from the fleet API because it is used as soon
   // as the store middleware for Endpoint list is initialized, thus mocking it here would avoid
   // unnecessary errors being output to the console
-  fleetGetPackageListHttpMock(http, { ignoreUnMockedApiRouteErrors: true });
+  fleetGetPackageHttpMock(http, { ignoreUnMockedApiRouteErrors: true });
 };

--- a/x-pack/plugins/security_solution/public/management/links.test.ts
+++ b/x-pack/plugins/security_solution/public/management/links.test.ts
@@ -154,7 +154,6 @@ describe('links', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
-        expect.anything(),
         false
       );
       expect(filteredLinks).toEqual(getLinksWithout(SecurityPageName.hostIsolationExceptions));
@@ -192,7 +191,6 @@ describe('links', () => {
         }),
       });
       expect(calculateEndpointAuthz as jest.Mock).toHaveBeenLastCalledWith(
-        expect.anything(),
         expect.anything(),
         expect.anything(),
         expect.anything(),

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -13,7 +13,6 @@ import { checkArtifactHasData } from './services/exceptions_list/check_artifact_
 import {
   calculateEndpointAuthz,
   getEndpointAuthzInitialState,
-  calculatePermissionsFromCapabilities,
 } from '../../common/endpoint/service/authz';
 import {
   BLOCKLIST_PATH,
@@ -243,7 +242,6 @@ export const getManagementFilteredLinks = async (
 
   const { endpointRbacEnabled, endpointRbacV1Enabled } = ExperimentalFeaturesService.get();
   const isEndpointRbacEnabled = endpointRbacEnabled || endpointRbacV1Enabled;
-  const endpointPermissions = calculatePermissionsFromCapabilities(core.application.capabilities);
 
   const linksToExclude: SecurityPageName[] = [];
 
@@ -287,7 +285,6 @@ export const getManagementFilteredLinks = async (
         fleetAuthz,
         currentUser.roles,
         isEndpointRbacEnabled,
-        endpointPermissions,
         hasHostIsolationExceptions
       )
     : getEndpointAuthzInitialState();

--- a/x-pack/plugins/security_solution/public/management/mocks/fleet_mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/mocks/fleet_mocks.ts
@@ -12,6 +12,7 @@ import type {
   GetAgentStatusResponse,
   GetPackagePoliciesResponse,
   GetPackagesResponse,
+  GetInfoResponse,
   BulkGetPackagePoliciesResponse,
   BulkGetAgentPoliciesResponse,
 } from '@kbn/fleet-plugin/common';
@@ -138,6 +139,24 @@ export const fleetGetPackageListHttpMock =
       },
     },
   ]);
+
+export type FleetGetPackageHttpMockInterface = ResponseProvidersInterface<{
+  endpointPackage: () => GetInfoResponse;
+}>;
+export const fleetGetPackageHttpMock = httpHandlerMockFactory<FleetGetPackageHttpMockInterface>([
+  {
+    id: 'endpointPackage',
+    method: 'get',
+    path: EPM_API_ROUTES.INFO_PATTERN_DEPRECATED,
+    handler() {
+      const generator = new EndpointDocGenerator('seed');
+
+      return {
+        item: generator.generateEpmPackageInfo(),
+      };
+    },
+  },
+]);
 
 export type FleetGetEndpointPackagePolicyHttpMockInterface = ResponseProvidersInterface<{
   endpointPackagePolicy: () => GetPolicyResponse;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
@@ -32,12 +32,14 @@ import type {
   FleetGetAgentStatusHttpMockInterface,
   FleetGetCheckPermissionsInterface,
   FleetGetEndpointPackagePolicyHttpMockInterface,
+  FleetGetPackageHttpMockInterface,
   FleetGetPackageListHttpMockInterface,
 } from '../../mocks';
 import {
   fleetGetAgentPolicyListHttpMock,
   fleetGetCheckPermissionsHttpMock,
   fleetGetPackageListHttpMock,
+  fleetGetPackageHttpMock,
   fleetBulkGetPackagePoliciesListHttpMock,
   fleetBulkGetAgentPolicyListHttpMock,
   fleetGetPackagePoliciesListHttpMock,
@@ -125,6 +127,7 @@ export const transformsHttpMocks = httpHandlerMockFactory<TransformHttpMocksInte
 ]);
 
 export type EndpointListFleetApisHttpMockInterface = FleetGetPackageListHttpMockInterface &
+  FleetGetPackageHttpMockInterface &
   FleetGetAgentPolicyListHttpMockInterface &
   FleetGetCheckPermissionsInterface &
   FleetGetAgentStatusHttpMockInterface &
@@ -135,6 +138,7 @@ export type EndpointListFleetApisHttpMockInterface = FleetGetPackageListHttpMock
 export const endpointListFleetApisHttpMock =
   composeHttpHandlerMocks<EndpointListFleetApisHttpMockInterface>([
     fleetGetPackageListHttpMock,
+    fleetGetPackageHttpMock,
     fleetGetAgentPolicyListHttpMock,
     fleetBulkGetPackagePoliciesListHttpMock,
     fleetBulkGetAgentPolicyListHttpMock,

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DataViewBase } from '@kbn/es-query';
-import type { GetPackagesResponse } from '@kbn/fleet-plugin/common';
+import type { GetInfoResponse } from '@kbn/fleet-plugin/common';
 import type {
   HostInfo,
   Immutable,
@@ -60,7 +60,7 @@ export interface EndpointState {
   /** the selected policy ID in the onboarding flow */
   selectedPolicyId?: string;
   /** Endpoint package info */
-  endpointPackageInfo: AsyncResourceState<GetPackagesResponse['items'][0]>;
+  endpointPackageInfo: AsyncResourceState<GetInfoResponse['item']>;
   /** Tracks the list of policies IDs used in Host metadata that may no longer exist */
   nonExistingPolicies: PolicyIds['packagePolicy'];
   /** List of Package Policy Ids mapped to an associated Fleet Parent Agent Policy Id*/

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/test_mock_utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/test_mock_utils.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { GetPackagesResponse } from '@kbn/fleet-plugin/common';
+import type { GetPackagesResponse, GetInfoResponse } from '@kbn/fleet-plugin/common';
+import { epmRouteService } from '@kbn/fleet-plugin/common';
 import {
   INGEST_API_EPM_PACKAGES,
   INGEST_API_PACKAGE_POLICIES,
@@ -61,6 +62,11 @@ export const policyListApiPathHandlers = (totalPolicies: number = 1) => {
     [INGEST_API_EPM_PACKAGES]: (): GetPackagesResponse => {
       return {
         items: [generator.generateEpmPackage()],
+      };
+    },
+    [epmRouteService.getInfoPath('endpoint')]: (): GetInfoResponse => {
+      return {
+        item: generator.generateEpmPackageInfo(),
       };
     },
   };

--- a/x-pack/plugins/security_solution/public/management/services/policies/hooks.test.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/hooks.test.ts
@@ -7,7 +7,7 @@
 
 import type { UseQueryOptions } from '@tanstack/react-query';
 import type { IHttpFetchError, HttpSetup } from '@kbn/core-http-browser';
-import type { GetPackagesResponse } from '@kbn/fleet-plugin/common';
+import type { GetInfoResponse } from '@kbn/fleet-plugin/common';
 import { useGetEndpointSecurityPackage } from './hooks';
 import { getFakeHttpService, renderQuery } from '../../hooks/test_utils';
 import { EndpointDocGenerator } from '../../../../common/endpoint/generate_data';
@@ -19,7 +19,7 @@ describe('useGetEndpointSecurityPackage hook', () => {
   let result: ReturnType<typeof useGetEndpointSecurityPackage>;
   let fakeHttpServices: jest.Mocked<HttpSetup>;
   let generator: EndpointDocGenerator;
-  let options: UseQueryOptions<GetPackagesResponse['items'][number], IHttpFetchError> | undefined;
+  let options: UseQueryOptions<GetInfoResponse['item'], IHttpFetchError> | undefined;
 
   beforeEach(() => {
     fakeHttpServices = getFakeHttpService();
@@ -33,7 +33,7 @@ describe('useGetEndpointSecurityPackage hook', () => {
 
   it('retrieves the endpoint package', async () => {
     const apiResponse = {
-      items: [generator.generateEpmPackage()],
+      item: [generator.generateEpmPackageInfo()],
     };
     fakeHttpServices.get.mockResolvedValue(apiResponse);
     const onSuccessMock: jest.Mock = jest.fn();
@@ -47,7 +47,7 @@ describe('useGetEndpointSecurityPackage hook', () => {
       () => useGetEndpointSecurityPackage({ customQueryOptions: options }),
       'isSuccess'
     );
-    expect(result.data).toBe(apiResponse.items[0]);
+    expect(result.data).toBe(apiResponse.item);
     expect(fakeHttpServices.get).toHaveBeenCalledTimes(1);
     expect(onSuccessMock).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/plugins/security_solution/public/management/services/policies/hooks.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/hooks.ts
@@ -7,7 +7,7 @@
 import type { QueryObserverResult, UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
-import type { GetPackagesResponse } from '@kbn/fleet-plugin/common';
+import type { GetInfoResponse } from '@kbn/fleet-plugin/common';
 import { useHttp } from '../../../common/lib/kibana';
 import { MANAGEMENT_DEFAULT_PAGE_SIZE } from '../../common/constants';
 import { sendGetEndpointSecurityPackage } from './ingest';
@@ -52,10 +52,10 @@ export function useGetEndpointSpecificPolicies(
 export function useGetEndpointSecurityPackage({
   customQueryOptions,
 }: {
-  customQueryOptions?: UseQueryOptions<GetPackagesResponse['items'][number], IHttpFetchError>;
-}): QueryObserverResult<GetPackagesResponse['items'][number], IHttpFetchError> {
+  customQueryOptions?: UseQueryOptions<GetInfoResponse['item'], IHttpFetchError>;
+}): QueryObserverResult<GetInfoResponse['item'], IHttpFetchError> {
   const http = useHttp();
-  return useQuery<GetPackagesResponse['items'][number], IHttpFetchError>(
+  return useQuery<GetInfoResponse['item'], IHttpFetchError>(
     ['endpointPackageVersion', customQueryOptions],
     () => {
       return sendGetEndpointSecurityPackage(http);

--- a/x-pack/plugins/security_solution/public/management/services/policies/ingest.test.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/ingest.test.ts
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-import {
-  INGEST_API_EPM_PACKAGES,
-  sendGetPackagePolicy,
-  sendGetEndpointSecurityPackage,
-} from './ingest';
+import { sendGetPackagePolicy, sendGetEndpointSecurityPackage } from './ingest';
 import { httpServiceMock } from '@kbn/core/public/mocks';
-import { EPM_API_ROUTES, PACKAGE_POLICY_API_ROOT } from '@kbn/fleet-plugin/common';
+import { PACKAGE_POLICY_API_ROOT, epmRouteService } from '@kbn/fleet-plugin/common';
 import { policyListApiPathHandlers } from '../../pages/policy/store/test_mock_utils';
 
 describe('ingest service', () => {
@@ -37,14 +33,11 @@ describe('ingest service', () => {
   });
 
   describe('sendGetEndpointSecurityPackage()', () => {
-    it('should query EPM with category=security', async () => {
-      http.get.mockReturnValue(
-        Promise.resolve(policyListApiPathHandlers()[INGEST_API_EPM_PACKAGES]())
-      );
+    it('should query for endpoint package', async () => {
+      const path = epmRouteService.getInfoPath('endpoint');
+      http.get.mockReturnValue(Promise.resolve(policyListApiPathHandlers()[path]()));
       await sendGetEndpointSecurityPackage(http);
-      expect(http.get).toHaveBeenCalledWith(`${EPM_API_ROUTES.LIST_PATTERN}`, {
-        query: { category: 'security' },
-      });
+      expect(http.get).toHaveBeenCalledWith(path);
     });
 
     it('should throw if package is not found', async () => {

--- a/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
@@ -8,11 +8,13 @@
 import type { HttpFetchOptions, HttpStart } from '@kbn/core/public';
 import type {
   GetAgentStatusResponse,
-  GetPackagesResponse,
   GetAgentPoliciesRequest,
   GetAgentPoliciesResponse,
   GetPackagePoliciesResponse,
+  GetInfoResponse,
 } from '@kbn/fleet-plugin/common';
+import { epmRouteService } from '@kbn/fleet-plugin/common';
+
 import type { NewPolicyData } from '../../../../common/endpoint/types';
 import type { GetPolicyResponse, UpdatePolicyResponse } from '../../pages/policy/types';
 
@@ -135,12 +137,10 @@ export const sendGetFleetAgentStatusForPolicy = (
  */
 export const sendGetEndpointSecurityPackage = async (
   http: HttpStart
-): Promise<GetPackagesResponse['items'][0]> => {
-  const options = { query: { category: 'security' } };
-  const securityPackages = await http.get<GetPackagesResponse>(INGEST_API_EPM_PACKAGES, options);
-  const endpointPackageInfo = securityPackages.items.find(
-    (epmPackage) => epmPackage.name === 'endpoint'
-  );
+): Promise<GetInfoResponse['item']> => {
+  const path = epmRouteService.getInfoPath('endpoint');
+  const endpointPackageResponse = await http.get<GetInfoResponse>(path);
+  const endpointPackageInfo = endpointPackageResponse.item;
   if (!endpointPackageInfo) {
     throw new Error('Endpoint package was not found.');
   }

--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_loader.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_loader.ts
@@ -20,9 +20,9 @@ import { fetchEndpointMetadataList } from '../../common/endpoint_metadata_servic
 import { indexEndpointHostDocs } from '../../../../common/endpoint/data_loaders/index_endpoint_hosts';
 import { setupFleetForEndpoint } from '../../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
 import { enableFleetServerIfNecessary } from '../../../../common/endpoint/data_loaders/index_fleet_server';
-import { fetchEndpointPackageInfo } from '../../common/fleet_services';
 import { METADATA_DATASTREAM } from '../../../../common/endpoint/constants';
 import { EndpointMetadataGenerator } from '../../../../common/endpoint/data_generators/endpoint_metadata_generator';
+import { getEndpointPackageInfo } from '../../../../common/endpoint/index_data';
 import { ENDPOINT_ALERTS_INDEX, ENDPOINT_EVENTS_INDEX } from '../../common/constants';
 
 let WAS_FLEET_SETUP_DONE = false;
@@ -105,7 +105,7 @@ export const loadEndpoints = async ({
     WAS_FLEET_SETUP_DONE = true;
   }
 
-  const endpointPackage = await fetchEndpointPackageInfo(kbnClient);
+  const endpointPackage = await getEndpointPackageInfo(kbnClient);
   const realPolicies: Record<string, CreatePackagePolicyResponse['item']> = {};
 
   let progress: LoadEndpointsProgress = {

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -6,12 +6,10 @@
  */
 
 import type { Client, estypes } from '@elastic/elasticsearch';
-import { AGENTS_INDEX, EPM_API_ROUTES } from '@kbn/fleet-plugin/common';
-import type { AgentStatus, GetPackagesResponse } from '@kbn/fleet-plugin/common';
+import { AGENTS_INDEX } from '@kbn/fleet-plugin/common';
+import type { AgentStatus } from '@kbn/fleet-plugin/common';
 import { pick } from 'lodash';
 import { ToolingLog } from '@kbn/tooling-log';
-import type { AxiosResponse } from 'axios';
-import type { KbnClient } from '@kbn/test';
 import { FleetAgentGenerator } from '../../../common/endpoint/data_generators/fleet_agent_generator';
 
 const fleetGenerator = new FleetAgentGenerator();
@@ -65,21 +63,4 @@ export const checkInFleetAgent = async (
       doc: update,
     },
   });
-};
-
-export const fetchEndpointPackageInfo = async (
-  kbnClient: KbnClient
-): Promise<GetPackagesResponse['items'][number]> => {
-  const endpointPackage = (
-    (await kbnClient.request({
-      path: `${EPM_API_ROUTES.LIST_PATTERN}?category=security`,
-      method: 'GET',
-    })) as AxiosResponse<GetPackagesResponse>
-  ).data.items.find((epmPackage) => epmPackage.name === 'endpoint');
-
-  if (!endpointPackage) {
-    throw new Error('EPM Endpoint package was not found!');
-  }
-
-  return endpointPackage;
 };

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -41,11 +41,7 @@ import type {
 } from './services/fleet/endpoint_fleet_services_factory';
 import { registerListsPluginEndpointExtensionPoints } from '../lists_integration';
 import type { EndpointAuthz } from '../../common/endpoint/types/authz';
-import {
-  calculateEndpointAuthz,
-  calculatePermissionsFromPrivileges,
-  defaultEndpointPermissions,
-} from '../../common/endpoint/service/authz';
+import { calculateEndpointAuthz } from '../../common/endpoint/service/authz';
 import type { FeatureUsageService } from './services/feature_usage/service';
 import type { ExperimentalFeatures } from '../../common/experimental_features';
 import { doesArtifactHaveData } from './services';
@@ -173,18 +169,6 @@ export class EndpointAppContextService {
     const isPlatinumPlus = this.getLicenseService().isPlatinumPlus();
     const listClient = this.getExceptionListsClient();
 
-    let endpointPermissions = defaultEndpointPermissions();
-    if (this.security) {
-      const checkPrivileges = this.security.authz.checkPrivilegesDynamicallyWithRequest(request);
-      const { privileges } = await checkPrivileges({
-        kibana: [
-          this.security.authz.actions.ui.get('siem', 'crud'),
-          this.security.authz.actions.ui.get('siem', 'show'),
-        ],
-      });
-      endpointPermissions = calculatePermissionsFromPrivileges(privileges.kibana);
-    }
-
     const hasExceptionsListItems = !isPlatinumPlus
       ? await doesArtifactHaveData(listClient, ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID)
       : true;
@@ -194,7 +178,6 @@ export class EndpointAppContextService {
       fleetAuthz,
       userRoles,
       endpointRbacEnabled || endpointRbacV1Enabled,
-      endpointPermissions,
       hasExceptionsListItems
     );
   }

--- a/x-pack/test/fleet_api_integration/apis/package_policy/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/get.ts
@@ -144,8 +144,7 @@ export default function (providerContext: FtrProviderContext) {
           .expect(403, {
             statusCode: 403,
             error: 'Forbidden',
-            message:
-              "Authorization denied to [package.name=filetest]. Allowed package.name's: endpoint",
+            message: 'Authorization denied to package: filetest. Allowed package(s): endpoint',
           });
       });
 
@@ -267,8 +266,7 @@ export default function (providerContext: FtrProviderContext) {
           .send({ ids: [packagePolicyId] })
           .expect(403, {
             error: 'Forbidden',
-            message:
-              "Authorization denied to [package.name=filetest]. Allowed package.name's: endpoint",
+            message: 'Authorization denied to package: filetest. Allowed package(s): endpoint',
             statusCode: 403,
           });
       });

--- a/x-pack/test/fleet_api_integration/apis/test_users.ts
+++ b/x-pack/test/fleet_api_integration/apis/test_users.ts
@@ -128,6 +128,17 @@ export const testUsers: {
     username: 'endpoint_fleet_read_integr_none',
     password: 'changeme',
   },
+  // no fleet or integrations but read access to security solution app
+  endpoint_integr_read_only_fleet_none: {
+    permissions: {
+      feature: {
+        siem: ['minimal_all'],
+      },
+      spaces: ['*'],
+    },
+    username: 'endpoint_integr_read_only_fleet_none',
+    password: 'changeme',
+  },
 };
 
 export const setupTestUsers = async (security: SecurityService) => {

--- a/x-pack/test/security_solution_endpoint/services/endpoint_policy.ts
+++ b/x-pack/test/security_solution_endpoint/services/endpoint_policy.ts
@@ -14,9 +14,10 @@ import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   DeleteAgentPolicyRequest,
   DeletePackagePoliciesRequest,
+  epmRouteService,
   GetPackagePoliciesResponse,
   GetFullAgentPolicyResponse,
-  GetPackagesResponse,
+  type GetInfoResponse,
 } from '@kbn/fleet-plugin/common';
 import { policyFactory } from '@kbn/security-solution-plugin/common/endpoint/models/policy_config';
 import { Immutable } from '@kbn/security-solution-plugin/common/endpoint/types';
@@ -31,9 +32,6 @@ const INGEST_API_AGENT_POLICIES = `${INGEST_API_ROOT}/agent_policies`;
 const INGEST_API_AGENT_POLICIES_DELETE = `${INGEST_API_AGENT_POLICIES}/delete`;
 const INGEST_API_PACKAGE_POLICIES = `${INGEST_API_ROOT}/package_policies`;
 const INGEST_API_PACKAGE_POLICIES_DELETE = `${INGEST_API_PACKAGE_POLICIES}/delete`;
-const INGEST_API_EPM_PACKAGES = `${INGEST_API_ROOT}/epm/packages`;
-
-const SECURITY_PACKAGES_ROUTE = `${INGEST_API_EPM_PACKAGES}?category=security&prerelease=true`;
 
 /**
  * Holds information about the test resources created to support an Endpoint Policy
@@ -48,7 +46,7 @@ export interface PolicyTestResourceInfo {
   /**
    * Information about the endpoint package
    */
-  packageInfo: Immutable<GetPackagesResponse['items'][0]>;
+  packageInfo: Immutable<GetInfoResponse['item']>;
   /** will clean up (delete) the objects created (Agent Policy + Package Policy) */
   cleanup: () => Promise<void>;
 }
@@ -72,18 +70,19 @@ export function EndpointPolicyTestResourcesProvider({ getService }: FtrProviderC
     // so we'll retrieve a list of packages for a category of Security, and will then find the
     // endpoint package info. in the list. The request is kicked off here, but handled below after
     // Agent Policy creation so that they can be executed concurrently
-    let apiRequest: Promise<GetPackagesResponse['items'][0] | undefined>;
+    let apiRequest: Promise<GetInfoResponse['item'] | undefined>;
+    const path = epmRouteService.getInfoPath('endpoint');
 
     return () => {
       if (!apiRequest) {
-        log.info(`Setting up call to retrieve Endpoint package from ${SECURITY_PACKAGES_ROUTE}`);
+        log.info(`Setting up call to retrieve Endpoint package from ${path}`);
 
         // Currently (as of 2020-june) the package registry used in CI is the public one and
         // at times it encounters network connection issues. We use `retry.try` below to see if
         // subsequent requests get through.
         apiRequest = retry.try(() => {
           return supertest
-            .get(SECURITY_PACKAGES_ROUTE)
+            .get(path)
             .set('kbn-xsrf', 'xxx')
             .expect(200)
             .catch((error) => {
@@ -92,15 +91,10 @@ export function EndpointPolicyTestResourcesProvider({ getService }: FtrProviderC
                 error
               );
             })
-            .then((response: { body: GetPackagesResponse }) => {
-              const { body: secPackages } = response;
-              const endpointPackageInfo = secPackages.items.find(
-                (epmPackage) => epmPackage.name === 'endpoint'
-              );
+            .then((response: { body: GetInfoResponse }) => {
+              const endpointPackageInfo = response.body.item;
               if (!endpointPackageInfo) {
-                throw new Error(
-                  `Endpoint package was not in response from ${SECURITY_PACKAGES_ROUTE}`
-                );
+                throw new Error(`Endpoint package was not in response from ${path}`);
               }
 
               log.info(`Endpoint package version: ${endpointPackageInfo.version}`);
@@ -127,7 +121,7 @@ export function EndpointPolicyTestResourcesProvider({ getService }: FtrProviderC
     /**
      * Retrieves the currently installed endpoint package
      */
-    async getEndpointPackage(): Promise<Immutable<GetPackagesResponse['items'][0]>> {
+    async getEndpointPackage(): Promise<Immutable<GetInfoResponse['item']>> {
       const endpointPackage = await retrieveEndpointPackageInfo();
 
       if (!endpointPackage) {


### PR DESCRIPTION
## Summary

Update get package info API to support package level permissions. If user has no fleet permissions but has package level permissions (currently only supporting endpoint), the API will now return the package. Also includes some minor logic consolidation for package permission checking in package policy handler.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
