### PR TITLE
[Fleet]: `Discard Changes?` confirmation popup without making any changes on Edit Endpoint Defend integration page.

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -138,8 +138,7 @@ export const EditPackagePolicyForm = memo<{
   const handleExtensionViewOnChange = useCallback<
     PackagePolicyEditExtensionComponentProps['onChange']
   >(
-    ({ isValid, updatedPolicy }) => {
-      updatePackagePolicy(updatedPolicy);
+    ({ isValid }) => {
       setFormState((prevState) => {
         if (prevState === 'VALID' && !isValid) {
           return 'INVALID';
@@ -147,7 +146,7 @@ export const EditPackagePolicyForm = memo<{
         return prevState;
       });
     },
-    [updatePackagePolicy, setFormState]
+    [setFormState]
   );
 
   // Cancel url + Success redirect Path:


### PR DESCRIPTION
`Discard Changes?` confirmation popup without making any changes on Edit Endpoint Defend integration page

Resoves https://github.com/elastic/kibana/issues/141888