### PR TITLE
fix(slo): global nav link

### DIFF
--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -279,7 +279,7 @@ export class Plugin
           // See https://github.com/elastic/kibana/issues/103325.
           const otherLinks: NavigationEntry[] = deepLinks
             .filter((link) => link.navLinkStatus === AppNavLinkStatus.visible)
-            .filter((link) => (link.id === 'slos' ? config.unsafe.slo.enabled : link))
+            .filter((link) => (link.id === 'slos' ? config.unsafe.slo.enabled : true))
             .map((link) => ({
               app: observabilityAppId,
               label: link.title,
@@ -313,6 +313,7 @@ export class Plugin
     const { application } = coreStart;
 
     updateGlobalNavigation({
+      config: this.initContext.config.get(),
       capabilities: application.capabilities,
       deepLinks: this.deepLinks,
       updater$: this.appUpdater$,

--- a/x-pack/plugins/observability/public/update_global_navigation.test.tsx
+++ b/x-pack/plugins/observability/public/update_global_navigation.test.tsx
@@ -9,9 +9,22 @@ import { Subject } from 'rxjs';
 import { App, AppDeepLink, ApplicationStart, AppNavLinkStatus, AppUpdater } from '@kbn/core/public';
 import { casesFeatureId } from '../common';
 import { updateGlobalNavigation } from './update_global_navigation';
+import { ConfigSchema } from './plugin';
 
 // Used in updater callback
 const app = {} as unknown as App;
+
+const config: ConfigSchema = {
+  unsafe: {
+    slo: { enabled: false },
+    alertDetails: {
+      apm: { enabled: false },
+      logs: { enabled: false },
+      metrics: { enabled: false },
+      uptime: { enabled: false },
+    },
+  },
+};
 
 describe('updateGlobalNavigation', () => {
   describe('when no observability apps are enabled', () => {
@@ -25,7 +38,7 @@ describe('updateGlobalNavigation', () => {
         next: (cb: AppUpdater) => callback(cb(app)),
       } as unknown as Subject<AppUpdater>;
 
-      updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+      updateGlobalNavigation({ config, capabilities, deepLinks, updater$ });
 
       expect(callback).toHaveBeenCalledWith({
         deepLinks,
@@ -45,7 +58,7 @@ describe('updateGlobalNavigation', () => {
         next: (cb: AppUpdater) => callback(cb(app)),
       } as unknown as Subject<AppUpdater>;
 
-      updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+      updateGlobalNavigation({ config, capabilities, deepLinks, updater$ });
 
       expect(callback).toHaveBeenCalledWith({
         deepLinks,
@@ -75,7 +88,7 @@ describe('updateGlobalNavigation', () => {
           next: (cb: AppUpdater) => callback(cb(app)),
         } as unknown as Subject<AppUpdater>;
 
-        updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+        updateGlobalNavigation({ config, capabilities, deepLinks, updater$ });
 
         expect(callback).toHaveBeenCalledWith({
           deepLinks: [
@@ -111,7 +124,7 @@ describe('updateGlobalNavigation', () => {
           next: (cb: AppUpdater) => callback(cb(app)),
         } as unknown as Subject<AppUpdater>;
 
-        updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+        updateGlobalNavigation({ config, capabilities, deepLinks, updater$ });
 
         expect(callback).toHaveBeenCalledWith({
           deepLinks: [
@@ -146,7 +159,7 @@ describe('updateGlobalNavigation', () => {
           next: (cb: AppUpdater) => callback(cb(app)),
         } as unknown as Subject<AppUpdater>;
 
-        updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+        updateGlobalNavigation({ config, capabilities, deepLinks, updater$ });
 
         expect(callback).toHaveBeenCalledWith({
           deepLinks: [
@@ -167,7 +180,7 @@ describe('updateGlobalNavigation', () => {
       it('shows the slos deep link', () => {
         const capabilities = {
           [casesFeatureId]: { read_cases: true },
-          navLinks: { apm: true, logs: false, metrics: false, uptime: false },
+          navLinks: { apm: false, logs: false, metrics: false, uptime: false },
         } as unknown as ApplicationStart['capabilities'];
 
         const sloRoute = {
@@ -185,7 +198,12 @@ describe('updateGlobalNavigation', () => {
           next: (cb: AppUpdater) => callback(cb(app)),
         } as unknown as Subject<AppUpdater>;
 
-        updateGlobalNavigation({ capabilities, deepLinks, updater$ });
+        updateGlobalNavigation({
+          config: { unsafe: { ...config.unsafe, slo: { enabled: true } } },
+          capabilities,
+          deepLinks,
+          updater$,
+        });
 
         expect(callback).toHaveBeenCalledWith({
           deepLinks: [

--- a/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
+++ b/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
@@ -64,7 +64,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
           'Alerts',
-          'SLOs',
           'APM',
           'User Experience',
           'Stack Management',
@@ -120,7 +119,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(navLinks).to.eql([
           'Overview',
           'Alerts',
-          'SLOs',
           'APM',
           'User Experience',
           'Stack Management',

--- a/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -63,13 +63,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows infrastructure navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql([
-          'Overview',
-          'Alerts',
-          'SLOs',
-          'Infrastructure',
-          'Stack Management',
-        ]);
+        expect(navLinks).to.eql(['Overview', 'Alerts', 'Infrastructure', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {
@@ -167,13 +161,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows metrics navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql([
-          'Overview',
-          'Alerts',
-          'SLOs',
-          'Infrastructure',
-          'Stack Management',
-        ]);
+        expect(navLinks).to.eql(['Overview', 'Alerts', 'Infrastructure', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {

--- a/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
@@ -60,7 +60,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'SLOs', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {
@@ -123,7 +123,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'SLOs', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {

--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -70,7 +70,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
           'Alerts',
-          'SLOs',
           'Uptime',
           'Synthetics',
           'Stack Management',
@@ -125,14 +124,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows uptime navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql([
-          'Overview',
-          'Alerts',
-          'SLOs',
-          'Uptime',
-          'Synthetics',
-          'Stack Management',
-        ]);
+        expect(navLinks).to.eql(['Overview', 'Alerts', 'Uptime', 'Synthetics', 'Stack Management']);
       });
 
       it('can navigate to Uptime app', async () => {


### PR DESCRIPTION
## 📝  Summary

Fix https://github.com/elastic/kibana/issues/147972

## ✅ Manual testing

Disable the slo feature flag from your kibana.dev.yml and check that global and observability navigations don't contain an `SLOs` link.
Enable the flag, and check SLOs is present in both navigation.