### PR TITLE
[TIP] Extract testIds to separate files to maintain them easier

### DIFF
--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -7,19 +7,65 @@
 
 /* Breadcrumbs */
 
-export const BREADCRUMBS = '[data-test-subj="breadcrumbs"]';
+import { INSPECT_BUTTON_TEST_ID } from '../../public/modules/indicators/components/table/hooks/test_ids';
+import { PANEL_TEST_ID } from '../../public/components/empty_state/test_ids';
+import {
+  FILTER_IN_BUTTON_TEST_ID as LEGEND_FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID as LEGEND_FILTER_OUT_BUTTON_TEST_ID,
+  POPOVER_BUTTON_TEST_ID as LEGEND_POPOVER_BUTTON_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID as LEGEND_TIMELINE_BUTTON_TEST_ID,
+} from '../../public/modules/indicators/components/barchart/legend_action/test_ids';
+import { DROPDOWN_TEST_ID } from '../../public/modules/indicators/components/barchart/field_selector/test_ids';
+import {
+  ADD_TO_EXISTING_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID,
+  INVESTIGATE_IN_TIMELINE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID,
+  TAKE_ACTION_BUTTON_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_TAKE_ACTION_BUTTON_TEST_ID,
+} from '../../public/modules/indicators/components/flyout/take_action/test_ids';
+import {
+  INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
+  INDICATORS_FLYOUT_OVERVIEW_TABLE,
+} from '../../public/modules/indicators/components/flyout/overview_tab/test_ids';
+import { CODE_BLOCK_TEST_ID } from '../../public/modules/indicators/components/flyout/json_tab/test_ids';
+import { FLYOUT_TABLE_TEST_ID } from '../../public/modules/indicators/components/flyout/table_tab/test_ids';
+import {
+  INDICATORS_FLYOUT_TABS_TEST_ID,
+  INDICATORS_FLYOUT_TITLE_TEST_ID,
+} from '../../public/modules/indicators/components/flyout/test_ids';
+import {
+  ADD_TO_EXISTING_TEST_ID as INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID as INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID,
+  MORE_ACTIONS_TEST_ID as INDICATORS_TABLE_MORE_ACTIONS_TEST_ID,
+} from '../../public/modules/indicators/components/table/components/more_actions/test_ids';
+import { BUTTON_TEST_ID } from '../../public/modules/indicators/components/table/components/open_flyout_button/test_ids';
+import {
+  FILTER_IN_BUTTON_TEST_ID as CELL_FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID as CELL_FILTER_OUT_BUTTON_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID as CELL_TIMELINE_BUTTON_TEST_ID,
+  INVESTIGATE_IN_TIMELINE_TEST_ID as CELL_INVESTIGATE_IN_TIMELINE_TEST_ID,
+} from '../../public/modules/indicators/components/table/components/test_ids';
+import { TABLE_TEST_ID } from '../../public/modules/indicators/components/table/test_ids';
+import { TITLE_TEST_ID } from '../../public/components/layout/test_ids';
+import {
+  TIMELINE_BUTTON_TEST_ID as VALUE_ACTION_TIMELINE_BUTTON_TEST_ID,
+  FILTER_IN_BUTTON_TEST_ID as VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID as VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID,
+  POPOVER_BUTTON_TEST_ID as VALUE_ACTION_POPOVER_BUTTON_TEST_ID,
+} from '../../public/modules/indicators/components/flyout/indicator_value_actions/test_ids';
 
-export const LEADING_BREADCRUMB = '[data-test-subj="breadcrumb first"]';
+export const BREADCRUMBS = `[data-test-subj="breadcrumbs"]`;
 
-export const ENDING_BREADCRUMB = '[data-test-subj="breadcrumb last"]';
+export const LEADING_BREADCRUMB = `[data-test-subj="breadcrumb first"]`;
 
-/* Titles */
+export const ENDING_BREADCRUMB = `[data-test-subj="breadcrumb last"]`;
 
-export const DEFAULT_LAYOUT_TITLE = `[data-test-subj="tiDefaultPageLayoutTitle"]`;
+/* Title */
+
+export const DEFAULT_LAYOUT_TITLE = `[data-test-subj="${TITLE_TEST_ID}"]`;
 
 /* Indicators Table */
 
-export const INDICATORS_TABLE = `[data-test-subj="tiIndicatorsTable"]`;
+export const INDICATORS_TABLE = `[data-test-subj="${TABLE_TEST_ID}"]`;
 
 export const INDICATORS_TABLE_ROW_CELL = `[data-test-subj="dataGridRowCell"]`;
 
@@ -37,103 +83,79 @@ export const INDICATORS_TABLE_FIRST_SEEN_COLUMN_HEADER = `[data-test-subj="dataG
 
 export const INDICATORS_TABLE_LAST_SEEN_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.indicator.last_seen"]`;
 
-export const TABLE_CONTROLS = '[data-test-subj="dataGridControls"]';
+export const TABLE_CONTROLS = `[data-test-subj="dataGridControls"]`;
 
-export const INDICATOR_TYPE_CELL =
-  '[role="gridcell"][data-gridcell-column-id="threat.indicator.type"]';
+export const INDICATOR_TYPE_CELL = `[role="gridcell"][data-gridcell-column-id="threat.indicator.type"]`;
 
-export const INDICATORS_TABLE_CELL_TIMELINE_BUTTON =
-  '[data-test-subj="tiIndicatorsTableCellTimelineButton"] button';
+export const INDICATORS_TABLE_CELL_TIMELINE_BUTTON = `[data-test-subj="${CELL_TIMELINE_BUTTON_TEST_ID}"] button`;
 
-export const INDICATORS_TABLE_CELL_FILTER_IN_BUTTON =
-  '[data-test-subj="tiIndicatorsTableCellFilterInButton"] button';
+export const INDICATORS_TABLE_CELL_FILTER_IN_BUTTON = `[data-test-subj="${CELL_FILTER_IN_BUTTON_TEST_ID}"] button`;
 
-export const INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON =
-  '[data-test-subj="tiIndicatorsTableCellFilterOutButton"] button';
+export const INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON = `[data-test-subj="${CELL_FILTER_OUT_BUTTON_TEST_ID}"] button`;
 
