### PR TITLE
fix(slo): saved object mapping definition converted to camelCase

### DIFF
--- a/x-pack/plugins/observability/server/saved_objects/slo.ts
+++ b/x-pack/plugins/observability/server/saved_objects/slo.ts
@@ -27,35 +27,35 @@ export const slo: SavedObjectsType = {
           params: { type: 'flattened' },
         },
       },
-      time_window: {
+      timeWindow: {
         properties: {
           duration: { type: 'keyword' },
-          is_rolling: { type: 'boolean' },
+          isRolling: { type: 'boolean' },
           calendar: {
             properties: {
-              start_time: { type: 'date' },
+              startTime: { type: 'date' },
             },
           },
         },
       },
-      budgeting_method: { type: 'keyword' },
+      budgetingMethod: { type: 'keyword' },
       objective: {
         properties: {
           target: { type: 'float' },
-          timeslice_target: { type: 'float' },
-          timeslice_window: { type: 'keyword' },
+          timesliceTarget: { type: 'float' },
+          timesliceWindow: { type: 'keyword' },
         },
       },
       settings: {
         properties: {
-          timestamp_field: { type: 'keyword' },
-          sync_delay: { type: 'keyword' },
+          timestampField: { type: 'keyword' },
+          syncDelay: { type: 'keyword' },
           frequency: { type: 'keyword' },
         },
       },
       revision: { type: 'short' },
-      created_at: { type: 'date' },
-      updated_at: { type: 'date' },
+      createdAt: { type: 'date' },
+      updatedAt: { type: 'date' },
     },
   },
   management: {


### PR DESCRIPTION
## 📝 Summary

Related to https://github.com/elastic/kibana/issues/148110

Forgot to change the saved object mapping definition.