### PR TITLE
[Synthetics UI] Remove nested button

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_header.tsx
@@ -6,14 +6,7 @@
  */
 
 import React from 'react';
-import {
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiTitle,
-  EuiLink,
-} from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
 import { css } from '@emotion/css';
 import { useHistory } from 'react-router-dom';
 
@@ -68,7 +61,7 @@ export const MonitorStatusHeader = ({
 
       {showViewHistoryButton ? (
         <EuiFlexItem grow={false}>
-          <EuiLink
+          <EuiButtonEmpty
             href={
               monitor?.[ConfigKey.CONFIG_ID]
                 ? history.createHref({
@@ -83,15 +76,12 @@ export const MonitorStatusHeader = ({
                   })
                 : undefined
             }
+            data-test-subj="monitorStatusChartViewHistoryButton"
+            size="xs"
+            iconType="list"
           >
-            <EuiButtonEmpty
-              data-test-subj="monitorStatusChartViewHistoryButton"
-              size="xs"
-              iconType="list"
-            >
-              {labels.VIEW_HISTORY_LABEL}
-            </EuiButtonEmpty>
-          </EuiLink>
+            {labels.VIEW_HISTORY_LABEL}
+          </EuiButtonEmpty>
         </EuiFlexItem>
       ) : null}
     </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Fixes this error

<img width="1278" alt="Screenshot 2022-12-29 at 16 03 39" src="https://user-images.githubusercontent.com/57448/209971732-8eb5869d-7791-46d7-a6e4-060794735e7f.png">

The diff doesn't make it easy to see, but basically the change is this:

```tsx
// Before
<EuiLink href="...">
   <EuiEmptyButton {...props}>...</EuiEmptyButton>
</EuiLink>

// After
<EuiEmptyButton href="..." {...props}>...</EuiEmptyButton>
```
