### PR TITLE
[ResponseOps] Add intermediate status info to outcomeMsg of Rule lastRun

### DIFF
--- a/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
+++ b/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
@@ -71,7 +71,10 @@ describe('lastRunFromState', () => {
     );
 
     expect(result.lastRun.outcome).toEqual('warning');
-    expect(result.lastRun.outcomeMsg).toEqual(['MOCK_WARNING', 'Rule execution reported a warning']);
+    expect(result.lastRun.outcomeMsg).toEqual([
+      'MOCK_WARNING',
+      'Rule execution reported a warning',
+    ]);
     expect(result.lastRun.warning).toEqual(null);
 
     expect(result.lastRun.alertsCount).toEqual({

--- a/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
+++ b/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
@@ -71,7 +71,7 @@ describe('lastRunFromState', () => {
     );
 
     expect(result.lastRun.outcome).toEqual('warning');
-    expect(result.lastRun.outcomeMsg).toEqual(['Rule execution reported a warning']);
+    expect(result.lastRun.outcomeMsg).toEqual(['MOCK_WARNING', 'Rule execution reported a warning']);
     expect(result.lastRun.warning).toEqual(null);
 
     expect(result.lastRun.alertsCount).toEqual({
@@ -136,12 +136,13 @@ describe('lastRunFromState', () => {
       },
       getRuleResultService({
         warnings: ['MOCK_WARNING'],
-        outcomeMessage: 'Rule execution reported a warning',
+        outcomeMessage: ruleExecutionOutcomeMessage,
       })
     );
 
     expect(result.lastRun.outcome).toEqual('warning');
     expect(result.lastRun.outcomeMsg).toEqual([
+      'MOCK_WARNING',
       frameworkOutcomeMessage,
       ruleExecutionOutcomeMessage,
     ]);
@@ -171,6 +172,7 @@ describe('lastRunFromState', () => {
 
     expect(result.lastRun.outcome).toEqual('warning');
     expect(result.lastRun.outcomeMsg).toEqual([
+      'MOCK_WARNING',
       frameworkOutcomeMessage,
       ruleExecutionOutcomeMessage,
     ]);
@@ -197,6 +199,7 @@ describe('lastRunFromState', () => {
 
     expect(result.lastRun.outcome).toEqual('failed');
     expect(result.lastRun.outcomeMsg).toEqual([
+      'MOCK_ERROR',
       'Rule reported more than the maximum number of alerts in a single run. Alerts may be missed and recovery notifications may be delayed',
       'Rule execution reported an error',
     ]);

--- a/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
+++ b/x-pack/plugins/alerting/server/lib/last_run_status.test.ts
@@ -202,8 +202,8 @@ describe('lastRunFromState', () => {
 
     expect(result.lastRun.outcome).toEqual('failed');
     expect(result.lastRun.outcomeMsg).toEqual([
-      'MOCK_ERROR',
       'Rule reported more than the maximum number of alerts in a single run. Alerts may be missed and recovery notifications may be delayed',
+      'MOCK_ERROR',
       'Rule execution reported an error',
     ]);
     expect(result.lastRun.warning).toEqual('maxAlerts');

--- a/x-pack/plugins/alerting/server/lib/last_run_status.ts
+++ b/x-pack/plugins/alerting/server/lib/last_run_status.ts
@@ -38,6 +38,7 @@ export const lastRunFromState = (
 
   if (warnings.length > 0) {
     outcome = RuleLastRunOutcomeValues[1];
+    outcomeMsg.push(...warnings);
   }
 
   // We only have a single warning field so prioritizing the alert circuit breaker over the actions circuit breaker
@@ -54,6 +55,7 @@ export const lastRunFromState = (
   // Overwrite outcome to be error if last run reported any errors
   if (errors.length > 0) {
     outcome = RuleLastRunOutcomeValues[2];
+    outcomeMsg.push(...errors);
   }
 
   // Optionally push outcome message reported by


### PR DESCRIPTION
## Summary

Modify the `lastRunFromState` function from `x-pack/plugins/alerting/server/lib/last_run_status.ts`, which takes metrics produced during Rule Execution, as well as results produced during execution by the `RuleResultService`, so that now:

- `warnings` produced in the Solution side by the `RuleResultService` are added to the `outcomeMsg` array.
- `errors` produced in the Solution side by the `RuleResultService` are added to the `outcomeMsg` array.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
