### PR TITLE
[ResponseOps] Opsgenie fix flaky execute button test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
@@ -22,7 +22,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const browser = getService('browser');
   let objectRemover: ObjectRemover;
 
-  describe.only('Opsgenie', () => {
+  describe('Opsgenie', () => {
     before(async () => {
       objectRemover = await createSlackConnectorAndObjectRemover({ getService });
     });

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
@@ -22,7 +22,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const browser = getService('browser');
   let objectRemover: ObjectRemover;
 
-  describe('Opsgenie', () => {
+  describe.only('Opsgenie', () => {
     before(async () => {
       objectRemover = await createSlackConnectorAndObjectRemover({ getService });
     });
@@ -138,7 +138,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         await find.clickByCssSelector('[data-test-subj="testConnectorTab"]');
 
-        expect(await (await testSubjects.find('executeActionButton')).isEnabled()).to.be(false);
+        expect(await testSubjects.isEnabled('executeActionButton')).to.be(false);
       });
 
       describe('test page', () => {


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/147509

This PR tries to fix a flaky test where the execute button is enable when it should not.

Flaky test run passed: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1707