### PR TITLE
[Console] Improve check for response size in `/autocomplete_entities` endpoint 

### DIFF
--- a/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
+++ b/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
@@ -117,11 +117,16 @@ const getEntity = (path: string, config: Config) => {
       try {
         const req = client.request(options, (res) => {
           const chunks: Buffer[] = [];
+
+          let currentLength = 0;
+
           res.on('data', (chunk) => {
+            currentLength += Buffer.byteLength(chunk);
+
             chunks.push(chunk);
 
             // Destroy the request if the response is too large
-            if (Buffer.byteLength(Buffer.concat(chunks)) > MAX_RESPONSE_SIZE) {
+            if (currentLength > MAX_RESPONSE_SIZE) {
               req.destroy();
               reject(Boom.badRequest(`Response size is too large for ${path}`));
             }


### PR DESCRIPTION
## Summary

Fixes the performance issue in `/autocomplete_entities` endpoint by replacing the `Buffer.concat` with accumulating bytes length on the `data` event for checking the response size.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/5236598/210404277-ad8f35b7-de97-4066-bbb6-d67c6f50f62f.png">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->