### PR TITLE
[7.17] Fix autocommiting from CI (#148066)

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -110,3 +110,6 @@ export DISABLE_BOOTSTRAP_VALIDATION=true
 
 # Prevent Browserlist from logging on CI about outdated database versions
 export BROWSERSLIST_IGNORE_OLD_DATA=true
+
+# tells the gh command what our default repo is
+export GH_REPO=github.com/elastic/kibana


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix autocommiting from CI (#148066)](https://github.com/elastic/kibana/pull/148066)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Spencer","email":"spencer@elastic.co"},"sourceCommit":{"committedDate":"2022-12-23T16:31:54Z","message":"Fix autocommiting from CI (#148066)\n\nThe new images have an updated gh binary which now requires setting the\r\n`GITHUB_REPO` env var, or calling `gh repo set-default`. I opted for the\r\nenv var so that we didn't need to find a good time to execute the CLI\r\n(after the keys are in the env, but before all other user code) or worry\r\nabout the logging. This also allows other users of our scripts to\r\ncustomize as makes sense without having to dive into a bunch of\r\nimperative shell code.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b8ddc626765af542d4270bdb372a6e8bec14419","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v8.7.0"],"number":148066,"url":"https://github.com/elastic/kibana/pull/148066","mergeCommit":{"message":"Fix autocommiting from CI (#148066)\n\nThe new images have an updated gh binary which now requires setting the\r\n`GITHUB_REPO` env var, or calling `gh repo set-default`. I opted for the\r\nenv var so that we didn't need to find a good time to execute the CLI\r\n(after the keys are in the env, but before all other user code) or worry\r\nabout the logging. This also allows other users of our scripts to\r\ncustomize as makes sense without having to dive into a bunch of\r\nimperative shell code.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b8ddc626765af542d4270bdb372a6e8bec14419"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148066","number":148066,"mergeCommit":{"message":"Fix autocommiting from CI (#148066)\n\nThe new images have an updated gh binary which now requires setting the\r\n`GITHUB_REPO` env var, or calling `gh repo set-default`. I opted for the\r\nenv var so that we didn't need to find a good time to execute the CLI\r\n(after the keys are in the env, but before all other user code) or worry\r\nabout the logging. This also allows other users of our scripts to\r\ncustomize as makes sense without having to dive into a bunch of\r\nimperative shell code.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b8ddc626765af542d4270bdb372a6e8bec14419"}},{"url":"https://github.com/elastic/kibana/pull/148068","number":148068,"branch":"8.5","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/148069","number":148069,"branch":"8.6","state":"OPEN"}]}] BACKPORT-->