### PR TITLE
Increase the maximum number of saved objects that could be installed with a Fleet package

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/saved_objects_service.ts
@@ -335,11 +335,11 @@ export class SavedObjectsService
           exportSizeLimit: this.config!.maxImportExportSize,
           logger: this.logger.get('exporter'),
         }),
-      createImporter: (savedObjectsClient) =>
+      createImporter: (savedObjectsClient, options) =>
         new SavedObjectsImporter({
           savedObjectsClient,
           typeRegistry: this.typeRegistry,
-          importSizeLimit: this.config!.maxImportExportSize,
+          importSizeLimit: options?.importSizeLimit ?? this.config!.maxImportExportSize,
         }),
       getTypeRegistry: () => this.typeRegistry,
     };

--- a/packages/core/saved-objects/core-saved-objects-server/src/contracts.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/contracts.ts
@@ -22,7 +22,7 @@ import type {
 import type { SavedObjectsType } from './saved_objects_type';
 import type { ISavedObjectTypeRegistry } from './type_registry';
 import type { ISavedObjectsExporter } from './export';
-import type { ISavedObjectsImporter } from './import';
+import type { ISavedObjectsImporter, SavedObjectsImporterOptions } from './import';
 import type { SavedObjectsExtensions } from './extensions/extensions';
 
 /**
@@ -200,7 +200,10 @@ export interface SavedObjectsServiceStart {
   /**
    * Creates an {@link ISavedObjectsImporter | importer} bound to given client.
    */
-  createImporter: (client: SavedObjectsClientContract) => ISavedObjectsImporter;
+  createImporter: (
+    client: SavedObjectsClientContract,
+    options?: SavedObjectsImporterOptions
+  ) => ISavedObjectsImporter;
   /**
    * Returns the {@link ISavedObjectTypeRegistry | registry} containing all registered
    * {@link SavedObjectsType | saved object types}

--- a/packages/core/saved-objects/core-saved-objects-server/src/import.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/import.ts
@@ -40,6 +40,16 @@ export interface ISavedObjectsImporter {
 }
 
 /**
+ * Options to control the importer
+ *
+ * @public
+ */
+export interface SavedObjectsImporterOptions {
+  /** Overwrites the maximum number of saved objects that could be imported */
+  importSizeLimit?: number;
+}
+
+/**
  * Options to control the import operation.
  * @public
  */

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -363,7 +363,7 @@ async function installPackageFromRegistry({
 
     const savedObjectsImporter = appContextService
       .getSavedObjects()
-      .createImporter(savedObjectsClient);
+      .createImporter(savedObjectsClient, { importSizeLimit: 15_000 });
 
     const savedObjectTagAssignmentService = appContextService
       .getSavedObjectsTagging()


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/148175**

## Summary

If we try to install a package that contains more than 10000 saved objects, the installation fails with the following error: 

```
Error installing security_detection_engine 8.4.1: Can't import more than 10000 objects
```

The max number of objects to import is controlled by the `savedObjects.maxImportExportSize` config option in `kibana.yml`. However, we cannot control that option when installing packages, so we must find out how to overcome this limitation.

### Implemented solution

I've created a setting for the saved object importer that allows you to override the default limit of 10,000 saved objects per import. This setting can be used when initializing the importer if it is determined that the limit can be increased safely. 

Usage example:

```ts
const savedObjectsImporter = appContextService
  .getSavedObjects()
  .createImporter(savedObjectsClient, { importSizeLimit: 15_000 });
```

I tested various limit values using the `security_detection_engine package` and found that a safe limit for our use case is around 30,000 saved objects. To test that, I limited Kibana's available memory to 1 GB using the `NODE_OPTIONS=--max-old-space-size=1024` flag and tried importing packages of different sizes to determine the upper limit. I found that packages with 35,000 to 40,000 saved objects can cause Kibana to crash due to an out-of-memory error. However, this should be more than sufficient for the needs of the security solution, as we will likely never have more than 30,000 saved objects in a package.

### Alternative solutions

It may be possible to divide the installation of a package into smaller chunks, but this approach may only work for certain types of saved objects. One of the steps in the import process is reference validation, which requires all of the saved objects from a package to be loaded into memory at once. This may be fine for the `security_detection_engine` package, as it does not contain any references. However, creating separate import logic based on the contents of a package could result in additional maintenance costs on the Fleet side.

An alternative solution would be to use [the `maxImportPayloadBytes` setting](https://github.com/elastic/kibana/issues/137420#issuecomment-1233558266) instead of `maxImportExportSize` for the saved objects importer. This is because the size of saved objects in a package can vary significantly, and a package with a small number of large objects could potentially create more memory pressure than a package with a large number of small objects. Therefore, using the payload size as a reference point may be a more stable approach.

I welcome any thoughts or suggestions from the @elastic/kibana-core and @elastic/fleet teams regarding this issue and potential solutions.