### PR TITLE
[kbn/es] Add dev docs for snapshot promotion pipeline 

### DIFF
--- a/packages/kbn-es/README.mdx
+++ b/packages/kbn-es/README.mdx
@@ -74,7 +74,8 @@ Location where snapshots are cached
 
 Snapshots are built and tested daily.  If tests pass, the snapshot is promoted and will automatically be used when started from the CLI.
 
-CI pipelines supporting this can be found at
+CI pipelines supporting this can be found at:
+
 - https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build
 - https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify
 - https://buildkite.com/elastic/kibana-elasticsearch-snapshot-promote

--- a/packages/kbn-es/README.mdx
+++ b/packages/kbn-es/README.mdx
@@ -70,6 +70,15 @@ Type: `String`
 
 Location where snapshots are cached
 
+## Snapshot Updates
+
+Snapshots are built and tested daily.  If tests pass, the snapshot is promoted and will automatically be used when started from the CLI.
+
+CI pipelines supporting this can be found at
+- https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build
+- https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify
+- https://buildkite.com/elastic/kibana-elasticsearch-snapshot-promote
+
 ## Snapshot Pinning
 
 Sometimes we need to pin snapshots for a specific version. We'd really like to get this automated, but until that is completed here are the steps to take to build, upload, and switch to pinned snapshots for a branch.


### PR DESCRIPTION
There was recent discussion on tracking down a possible ES regression, and the best way to find the snapshot build schedule.  This updates our dev docs to include links to the snapshot update pipelines.