### PR TITLE
[discover] load field list via field caps api

### DIFF
--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -225,7 +225,7 @@ export interface DataViewsServicePublicMethods {
    */
   getFieldsForIndexPattern: (
     indexPattern: DataView | DataViewSpec,
-    options?: GetFieldsOptions | undefined
+    options?: Omit<GetFieldsOptions, 'pattern'> | undefined
   ) => Promise<FieldSpec[]>;
   /**
    * Get fields for index pattern string
@@ -511,7 +511,7 @@ export class DataViewsService {
    */
   getFieldsForIndexPattern = async (
     indexPattern: DataView | DataViewSpec,
-    options?: GetFieldsOptions
+    options?: Omit<GetFieldsOptions, 'pattern'>
   ) =>
     this.getFieldsForWildcard({
       type: indexPattern.type,

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -252,16 +252,18 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
   }, []);
 
   const { dataViewFieldEditor, dataViewEditor } = services;
-  const { availableFields$ } = props;
+  // const { availableFields$ } = props;
 
   const canEditDataView =
     Boolean(dataViewEditor?.userPermissions.editDataView()) || !selectedDataView?.isPersisted();
 
+  /**
   useEffect(() => {
     // For an external embeddable like the Field stats
     // it is useful to know what fields are populated in the docs fetched
     // or what fields are selected by the user
 
+    // todo this needs to be removed
     const availableFields =
       props.columns.length > 0 ? props.columns : Object.keys(sidebarState.fieldCounts || {});
     availableFields$.next({
@@ -269,6 +271,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
       fields: availableFields,
     });
   }, [selectedDataView, sidebarState.fieldCounts, props.columns, availableFields$]);
+*/
 
   const editField = useMemo(
     () =>

--- a/src/plugins/discover/public/application/main/utils/fetch_all.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.ts
@@ -11,7 +11,6 @@ import { ReduxLikeStateContainer } from '@kbn/kibana-utils-plugin/common';
 import type { SavedSearch, SortOrder } from '@kbn/saved-search-plugin/public';
 import { BehaviorSubject, filter, firstValueFrom, map, merge, scan } from 'rxjs';
 import { Query } from '@kbn/es-query';
-import { map as loMap } from 'lodash';
 import { getRawRecordType } from './get_raw_record_type';
 import {
   checkHitCount,


### PR DESCRIPTION
## Summary

Discover should use the field caps api to load the field list instead of basing it off returned documents. 

I'm currently trying to figure out how to stop loading the field list so I can determine that I'm actually doing something.