### PR TITLE
[Discover][Unified search] Scrollbar visibility only when the editor’s height is greater than the maximum height

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
@@ -337,8 +337,8 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     overviewRulerLanes: 0,
     hideCursorInOverviewRuler: true,
     scrollbar: {
-      vertical: 'hidden',
       horizontal: 'hidden',
+      vertical: 'auto',
     },
     overviewRulerBorder: false,
     readOnly: isDisabled,


### PR DESCRIPTION
## Summary
Completes part of https://github.com/elastic/kibana/issues/136950.

Made scrollbar visibility only when the editor’s height is greater than the maximum height.

https://user-images.githubusercontent.com/22456368/209835330-a731ddb5-6c50-4520-89ae-5461bbc34b8a.mov

