### PR TITLE
[Infra UI] Remove dependence on ResizeObserver polyfill 

### DIFF
--- a/x-pack/plugins/infra/public/components/auto_sizer.tsx
+++ b/x-pack/plugins/infra/public/components/auto_sizer.tsx
@@ -7,7 +7,6 @@
 
 import { isEqual } from 'lodash';
 import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
 
 interface Measurement {
   width?: number;


### PR DESCRIPTION
Closes [#122022](https://github.com/elastic/kibana/issues/122022)
## Summary

This PR removes the import of `resize-observer-polyfill` in the Autosizer component