### PR TITLE
Controls group loading issue

### DIFF
--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -41,13 +41,16 @@ export const SortableControl = (frameProps: SortableControlProps) => {
       disabled: !isEditable,
     });
 
-  frameProps.dragInfo = { ...frameProps.dragInfo, isOver: over?.id === embeddableId, isDragging };
+  const sortableFrameProps = {
+    ...frameProps,
+    dragInfo: { ...frameProps.dragInfo, isOver: over?.id === embeddableId, isDragging },
+  };
 
   return (
     <SortableControlInner
       key={embeddableId}
       ref={setNodeRef}
-      {...frameProps}
+      {...sortableFrameProps}
       {...attributes}
       {...listeners}
       style={{


### PR DESCRIPTION
Closes #148121
## Summary

This PR fixes an issue on the host view. 
Console Error:
![image](https://user-images.githubusercontent.com/14139027/209699899-8b74c3c1-cb46-42d7-9c08-308d1b5d8816.png)

Together with @crespocarlos we checked this issue we found on the latest `main` version and added this solution. The idea is instead of mutating the frame props we added a different variable to merge existing props with the new data to avoid issues related to the frame props' value. Thanks to that the console error is gone and the host page loads without an issue