### PR TITLE
changed error log to warn

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -108,7 +108,7 @@ export async function getAgentStatusForAgentPolicy(
       },
     });
   } catch (error) {
-    logger.error(`Error getting agent statuses: ${error}`);
+    logger.warn(`Error getting agent statuses: ${error}`);
     throw error;
   }
 

--- a/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
@@ -39,7 +39,7 @@ export async function registerFleetUsageLogger(
             } catch (error) {
               appContextService
                 .getLogger()
-                .error('Error occurred while fetching fleet usage: ' + error);
+                .warn('Error occurred while fetching fleet usage: ' + error);
             }
           },
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148060

Changed log level to warn when `.fleet-agents` index doesn't exist