### PR TITLE
[kibana server with ssl] temporary skip failing test

### DIFF
--- a/test/server_integration/http/ssl_with_p12_intermediate/index.js
+++ b/test/server_integration/http/ssl_with_p12_intermediate/index.js
@@ -9,6 +9,7 @@
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
+  // https://github.com/elastic/kibana/issues/148515
   describe.skip('kibana server with ssl', () => {
     it('handles requests using ssl with a P12 keystore that uses an intermediate CA', async () => {
       await supertest.get('/').expect(302);

--- a/test/server_integration/http/ssl_with_p12_intermediate/index.js
+++ b/test/server_integration/http/ssl_with_p12_intermediate/index.js
@@ -9,7 +9,7 @@
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  describe('kibana server with ssl', () => {
+  describe.skip('kibana server with ssl', () => {
     it('handles requests using ssl with a P12 keystore that uses an intermediate CA', async () => {
       await supertest.get('/').expect(302);
     });


### PR DESCRIPTION
This test fails on main #148515 and the PRs

https://buildkite.com/elastic/kibana-on-merge/builds/25434

Temporary skipping


