### PR TITLE
[Onboarding - ECMA] Add migration link to help menu

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
@@ -33,7 +33,7 @@ describe('HeaderHelpMenu', () => {
     component.find('EuiButtonEmpty').simulate('click');
 
     // 4 default links + the toggle button
-    expect(component.find('EuiButtonEmpty').length).toBe(5);
+    expect(component.find('EuiButtonEmpty').length).toBe(6);
   });
 
   test('it renders the global custom content + the default content', () => {
@@ -70,7 +70,7 @@ describe('HeaderHelpMenu', () => {
     component.find('EuiButtonEmpty').simulate('click');
 
     // 2 custom global link + 4 default links + the toggle button
-    expect(component.find('EuiButtonEmpty').length).toBe(7);
+    expect(component.find('EuiButtonEmpty').length).toBe(8);
 
     expect(component.find('[data-test-subj="my-test-custom-link"]').exists()).toBeTruthy();
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
@@ -33,7 +33,7 @@ describe('HeaderHelpMenu', () => {
     component.find('EuiButtonEmpty').simulate('click');
 
     // 4 default links + the toggle button
-    expect(component.find('EuiButtonEmpty').length).toBe(6);
+    expect(component.find('EuiButtonEmpty').length).toBe(5);
   });
 
   test('it renders the global custom content + the default content', () => {
@@ -70,7 +70,7 @@ describe('HeaderHelpMenu', () => {
     component.find('EuiButtonEmpty').simulate('click');
 
     // 2 custom global link + 4 default links + the toggle button
-    expect(component.find('EuiButtonEmpty').length).toBe(8);
+    expect(component.find('EuiButtonEmpty').length).toBe(7);
 
     expect(component.find('[data-test-subj="my-test-custom-link"]').exists()).toBeTruthy();
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -159,21 +159,6 @@ export class HeaderHelpMenu extends Component<Props, State> {
 
         <EuiSpacer size="xs" />
 
-        <EuiButtonEmpty
-          href="https://ela.st/cloud-migration"
-          target="_blank"
-          size="s"
-          flush="left"
-          data-test-subj="migrate_data_to_cloud__help_menu_link"
-        >
-          <FormattedMessage
-            id="core.ui.chrome.headerGlobalNav.helpMenuMoveDataTitle"
-            defaultMessage="Move data to Elastic Cloud"
-          />
-        </EuiButtonEmpty>
-
-        <EuiSpacer size="xs" />
-
         <EuiButtonEmpty href={helpSupportUrl} target="_blank" size="s" flush="left">
           <FormattedMessage
             id="core.ui.chrome.headerGlobalNav.helpMenuAskElasticTitle"

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -159,6 +159,21 @@ export class HeaderHelpMenu extends Component<Props, State> {
 
         <EuiSpacer size="xs" />
 
+        <EuiButtonEmpty
+          href="https://ela.st/cloud-migration"
+          target="_blank"
+          size="s"
+          flush="left"
+          data-test-subj="migrate_data_to_cloud__help_menu_link"
+        >
+          <FormattedMessage
+            id="core.ui.chrome.headerGlobalNav.helpMenuMoveDataTitle"
+            defaultMessage="Move data to Elastic Cloud"
+          />
+        </EuiButtonEmpty>
+
+        <EuiSpacer size="xs" />
+
         <EuiButtonEmpty href={helpSupportUrl} target="_blank" size="s" flush="left">
           <FormattedMessage
             id="core.ui.chrome.headerGlobalNav.helpMenuAskElasticTitle"

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -8,7 +8,6 @@
 
 import React, { Component, Fragment } from 'react';
 import { combineLatest, Observable, Subscription } from 'rxjs';
-import { noop } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -201,10 +200,10 @@ export class HeaderHelpMenu extends Component<Props, State> {
     return globalHelpExtensionMenuLinks
       .sort((a, b) => b.priority - a.priority)
       .map((link, index) => {
-        const { linkType, content: text, href, ...rest } = link;
+        const { linkType, content: text, href, external, ...rest } = link;
         return createCustomLink(index, text, true, {
           href,
-          onClick: this.createOnClickHandler(href, navigateToUrl),
+          onClick: external ? undefined : this.createOnClickHandler(href, navigateToUrl),
           ...rest,
         });
       });
@@ -268,7 +267,7 @@ export class HeaderHelpMenu extends Component<Props, State> {
             const { linkType, content: text, href, external, ...rest } = link;
             return createCustomLink(index, text, addSpacer, {
               href,
-              onClick: external ? noop : this.createOnClickHandler(href, navigateToUrl),
+              onClick: this.createOnClickHandler(href, navigateToUrl),
               ...rest,
             });
           }

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -8,6 +8,7 @@
 
 import React, { Component, Fragment } from 'react';
 import { combineLatest, Observable, Subscription } from 'rxjs';
+import { noop } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -264,10 +265,10 @@ export class HeaderHelpMenu extends Component<Props, State> {
             });
           }
           case 'custom': {
-            const { linkType, content: text, href, ...rest } = link;
+            const { linkType, content: text, href, external, ...rest } = link;
             return createCustomLink(index, text, addSpacer, {
               href,
-              onClick: this.createOnClickHandler(href, navigateToUrl),
+              onClick: external ? noop : this.createOnClickHandler(href, navigateToUrl),
               ...rest,
             });
           }

--- a/packages/core/chrome/core-chrome-browser/src/help_extension.ts
+++ b/packages/core/chrome/core-chrome-browser/src/help_extension.ts
@@ -92,6 +92,10 @@ export interface ChromeHelpExtensionMenuCustomLink extends ChromeHelpExtensionLi
    * Content of the button (in lieu of `children`)
    */
   content: React.ReactNode;
+  /**
+   * Opens link in new tab
+   */
+  external?: boolean;
 }
 
 /** @public */

--- a/src/plugins/home/public/application/components/__snapshots__/home.test.tsx.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/home.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`home change home route should render a link to change the default route
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -88,6 +89,7 @@ exports[`home directories should not render directory entry when showOnHomePage 
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -144,6 +146,7 @@ exports[`home directories should render ADMIN directory entry in "Manage your da
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -247,6 +250,7 @@ exports[`home directories should render solutions in the "solution section" 1`] 
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -315,6 +319,7 @@ exports[`home isNewKibanaInstance should safely handle exceptions 1`] = `
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -395,6 +400,7 @@ exports[`home isNewKibanaInstance should set isNewKibanaInstance to false when t
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -470,6 +476,7 @@ exports[`home should render home component 1`] = `
       }
     }
     isCloudEnabled={false}
+    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}

--- a/src/plugins/home/public/application/components/__snapshots__/home.test.tsx.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/home.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`home change home route should render a link to change the default route
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -89,7 +88,6 @@ exports[`home directories should not render directory entry when showOnHomePage 
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -146,7 +144,6 @@ exports[`home directories should render ADMIN directory entry in "Manage your da
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -250,7 +247,6 @@ exports[`home directories should render solutions in the "solution section" 1`] 
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -319,7 +315,6 @@ exports[`home isNewKibanaInstance should safely handle exceptions 1`] = `
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -400,7 +395,6 @@ exports[`home isNewKibanaInstance should set isNewKibanaInstance to false when t
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}
@@ -476,7 +470,6 @@ exports[`home should render home component 1`] = `
       }
     }
     isCloudEnabled={false}
-    isDarkMode={false}
   />
   <ManageData
     addBasePath={[Function]}

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -103,61 +103,39 @@ exports[`AddData render 1`] = `
       </EuiFlexGroup>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiPanel
-        paddingSize="l"
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xl"
-        >
-          <EuiFlexItem>
-            <EuiImage
-              alt="Illustration for cloud data migration"
-              src="/plugins/kibanaReact/assets/illustration_cloud_migration.png"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiTitle
-              size="xs"
-            >
-              <h4>
-                <FormattedMessage
-                  defaultMessage="Considering Elastic Cloud?"
-                  id="home.addData.moveYourDataTitle"
-                  values={Object {}}
-                />
-              </h4>
-            </EuiTitle>
-            <EuiSpacer
-              size="s"
-            />
-            <EuiText
-              size="s"
-            >
-              <FormattedMessage
-                defaultMessage="Moving your data to Elastic Cloud is easy and can save you time and money."
-                id="home.addData.moveYourDataToElasticCloud"
-                values={Object {}}
-              />
-            </EuiText>
-            <EuiSpacer
-              size="m"
-            />
-            <EuiButton
-              color="primary"
-              href="/app/management/data/migrate_data"
-              onClick={[Function]}
-              size="m"
-            >
-              <FormattedMessage
-                defaultMessage="Explore the benefits"
-                id="home.addData.moveYourDataButtonLabel"
-                values={Object {}}
-              />
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
+      <MoveData
+        addBasePath={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                "/app/integrations/browse",
+              ],
+              Array [
+                "#/tutorial_directory/sampleData",
+              ],
+              Array [
+                "#/tutorial_directory/fileDataViz",
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": "/app/integrations/browse",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/sampleData",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/fileDataViz",
+              },
+            ],
+          }
+        }
+        isCloudEnabled={false}
+        trackUiMetric={[MockFunction]}
+      />
     </EuiFlexItem>
   </EuiFlexGroup>
 </_EuiPageSection>

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -103,10 +103,36 @@ exports[`AddData render 1`] = `
       </EuiFlexGroup>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiImage
-        alt="Illustration of Elastic data integrations"
-        className="homDataAdd__illustration"
-        src="/plugins/kibanaReact/assets/illustration_integrations_lightmode.svg"
+      <MoveData
+        addBasePath={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                "/app/integrations/browse",
+              ],
+              Array [
+                "#/tutorial_directory/sampleData",
+              ],
+              Array [
+                "#/tutorial_directory/fileDataViz",
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": "/app/integrations/browse",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/sampleData",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/fileDataViz",
+              },
+            ],
+          }
+        }
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -103,38 +103,10 @@ exports[`AddData render 1`] = `
       </EuiFlexGroup>
     </EuiFlexItem>
     <EuiFlexItem>
-      <MoveData
-        addBasePath={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                "/app/integrations/browse",
-              ],
-              Array [
-                "#/tutorial_directory/sampleData",
-              ],
-              Array [
-                "#/tutorial_directory/fileDataViz",
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": "/app/integrations/browse",
-              },
-              Object {
-                "type": "return",
-                "value": "#/tutorial_directory/sampleData",
-              },
-              Object {
-                "type": "return",
-                "value": "#/tutorial_directory/fileDataViz",
-              },
-            ],
-          }
-        }
-        isCloudEnabled={false}
-        trackUiMetric={[MockFunction]}
+      <EuiImage
+        alt="Illustration of Elastic data integrations"
+        className="homDataAdd__illustration"
+        src="/plugins/kibanaReact/assets/illustration_integrations_lightmode.svg"
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -39,6 +39,7 @@ describe('AddData', () => {
       <AddData
         addBasePath={addBasePathMock}
         application={applicationStartMock}
+        isDarkMode={false}
         isCloudEnabled={false}
       />
     );

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -39,7 +39,6 @@ describe('AddData', () => {
       <AddData
         addBasePath={addBasePathMock}
         application={applicationStartMock}
-        isDarkMode={false}
         isCloudEnabled={false}
       />
     );

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -6,15 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { i18n } from '@kbn/i18n';
 import React, { FC, MouseEvent } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiImage,
-  EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -24,17 +21,17 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { ApplicationStart } from '@kbn/core/public';
 import { RedirectAppLinks } from '@kbn/kibana-react-plugin/public';
+import { MoveData } from '../move_data';
 import { createAppNavigationHandler } from '../app_navigation_handler';
 import { getServices } from '../../kibana_services';
 
 interface Props {
   addBasePath: (path: string) => string;
   application: ApplicationStart;
-  isDarkMode: boolean;
   isCloudEnabled: boolean;
 }
 
-export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
+export const AddData: FC<Props> = ({ addBasePath, application, isCloudEnabled }) => {
   const { trackUiMetric } = getServices();
   const canAccessIntegrations = application.capabilities.navLinks.integrations;
   if (canAccessIntegrations) {
@@ -140,76 +137,13 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
             </EuiFlexGroup>
           </EuiFlexItem>
 
-          {!isCloudEnabled ? (
-            <EuiFlexItem>
-              <EuiPanel paddingSize="l">
-                <EuiFlexGroup alignItems="center" gutterSize="xl">
-                  <EuiFlexItem>
-                    <EuiImage
-                      alt={i18n.translate('home.moveData.illustration.alt.text', {
-                        defaultMessage: 'Illustration for cloud data migration',
-                      })}
-                      src={
-                        addBasePath('/plugins/kibanaReact/assets/') +
-                        'illustration_cloud_migration.png'
-                      }
-                    />
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <EuiTitle size="xs">
-                      <h4>
-                        <FormattedMessage
-                          id="home.addData.moveYourDataTitle"
-                          defaultMessage="Considering Elastic Cloud?"
-                        />
-                      </h4>
-                    </EuiTitle>
-
-                    <EuiSpacer size="s" />
-
-                    <EuiText size="s">
-                      <FormattedMessage
-                        id="home.addData.moveYourDataToElasticCloud"
-                        defaultMessage="Moving your data to Elastic Cloud is easy and can save you time and money."
-                      />
-                    </EuiText>
-
-                    <EuiSpacer size="m" />
-
-                    {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
-                    <EuiButton
-                      color="primary"
-                      href={addBasePath('/app/management/data/migrate_data')}
-                      onClick={(event: MouseEvent) => {
-                        trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud');
-                        createAppNavigationHandler('/app/management/data/migrate_data')(event);
-                      }}
-                    >
-                      <FormattedMessage
-                        id="home.addData.moveYourDataButtonLabel"
-                        defaultMessage="Explore the benefits"
-                      />
-                    </EuiButton>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiPanel>
-            </EuiFlexItem>
-          ) : (
-            <EuiFlexItem>
-              <EuiImage
-                alt={i18n.translate('home.addData.illustration.alt.text', {
-                  defaultMessage: 'Illustration of Elastic data integrations',
-                })}
-                className="homDataAdd__illustration"
-                src={
-                  addBasePath('/plugins/kibanaReact/assets/') +
-                  (isDarkMode
-                    ? 'illustration_integrations_darkmode.svg'
-                    : 'illustration_integrations_lightmode.svg')
-                }
-              />
-            </EuiFlexItem>
-          )}
+          <EuiFlexItem>
+            <MoveData
+              addBasePath={addBasePath}
+              isCloudEnabled={isCloudEnabled}
+              trackUiMetric={trackUiMetric}
+            />
+          </EuiFlexItem>
         </EuiFlexGroup>
       </KibanaPageTemplate.Section>
     );

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -37,7 +37,6 @@ interface Props {
 export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric } = getServices();
   const { navLinks } = application.capabilities;
-  const { management: isManagementEnabled } = navLinks;
   const canAccessIntegrations = navLinks.integrations;
   if (canAccessIntegrations) {
     return (
@@ -143,7 +142,7 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
           </EuiFlexItem>
 
           <EuiFlexItem>
-            {isManagementEnabled && !isCloudEnabled ? (
+            {!isCloudEnabled ? (
               <MoveData addBasePath={addBasePath} />
             ) : (
               <EuiImage

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -6,12 +6,14 @@
  * Side Public License, v 1.
  */
 
+import { i18n } from '@kbn/i18n';
 import React, { FC, MouseEvent } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiImage,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -28,12 +30,15 @@ import { getServices } from '../../kibana_services';
 interface Props {
   addBasePath: (path: string) => string;
   application: ApplicationStart;
+  isDarkMode: boolean;
   isCloudEnabled: boolean;
 }
 
-export const AddData: FC<Props> = ({ addBasePath, application, isCloudEnabled }) => {
+export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric } = getServices();
-  const canAccessIntegrations = application.capabilities.navLinks.integrations;
+  const { navLinks } = application.capabilities;
+  const { management: isManagementEnabled } = navLinks;
+  const canAccessIntegrations = navLinks.integrations;
   if (canAccessIntegrations) {
     return (
       <KibanaPageTemplate.Section
@@ -138,11 +143,26 @@ export const AddData: FC<Props> = ({ addBasePath, application, isCloudEnabled })
           </EuiFlexItem>
 
           <EuiFlexItem>
-            <MoveData
-              addBasePath={addBasePath}
-              isCloudEnabled={isCloudEnabled}
-              trackUiMetric={trackUiMetric}
-            />
+            {isManagementEnabled && !isCloudEnabled ? (
+              <MoveData
+                addBasePath={addBasePath}
+                isManagementEnabled={isManagementEnabled}
+                trackUiMetric={trackUiMetric}
+              />
+            ) : (
+              <EuiImage
+                alt={i18n.translate('home.addData.illustration.alt.text', {
+                  defaultMessage: 'Illustration of Elastic data integrations',
+                })}
+                className="homDataAdd__illustration"
+                src={
+                  addBasePath('/plugins/kibanaReact/assets/') +
+                  (isDarkMode
+                    ? 'illustration_integrations_darkmode.svg'
+                    : 'illustration_integrations_lightmode.svg')
+                }
+              />
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </KibanaPageTemplate.Section>

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -144,11 +144,7 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
 
           <EuiFlexItem>
             {isManagementEnabled && !isCloudEnabled ? (
-              <MoveData
-                addBasePath={addBasePath}
-                isManagementEnabled={isManagementEnabled}
-                trackUiMetric={trackUiMetric}
-              />
+              <MoveData addBasePath={addBasePath} />
             ) : (
               <EuiImage
                 alt={i18n.translate('home.addData.illustration.alt.text', {

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -36,8 +36,7 @@ interface Props {
 
 export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric } = getServices();
-  const { navLinks } = application.capabilities;
-  const canAccessIntegrations = navLinks.integrations;
+  const canAccessIntegrations = application.capabilities.navLinks.integrations;
   if (canAccessIntegrations) {
     return (
       <KibanaPageTemplate.Section

--- a/src/plugins/home/public/application/components/home.tsx
+++ b/src/plugins/home/public/application/components/home.tsx
@@ -129,7 +129,6 @@ export class Home extends Component<HomeProps, State> {
   private renderNormal() {
     const { addBasePath, solutions, isCloudEnabled } = this.props;
     const { application, trackUiMetric } = getServices();
-    const isDarkMode = getServices().uiSettings?.get('theme:darkMode') || false;
     const devTools = this.findDirectoryById('console');
     const manageDataFeatures = this.getFeaturesByCategory('admin');
 
@@ -152,7 +151,6 @@ export class Home extends Component<HomeProps, State> {
         <AddData
           addBasePath={addBasePath}
           application={application}
-          isDarkMode={isDarkMode}
           isCloudEnabled={isCloudEnabled}
         />
 

--- a/src/plugins/home/public/application/components/home.tsx
+++ b/src/plugins/home/public/application/components/home.tsx
@@ -129,6 +129,7 @@ export class Home extends Component<HomeProps, State> {
   private renderNormal() {
     const { addBasePath, solutions, isCloudEnabled } = this.props;
     const { application, trackUiMetric } = getServices();
+    const isDarkMode = getServices().uiSettings?.get('theme:darkMode') || false;
     const devTools = this.findDirectoryById('console');
     const manageDataFeatures = this.getFeaturesByCategory('admin');
 
@@ -151,6 +152,7 @@ export class Home extends Component<HomeProps, State> {
         <AddData
           addBasePath={addBasePath}
           application={application}
+          isDarkMode={isDarkMode}
           isCloudEnabled={isCloudEnabled}
         />
 

--- a/src/plugins/home/public/application/components/move_data/index.tsx
+++ b/src/plugins/home/public/application/components/move_data/index.tsx
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from './move_data';

--- a/src/plugins/home/public/application/components/move_data/move_data.test.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.test.tsx
@@ -13,29 +13,8 @@ import { shallowWithIntl } from '@kbn/test-jest-helpers';
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
 describe('MoveData', () => {
-  test('render when management NOT enabled', () => {
-    const component = shallowWithIntl(
-      <MoveData
-        addBasePath={addBasePathMock}
-        isManagementEnabled={false}
-        trackUiMetric={jest.fn()}
-      />
-    );
-
-    const button = component.find('EuiButton');
-    const buttonProps = button.props();
-    expect(buttonProps.href).toBe('https://ela.st/cloud-migration');
-    expect(buttonProps.target).toBe('_blank');
-  });
-
-  test('render when management enabled', () => {
-    const component = shallowWithIntl(
-      <MoveData
-        addBasePath={addBasePathMock}
-        isManagementEnabled={true}
-        trackUiMetric={jest.fn()}
-      />
-    );
+  test('renders as expected', () => {
+    const component = shallowWithIntl(<MoveData addBasePath={addBasePathMock} />);
 
     const $button = component.find('EuiButton');
     expect($button.props().href).toBe('/app/management/data/migrate_data');

--- a/src/plugins/home/public/application/components/move_data/move_data.test.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.test.tsx
@@ -13,9 +13,13 @@ import { shallowWithIntl } from '@kbn/test-jest-helpers';
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
 describe('MoveData', () => {
-  test('render when cloud enabled', () => {
+  test('render when management NOT enabled', () => {
     const component = shallowWithIntl(
-      <MoveData addBasePath={addBasePathMock} isCloudEnabled={true} trackUiMetric={jest.fn()} />
+      <MoveData
+        addBasePath={addBasePathMock}
+        isManagementEnabled={false}
+        trackUiMetric={jest.fn()}
+      />
     );
 
     const button = component.find('EuiButton');
@@ -24,9 +28,13 @@ describe('MoveData', () => {
     expect(buttonProps.target).toBe('_blank');
   });
 
-  test('render when cloud NOT enabled', () => {
+  test('render when management enabled', () => {
     const component = shallowWithIntl(
-      <MoveData addBasePath={addBasePathMock} isCloudEnabled={false} trackUiMetric={jest.fn()} />
+      <MoveData
+        addBasePath={addBasePathMock}
+        isManagementEnabled={true}
+        trackUiMetric={jest.fn()}
+      />
     );
 
     const $button = component.find('EuiButton');

--- a/src/plugins/home/public/application/components/move_data/move_data.test.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { MoveData } from './move_data';
+import { shallowWithIntl } from '@kbn/test-jest-helpers';
+
+const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
+
+describe('MoveData', () => {
+  test('render when cloud enabled', () => {
+    const component = shallowWithIntl(
+      <MoveData addBasePath={addBasePathMock} isCloudEnabled={true} trackUiMetric={jest.fn()} />
+    );
+
+    const button = component.find('EuiButton');
+    const buttonProps = button.props();
+    expect(buttonProps.href).toBe('https://ela.st/cloud-migration');
+    expect(buttonProps.target).toBe('_blank');
+  });
+
+  test('render when cloud NOT enabled', () => {
+    const component = shallowWithIntl(
+      <MoveData addBasePath={addBasePathMock} isCloudEnabled={false} trackUiMetric={jest.fn()} />
+    );
+
+    const $button = component.find('EuiButton');
+    expect($button.props().href).toBe('/app/management/data/migrate_data');
+  });
+});

--- a/src/plugins/home/public/application/components/move_data/move_data.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.tsx
@@ -18,20 +18,15 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
 import { createAppNavigationHandler } from '../app_navigation_handler';
 
 interface Props {
   addBasePath: (path: string) => string;
-  isManagementEnabled: boolean;
-  trackUiMetric: (type: UiCounterMetricType, eventNames: string | string[], count?: number) => void;
 }
 
-export const MoveData: FC<Props> = ({ addBasePath, isManagementEnabled, trackUiMetric }) => {
-  const migrateDataUrl = isManagementEnabled
-    ? '/app/management/data/migrate_data'
-    : 'https://ela.st/cloud-migration';
+export const MoveData: FC<Props> = ({ addBasePath }) => {
+  const migrateDataUrl = '/app/management/data/migrate_data';
   const buttonLabel = (
     <FormattedMessage
       id="home.addData.moveYourDataButtonLabel"
@@ -67,34 +62,17 @@ export const MoveData: FC<Props> = ({ addBasePath, isManagementEnabled, trackUiM
             />
           </EuiText>
           <EuiSpacer size="m" />
-          {isManagementEnabled ? (
-            // eslint-disable-next-line @elastic/eui/href-or-on-click
-            <EuiButton
-              color="primary"
-              href={addBasePath(migrateDataUrl)}
-              onClick={(event: MouseEvent) => {
-                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_self_managed_link');
-                createAppNavigationHandler(migrateDataUrl)(event);
-              }}
-            >
-              {buttonLabel}
-            </EuiButton>
-          ) : (
-            // eslint-disable-next-line @elastic/eui/href-or-on-click
-            <EuiButton
-              fill={true}
-              target="_blank"
-              href={migrateDataUrl}
-              onClick={() => {
-                trackUiMetric(
-                  METRIC_TYPE.CLICK,
-                  'migrate_data_to_cloud__home_management_disabled_link'
-                );
-              }}
-            >
-              {buttonLabel}
-            </EuiButton>
-          )}
+          {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+          <EuiButton
+            data-test-subj="migrate_data_to_cloud__migrate_data_docs_link"
+            color="primary"
+            href={addBasePath(migrateDataUrl)}
+            onClick={(event: MouseEvent) => {
+              createAppNavigationHandler(migrateDataUrl)(event);
+            }}
+          >
+            {buttonLabel}
+          </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/src/plugins/home/public/application/components/move_data/move_data.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FC, MouseEvent } from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiImage,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
+import { i18n } from '@kbn/i18n';
+import { createAppNavigationHandler } from '../app_navigation_handler';
+
+interface Props {
+  addBasePath: (path: string) => string;
+  isCloudEnabled: boolean;
+  trackUiMetric: (type: UiCounterMetricType, eventNames: string | string[], count?: number) => void;
+}
+
+export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric }) => {
+  const migrateDataUrl = !isCloudEnabled
+    ? '/app/management/data/migrate_data'
+    : 'https://ela.st/cloud-migration';
+  const buttonLabel = (
+    <FormattedMessage
+      id="home.addData.moveYourDataButtonLabel"
+      defaultMessage="Explore the benefits"
+    />
+  );
+
+  return (
+    <EuiPanel paddingSize="l">
+      <EuiFlexGroup alignItems="center" gutterSize="xl">
+        <EuiFlexItem>
+          <EuiImage
+            alt={i18n.translate('home.moveData.illustration.alt.text', {
+              defaultMessage: 'Illustration for cloud data migration',
+            })}
+            src={addBasePath('/plugins/kibanaReact/assets/') + 'illustration_cloud_migration.png'}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="xs">
+            <h4>
+              <FormattedMessage
+                id="home.addData.moveYourDataTitle"
+                defaultMessage="Considering Elastic Cloud?"
+              />
+            </h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s">
+            <FormattedMessage
+              id="home.addData.moveYourDataToElasticCloud"
+              defaultMessage="Moving your data to Elastic Cloud is easy and can save you time and money."
+            />
+          </EuiText>
+          <EuiSpacer size="m" />
+          {!isCloudEnabled /* eslint-disable-next-line @elastic/eui/href-or-on-click */ ? (
+            <EuiButton
+              color="primary"
+              href={addBasePath(migrateDataUrl)}
+              onClick={(event: MouseEvent) => {
+                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud');
+                createAppNavigationHandler(migrateDataUrl)(event);
+              }}
+            >
+              {buttonLabel}
+            </EuiButton>
+          ) : (
+            <EuiButton fill={true} target="_blank" href={migrateDataUrl}>
+              {buttonLabel}
+            </EuiButton>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/src/plugins/home/public/application/components/move_data/move_data.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.tsx
@@ -29,9 +29,9 @@ interface Props {
 }
 
 export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric }) => {
-  const migrateDataUrl = !isCloudEnabled
-    ? '/app/management/data/migrate_data'
-    : 'https://ela.st/cloud-migration';
+  const migrateDataUrl = isCloudEnabled
+    ? 'https://ela.st/cloud-migration'
+    : '/app/management/data/migrate_data';
   const buttonLabel = (
     <FormattedMessage
       id="home.addData.moveYourDataButtonLabel"
@@ -67,18 +67,7 @@ export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric
             />
           </EuiText>
           <EuiSpacer size="m" />
-          {!isCloudEnabled /* eslint-disable-next-line @elastic/eui/href-or-on-click */ ? (
-            <EuiButton
-              color="primary"
-              href={addBasePath(migrateDataUrl)}
-              onClick={(event: MouseEvent) => {
-                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_self_managed_link');
-                createAppNavigationHandler(migrateDataUrl)(event);
-              }}
-            >
-              {buttonLabel}
-            </EuiButton>
-          ) : (
+          {isCloudEnabled ? (
             // eslint-disable-next-line @elastic/eui/href-or-on-click
             <EuiButton
               fill={true}
@@ -86,6 +75,18 @@ export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric
               href={migrateDataUrl}
               onClick={() => {
                 trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_cloud_enabled_link');
+              }}
+            >
+              {buttonLabel}
+            </EuiButton>
+          ) : (
+            // eslint-disable-next-line @elastic/eui/href-or-on-click
+            <EuiButton
+              color="primary"
+              href={addBasePath(migrateDataUrl)}
+              onClick={(event: MouseEvent) => {
+                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_self_managed_link');
+                createAppNavigationHandler(migrateDataUrl)(event);
               }}
             >
               {buttonLabel}

--- a/src/plugins/home/public/application/components/move_data/move_data.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.tsx
@@ -72,14 +72,22 @@ export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric
               color="primary"
               href={addBasePath(migrateDataUrl)}
               onClick={(event: MouseEvent) => {
-                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud');
+                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_self_managed_link');
                 createAppNavigationHandler(migrateDataUrl)(event);
               }}
             >
               {buttonLabel}
             </EuiButton>
           ) : (
-            <EuiButton fill={true} target="_blank" href={migrateDataUrl}>
+            // eslint-disable-next-line @elastic/eui/href-or-on-click
+            <EuiButton
+              fill={true}
+              target="_blank"
+              href={migrateDataUrl}
+              onClick={() => {
+                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_cloud_enabled_link');
+              }}
+            >
               {buttonLabel}
             </EuiButton>
           )}

--- a/src/plugins/home/public/application/components/move_data/move_data.tsx
+++ b/src/plugins/home/public/application/components/move_data/move_data.tsx
@@ -24,14 +24,14 @@ import { createAppNavigationHandler } from '../app_navigation_handler';
 
 interface Props {
   addBasePath: (path: string) => string;
-  isCloudEnabled: boolean;
+  isManagementEnabled: boolean;
   trackUiMetric: (type: UiCounterMetricType, eventNames: string | string[], count?: number) => void;
 }
 
-export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric }) => {
-  const migrateDataUrl = isCloudEnabled
-    ? 'https://ela.st/cloud-migration'
-    : '/app/management/data/migrate_data';
+export const MoveData: FC<Props> = ({ addBasePath, isManagementEnabled, trackUiMetric }) => {
+  const migrateDataUrl = isManagementEnabled
+    ? '/app/management/data/migrate_data'
+    : 'https://ela.st/cloud-migration';
   const buttonLabel = (
     <FormattedMessage
       id="home.addData.moveYourDataButtonLabel"
@@ -67,19 +67,7 @@ export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric
             />
           </EuiText>
           <EuiSpacer size="m" />
-          {isCloudEnabled ? (
-            // eslint-disable-next-line @elastic/eui/href-or-on-click
-            <EuiButton
-              fill={true}
-              target="_blank"
-              href={migrateDataUrl}
-              onClick={() => {
-                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_cloud_enabled_link');
-              }}
-            >
-              {buttonLabel}
-            </EuiButton>
-          ) : (
+          {isManagementEnabled ? (
             // eslint-disable-next-line @elastic/eui/href-or-on-click
             <EuiButton
               color="primary"
@@ -87,6 +75,21 @@ export const MoveData: FC<Props> = ({ addBasePath, isCloudEnabled, trackUiMetric
               onClick={(event: MouseEvent) => {
                 trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__home_self_managed_link');
                 createAppNavigationHandler(migrateDataUrl)(event);
+              }}
+            >
+              {buttonLabel}
+            </EuiButton>
+          ) : (
+            // eslint-disable-next-line @elastic/eui/href-or-on-click
+            <EuiButton
+              fill={true}
+              target="_blank"
+              href={migrateDataUrl}
+              onClick={() => {
+                trackUiMetric(
+                  METRIC_TYPE.CLICK,
+                  'migrate_data_to_cloud__home_management_disabled_link'
+                );
               }}
             >
               {buttonLabel}

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/application/components/app.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/application/components/app.tsx
@@ -26,6 +26,8 @@ import {
 import { CoreStart, CoreTheme } from '@kbn/core/public';
 
 import { Observable } from 'rxjs';
+import { METRIC_TYPE } from '@kbn/analytics';
+import { getServices } from '@kbn/home-plugin/public/application/kibana_services';
 import { getAppStyles } from '../../app.styles';
 import { BreadcrumbService } from '../services/breadcrumbs';
 
@@ -44,6 +46,7 @@ export const CloudDataMigrationApp = ({ http, breadcrumbService }: CloudDataMigr
     wrapText: true,
   };
   const styles = getAppStyles(euiTheme);
+  const { trackUiMetric } = getServices();
 
   useEffect(() => {
     breadcrumbService.setBreadcrumbs('home');
@@ -132,7 +135,15 @@ export const CloudDataMigrationApp = ({ http, breadcrumbService }: CloudDataMigr
           <EuiSpacer size="l" />
 
           <div>
-            <EuiButton fill={true} target="_blank" href="https://ela.st/cloud-migration">
+            {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+            <EuiButton
+              fill={true}
+              target="_blank"
+              href="https://ela.st/cloud-migration"
+              onClick={() => {
+                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__stack_management_link');
+              }}
+            >
               <FormattedMessage
                 id="xpack.cloudDataMigration.readInstructionsButtonLabel"
                 defaultMessage="Help me move"

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/application/components/app.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/application/components/app.tsx
@@ -26,8 +26,6 @@ import {
 import { CoreStart, CoreTheme } from '@kbn/core/public';
 
 import { Observable } from 'rxjs';
-import { METRIC_TYPE } from '@kbn/analytics';
-import { getServices } from '@kbn/home-plugin/public/application/kibana_services';
 import { getAppStyles } from '../../app.styles';
 import { BreadcrumbService } from '../services/breadcrumbs';
 
@@ -46,7 +44,6 @@ export const CloudDataMigrationApp = ({ http, breadcrumbService }: CloudDataMigr
     wrapText: true,
   };
   const styles = getAppStyles(euiTheme);
-  const { trackUiMetric } = getServices();
 
   useEffect(() => {
     breadcrumbService.setBreadcrumbs('home');
@@ -135,14 +132,12 @@ export const CloudDataMigrationApp = ({ http, breadcrumbService }: CloudDataMigr
           <EuiSpacer size="l" />
 
           <div>
-            {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
             <EuiButton
               fill={true}
               target="_blank"
               href="https://ela.st/cloud-migration"
-              onClick={() => {
-                trackUiMetric(METRIC_TYPE.CLICK, 'migrate_data_to_cloud__stack_management_link');
-              }}
+              // data-test-subj used for Telemetry
+              data-test-subj="migrate_data_to_cloud__stack_management_link"
             >
               <FormattedMessage
                 id="xpack.cloudDataMigration.readInstructionsButtonLabel"

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
@@ -48,12 +48,13 @@ export class CloudDataMigrationPlugin
     if (!cloud?.isCloudEnabled) {
       core.chrome.registerGlobalHelpExtensionMenuLink({
         linkType: 'custom',
+        target: '_blank',
         href: 'https://ela.st/cloud-migration',
         content: i18n.translate('xpack.cloudDataMigration.helpMenuMoveDataTitle', {
           defaultMessage: 'Move data to Elastic Cloud',
         }),
         'data-test-subj': 'migrate_data_to_cloud__help_menu_link',
-        priority: 999, // We want this link to be at the very top.
+        priority: 200,
       });
     }
   }

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
@@ -55,6 +55,7 @@ export class CloudDataMigrationPlugin
         }),
         'data-test-subj': 'migrate_data_to_cloud__help_menu_link',
         priority: 200,
+        external: true,
       });
     }
   }

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/plugin.ts
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import { CloudDataMigrationPluginSetup, CloudDataMigrationPluginStart } from './types';
 import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { BreadcrumbService } from './application/services/breadcrumbs';
 
-export class CloudDataMigrationPlugin implements Plugin<void, CloudDataMigrationPluginStart> {
+export class CloudDataMigrationPlugin
+  implements Plugin<void, void, CloudDataMigrationPluginSetup, CloudDataMigrationPluginStart>
+{
   private breadcrumbService = new BreadcrumbService();
 
   public setup(core: CoreSetup, { cloud, management }: CloudDataMigrationPluginSetup) {
@@ -41,8 +44,18 @@ export class CloudDataMigrationPlugin implements Plugin<void, CloudDataMigration
     }
   }
 
-  public start(core: CoreStart): CloudDataMigrationPluginStart {
-    return {};
+  public start(core: CoreStart, { cloud }: CloudDataMigrationPluginStart) {
+    if (!cloud?.isCloudEnabled) {
+      core.chrome.registerGlobalHelpExtensionMenuLink({
+        linkType: 'custom',
+        href: 'https://ela.st/cloud-migration',
+        content: i18n.translate('xpack.cloudDataMigration.helpMenuMoveDataTitle', {
+          defaultMessage: 'Move data to Elastic Cloud',
+        }),
+        'data-test-subj': 'migrate_data_to_cloud__help_menu_link',
+        priority: 999, // We want this link to be at the very top.
+      });
+    }
   }
 
   public stop() {}

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/public/types.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/public/types.ts
@@ -7,7 +7,7 @@
 
 import { ManagementSetup } from '@kbn/management-plugin/public';
 
-import { CloudSetup } from '@kbn/cloud-plugin/public';
+import { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import { BreadcrumbService } from './application/services/breadcrumbs';
 
 export interface CloudDataMigrationPluginSetup {
@@ -16,5 +16,6 @@ export interface CloudDataMigrationPluginSetup {
   breadcrumbService: BreadcrumbService;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface CloudDataMigrationPluginStart {}
+export interface CloudDataMigrationPluginStart {
+  cloud?: CloudStart;
+}


### PR DESCRIPTION
Fixes #147462 
Fixes #147474

- Update link to instructions for migrating to Elastic Cloud on homepage to go directly to documentation if Stack Management page is not available to user
- Telemetry / Platform Analytics - We need to to be able to track how many people click the "Help me move" button from the static page.

### Telemetry
Telemetry click events added as follows:
- `migrate_data_to_cloud__migrate_data_docs_link`:  "Homepage" link
- `migrate_data_to_cloud__help_menu_link`: Help menu link
