### PR TITLE
[Lens] Ignore invalid references

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/loader.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/loader.ts
@@ -69,10 +69,16 @@ export function injectReferences(
 ) {
   const layers: Record<string, FormBasedLayer> = {};
   Object.entries(state.layers).forEach(([layerId, persistedLayer]) => {
-    layers[layerId] = {
-      ...persistedLayer,
-      indexPatternId: references.find(({ name }) => name === getLayerReferenceName(layerId))!.id,
-    };
+    const indexPatternId = references.find(
+      ({ name }) => name === getLayerReferenceName(layerId)
+    )?.id;
+
+    if (indexPatternId) {
+      layers[layerId] = {
+        ...persistedLayer,
+        indexPatternId,
+      };
+    }
   });
   return {
     layers,


### PR DESCRIPTION
## Summary

In Synthetics we heavily use the lens embeddable. We saw there is a faulty check in https://github.com/elastic/kibana/blob/3d7b01e28bb1c42bb57c63e6ee00381acb720eea/x-pack/plugins/lens/public/datasources/form_based/loader.ts#L74, where we blindly get the an `id` for an object that might be `undefined`.

This PR checks for that and prevents the code from creating and invalid layer from an invalid reference.

We notice this as numerous console errors while working in the synthetics app.

<img width="1279" alt="Screenshot 2022-12-29 at 15 39 20" src="https://user-images.githubusercontent.com/57448/209969475-2242d2f0-3a88-4437-9d40-0f8da156b030.png">