-export const INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON =
-  '[data-test-subj="tiIndicatorTableInvestigateInTimelineButtonIcon"]';
+export const INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON = `[data-test-subj="${CELL_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
 
-export const INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON =
-  '[data-test-subj="tiIndicatorTableMoreActionsButton"]';
+export const INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_MORE_ACTIONS_TEST_ID}"]`;
 
-export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON =
-  '[data-test-subj="tiIndicatorTableAddToNewCaseContextMenu"]';
+export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID}"]`;
 
-export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON =
-  '[data-test-subj="tiIndicatorTableAddToExistingCaseContextMenu"]';
+export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID}"]`;
 
 /* Flyout */
 
-export const TOGGLE_FLYOUT_BUTTON = `[data-test-subj="tiToggleIndicatorFlyoutButton"]`;
+export const TOGGLE_FLYOUT_BUTTON = `[data-test-subj="${BUTTON_TEST_ID}"]`;
 
 export const FLYOUT_CLOSE_BUTTON = `[data-test-subj="euiFlyoutCloseButton"]`;
 
-export const FLYOUT_TITLE = `[data-test-subj="tiIndicatorFlyoutTitle"]`;
+export const FLYOUT_TITLE = `[data-test-subj="${INDICATORS_FLYOUT_TITLE_TEST_ID}"]`;
 
-export const FLYOUT_TABS = `[data-test-subj="tiIndicatorFlyoutTabs"]`;
+export const FLYOUT_TABS = `[data-test-subj="${INDICATORS_FLYOUT_TABS_TEST_ID}"]`;
 
-export const FLYOUT_TABLE = `[data-test-subj="tiFlyoutTable"]`;
+export const FLYOUT_TABLE = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}"]`;
 
-export const FLYOUT_JSON = `[data-test-subj="tiFlyoutJsonCodeBlock"]`;
+export const FLYOUT_JSON = `[data-test-subj="${CODE_BLOCK_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewTableRowTimelineButton"]';
+export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewTableRowFilterInButton"]';
+export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewTableRowFilterOutButton"]';
+export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM =
-  '[data-test-subj="tiFlyoutOverviewHighLevelBlocksItem"]';
+export const FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}Item"]`;
 
-export const FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewHighLevelBlocksTimelineButton"]';
+export const FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewHighLevelBlocksFilterInButton"]';
+export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewHighLevelBlocksFilterOutButton"]';
+export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_TABLE_MORE_ACTIONS_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewTableRowPopoverButton"] button';
+export const FLYOUT_TABLE_MORE_ACTIONS_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_POPOVER_BUTTON_TEST_ID}"] button`;
 
-export const FLYOUT_BLOCK_MORE_ACTIONS_BUTTON =
-  '[data-test-subj="tiFlyoutOverviewHighLevelBlocksPopoverButton"] button';
+export const FLYOUT_BLOCK_MORE_ACTIONS_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_POPOVER_BUTTON_TEST_ID}"] button`;
 
-export const FLYOUT_TABLE_TAB_ROW_TIMELINE_BUTTON =
-  '[data-test-subj="tiFlyoutTableTimelineButton"]';
+export const FLYOUT_TABLE_TAB_ROW_TIMELINE_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON =
-  '[data-test-subj="tiFlyoutTableFilterInButton"]';
+export const FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON =
-  '[data-test-subj="tiFlyoutTableFilterOutButton"]';
+export const FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_TAKE_ACTION_BUTTON = '[data-test-subj="tiIndicatorFlyoutTakeActionButton"]';
+export const FLYOUT_TAKE_ACTION_BUTTON = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_TAKE_ACTION_BUTTON_TEST_ID}"]`;
 
-export const FLYOUT_ADD_TO_EXISTING_CASE_ITEM =
-  '[data-test-subj="tiIndicatorFlyoutAddToExistingCaseContextMenu"]';
+export const FLYOUT_ADD_TO_EXISTING_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID}"]`;
 
-export const FLYOUT_ADD_TO_NEW_CASE_ITEM =
-  '[data-test-subj="tiIndicatorFlyoutAddToNewCaseContextMenu"]';
+export const FLYOUT_ADD_TO_NEW_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID}"]`;
 
-export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM =
-  '[data-test-subj="tiIndicatorFlyoutInvestigateInTimelineContextMenu"]';
+export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
 
 /* Field selector */
 
-export const FIELD_SELECTOR = '[data-test-subj="tiIndicatorFieldSelectorDropdown"]';
+export const FIELD_SELECTOR = `[data-test-subj="${DROPDOWN_TEST_ID}"]`;
 
-export const FIELD_SELECTOR_INPUT = '[data-test-subj="comboBoxInput"]';
+export const FIELD_SELECTOR_INPUT = `[data-test-subj="comboBoxInput"]`;
 
-export const FIELD_SELECTOR_TOGGLE_BUTTON = '[data-test-subj="comboBoxToggleListButton"]';
+export const FIELD_SELECTOR_TOGGLE_BUTTON = `[data-test-subj="comboBoxToggleListButton"]`;
 
-export const FIELD_SELECTOR_LIST =
-  '[data-test-subj="comboBoxOptionsList tiIndicatorFieldSelectorDropdown-optionsList"]';
+export const FIELD_SELECTOR_LIST = `[data-test-subj="comboBoxOptionsList ${DROPDOWN_TEST_ID}-optionsList"]`;
 
 /* Field browser */
 
@@ -143,60 +165,58 @@ export const FIELD_BROWSER_MODAL = `[data-test-subj="fields-browser-container"]`
 
 /* Barchart */
 
-export const BARCHART_POPOVER_BUTTON = '[data-test-subj="tiBarchartPopoverButton"]';
+export const BARCHART_POPOVER_BUTTON = `[data-test-subj="${LEGEND_POPOVER_BUTTON_TEST_ID}"]`;
 
-export const BARCHART_TIMELINE_BUTTON = '[data-test-subj="tiBarchartTimelineButton"]';
+export const BARCHART_TIMELINE_BUTTON = `[data-test-subj="${LEGEND_TIMELINE_BUTTON_TEST_ID}"]`;
 
-export const BARCHART_FILTER_IN_BUTTON = '[data-test-subj="tiBarchartFilterInButton"]';
+export const BARCHART_FILTER_IN_BUTTON = `[data-test-subj="${LEGEND_FILTER_IN_BUTTON_TEST_ID}"]`;
 
