### PR TITLE
[Enterprise Search] Make add domain input full width

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_form.tsx
@@ -57,7 +57,10 @@ export const AddDomainForm: React.FC = () => {
         >
           <EuiFlexGroup>
             <EuiFlexItem grow>
-              <EuiFormControlLayout clear={{ onClick: () => setAddDomainFormInputValue('') }}>
+              <EuiFormControlLayout
+                clear={{ onClick: () => setAddDomainFormInputValue('') }}
+                fullWidth
+              >
                 <EuiFieldText
                   autoFocus
                   value={addDomainFormInputValue}


### PR DESCRIPTION
This makes the add domain input in the Elastic crawler full width

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->