### PR TITLE
[8.6] Disable performance journeys

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -53,7 +53,6 @@ disabled:
   - x-pack/test/alerting_api_integration/spaces_only_legacy/config.ts
   - x-pack/test/cloud_integration/config.ts
   - x-pack/test/performance/config.playwright.ts
-
   - x-pack/test/load/config.ts
   - x-pack/test/plugin_api_perf/config.js
   - x-pack/test/screenshot_creation/config.ts

--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -52,7 +52,9 @@ disabled:
   - x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/config.ts
   - x-pack/test/alerting_api_integration/spaces_only_legacy/config.ts
   - x-pack/test/cloud_integration/config.ts
-  - x-pack/test/performance/config.playwright.ts
+  # Failing: browserType.launch: Executable doesn't exist
+  # https://github.com/elastic/kibana/issues/148219
+  # - x-pack/test/performance/config.playwright.ts
   - x-pack/test/load/config.ts
   - x-pack/test/plugin_api_perf/config.js
   - x-pack/test/screenshot_creation/config.ts

--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -62,7 +62,14 @@ disabled:
   - x-pack/test/scalability/config.ts
 
   # Failing: browserType.launch: Executable doesn't exist
+  # https://github.com/elastic/kibana/issues/148213
+  # https://github.com/elastic/kibana/issues/148214
+  # https://github.com/elastic/kibana/issues/148215
+  # https://github.com/elastic/kibana/issues/148216
+  # https://github.com/elastic/kibana/issues/148217
+  # https://github.com/elastic/kibana/issues/148218
   # https://github.com/elastic/kibana/issues/148219
+  # https://github.com/elastic/kibana/issues/148220
   - x-pack/performance/journeys/ecommerce_dashboard.ts
   - x-pack/performance/journeys/ecommerce_dashboard_map_only.ts
   - x-pack/performance/journeys/flight_dashboard.ts

--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -52,9 +52,8 @@ disabled:
   - x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/config.ts
   - x-pack/test/alerting_api_integration/spaces_only_legacy/config.ts
   - x-pack/test/cloud_integration/config.ts
-  # Failing: browserType.launch: Executable doesn't exist
-  # https://github.com/elastic/kibana/issues/148219
-  # - x-pack/test/performance/config.playwright.ts
+  - x-pack/test/performance/config.playwright.ts
+
   - x-pack/test/load/config.ts
   - x-pack/test/plugin_api_perf/config.js
   - x-pack/test/screenshot_creation/config.ts
@@ -62,6 +61,19 @@ disabled:
 
   # Scalability testing config that we run in its own pipeline
   - x-pack/test/scalability/config.ts
+
+  # Failing: browserType.launch: Executable doesn't exist
+  # https://github.com/elastic/kibana/issues/148219
+  - x-pack/performance/journeys/ecommerce_dashboard.ts
+  - x-pack/performance/journeys/ecommerce_dashboard_map_only.ts
+  - x-pack/performance/journeys/flight_dashboard.ts
+  - x-pack/performance/journeys/login.ts
+  - x-pack/performance/journeys/many_fields_discover.ts
+  - x-pack/performance/journeys/promotion_tracking_dashboard.ts
+  - x-pack/performance/journeys/web_logs_dashboard.ts
+  - x-pack/performance/journeys/data_stress_test_lens.ts
+  - x-pack/performance/journeys/ecommerce_dashboard_saved_search_only.ts
+  - x-pack/performance/journeys/ecommerce_dashboard_tsvb_gauge_only.ts
 
 defaultQueue: 'n2-4-spot'
 enabled:
@@ -279,13 +291,3 @@ enabled:
   - x-pack/test/ui_capabilities/spaces_only/config.ts
   - x-pack/test/upgrade_assistant_integration/config.js
   - x-pack/test/usage_collection/config.ts
-  - x-pack/performance/journeys/ecommerce_dashboard.ts
-  - x-pack/performance/journeys/ecommerce_dashboard_map_only.ts
-  - x-pack/performance/journeys/flight_dashboard.ts
-  - x-pack/performance/journeys/login.ts
-  - x-pack/performance/journeys/many_fields_discover.ts
-  - x-pack/performance/journeys/promotion_tracking_dashboard.ts
-  - x-pack/performance/journeys/web_logs_dashboard.ts
-  - x-pack/performance/journeys/data_stress_test_lens.ts
-  - x-pack/performance/journeys/ecommerce_dashboard_saved_search_only.ts
-  - x-pack/performance/journeys/ecommerce_dashboard_tsvb_gauge_only.ts


### PR DESCRIPTION
These are currently failing: `browserType.launch: Executable doesn't exist`

https://github.com/elastic/kibana/issues/148213
https://github.com/elastic/kibana/issues/148214
https://github.com/elastic/kibana/issues/148215
https://github.com/elastic/kibana/issues/148216
https://github.com/elastic/kibana/issues/148217
https://github.com/elastic/kibana/issues/148218
https://github.com/elastic/kibana/issues/148219
https://github.com/elastic/kibana/issues/148220