### PR TITLE
[AO] Sync Alert Summary Widget time range with Alert search bar

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/helpers/get_alert_summary_time_range.test.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/helpers/get_alert_summary_time_range.test.tsx
@@ -6,11 +6,11 @@
  */
 
 import moment from 'moment';
-import { getDefaultAlertSummaryTimeRange } from '.';
+import { getAlertSummaryWidgetTimeRange } from '.';
 
 describe('getDefaultAlertSummaryTimeRange', () => {
   it('should return default time in UTC format', () => {
-    const defaultTimeRange = getDefaultAlertSummaryTimeRange();
+    const defaultTimeRange = getAlertSummaryWidgetTimeRange();
     const utcFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
     expect(moment(defaultTimeRange.utcFrom, utcFormat, true).isValid()).toBeTruthy();

--- a/x-pack/plugins/observability/public/pages/rule_details/helpers/get_alert_summary_time_range.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/helpers/get_alert_summary_time_range.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { getAbsoluteTimeRange } from '@kbn/data-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-export const getDefaultAlertSummaryTimeRange = (): AlertSummaryTimeRange => {
+export const getAlertSummaryWidgetTimeRange = (): AlertSummaryTimeRange => {
   const { to, from } = getAbsoluteTimeRange({
     from: 'now-30d',
     to: 'now',

--- a/x-pack/plugins/observability/public/pages/rule_details/helpers/index.ts
+++ b/x-pack/plugins/observability/public/pages/rule_details/helpers/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { getDefaultAlertSummaryTimeRange } from './get_alert_summary_time_range';
+export { getAlertSummaryWidgetTimeRange } from './get_alert_summary_time_range';

--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -42,7 +42,7 @@ import { fromQuery, toQuery } from '../../utils/url';
 import { ObservabilityAlertSearchbarWithUrlSync } from '../../components/shared/alert_search_bar';
 import { DeleteModalConfirmation } from './components/delete_modal_confirmation';
 import { CenterJustifiedSpinner } from './components/center_justified_spinner';
-import { getDefaultAlertSummaryTimeRange } from './helpers';
+import { getAlertSummaryWidgetTimeRange } from './helpers';
 
 import {
   EXECUTION_TAB,
@@ -111,7 +111,9 @@ export function RuleDetailsPage() {
   const [editFlyoutVisible, setEditFlyoutVisible] = useState<boolean>(false);
   const [isRuleEditPopoverOpen, setIsRuleEditPopoverOpen] = useState(false);
   const [esQuery, setEsQuery] = useState<{ bool: BoolQuery }>();
-  const [defaultAlertTimeRange] = useState(getDefaultAlertSummaryTimeRange);
+  const [alertSummaryWidgetTimeRange, setAlertSummaryWidgetTimeRange] = useState(
+    getAlertSummaryWidgetTimeRange
+  );
   const ruleQuery = useRef<Query[]>([
     { query: `kibana.alert.rule.uuid: ${ruleId}`, language: 'kuery' },
   ]);
@@ -123,11 +125,15 @@ export function RuleDetailsPage() {
   const tabsRef = useRef<HTMLDivElement>(null);
 
   const onAlertSummaryWidgetClick = async (status: AlertStatus = ALERT_STATUS_ALL) => {
+    const timeRange = getAlertSummaryWidgetTimeRange();
+    setAlertSummaryWidgetTimeRange(timeRange);
     await locators.get(ruleDetailsLocatorID)?.navigate(
       {
+        rangeFrom: timeRange.utcFrom,
+        rangeTo: timeRange.utcTo,
         ruleId,
-        tabId: ALERTS_TAB,
         status,
+        tabId: ALERTS_TAB,
       },
       {
         replace: true,
@@ -386,7 +392,7 @@ export function RuleDetailsPage() {
           <AlertSummaryWidget
             featureIds={featureIds}
             onClick={onAlertSummaryWidgetClick}
-            timeRange={defaultAlertTimeRange}
+            timeRange={alertSummaryWidgetTimeRange}
             filter={alertSummaryWidgetFilter.current}
           />
         </EuiFlexItem>


### PR DESCRIPTION
Resolves #147971

## 📝 Summary

Sync Alert Summary Widget time range with Alert search bar.

![image](https://user-images.githubusercontent.com/12370520/210566612-6e557dc6-c46a-4b1a-a83d-c3f13601445c.png)

## 🧪 How to test
- Check the Alert Summary Widget on the rule details page, by clicking on the active/recovered, you should be able to see the absolute time for the last 30 days in the alert search bar and the number of alerts in the table should match the number in the widget.
