### PR TITLE
[@kbn/babel-register] ensure that source maps are included inline

### DIFF
--- a/packages/kbn-babel-transform/options.js
+++ b/packages/kbn-babel-transform/options.js
@@ -31,7 +31,7 @@ function getBabelOptions(path, config = {}) {
     ],
     cwd,
     babelrc: false,
-    sourceMaps: !config.disableSourceMaps,
+    sourceMaps: config.disableSourceMaps ? false : 'both',
     ast: false,
   };
 }


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/146212 the default `sourceMaps` config for babel register changed from `both` to `true`, which creates the source maps but does not embed them in the compiled output so that dev-tools are able to inspect them even though they are not on the filesystem.

cc @vitaliidm