### PR TITLE
[TIP] Add to blocklist functionality

### DIFF
--- a/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
+++ b/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
@@ -12,6 +12,9 @@ import { THREAT_INTELLIGENCE_BASE_PATH } from '@kbn/threat-intelligence-plugin/p
 import type { SourcererDataView } from '@kbn/threat-intelligence-plugin/public/types';
 import type { Store } from 'redux';
 import { useSelector } from 'react-redux';
+import { useSetUrlParams } from '../management/components/artifact_list_page/hooks/use_set_url_params';
+import { BlockListForm } from '../management/pages/blocklist/view/components/blocklist_form';
+import { BlocklistsApiClient } from '../management/pages/blocklist/services';
 import { useInvestigateInTimeline } from './use_investigate_in_timeline';
 import { getStore, inputsSelectors } from '../common/store';
 import { useKibana } from '../common/lib/kibana';
@@ -26,9 +29,10 @@ import { SiemSearchBar } from '../common/components/search_bar';
 import { useGlobalTime } from '../common/containers/use_global_time';
 import { deleteOneQuery, setQuery } from '../common/store/inputs/actions';
 import { InputsModelId } from '../common/store/inputs/constants';
+import { ArtifactFlyout } from '../management/components/artifact_list_page/components/artifact_flyout';
 
 const ThreatIntelligence = memo(() => {
-  const { threatIntelligence } = useKibana().services;
+  const { threatIntelligence, http } = useKibana().services;
   const ThreatIntelligencePlugin = threatIntelligence.getComponent();
 
   const sourcererDataView = useSourcererDataView();
@@ -43,6 +47,15 @@ const ThreatIntelligence = memo(() => {
     licenseService,
     sourcererDataView: sourcererDataView as unknown as SourcererDataView,
     getUseInvestigateInTimeline: useInvestigateInTimeline,
+
+    blockList: {
+      exceptionListApiClient: BlocklistsApiClient.getInstance(http),
+      useSetUrlParams,
+      // @ts-ignore
+      getFlyoutComponent: () => ArtifactFlyout,
+      // @ts-ignore
+      getFormComponent: () => BlockListForm,
+    },
 
     useQuery: () => useSelector(inputsSelectors.globalQuerySelector()),
     useFilters: () => useSelector(inputsSelectors.globalFiltersQuerySelector()),

--- a/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  BLOCK_LIST_ADD_BUTTON,
+  BLOCK_LIST_DESCRIPTION,
+  BLOCK_LIST_NAME,
+  BLOCK_LIST_TOAST_LIST,
+  FLYOUT_ADD_TO_BLOCK_LIST_ITEM,
+  FLYOUT_TAKE_ACTION_BUTTON,
+  INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON,
+  INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON,
+  TOGGLE_FLYOUT_BUTTON,
+} from '../screens/indicators';
+import { login } from '../tasks/login';
+import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
+import { selectRange } from '../tasks/select_range';
+
+const THREAT_INTELLIGENCE = '/app/security/threat_intelligence/indicators';
+
+const BLOCK_LIST_NEW_NAME = 'new blocklist entry';
+
+const fillBlocklistForm = () => {
+  cy.get(BLOCK_LIST_NAME).type(BLOCK_LIST_NEW_NAME);
+  cy.get(BLOCK_LIST_DESCRIPTION).type('the best description');
+  cy.get(BLOCK_LIST_ADD_BUTTON).last().click();
+
+  const text: string = `"${BLOCK_LIST_NEW_NAME}" has been added`;
+  cy.get(BLOCK_LIST_TOAST_LIST).should('exist').and('contain.text', text);
+};
+
+describe('Block list with invalid indicators', () => {
+  before(() => {
+    esArchiverLoad('threat_intelligence/invalid_indicators_data');
+    login();
+  });
+
+  beforeEach(() => {
+    cy.visit(THREAT_INTELLIGENCE);
+    selectRange();
+  });
+
+  after(() => {
+    esArchiverUnload('threat_intelligence/invalid_indicators_data');
+  });
+
+  it('should disabled the indicators table context menu item if invalid indicator', () => {
+    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).eq(3).click();
+    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).should('be.disabled');
+  });
+
+  it('should disable the flyout context menu items if invalid indicator', () => {
+    cy.get(TOGGLE_FLYOUT_BUTTON).eq(3).click({ force: true });
+    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
+    cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).should('be.disabled');
+  });
+});
+
+describe('Block list interactions', () => {
+  before(() => {
+    esArchiverLoad('threat_intelligence/indicators_data');
+    login();
+  });
+
+  beforeEach(() => {
+    cy.visit(THREAT_INTELLIGENCE);
+    selectRange();
+  });
+
+  after(() => {
+    esArchiverUnload('threat_intelligence/indicators_data');
+  });
+
+  it('should add to block list from the indicators table', () => {
+    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
+    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+
+    fillBlocklistForm();
+  });
+
+  it('should add to block list from the indicator flyout', () => {
+    cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
+    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
+    cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).first().click();
+
+    fillBlocklistForm();
+  });
+});

