### PR TITLE
[ML] Anomaly Detection geo wizard: hide bucket span estimator since not supported

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/geo_view/settings.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/geo_view/settings.tsx
@@ -29,7 +29,7 @@ export const GeoSettings: FC<Props> = ({ setIsValid }) => {
       </EuiFlexGroup>
       <EuiFlexGroup gutterSize="xl">
         <EuiFlexItem>
-          <BucketSpan setIsValid={setIsValid} />
+          <BucketSpan setIsValid={setIsValid} hideEstimateButton={true} />
         </EuiFlexItem>
         <EuiFlexItem />
       </EuiFlexGroup>


### PR DESCRIPTION
## Summary

This PR hides the estimate bucket span button in the geo wizard as bucket estimation is not currently supported.
Fixes https://github.com/elastic/kibana/issues/147299




