### PR TITLE
[Security Solution] Support arbitrary aggregations in the rules client

### DIFF
--- a/x-pack/plugins/alerting/server/routes/aggregate_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/aggregate_rules.ts
@@ -9,11 +9,14 @@ import { IRouter } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
 import { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { ILicenseState } from '../lib';
-import { AggregateResult, AggregateOptions } from '../rules_client';
+import { AggregateOptions } from '../rules_client';
 import { RewriteResponseCase, RewriteRequestCase, verifyAccessAndContext } from './lib';
 import { AlertingRequestHandlerContext, INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { trackLegacyTerminology } from './lib/track_legacy_terminology';
-import { fetchDefaultRuleAggregations } from './lib/fetch_default_rule_aggregations';
+import {
+  AggregateResult,
+  fetchDefaultRuleAggregations,
+} from './lib/fetch_default_rule_aggregations';
 
 // config definition
 const querySchema = schema.object({

--- a/x-pack/plugins/alerting/server/routes/aggregate_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/aggregate_rules.ts
@@ -13,6 +13,7 @@ import { AggregateResult, AggregateOptions } from '../rules_client';
 import { RewriteResponseCase, RewriteRequestCase, verifyAccessAndContext } from './lib';
 import { AlertingRequestHandlerContext, INTERNAL_BASE_ALERTING_API_PATH } from '../types';
 import { trackLegacyTerminology } from './lib/track_legacy_terminology';
+import { fetchDefaultRuleAggregations } from './lib/fetch_default_rule_aggregations';
 
 // config definition
 const querySchema = schema.object({
@@ -86,7 +87,9 @@ export const aggregateRulesRoute = (
           [req.query.search, req.query.search_fields].filter(Boolean) as string[],
           usageCounter
         );
-        const aggregateResult = await rulesClient.aggregate({ options });
+
+        const aggregateResult = await fetchDefaultRuleAggregations(rulesClient, options);
+
         return res.ok({
           body: rewriteBodyRes(aggregateResult),
         });

--- a/x-pack/plugins/alerting/server/routes/legacy/aggregate.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/aggregate.ts
@@ -15,6 +15,7 @@ import { renameKeys } from '../lib/rename_keys';
 import { FindOptions } from '../../rules_client';
 import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 import { trackLegacyTerminology } from '../lib/track_legacy_terminology';
+import { fetchDefaultRuleAggregations } from '../lib/fetch_default_rule_aggregations';
 
 // config definition
 const querySchema = schema.object({
@@ -77,7 +78,8 @@ export const aggregateAlertRoute = (
           : [query.search_fields];
       }
 
-      const aggregateResult = await rulesClient.aggregate({ options });
+      const aggregateResult = await fetchDefaultRuleAggregations(rulesClient, options);
+
       return res.ok({
         body: aggregateResult,
       });

--- a/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.test.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '../../rules_client.mock';
+import { fetchDefaultRuleAggregations } from './fetch_default_rule_aggregations';
+
+describe('fetchDefaultRuleAggregations', () => {
+  it('returns default rule aggregate results', async () => {
+    const rulesClient = rulesClientMock.create();
+
+    rulesClient.aggregate.mockResolvedValue({
+      status: {
+        buckets: [
+          { key: 'active', doc_count: 23 },
+          { key: 'error', doc_count: 2 },
+          { key: 'ok', doc_count: 15 },
+          { key: 'pending', doc_count: 1 },
+        ],
+      },
+      outcome: {
+        buckets: [
+          { key: 'failed', doc_count: 2 },
+          { key: 'succeeded', doc_count: 1 },
+          { key: 'warning', doc_count: 3 },
+        ],
+      },
+      muted: {
+        buckets: [
+          { key: 1, key_as_string: '1', doc_count: 2 },
+          { key: 0, key_as_string: '0', doc_count: 39 },
+        ],
+      },
+      enabled: {
+        buckets: [
+          { key: 1, key_as_string: '1', doc_count: 40 },
+          { key: 0, key_as_string: '0', doc_count: 1 },
+        ],
+      },
+      snoozed: {
+        count: {
+          doc_count: 4,
+        },
+      },
+      tags: {
+        buckets: [
+          { key: 'a', doc_count: 1 },
+          { key: 'b', doc_count: 2 },
+          { key: 'c', doc_count: 3 },
+        ],
+      },
+    });
+
+    const result = await fetchDefaultRuleAggregations(rulesClient, {});
+
+    expect(result).toEqual({
+      alertExecutionStatus: {
+        active: 23,
+        error: 2,
+        ok: 15,
+        pending: 1,
+        unknown: 0,
+        warning: 0,
+      },
+      ruleEnabledStatus: {
+        disabled: 1,
+        enabled: 40,
+      },
+      ruleLastRunOutcome: {
+        failed: 2,
+        succeeded: 1,
+        warning: 3,
+      },
+      ruleMutedStatus: {
+        muted: 2,
+        unmuted: 39,
+      },
+      ruleSnoozedStatus: {
+        snoozed: 4,
+      },
+      ruleTags: ['a', 'b', 'c'],
+    });
+  });
+
+  it('returns zeroed results if saved objects client have not returned aggregations', async () => {
+    const rulesClient = rulesClientMock.create();
+
+    rulesClient.aggregate.mockResolvedValue(undefined);
+
+    const result = await fetchDefaultRuleAggregations(rulesClient, {});
+
+    expect(result).toEqual({
+      alertExecutionStatus: {
+        active: 0,
+        error: 0,
+        ok: 0,
+        pending: 0,
+        unknown: 0,
+        warning: 0,
+      },
+      ruleEnabledStatus: {
+        disabled: 0,
+        enabled: 0,
+      },
+      ruleLastRunOutcome: {},
+      ruleMutedStatus: {
+        muted: 0,
+        unmuted: 0,
+      },
+      ruleSnoozedStatus: {
+        snoozed: 0,
+      },
+    });
+  });
+
+  it('throws if saved objects client throws', async () => {
+    const rulesClient = rulesClientMock.create();
+    const expectedError = new Error('some error');
+
+    rulesClient.aggregate.mockRejectedValue(expectedError);
+
+    await expect(fetchDefaultRuleAggregations(rulesClient, {})).rejects.toThrowError(expectedError);
+  });
+});

--- a/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { AggregateOptions, RulesClient } from '../../rules_client';
+import { RulesClient } from '../..';
+import { AggregateOptions } from '../../rules_client';
 import { RuleExecutionStatusValues, RuleLastRunOutcomeValues } from '../../types';
 
 interface AggregateResult {

--- a/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
@@ -9,7 +9,7 @@ import { RulesClient } from '../..';
 import { AggregateOptions } from '../../rules_client';
 import { RuleExecutionStatusValues, RuleLastRunOutcomeValues } from '../../types';
 
-interface AggregateResult {
+export interface AggregateResult {
   alertExecutionStatus: { [status: string]: number };
   ruleLastRunOutcome: { [status: string]: number };
   ruleEnabledStatus?: { enabled: number; disabled: number };

--- a/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/fetch_default_rule_aggregations.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AggregateOptions, RulesClient } from '../../rules_client';
+import { RuleExecutionStatusValues, RuleLastRunOutcomeValues } from '../../types';
+
+interface AggregateResult {
+  alertExecutionStatus: { [status: string]: number };
+  ruleLastRunOutcome: { [status: string]: number };
+  ruleEnabledStatus?: { enabled: number; disabled: number };
+  ruleMutedStatus?: { muted: number; unmuted: number };
+  ruleSnoozedStatus?: { snoozed: number };
+  ruleTags?: string[];
+}
+
+interface RuleAggregations {
+  status: {
+    buckets: Array<{
+      key: string;
+      doc_count: number;
+    }>;
+  };
+  outcome: {
+    buckets: Array<{
+      key: string;
+      doc_count: number;
+    }>;
+  };
+  muted: {
+    buckets: Array<{
+      key: number;
+      key_as_string: string;
+      doc_count: number;
+    }>;
+  };
+  enabled: {
+    buckets: Array<{
+      key: number;
+      key_as_string: string;
+      doc_count: number;
+    }>;
+  };
+  snoozed: {
+    count: {
+      doc_count: number;
+    };
+  };
+  tags: {
+    buckets: Array<{
+      key: string;
+      doc_count: number;
+    }>;
+  };
+}
+
+export async function fetchDefaultRuleAggregations(
+  client: RulesClient,
+  options: AggregateOptions
+): Promise<AggregateResult> {
+  const aggregations = await client.aggregate<RuleAggregations>(
+    {
+      status: {
+        terms: { field: 'alert.attributes.executionStatus.status' },
+      },
+      outcome: {
+        terms: { field: 'alert.attributes.lastRun.outcome' },
+      },
+      enabled: {
+        terms: { field: 'alert.attributes.enabled' },
+      },
+      muted: {
+        terms: { field: 'alert.attributes.muteAll' },
+      },
+      tags: {
+        terms: { field: 'alert.attributes.tags', order: { _key: 'asc' }, size: 50 },
+      },
+      snoozed: {
+        nested: {
+          path: 'alert.attributes.snoozeSchedule',
+        },
+        aggs: {
+          count: {
+            filter: {
+              exists: {
+                field: 'alert.attributes.snoozeSchedule.duration',
+              },
+            },
+          },
+        },
+      },
+    },
+    options
+  );
+
+  if (!aggregations) {
+    const placeholder: AggregateResult = {
+      alertExecutionStatus: {},
+      ruleLastRunOutcome: {},
+      ruleEnabledStatus: {
+        enabled: 0,
+        disabled: 0,
+      },
+      ruleMutedStatus: {
+        muted: 0,
+        unmuted: 0,
+      },
+      ruleSnoozedStatus: { snoozed: 0 },
+    };
+
+    for (const key of RuleExecutionStatusValues) {
+      placeholder.alertExecutionStatus[key] = 0;
+    }
+
+    return placeholder;
+  }
+
+  const alertExecutionStatus = aggregations.status.buckets.map(({ key, doc_count: docCount }) => ({
+    [key]: docCount,
+  }));
+
+  const ruleLastRunOutcome = aggregations.outcome.buckets.map(({ key, doc_count: docCount }) => ({
+    [key]: docCount,
+  }));
+
+  const result: AggregateResult = {
+    alertExecutionStatus: alertExecutionStatus.reduce(
+      (acc, curr: { [status: string]: number }) => Object.assign(acc, curr),
+      {}
+    ),
+    ruleLastRunOutcome: ruleLastRunOutcome.reduce(
+      (acc, curr: { [status: string]: number }) => Object.assign(acc, curr),
+      {}
+    ),
+  };
+
+  // Fill missing keys with zeroes
+  for (const key of RuleExecutionStatusValues) {
+    if (!result.alertExecutionStatus.hasOwnProperty(key)) {
+      result.alertExecutionStatus[key] = 0;
+    }
+  }
+  for (const key of RuleLastRunOutcomeValues) {
+    if (!result.ruleLastRunOutcome.hasOwnProperty(key)) {
+      result.ruleLastRunOutcome[key] = 0;
+    }
+  }
+
+  const enabledBuckets = aggregations.enabled.buckets;
+  result.ruleEnabledStatus = {
+    enabled: enabledBuckets.find((bucket) => bucket.key === 1)?.doc_count ?? 0,
+    disabled: enabledBuckets.find((bucket) => bucket.key === 0)?.doc_count ?? 0,
+  };
+
+  const mutedBuckets = aggregations.muted.buckets;
+  result.ruleMutedStatus = {
+    muted: mutedBuckets.find((bucket) => bucket.key === 1)?.doc_count ?? 0,
+    unmuted: mutedBuckets.find((bucket) => bucket.key === 0)?.doc_count ?? 0,
+  };
+
+  result.ruleSnoozedStatus = {
+    snoozed: aggregations.snoozed?.count?.doc_count ?? 0,
+  };
+
+  const tagsBuckets = aggregations.tags?.buckets || [];
+  result.ruleTags = tagsBuckets.map((bucket) => bucket.key);
+
+  return result;
+}

--- a/x-pack/plugins/alerting/server/rules_client/methods/aggregate.ts
+++ b/x-pack/plugins/alerting/server/rules_client/methods/aggregate.ts
@@ -6,7 +6,7 @@
  */
 
 import { KueryNode, nodeBuilder } from '@kbn/es-query';
-import { RawRule, RuleExecutionStatusValues, RuleLastRunOutcomeValues } from '../../types';
+import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AlertingAuthorizationEntity } from '../../authorization';
 import { ruleAuditEvent, RuleAuditAction } from '../common/audit_events';
 import { buildKueryNodeFilter } from '../common';
@@ -22,68 +22,19 @@ export interface AggregateOptions extends IndexType {
     id: string;
   };
   filter?: string | KueryNode;
-  maxTags?: number;
 }
 
 interface IndexType {
   [key: string]: unknown;
 }
 
-export interface AggregateResult {
-  alertExecutionStatus: { [status: string]: number };
-  ruleLastRunOutcome: { [status: string]: number };
-  ruleEnabledStatus?: { enabled: number; disabled: number };
-  ruleMutedStatus?: { muted: number; unmuted: number };
-  ruleSnoozedStatus?: { snoozed: number };
-  ruleTags?: string[];
-}
+export type Aggregations<Keys extends string> = Record<Keys, AggregationsAggregationContainer>;
 
-export interface RuleAggregation {
-  status: {
-    buckets: Array<{
-      key: string;
-      doc_count: number;
-    }>;
-  };
-  outcome: {
-    buckets: Array<{
-      key: string;
-      doc_count: number;
-    }>;
-  };
-  muted: {
-    buckets: Array<{
-      key: number;
-      key_as_string: string;
-      doc_count: number;
-    }>;
-  };
-  enabled: {
-    buckets: Array<{
-      key: number;
-      key_as_string: string;
-      doc_count: number;
-    }>;
-  };
-  snoozed: {
-    count: {
-      doc_count: number;
-    };
-  };
-  tags: {
-    buckets: Array<{
-      key: string;
-      doc_count: number;
-    }>;
-  };
-}
-
-export async function aggregate(
+export async function aggregate<AggregationsResult = Record<string, unknown>>(
   context: RulesClientContext,
-  {
-    options: { fields, filter, maxTags = 50, ...options } = {},
-  }: { options?: AggregateOptions } = {}
-): Promise<AggregateResult> {
+  aggs: Record<keyof AggregationsResult, AggregationsAggregationContainer>,
+  options?: AggregateOptions
+): Promise<AggregationsResult | undefined> {
   let authorizationTuple;
   try {
     authorizationTuple = await context.authorization.getFindAuthorizationFilter(
@@ -101,9 +52,8 @@ export async function aggregate(
   }
 
   const { filter: authorizationFilter } = authorizationTuple;
-  const filterKueryNode = buildKueryNodeFilter(filter);
-
-  const resp = await context.unsecuredSavedObjectsClient.find<RawRule, RuleAggregation>({
+  const filterKueryNode = buildKueryNodeFilter(options?.filter);
+  const result = await context.unsecuredSavedObjectsClient.find<unknown, AggregationsResult>({
     ...options,
     filter:
       authorizationFilter && filterKueryNode
@@ -112,115 +62,8 @@ export async function aggregate(
     page: 1,
     perPage: 0,
     type: 'alert',
-    aggs: {
-      status: {
-        terms: { field: 'alert.attributes.executionStatus.status' },
-      },
-      outcome: {
-        terms: { field: 'alert.attributes.lastRun.outcome' },
-      },
-      enabled: {
-        terms: { field: 'alert.attributes.enabled' },
-      },
-      muted: {
-        terms: { field: 'alert.attributes.muteAll' },
-      },
-      tags: {
-        terms: { field: 'alert.attributes.tags', order: { _key: 'asc' }, size: maxTags },
-      },
-      snoozed: {
-        nested: {
-          path: 'alert.attributes.snoozeSchedule',
-        },
-        aggs: {
-          count: {
-            filter: {
-              exists: {
-                field: 'alert.attributes.snoozeSchedule.duration',
-              },
-            },
-          },
-        },
-      },
-    },
+    aggs,
   });
 
-  if (!resp.aggregations) {
-    // Return a placeholder with all zeroes
-    const placeholder: AggregateResult = {
-      alertExecutionStatus: {},
-      ruleLastRunOutcome: {},
-      ruleEnabledStatus: {
-        enabled: 0,
-        disabled: 0,
-      },
-      ruleMutedStatus: {
-        muted: 0,
-        unmuted: 0,
-      },
-      ruleSnoozedStatus: { snoozed: 0 },
-    };
-
-    for (const key of RuleExecutionStatusValues) {
-      placeholder.alertExecutionStatus[key] = 0;
-    }
-
-    return placeholder;
-  }
-
-  const alertExecutionStatus = resp.aggregations.status.buckets.map(
-    ({ key, doc_count: docCount }) => ({
-      [key]: docCount,
-    })
-  );
-
-  const ruleLastRunOutcome = resp.aggregations.outcome.buckets.map(
-    ({ key, doc_count: docCount }) => ({
-      [key]: docCount,
-    })
-  );
-
-  const ret: AggregateResult = {
-    alertExecutionStatus: alertExecutionStatus.reduce(
-      (acc, curr: { [status: string]: number }) => Object.assign(acc, curr),
-      {}
-    ),
-    ruleLastRunOutcome: ruleLastRunOutcome.reduce(
-      (acc, curr: { [status: string]: number }) => Object.assign(acc, curr),
-      {}
-    ),
-  };
-
-  // Fill missing keys with zeroes
-  for (const key of RuleExecutionStatusValues) {
-    if (!ret.alertExecutionStatus.hasOwnProperty(key)) {
-      ret.alertExecutionStatus[key] = 0;
-    }
-  }
-  for (const key of RuleLastRunOutcomeValues) {
-    if (!ret.ruleLastRunOutcome.hasOwnProperty(key)) {
-      ret.ruleLastRunOutcome[key] = 0;
-    }
-  }
-
-  const enabledBuckets = resp.aggregations.enabled.buckets;
-  ret.ruleEnabledStatus = {
-    enabled: enabledBuckets.find((bucket) => bucket.key === 1)?.doc_count ?? 0,
-    disabled: enabledBuckets.find((bucket) => bucket.key === 0)?.doc_count ?? 0,
-  };
-
-  const mutedBuckets = resp.aggregations.muted.buckets;
-  ret.ruleMutedStatus = {
-    muted: mutedBuckets.find((bucket) => bucket.key === 1)?.doc_count ?? 0,
-    unmuted: mutedBuckets.find((bucket) => bucket.key === 0)?.doc_count ?? 0,
-  };
-
-  ret.ruleSnoozedStatus = {
-    snoozed: resp.aggregations.snoozed?.count?.doc_count ?? 0,
-  };
-
-  const tagsBuckets = resp.aggregations.tags?.buckets || [];
-  ret.ruleTags = tagsBuckets.map((bucket) => bucket.key);
-
-  return ret;
+  return result.aggregations;
 }

--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import { SanitizedRule, RuleTypeParams } from '../types';
 import { parseDuration } from '../../common/parse_duration';
 import { RulesClientContext, BulkOptions, MuteOptions } from './types';
@@ -77,7 +79,10 @@ export class RulesClient {
     };
   }
 
-  public aggregate = (params?: { options?: AggregateOptions }) => aggregate(this.context, params);
+  public aggregate = <AggregationsResult = Record<string, unknown>>(
+    aggs: Record<keyof AggregationsResult, AggregationsAggregationContainer>,
+    options?: AggregateOptions
+  ): Promise<AggregationsResult | undefined> => aggregate(this.context, aggs, options);
   public clone = <Params extends RuleTypeParams = never>(...args: CloneArguments) =>
     clone<Params>(this.context, ...args);
   public create = <Params extends RuleTypeParams = never>(params: CreateOptions<Params>) =>

--- a/x-pack/plugins/alerting/server/rules_client/types.ts
+++ b/x-pack/plugins/alerting/server/rules_client/types.ts
@@ -37,7 +37,7 @@ export type {
 export type { CreateOptions } from './methods/create';
 export type { FindOptions, FindResult } from './methods/find';
 export type { UpdateOptions } from './methods/update';
-export type { AggregateOptions, AggregateResult } from './methods/aggregate';
+export type { AggregateOptions } from './methods/aggregate';
 export type { GetAlertSummaryParams } from './methods/get_alert_summary';
 export type {
   GetExecutionLogByIdParams,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
@@ -85,7 +85,6 @@ export const getRuleManagementFilters = (router: SecuritySolutionPluginRouter) =
           return response.ok({ body: validatedBody ?? {} });
         }
       } catch (err) {
-        console.log(err);
         const error = transformError(err);
         return siemResponse.error({
           body: error.message,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
@@ -64,7 +64,7 @@ export const getRuleManagementFilters = (router: SecuritySolutionPluginRouter) =
 
       try {
         const [{ prebuilt: prebuiltRulesCount, custom: customRulesCount }, tags] =
-          await Promise.all([fetchRulesCount(rulesClient), readTags({ rulesClient })]);
+          await Promise.all([fetchRulesCount(rulesClient), readTags(rulesClient)]);
         const responseBody: RuleManagementFiltersResponse = {
           rules_summary: {
             custom_count: customRulesCount,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
@@ -85,6 +85,7 @@ export const getRuleManagementFilters = (router: SecuritySolutionPluginRouter) =
           return response.ok({ body: validatedBody ?? {} });
         }
       } catch (err) {
+        console.log(err);
         const error = transformError(err);
         return siemResponse.error({
           body: error.message,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/read_tags.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/read_tags.test.ts
@@ -22,7 +22,7 @@ describe('read_tags', () => {
         ruleTags: ['tag 1', 'tag 2', 'tag 3', 'tag 4'],
       });
 
-      const tags = await readTags({ rulesClient });
+      const tags = await readTags(rulesClient);
       expect(tags).toEqual(['tag 1', 'tag 2', 'tag 3', 'tag 4']);
     });
   });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/read_tags.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/read_tags.test.ts
@@ -17,9 +17,14 @@ describe('read_tags', () => {
     test('it should return tags from the aggregation', async () => {
       const rulesClient = rulesClientMock.create();
       rulesClient.aggregate.mockResolvedValue({
-        alertExecutionStatus: {},
-        ruleLastRunOutcome: {},
-        ruleTags: ['tag 1', 'tag 2', 'tag 3', 'tag 4'],
+        tags: {
+          buckets: [
+            { key: 'tag 1', doc_count: 1 },
+            { key: 'tag 2', doc_count: 1 },
+            { key: 'tag 3', doc_count: 1 },
+            { key: 'tag 4', doc_count: 1 },
+          ],
+        },
       });
 
       const tags = await readTags(rulesClient);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/route.ts
@@ -30,9 +30,7 @@ export const readTagsRoute = (router: SecuritySolutionPluginRouter) => {
       }
 
       try {
-        const tags = await readTags({
-          rulesClient,
-        });
+        const tags = await readTags(rulesClient);
         return response.ok({ body: tags });
       } catch (err) {
         const error = transformError(err);


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/125659

## Summary

This PR allows to execute arbitrary aggregations via `rulesClient.aggregate()` method.

## Details

By giving an ability to execute arbitrary aggregations it helps to fetch rules data like the number of installed prebuilt rules without additional overhead which can be used [here](https://github.com/elastic/kibana/issues/137428). On top of that it allows to extend Rules API further in the most performant and unbound way.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