-export const BARCHART_FILTER_OUT_BUTTON = '[data-test-subj="tiBarchartFilterOutButton"]';
+export const BARCHART_FILTER_OUT_BUTTON = `[data-test-subj="${LEGEND_FILTER_OUT_BUTTON_TEST_ID}"]`;
 
 /* Cases */
 
-export const CREAT_CASE_BUTTON = '[data-test-subj="createNewCaseBtn"]';
+export const CREAT_CASE_BUTTON = `[data-test-subj="createNewCaseBtn"]`;
 
-export const SELECT_EXISTING_CASE = '[class="eui-textTruncate"]';
+export const SELECT_EXISTING_CASE = `[class="eui-textTruncate"]`;
 
-export const VIEW_CASE_TOASTER_LINK = '[data-test-subj="toaster-content-case-view-link"]';
+export const VIEW_CASE_TOASTER_LINK = `[data-test-subj="toaster-content-case-view-link"]`;
 
-export const CASE_COMMENT_EXTERNAL_REFERENCE =
-  '[data-test-subj="comment-externalReference-indicator"]';
+export const CASE_COMMENT_EXTERNAL_REFERENCE = `[data-test-subj="comment-externalReference-indicator"]`;
 
-export const CASE_ACTION_WRAPPER = '[data-test-subj="case-action-bar-wrapper"]';
+export const CASE_ACTION_WRAPPER = `[data-test-subj="case-action-bar-wrapper"]`;
 
-export const CASE_ELLIPSE_BUTTON = '[data-test-subj="property-actions-ellipses"]';
+export const CASE_ELLIPSE_BUTTON = `[data-test-subj="property-actions-ellipses"]`;
 
-export const CASE_ELLIPSE_DELETE_CASE_OPTION = '[data-test-subj="property-actions-trash"]';
+export const CASE_ELLIPSE_DELETE_CASE_OPTION = `[data-test-subj="property-actions-trash"]`;
 
-export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON =
-  '[data-test-subj="confirmModalConfirmButton"]';
+export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON = `[data-test-subj="confirmModalConfirmButton"]`;
 
