### PR TITLE
[DOCS] Update 'xpack.screenshotting.browser.chromium.disableSandbox` documentation

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -123,7 +123,7 @@ deprecated:[8.0.0,This setting has no effect.] Specify the {time-units}[amount o
 For PDF and PNG reports, Reporting spawns a headless Chromium browser process on the server to load and capture a screenshot of the {kib} app. When installing {kib} on Linux and Windows platforms, the Chromium binary comes bundled with the {kib} download. For Mac platforms, the Chromium binary is downloaded the first time {kib} is started.
 
 `xpack.screenshotting.browser.chromium.disableSandbox`::
-It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {kib} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to <<reporting-chromium-sandbox>>. Defaults to `false` for all operating systems except Debian and Red Hat Linux, which use `true`.
+It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {kib} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to <<reporting-chromium-sandbox>>. Defaults to `false` for all operating systems except CentOS, Debian, and Red Hat Linux, which use `true`.
 
 `xpack.screenshotting.browser.chromium.proxy.enabled`::
 Enables the proxy for Chromium to use. When set to `true`, you must also specify the `xpack.screenshotting.browser.chromium.proxy.server` setting. Defaults to `false`.

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -109,7 +109,9 @@ distribution.
 ==== Unable to use Chromium sandbox
 Chromium uses sandboxing techniques that are built on top of operating system primitives. The Linux sandbox depends on user namespaces,
 which were introduced with the 3.8 Linux kernel. However, many distributions don't have user namespaces enabled by default, or they require
-the CAP_SYS_ADMIN capability.
+the CAP_SYS_ADMIN capability. If the sandbox is not explicitly disabled in Kibana, either based on OS detection or with the
+`xpack.screenshotting.browser.chromium.disableSandbox` setting, Chrome will try to enable the sandbox. If it fails due to OS or permissions
+restrictions, Chrome will crash during initialization.
 
 Elastic recommends that you research the feasibility of enabling unprivileged user namespaces before disabling the sandbox. An exception
 is if you are running Kibana in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters.


### PR DESCRIPTION
- Adds CentOS to the list of exceptions to the default value. CentOS, Debian, and Red Hat Linux use `true`, but all other OS use `false`. Previously, CentOS was not documented.

- Adds note regarding Chrome crash in the troubleshooting doc.