### PR TITLE
[Security Solution] Remove unused CSS selectors in function tests

### DIFF
--- a/x-pack/test/security_solution_ftr/page_objects/detections/index.ts
+++ b/x-pack/test/security_solution_ftr/page_objects/detections/index.ts
@@ -42,14 +42,6 @@ export class DetectionsPageObject extends FtrService {
     await this.navigateToDetectionsPage('rules');
   }
 
-  async navigateToRuleMonitoring(): Promise<void> {
-    await this.common.clickAndValidate('allRulesTableTab-monitoring', 'monitoring-table');
-  }
-
-  async navigateToExceptionList(): Promise<void> {
-    await this.common.clickAndValidate('allRulesTableTab-exceptions', 'exceptions-table');
-  }
-
   async navigateToCreateRule(): Promise<void> {
     await this.navigateToDetectionsPage('rules/create');
   }


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/pull/147471 and https://github.com/elastic/kibana/issues/140263

## Summary

Removed unused methods which use outdated selectors from the rules table page.