-export const NEW_CASE_NAME_INPUT = '[data-test-subj="input"][aria-describedby="caseTitle"]';
+export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="caseTitle"]`;
 
-export const NEW_CASE_DESCRIPTION_INPUT = '[data-test-subj="euiMarkdownEditorTextArea"]';
+export const NEW_CASE_DESCRIPTION_INPUT = `[data-test-subj="euiMarkdownEditorTextArea"]`;
 
-export const NEW_CASE_CREATE_BUTTON = '[data-test-subj="create-case-submit"]';
+export const NEW_CASE_CREATE_BUTTON = `[data-test-subj="create-case-submit"]`;
 
 /* Miscellaneous */
 
-export const UNTITLED_TIMELINE_BUTTON = '[data-test-subj="flyoutOverlay"]';
+export const UNTITLED_TIMELINE_BUTTON = `[data-test-subj="flyoutOverlay"]`;
 
-export const TIMELINE_DRAGGABLE_ITEM = '[data-test-subj="providerContainer"]';
+export const TIMELINE_DRAGGABLE_ITEM = `[data-test-subj="providerContainer"]`;
 
-export const KQL_FILTER = '[id="popoverFor_filter0"]';
+export const KQL_FILTER = `[id="popoverFor_filter0"]`;
 
-export const FILTERS_GLOBAL_CONTAINER = '[data-test-subj="filters-global-container"]';
+export const FILTERS_GLOBAL_CONTAINER = `[data-test-subj="filters-global-container"]`;
 
 export const TIME_RANGE_PICKER = `[data-test-subj="superDatePickerToggleQuickMenuButton"]`;
 
 export const QUERY_INPUT = `[data-test-subj="queryInput"]`;
 
-export const EMPTY_STATE = '[data-test-subj="indicatorsTableEmptyState"]';
+export const EMPTY_STATE = `[data-test-subj="${PANEL_TEST_ID}"]`;
 
-export const INSPECTOR_BUTTON = '[data-test-subj="tiIndicatorsGridInspect"]';
+export const INSPECTOR_BUTTON = `[data-test-subj="${INSPECT_BUTTON_TEST_ID}"]`;
 
-export const INSPECTOR_PANEL = '[data-test-subj="inspectorPanel"]';
+export const INSPECTOR_PANEL = `[data-test-subj="inspectorPanel"]`;
 
-export const ADD_INTEGRATIONS_BUTTON = '[data-test-subj="add-data"]';
+export const ADD_INTEGRATIONS_BUTTON = `[data-test-subj="add-data"]`;
 
-export const REFRESH_BUTTON = '[data-test-subj="querySubmitButton"]';
+export const REFRESH_BUTTON = `[data-test-subj="querySubmitButton"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/select_range.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/select_range.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { TIME_RANGE_PICKER } from '../screens/indicators';
+import { EMPTY_STATE, TIME_RANGE_PICKER } from '../screens/indicators';
 
 export const selectRange = () => {
-  cy.get(`[data-test-subj="indicatorsTableEmptyState"]`);
+  cy.get(EMPTY_STATE);
 
   cy.get(TIME_RANGE_PICKER).first().click({ force: true });
   cy.get('[aria-label="Time unit"]').select('y');

--- a/x-pack/plugins/threat_intelligence/cypress/tsconfig.json
+++ b/x-pack/plugins/threat_intelligence/cypress/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "include": [
-    "**/*",
-    "fixtures/**/*.json"
-  ],
-  "exclude": [
-    "target/**/*"
-  ],
+  "include": ["**/*", "fixtures/**/*.json"],
+  "exclude": ["target/**/*"],
   "compilerOptions": {
     "outDir": "target/types",
-    "types": [
-      "cypress",
-      "cypress-file-upload",
-      "cypress-pipe",
-      "node",
-    ],
+    "types": ["cypress", "cypress-file-upload", "cypress-pipe", "node"]
   },
 }

--- a/x-pack/plugins/threat_intelligence/public/components/empty_state/empty_state.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/empty_state/empty_state.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiImage, EuiPanel, EuiText, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import icon from './no_results.svg';
+import { PANEL_TEST_ID } from './test_ids';
 
 const heights = {
   tall: 490,
@@ -21,7 +22,7 @@ const panelStyle = {
 
 export const EmptyState: React.FC<{ height?: keyof typeof heights }> = ({ height = 'tall' }) => {
   return (
-    <EuiPanel color="subdued" data-test-subj="indicatorsTableEmptyState">
+    <EuiPanel color="subdued" data-test-subj={PANEL_TEST_ID}>
       <EuiFlexGroup style={{ height: heights[height] }} alignItems="center" justifyContent="center">
         <EuiFlexItem grow={false}>
           <EuiPanel hasBorder={true} style={panelStyle}>

--- a/x-pack/plugins/threat_intelligence/public/components/empty_state/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/components/empty_state/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const PANEL_TEST_ID = 'tiIndicatorsTableEmptyState';

--- a/x-pack/plugins/threat_intelligence/public/components/layout/layout.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/layout/layout.test.tsx
@@ -7,9 +7,10 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { DefaultPageLayout, TITLE_TEST_ID } from './layout';
+import { DefaultPageLayout } from './layout';
 import '@testing-library/jest-dom';
 import { TestProvidersComponent } from '../../common/mocks/test_providers';
+import { TITLE_TEST_ID } from './test_ids';
 
 describe('<Layout />', () => {
   describe('when pageTitle is not specified', () => {

--- a/x-pack/plugins/threat_intelligence/public/components/layout/layout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/layout/layout.tsx
@@ -8,14 +8,13 @@
 import { EuiPageHeader, EuiPageHeaderSection, EuiSpacer, EuiText } from '@elastic/eui';
 import React, { FC, ReactNode } from 'react';
 import { SecuritySolutionPageWrapper } from '../../containers/security_solution_page_wrapper';
+import { TITLE_TEST_ID } from './test_ids';
 
 export interface LayoutProps {
   pageTitle?: string;
   border?: boolean;
   subHeader?: ReactNode;
 }
-
-export const TITLE_TEST_ID = 'tiDefaultPageLayoutTitle';
 
 export const DefaultPageLayout: FC<LayoutProps> = ({
   children,

--- a/x-pack/plugins/threat_intelligence/public/components/layout/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/components/layout/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TITLE_TEST_ID = 'tiDefaultPageLayoutTitle';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/field_selector.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/field_selector.tsx
@@ -13,8 +13,7 @@ import { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/t
 import { SecuritySolutionDataViewBase } from '../../../../../types';
 import { RawIndicatorFieldId } from '../../../../../../common/types/indicator';
 import { useStyles } from './styles';
-
-export const DROPDOWN_TEST_ID = 'tiIndicatorFieldSelectorDropdown';
+import { DROPDOWN_TEST_ID } from './test_ids';
 
 export interface IndicatorsFieldSelectorProps {
   indexPattern: SecuritySolutionDataViewBase;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const DROPDOWN_TEST_ID = 'tiIndicatorFieldSelectorDropdown';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
@@ -11,12 +11,13 @@ import { i18n } from '@kbn/i18n';
 import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 import { FilterInContextMenu, FilterOutContextMenu } from '../../../../query_bar';
 import { AddToTimelineContextMenu } from '../../../../timeline';
-
-export const POPOVER_BUTTON_TEST_ID = 'tiBarchartPopoverButton';
-export const TIMELINE_BUTTON_TEST_ID = 'tiBarchartTimelineButton';
-export const FILTER_IN_BUTTON_TEST_ID = 'tiBarchartFilterInButton';
-export const FILTER_OUT_BUTTON_TEST_ID = 'tiBarchartFilterOutButton';
-export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'tiBarchartCopyToClipboardButton';
+import {
+  COPY_TO_CLIPBOARD_BUTTON_TEST_ID,
+  FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID,
+  POPOVER_BUTTON_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID,
+} from './test_ids';
 
 const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.barChart.popover', {
   defaultMessage: 'More actions',

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/test_ids.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const POPOVER_BUTTON_TEST_ID = 'tiBarchartPopoverButton';
+export const TIMELINE_BUTTON_TEST_ID = 'tiBarchartTimelineButton';
+export const FILTER_IN_BUTTON_TEST_ID = 'tiBarchartFilterInButton';
+export const FILTER_OUT_BUTTON_TEST_ID = 'tiBarchartFilterOutButton';
+export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'tiBarchartCopyToClipboardButton';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.test.tsx
@@ -7,9 +7,10 @@
 
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
-import { IndicatorsFlyout, SUBTITLE_TEST_ID, TITLE_TEST_ID } from '.';
+import { IndicatorsFlyout } from '.';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
+import { INDICATORS_FLYOUT_SUBTITLE_TEST_ID, INDICATORS_FLYOUT_TITLE_TEST_ID } from './test_ids';
 
 const mockIndicator = generateMockIndicator();
 
@@ -35,7 +36,9 @@ describe('<IndicatorsFlyout />', () => {
   describe('title and subtitle', () => {
     describe('valid indicator', () => {
       it('should render correct title and subtitle', async () => {
-        expect(screen.getByTestId(TITLE_TEST_ID)).toHaveTextContent('Indicator details');
+        expect(screen.getByTestId(INDICATORS_FLYOUT_TITLE_TEST_ID)).toHaveTextContent(
+          'Indicator details'
+        );
       });
     });
 
@@ -54,8 +57,12 @@ describe('<IndicatorsFlyout />', () => {
       });
 
       it('should render correct labels', () => {
-        expect(screen.getByTestId(TITLE_TEST_ID)).toHaveTextContent('Indicator details');
-        expect(screen.getByTestId(SUBTITLE_TEST_ID)).toHaveTextContent('First seen: -');
+        expect(screen.getByTestId(INDICATORS_FLYOUT_TITLE_TEST_ID)).toHaveTextContent(
+          'Indicator details'
+        );
+        expect(screen.getByTestId(INDICATORS_FLYOUT_SUBTITLE_TEST_ID)).toHaveTextContent(
+          'First seen: -'
+        );
       });
     });
   });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/flyout.tsx
@@ -29,12 +29,11 @@ import { IndicatorsFlyoutJson } from './json_tab';
 import { IndicatorsFlyoutTable } from './table_tab';
 import { unwrapValue } from '../../utils';
 import { IndicatorsFlyoutOverview } from './overview_tab';
-
-export const TITLE_TEST_ID = 'tiIndicatorFlyoutTitle';
-export const SUBTITLE_TEST_ID = 'tiIndicatorFlyoutSubtitle';
-export const TABS_TEST_ID = 'tiIndicatorFlyoutTabs';
-export const MORE_ACTIONS_ID = 'tiIndicatorFlyoutMoreActions';
-
+import {
+  INDICATORS_FLYOUT_TABS_TEST_ID,
+  INDICATORS_FLYOUT_TITLE_TEST_ID,
+  INDICATORS_FLYOUT_SUBTITLE_TEST_ID,
+} from './test_ids';
 enum TAB_IDS {
   overview,
   table,
@@ -142,7 +141,7 @@ export const IndicatorsFlyout: VFC<IndicatorsFlyoutProps> = ({
     <EuiFlyout onClose={closeFlyout} aria-labelledby={flyoutTitleId}>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle>
-          <h2 data-test-subj={TITLE_TEST_ID} id={flyoutTitleId}>
+          <h2 data-test-subj={INDICATORS_FLYOUT_TITLE_TEST_ID} id={flyoutTitleId}>
             <FormattedMessage
               id="xpack.threatIntelligence.indicator.flyout.panelTitleWithOverviewTab"
               defaultMessage="Indicator details"
@@ -151,7 +150,7 @@ export const IndicatorsFlyout: VFC<IndicatorsFlyoutProps> = ({
         </EuiTitle>
         <EuiSpacer size="s" />
         <EuiText size={'xs'}>
-          <p data-test-subj={SUBTITLE_TEST_ID}>
+          <p data-test-subj={INDICATORS_FLYOUT_SUBTITLE_TEST_ID}>
             <FormattedMessage
               id="xpack.threatIntelligence.indicator.flyout.panelSubTitle"
               defaultMessage="First seen: "
@@ -160,7 +159,7 @@ export const IndicatorsFlyout: VFC<IndicatorsFlyoutProps> = ({
           </p>
         </EuiText>
         <EuiSpacer size="m" />
-        <EuiTabs data-test-subj={TABS_TEST_ID} style={{ marginBottom: '-25px' }}>
+        <EuiTabs data-test-subj={INDICATORS_FLYOUT_TABS_TEST_ID} style={{ marginBottom: '-25px' }}>
           {renderTabs}
         </EuiTabs>
       </EuiFlyoutHeader>

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
@@ -20,12 +20,13 @@ import { FilterInButtonIcon, FilterOutButtonIcon } from '../../../../query_bar';
 import { AddToTimelineButtonIcon, AddToTimelineContextMenu } from '../../../../timeline';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils';
 import { CopyToClipboardButtonIcon, CopyToClipboardContextMenu } from '../../copy_to_clipboard';
-
-export const TIMELINE_BUTTON_TEST_ID = 'TimelineButton';
-export const FILTER_IN_BUTTON_TEST_ID = 'FilterInButton';
-export const FILTER_OUT_BUTTON_TEST_ID = 'FilterOutButton';
-export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'CopyToClipboardButton';
-export const POPOVER_BUTTON_TEST_ID = 'PopoverButton';
+import {
+  COPY_TO_CLIPBOARD_BUTTON_TEST_ID,
+  FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID,
+  POPOVER_BUTTON_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID,
+} from './test_ids';
 
 const MORE_ACTIONS_BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.more-actions.popover', {
   defaultMessage: 'More actions',

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/test_ids.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TIMELINE_BUTTON_TEST_ID = 'TimelineButton';
+export const FILTER_IN_BUTTON_TEST_ID = 'FilterInButton';
+export const FILTER_OUT_BUTTON_TEST_ID = 'FilterOutButton';
+export const COPY_TO_CLIPBOARD_BUTTON_TEST_ID = 'CopyToClipboardButton';
+export const POPOVER_BUTTON_TEST_ID = 'PopoverButton';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/json_tab.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/json_tab.test.tsx
@@ -9,8 +9,9 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { TestProvidersComponent } from '../../../../../common/mocks/test_providers';
 import { generateMockIndicator, Indicator } from '../../../../../../common/types/indicator';
-import { CODE_BLOCK_TEST_ID, IndicatorsFlyoutJson } from '.';
+import { IndicatorsFlyoutJson } from '.';
 import { EMPTY_PROMPT_TEST_ID } from '../empty_prompt';
+import { CODE_BLOCK_TEST_ID } from './test_ids';
 
 const mockIndicator: Indicator = generateMockIndicator();
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/json_tab.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/json_tab.tsx
@@ -9,8 +9,7 @@ import React, { VFC } from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { IndicatorEmptyPrompt } from '../empty_prompt';
-
-export const CODE_BLOCK_TEST_ID = 'tiFlyoutJsonCodeBlock';
+import { CODE_BLOCK_TEST_ID } from './test_ids';
 
 export interface IndicatorsFlyoutJsonProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/json_tab/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CODE_BLOCK_TEST_ID = 'tiFlyoutJsonCodeBlock';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.test.tsx
@@ -9,14 +9,14 @@ import { TestProvidersComponent } from '../../../../../common/mocks/test_provide
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { generateMockIndicator, Indicator } from '../../../../../../common/types/indicator';
-import {
-  IndicatorsFlyoutOverview,
-  TI_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
-  TI_FLYOUT_OVERVIEW_TABLE,
-  TI_FLYOUT_OVERVIEW_TITLE,
-} from '.';
+import { IndicatorsFlyoutOverview } from '.';
 import { EMPTY_PROMPT_TEST_ID } from '../empty_prompt';
 import { IndicatorsFlyoutContext } from '../context';
+import {
+  INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
+  INDICATORS_FLYOUT_OVERVIEW_TABLE,
+  INDICATORS_FLYOUT_OVERVIEW_TITLE,
+} from './test_ids';
 
 describe('<IndicatorsFlyoutOverview />', () => {
   describe('invalid indicator', () => {
@@ -56,8 +56,8 @@ describe('<IndicatorsFlyoutOverview />', () => {
       </TestProvidersComponent>
     );
 
-    expect(screen.queryByTestId(TI_FLYOUT_OVERVIEW_TABLE)).toBeInTheDocument();
-    expect(screen.queryByTestId(TI_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS)).toBeInTheDocument();
+    expect(screen.queryByTestId(INDICATORS_FLYOUT_OVERVIEW_TABLE)).toBeInTheDocument();
+    expect(screen.queryByTestId(INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS)).toBeInTheDocument();
   });
 
   it('should render the indicator name value in the title', () => {
@@ -75,7 +75,9 @@ describe('<IndicatorsFlyoutOverview />', () => {
       </TestProvidersComponent>
     );
 
-    expect(screen.queryByTestId(TI_FLYOUT_OVERVIEW_TITLE)?.innerHTML).toContain(indicatorName);
+    expect(screen.queryByTestId(INDICATORS_FLYOUT_OVERVIEW_TITLE)?.innerHTML).toContain(
+      indicatorName
+    );
   });
 
   it('should render the indicator name passed via context in the title', () => {
@@ -95,7 +97,7 @@ describe('<IndicatorsFlyoutOverview />', () => {
       </TestProvidersComponent>
     );
 
-    expect(screen.queryByTestId(TI_FLYOUT_OVERVIEW_TITLE)?.innerHTML).toContain(
+    expect(screen.queryByTestId(INDICATORS_FLYOUT_OVERVIEW_TITLE)?.innerHTML).toContain(
       context.indicatorName
     );
   });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/overview_tab.tsx
@@ -23,6 +23,11 @@ import { unwrapValue } from '../../../utils';
 import { IndicatorEmptyPrompt } from '../empty_prompt';
 import { IndicatorBlock } from './block';
 import { HighlightedValuesTable } from './highlighted_values_table';
+import {
+  INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
+  INDICATORS_FLYOUT_OVERVIEW_TABLE,
+  INDICATORS_FLYOUT_OVERVIEW_TITLE,
+} from './test_ids';
 
 const highLevelFields = [
   RawIndicatorFieldId.Feed,
@@ -30,10 +35,6 @@ const highLevelFields = [
   RawIndicatorFieldId.MarkingTLP,
   RawIndicatorFieldId.Confidence,
 ];
-
-export const TI_FLYOUT_OVERVIEW_TITLE = 'tiFlyoutOverviewTitle';
-export const TI_FLYOUT_OVERVIEW_TABLE = 'tiFlyoutOverviewTableRow';
-export const TI_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS = 'tiFlyoutOverviewHighLevelBlocks';
 
 export interface IndicatorsFlyoutOverviewProps {
   indicator: Indicator;
@@ -50,13 +51,13 @@ export const IndicatorsFlyoutOverview: VFC<IndicatorsFlyoutOverviewProps> = ({
 
   const highLevelBlocks = useMemo(
     () => (
-      <EuiFlexGroup data-test-subj={TI_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}>
+      <EuiFlexGroup data-test-subj={INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}>
         {highLevelFields.map((field) => (
           <EuiFlexItem key={field}>
             <IndicatorBlock
               indicator={indicator}
               field={field}
-              data-test-subj={TI_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}
+              data-test-subj={INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}
             />
           </EuiFlexItem>
         ))}
@@ -83,7 +84,7 @@ export const IndicatorsFlyoutOverview: VFC<IndicatorsFlyoutOverviewProps> = ({
   return (
     <>
       <EuiTitle>
-        <h2 data-test-subj={TI_FLYOUT_OVERVIEW_TITLE}>{title}</h2>
+        <h2 data-test-subj={INDICATORS_FLYOUT_OVERVIEW_TITLE}>{title}</h2>
       </EuiTitle>
 
       {indicatorDescription}
@@ -115,7 +116,10 @@ export const IndicatorsFlyoutOverview: VFC<IndicatorsFlyoutOverviewProps> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <HighlightedValuesTable indicator={indicator} data-test-subj={TI_FLYOUT_OVERVIEW_TABLE} />
+      <HighlightedValuesTable
+        indicator={indicator}
+        data-test-subj={INDICATORS_FLYOUT_OVERVIEW_TABLE}
+      />
     </>
   );
 };

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/overview_tab/test_ids.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const INDICATORS_FLYOUT_OVERVIEW_TITLE = 'tiFlyoutOverviewTitle';
+export const INDICATORS_FLYOUT_OVERVIEW_TABLE = 'tiFlyoutOverviewTableRow';
+export const INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS = 'tiFlyoutOverviewHighLevelBlocks';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.test.tsx
@@ -13,10 +13,11 @@ import {
   Indicator,
   RawIndicatorFieldId,
 } from '../../../../../../common/types/indicator';
-import { IndicatorsFlyoutTable, TABLE_TEST_ID } from '.';
+import { IndicatorsFlyoutTable } from '.';
 import { unwrapValue } from '../../../utils';
 import { EMPTY_PROMPT_TEST_ID } from '../empty_prompt';
 import { IndicatorsFlyoutContext } from '../context';
+import { FLYOUT_TABLE_TEST_ID } from './test_ids';
 
 const mockIndicator: Indicator = generateMockIndicator();
 
@@ -34,7 +35,7 @@ describe('<IndicatorsFlyoutTable />', () => {
       </TestProvidersComponent>
     );
 
-    expect(getByTestId(TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(FLYOUT_TABLE_TEST_ID)).toBeInTheDocument();
 
     expect(getByText(RawIndicatorFieldId.Feed)).toBeInTheDocument();
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/table_tab.tsx
@@ -9,8 +9,7 @@ import React, { VFC } from 'react';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { IndicatorEmptyPrompt } from '../empty_prompt';
 import { IndicatorFieldsTable } from '../fields_table';
-
-export const TABLE_TEST_ID = 'tiFlyoutTable';
+import { FLYOUT_TABLE_TEST_ID } from './test_ids';
 
 const search = {
   box: {
@@ -37,7 +36,7 @@ export const IndicatorsFlyoutTable: VFC<IndicatorsFlyoutTableProps> = ({ indicat
     <IndicatorEmptyPrompt />
   ) : (
     <IndicatorFieldsTable
-      data-test-subj={TABLE_TEST_ID}
+      data-test-subj={FLYOUT_TABLE_TEST_ID}
       search={search}
       fields={items}
       indicator={indicator}

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/table_tab/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const FLYOUT_TABLE_TEST_ID = 'tiFlyoutTable';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
@@ -12,13 +12,12 @@ import { AddToNewCase } from '../../../../cases/components/add_to_new_case/add_t
 import { AddToExistingCase } from '../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { InvestigateInTimelineContextMenu } from '../../../../timeline';
-
-export const TAKE_ACTION_BUTTON_TEST_ID = 'tiIndicatorFlyoutTakeActionButton';
-export const INVESTIGATE_IN_TIMELINE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorFlyoutInvestigateInTimelineContextMenu';
-export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorFlyoutAddToExistingCaseContextMenu';
-export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorFlyoutAddToNewCaseContextMenu';
+import {
+  ADD_TO_EXISTING_CASE_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID,
+  INVESTIGATE_IN_TIMELINE_TEST_ID,
+  TAKE_ACTION_BUTTON_TEST_ID,
+} from './test_ids';
 
 export interface TakeActionProps {
   /**
@@ -44,17 +43,17 @@ export const TakeAction: VFC<TakeActionProps> = ({ indicator }) => {
     <InvestigateInTimelineContextMenu
       data={indicator}
       onClick={closePopover}
-      data-test-subj={INVESTIGATE_IN_TIMELINE_CONTEXT_MENU_TEST_ID}
+      data-test-subj={INVESTIGATE_IN_TIMELINE_TEST_ID}
     />,
     <AddToExistingCase
       indicator={indicator}
       onClick={closePopover}
-      data-test-subj={ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_EXISTING_CASE_TEST_ID}
     />,
     <AddToNewCase
       indicator={indicator}
       onClick={closePopover}
-      data-test-subj={ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_NEW_CASE_TEST_ID}
     />,
   ];
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/test_ids.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TAKE_ACTION_BUTTON_TEST_ID = 'tiIndicatorFlyoutTakeActionButton';
+export const INVESTIGATE_IN_TIMELINE_TEST_ID = 'tiIndicatorFlyoutInvestigateInTimelineContextMenu';
+export const ADD_TO_EXISTING_CASE_TEST_ID = 'tiIndicatorFlyoutAddToExistingCaseContextMenu';
+export const ADD_TO_NEW_CASE_TEST_ID = 'tiIndicatorFlyoutAddToNewCaseContextMenu';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/test_ids.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const INDICATORS_FLYOUT_TITLE_TEST_ID = 'tiIndicatorFlyoutTitle';
+export const INDICATORS_FLYOUT_SUBTITLE_TEST_ID = 'tiIndicatorFlyoutSubtitle';
+export const INDICATORS_FLYOUT_TABS_TEST_ID = 'tiIndicatorFlyoutTabs';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/actions_row_cell.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/actions_row_cell.tsx
@@ -12,8 +12,7 @@ import { InvestigateInTimelineButtonIcon } from '../../../../timeline';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { OpenIndicatorFlyoutButton } from './open_flyout_button';
 import { IndicatorsTableContext } from '../contexts';
-
-const INVESTIGATE_TEST_ID = 'tiIndicatorTableInvestigateInTimelineButtonIcon';
+import { INVESTIGATE_IN_TIMELINE_TEST_ID } from './test_ids';
 
 export const ActionsRowCell: VFC<{ indicator: Indicator }> = ({ indicator }) => {
   const indicatorTableContext = useContext(IndicatorsTableContext);
@@ -34,7 +33,10 @@ export const ActionsRowCell: VFC<{ indicator: Indicator }> = ({ indicator }) => 
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <InvestigateInTimelineButtonIcon data={indicator} data-test-subj={INVESTIGATE_TEST_ID} />
+        <InvestigateInTimelineButtonIcon
+          data={indicator}
+          data-test-subj={INVESTIGATE_IN_TIMELINE_TEST_ID}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <MoreActions indicator={indicator} />

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/cell_actions.tsx
@@ -12,10 +12,11 @@ import { AddToTimelineCellAction } from '../../../../timeline';
 import { FilterInCellAction, FilterOutCellAction } from '../../../../query_bar';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../utils';
 import type { Pagination } from '../../../services';
-
-export const CELL_TIMELINE_BUTTON_TEST_ID = 'tiIndicatorsTableCellTimelineButton';
-export const CELL_FILTER_IN_BUTTON_TEST_ID = 'tiIndicatorsTableCellFilterInButton';
-export const CELL_FILTER_OUT_BUTTON_TEST_ID = 'tiIndicatorsTableCellFilterOutButton';
+import {
+  FILTER_IN_BUTTON_TEST_ID,
+  FILTER_OUT_BUTTON_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID,
+} from './test_ids';
 
 export interface CellActionsProps
   extends Omit<EuiDataGridColumnCellActionProps, 'colIndex' | 'isExpanded'> {
@@ -54,19 +55,19 @@ export const CellActions: VFC<CellActionsProps> = ({
         data={indicator}
         field={key}
         Component={Component}
-        data-test-subj={CELL_FILTER_IN_BUTTON_TEST_ID}
+        data-test-subj={FILTER_IN_BUTTON_TEST_ID}
       />
       <FilterOutCellAction
         data={indicator}
         field={key}
         Component={Component}
-        data-test-subj={CELL_FILTER_OUT_BUTTON_TEST_ID}
+        data-test-subj={FILTER_OUT_BUTTON_TEST_ID}
       />
       <AddToTimelineCellAction
         data={indicator}
         field={key}
         Component={Component}
-        data-test-subj={CELL_TIMELINE_BUTTON_TEST_ID}
+        data-test-subj={TIMELINE_BUTTON_TEST_ID}
       />
     </>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
@@ -17,11 +17,7 @@ import { i18n } from '@kbn/i18n';
 import { AddToNewCase } from '../../../../../cases/components/add_to_new_case/add_to_new_case';
 import { AddToExistingCase } from '../../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../../common/types/indicator';
-
-export const MORE_ACTIONS_BUTTON_TEST_ID = 'tiIndicatorTableMoreActionsButton';
-export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorTableAddToExistingCaseContextMenu';
-export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorTableAddToNewCaseContextMenu';
+import { ADD_TO_EXISTING_TEST_ID, ADD_TO_NEW_CASE_TEST_ID, MORE_ACTIONS_TEST_ID } from './test_ids';
 
 const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.table.moreActions', {
   defaultMessage: 'More actions',
@@ -52,12 +48,12 @@ export const MoreActions: VFC<TakeActionProps> = ({ indicator }) => {
     <AddToExistingCase
       indicator={indicator}
       onClick={closePopover}
-      data-test-subj={ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_EXISTING_TEST_ID}
     />,
     <AddToNewCase
       indicator={indicator}
       onClick={closePopover}
-      data-test-subj={ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_NEW_CASE_TEST_ID}
     />,
   ];
 
@@ -70,7 +66,7 @@ export const MoreActions: VFC<TakeActionProps> = ({ indicator }) => {
         size="xs"
         onClick={() => setPopover((prevIsPopoverOpen) => !prevIsPopoverOpen)}
         style={{ height: '100%' }}
-        data-test-subj={MORE_ACTIONS_BUTTON_TEST_ID}
+        data-test-subj={MORE_ACTIONS_TEST_ID}
       />
     </EuiToolTip>
   );

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/test_ids.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const MORE_ACTIONS_TEST_ID = 'tiIndicatorTableMoreActionsButton';
+export const ADD_TO_EXISTING_TEST_ID = 'tiIndicatorTableAddToExistingCaseContextMenu';
+export const ADD_TO_NEW_CASE_TEST_ID = 'tiIndicatorTableAddToNewCaseContextMenu';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.test.tsx
@@ -7,9 +7,10 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { BUTTON_TEST_ID, OpenIndicatorFlyoutButton } from '.';
+import { OpenIndicatorFlyoutButton } from '.';
 import { generateMockIndicator } from '../../../../../../../common/types/indicator';
 import { TestProvidersComponent } from '../../../../../../common/mocks/test_providers';
+import { BUTTON_TEST_ID } from './test_ids';
 
 const mockIndicator = generateMockIndicator();
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.tsx
@@ -9,8 +9,7 @@ import React, { VFC } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Indicator } from '../../../../../../../common/types/indicator';
-
-export const BUTTON_TEST_ID = 'tiToggleIndicatorFlyoutButton';
+import { BUTTON_TEST_ID } from './test_ids';
 
 const BUTTON_LABEL: string = i18n.translate(
   'xpack.threatIntelligence.indicator.table.viewDetailsButton',

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const BUTTON_TEST_ID = 'tiToggleIndicatorFlyoutButton';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/test_ids.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TIMELINE_BUTTON_TEST_ID = 'tiIndicatorsTableCellTimelineButton';
+export const FILTER_IN_BUTTON_TEST_ID = 'tiIndicatorsTableCellFilterInButton';
+export const FILTER_OUT_BUTTON_TEST_ID = 'tiIndicatorsTableCellFilterOutButton';
+export const INVESTIGATE_IN_TIMELINE_TEST_ID = 'tiIndicatorTableInvestigateInTimelineButtonIcon';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/test_ids.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const INSPECT_BUTTON_TEST_ID = 'tiIndicatorsGridInspect';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/use_toolbar_options.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/use_toolbar_options.tsx
@@ -11,8 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { BrowserField } from '@kbn/rule-registry-plugin/common';
 import { useInspector } from '../../../../../hooks';
 import { IndicatorsFieldBrowser } from '../components';
-
-const INSPECT_BUTTON_TEST_ID = 'tiIndicatorsGridInspect';
+import { INSPECT_BUTTON_TEST_ID } from './test_ids';
 
 const INSPECT_BUTTON_TITLE = i18n.translate('xpack.threatIntelligence.inspectTitle', {
   defaultMessage: 'Inspect',

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.test.tsx
@@ -7,12 +7,13 @@
 
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
-import { IndicatorsTable, IndicatorsTableProps, TABLE_UPDATE_PROGRESS_TEST_ID } from '.';
+import { IndicatorsTable, IndicatorsTableProps } from '.';
 import { TestProvidersComponent } from '../../../../common/mocks/test_providers';
 import { generateMockIndicator, Indicator } from '../../../../../common/types/indicator';
-import { BUTTON_TEST_ID } from './components/open_flyout_button';
-import { TITLE_TEST_ID } from '../flyout';
+import { BUTTON_TEST_ID } from './components/open_flyout_button/test_ids';
 import { SecuritySolutionDataViewBase } from '../../../../types';
+import { TABLE_UPDATE_PROGRESS_TEST_ID } from './test_ids';
+import { INDICATORS_FLYOUT_TITLE_TEST_ID } from '../flyout/test_ids';
 
 const stub = () => {};
 
@@ -111,7 +112,7 @@ describe('<IndicatorsTable />', () => {
       screen.getAllByTestId(BUTTON_TEST_ID)[0].click();
     });
 
-    expect(screen.queryByTestId(TITLE_TEST_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(INDICATORS_FLYOUT_TITLE_TEST_ID)).toBeInTheDocument();
 
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     expect(screen.queryByTestId(TABLE_UPDATE_PROGRESS_TEST_ID)).not.toBeInTheDocument();

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/table.tsx
@@ -32,6 +32,7 @@ import { ColumnSettingsValue, useToolbarOptions } from './hooks';
 import { useFieldTypes } from '../../../../hooks';
 import { getFieldSchema } from '../../utils';
 import { Pagination } from '../../services';
+import { TABLE_TEST_ID, TABLE_UPDATE_PROGRESS_TEST_ID } from './test_ids';
 
 export interface IndicatorsTableProps {
   indicators: Indicator[];
@@ -49,16 +50,12 @@ export interface IndicatorsTableProps {
   columnSettings: ColumnSettingsValue;
 }
 
-export const TABLE_TEST_ID = 'tiIndicatorsTable';
-
 const gridStyle = {
   border: 'horizontal',
   header: 'underline',
   cellPadding: 'm',
   fontSize: 's',
 } as const;
-
-export const TABLE_UPDATE_PROGRESS_TEST_ID = `${TABLE_TEST_ID}-updating` as const;
 
 export const IndicatorsTable: VFC<IndicatorsTableProps> = ({
   indicators,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/test_ids.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TABLE_TEST_ID = 'tiIndicatorsTable';
+export const TABLE_UPDATE_PROGRESS_TEST_ID = `${TABLE_TEST_ID}-updating` as const;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.test.tsx
@@ -12,7 +12,7 @@ import { useAggregatedIndicators, useIndicators } from '../hooks';
 import { useFilters } from '../../query_bar/hooks/use_filters';
 import moment from 'moment';
 import { TestProvidersComponent } from '../../../common/mocks/test_providers';
-import { TABLE_TEST_ID } from '../components/table';
+import { TABLE_TEST_ID } from '../components/table/test_ids';
 import { mockTimeRange } from '../../../common/mocks/mock_indicators_filters_context';
 
 jest.mock('../../query_bar/hooks/use_filters');


### PR DESCRIPTION
## Summary

Maintaining testids in two locations makes it hard to maintain them - and is error prone. This PR suggests an alternative approach, by having separate `testid.ts` next to the component (with 0 dependencies inside of it) so that it can be reused both by the component code and external codebases, like Cypress tests - so that this does not cause conflicts.