### PR TITLE
[Fleet] Add `packagePoliceDelete` callback

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/plugin.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.test.ts
@@ -29,7 +29,7 @@ import {
 import {
   ExternalCallback,
   FleetStartContract,
-  PostPackagePolicyDeleteCallback,
+  PostPackagePolicyPostDeleteCallback,
   PostPackagePolicyPostCreateCallback,
 } from '@kbn/fleet-plugin/server';
 import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../common/constants';
@@ -298,9 +298,9 @@ describe('Cloud Security Posture Plugin', () => {
         const deletedPackagePolicyMock = deletePackagePolicyMock();
         deletedPackagePolicyMock[0].package!.name = CLOUD_SECURITY_POSTURE_PACKAGE_NAME;
 
-        const packagePolicyPostDeleteCallbacks: PostPackagePolicyDeleteCallback[] = [];
+        const packagePolicyPostDeleteCallbacks: PostPackagePolicyPostDeleteCallback[] = [];
         fleetMock.registerExternalCallback.mockImplementation((...args) => {
-          if (args[0] === 'postPackagePolicyDelete') {
+          if (args[0] === 'packagePolicyPostDelete') {
             packagePolicyPostDeleteCallbacks.push(args[1]);
           }
         });

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -16,7 +16,7 @@ import type {
 } from '@kbn/core/server';
 import type { DeepReadonly } from 'utility-types';
 import type {
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
   PackagePolicy,
   NewPackagePolicy,
 } from '@kbn/fleet-plugin/common';
@@ -145,8 +145,8 @@ export class CspPlugin
       );
 
       plugins.fleet.registerExternalCallback(
-        'postPackagePolicyDelete',
-        async (deletedPackagePolicies: DeepReadonly<DeletePackagePoliciesResponse>) => {
+        'packagePolicyPostDelete',
+        async (deletedPackagePolicies: DeepReadonly<PostDeletePackagePoliciesResponse>) => {
           for (const deletedPackagePolicy of deletedPackagePolicies) {
             if (isCspPackage(deletedPackagePolicy.package?.name)) {
               const soClient = core.savedObjects.createInternalRepository();

--- a/x-pack/plugins/fleet/common/index.ts
+++ b/x-pack/plugins/fleet/common/index.ts
@@ -95,7 +95,7 @@ export type {
   GetAgentPoliciesRequest,
   GetAgentPoliciesResponse,
   GetAgentPoliciesResponseItem,
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
   GetPackagesResponse,
   BulkInstallPackagesResponse,
   FleetErrorResponse,

--- a/x-pack/plugins/fleet/common/mocks.ts
+++ b/x-pack/plugins/fleet/common/mocks.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { DeletePackagePoliciesResponse, NewPackagePolicy, PackagePolicy } from './types';
+import type { PostDeletePackagePoliciesResponse, NewPackagePolicy, PackagePolicy } from './types';
 import type { FleetAuthz } from './authz';
 import { ENDPOINT_PRIVILEGES } from './constants';
 
@@ -47,7 +47,7 @@ export const createPackagePolicyMock = (): PackagePolicy => {
   };
 };
 
-export const deletePackagePolicyMock = (): DeletePackagePoliciesResponse => {
+export const deletePackagePolicyMock = (): PostDeletePackagePoliciesResponse => {
   const newPackagePolicy = createNewPackagePolicyMock();
   return [
     {

--- a/x-pack/plugins/fleet/common/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/package_policy.ts
@@ -54,7 +54,9 @@ export interface DeletePackagePoliciesRequest {
   };
 }
 
-export type DeletePackagePoliciesResponse = Array<{
+export type DeletePackagePoliciesResponse = PackagePolicy[];
+
+export type PostDeletePackagePoliciesResponse = Array<{
   id: string;
   name?: string;
   success: boolean;

--- a/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../types';
 import type {
   DeletePackagePoliciesRequest,
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
   GetPackagePoliciesRequest,
   GetPackagePoliciesResponse,
   GetOnePackagePolicyResponse,
@@ -44,7 +44,7 @@ export const sendUpdatePackagePolicy = (
 };
 
 export const sendDeletePackagePolicy = (body: DeletePackagePoliciesRequest['body']) => {
-  return sendRequest<DeletePackagePoliciesResponse>({
+  return sendRequest<PostDeletePackagePoliciesResponse>({
     path: packagePolicyRouteService.getDeletePath(),
     method: 'post',
     body: JSON.stringify(body),

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -27,7 +27,7 @@ export type { FleetSetupContract, FleetSetupDeps, FleetStartContract } from './p
 export type {
   ExternalCallback,
   PutPackagePolicyUpdateCallback,
-  PostPackagePolicyDeleteCallback,
+  PostPackagePolicyPostDeleteCallback,
   PostPackagePolicyCreateCallback,
   FleetRequestHandlerContext,
   PostPackagePolicyPostCreateCallback,

--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -122,6 +122,7 @@ export const createPackagePolicyServiceMock = (): jest.Mocked<PackagePolicyClien
     bulkUpdate: jest.fn(),
     runExternalCallbacks: jest.fn(),
     runDeleteExternalCallbacks: jest.fn(),
+    runPostDeleteExternalCallbacks: jest.fn(),
     upgrade: jest.fn(),
     getUpgradeDryRunDiff: jest.fn(),
     getUpgradePackagePolicyInfo: jest.fn(),

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.test.ts
@@ -98,7 +98,7 @@ jest.mock(
         update: jest.fn(),
         // @ts-ignore
         runExternalCallbacks: jest.fn((callbackType, packagePolicy, context, request) =>
-          callbackType === 'postPackagePolicyDelete'
+          callbackType === 'packagePolicyPostDelete'
             ? Promise.resolve(undefined)
             : Promise.resolve(packagePolicy)
         ),

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -171,7 +171,7 @@ describe('agent policy', () => {
 
     it('should run package policy delete external callbacks', async () => {
       await agentPolicyService.delete(soClient, esClient, 'mocked');
-      expect(packagePolicyService.runDeleteExternalCallbacks).toHaveBeenCalledWith([
+      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith([
         { id: 'package-1' },
       ]);
     });
@@ -195,7 +195,7 @@ describe('agent policy', () => {
 
       await agentPolicyService.delete(soClient, esClient, 'mocked', { force: true });
 
-      expect(packagePolicyService.runDeleteExternalCallbacks).toHaveBeenCalledWith([
+      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith([
         { id: 'package-1' },
       ]);
     });

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -51,7 +51,7 @@ import type {
   FleetServerPolicy,
   Installation,
   Output,
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
   PackageInfo,
 } from '../../common/types';
 import {
@@ -680,7 +680,10 @@ class AgentPolicyService {
           `Cannot delete agent policy ${id} that contains managed package policies`
         );
       }
-      const deletedPackagePolicies: DeletePackagePoliciesResponse =
+
+      await packagePolicyService.runDeleteExternalCallbacks(packagePolicies);
+
+      const deletedPackagePolicies: PostDeletePackagePoliciesResponse =
         await packagePolicyService.delete(
           soClient,
           esClient,
@@ -691,7 +694,7 @@ class AgentPolicyService {
           }
         );
       try {
-        await packagePolicyService.runDeleteExternalCallbacks(deletedPackagePolicies);
+        await packagePolicyService.runPostDeleteExternalCallbacks(deletedPackagePolicies);
       } catch (error) {
         const logger = appContextService.getLogger();
         logger.error(`An error occurred executing external callback: ${error}`);

--- a/x-pack/plugins/fleet/server/services/app_context.ts
+++ b/x-pack/plugins/fleet/server/services/app_context.ts
@@ -35,8 +35,9 @@ import type { ExperimentalFeatures } from '../../common/experimental_features';
 import type {
   ExternalCallback,
   ExternalCallbacksStorage,
-  PostPackagePolicyCreateCallback,
   PostPackagePolicyDeleteCallback,
+  PostPackagePolicyCreateCallback,
+  PostPackagePolicyPostDeleteCallback,
   PostPackagePolicyPostCreateCallback,
   PutPackagePolicyUpdateCallback,
 } from '../types';
@@ -211,8 +212,10 @@ class AppContextService {
     | Set<
         T extends 'packagePolicyCreate'
           ? PostPackagePolicyCreateCallback
-          : T extends 'postPackagePolicyDelete'
+          : T extends 'packagePolicyDelete'
           ? PostPackagePolicyDeleteCallback
+          : T extends 'packagePolicyPostDelete'
+          ? PostPackagePolicyPostDeleteCallback
           : T extends 'packagePolicyPostCreate'
           ? PostPackagePolicyPostCreateCallback
           : PutPackagePolicyUpdateCallback
@@ -222,8 +225,10 @@ class AppContextService {
       return this.externalCallbacks.get(type) as Set<
         T extends 'packagePolicyCreate'
           ? PostPackagePolicyCreateCallback
-          : T extends 'postPackagePolicyDelete'
+          : T extends 'packagePolicyDelete'
           ? PostPackagePolicyDeleteCallback
+          : T extends 'packagePolicyPostDelete'
+          ? PostPackagePolicyPostDeleteCallback
           : T extends 'packagePolicyPostCreate'
           ? PostPackagePolicyPostCreateCallback
           : PutPackagePolicyUpdateCallback

--- a/x-pack/plugins/fleet/server/types/extensions.ts
+++ b/x-pack/plugins/fleet/server/types/extensions.ts
@@ -10,14 +10,19 @@ import type { KibanaRequest, RequestHandlerContext } from '@kbn/core/server';
 import type { DeepReadonly } from 'utility-types';
 
 import type {
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
   NewPackagePolicy,
   UpdatePackagePolicy,
   PackagePolicy,
+  DeletePackagePoliciesResponse,
 } from '../../common/types';
 
 export type PostPackagePolicyDeleteCallback = (
-  deletedPackagePolicies: DeepReadonly<DeletePackagePoliciesResponse>
+  packagePolicies: DeletePackagePoliciesResponse
+) => Promise<void>;
+
+export type PostPackagePolicyPostDeleteCallback = (
+  deletedPackagePolicies: DeepReadonly<PostDeletePackagePoliciesResponse>
 ) => Promise<void>;
 
 export type PostPackagePolicyCreateCallback = (
@@ -43,7 +48,12 @@ export type ExternalCallbackPostCreate = [
   'packagePolicyPostCreate',
   PostPackagePolicyPostCreateCallback
 ];
-export type ExternalCallbackDelete = ['postPackagePolicyDelete', PostPackagePolicyDeleteCallback];
+
+export type ExternalCallbackDelete = ['packagePolicyDelete', PostPackagePolicyDeleteCallback];
+export type ExternalCallbackPostDelete = [
+  'packagePolicyPostDelete',
+  PostPackagePolicyPostDeleteCallback
+];
 export type ExternalCallbackUpdate = ['packagePolicyUpdate', PutPackagePolicyUpdateCallback];
 
 /**
@@ -53,6 +63,7 @@ export type ExternalCallback =
   | ExternalCallbackCreate
   | ExternalCallbackPostCreate
   | ExternalCallbackDelete
+  | ExternalCallbackPostDelete
   | ExternalCallbackUpdate;
 
 export type ExternalCallbacksStorage = Map<ExternalCallback[0], Set<ExternalCallback[1]>>;

--- a/x-pack/plugins/osquery/server/lib/fleet_integration.ts
+++ b/x-pack/plugins/osquery/server/lib/fleet_integration.ts
@@ -7,13 +7,13 @@
 
 import type { SavedObjectReference, SavedObjectsClient } from '@kbn/core/server';
 import { filter, map } from 'lodash';
-import type { PostPackagePolicyDeleteCallback } from '@kbn/fleet-plugin/server';
+import type { PostPackagePolicyPostDeleteCallback } from '@kbn/fleet-plugin/server';
 import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import { packSavedObjectType } from '../../common/types';
 import { OSQUERY_INTEGRATION_NAME } from '../../common';
 
 export const getPackagePolicyDeleteCallback =
-  (packsClient: SavedObjectsClient): PostPackagePolicyDeleteCallback =>
+  (packsClient: SavedObjectsClient): PostPackagePolicyPostDeleteCallback =>
   async (deletedPackagePolicy) => {
     const deletedOsqueryManagerPolicies = filter(deletedPackagePolicy, [
       'package.name',

--- a/x-pack/plugins/osquery/server/plugin.ts
+++ b/x-pack/plugins/osquery/server/plugin.ts
@@ -160,7 +160,7 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
           }
         );
 
-        registerIngestCallback('postPackagePolicyDelete', getPackagePolicyDeleteCallback(client));
+        registerIngestCallback('packagePolicyPostDelete', getPackagePolicyDeleteCallback(client));
       }
     });
 

--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_fleet_endpoint_policy.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_fleet_endpoint_policy.ts
@@ -14,7 +14,7 @@ import type {
   CreatePackagePolicyRequest,
   CreatePackagePolicyResponse,
   DeleteAgentPolicyResponse,
-  DeletePackagePoliciesResponse,
+  PostDeletePackagePoliciesResponse,
 } from '@kbn/fleet-plugin/common';
 import { AGENT_POLICY_API_ROUTES, PACKAGE_POLICY_API_ROUTES } from '@kbn/fleet-plugin/common';
 import type { PolicyData } from '../types';
@@ -102,7 +102,7 @@ export const indexFleetEndpointPolicy = async (
 };
 
 export interface DeleteIndexedFleetEndpointPoliciesResponse {
-  integrationPolicies: DeletePackagePoliciesResponse | undefined;
+  integrationPolicies: PostDeletePackagePoliciesResponse | undefined;
   agentPolicies: DeleteAgentPolicyResponse[] | undefined;
 }
 
@@ -132,7 +132,7 @@ export const deleteIndexedFleetEndpointPolicies = async (
             packagePolicyIds: indexData.integrationPolicies.map((policy) => policy.id),
           },
         })
-        .catch(wrapErrorAndRejectPromise)) as AxiosResponse<DeletePackagePoliciesResponse>
+        .catch(wrapErrorAndRejectPromise)) as AxiosResponse<PostDeletePackagePoliciesResponse>
     ).data;
   }
 

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -140,7 +140,7 @@ export class EndpointAppContextService {
       );
 
       registerIngestCallback(
-        'postPackagePolicyDelete',
+        'packagePolicyPostDelete',
         getPackagePolicyDeleteCallback(exceptionListsClient)
       );
     }

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -43,7 +43,7 @@ import { getMockArtifacts, toArtifactRecords } from '../endpoint/lib/artifacts/m
 import { Manifest } from '../endpoint/lib/artifacts';
 import type { NewPackagePolicy, PackagePolicy } from '@kbn/fleet-plugin/common/types/models';
 import type { ManifestSchema } from '../../common/endpoint/schema/manifest';
-import type { DeletePackagePoliciesResponse } from '@kbn/fleet-plugin/common';
+import type { PostDeletePackagePoliciesResponse } from '@kbn/fleet-plugin/common';
 import { createMockPolicyData } from '../endpoint/services/feature_usage/mocks';
 import { ALL_ENDPOINT_ARTIFACT_LIST_IDS } from '../../common/endpoint/service/artifacts/constants';
 import { ENDPOINT_EVENT_FILTERS_LIST_ID } from '@kbn/securitysolution-list-constants';
@@ -396,7 +396,7 @@ describe('ingest_integration tests ', () => {
       await callback(deletePackagePolicyMock());
     };
 
-    let removedPolicies: DeletePackagePoliciesResponse;
+    let removedPolicies: PostDeletePackagePoliciesResponse;
     let policyId: string;
     let fakeArtifact: ExceptionListSchema;
 

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -10,7 +10,7 @@ import type { ExceptionListClient } from '@kbn/lists-plugin/server';
 import type { PluginStartContract as AlertsStartContract } from '@kbn/alerting-plugin/server';
 import type {
   PostPackagePolicyCreateCallback,
-  PostPackagePolicyDeleteCallback,
+  PostPackagePolicyPostDeleteCallback,
   PutPackagePolicyUpdateCallback,
   PostPackagePolicyPostCreateCallback,
 } from '@kbn/fleet-plugin/server';
@@ -190,7 +190,7 @@ export const getPackagePolicyPostCreateCallback = (
 
 export const getPackagePolicyDeleteCallback = (
   exceptionsClient: ExceptionListClient | undefined
-): PostPackagePolicyDeleteCallback => {
+): PostPackagePolicyPostDeleteCallback => {
   return async (deletePackagePolicy): Promise<void> => {
     if (!exceptionsClient) {
       return;

--- a/x-pack/plugins/security_solution/server/fleet_integration/handlers/remove_policy_from_artifacts.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/handlers/remove_policy_from_artifacts.ts
@@ -8,7 +8,7 @@
 import pMap from 'p-map';
 
 import type { ExceptionListClient } from '@kbn/lists-plugin/server';
-import type { PostPackagePolicyDeleteCallback } from '@kbn/fleet-plugin/server';
+import type { PostPackagePolicyPostDeleteCallback } from '@kbn/fleet-plugin/server';
 import { ALL_ENDPOINT_ARTIFACT_LIST_IDS } from '../../../common/endpoint/service/artifacts/constants';
 
 /**
@@ -16,7 +16,7 @@ import { ALL_ENDPOINT_ARTIFACT_LIST_IDS } from '../../../common/endpoint/service
  */
 export const removePolicyFromArtifacts = async (
   exceptionsClient: ExceptionListClient,
-  policy: Parameters<PostPackagePolicyDeleteCallback>[0][0]
+  policy: Parameters<PostPackagePolicyPostDeleteCallback>[0][0]
 ) => {
   let page = 1;
 


### PR DESCRIPTION
Required by: https://github.com/elastic/kibana/pull/147650

This PR adds a callback that runs just _before_ a package policy is deleted. This is needed for the APM package (and possible other use cases) where API keys embedded in the package policy will need to be deleted/invalidated so they don't linger in the system after the policy has been removed.

The new callback is called `packagePoliceDelete`. A delete callback already exists, however, this callback is called _after_ the policy is deleted. 

Renaming in this PR:

- `postPackagePolicyDelete` -> `packagePolicyPostDelete`
- `DeletePackagePoliciesResponse` -> `PostDeletePackagePoliciesResponse`
- `PostPackagePolicyDeleteCallback` -> `PostPackagePolicyPostDeleteCallback`
