### PR TITLE
[8.6] [Security Solution][Endpoint] Removes id field on nested entries for event filters (#148000)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/service/api_client.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/service/api_client.ts
@@ -7,8 +7,19 @@
 
 import { ENDPOINT_EVENT_FILTERS_LIST_ID } from '@kbn/securitysolution-list-constants';
 import type { HttpStart } from '@kbn/core/public';
+import type {
+  CreateExceptionListItemSchema,
+  UpdateExceptionListItemSchema,
+} from '@kbn/securitysolution-io-ts-list-types';
+import { removeIdFromExceptionItemsEntries } from '@kbn/securitysolution-list-hooks';
 import { ExceptionsListApiClient } from '../../../services/exceptions_list/exceptions_list_api_client';
 import { EVENT_FILTER_LIST_DEFINITION } from '../constants';
+
+function writeTransform<T extends CreateExceptionListItemSchema | UpdateExceptionListItemSchema>(
+  item: T
+): T {
+  return removeIdFromExceptionItemsEntries(item) as T;
+}
 
 /**
  * Event filters Api client class using ExceptionsListApiClient as base class
@@ -17,10 +28,22 @@ import { EVENT_FILTER_LIST_DEFINITION } from '../constants';
  */
 export class EventFiltersApiClient extends ExceptionsListApiClient {
   constructor(http: HttpStart) {
-    super(http, ENDPOINT_EVENT_FILTERS_LIST_ID, EVENT_FILTER_LIST_DEFINITION);
+    super(
+      http,
+      ENDPOINT_EVENT_FILTERS_LIST_ID,
+      EVENT_FILTER_LIST_DEFINITION,
+      undefined,
+      writeTransform
+    );
   }
 
   public static getInstance(http: HttpStart): ExceptionsListApiClient {
-    return super.getInstance(http, ENDPOINT_EVENT_FILTERS_LIST_ID, EVENT_FILTER_LIST_DEFINITION);
+    return super.getInstance(
+      http,
+      ENDPOINT_EVENT_FILTERS_LIST_ID,
+      EVENT_FILTER_LIST_DEFINITION,
+      undefined,
+      writeTransform
+    );
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Endpoint] Removes id field on nested entries for event filters (#148000)](https://github.com/elastic/kibana/pull/148000)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"David Sánchez","email":"david.sanchezsoler@elastic.co"},"sourceCommit":{"committedDate":"2022-12-22T17:12:39Z","message":"[Security Solution][Endpoint] Removes id field on nested entries for event filters (#148000)\n\n## Summary\r\n\r\n- Removes id field on nested entries for event filters using the write\r\ntransform method.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6bdbf70fe3efc6fdf1877aaabbe4e525411b6d31","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Onboarding and Lifecycle Mgt","v8.6.0","v8.7.0"],"number":148000,"url":"https://github.com/elastic/kibana/pull/148000","mergeCommit":{"message":"[Security Solution][Endpoint] Removes id field on nested entries for event filters (#148000)\n\n## Summary\r\n\r\n- Removes id field on nested entries for event filters using the write\r\ntransform method.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6bdbf70fe3efc6fdf1877aaabbe4e525411b6d31"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148000","number":148000,"mergeCommit":{"message":"[Security Solution][Endpoint] Removes id field on nested entries for event filters (#148000)\n\n## Summary\r\n\r\n- Removes id field on nested entries for event filters using the write\r\ntransform method.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6bdbf70fe3efc6fdf1877aaabbe4e525411b6d31"}}]}] BACKPORT-->