### PR TITLE
feat(slo): Handle lookback window in transform query

### DIFF
--- a/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
@@ -39,8 +39,6 @@ export const getSLOMappingsTemplate = (name: string) => ({
                 objective: {
                   properties: {
                     target: { type: 'double' },
-                    timeslice_target: { type: 'double' },
-                    timeslice_window: { type: 'keyword' },
                   },
                 },
                 time_window: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -9,6 +9,13 @@ Object {
           "transaction.root": true,
         },
       },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
     ],
   },
 }
@@ -105,6 +112,13 @@ Object {
           Object {
             "match": Object {
               "transaction.root": true,
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "gte": "now-7d",
+              },
             },
           },
           Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -9,6 +9,13 @@ Object {
           "transaction.root": true,
         },
       },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
     ],
   },
 }
@@ -110,6 +117,13 @@ Object {
           Object {
             "match": Object {
               "transaction.root": true,
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "gte": "now-7d",
+              },
             },
           },
           Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -17,6 +17,7 @@ import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo
 import { SLO, APMTransactionDurationIndicator } from '../../../domain/models';
 import { TransformGenerator } from '.';
 import { DEFAULT_APM_INDEX } from './constants';
+import { Query } from './types';
 
 export class ApmTransactionDurationTransformGenerator extends TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
@@ -39,7 +40,15 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
   }
 
   private buildSource(slo: SLO, indicator: APMTransactionDurationIndicator) {
-    const queryFilter = [];
+    const queryFilter: Query[] = [
+      {
+        range: {
+          [slo.settings.timestampField]: {
+            gte: `now-${slo.timeWindow.duration.format()}`,
+          },
+        },
+      },
+    ];
     if (indicator.params.service !== ALL_VALUE) {
       queryFilter.push({
         match: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../assets/constants';
 import { APMTransactionErrorRateIndicator, SLO } from '../../../domain/models';
 import { DEFAULT_APM_INDEX } from './constants';
+import { Query } from './types';
 
 const ALLOWED_STATUS_CODES = ['2xx', '3xx', '4xx', '5xx'];
 const DEFAULT_GOOD_STATUS_CODES = ['2xx', '3xx', '4xx'];
@@ -43,7 +44,16 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
   }
 
   private buildSource(slo: SLO, indicator: APMTransactionErrorRateIndicator) {
-    const queryFilter = [];
+    const queryFilter: Query[] = [
+      {
+        range: {
+          [slo.settings.timestampField]: {
+            gte: `now-${slo.timeWindow.duration.format()}`,
+          },
+        },
+      },
+    ];
+
     if (indicator.params.service !== ALL_VALUE) {
       queryFilter.push({
         match: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/types.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+type QueryKey = 'match' | 'range';
+
+export type Query = {
+  [key in QueryKey]?: any;
+};


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/147549

This PR filters the source data and limits the lookback period to the SLO time window duration.
This means that for a 30 days SLO, we won't transform the data that is older than 30days. This is a performance improvement in case the source data contains years or months of data.

For custom KQL, the user needs to enter a condition like `and @timestamp > now-30d` in the filter definition part.

🧹 I've also removed some `_internal` fields (related to timeslices and calendar aligned SLO) from the destination index that is not usable for the temporary dashboard we built.