### PR TITLE
Ensure that API keys are rendered before performing bulk delete in functional tests.

### DIFF
--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.test.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.test.tsx
@@ -116,7 +116,7 @@ describe('APIKeysGridPage', () => {
     const secondKey = getByText(/second-api-key/).closest('td');
     const secondKeyEuiLink = secondKey!.querySelector('button');
     expect(secondKeyEuiLink).not.toBeNull();
-    expect(secondKeyEuiLink!.getAttribute('data-test-subj')).toBe('roleRowName-second-api-key');
+    expect(secondKeyEuiLink!.getAttribute('data-test-subj')).toBe('apiKeyRowName-second-api-key');
   });
 
   afterAll(() => {

--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -518,7 +518,7 @@ export class APIKeysGridPage extends Component<Props, State> {
           return (
             <EuiText color="subdued" size="s">
               <EuiLink
-                data-test-subj={`roleRowName-${recordAP.name}`}
+                data-test-subj={`apiKeyRowName-${recordAP.name}`}
                 onClick={() => {
                   this.setState({ selectedApiKey: recordAP, isUpdateFlyoutVisible: true });
                 }}

--- a/x-pack/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/test/functional/apps/api_keys/home_page.ts
@@ -17,6 +17,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const browser = getService('browser');
+  const retry = getService('retry');
 
   const testRoles: Record<string, any> = {
     viewer: {
@@ -37,8 +38,17 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     },
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/141868
-  describe.skip('Home page', function () {
+  async function ensureApiKeysExist(apiKeysNames: string[]) {
+    await retry.try(async () => {
+      for (const apiKeyName of apiKeysNames) {
+        log.debug(`Checking if API key ("${apiKeyName}") exists.`);
+        await pageObjects.apiKeys.ensureApiKeyExists(apiKeyName);
+        log.debug(`API key ("${apiKeyName}") exists.`);
+      }
+    });
+  }
+
+  describe('Home page', function () {
     before(async () => {
       await clearAllApiKeys(es, log);
       await security.testUser.setRoles(['kibana_admin']);
@@ -392,6 +402,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.apiKeys.clickOnPromptCreateApiKey();
         await pageObjects.apiKeys.setApiKeyName('api key 1');
         await pageObjects.apiKeys.clickSubmitButtonOnApiKeyFlyout();
+        await ensureApiKeysExist(['api key 1']);
       });
 
       it('one by one', async () => {
@@ -405,6 +416,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.apiKeys.clickOnTableCreateApiKey();
         await pageObjects.apiKeys.setApiKeyName('api key 2');
         await pageObjects.apiKeys.clickSubmitButtonOnApiKeyFlyout();
+
+        // Make sure all API keys we want to delete are created and rendered.
+        await ensureApiKeysExist(['api key 1', 'api key 2']);
 
         await pageObjects.apiKeys.bulkDeleteApiKeys();
         expect(await pageObjects.apiKeys.getApiKeysFirstPromptTitle()).to.be(

--- a/x-pack/test/functional/page_objects/api_keys_page.ts
+++ b/x-pack/test/functional/page_objects/api_keys_page.ts
@@ -103,7 +103,11 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
     },
 
     async clickExistingApiKeyToOpenFlyout(apiKeyName: string) {
-      await testSubjects.click(`roleRowName-${apiKeyName}`);
+      await testSubjects.click(`apiKeyRowName-${apiKeyName}`);
+    },
+
+    async ensureApiKeyExists(apiKeyName: string) {
+      await testSubjects.existOrFail(`apiKeyRowName-${apiKeyName}`);
     },
 
     async getMetadataSwitch() {


### PR DESCRIPTION
## Summary

Based on the [logs and screenshot from failed test runs](https://buildkite.com/elastic/kibana-on-merge/builds/24947#01851a95-d2ac-4ebb-94b9-98e6f76dd0f3), the test was able to perform all required actions, but didn't manage to bulk delete all the keys. The last created key (`api key 2`) was still in the API keys grid after bulk delete.

My assumption is that it took quite some time for the last added key to appear in the grid so that the bulk delete action didn't affect it. In this PR I'm making sure that both created keys are rendered before the test tries to delete them in bulk.

__Flaky Test Runner: :heavy_check_mark: [1673](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1673) (x50)__
__Fixes: https://github.com/elastic/kibana/issues/141868__

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->