### PR TITLE
[Lens] Allows cleaning up of the filters agg custom label

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/shared_components/label_input.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/shared_components/label_input.tsx
@@ -27,7 +27,10 @@ export const LabelInput = ({
   dataTestSubj?: string;
   compressed?: boolean;
 }) => {
-  const { inputValue, handleInputChange } = useDebouncedValue({ value, onChange });
+  const { inputValue, handleInputChange } = useDebouncedValue(
+    { value, onChange },
+    { allowFalsyValue: true }
+  );
   const localKeyHold = useRef(false);
 
   return (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148456

![lens](https://user-images.githubusercontent.com/17003240/211315302-5a4b173a-63ad-4ab6-863f-75a384574223.gif)

By adding the `allowFaslyValue` setting this is fixed and now you can clean up the custom label on a Filters agg.