### PR TITLE
[Fleet] Use `enrollled_at` timestamp for inactive status calulcation if `last_checkin` not present

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/build_status_runtime_field.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/build_status_runtime_field.test.ts
@@ -24,7 +24,11 @@ describe('buildStatusRuntimeField', () => {
             "source": "
           long lastCheckinMillis = doc['last_checkin'].size() > 0 
             ? doc['last_checkin'].value.toInstant().toEpochMilli() 
-            : -1;
+            : (
+                doc['enrolled_at'].size() > 0 
+                ? doc['enrolled_at'].value.toInstant().toEpochMilli() 
+                : -1
+              );
           if (doc['active'].size() > 0 && doc['active'].value == false) {
             emit('unenrolled'); 
           } else if (lastCheckinMillis > 0 && doc['policy_id'].size() > 0 && false) {
@@ -76,7 +80,11 @@ describe('buildStatusRuntimeField', () => {
             "source": "
           long lastCheckinMillis = doc['my.prefix.last_checkin'].size() > 0 
             ? doc['my.prefix.last_checkin'].value.toInstant().toEpochMilli() 
-            : -1;
+            : (
+                doc['my.prefix.enrolled_at'].size() > 0 
+                ? doc['my.prefix.enrolled_at'].value.toInstant().toEpochMilli() 
+                : -1
+              );
           if (doc['my.prefix.active'].size() > 0 && doc['my.prefix.active'].value == false) {
             emit('unenrolled'); 
           } else if (lastCheckinMillis > 0 && doc['my.prefix.policy_id'].size() > 0 && false) {
@@ -133,7 +141,11 @@ describe('buildStatusRuntimeField', () => {
             "source": "
           long lastCheckinMillis = doc['last_checkin'].size() > 0 
             ? doc['last_checkin'].value.toInstant().toEpochMilli() 
-            : -1;
+            : (
+                doc['enrolled_at'].size() > 0 
+                ? doc['enrolled_at'].value.toInstant().toEpochMilli() 
+                : -1
+              );
           if (doc['active'].size() > 0 && doc['active'].value == false) {
             emit('unenrolled'); 
           } else if (lastCheckinMillis > 0 && doc['policy_id'].size() > 0 && (doc['policy_id'].value == 'policy-1') && lastCheckinMillis < 1234567590123L) {
@@ -190,7 +202,11 @@ describe('buildStatusRuntimeField', () => {
             "source": "
           long lastCheckinMillis = doc['last_checkin'].size() > 0 
             ? doc['last_checkin'].value.toInstant().toEpochMilli() 
-            : -1;
+            : (
+                doc['enrolled_at'].size() > 0 
+                ? doc['enrolled_at'].value.toInstant().toEpochMilli() 
+                : -1
+              );
           if (doc['active'].size() > 0 && doc['active'].value == false) {
             emit('unenrolled'); 
           } else if (lastCheckinMillis > 0 && doc['policy_id'].size() > 0 && (doc['policy_id'].value == 'policy-1' || doc['policy_id'].value == 'policy-2') && lastCheckinMillis < 1234567590123L) {
@@ -251,7 +267,11 @@ describe('buildStatusRuntimeField', () => {
             "source": "
           long lastCheckinMillis = doc['last_checkin'].size() > 0 
             ? doc['last_checkin'].value.toInstant().toEpochMilli() 
-            : -1;
+            : (
+                doc['enrolled_at'].size() > 0 
+                ? doc['enrolled_at'].value.toInstant().toEpochMilli() 
+                : -1
+              );
           if (doc['active'].size() > 0 && doc['active'].value == false) {
             emit('unenrolled'); 
           } else if (lastCheckinMillis > 0 && doc['policy_id'].size() > 0 && (doc['policy_id'].value == 'policy-1' || doc['policy_id'].value == 'policy-2') && lastCheckinMillis < 1234567590123L || (doc['policy_id'].value == 'policy-3') && lastCheckinMillis < 1234567490123L) {

--- a/x-pack/plugins/fleet/server/services/agents/build_status_runtime_field.ts
+++ b/x-pack/plugins/fleet/server/services/agents/build_status_runtime_field.ts
@@ -45,7 +45,11 @@ function _buildSource(inactivityTimeouts: InactivityTimeouts, pathPrefix?: strin
   return `
     long lastCheckinMillis = ${field('last_checkin')}.size() > 0 
       ? ${field('last_checkin')}.value.toInstant().toEpochMilli() 
-      : -1;
+      : (
+          ${field('enrolled_at')}.size() > 0 
+          ? ${field('enrolled_at')}.value.toInstant().toEpochMilli() 
+          : -1
+        );
     if (${field('active')}.size() > 0 && ${field('active')}.value == false) {
       emit('unenrolled'); 
     } else if (${_buildInactiveClause(now, inactivityTimeouts, field)}) {

--- a/x-pack/test/fleet_api_integration/apis/agents/status.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/status.ts
@@ -212,7 +212,6 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should return the status of agents', async () => {
-      const { body: apiResponse1 } = await supertest.get(`/api/fleet/agents`).expect(200);
       const { body: apiResponse } = await supertest.get(`/api/fleet/agent_status`).expect(200);
       expect(apiResponse).to.eql({
         results: {

--- a/x-pack/test/fleet_api_integration/apis/agents/status.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/status.ts
@@ -91,9 +91,25 @@ export default function ({ getService }: FtrProviderContext) {
           },
         },
       });
-      // 1 agent upgrading
+      // 1 agents inactive through enrolled_at as no last_checkin
       await es.create({
         id: 'agent5',
+        refresh: 'wait_for',
+        index: AGENTS_INDEX,
+        document: {
+          active: true,
+          access_api_key_id: 'api-key-4',
+          policy_id: 'policy-inactivity-timeout',
+          type: 'PERMANENT',
+          local_metadata: { host: { hostname: 'host6' } },
+          user_provided_metadata: {},
+          enrolled_at: new Date(Date.now() - 1000 * 60).toISOString(), // policy timeout 1 min
+        },
+      });
+
+      // 1 agent upgrading
+      await es.create({
+        id: 'agent6',
         refresh: 'wait_for',
         index: AGENTS_INDEX,
         document: {
@@ -104,7 +120,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
       // 1 agent reassigned to a new policy
       await es.create({
-        id: 'agent6',
+        id: 'agent7',
         refresh: 'wait_for',
         index: AGENTS_INDEX,
         document: {
@@ -122,7 +138,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       // 1 agent unenrolled
       await es.create({
-        id: 'agent7',
+        id: 'agent8',
         refresh: 'wait_for',
         index: AGENTS_INDEX,
         document: {
@@ -140,7 +156,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
       // 1 agent error
       await es.create({
-        id: 'agent8',
+        id: 'agent9',
         refresh: 'wait_for',
         index: AGENTS_INDEX,
         document: {
@@ -158,7 +174,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
       // 1 agent degraded (error category)
       await es.create({
-        id: 'agent9',
+        id: 'agent10',
         refresh: 'wait_for',
         index: AGENTS_INDEX,
         document: {
@@ -174,23 +190,40 @@ export default function ({ getService }: FtrProviderContext) {
           last_checkin_status: 'DEGRADED',
         },
       });
+      // 1 agent enrolling, no last_checkin yet
+      await es.create({
+        id: 'agent11',
+        refresh: 'wait_for',
+        index: AGENTS_INDEX,
+        document: {
+          active: true,
+          access_api_key_id: 'api-key-4',
+          policy_id: 'policy-inactivity-timeout',
+          type: 'PERMANENT',
+          policy_revision_idx: 1,
+          local_metadata: { host: { hostname: 'host6' } },
+          user_provided_metadata: {},
+          enrolled_at: new Date().toISOString(),
+        },
+      });
     });
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/fleet/agents');
     });
 
     it('should return the status of agents', async () => {
+      const { body: apiResponse1 } = await supertest.get(`/api/fleet/agents`).expect(200);
       const { body: apiResponse } = await supertest.get(`/api/fleet/agent_status`).expect(200);
       expect(apiResponse).to.eql({
         results: {
           events: 0,
           other: 0,
-          total: 7,
+          total: 8,
           online: 2,
           error: 2,
           offline: 1,
-          updating: 2,
-          inactive: 1,
+          updating: 3,
+          inactive: 2,
           unenrolled: 1,
         },
       });


### PR DESCRIPTION
An agent that never checks in but has enrolled will now have the inactivity timeout applied. Integration tests updated.