### PR TITLE
Removes Tyler as Ironbank maintainer

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -48,10 +48,6 @@ resources:
 
 # List of project maintainers
 maintainers:
-  - email: 'tyler.smalley@elastic.co'
-    name: 'Tyler Smalley'
-    username: 'tylersmalley'
-    cht_member: false
   - email: 'klepal_alexander@bah.com'
     name: 'Alexander Klepal'
     username: 'alexander.klepal'


### PR DESCRIPTION
I was originally added as a maintainer to manage the deployments, however that is no longer the case as we have integrated into the release manager automation. Someone from @elastic/kibana-security might make sense to take my place as it's mostly responding to security findings at this point though I believe there is already a separate process for that.