### PR TITLE
[Security Solution] Create Security Solution UI Actions

### DIFF
--- a/src/plugins/ui_actions/public/index.ts
+++ b/src/plugins/ui_actions/public/index.ts
@@ -44,3 +44,5 @@ export {
   CellActionsMode,
   CellActionsContextProvider,
 } from './cell_actions/components';
+
+export type { CellActionExecutionContext } from './cell_actions/components/cell_actions';

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -492,3 +492,6 @@ export const DEFAULT_DETECTION_PAGE_FILTERS = [
     fieldName: 'host.name',
   },
 ];
+
+export const SECURITY_SOLUTION_ACTION_TRIGGER = 'security-solution-default';
+export const TIMELINE_ACTION_TRIGGER = 'security-solution-timeline';

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -493,5 +493,5 @@ export const DEFAULT_DETECTION_PAGE_FILTERS = [
   },
 ];
 
-export const SECURITY_SOLUTION_ACTION_TRIGGER = 'security-solution-default';
-export const TIMELINE_ACTION_TRIGGER = 'security-solution-timeline';
+export const CELL_ACTIONS_DEFAULT_TRIGGER = 'security-solution-default-cellActions';
+export const CELL_ACTIONS_TIMELINE_TRIGGER = 'security-solution-timeline-cellActions';

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/add_to_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/add_to_timeline.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SecurityAppStore } from '../../common/store/types';
+import { KibanaServices } from '../../common/lib/kibana';
+import { APP_UI_ID } from '../../../common/constants';
+import { Subject } from 'rxjs';
+import { TimelineId } from '../../../common/types';
+import { addProvider } from '../../timelines/store/timeline/actions';
+import { createAddToTimelineAction } from './add_to_timeline';
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { GEO_FIELD_TYPE } from '../../timelines/components/timeline/body/renderers/constants';
+
+jest.mock('../../common/lib/kibana');
+const currentAppId$ = new Subject<string | undefined>();
+KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
+const mockWarningToast = jest.fn();
+KibanaServices.get().notifications.toasts.addWarning = mockWarningToast;
+
+const mockDispatch = jest.fn();
+const store = {
+  dispatch: mockDispatch,
+} as unknown as SecurityAppStore;
+
+const value = 'the-value';
+
+const context = {
+  field: { name: 'user.name', value, type: 'text' },
+} as CellActionExecutionContext;
+
+describe('createAddToTimelineAction', () => {
+  const addToTimelineAction = createAddToTimelineAction({ store, order: 1 });
+
+  beforeEach(() => {
+    currentAppId$.next(APP_UI_ID);
+    jest.clearAllMocks();
+  });
+
+  it('should return display name', () => {
+    expect(addToTimelineAction.getDisplayName(context)).toEqual('Add to timeline');
+  });
+
+  it('should return icon type', () => {
+    expect(addToTimelineAction.getIconType(context)).toEqual('timeline');
+  });
+
+  describe('isCompatible', () => {
+    it('should return false if not in Security', async () => {
+      currentAppId$.next('not security');
+      expect(await addToTimelineAction.isCompatible(context)).toEqual(false);
+    });
+
+    it('should return true if everything is okay', async () => {
+      expect(await addToTimelineAction.isCompatible(context)).toEqual(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await addToTimelineAction.execute(context);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: addProvider.type,
+        payload: {
+          id: TimelineId.active,
+          providers: [
+            {
+              and: [],
+              enabled: true,
+              excluded: false,
+              id: 'event-details-value-default-draggable-timeline-1-user_name-0-the-value',
+              kqlQuery: '',
+              name: 'user.name',
+              queryMatch: {
+                field: 'user.name',
+                operator: ':',
+                value: 'the-value',
+              },
+            },
+          ],
+        },
+      });
+      expect(mockWarningToast).not.toHaveBeenCalled();
+    });
+
+    it('should show warning if no provider added', async () => {
+      await addToTimelineAction.execute({
+        ...context,
+        field: {
+          ...context.field,
+          type: GEO_FIELD_TYPE,
+        },
+      });
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockWarningToast).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/add_to_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/add_to_timeline.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { addProvider } from '../../timelines/store/timeline/actions';
+import { TimelineId } from '../../../common/types';
+import { KibanaServices } from '../../common/lib/kibana';
+import type { SecurityAppStore } from '../../common/store';
+import { isInSecurityApp } from '../utils';
+import {
+  ADD_TO_TIMELINE,
+  ADD_TO_TIMELINE_FAILED_TEXT,
+  ADD_TO_TIMELINE_FAILED_TITLE,
+  ADD_TO_TIMELINE_ICON,
+  ADD_TO_TIMELINE_SUCCESS_TITLE,
+} from './constants';
+import { createDataProviders } from './data_provider';
+
+export const ACTION_ID = 'security_addToTimeline';
+
+export const createAddToTimelineAction = ({
+  store,
+  order,
+}: {
+  store: SecurityAppStore;
+  order?: number;
+}) => {
+  const { application: applicationService, notifications: notificationsService } =
+    KibanaServices.get();
+  let currentAppId: string | undefined;
+  applicationService.currentAppId$.subscribe((appId) => {
+    currentAppId = appId;
+  });
+
+  return createAction<CellActionExecutionContext>({
+    id: ACTION_ID,
+    type: ACTION_ID,
+    order,
+    getIconType: (): string => ADD_TO_TIMELINE_ICON,
+    getDisplayName: () => ADD_TO_TIMELINE,
+    getDisplayNameTooltip: () => ADD_TO_TIMELINE,
+    isCompatible: async ({ field }) =>
+      isInSecurityApp(currentAppId) && field.name != null && field.value != null,
+    execute: async ({ field }) => {
+      const dataProviders =
+        createDataProviders({
+          contextId: TimelineId.active,
+          fieldType: field.type,
+          values: field.value,
+          field: field.name,
+        }) ?? [];
+
+      if (dataProviders.length > 0) {
+        store.dispatch(addProvider({ id: TimelineId.active, providers: dataProviders }));
+
+        notificationsService.toasts.addSuccess({
+          title: ADD_TO_TIMELINE_SUCCESS_TITLE(field.value),
+        });
+      } else {
+        notificationsService.toasts.addWarning({
+          title: ADD_TO_TIMELINE_FAILED_TITLE,
+          text: ADD_TO_TIMELINE_FAILED_TEXT,
+        });
+      }
+    },
+  });
+};

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/constants.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/constants.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ADD_TO_TIMELINE_ICON = 'timeline';
+
+export const ADD_TO_TIMELINE = i18n.translate(
+  'xpack.securitySolution.actions.cellValue.addToTimeline.displayName',
+  {
+    defaultMessage: 'Add to timeline',
+  }
+);
+
+export const ADD_TO_TIMELINE_SUCCESS_TITLE = (value: string) =>
+  i18n.translate('xpack.securitySolution.actions.addToTimeline.addedFieldMessage', {
+    values: { fieldOrValue: value },
+    defaultMessage: `Added {fieldOrValue} to timeline`,
+  });
+
+export const ADD_TO_TIMELINE_FAILED_TITLE = i18n.translate(
+  'xpack.securitySolution.actions.cellValue.addToTimeline.warningTitle',
+  { defaultMessage: 'Unable to add to timeline' }
+);
+
+export const ADD_TO_TIMELINE_FAILED_TEXT = i18n.translate(
+  'xpack.securitySolution.actions.cellValue.addToTimeline.warningMessage',
+  { defaultMessage: 'Filter received is empty or cannot be added to timeline' }
+);

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
@@ -67,12 +67,16 @@ export const createDataProviders = ({
   const arrayValues = Array.isArray(values) ? values : [values];
   return arrayValues.reduce<DataProvider[]>((dataProviders, value, index) => {
     let id: string = '';
-    const appendedUniqueId = `${contextId}-${eventId}-${field}-${index}-${value}`;
+    const appendedUniqueId = `${contextId}${
+      eventId ? `-${eventId}` : ''
+    }-${field}-${index}-${value}`;
 
     if (fieldType === GEO_FIELD_TYPE || field === MESSAGE_FIELD_NAME) {
       return dataProviders;
     } else if (fieldType === IP_FIELD_TYPE) {
-      id = `formatted-ip-data-provider-${contextId}-${field}-${value}-${eventId}`;
+      id = `formatted-ip-data-provider-${contextId}-${field}-${value}${
+        eventId ? `-${eventId}` : ''
+      }`;
       if (isString(value) && !isEmpty(value)) {
         let addresses = value;
         try {

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.test.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import type { SecurityAppStore } from '../../common/store/types';
-import { KibanaServices } from '../../common/lib/kibana';
-import { APP_UI_ID } from '../../../common/constants';
+import type { SecurityAppStore } from '../../../common/store/types';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { APP_UI_ID } from '../../../../common/constants';
 import { Subject } from 'rxjs';
-import { TimelineId } from '../../../common/types';
-import { addProvider } from '../../timelines/store/timeline/actions';
+import { TimelineId } from '../../../../common/types';
+import { addProvider } from '../../../timelines/store/timeline/actions';
 import { createAddToTimelineAction } from './add_to_timeline';
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
-import { GEO_FIELD_TYPE } from '../../timelines/components/timeline/body/renderers/constants';
+import { GEO_FIELD_TYPE } from '../../../timelines/components/timeline/body/renderers/constants';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 const currentAppId$ = new Subject<string | undefined>();
 KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
 const mockWarningToast = jest.fn();

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.test.ts
@@ -32,7 +32,7 @@ const context = {
   field: { name: 'user.name', value, type: 'text' },
 } as CellActionExecutionContext;
 
-describe('createAddToTimelineAction', () => {
+describe('Default createAddToTimelineAction', () => {
   const addToTimelineAction = createAddToTimelineAction({ store, order: 1 });
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/default/add_to_timeline.tsx
@@ -7,19 +7,19 @@
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
-import { addProvider } from '../../timelines/store/timeline/actions';
-import { TimelineId } from '../../../common/types';
-import { KibanaServices } from '../../common/lib/kibana';
-import type { SecurityAppStore } from '../../common/store';
-import { isInSecurityApp } from '../utils';
+import { addProvider } from '../../../timelines/store/timeline/actions';
+import { TimelineId } from '../../../../common/types';
+import { KibanaServices } from '../../../common/lib/kibana';
+import type { SecurityAppStore } from '../../../common/store';
+import { isInSecurityApp } from '../../utils';
 import {
   ADD_TO_TIMELINE,
   ADD_TO_TIMELINE_FAILED_TEXT,
   ADD_TO_TIMELINE_FAILED_TITLE,
   ADD_TO_TIMELINE_ICON,
   ADD_TO_TIMELINE_SUCCESS_TITLE,
-} from './constants';
-import { createDataProviders } from './data_provider';
+} from '../constants';
+import { createDataProviders } from '../data_provider';
 
 export const ACTION_ID = 'security_addToTimeline';
 

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/embeddable_add_to_timeline_action.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/embeddable_add_to_timeline_action.test.ts
@@ -9,7 +9,7 @@ import type { CellValueContext, EmbeddableInput, IEmbeddable } from '@kbn/embedd
 import { ErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
 import type { SecurityAppStore } from '../../common/store/types';
-import { AddToTimelineAction } from './add_to_timeline_action';
+import { EmbeddableAddToTimelineAction } from './embeddable_add_to_timeline_action';
 import { KibanaServices } from '../../common/lib/kibana';
 import { APP_UI_ID } from '../../../common/constants';
 import { Subject } from 'rxjs';
@@ -48,8 +48,8 @@ const value = 'the value';
 const eventId = 'event_1';
 const data: CellValueContext['data'] = [{ columnMeta, value, eventId }];
 
-describe('AddToTimelineAction', () => {
-  const addToTimelineAction = new AddToTimelineAction(store);
+describe('EmbeddableAddToTimelineAction', () => {
+  const addToTimelineAction = new EmbeddableAddToTimelineAction(store);
 
   beforeEach(() => {
     currentAppId$.next(APP_UI_ID);

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/embeddable_add_to_timeline_action.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/embeddable_add_to_timeline_action.ts
@@ -7,17 +7,22 @@
 
 import type { CellValueContext } from '@kbn/embeddable-plugin/public';
 import { isErrorEmbeddable, isFilterableEmbeddable } from '@kbn/embeddable-plugin/public';
-import { i18n } from '@kbn/i18n';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import { KibanaServices } from '../../common/lib/kibana';
 import type { SecurityAppStore } from '../../common/store/types';
 import { addProvider, showTimeline } from '../../timelines/store/timeline/actions';
 import type { DataProvider } from '../../../common/types';
 import { TimelineId } from '../../../common/types';
-import { createDataProviders } from './data_provider';
 import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../utils';
+import {
+  ADD_TO_TIMELINE,
+  ADD_TO_TIMELINE_FAILED_TEXT,
+  ADD_TO_TIMELINE_FAILED_TITLE,
+  ADD_TO_TIMELINE_ICON,
+} from './constants';
+import { createDataProviders } from './data_provider';
 
-export const ACTION_ID = 'addToTimeline';
+export const ACTION_ID = 'embeddable_addToTimeline';
 
 function isDataColumnsFilterable(data?: CellValueContext['data']): boolean {
   return (
@@ -33,12 +38,12 @@ function isDataColumnsFilterable(data?: CellValueContext['data']): boolean {
   );
 }
 
-export class AddToTimelineAction implements Action<CellValueContext> {
+export class EmbeddableAddToTimelineAction implements Action<CellValueContext> {
   public readonly type = ACTION_ID;
   public readonly id = ACTION_ID;
   public order = 1;
 
-  private icon = 'timeline';
+  private icon = ADD_TO_TIMELINE_ICON;
   private toastsService;
   private store;
   private currentAppId: string | undefined;
@@ -54,9 +59,7 @@ export class AddToTimelineAction implements Action<CellValueContext> {
   }
 
   public getDisplayName() {
-    return i18n.translate('xpack.securitySolution.actions.cellValue.addToTimeline.displayName', {
-      defaultMessage: 'Add to timeline',
-    });
+    return ADD_TO_TIMELINE;
   }
 
   public getIconType() {
@@ -93,14 +96,8 @@ export class AddToTimelineAction implements Action<CellValueContext> {
       this.store.dispatch(showTimeline({ id: TimelineId.active, show: true }));
     } else {
       this.toastsService.addWarning({
-        title: i18n.translate(
-          'xpack.securitySolution.actions.cellValue.addToTimeline.warningTitle',
-          { defaultMessage: 'Unable to add to timeline' }
-        ),
-        text: i18n.translate(
-          'xpack.securitySolution.actions.cellValue.addToTimeline.warningMessage',
-          { defaultMessage: 'Filter received is empty or cannot be added to timeline' }
-        ),
+        title: ADD_TO_TIMELINE_FAILED_TITLE,
+        text: ADD_TO_TIMELINE_FAILED_TEXT,
       });
     }
   }

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/index.ts
@@ -6,4 +6,4 @@
  */
 
 export { createAddToTimelineAction as createDefaultAddToTimelineAction } from './default/add_to_timeline';
-export { LensAddToTimelineAction } from './lens/add_to_timeline';
+export { createAddToTimelineAction as createLensAddToTimelineAction } from './lens/add_to_timeline';

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/index.ts
@@ -5,4 +5,5 @@
  * 2.0.
  */
 
-export { AddToTimelineAction } from './add_to_timeline_action';
+export { createAddToTimelineAction } from './add_to_timeline';
+export { EmbeddableAddToTimelineAction } from './embeddable_add_to_timeline_action';

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/lens/add_to_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/lens/add_to_timeline.test.ts
@@ -8,15 +8,15 @@
 import type { CellValueContext, EmbeddableInput, IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { ErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
-import type { SecurityAppStore } from '../../common/store/types';
-import { EmbeddableAddToTimelineAction } from './embeddable_add_to_timeline_action';
-import { KibanaServices } from '../../common/lib/kibana';
-import { APP_UI_ID } from '../../../common/constants';
+import type { SecurityAppStore } from '../../../common/store/types';
+import { LensEmbeddableAddToTimelineAction } from './add_to_timeline';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { APP_UI_ID } from '../../../../common/constants';
 import { Subject } from 'rxjs';
-import { TimelineId } from '../../../common/types';
-import { addProvider, showTimeline } from '../../timelines/store/timeline/actions';
+import { TimelineId } from '../../../../common/types';
+import { addProvider, showTimeline } from '../../../timelines/store/timeline/actions';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 const currentAppId$ = new Subject<string | undefined>();
 KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
 const mockWarningToast = jest.fn();
@@ -49,7 +49,7 @@ const eventId = 'event_1';
 const data: CellValueContext['data'] = [{ columnMeta, value, eventId }];
 
 describe('EmbeddableAddToTimelineAction', () => {
-  const addToTimelineAction = new EmbeddableAddToTimelineAction(store);
+  const addToTimelineAction = new LensEmbeddableAddToTimelineAction(store);
 
   beforeEach(() => {
     currentAppId$.next(APP_UI_ID);

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/lens/add_to_timeline.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/lens/add_to_timeline.ts
@@ -8,19 +8,19 @@
 import type { CellValueContext } from '@kbn/embeddable-plugin/public';
 import { isErrorEmbeddable, isFilterableEmbeddable } from '@kbn/embeddable-plugin/public';
 import type { Action } from '@kbn/ui-actions-plugin/public';
-import { KibanaServices } from '../../common/lib/kibana';
-import type { SecurityAppStore } from '../../common/store/types';
-import { addProvider, showTimeline } from '../../timelines/store/timeline/actions';
-import type { DataProvider } from '../../../common/types';
-import { TimelineId } from '../../../common/types';
-import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../utils';
+import { KibanaServices } from '../../../common/lib/kibana';
+import type { SecurityAppStore } from '../../../common/store/types';
+import { addProvider, showTimeline } from '../../../timelines/store/timeline/actions';
+import type { DataProvider } from '../../../../common/types';
+import { TimelineId } from '../../../../common/types';
+import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../../utils';
 import {
   ADD_TO_TIMELINE,
   ADD_TO_TIMELINE_FAILED_TEXT,
   ADD_TO_TIMELINE_FAILED_TITLE,
   ADD_TO_TIMELINE_ICON,
-} from './constants';
-import { createDataProviders } from './data_provider';
+} from '../constants';
+import { createDataProviders } from '../data_provider';
 
 export const ACTION_ID = 'embeddable_addToTimeline';
 
@@ -38,7 +38,7 @@ function isDataColumnsFilterable(data?: CellValueContext['data']): boolean {
   );
 }
 
-export class EmbeddableAddToTimelineAction implements Action<CellValueContext> {
+export class LensAddToTimelineAction implements Action<CellValueContext> {
   public readonly type = ACTION_ID;
   public readonly id = ACTION_ID;
   public order = 1;

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/constants.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/constants.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const COPY_TO_CLIPBOARD_ICON = 'copyClipboard';
+export const COPY_TO_CLIPBOARD = i18n.translate(
+  'xpack.securitySolution.actions.cellValue.copyToClipboard.displayName',
+  {
+    defaultMessage: 'Copy to Clipboard',
+  }
+);
+
+export const COPY_TO_CLIPBOARD_SUCCESS = i18n.translate(
+  'xpack.securitySolution.actions.cellValue.copyToClipboard.successMessage',
+  {
+    defaultMessage: 'Copied to the clipboard',
+  }
+);

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/copy_to_clipboard.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/copy_to_clipboard.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KibanaServices } from '../../common/lib/kibana';
+import { createCopyToClipboardAction } from './copy_to_clipboard';
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+
+jest.mock('../../common/lib/kibana');
+const mockSuccessToast = jest.fn();
+KibanaServices.get().notifications.toasts.addSuccess = mockSuccessToast;
+
+const mockCopy = jest.fn((text: string) => true);
+jest.mock('copy-to-clipboard', () => (text: string) => mockCopy(text));
+
+describe('createCopyToClipboardAction', () => {
+  const copyToClipboardAction = createCopyToClipboardAction({ order: 1 });
+  const context = {
+    field: { name: 'user.name', value: 'the value', type: 'text' },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return display name', () => {
+    expect(copyToClipboardAction.getDisplayName(context)).toEqual('Copy to Clipboard');
+  });
+
+  it('should return icon type', () => {
+    expect(copyToClipboardAction.getIconType(context)).toEqual('copyClipboard');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await copyToClipboardAction.isCompatible(context)).toEqual(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await copyToClipboardAction.execute(context);
+      expect(mockCopy).toHaveBeenCalledWith('user.name: "the value"');
+      expect(mockSuccessToast).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/copy_to_clipboard.tsx
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/copy_to_clipboard.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import copy from 'copy-to-clipboard';
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public/cell_actions/components/cell_actions';
+import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from './constants';
+import { KibanaServices } from '../../common/lib/kibana';
+
+const ID = 'security_copyToClipboard';
+
+export const createCopyToClipboardAction = ({ order }: { order?: number }) =>
+  createAction<CellActionExecutionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => COPY_TO_CLIPBOARD_ICON,
+    getDisplayName: () => COPY_TO_CLIPBOARD,
+    getDisplayNameTooltip: () => COPY_TO_CLIPBOARD,
+    isCompatible: async (context) => context.field.name != null && context.field.value != null,
+    execute: async ({ field }) => {
+      const { notifications } = KibanaServices.get();
+      const text = `${field.name}: "${field.value}"`;
+      const isSuccess = copy(text, { debug: true });
+
+      if (isSuccess) {
+        notifications.toasts.addSuccess(
+          {
+            title: COPY_TO_CLIPBOARD_SUCCESS,
+          },
+          {
+            toastLifeTimeMs: 800,
+          }
+        );
+      }
+    },
+  });

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.test.ts
@@ -16,7 +16,7 @@ KibanaServices.get().notifications.toasts.addSuccess = mockSuccessToast;
 const mockCopy = jest.fn((text: string) => true);
 jest.mock('copy-to-clipboard', () => (text: string) => mockCopy(text));
 
-describe('createCopyToClipboardAction', () => {
+describe('Default createCopyToClipboardAction', () => {
   const copyToClipboardAction = createCopyToClipboardAction({ order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.test.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { KibanaServices } from '../../common/lib/kibana';
+import { KibanaServices } from '../../../common/lib/kibana';
 import { createCopyToClipboardAction } from './copy_to_clipboard';
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 const mockSuccessToast = jest.fn();
 KibanaServices.get().notifications.toasts.addSuccess = mockSuccessToast;
 

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.tsx
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/default/copy_to_clipboard.tsx
@@ -8,8 +8,8 @@
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import copy from 'copy-to-clipboard';
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public/cell_actions/components/cell_actions';
-import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from './constants';
-import { KibanaServices } from '../../common/lib/kibana';
+import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from '../constants';
+import { KibanaServices } from '../../../common/lib/kibana';
 
 const ID = 'security_copyToClipboard';
 

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/embeddable_copy_to_clipboard_action.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/embeddable_copy_to_clipboard_action.test.ts
@@ -8,7 +8,7 @@
 import type { CellValueContext, EmbeddableInput, IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { ErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
-import { CopyToClipboardAction } from './copy_to_clipboard_action';
+import { EmbeddableCopyToClipboardAction } from './embeddable_copy_to_clipboard_action';
 import { KibanaServices } from '../../common/lib/kibana';
 import { APP_UI_ID } from '../../../common/constants';
 import { Subject } from 'rxjs';
@@ -41,8 +41,8 @@ const columnMeta = {
 };
 const data: CellValueContext['data'] = [{ columnMeta, value: 'the value' }];
 
-describe('CopyToClipboardAction', () => {
-  const addToTimelineAction = new CopyToClipboardAction();
+describe('EmbeddableCopyToClipboardAction', () => {
+  const copyToClipboardAction = new EmbeddableCopyToClipboardAction();
 
   beforeEach(() => {
     currentAppId$.next(APP_UI_ID);
@@ -50,17 +50,17 @@ describe('CopyToClipboardAction', () => {
   });
 
   it('should return display name', () => {
-    expect(addToTimelineAction.getDisplayName()).toEqual('Copy to clipboard');
+    expect(copyToClipboardAction.getDisplayName()).toEqual('Copy to Clipboard');
   });
 
   it('should return icon type', () => {
-    expect(addToTimelineAction.getIconType()).toEqual('copyClipboard');
+    expect(copyToClipboardAction.getIconType()).toEqual('copyClipboard');
   });
 
   describe('isCompatible', () => {
     it('should return false if error embeddable', async () => {
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: new ErrorEmbeddable('some error', {} as EmbeddableInput),
           data,
         })
@@ -69,7 +69,7 @@ describe('CopyToClipboardAction', () => {
 
     it('should return false if not lens embeddable', async () => {
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: new MockEmbeddable('not_lens') as unknown as IEmbeddable,
           data,
         })
@@ -78,7 +78,7 @@ describe('CopyToClipboardAction', () => {
 
     it('should return false if data is empty', async () => {
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data: [],
         })
@@ -87,7 +87,7 @@ describe('CopyToClipboardAction', () => {
 
     it('should return false if data do not have column meta', async () => {
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data: [{}],
         })
@@ -97,7 +97,7 @@ describe('CopyToClipboardAction', () => {
     it('should return false if data column meta do not have field', async () => {
       const { field, ...testColumnMeta } = columnMeta;
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data: [{ columnMeta: testColumnMeta }],
         })
@@ -107,7 +107,7 @@ describe('CopyToClipboardAction', () => {
     it('should return false if data column meta field is blacklisted', async () => {
       const testColumnMeta = { ...columnMeta, field: 'signal.reason' };
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data: [{ columnMeta: testColumnMeta }],
         })
@@ -117,7 +117,7 @@ describe('CopyToClipboardAction', () => {
     it('should return false if not in Security', async () => {
       currentAppId$.next('not security');
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data,
         })
@@ -126,7 +126,7 @@ describe('CopyToClipboardAction', () => {
 
     it('should return true if everything is okay', async () => {
       expect(
-        await addToTimelineAction.isCompatible({
+        await copyToClipboardAction.isCompatible({
           embeddable: lensEmbeddable,
           data,
         })
@@ -136,7 +136,7 @@ describe('CopyToClipboardAction', () => {
 
   describe('execute', () => {
     it('should execute normally', async () => {
-      await addToTimelineAction.execute({
+      await copyToClipboardAction.execute({
         embeddable: lensEmbeddable,
         data,
       });
@@ -145,7 +145,7 @@ describe('CopyToClipboardAction', () => {
     });
 
     it('should execute with multiple values', async () => {
-      await addToTimelineAction.execute({
+      await copyToClipboardAction.execute({
         embeddable: lensEmbeddable,
         data: [
           ...data,
@@ -158,9 +158,9 @@ describe('CopyToClipboardAction', () => {
       expect(mockSuccessToast).toHaveBeenCalled();
     });
 
-    it('should show warning if no provider added', async () => {
+    it('should not show success message if no provider added', async () => {
       mockCopy.mockReturnValue(false);
-      await addToTimelineAction.execute({
+      await copyToClipboardAction.execute({
         embeddable: lensEmbeddable,
         data: [],
       });

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/embeddable_copy_to_clipboard_action.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/embeddable_copy_to_clipboard_action.ts
@@ -7,13 +7,13 @@
 
 import type { CellValueContext } from '@kbn/embeddable-plugin/public';
 import { isErrorEmbeddable } from '@kbn/embeddable-plugin/public';
-import { i18n } from '@kbn/i18n';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import copy from 'copy-to-clipboard';
 import { KibanaServices } from '../../common/lib/kibana';
 import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../utils';
+import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from './constants';
 
-export const ACTION_ID = 'copyToClipboard';
+export const ACTION_ID = 'embeddable_copyToClipboard';
 
 function isDataColumnsValid(data?: CellValueContext['data']): boolean {
   return (
@@ -23,12 +23,10 @@ function isDataColumnsValid(data?: CellValueContext['data']): boolean {
   );
 }
 
-export class CopyToClipboardAction implements Action<CellValueContext> {
+export class EmbeddableCopyToClipboardAction implements Action<CellValueContext> {
   public readonly type = ACTION_ID;
   public readonly id = ACTION_ID;
   public order = 2;
-
-  private icon = 'copyClipboard';
 
   private toastsService;
   private currentAppId: string | undefined;
@@ -43,13 +41,11 @@ export class CopyToClipboardAction implements Action<CellValueContext> {
   }
 
   public getDisplayName() {
-    return i18n.translate('xpack.securitySolution.actions.cellValue.copyToClipboard.displayName', {
-      defaultMessage: 'Copy to clipboard',
-    });
+    return COPY_TO_CLIPBOARD;
   }
 
   public getIconType() {
-    return this.icon;
+    return COPY_TO_CLIPBOARD_ICON;
   }
 
   public async isCompatible({ embeddable, data }: CellValueContext) {
@@ -70,10 +66,7 @@ export class CopyToClipboardAction implements Action<CellValueContext> {
 
     if (isSuccess) {
       this.toastsService.addSuccess({
-        title: i18n.translate(
-          'xpack.securitySolution.actions.cellValue.copyToClipboard.successMessage',
-          { defaultMessage: 'Copied to the clipboard' }
-        ),
+        title: COPY_TO_CLIPBOARD_SUCCESS,
         toastLifeTimeMs: 800,
       });
     }

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/index.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { LensCopyToClipboardAction } from './lens/copy_to_clipboard';
+export { createCopyToClipboardAction as createLensCopyToClipboardAction } from './lens/copy_to_clipboard';
 export { createCopyToClipboardAction as createDefaultCopyToClipboardAction } from './default/copy_to_clipboard';

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/index.ts
@@ -5,4 +5,5 @@
  * 2.0.
  */
 
-export { EmbeddableCopyToClipboardAction as CopyToClipboardAction } from './embeddable_copy_to_clipboard_action';
+export { LensCopyToClipboardAction } from './lens/copy_to_clipboard';
+export { createCopyToClipboardAction as createDefaultCopyToClipboardAction } from './default/copy_to_clipboard';

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/lens/copy_to_clipboard.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/lens/copy_to_clipboard.test.ts
@@ -8,12 +8,12 @@
 import type { CellValueContext, EmbeddableInput, IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { ErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
-import { EmbeddableCopyToClipboardAction } from './embeddable_copy_to_clipboard_action';
-import { KibanaServices } from '../../common/lib/kibana';
-import { APP_UI_ID } from '../../../common/constants';
+import { LensCopyToClipboardAction } from './copy_to_clipboard';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { APP_UI_ID } from '../../../../common/constants';
 import { Subject } from 'rxjs';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 const currentAppId$ = new Subject<string | undefined>();
 KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
 const mockSuccessToast = jest.fn();
@@ -42,7 +42,7 @@ const columnMeta = {
 const data: CellValueContext['data'] = [{ columnMeta, value: 'the value' }];
 
 describe('EmbeddableCopyToClipboardAction', () => {
-  const copyToClipboardAction = new EmbeddableCopyToClipboardAction();
+  const copyToClipboardAction = new LensCopyToClipboardAction();
 
   beforeEach(() => {
     currentAppId$.next(APP_UI_ID);

--- a/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/lens/copy_to_clipboard.ts
+++ b/x-pack/plugins/security_solution/public/actions/copy_to_clipboard/lens/copy_to_clipboard.ts
@@ -9,9 +9,9 @@ import type { CellValueContext } from '@kbn/embeddable-plugin/public';
 import { isErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import copy from 'copy-to-clipboard';
-import { KibanaServices } from '../../common/lib/kibana';
-import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../utils';
-import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from './constants';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { fieldHasCellActions, isInSecurityApp, isLensEmbeddable } from '../../utils';
+import { COPY_TO_CLIPBOARD, COPY_TO_CLIPBOARD_ICON, COPY_TO_CLIPBOARD_SUCCESS } from '../constants';
 
 export const ACTION_ID = 'embeddable_copyToClipboard';
 
@@ -23,7 +23,7 @@ function isDataColumnsValid(data?: CellValueContext['data']): boolean {
   );
 }
 
-export class EmbeddableCopyToClipboardAction implements Action<CellValueContext> {
+export class LensCopyToClipboardAction implements Action<CellValueContext> {
   public readonly type = ACTION_ID;
   public readonly id = ACTION_ID;
   public order = 2;

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../common/lib/kibana');
 
 const mockFilterManager = KibanaServices.get().data.query.filterManager;
 
-describe('createFilterInAction', () => {
+describe('Default createFilterInAction', () => {
   const filterInAction = createFilterInAction({ order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.test.ts
@@ -6,15 +6,15 @@
  */
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
-import { KibanaServices } from '../../common/lib/kibana';
-import { createFilterOutAction } from './filter_out';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { createFilterInAction } from './filter_in';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 
 const mockFilterManager = KibanaServices.get().data.query.filterManager;
 
-describe('createFilterOutAction', () => {
-  const filterInAction = createFilterOutAction({ order: 1 });
+describe('createFilterInAction', () => {
+  const filterInAction = createFilterInAction({ order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;
@@ -24,11 +24,11 @@ describe('createFilterOutAction', () => {
   });
 
   it('should return display name', () => {
-    expect(filterInAction.getDisplayName(context)).toEqual('Filter Out');
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
   });
 
   it('should return icon type', () => {
-    expect(filterInAction.getIconType(context)).toEqual('minusInCircle');
+    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
   });
 
   describe('isCompatible', () => {

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_in.tsx
@@ -8,8 +8,8 @@
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import { i18n } from '@kbn/i18n';
-import { createFilter } from './helpers';
-import { KibanaServices } from '../../common/lib/kibana';
+import { createFilter } from '../helpers';
+import { KibanaServices } from '../../../common/lib/kibana';
 
 export const FILTER_IN = i18n.translate('xpack.securitySolution.actions.filterIn', {
   defaultMessage: 'Filter In',

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../common/lib/kibana');
 
 const mockFilterManager = KibanaServices.get().data.query.filterManager;
 
-describe('createFilterOutAction', () => {
+describe('Default createFilterOutAction', () => {
   const filterInAction = createFilterOutAction({ order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.test.ts
@@ -6,15 +6,15 @@
  */
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
-import { KibanaServices } from '../../common/lib/kibana';
-import { createFilterInAction } from './filter_in';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { createFilterOutAction } from './filter_out';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 
 const mockFilterManager = KibanaServices.get().data.query.filterManager;
 
-describe('createFilterInAction', () => {
-  const filterInAction = createFilterInAction({ order: 1 });
+describe('createFilterOutAction', () => {
+  const filterInAction = createFilterOutAction({ order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;
@@ -24,11 +24,11 @@ describe('createFilterInAction', () => {
   });
 
   it('should return display name', () => {
-    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter Out');
   });
 
   it('should return icon type', () => {
-    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
+    expect(filterInAction.getIconType(context)).toEqual('minusInCircle');
   });
 
   describe('isCompatible', () => {

--- a/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/default/filter_out.tsx
@@ -8,8 +8,8 @@
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import { i18n } from '@kbn/i18n';
-import { createFilter } from './helpers';
-import { KibanaServices } from '../../common/lib/kibana';
+import { createFilter } from '../helpers';
+import { KibanaServices } from '../../../common/lib/kibana';
 
 export const FILTER_OUT = i18n.translate('xpack.securitySolution.actions.filterOut', {
   defaultMessage: 'Filter Out',

--- a/x-pack/plugins/security_solution/public/actions/filter/filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/filter_in.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { KibanaServices } from '../../common/lib/kibana';
+import { createFilterInAction } from './filter_in';
+
+jest.mock('../../common/lib/kibana');
+
+const mockFilterManager = KibanaServices.get().data.query.filterManager;
+
+describe('createFilterInAction', () => {
+  const filterInAction = createFilterInAction({ order: 1 });
+  const context = {
+    field: { name: 'user.name', value: 'the value', type: 'text' },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return display name', () => {
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
+  });
+
+  it('should return icon type', () => {
+    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await filterInAction.isCompatible(context)).toEqual(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await filterInAction.execute(context);
+      expect(mockFilterManager.addFilters).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/filter/filter_in.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/filter_in.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { createFilter } from './helpers';
+import { KibanaServices } from '../../common/lib/kibana';
+
+export const FILTER_IN = i18n.translate('xpack.securitySolution.actions.filterIn', {
+  defaultMessage: 'Filter In',
+});
+const ID = 'security_filterIn';
+const ICON = 'plusInCircle';
+
+export const createFilterInAction = ({ order }: { order?: number }) =>
+  createAction<CellActionExecutionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => ICON,
+    getDisplayName: () => FILTER_IN,
+    getDisplayNameTooltip: () => FILTER_IN,
+    isCompatible: async ({ field }) => field.name != null && field.value != null,
+    execute: async ({ field }) => {
+      const services = KibanaServices.get();
+      const filterManager = services.data.query.filterManager;
+
+      const makeFilter = (currentVal: string | null | undefined) =>
+        currentVal?.length === 0
+          ? createFilter(field.name, undefined)
+          : createFilter(field.name, currentVal);
+
+      if (filterManager != null) {
+        filterManager.addFilters(makeFilter(field.value));
+      }
+    },
+  });

--- a/x-pack/plugins/security_solution/public/actions/filter/filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/filter_out.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { KibanaServices } from '../../common/lib/kibana';
+import { createFilterOutAction } from './filter_out';
+
+jest.mock('../../common/lib/kibana');
+
+const mockFilterManager = KibanaServices.get().data.query.filterManager;
+
+describe('createFilterOutAction', () => {
+  const filterInAction = createFilterOutAction({ order: 1 });
+  const context = {
+    field: { name: 'user.name', value: 'the value', type: 'text' },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return display name', () => {
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter Out');
+  });
+
+  it('should return icon type', () => {
+    expect(filterInAction.getIconType(context)).toEqual('minusInCircle');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await filterInAction.isCompatible(context)).toEqual(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await filterInAction.execute(context);
+      expect(mockFilterManager.addFilters).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/filter/filter_out.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/filter_out.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { createFilter } from './helpers';
+import { KibanaServices } from '../../common/lib/kibana';
+
+export const FILTER_OUT = i18n.translate('xpack.securitySolution.actions.filterOut', {
+  defaultMessage: 'Filter Out',
+});
+const ID = 'security_filterOut';
+const ICON = 'minusInCircle';
+
+export const createFilterOutAction = ({ order }: { order?: number }) =>
+  createAction<CellActionExecutionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => ICON,
+    getDisplayName: () => FILTER_OUT,
+    getDisplayNameTooltip: () => FILTER_OUT,
+    isCompatible: async ({ field }: CellActionExecutionContext) =>
+      field.name != null && field.value != null,
+    execute: async ({ field }: CellActionExecutionContext) => {
+      const services = KibanaServices.get();
+      const filterManager = services.data.query.filterManager;
+
+      const makeFilter = (currentVal: string | null | undefined) =>
+        currentVal == null || currentVal?.length === 0
+          ? createFilter(field.name, null, false)
+          : createFilter(field.name, currentVal, true);
+
+      if (filterManager != null) {
+        filterManager.addFilters(makeFilter(field.value));
+      }
+    },
+  });

--- a/x-pack/plugins/security_solution/public/actions/filter/helpers.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/helpers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Filter } from '@kbn/es-query';
+
+export const createFilter = (
+  key: string,
+  value: string[] | string | null | undefined,
+  negate: boolean = false
+): Filter => {
+  const queryValue = value != null ? (Array.isArray(value) ? value[0] : value) : null;
+  return queryValue != null
+    ? {
+        meta: {
+          alias: null,
+          negate,
+          disabled: false,
+          type: 'phrase',
+          key,
+          value: queryValue,
+          params: {
+            query: queryValue,
+          },
+        },
+        query: {
+          match: {
+            [key]: {
+              query: queryValue,
+              type: 'phrase',
+            },
+          },
+        },
+      }
+    : ({
+        exists: {
+          field: key,
+        },
+        meta: {
+          alias: null,
+          disabled: false,
+          key,
+          negate: value === undefined,
+          type: 'exists',
+          value: 'exists',
+        },
+      } as Filter);
+};

--- a/x-pack/plugins/security_solution/public/actions/filter/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/index.ts
@@ -5,4 +5,8 @@
  * 2.0.
  */
 
-export { EmbeddableCopyToClipboardAction as CopyToClipboardAction } from './embeddable_copy_to_clipboard_action';
+export { createFilterInAction } from './filter_in';
+export { createFilterOutAction } from './filter_out';
+
+export { createTimelineFilterInAction } from './timeline_filter_in';
+export { createTimelineFilterOutAction } from './timeline_filter_out';

--- a/x-pack/plugins/security_solution/public/actions/filter/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/index.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-export { createFilterInAction } from './filter_in';
-export { createFilterOutAction } from './filter_out';
+export { createFilterInAction as createDefaultFilterInAction } from './default/filter_in';
+export { createFilterOutAction as createDefaultFilterOutAction } from './default/filter_out';
 
-export { createTimelineFilterInAction } from './timeline_filter_in';
-export { createTimelineFilterOutAction } from './timeline_filter_out';
+export { createFilterInAction as createTimelineFilterInAction } from './timeline/filter_in';
+export { createFilterOutAction as createTimelineFilterOutAction } from './timeline/filter_out';

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.test.ts
@@ -15,7 +15,7 @@ import {
   SUB_PLUGINS_REDUCER,
 } from '../../../common/mock';
 import { createStore } from '../../../common/store';
-import { createTimelineFilterInAction } from './filter_in';
+import { createFilterInAction } from './filter_in';
 import { Subject } from 'rxjs';
 import { KibanaServices } from '../../../common/lib/kibana';
 import { APP_UI_ID } from '../../../../common/constants';
@@ -42,8 +42,8 @@ const mockState = {
 const { storage } = createSecuritySolutionStorageMock();
 const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
-describe('createTimelineFilterInAction', () => {
-  const filterInAction = createTimelineFilterInAction({ store: mockStore, order: 1 });
+describe('Timeline createFilterInAction', () => {
+  const filterInAction = createFilterInAction({ store: mockStore, order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.test.ts
@@ -7,20 +7,20 @@
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
-import { TimelineId } from '../../../common/types';
+import { TimelineId } from '../../../../common/types';
 import {
   createSecuritySolutionStorageMock,
   kibanaObservable,
   mockGlobalState,
   SUB_PLUGINS_REDUCER,
-} from '../../common/mock';
-import { createStore } from '../../common/store';
+} from '../../../common/mock';
+import { createStore } from '../../../common/store';
+import { createTimelineFilterInAction } from './filter_in';
 import { Subject } from 'rxjs';
-import { KibanaServices } from '../../common/lib/kibana';
-import { APP_UI_ID } from '../../../common/constants';
-import { createTimelineFilterOutAction } from './timeline_filter_out';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { APP_UI_ID } from '../../../../common/constants';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 
 const currentAppId$ = new Subject<string | undefined>();
 KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
@@ -42,8 +42,8 @@ const mockState = {
 const { storage } = createSecuritySolutionStorageMock();
 const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
-describe('createTimelineFilterOutAction', () => {
-  const filterOutAction = createTimelineFilterOutAction({ store: mockStore, order: 1 });
+describe('createTimelineFilterInAction', () => {
+  const filterInAction = createTimelineFilterInAction({ store: mockStore, order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;
@@ -54,27 +54,27 @@ describe('createTimelineFilterOutAction', () => {
   });
 
   it('should return display name', () => {
-    expect(filterOutAction.getDisplayName(context)).toEqual('Filter Out');
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
   });
 
   it('should return icon type', () => {
-    expect(filterOutAction.getIconType(context)).toEqual('minusInCircle');
+    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
   });
 
   describe('isCompatible', () => {
     it('should return true if everything is okay', async () => {
-      expect(await filterOutAction.isCompatible(context)).toEqual(true);
+      expect(await filterInAction.isCompatible(context)).toEqual(true);
     });
 
     it('should return false if not in Security', async () => {
       currentAppId$.next('not security');
-      expect(await filterOutAction.isCompatible(context)).toEqual(false);
+      expect(await filterInAction.isCompatible(context)).toEqual(false);
     });
   });
 
   describe('execute', () => {
     it('should execute normally', async () => {
-      await filterOutAction.execute(context);
+      await filterInAction.execute(context);
       expect(
         mockState.timeline.timelineById[TimelineId.active].filterManager?.addFilters
       ).toHaveBeenCalled();

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_in.tsx
@@ -8,12 +8,12 @@
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import { i18n } from '@kbn/i18n';
-import { createFilter } from './helpers';
-import type { SecurityAppStore } from '../../common/store';
-import { timelineSelectors } from '../../timelines/store/timeline';
-import { isInSecurityApp } from '../utils';
-import { KibanaServices } from '../../common/lib/kibana';
-import { TimelineId } from '../../../common/types';
+import { createFilter } from '../helpers';
+import type { SecurityAppStore } from '../../../common/store';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { isInSecurityApp } from '../../utils';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { TimelineId } from '../../../../common/types';
 
 export const FILTER_IN = i18n.translate('xpack.securitySolution.actions.filterIn', {
   defaultMessage: 'Filter In',
@@ -21,7 +21,7 @@ export const FILTER_IN = i18n.translate('xpack.securitySolution.actions.filterIn
 const ID = 'security_timeline_filterIn';
 const ICON = 'plusInCircle';
 
-export const createTimelineFilterInAction = ({
+export const createFilterInAction = ({
   store,
   order,
 }: {

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.test.ts
@@ -7,20 +7,20 @@
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
-import { TimelineId } from '../../../common/types';
+import { TimelineId } from '../../../../common/types';
 import {
   createSecuritySolutionStorageMock,
   kibanaObservable,
   mockGlobalState,
   SUB_PLUGINS_REDUCER,
-} from '../../common/mock';
-import { createStore } from '../../common/store';
-import { createTimelineFilterInAction } from './timeline_filter_in';
+} from '../../../common/mock';
+import { createStore } from '../../../common/store';
 import { Subject } from 'rxjs';
-import { KibanaServices } from '../../common/lib/kibana';
-import { APP_UI_ID } from '../../../common/constants';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { APP_UI_ID } from '../../../../common/constants';
+import { createTimelineFilterOutAction } from './filter_out';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 
 const currentAppId$ = new Subject<string | undefined>();
 KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
@@ -42,8 +42,8 @@ const mockState = {
 const { storage } = createSecuritySolutionStorageMock();
 const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
-describe('createTimelineFilterInAction', () => {
-  const filterInAction = createTimelineFilterInAction({ store: mockStore, order: 1 });
+describe('createTimelineFilterOutAction', () => {
+  const filterOutAction = createTimelineFilterOutAction({ store: mockStore, order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;
@@ -54,27 +54,27 @@ describe('createTimelineFilterInAction', () => {
   });
 
   it('should return display name', () => {
-    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
+    expect(filterOutAction.getDisplayName(context)).toEqual('Filter Out');
   });
 
   it('should return icon type', () => {
-    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
+    expect(filterOutAction.getIconType(context)).toEqual('minusInCircle');
   });
 
   describe('isCompatible', () => {
     it('should return true if everything is okay', async () => {
-      expect(await filterInAction.isCompatible(context)).toEqual(true);
+      expect(await filterOutAction.isCompatible(context)).toEqual(true);
     });
 
     it('should return false if not in Security', async () => {
       currentAppId$.next('not security');
-      expect(await filterInAction.isCompatible(context)).toEqual(false);
+      expect(await filterOutAction.isCompatible(context)).toEqual(false);
     });
   });
 
   describe('execute', () => {
     it('should execute normally', async () => {
-      await filterInAction.execute(context);
+      await filterOutAction.execute(context);
       expect(
         mockState.timeline.timelineById[TimelineId.active].filterManager?.addFilters
       ).toHaveBeenCalled();

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.test.ts
@@ -18,7 +18,7 @@ import { createStore } from '../../../common/store';
 import { Subject } from 'rxjs';
 import { KibanaServices } from '../../../common/lib/kibana';
 import { APP_UI_ID } from '../../../../common/constants';
-import { createTimelineFilterOutAction } from './filter_out';
+import { createFilterOutAction } from './filter_out';
 
 jest.mock('../../../common/lib/kibana');
 
@@ -42,8 +42,8 @@ const mockState = {
 const { storage } = createSecuritySolutionStorageMock();
 const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 
-describe('createTimelineFilterOutAction', () => {
-  const filterOutAction = createTimelineFilterOutAction({ store: mockStore, order: 1 });
+describe('Timeline createFilterOutAction', () => {
+  const filterOutAction = createFilterOutAction({ store: mockStore, order: 1 });
   const context = {
     field: { name: 'user.name', value: 'the value', type: 'text' },
   } as CellActionExecutionContext;

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline/filter_out.tsx
@@ -8,12 +8,12 @@
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import { i18n } from '@kbn/i18n';
-import { createFilter } from './helpers';
-import { KibanaServices } from '../../common/lib/kibana';
-import { isInSecurityApp } from '../utils';
-import type { SecurityAppStore } from '../../common/store';
-import { timelineSelectors } from '../../timelines/store/timeline';
-import { TimelineId } from '../../../common/types';
+import { createFilter } from '../helpers';
+import { KibanaServices } from '../../../common/lib/kibana';
+import { isInSecurityApp } from '../../utils';
+import type { SecurityAppStore } from '../../../common/store';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { TimelineId } from '../../../../common/types';
 
 export const FILTER_OUT = i18n.translate('xpack.securitySolution.actions.filterOut', {
   defaultMessage: 'Filter Out',
@@ -21,7 +21,7 @@ export const FILTER_OUT = i18n.translate('xpack.securitySolution.actions.filterO
 const ID = 'security_timeline_filterOut';
 const ICON = 'minusInCircle';
 
-export const createTimelineFilterOutAction = ({
+export const createFilterOutAction = ({
   store,
   order,
 }: {

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_in.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_in.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
+import { TimelineId } from '../../../common/types';
+import {
+  createSecuritySolutionStorageMock,
+  kibanaObservable,
+  mockGlobalState,
+  SUB_PLUGINS_REDUCER,
+} from '../../common/mock';
+import { createStore } from '../../common/store';
+import { createTimelineFilterInAction } from './timeline_filter_in';
+import { Subject } from 'rxjs';
+import { KibanaServices } from '../../common/lib/kibana';
+import { APP_UI_ID } from '../../../common/constants';
+
+jest.mock('../../common/lib/kibana');
+
+const currentAppId$ = new Subject<string | undefined>();
+KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
+
+const mockState = {
+  ...mockGlobalState,
+  timeline: {
+    ...mockGlobalState.timeline,
+    timelineById: {
+      ...mockGlobalState.timeline.timelineById,
+      [TimelineId.active]: {
+        ...mockGlobalState.timeline.timelineById[TimelineId.active],
+        filterManager: createFilterManagerMock(),
+      },
+    },
+  },
+};
+
+const { storage } = createSecuritySolutionStorageMock();
+const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+
+describe('createTimelineFilterInAction', () => {
+  const filterInAction = createTimelineFilterInAction({ store: mockStore, order: 1 });
+  const context = {
+    field: { name: 'user.name', value: 'the value', type: 'text' },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentAppId$.next(APP_UI_ID);
+  });
+
+  it('should return display name', () => {
+    expect(filterInAction.getDisplayName(context)).toEqual('Filter In');
+  });
+
+  it('should return icon type', () => {
+    expect(filterInAction.getIconType(context)).toEqual('plusInCircle');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await filterInAction.isCompatible(context)).toEqual(true);
+    });
+
+    it('should return false if not in Security', async () => {
+      currentAppId$.next('not security');
+      expect(await filterInAction.isCompatible(context)).toEqual(false);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await filterInAction.execute(context);
+      expect(
+        mockState.timeline.timelineById[TimelineId.active].filterManager?.addFilters
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_in.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_in.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { createFilter } from './helpers';
+import type { SecurityAppStore } from '../../common/store';
+import { timelineSelectors } from '../../timelines/store/timeline';
+import { isInSecurityApp } from '../utils';
+import { KibanaServices } from '../../common/lib/kibana';
+import { TimelineId } from '../../../common/types';
+
+export const FILTER_IN = i18n.translate('xpack.securitySolution.actions.filterIn', {
+  defaultMessage: 'Filter In',
+});
+const ID = 'security_timeline_filterIn';
+const ICON = 'plusInCircle';
+
+export const createTimelineFilterInAction = ({
+  store,
+  order,
+}: {
+  store: SecurityAppStore;
+  order?: number;
+}) => {
+  const { application: applicationService } = KibanaServices.get();
+  let currentAppId: string | undefined;
+  applicationService.currentAppId$.subscribe((appId) => {
+    currentAppId = appId;
+  });
+
+  return createAction<CellActionExecutionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => ICON,
+    getDisplayName: () => FILTER_IN,
+    getDisplayNameTooltip: () => FILTER_IN,
+    isCompatible: async ({ field }) =>
+      isInSecurityApp(currentAppId) && field.name != null && field.value != null,
+    execute: async ({ field }) => {
+      const makeFilter = (currentVal: string | null | undefined) =>
+        currentVal?.length === 0
+          ? createFilter(field.name, undefined)
+          : createFilter(field.name, currentVal);
+
+      const state = store.getState();
+      const getTimeline = timelineSelectors.getTimelineByIdSelector();
+      const filterManager = getTimeline(state, TimelineId.active)?.filterManager;
+
+      if (filterManager != null) {
+        filterManager.addFilters(makeFilter(field.value));
+      }
+    },
+  });
+};

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_out.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_out.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
+import { TimelineId } from '../../../common/types';
+import {
+  createSecuritySolutionStorageMock,
+  kibanaObservable,
+  mockGlobalState,
+  SUB_PLUGINS_REDUCER,
+} from '../../common/mock';
+import { createStore } from '../../common/store';
+import { Subject } from 'rxjs';
+import { KibanaServices } from '../../common/lib/kibana';
+import { APP_UI_ID } from '../../../common/constants';
+import { createTimelineFilterOutAction } from './timeline_filter_out';
+
+jest.mock('../../common/lib/kibana');
+
+const currentAppId$ = new Subject<string | undefined>();
+KibanaServices.get().application.currentAppId$ = currentAppId$.asObservable();
+
+const mockState = {
+  ...mockGlobalState,
+  timeline: {
+    ...mockGlobalState.timeline,
+    timelineById: {
+      ...mockGlobalState.timeline.timelineById,
+      [TimelineId.active]: {
+        ...mockGlobalState.timeline.timelineById[TimelineId.active],
+        filterManager: createFilterManagerMock(),
+      },
+    },
+  },
+};
+
+const { storage } = createSecuritySolutionStorageMock();
+const mockStore = createStore(mockState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+
+describe('createTimelineFilterOutAction', () => {
+  const filterOutAction = createTimelineFilterOutAction({ store: mockStore, order: 1 });
+  const context = {
+    field: { name: 'user.name', value: 'the value', type: 'text' },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentAppId$.next(APP_UI_ID);
+  });
+
+  it('should return display name', () => {
+    expect(filterOutAction.getDisplayName(context)).toEqual('Filter Out');
+  });
+
+  it('should return icon type', () => {
+    expect(filterOutAction.getIconType(context)).toEqual('minusInCircle');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await filterOutAction.isCompatible(context)).toEqual(true);
+    });
+
+    it('should return false if not in Security', async () => {
+      currentAppId$.next('not security');
+      expect(await filterOutAction.isCompatible(context)).toEqual(false);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await filterOutAction.execute(context);
+      expect(
+        mockState.timeline.timelineById[TimelineId.active].filterManager?.addFilters
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_out.tsx
+++ b/x-pack/plugins/security_solution/public/actions/filter/timeline_filter_out.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { createFilter } from './helpers';
+import { KibanaServices } from '../../common/lib/kibana';
+import { isInSecurityApp } from '../utils';
+import type { SecurityAppStore } from '../../common/store';
+import { timelineSelectors } from '../../timelines/store/timeline';
+import { TimelineId } from '../../../common/types';
+
+export const FILTER_OUT = i18n.translate('xpack.securitySolution.actions.filterOut', {
+  defaultMessage: 'Filter Out',
+});
+const ID = 'security_timeline_filterOut';
+const ICON = 'minusInCircle';
+
+export const createTimelineFilterOutAction = ({
+  store,
+  order,
+}: {
+  store: SecurityAppStore;
+  order?: number;
+}) => {
+  const { application: applicationService } = KibanaServices.get();
+  let currentAppId: string | undefined;
+  applicationService.currentAppId$.subscribe((appId) => {
+    currentAppId = appId;
+  });
+
+  return createAction<CellActionExecutionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => ICON,
+    getDisplayName: () => FILTER_OUT,
+    getDisplayNameTooltip: () => FILTER_OUT,
+    isCompatible: async ({ field }) =>
+      isInSecurityApp(currentAppId) && field.name != null && field.value != null,
+    execute: async ({ field, metadata }) => {
+      const makeFilter = (currentVal: string | null | undefined) =>
+        currentVal == null || currentVal?.length === 0
+          ? createFilter(field.name, null, false)
+          : createFilter(field.name, currentVal, true);
+
+      const state = store.getState();
+      const getTimeline = timelineSelectors.getTimelineByIdSelector();
+      const filterManager = getTimeline(state, TimelineId.active)?.filterManager;
+
+      if (filterManager != null) {
+        filterManager.addFilters(makeFilter(field.value));
+      }
+    },
+  });
+};

--- a/x-pack/plugins/security_solution/public/actions/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { registerActions } from './register';
+export { registerUIActions as registerActions } from './register';

--- a/x-pack/plugins/security_solution/public/actions/register.ts
+++ b/x-pack/plugins/security_solution/public/actions/register.ts
@@ -15,7 +15,10 @@ import { createFilterInAction } from './filter/filter_in';
 import { createFilterOutAction } from './filter/filter_out';
 import { createAddToTimelineAction, EmbeddableAddToTimelineAction } from './add_to_timeline';
 import { createShowTopNAction } from './show_top_n/show_top_n';
-import { SECURITY_SOLUTION_ACTION_TRIGGER, TIMELINE_ACTION_TRIGGER } from '../../common/constants';
+import {
+  CELL_ACTIONS_DEFAULT_TRIGGER,
+  CELL_ACTIONS_TIMELINE_TRIGGER,
+} from '../../common/constants';
 import { createCopyToClipboardAction } from './copy_to_clipboard/copy_to_clipboard';
 import { createTimelineFilterInAction, createTimelineFilterOutAction } from './filter';
 
@@ -55,14 +58,14 @@ const registerUiActions = (
   const copyAction = createCopyToClipboardAction({ order: 5 });
 
   uiActions.registerTrigger({
-    id: SECURITY_SOLUTION_ACTION_TRIGGER,
+    id: CELL_ACTIONS_DEFAULT_TRIGGER,
   });
 
-  uiActions.addTriggerAction(SECURITY_SOLUTION_ACTION_TRIGGER, copyAction);
-  uiActions.addTriggerAction(SECURITY_SOLUTION_ACTION_TRIGGER, filterInAction);
-  uiActions.addTriggerAction(SECURITY_SOLUTION_ACTION_TRIGGER, filterOutAction);
-  uiActions.addTriggerAction(SECURITY_SOLUTION_ACTION_TRIGGER, showTopNAction);
-  uiActions.addTriggerAction(SECURITY_SOLUTION_ACTION_TRIGGER, addToTimeline);
+  uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, copyAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, filterInAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, filterOutAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, showTopNAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, addToTimeline);
 };
 
 const registerTimelineUiActions = (
@@ -84,12 +87,12 @@ const registerTimelineUiActions = (
   const copyAction = createCopyToClipboardAction({ order: 5 });
 
   uiActions.registerTrigger({
-    id: TIMELINE_ACTION_TRIGGER,
+    id: CELL_ACTIONS_TIMELINE_TRIGGER,
   });
 
-  uiActions.addTriggerAction(TIMELINE_ACTION_TRIGGER, copyAction);
-  uiActions.addTriggerAction(TIMELINE_ACTION_TRIGGER, filterInAction);
-  uiActions.addTriggerAction(TIMELINE_ACTION_TRIGGER, filterOutAction);
-  uiActions.addTriggerAction(TIMELINE_ACTION_TRIGGER, showTopNAction);
-  uiActions.addTriggerAction(TIMELINE_ACTION_TRIGGER, addToTimeline);
+  uiActions.addTriggerAction(CELL_ACTIONS_TIMELINE_TRIGGER, copyAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_TIMELINE_TRIGGER, filterInAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_TIMELINE_TRIGGER, filterOutAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_TIMELINE_TRIGGER, showTopNAction);
+  uiActions.addTriggerAction(CELL_ACTIONS_TIMELINE_TRIGGER, addToTimeline);
 };

--- a/x-pack/plugins/security_solution/public/actions/register.ts
+++ b/x-pack/plugins/security_solution/public/actions/register.ts
@@ -10,14 +10,17 @@ import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type * as H from 'history';
 import type { SecurityAppStore } from '../common/store/types';
 import type { StartPlugins, StartServices } from '../types';
-import { LensCopyToClipboardAction, createDefaultCopyToClipboardAction } from './copy_to_clipboard';
+import {
+  createLensCopyToClipboardAction,
+  createDefaultCopyToClipboardAction,
+} from './copy_to_clipboard';
 import {
   createDefaultFilterInAction,
   createDefaultFilterOutAction,
   createTimelineFilterInAction,
   createTimelineFilterOutAction,
 } from './filter';
-import { LensAddToTimelineAction, createDefaultAddToTimelineAction } from './add_to_timeline';
+import { createLensAddToTimelineAction, createDefaultAddToTimelineAction } from './add_to_timeline';
 import { createDefaultShowTopNAction } from './show_top_n';
 import {
   CELL_ACTIONS_DEFAULT_TRIGGER,
@@ -36,10 +39,10 @@ export const registerUIActions = (
 };
 
 const registerLensActions = (uiActions: UiActionsStart, store: SecurityAppStore) => {
-  const addToTimelineAction = new LensAddToTimelineAction(store);
+  const addToTimelineAction = createLensAddToTimelineAction({ store, order: 1 });
   uiActions.addTriggerAction(CELL_VALUE_TRIGGER, addToTimelineAction);
 
-  const copyToClipboardAction = new LensCopyToClipboardAction();
+  const copyToClipboardAction = createLensCopyToClipboardAction({ order: 2 });
   uiActions.addTriggerAction(CELL_VALUE_TRIGGER, copyToClipboardAction);
 };
 

--- a/x-pack/plugins/security_solution/public/actions/register.ts
+++ b/x-pack/plugins/security_solution/public/actions/register.ts
@@ -10,52 +10,54 @@ import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type * as H from 'history';
 import type { SecurityAppStore } from '../common/store/types';
 import type { StartPlugins, StartServices } from '../types';
-import { EmbeddableCopyToClipboardAction } from './copy_to_clipboard/embeddable_copy_to_clipboard_action';
-import { createFilterInAction } from './filter/filter_in';
-import { createFilterOutAction } from './filter/filter_out';
-import { createAddToTimelineAction, EmbeddableAddToTimelineAction } from './add_to_timeline';
-import { createShowTopNAction } from './show_top_n/show_top_n';
+import { LensCopyToClipboardAction, createDefaultCopyToClipboardAction } from './copy_to_clipboard';
+import {
+  createDefaultFilterInAction,
+  createDefaultFilterOutAction,
+  createTimelineFilterInAction,
+  createTimelineFilterOutAction,
+} from './filter';
+import { LensAddToTimelineAction, createDefaultAddToTimelineAction } from './add_to_timeline';
+import { createDefaultShowTopNAction } from './show_top_n';
 import {
   CELL_ACTIONS_DEFAULT_TRIGGER,
   CELL_ACTIONS_TIMELINE_TRIGGER,
 } from '../../common/constants';
-import { createCopyToClipboardAction } from './copy_to_clipboard/copy_to_clipboard';
-import { createTimelineFilterInAction, createTimelineFilterOutAction } from './filter';
 
-export const registerActions = (
+export const registerUIActions = (
   plugins: StartPlugins,
   store: SecurityAppStore,
   history: H.History,
   services: StartServices
 ) => {
-  registerEmbeddableActions(plugins.uiActions, store);
-  registerUiActions(plugins.uiActions, store, history, services);
-  registerTimelineUiActions(plugins.uiActions, store, history, services);
+  registerLensActions(plugins.uiActions, store);
+  registerDefaultActions(plugins.uiActions, store, history, services);
+  registerTimelineActions(plugins.uiActions, store, history, services);
 };
 
-const registerEmbeddableActions = (uiActions: UiActionsStart, store: SecurityAppStore) => {
-  const addToTimelineAction = new EmbeddableAddToTimelineAction(store);
+const registerLensActions = (uiActions: UiActionsStart, store: SecurityAppStore) => {
+  const addToTimelineAction = new LensAddToTimelineAction(store);
   uiActions.addTriggerAction(CELL_VALUE_TRIGGER, addToTimelineAction);
 
-  const copyToClipboardAction = new EmbeddableCopyToClipboardAction();
+  const copyToClipboardAction = new LensCopyToClipboardAction();
   uiActions.addTriggerAction(CELL_VALUE_TRIGGER, copyToClipboardAction);
 };
 
-const registerUiActions = (
+const registerDefaultActions = (
   uiActions: UiActionsStart,
   store: SecurityAppStore,
   history: H.History,
   services: StartServices
 ) => {
-  const filterInAction = createFilterInAction({
+  const filterInAction = createDefaultFilterInAction({
     order: 1,
   });
-  const filterOutAction = createFilterOutAction({
+  const filterOutAction = createDefaultFilterOutAction({
     order: 2,
   });
-  const addToTimeline = createAddToTimelineAction({ store, order: 3 });
-  const showTopNAction = createShowTopNAction({ store, history, services, order: 4 });
-  const copyAction = createCopyToClipboardAction({ order: 5 });
+  const addToTimeline = createDefaultAddToTimelineAction({ store, order: 3 });
+  const showTopNAction = createDefaultShowTopNAction({ store, history, services, order: 4 });
+  const copyAction = createDefaultCopyToClipboardAction({ order: 5 });
 
   uiActions.registerTrigger({
     id: CELL_ACTIONS_DEFAULT_TRIGGER,
@@ -68,7 +70,7 @@ const registerUiActions = (
   uiActions.addTriggerAction(CELL_ACTIONS_DEFAULT_TRIGGER, addToTimeline);
 };
 
-const registerTimelineUiActions = (
+const registerTimelineActions = (
   uiActions: UiActionsStart,
   store: SecurityAppStore,
   history: H.History,
@@ -82,9 +84,9 @@ const registerTimelineUiActions = (
     store,
     order: 2,
   });
-  const addToTimeline = createAddToTimelineAction({ store, order: 3 });
-  const showTopNAction = createShowTopNAction({ store, history, services, order: 4 });
-  const copyAction = createCopyToClipboardAction({ order: 5 });
+  const addToTimeline = createDefaultAddToTimelineAction({ store, order: 3 });
+  const showTopNAction = createDefaultShowTopNAction({ store, history, services, order: 4 });
+  const copyAction = createDefaultCopyToClipboardAction({ order: 5 });
 
   uiActions.registerTrigger({
     id: CELL_ACTIONS_TIMELINE_TRIGGER,

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/default/show_top_n.test.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/default/show_top_n.test.tsx
@@ -7,22 +7,22 @@
 
 import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { Subject } from 'rxjs';
-import { APP_UI_ID } from '../../../common/constants';
+import { APP_UI_ID } from '../../../../common/constants';
 import {
   createSecuritySolutionStorageMock,
   kibanaObservable,
   mockGlobalState,
   SUB_PLUGINS_REDUCER,
-} from '../../common/mock';
-import { mockHistory } from '../../common/mock/router';
-import { createStore } from '../../common/store';
+} from '../../../common/mock';
+import { mockHistory } from '../../../common/mock/router';
+import { createStore } from '../../../common/store';
 import { createShowTopNAction } from './show_top_n';
 import React from 'react';
-import { createStartServicesMock } from '../../common/lib/kibana/kibana_react.mock';
+import { createStartServicesMock } from '../../../common/lib/kibana/kibana_react.mock';
 
-jest.mock('../../common/lib/kibana');
+jest.mock('../../../common/lib/kibana');
 
-jest.mock('./show_top_n_component', () => ({
+jest.mock('../show_top_n_component', () => ({
   TopNAction: () => <span>{'TEST COMPONENT'}</span>,
 }));
 

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/default/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/default/show_top_n.tsx
@@ -16,12 +16,12 @@ import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 
-import { KibanaContextProvider } from '../../common/lib/kibana';
-import { APP_NAME, DEFAULT_DARK_MODE } from '../../../common/constants';
-import type { SecurityAppStore } from '../../common/store';
-import { isInSecurityApp } from '../utils';
-import { TopNAction } from './show_top_n_component';
-import type { StartServices } from '../../types';
+import { KibanaContextProvider } from '../../../common/lib/kibana';
+import { APP_NAME, DEFAULT_DARK_MODE } from '../../../../common/constants';
+import type { SecurityAppStore } from '../../../common/store';
+import { isInSecurityApp } from '../../utils';
+import { TopNAction } from '../show_top_n_component';
+import type { StartServices } from '../../../types';
 
 const SHOW_TOP = (fieldName: string) =>
   i18n.translate('xpack.securitySolution.actions.showTopTooltip', {

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/index.ts
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export { createAddToTimelineAction as createDefaultAddToTimelineAction } from './default/add_to_timeline';
-export { LensAddToTimelineAction } from './lens/add_to_timeline';
+export { createShowTopNAction as createDefaultShowTopNAction } from './default/show_top_n';

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n.test.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { Subject } from 'rxjs';
+import { APP_UI_ID } from '../../../common/constants';
+import {
+  createSecuritySolutionStorageMock,
+  kibanaObservable,
+  mockGlobalState,
+  SUB_PLUGINS_REDUCER,
+} from '../../common/mock';
+import { mockHistory } from '../../common/mock/router';
+import { createStore } from '../../common/store';
+import { createShowTopNAction } from './show_top_n';
+import React from 'react';
+import { createStartServicesMock } from '../../common/lib/kibana/kibana_react.mock';
+
+jest.mock('../../common/lib/kibana');
+
+jest.mock('./show_top_n_component', () => ({
+  TopNAction: () => <span>{'TEST COMPONENT'}</span>,
+}));
+
+const currentAppId$ = new Subject<string | undefined>();
+const startServices = createStartServicesMock();
+
+const mockServices = {
+  ...startServices,
+  application: {
+    ...startServices.application,
+    currentAppId$: currentAppId$.asObservable(),
+  },
+};
+
+const { storage } = createSecuritySolutionStorageMock();
+const mockStore = createStore(mockGlobalState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+
+const element = document.createElement('div');
+document.body.appendChild(element);
+
+describe('createShowTopNAction', () => {
+  const showTopNAction = createShowTopNAction({
+    store: mockStore,
+    history: mockHistory,
+    order: 1,
+    services: mockServices,
+  });
+  const context = {
+    field: { name: 'user.name', value: 'the-value', type: 'keyword' },
+    extraContentNodeRef: {
+      current: element,
+    },
+    nodeRef: {
+      current: element,
+    },
+  } as CellActionExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentAppId$.next(APP_UI_ID);
+  });
+
+  it('should return display name', () => {
+    expect(showTopNAction.getDisplayName(context)).toEqual('Show top user.name');
+  });
+
+  it('should return icon type', () => {
+    expect(showTopNAction.getIconType(context)).toEqual('visBarVertical');
+  });
+
+  describe('isCompatible', () => {
+    it('should return true if everything is okay', async () => {
+      expect(await showTopNAction.isCompatible(context)).toEqual(true);
+    });
+
+    it('should return false if not in Security', async () => {
+      currentAppId$.next('not security');
+      expect(await showTopNAction.isCompatible(context)).toEqual(false);
+    });
+
+    it('should return false if field type does not support aggregations', async () => {
+      currentAppId$.next('not security');
+      expect(
+        await showTopNAction.isCompatible({ ...context, field: { ...context.field, type: 'text' } })
+      ).toEqual(false);
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute normally', async () => {
+      await showTopNAction.execute(context);
+      expect(document.body.textContent).toContain('TEST COMPONENT');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import { createAction } from '@kbn/ui-actions-plugin/public';
+import { i18n } from '@kbn/i18n';
+import ReactDOM, { unmountComponentAtNode } from 'react-dom';
+import React from 'react';
+
+import type * as H from 'history';
+import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+
+import { KibanaContextProvider } from '../../common/lib/kibana';
+import { APP_NAME, DEFAULT_DARK_MODE } from '../../../common/constants';
+import type { SecurityAppStore } from '../../common/store';
+import { isInSecurityApp } from '../utils';
+import { TopNAction } from './show_top_n_component';
+import type { StartServices } from '../../types';
+
+const SHOW_TOP = (fieldName: string) =>
+  i18n.translate('xpack.securitySolution.actions.showTopTooltip', {
+    values: { fieldName },
+    defaultMessage: `Show top {fieldName}`,
+  });
+
+const ID = 'security_showTopN';
+const ICON = 'visBarVertical';
+const UNSUPPORTED_FIELD_TYPES = ['date', 'text'];
+
+export interface ShowTopNActionContext extends CellActionExecutionContext {
+  metadata?: {
+    scopeId?: string;
+  };
+}
+
+export const createShowTopNAction = ({
+  store,
+  history,
+  services,
+  order,
+}: {
+  store: SecurityAppStore;
+  history: H.History;
+  services: StartServices;
+  order?: number;
+}) => {
+  let currentAppId: string | undefined;
+
+  services.application.currentAppId$.subscribe((appId) => {
+    currentAppId = appId;
+  });
+
+  return createAction<ShowTopNActionContext>({
+    id: ID,
+    type: ID,
+    order,
+    getIconType: (): string => ICON,
+    getDisplayName: ({ field }) => SHOW_TOP(field.name),
+    getDisplayNameTooltip: ({ field }) => SHOW_TOP(field.name),
+    isCompatible: async ({ field }) =>
+      isInSecurityApp(currentAppId) &&
+      field.name != null &&
+      field.value != null &&
+      !UNSUPPORTED_FIELD_TYPES.includes(field.type),
+    execute: async (context) => {
+      const onClose = () => {
+        if (context.extraContentNodeRef.current !== null) {
+          unmountComponentAtNode(context.extraContentNodeRef.current);
+        }
+      };
+
+      const element = (
+        <KibanaContextProvider
+          services={{
+            appName: APP_NAME,
+            ...services,
+          }}
+        >
+          <EuiThemeProvider darkMode={services.uiSettings.get(DEFAULT_DARK_MODE)}>
+            <Provider store={store}>
+              <Router history={history}>
+                <TopNAction onClose={onClose} context={context} casesService={services.cases} />
+              </Router>
+            </Provider>
+          </EuiThemeProvider>
+        </KibanaContextProvider>
+      );
+
+      ReactDOM.render(element, context.extraContentNodeRef.current);
+    },
+  });
+};

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.test.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { mockCasesContext } from '@kbn/cases-plugin/public/mocks/mock_cases_context';
+import { TestProviders } from '../../common/mock';
+import { TopNAction } from './show_top_n_component';
+import type { CellActionExecutionContext } from '@kbn/ui-actions-plugin/public';
+import type { CasesUiStart } from '@kbn/cases-plugin/public';
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original,
+    useLocation: jest.fn().mockReturnValue({ pathname: '/test' }),
+  };
+});
+
+const casesService = {
+  ui: { getCasesContext: () => mockCasesContext },
+} as unknown as CasesUiStart;
+
+const element = document.createElement('div');
+document.body.appendChild(element);
+
+const context = {
+  field: { name: 'user.name', value: 'the-value', type: 'keyword' },
+  nodeRef: {
+    current: element,
+  },
+} as CellActionExecutionContext;
+
+describe('TopNAction', () => {
+  it('renders', () => {
+    const { getByTestId } = render(
+      <TopNAction onClose={() => {}} context={context} casesService={casesService} />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(getByTestId('topN-container')).toBeInTheDocument();
+  });
+
+  it('does not render when nodeRef is null', () => {
+    const { queryByTestId } = render(
+      <TopNAction
+        onClose={() => {}}
+        context={{ ...context, nodeRef: { current: null } }}
+        casesService={casesService}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(queryByTestId('topN-container')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
@@ -14,7 +14,7 @@ import { StatefulTopN } from '../../common/components/top_n';
 import { useGetUserCasesPermissions } from '../../common/lib/kibana';
 import { APP_ID } from '../../../common/constants';
 import { getScopeFromPath, useSourcererDataView } from '../../common/containers/sourcerer';
-import type { ShowTopNActionContext } from './show_top_n';
+import type { ShowTopNActionContext } from './default/show_top_n';
 
 export const TopNAction = ({
   onClose,

--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiWrappingPopover } from '@elastic/eui';
+
+import { useLocation } from 'react-router-dom';
+import type { CasesUiStart } from '@kbn/cases-plugin/public';
+import { StatefulTopN } from '../../common/components/top_n';
+import { useGetUserCasesPermissions } from '../../common/lib/kibana';
+import { APP_ID } from '../../../common/constants';
+import { getScopeFromPath, useSourcererDataView } from '../../common/containers/sourcerer';
+import type { ShowTopNActionContext } from './show_top_n';
+
+export const TopNAction = ({
+  onClose,
+  context,
+  casesService,
+}: {
+  onClose: () => void;
+  context: ShowTopNActionContext;
+  casesService: CasesUiStart;
+}) => {
+  const { pathname } = useLocation();
+  const { browserFields, indexPattern } = useSourcererDataView(getScopeFromPath(pathname));
+  const userCasesPermissions = useGetUserCasesPermissions();
+  const CasesContext = casesService.ui.getCasesContext();
+
+  if (!context.nodeRef.current) return null;
+
+  return (
+    <CasesContext owner={[APP_ID]} permissions={userCasesPermissions}>
+      <EuiWrappingPopover
+        button={context.nodeRef.current}
+        isOpen={true}
+        closePopover={onClose}
+        anchorPosition={'downCenter'}
+        hasArrow={false}
+        repositionOnScroll
+        ownFocus
+        attachToAnchor={false}
+      >
+        <StatefulTopN
+          field={context.field.name}
+          showLegend
+          scopeId={context.metadata?.scopeId}
+          toggleTopN={onClose}
+          value={context.field.value}
+          indexPattern={indexPattern}
+          browserFields={browserFields}
+        />
+      </EuiWrappingPopover>
+    </CasesContext>
+  );
+};

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/services.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/services.ts
@@ -24,7 +24,14 @@ export class KibanaServices {
     uiSettings,
     notifications,
   }: GlobalServices & { kibanaVersion: string }) {
-    this.services = { application, data, http, uiSettings, unifiedSearch, notifications };
+    this.services = {
+      application,
+      data,
+      http,
+      uiSettings,
+      unifiedSearch,
+      notifications,
+    };
     this.kibanaVersion = kibanaVersion;
   }
 

--- a/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
@@ -22,6 +22,8 @@
       "path": "../../../tsconfig.json",
       "force": true
     },
-    "@kbn/security-plugin"
+    "@kbn/security-plugin",
+    "@kbn/securitysolution-list-constants",
+    "@kbn/fleet-plugin"
   ]
 }


### PR DESCRIPTION
## Summary

Create security solutions UI actions and register them. These actions will be used in a [follow-up PR](https://github.com/elastic/kibana/pull/148056).
This PR is part of [UI actions refactor](https://github.com/elastic/kibana/issues/145663) effort

### Implementation details

It creates `filter-in`, `filter-out`, `copy-to-clipboard`, `add-to-timeline`, and `show-top-n` security solution actions.
We can't reuse actions used on embeddable because they have a different context interface, which makes `execute` and `isCompatible` implementations slightly different. But they do share code.

This PR also creates and registers `filter-in` and `filter-out` actions for the timeline because the timeline doesn't use the global filter manager. Instead, it uses the filter manager that is inside the timeline store.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

