### PR TITLE
feat(slo): use sync delay for burn rate alerting

### DIFF
--- a/packages/kbn-slo-schema/src/models/duration.test.ts
+++ b/packages/kbn-slo-schema/src/models/duration.test.ts
@@ -78,4 +78,25 @@ describe('Duration', () => {
       expect(short.isLongerOrEqualThan(new Duration(1, DurationUnit.Year))).toBe(false);
     });
   });
+
+  describe('add', () => {
+    it('returns the duration result in minute', () => {
+      const someDuration = new Duration(1, DurationUnit.Minute);
+      expect(someDuration.add(new Duration(1, DurationUnit.Minute))).toEqual(
+        new Duration(2, DurationUnit.Minute)
+      );
+      expect(someDuration.add(new Duration(1, DurationUnit.Hour))).toEqual(
+        new Duration(61, DurationUnit.Minute)
+      );
+      expect(someDuration.add(new Duration(1, DurationUnit.Day))).toEqual(
+        new Duration(1441, DurationUnit.Minute)
+      );
+      expect(someDuration.add(new Duration(1, DurationUnit.Week))).toEqual(
+        new Duration(10081, DurationUnit.Minute)
+      );
+      expect(someDuration.add(new Duration(1, DurationUnit.Month))).toEqual(
+        new Duration(43201, DurationUnit.Minute)
+      );
+    });
+  });
 });

--- a/packages/kbn-slo-schema/src/models/duration.ts
+++ b/packages/kbn-slo-schema/src/models/duration.ts
@@ -29,6 +29,16 @@ class Duration {
     }
   }
 
+  add(other: Duration): Duration {
+    const currentDurationMoment = moment.duration(this.value, toMomentUnitOfTime(this.unit));
+    const otherDurationMoment = moment.duration(other.value, toMomentUnitOfTime(other.unit));
+
+    return new Duration(
+      currentDurationMoment.add(otherDurationMoment).asMinutes(),
+      DurationUnit.Minute
+    );
+  }
+
   isShorterThan(other: Duration): boolean {
     const otherDurationMoment = moment.duration(other.value, toMomentUnitOfTime(other.unit));
     const currentDurationMoment = moment.duration(this.value, toMomentUnitOfTime(this.unit));

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
@@ -58,8 +58,8 @@ export const getRuleExecutor = (): LifecycleRuleExecutor<
     );
 
     const sliData = await sliClient.fetchSLIDataFrom(slo, [
-      { name: LONG_WINDOW, duration: longWindowDuration },
-      { name: SHORT_WINDOW, duration: shortWindowDuration },
+      { name: LONG_WINDOW, duration: longWindowDuration.add(slo.settings.syncDelay) },
+      { name: SHORT_WINDOW, duration: shortWindowDuration.add(slo.settings.syncDelay) },
     ]);
 
     const longWindowBurnRate = computeBurnRate(slo, sliData[LONG_WINDOW]);


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/146475

This PR uses the SLO sync delay settings when querying the data for computing the burn rate values.
