### PR TITLE
[7.17] Ensure that API keys are rendered before performing bulk delete in functional tests. (#148013)

### DIFF
--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -491,6 +491,7 @@ export class APIKeysGridPage extends Component<Props, State> {
           defaultMessage: 'Name',
         }),
         sortable: true,
+        'data-test-subj': 'apiKeyNameCell',
       },
     ]);
 

--- a/x-pack/test/functional/page_objects/api_keys_page.ts
+++ b/x-pack/test/functional/page_objects/api_keys_page.ts
@@ -92,5 +92,16 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
         await testSubjects.click('confirmModalConfirmButton');
       }
     },
+
+    async ensureApiKeyExists(apiKeyName: string) {
+      const existingApiKeyNameCells = await testSubjects.findAll('apiKeyNameCell');
+      for (const existingApiKeyNameCell of existingApiKeyNameCells) {
+        if (apiKeyName === (await existingApiKeyNameCell.getVisibleText())) {
+          return;
+        }
+      }
+
+      throw new Error(`API key ("${apiKeyName}") does not exist.`);
+    },
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Ensure that API keys are rendered before performing bulk delete in functional tests. (#148013)](https://github.com/elastic/kibana/pull/148013)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2022-12-22T18:44:11Z","message":"Ensure that API keys are rendered before performing bulk delete in functional tests. (#148013)","sha":"3a5f5626b2c3631eb2646782937171d2f87ce525","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","Team:Security","Feature:Users/Roles/API Keys","release_note:skip","ci:no-auto-commit","backport:all-open","v8.7.0"],"number":148013,"url":"https://github.com/elastic/kibana/pull/148013","mergeCommit":{"message":"Ensure that API keys are rendered before performing bulk delete in functional tests. (#148013)","sha":"3a5f5626b2c3631eb2646782937171d2f87ce525"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148013","number":148013,"mergeCommit":{"message":"Ensure that API keys are rendered before performing bulk delete in functional tests. (#148013)","sha":"3a5f5626b2c3631eb2646782937171d2f87ce525"}}]}] BACKPORT-->