### PR TITLE
support disabling kibana build download in functional/common.sh

### DIFF
--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -14,6 +14,8 @@ steps:
     env:
       # ensure that the FTR logs all output for these tests
       DISABLE_CI_LOG_OUTPUT_CAPTURE: 'true'
+      # disable downloading a kibana build, this step does not use it
+      KIBANA_BUILD_ID: 'false'
     timeout_in_minutes: 90
 
   - wait: ~

--- a/.buildkite/scripts/download_build_artifacts.sh
+++ b/.buildkite/scripts/download_build_artifacts.sh
@@ -4,25 +4,27 @@ set -euo pipefail
 
 source "$(dirname "$0")/common/util.sh"
 
-if [[ ! -d "$KIBANA_BUILD_LOCATION/bin" ]]; then
-  echo '--- Downloading Distribution and Plugin artifacts'
+if [[ "${KIBANA_BUILD_ID:-}" != "false" ]]; then
+  if [[ ! -d "$KIBANA_BUILD_LOCATION/bin" ]]; then
+    echo '--- Downloading Distribution and Plugin artifacts'
 
-  cd "$WORKSPACE"
+    cd "$WORKSPACE"
 
-  download_artifact kibana-default.tar.gz . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-  download_artifact kibana-default-plugins.tar.gz . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+    download_artifact kibana-default.tar.gz . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+    download_artifact kibana-default-plugins.tar.gz . --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
-  mkdir -p "$KIBANA_BUILD_LOCATION"
-  tar -xzf kibana-default.tar.gz -C "$KIBANA_BUILD_LOCATION" --strip=1
+    mkdir -p "$KIBANA_BUILD_LOCATION"
+    tar -xzf kibana-default.tar.gz -C "$KIBANA_BUILD_LOCATION" --strip=1
 
-  if is_pr_with_label "ci:build-example-plugins"; then
-    # Testing against an example plugin distribution is not supported,
-    # mostly due to snapshot failures when testing UI element lists
-    rm -rf "$KIBANA_BUILD_LOCATION/plugins"
-    mkdir "$KIBANA_BUILD_LOCATION/plugins"
+    if is_pr_with_label "ci:build-example-plugins"; then
+      # Testing against an example plugin distribution is not supported,
+      # mostly due to snapshot failures when testing UI element lists
+      rm -rf "$KIBANA_BUILD_LOCATION/plugins"
+      mkdir "$KIBANA_BUILD_LOCATION/plugins"
+    fi
+
+    cd "$KIBANA_DIR"
+
+    tar -xzf ../kibana-default-plugins.tar.gz
   fi
-
-  cd "$KIBANA_DIR"
-
-  tar -xzf ../kibana-default-plugins.tar.gz
 fi


### PR DESCRIPTION
We need to disable downloading the Kibana build for steps which don't need it, especially in builds which skip building Kibana completely