--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -101,6 +101,9 @@ export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON = `[data-test-subj="${
 
 export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID}"]`;
 
+export const INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON =
+  '[data-test-subj="tiIndicatorsTableCellAddToBlockListContextMenu"]';
+
 /* Flyout */
 
 export const TOGGLE_FLYOUT_BUTTON = `[data-test-subj="${BUTTON_TEST_ID}"]`;
@@ -146,6 +149,9 @@ export const FLYOUT_ADD_TO_EXISTING_CASE_ITEM = `[data-test-subj="${INDICATOR_FL
 export const FLYOUT_ADD_TO_NEW_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID}"]`;
 
 export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
+
+export const FLYOUT_ADD_TO_BLOCK_LIST_ITEM =
+  '[data-test-subj="tiIndicatorFlyoutAddToBlockListContextMenu"]';
 
 /* Field selector */
 
@@ -196,6 +202,16 @@ export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="c
 export const NEW_CASE_DESCRIPTION_INPUT = `[data-test-subj="euiMarkdownEditorTextArea"]`;
 
 export const NEW_CASE_CREATE_BUTTON = `[data-test-subj="create-case-submit"]`;
+
+/* Block list */
+
+export const BLOCK_LIST_NAME = '[data-test-subj="blocklist-form-name-input"]';
+
+export const BLOCK_LIST_DESCRIPTION = '[data-test-subj="blocklist-form-description-input"]';
+
+export const BLOCK_LIST_ADD_BUTTON = '[class="eui-textTruncate"]';
+
+export const BLOCK_LIST_TOAST_LIST = '[data-test-subj="globalToastList"]';
 
 /* Miscellaneous */
 

