### PR TITLE
Fix autocommiting from CI

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -108,3 +108,6 @@ export BROWSERSLIST_IGNORE_OLD_DATA=true
 export TEST_GROUP_TYPE_UNIT="Jest Unit Tests"
 export TEST_GROUP_TYPE_INTEGRATION="Jest Integration Tests"
 export TEST_GROUP_TYPE_FUNCTIONAL="Functional Tests"
+
+# tells the gh command what our default repo is
+export GH_REPO=github.com/elastic/kibana

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -149,6 +149,9 @@ BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE="$HOME/.kibana-ci-bazel-remote-cache-loca
 export BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE
 retry 5 5 vault read -field=service_account_json secret/kibana-issues/dev/kibana-ci-bazel-remote-cache-local-dev > "$BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE"
 
+echo '--- Setup GH CLI'
+gh repo set-default https://github.com/elastic/kibana
+
 PIPELINE_PRE_COMMAND=${PIPELINE_PRE_COMMAND:-".buildkite/scripts/lifecycle/pipelines/$BUILDKITE_PIPELINE_SLUG/pre_command.sh"}
 if [[ -f "$PIPELINE_PRE_COMMAND" ]]; then
   source "$PIPELINE_PRE_COMMAND"

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -149,9 +149,6 @@ BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE="$HOME/.kibana-ci-bazel-remote-cache-loca
 export BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE
 retry 5 5 vault read -field=service_account_json secret/kibana-issues/dev/kibana-ci-bazel-remote-cache-local-dev > "$BAZEL_LOCAL_DEV_CACHE_CREDENTIALS_FILE"
 
-echo '--- Setup GH CLI'
-gh repo set-default https://github.com/elastic/kibana
-
 PIPELINE_PRE_COMMAND=${PIPELINE_PRE_COMMAND:-".buildkite/scripts/lifecycle/pipelines/$BUILDKITE_PIPELINE_SLUG/pre_command.sh"}
 if [[ -f "$PIPELINE_PRE_COMMAND" ]]; then
   source "$PIPELINE_PRE_COMMAND"

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -12,5 +12,8 @@
   ],
   "exclude": [
     "target/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/utility-types",
   ]
 }

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -10,10 +10,10 @@
   "include": [
     "**/*.ts",
   ],
+  "kbn_references": [
+    "@kbn/utility-types"
+  ],
   "exclude": [
     "target/**/*",
-  ],
-  "kbn_references": [
-    "@kbn/utility-types",
   ]
 }

--- a/packages/kbn-std/tsconfig.json
+++ b/packages/kbn-std/tsconfig.json
@@ -10,9 +10,6 @@
   "include": [
     "**/*.ts",
   ],
-  "kbn_references": [
-    "@kbn/utility-types"
-  ],
   "exclude": [
     "target/**/*",
   ]


### PR DESCRIPTION
The new images have an updated gh binary which now requires setting the `GITHUB_REPO` env var, or calling `gh repo set-default`. I opted for the env var so that we didn't need to find a good time to execute the CLI (after the keys are in the env, but before all other user code) or worry about the logging. This also allows other users of our scripts to customize as makes sense without having to dive into a bunch of imperative shell code.

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->