### PR TITLE
[Monitoring] Read expiryDateMS from the right path in License rule

### DIFF
--- a/x-pack/plugins/monitoring/common/types/alerts.ts
+++ b/x-pack/plugins/monitoring/common/types/alerts.ts
@@ -111,7 +111,9 @@ export interface AlertThreadPoolRejectionsState extends AlertNodeState {
 }
 
 export interface AlertLicenseState extends AlertState {
-  expiryDateMS: number;
+  meta: {
+    expiryDateMS: number;
+  };
 }
 
 export interface AlertNodesChangedState extends AlertState {

--- a/x-pack/plugins/monitoring/server/alerts/license_expiration_rule.ts
+++ b/x-pack/plugins/monitoring/server/alerts/license_expiration_rule.ts
@@ -155,7 +155,7 @@ export class LicenseExpirationRule extends BaseRule {
     // Logic in the base alert assumes that all alerts will operate against multiple nodes/instances (such as a CPU alert against ES nodes)
     // However, some alerts operate on the state of the cluster itself and are only concerned with a single state
     const state: AlertLicenseState = alertStates[0] as AlertLicenseState;
-    const $duration = moment.duration(+new Date() - state.expiryDateMS);
+    const $duration = moment.duration(+new Date() - state.meta.expiryDateMS);
     const actionText = i18n.translate('xpack.monitoring.alerts.licenseExpiration.action', {
       defaultMessage: 'Please update your license.',
     });


### PR DESCRIPTION
The license details have been placed under the `meta` property but the context messages were not updated to read correctly from that path, this PR fixes that little issue.

<!--ONMERGE {"backportTargets":["7.17","8.5","8.6"]} ONMERGE-->