--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -17,6 +17,7 @@ import {
 } from '../../public/modules/indicators/components/barchart/legend_action/test_ids';
 import { DROPDOWN_TEST_ID } from '../../public/modules/indicators/components/barchart/field_selector/test_ids';
 import {
+  ADD_TO_BLOCK_LIST_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID,
   ADD_TO_EXISTING_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID,
   ADD_TO_NEW_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID,
   INVESTIGATE_IN_TIMELINE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID,
@@ -33,6 +34,7 @@ import {
   INDICATORS_FLYOUT_TITLE_TEST_ID,
 } from '../../public/modules/indicators/components/flyout/test_ids';
 import {
+  ADD_TO_BLOCK_LIST_TEST_ID as INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID,
   ADD_TO_EXISTING_TEST_ID as INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID,
   ADD_TO_NEW_CASE_TEST_ID as INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID,
   MORE_ACTIONS_TEST_ID as INDICATORS_TABLE_MORE_ACTIONS_TEST_ID,
@@ -101,8 +103,7 @@ export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON = `[data-test-subj="${
 
 export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID}"]`;
 
-export const INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON =
-  '[data-test-subj="tiIndicatorsTableCellAddToBlockListContextMenu"]';
+export const INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
 
 /* Flyout */
 
@@ -150,8 +151,7 @@ export const FLYOUT_ADD_TO_NEW_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_
 
 export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
 
-export const FLYOUT_ADD_TO_BLOCK_LIST_ITEM =
-  '[data-test-subj="tiIndicatorFlyoutAddToBlockListContextMenu"]';
+export const FLYOUT_ADD_TO_BLOCK_LIST_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
 
 /* Field selector */
 

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { NamedExoticComponent } from 'react';
+import { BlockListFlyoutProps, BlockListFormProps } from '../../types';
 import { SecuritySolutionPluginContext } from '../..';
 
 export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext => ({
@@ -18,7 +19,10 @@ export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext 
     ({ children }) =>
       <div>{children}</div>,
   licenseService: {
-    isEnterprise() {
+    isEnterprise(): boolean {
+      return true;
+    },
+    isPlatinumPlus(): boolean {
       return true;
     },
   },
@@ -48,4 +52,11 @@ export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext 
   registerQuery: () => {},
 
   deregisterQuery: () => {},
+
+  blockList: {
+    exceptionListApiClient: {},
+    useSetUrlParams: () => (params, replace) => {},
+    getFlyoutComponent: () => (<div />) as unknown as NamedExoticComponent<BlockListFlyoutProps>,
+    getFormComponent: () => (<div />) as unknown as NamedExoticComponent<BlockListFormProps>,
+  },
 });

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/story_providers.tsx
@@ -23,6 +23,7 @@ import { mockUiSettingsService } from './mock_kibana_ui_settings_service';
 import { mockKibanaTimelinesService } from './mock_kibana_timelines_service';
 import { mockTriggersActionsUiService } from './mock_kibana_triggers_actions_ui_service';
 import { InspectorContext } from '../../containers/inspector';
+import { BlockListProvider } from '../../modules/indicators/containers/block_list_provider';
 
 export interface KibanaContextMock {
   /**
@@ -101,7 +102,9 @@ export const StoryProvidersComponent: VFC<StoryProvidersComponentProps> = ({
           <FieldTypesContext.Provider value={generateFieldTypeMap()}>
             <SecuritySolutionContext.Provider value={securitySolutionContextMock}>
               <IndicatorsFiltersContext.Provider value={mockIndicatorsFiltersContext}>
-                <KibanaReactContext.Provider>{children}</KibanaReactContext.Provider>
+                <KibanaReactContext.Provider>
+                  <BlockListProvider>{children}</BlockListProvider>
+                </KibanaReactContext.Provider>
               </IndicatorsFiltersContext.Provider>
             </SecuritySolutionContext.Provider>
           </FieldTypesContext.Provider>

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/__snapshots__/add_to_block_list.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/__snapshots__/add_to_block_list.test.tsx.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AddToBlockListContextMenu /> should render a disabled EuiContextMenuItem 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <button
+        class="euiContextMenuItem euiContextMenuItem-isDisabled"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            <span>
+              Add blocklist entry
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </body>,
+  "container": <div>
+    <button
+      class="euiContextMenuItem euiContextMenuItem-isDisabled"
+      disabled=""
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <span
+          class="euiContextMenuItem__text"
+        >
+          <span>
+            Add blocklist entry
+          </span>
+        </span>
+      </span>
+    </button>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`<AddToBlockListContextMenu /> should render an EuiContextMenuItem 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <button
+        class="euiContextMenuItem"
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            <span>
+              Add blocklist entry
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </body>,
+  "container": <div>
+    <button
+      class="euiContextMenuItem"
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <span
+          class="euiContextMenuItem__text"
+        >
+          <span>
+            Add blocklist entry
+          </span>
+        </span>
+      </span>
+    </button>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { EuiContextMenuPanel } from '@elastic/eui';
+import { SecuritySolutionContext } from '../../../../containers/security_solution_context';
+import { SecuritySolutionPluginContext } from '../../../..';
+import { getSecuritySolutionContextMock } from '../../../../common/mocks/mock_security_context';
+import { AddToBlockListContextMenu } from '.';
+import { BlockListProvider } from '../../../indicators/containers/block_list_provider';
+
+export default {
+  title: 'AddToBlocklist',
+};
+
+export const ContextMenu: Story<void> = () => {
+  const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
+
+  const mockIndicatorFileHashValue: string = 'abc';
+  const mockOnClick: () => void = () => window.alert('clicked!');
+  const items = [
+    <AddToBlockListContextMenu data={mockIndicatorFileHashValue} onClick={mockOnClick} />,
+  ];
+
+  return (
+    <SecuritySolutionContext.Provider value={mockSecurityContext}>
+      <BlockListProvider>
+        <EuiContextMenuPanel items={items} />
+      </BlockListProvider>
+    </SecuritySolutionContext.Provider>
+  );
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AddToBlockListContextMenu } from '.';
+import { BlockListProvider } from '../../../indicators/containers/block_list_provider';
+import { SecuritySolutionContext } from '../../../../containers/security_solution_context';
+import { SecuritySolutionPluginContext } from '../../../..';
+import { getSecuritySolutionContextMock } from '../../../../common/mocks/mock_security_context';
+
+describe('<AddToBlockListContextMenu />', () => {
+  it('should render an EuiContextMenuItem', () => {
+    const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
+
+    const mockIndicatorFileHashValue: string = 'abc';
+    const mockOnClick: () => void = () => window.alert('clicked!');
+
+    const component = render(
+      <SecuritySolutionContext.Provider value={mockSecurityContext}>
+        <BlockListProvider>
+          <AddToBlockListContextMenu data={mockIndicatorFileHashValue} onClick={mockOnClick} />
+        </BlockListProvider>
+      </SecuritySolutionContext.Provider>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render a disabled EuiContextMenuItem', () => {
+    const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
+
+    const mockIndicatorFileHashValue = null;
+    const mockOnClick: () => void = () => window.alert('clicked!');
+
+    const component = render(
+      <SecuritySolutionContext.Provider value={mockSecurityContext}>
+        <BlockListProvider>
+          <AddToBlockListContextMenu data={mockIndicatorFileHashValue} onClick={mockOnClick} />
+        </BlockListProvider>
+      </SecuritySolutionContext.Provider>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
@@ -9,7 +9,7 @@ import React, { VFC } from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useBlockListContext } from '../../../indicators/hooks/use_block_list_context';
-import { useSecurityContext } from '../../../../hooks';
+import { useSetUrlParams } from '../../hooks/use_set_url_params';
 
 export interface AddToBlockListProps {
   /**
@@ -23,7 +23,7 @@ export interface AddToBlockListProps {
   /**
    * Click event to notify the parent component (to for example close the popover)
    */
-  onClick?: () => void;
+  onClick: () => void;
 }
 
 /**
@@ -38,11 +38,10 @@ export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
   onClick,
 }) => {
   const { setBlockListIndicatorValue } = useBlockListContext();
-  const { blockList } = useSecurityContext();
-  const setUrlParams = blockList.useSetUrlParams();
+  const { setUrlParams } = useSetUrlParams();
 
   const menuItemClicked = () => {
-    if (onClick) onClick();
+    onClick();
     setBlockListIndicatorValue(data as string);
     setUrlParams({ show: 'create' });
   };

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { VFC } from 'react';
+import { EuiContextMenuItem } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useBlockListContext } from '../../../indicators/hooks/use_block_list_context';
+import { useSecurityContext } from '../../../../hooks';
+
+export interface AddToBlockListProps {
+  /**
+   * Indicator's filehash value (either sha256, sha1 or md5)
+   */
+  data: string | null;
+  /**
+   * Used for unit and e2e tests
+   */
+  ['data-test-subj']?: string;
+  /**
+   * Click event to notify the parent component (to for example close the popover)
+   */
+  onClick?: () => void;
+}
+
+/**
+ * Add to blocklist functionality displayed as a ContextMenuItem (in the main indicators table row and in the indicator flyout).
+ * The entry is disabled is the filehash isn't sha256, sha1 or md5.
+ * When clicking on the ContextMenuItem, the indicator filehash value is saved in context.
+ * The flyout is shown by adding a parameter to the url.
+ */
+export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
+  data,
+  'data-test-subj': dataTestSub,
+  onClick,
+}) => {
+  const { setBlockListIndicatorValue } = useBlockListContext();
+  const { blockList } = useSecurityContext();
+  const setUrlParams = blockList.useSetUrlParams();
+
+  const menuItemClicked = () => {
+    if (onClick) onClick();
+    setBlockListIndicatorValue(data as string);
+    setUrlParams({ show: 'create' });
+  };
+
+  return (
+    <EuiContextMenuItem
+      key="addToBlocklist"
+      onClick={() => menuItemClicked()}
+      data-test-subj={dataTestSub}
+      disabled={data == null}
+    >
+      <FormattedMessage
+        defaultMessage="Add blocklist entry"
+        id="xpack.threatIntelligence.addToBlockList"
+      />
+    </EuiContextMenuItem>
+  );
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './add_to_block_list';

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { VFC } from 'react';
+import {
+  CreateExceptionListItemSchema,
+  EntriesArray,
+} from '@kbn/securitysolution-io-ts-list-types';
+import { useSecurityContext } from '../../../hooks/use_security_context';
+
+export interface BlockListFlyoutProps {
+  /**
+   * Indicator file-hash value (sha256, sh1 or md5) to pass to the block list flyout.
+   */
+  indicatorFileHash: string;
+}
+
+/**
+ * Component calling the block list flyout (retrieved from the SecuritySolution plugin via context).
+ * This reuses a lot of components passed down via context from the Security Solution plugin:
+ * - the flyout component: https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_flyout.tsx
+ * - the form component: https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/management/pages/blocklist/view/components/blocklist_form.tsx
+ */
+export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }) => {
+  const { blockList } = useSecurityContext();
+  const Component = blockList.getFlyoutComponent();
+  const exceptionListApiClient = blockList.exceptionListApiClient;
+  const FormComponent = blockList.getFormComponent();
+
+  // prepopulate the for with the indicator file hash
+  const entries: EntriesArray = [
+    {
+      field: 'file.hash.*',
+      operator: 'included',
+      type: 'match_any',
+      value: [indicatorFileHash],
+    },
+  ];
+
+  // prepare the payload to pass to the form (and then sent to the blocklist endpoint)
+  const item: CreateExceptionListItemSchema = {
+    description: '',
+    entries,
+    list_id: 'endpoint_blocklists',
+    name: '',
+    namespace_type: 'agnostic',
+    os_types: ['windows'],
+    tags: ['policy:all'],
+    type: 'simple',
+  };
+
+  const props = {
+    apiClient: exceptionListApiClient,
+    item,
+    policies: [],
+    FormComponent,
+    onClose: () => {},
+  };
+
+  return <Component {...props} />;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/index.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './use_set_url_params';

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_set_url_params.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_set_url_params.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useSecurityContext } from '../../../hooks';
+
+/**
+ * Retrieve the useSetUrlParams hook from SecurityContext.
+ * The hook is passed down from the Security Solution plugin.
+ */
+export const useSetUrlParams = () => {
+  const { blockList } = useSecurityContext();
+  return { setUrlParams: blockList.useSetUrlParams() };
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/utils/can_add_to_block_list.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/utils/can_add_to_block_list.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  generateMockFileIndicator,
+  Indicator,
+  RawIndicatorFieldId,
+} from '../../../../common/types/indicator';
+import { canAddToBlockList } from './can_add_to_block_list';
+import { getIndicatorFieldAndValue } from '../../indicators';
+
+describe('canAddToBlockList', () => {
+  it('should return null if indicator has none of required fields', () => {
+    const indicator = {} as unknown as Indicator;
+    const result = canAddToBlockList(indicator);
+
+    expect(result).toEqual(null);
+  });
+
+  it('should return sha256 value if indicator has the field', () => {
+    const indicator = generateMockFileIndicator();
+    const sha256 = getIndicatorFieldAndValue(indicator, RawIndicatorFieldId.FileSha256).value;
+    const result = canAddToBlockList(indicator);
+
+    expect(result).toEqual(sha256);
+  });
+
+  it('should return sha1 value if sha256 is missing ', () => {
+    const indicator = generateMockFileIndicator();
+    indicator.fields['threat.indicator.file.hash.sha256'] = undefined;
+    const sha1 = getIndicatorFieldAndValue(indicator, RawIndicatorFieldId.FileSha1).value;
+    const result = canAddToBlockList(indicator);
+
+    expect(result).toEqual(sha1);
+  });
+
+  it('should return md5 value if sha256 and sha1 are missing', () => {
+    const indicator = generateMockFileIndicator();
+    indicator.fields['threat.indicator.file.hash.sha256'] = undefined;
+    indicator.fields['threat.indicator.file.hash.sha1'] = undefined;
+    const md5 = getIndicatorFieldAndValue(indicator, RawIndicatorFieldId.FileMd5).value;
+    const result = canAddToBlockList(indicator);
+
+    expect(result).toEqual(md5);
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/utils/can_add_to_block_list.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/utils/can_add_to_block_list.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Indicator, RawIndicatorFieldId } from '../../../../common/types/indicator';
+import { getIndicatorFieldAndValue } from '../../indicators';
+
+/**
+ * Checks if an indicator has sha256, sha1 or md5 (in that order) and returns an empty string if it does not.
+ * The value is returned to be used in the add to block list logic.
+ *
+ * @param indicator the indicator we want to
+ */
+export const canAddToBlockList = (indicator: Indicator): string | null => {
+  const sha256: string | null = getIndicatorFieldAndValue(
+    indicator,
+    RawIndicatorFieldId.FileSha256
+  ).value;
+  if (sha256 != null) {
+    return sha256;
+  }
+
+  const sha1: string | null = getIndicatorFieldAndValue(
+    indicator,
+    RawIndicatorFieldId.FileSha1
+  ).value;
+  if (sha1 != null) {
+    return sha1;
+  }
+
+  const md5: string | null = getIndicatorFieldAndValue(
+    indicator,
+    RawIndicatorFieldId.FileMd5
+  ).value;
+  if (md5 != null) {
+    return md5;
+  }
+
+  return null;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
@@ -8,10 +8,20 @@
 import React, { useState, VFC } from 'react';
 import { EuiButton, EuiContextMenuPanel, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { canAddToBlockList } from '../../../../block_list/utils/can_add_to_block_list';
+import { AddToBlockListContextMenu } from '../../../../block_list/components/add_to_block_list';
 import { AddToNewCase } from '../../../../cases/components/add_to_new_case/add_to_new_case';
 import { AddToExistingCase } from '../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { InvestigateInTimelineContextMenu } from '../../../../timeline';
+
+export const TAKE_ACTION_BUTTON_TEST_ID = 'tiIndicatorFlyoutTakeActionButton';
+export const INVESTIGATE_IN_TIMELINE_CONTEXT_MENU_TEST_ID =
+  'tiIndicatorFlyoutInvestigateInTimelineContextMenu';
+export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
+  'tiIndicatorFlyoutAddToExistingCaseContextMenu';
+export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorFlyoutAddToNewCaseContextMenu';
+export const ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID = 'tiIndicatorFlyoutAddToBlockListContextMenu';
 import {
   ADD_TO_EXISTING_CASE_TEST_ID,
   ADD_TO_NEW_CASE_TEST_ID,
@@ -39,6 +49,7 @@ export const TakeAction: VFC<TakeActionProps> = ({ indicator }) => {
     setPopover(false);
   };
 
+  const indicatorValue: string | null = canAddToBlockList(indicator);
   const items = [
     <InvestigateInTimelineContextMenu
       data={indicator}
@@ -54,6 +65,11 @@ export const TakeAction: VFC<TakeActionProps> = ({ indicator }) => {
       indicator={indicator}
       onClick={closePopover}
       data-test-subj={ADD_TO_NEW_CASE_TEST_ID}
+    />,
+    <AddToBlockListContextMenu
+      data={indicatorValue}
+      onClick={closePopover}
+      data-test-subj={ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID}
     />,
   ];
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/take_action.tsx
@@ -14,15 +14,8 @@ import { AddToNewCase } from '../../../../cases/components/add_to_new_case/add_t
 import { AddToExistingCase } from '../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { InvestigateInTimelineContextMenu } from '../../../../timeline';
-
-export const TAKE_ACTION_BUTTON_TEST_ID = 'tiIndicatorFlyoutTakeActionButton';
-export const INVESTIGATE_IN_TIMELINE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorFlyoutInvestigateInTimelineContextMenu';
-export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorFlyoutAddToExistingCaseContextMenu';
-export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorFlyoutAddToNewCaseContextMenu';
-export const ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID = 'tiIndicatorFlyoutAddToBlockListContextMenu';
 import {
+  ADD_TO_BLOCK_LIST_TEST_ID,
   ADD_TO_EXISTING_CASE_TEST_ID,
   ADD_TO_NEW_CASE_TEST_ID,
   INVESTIGATE_IN_TIMELINE_TEST_ID,
@@ -69,7 +62,7 @@ export const TakeAction: VFC<TakeActionProps> = ({ indicator }) => {
     <AddToBlockListContextMenu
       data={indicatorValue}
       onClick={closePopover}
-      data-test-subj={ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_BLOCK_LIST_TEST_ID}
     />,
   ];
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/take_action/test_ids.ts
@@ -9,3 +9,4 @@ export const TAKE_ACTION_BUTTON_TEST_ID = 'tiIndicatorFlyoutTakeActionButton';
 export const INVESTIGATE_IN_TIMELINE_TEST_ID = 'tiIndicatorFlyoutInvestigateInTimelineContextMenu';
 export const ADD_TO_EXISTING_CASE_TEST_ID = 'tiIndicatorFlyoutAddToExistingCaseContextMenu';
 export const ADD_TO_NEW_CASE_TEST_ID = 'tiIndicatorFlyoutAddToNewCaseContextMenu';
+export const ADD_TO_BLOCK_LIST_TEST_ID = 'tiIndicatorFlyoutAddToBlockListContextMenu';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
@@ -14,10 +14,20 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { AddToBlockListContextMenu } from '../../../../../block_list/components/add_to_block_list';
 import { AddToNewCase } from '../../../../../cases/components/add_to_new_case/add_to_new_case';
 import { AddToExistingCase } from '../../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../../common/types/indicator';
+import { canAddToBlockList } from '../../../../../block_list/utils/can_add_to_block_list';
+
+export const MORE_ACTIONS_BUTTON_TEST_ID = 'tiIndicatorTableMoreActionsButton';
+export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
+  'tiIndicatorTableAddToExistingCaseContextMenu';
+export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorTableAddToNewCaseContextMenu';
 import { ADD_TO_EXISTING_TEST_ID, ADD_TO_NEW_CASE_TEST_ID, MORE_ACTIONS_TEST_ID } from './test_ids';
+
+export const ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID =
+  'tiIndicatorsTableCellAddToBlockListContextMenu';
 
 const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.table.moreActions', {
   defaultMessage: 'More actions',
@@ -54,6 +64,11 @@ export const MoreActions: VFC<TakeActionProps> = ({ indicator }) => {
       indicator={indicator}
       onClick={closePopover}
       data-test-subj={ADD_TO_NEW_CASE_TEST_ID}
+    />,
+    <AddToBlockListContextMenu
+      data={canAddToBlockList(indicator)}
+      onClick={closePopover}
+      data-test-subj={ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID}
     />,
   ];
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
@@ -19,15 +19,12 @@ import { AddToNewCase } from '../../../../../cases/components/add_to_new_case/ad
 import { AddToExistingCase } from '../../../../../cases/components/add_to_existing_case/add_to_existing_case';
 import { Indicator } from '../../../../../../../common/types/indicator';
 import { canAddToBlockList } from '../../../../../block_list/utils/can_add_to_block_list';
-
-export const MORE_ACTIONS_BUTTON_TEST_ID = 'tiIndicatorTableMoreActionsButton';
-export const ADD_TO_EXISTING_CASE_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorTableAddToExistingCaseContextMenu';
-export const ADD_TO_NEW_CASE_CONTEXT_MENU_TEST_ID = 'tiIndicatorTableAddToNewCaseContextMenu';
-import { ADD_TO_EXISTING_TEST_ID, ADD_TO_NEW_CASE_TEST_ID, MORE_ACTIONS_TEST_ID } from './test_ids';
-
-export const ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID =
-  'tiIndicatorsTableCellAddToBlockListContextMenu';
+import {
+  ADD_TO_BLOCK_LIST_TEST_ID,
+  ADD_TO_EXISTING_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID,
+  MORE_ACTIONS_TEST_ID,
+} from './test_ids';
 
 const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.table.moreActions', {
   defaultMessage: 'More actions',
@@ -68,7 +65,7 @@ export const MoreActions: VFC<TakeActionProps> = ({ indicator }) => {
     <AddToBlockListContextMenu
       data={canAddToBlockList(indicator)}
       onClick={closePopover}
-      data-test-subj={ADD_TO_BLOCK_LIST_CONTEXT_MENU_TEST_ID}
+      data-test-subj={ADD_TO_BLOCK_LIST_TEST_ID}
     />,
   ];
 

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/test_ids.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/test_ids.ts
@@ -8,3 +8,4 @@
 export const MORE_ACTIONS_TEST_ID = 'tiIndicatorTableMoreActionsButton';
 export const ADD_TO_EXISTING_TEST_ID = 'tiIndicatorTableAddToExistingCaseContextMenu';
 export const ADD_TO_NEW_CASE_TEST_ID = 'tiIndicatorTableAddToNewCaseContextMenu';
+export const ADD_TO_BLOCK_LIST_TEST_ID = 'tiIndicatorsTableAddToBlockListContextMenu';

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/block_list_provider.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/block_list_provider.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, Dispatch, FC, SetStateAction, useState } from 'react';
+
+export interface BlockListContextValue {
+  blockListIndicatorValue: string;
+  setBlockListIndicatorValue: Dispatch<SetStateAction<string>>;
+}
+
+export const BlockListContext = createContext<BlockListContextValue | undefined>(undefined);
+
+export const BlockListProvider: FC = ({ children }) => {
+  const [blockListIndicatorValue, setBlockListIndicatorValue] = useState('');
+
+  const context: BlockListContextValue = {
+    blockListIndicatorValue,
+    setBlockListIndicatorValue,
+  };
+  return <BlockListContext.Provider value={context}>{children}</BlockListContext.Provider>;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_block_list_context.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_block_list_context.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useContext } from 'react';
+import { BlockListContext, BlockListContextValue } from '../containers/block_list_provider';
+
+/**
+ * Hook to retrieve {@link BlockListContext}
+ */
+export const useBlockListContext = (): BlockListContextValue => {
+  const contextValue = useContext(BlockListContext);
+
+  if (!contextValue) {
+    throw new Error('BlockListContext can only be used within BlockListContext provider');
+  }
+
+  return contextValue;
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
@@ -6,6 +6,9 @@
  */
 
 import React, { FC, VFC } from 'react';
+import { useBlockListContext } from '../hooks/use_block_list_context';
+import { BlockListProvider } from '../containers/block_list_provider';
+import { BlockListFlyout } from '../../block_list/containers/flyout';
 import { IndicatorsBarChartWrapper } from '../components/barchart';
 import { IndicatorsTable } from '../components/table';
 import { useAggregatedIndicators, useIndicators, useSourcererDataView } from '../hooks';
@@ -22,12 +25,16 @@ import { QueryBar } from '../../query_bar/query_bar';
 const IndicatorsPageProviders: FC = ({ children }) => (
   <IndicatorsFilters>
     <FieldTypesProvider>
-      <InspectorProvider>{children}</InspectorProvider>
+      <InspectorProvider>
+        <BlockListProvider>{children}</BlockListProvider>
+      </InspectorProvider>
     </FieldTypesProvider>
   </IndicatorsFilters>
 );
 
 const IndicatorsPageContent: VFC = () => {
+  const { blockListIndicatorValue } = useBlockListContext();
+
   const { browserFields, indexPattern } = useSourcererDataView();
 
   const columnSettings = useColumnSettings();
@@ -101,6 +108,8 @@ const IndicatorsPageContent: VFC = () => {
           onChangeItemsPerPage={onChangeItemsPerPage}
           onChangePage={onChangePage}
         />
+
+        {blockListIndicatorValue && <BlockListFlyout indicatorFileHash={blockListIndicatorValue} />}
       </DefaultPageLayout>
     </FieldTypesProvider>
   );

--- a/x-pack/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/plugins/threat_intelligence/public/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ComponentType, ReactElement, ReactNode, VFC } from 'react';
+import { ComponentType, NamedExoticComponent, ReactElement, ReactNode, VFC } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import {
@@ -22,6 +22,7 @@ import { Store } from 'redux';
 import { DataProvider } from '@kbn/timelines-plugin/common';
 import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { CasesUiSetup, CasesUiStart } from '@kbn/cases-plugin/public/types';
+import { CreateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 
 export interface SecuritySolutionDataViewBase extends DataViewBase {
   fields: Array<FieldSpec & DataViewField>;
@@ -57,6 +58,7 @@ export type Services = {
 
 export interface LicenseAware {
   isEnterprise(): boolean;
+  isPlatinumPlus(): boolean;
 }
 
 export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;
@@ -72,6 +74,18 @@ export interface UseInvestigateInTimelineProps {
   dataProviders: DataProvider[];
   from: string;
   to: string;
+}
+
+export interface BlockListFlyoutProps {
+  apiClient: unknown;
+  item: CreateExceptionListItemSchema;
+  policies: unknown[];
+  FormComponent: NamedExoticComponent<BlockListFormProps>;
+  onClose: () => void;
+}
+
+export interface BlockListFormProps {
+  item: CreateExceptionListItemSchema;
 }
 
 /**
@@ -124,4 +138,14 @@ export interface SecuritySolutionPluginContext {
    * Deregister stale query
    */
   deregisterQuery: (query: { id: string }) => void;
+
+  blockList: {
+    exceptionListApiClient: unknown;
+    useSetUrlParams: () => (
+      params: Record<string, string | number | null | undefined>,
+      replace?: boolean | undefined
+    ) => void;
+    getFlyoutComponent: () => NamedExoticComponent<BlockListFlyoutProps>;
+    getFormComponent: () => NamedExoticComponent<BlockListFormProps>;
+  };
 }

--- a/x-pack/plugins/threat_intelligence/tsconfig.json
+++ b/x-pack/plugins/threat_intelligence/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/kibana-react-plugin",
     "@kbn/utility-types",
     "@kbn/ui-theme",
+    "@kbn/securitysolution-io-ts-list-types"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Users should be able to add indicator of compromise to the block list.
The `add to blocklist` functionality is only available to IoCs  of type `file` and containing either a `sha256`, `sha1` or `md5` filehash. The others do not see the option. The option is visible in the `More Actions` dropdown menu in each row of the main indicators table, as well as in the `Take Action` deopdown menu at the bottom of the indicator flyout.

https://user-images.githubusercontent.com/17276605/211267849-6bf2f7ec-44c2-4e08-80db-9d8cdb7c2471.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))