### PR TITLE
[Synthetics UI] Fix thumbnail styles

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/empty_thumbnail.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/empty_thumbnail.tsx
@@ -13,7 +13,7 @@ import { useEuiTheme, useEuiBackgroundColor, EuiIcon, EuiLoadingContent } from '
 export const THUMBNAIL_WIDTH = 96;
 export const THUMBNAIL_HEIGHT = 64;
 
-export const thumbnailStyle = css`
+export const thumbnailStyle = `
   padding: 0;
   margin: auto;
   width: ${THUMBNAIL_WIDTH}px;


### PR DESCRIPTION
## Summary

Fixes the thumbnail styles in the monitor summary page.

Before:
<img width="977" alt="Screenshot 2022-12-29 at 15 35 40" src="https://user-images.githubusercontent.com/57448/209968285-60b1d415-df01-4f76-83e8-db739f896b4e.png">


After:
<img width="984" alt="Screenshot 2022-12-29 at 15 33 07" src="https://user-images.githubusercontent.com/57448/209968071-bbb99a46-a410-459a-9b8d-b28650fa92b8.png">
