### PR TITLE
[8.6] [ResponseOps] Opsgenie fix flaky execute button test (#148467)

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/opsgenie.ts
@@ -138,7 +138,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         await find.clickByCssSelector('[data-test-subj="testConnectorTab"]');
 
-        expect(await (await testSubjects.find('executeActionButton')).isEnabled()).to.be(false);
+        expect(await testSubjects.isEnabled('executeActionButton')).to.be(false);
       });
 
       describe('test page', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[ResponseOps] Opsgenie fix flaky execute button test (#148467)](https://github.com/elastic/kibana/pull/148467)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jonathan Buttner","email":"56361221+jonathan-buttner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-01-05T19:17:01Z","message":"[ResponseOps] Opsgenie fix flaky execute button test (#148467)\n\nFixes: https://github.com/elastic/kibana/issues/147509\r\n\r\nThis PR tries to fix a flaky test where the execute button is enable\r\nwhen it should not.\r\n\r\nFlaky test run passed:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1707","sha":"ef466343ff71be511dfaf5f7841bdf246a1cbd4b","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport missing","v8.7.0","v8.6.1"],"number":148467,"url":"https://github.com/elastic/kibana/pull/148467","mergeCommit":{"message":"[ResponseOps] Opsgenie fix flaky execute button test (#148467)\n\nFixes: https://github.com/elastic/kibana/issues/147509\r\n\r\nThis PR tries to fix a flaky test where the execute button is enable\r\nwhen it should not.\r\n\r\nFlaky test run passed:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1707","sha":"ef466343ff71be511dfaf5f7841bdf246a1cbd4b"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148467","number":148467,"mergeCommit":{"message":"[ResponseOps] Opsgenie fix flaky execute button test (#148467)\n\nFixes: https://github.com/elastic/kibana/issues/147509\r\n\r\nThis PR tries to fix a flaky test where the execute button is enable\r\nwhen it should not.\r\n\r\nFlaky test run passed:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1707","sha":"ef466343ff71be511dfaf5f7841bdf246a1cbd4b"}},{"branch":"8.6","label":"v8.6.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->