### PR TITLE
[controls] fix pin start text

### DIFF
--- a/src/plugins/controls/public/time_slider/components/time_slider_strings.ts
+++ b/src/plugins/controls/public/time_slider/components/time_slider_strings.ts
@@ -15,11 +15,11 @@ export const TimeSliderStrings = {
         defaultMessage: 'Clear time selection',
       }),
     getPinStart: () =>
-      i18n.translate('controls.timeSlider.settings.unanchorStartSwitchLabel', {
-        defaultMessage: 'Unpin start',
+      i18n.translate('controls.timeSlider.settings.pinStart', {
+        defaultMessage: 'Pin start',
       }),
     getUnpinStart: () =>
-      i18n.translate('controls.timeSlider.settings.unanchorStartSwitchLabel', {
+      i18n.translate('controls.timeSlider.settings.unpinStart', {
         defaultMessage: 'Unpin start',
       }),
   },


### PR DESCRIPTION
While working on review feedback for https://github.com/elastic/kibana/pull/148028 and moving i18n strings to a separate file, copy paste errors were introduced. This PR fixes the pinning text to return expected value