### PR TITLE
[Fleet] Validate pagination in fleet agents API

### DIFF
--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.test.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GetAgentsRequestSchema } from './agent';
+
+describe('GetAgentsRequestSchema', () => {
+  it('should allow pagination with less than 10000 agents', () => {
+    expect(() =>
+      GetAgentsRequestSchema.query.validate({
+        page: 500,
+        perPage: 20,
+      })
+    ).not.toThrow();
+  });
+  it('should not allow pagination to go over 10000 agents', () => {
+    expect(() =>
+      GetAgentsRequestSchema.query.validate({
+        page: 501,
+        perPage: 20,
+      })
+    ).toThrowError(/You cannot use page and perPage page through more than 10000 agents/);
+  });
+});

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.test.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.test.ts
@@ -22,6 +22,6 @@ describe('GetAgentsRequestSchema', () => {
         page: 501,
         perPage: 20,
       })
-    ).toThrowError(/You cannot use page and perPage page through more than 10000 agents/);
+    ).toThrowError(/You cannot use page and perPage page over 10000 agents/);
   });
 });

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -27,7 +27,7 @@ export const GetAgentsRequestSchema = {
     {
       validate: (request) => {
         if (request.page * request.perPage > SO_SEARCH_LIMIT) {
-          return `You cannot use page and perPage page through more than ${SO_SEARCH_LIMIT} agents`;
+          return `You cannot use page and perPage page over ${SO_SEARCH_LIMIT} agents`;
         }
       },
     }

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -8,19 +8,29 @@
 import { schema } from '@kbn/config-schema';
 import moment from 'moment';
 import semverIsValid from 'semver/functions/valid';
+import { SO_SEARCH_LIMIT } from '../../constants';
 
 import { NewAgentActionSchema } from '../models';
 
 export const GetAgentsRequestSchema = {
-  query: schema.object({
-    page: schema.number({ defaultValue: 1 }),
-    perPage: schema.number({ defaultValue: 20 }),
-    kuery: schema.maybe(schema.string()),
-    showInactive: schema.boolean({ defaultValue: false }),
-    showUpgradeable: schema.boolean({ defaultValue: false }),
-    sortField: schema.maybe(schema.string()),
-    sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
-  }),
+  query: schema.object(
+    {
+      page: schema.number({ defaultValue: 1 }),
+      perPage: schema.number({ defaultValue: 20 }),
+      kuery: schema.maybe(schema.string()),
+      showInactive: schema.boolean({ defaultValue: false }),
+      showUpgradeable: schema.boolean({ defaultValue: false }),
+      sortField: schema.maybe(schema.string()),
+      sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
+    },
+    {
+      validate: (request) => {
+        if (request.page * request.perPage > SO_SEARCH_LIMIT) {
+          return `You cannot use page and perPage page through more than ${SO_SEARCH_LIMIT} agents`;
+        }
+      },
+    }
+  ),
 };
 
 export const GetOneAgentRequestSchema = {

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import moment from 'moment';
 import semverIsValid from 'semver/functions/valid';
+
 import { SO_SEARCH_LIMIT } from '../../constants';
 
 import { NewAgentActionSchema } from '../models';


### PR DESCRIPTION
## Summary

Description validate the pagination in agents API is not going over 10000 hits to not throw that error 
```
search_phase_execution_exception: [illegal_argument_exception] Reason: Result window is too large, from + size must be less than or equal to: [10000] but was [10100]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.
```

but return a 400 with a more explicit message instead 

<img width="943" alt="Screen Shot 2022-12-22 at 8 48 12 AM" src="https://user-images.githubusercontent.com/1336873/209149262-b0d52a31-4c58-4283-bd76-e108503539c6.png">
