### PR TITLE
[Task Manager] [POC] Claim and queue tasks ahead of time

### DIFF
--- a/x-pack/plugins/task_manager/server/config.ts
+++ b/x-pack/plugins/task_manager/server/config.ts
@@ -10,6 +10,7 @@ import { schema, TypeOf } from '@kbn/config-schema';
 export const MAX_WORKERS_LIMIT = 100;
 export const DEFAULT_MAX_WORKERS = 10;
 export const DEFAULT_POLL_INTERVAL = 3000;
+export const DEFUALT_MAX_QUEUED_TASKS = 0;
 export const DEFAULT_MAX_POLL_INACTIVITY_CYCLES = 10;
 export const DEFAULT_VERSION_CONFLICT_THRESHOLD = 80;
 export const DEFAULT_MAX_EPHEMERAL_REQUEST_CAPACITY = MAX_WORKERS_LIMIT;
@@ -78,6 +79,8 @@ export const configSchema = schema.object(
       // disable the task manager rather than trying to specify it with 0 workers
       min: 1,
     }),
+    /* The maximum number of tasks that this Kibana instance will queue for running  */
+    max_queued_tasks: schema.number({ defaultValue: DEFUALT_MAX_QUEUED_TASKS }),
     /* The threshold percenatge for workers experiencing version conflicts for shifting the polling interval. */
     version_conflict_threshold: schema.number({
       defaultValue: DEFAULT_VERSION_CONFLICT_THRESHOLD,

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.ts
@@ -130,6 +130,7 @@ export class TaskPollingLifecycle {
     this.pool = new TaskPool({
       logger,
       maxWorkers$: maxWorkersConfiguration$,
+      maxQueuedTasks: config.max_queued_tasks,
     });
     this.pool.load.subscribe(emitEvent);
 
@@ -140,6 +141,8 @@ export class TaskPollingLifecycle {
       definitions,
       unusedTypes,
       logger: this.logger,
+      maxQueuedTasks: config.max_queued_tasks,
+      maxWorkers$: maxWorkersConfiguration$,
       getCapacity: (taskType?: string) =>
         taskType && this.definitions.get(taskType)?.maxConcurrency
           ? Math.max(
@@ -150,7 +153,7 @@ export class TaskPollingLifecycle {
               ),
               0
             )
-          : this.pool.availableWorkers,
+          : this.pool.numOfTasksToClaim,
     });
     // pipe taskClaiming events into the lifecycle event stream
     this.taskClaiming.events.subscribe(emitEvent);

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.ts
@@ -73,6 +73,7 @@ export interface TaskRunner {
   isEphemeral?: boolean;
   toString: () => string;
   isSameTask: (executionId: string) => boolean;
+  scheduledAt: Date;
 }
 
 export enum TaskRunningStage {
@@ -249,6 +250,13 @@ export class TaskManagerRunner implements TaskRunner {
    */
   public get startedAt() {
     return this.instance.task.startedAt;
+  }
+
+  /**
+   * Gets when the task was scheduled to run
+   */
+  public get scheduledAt() {
+    return this.instance.task.scheduledAt;
   }
 
   /**


### PR DESCRIPTION
In this PR, I made a POC of Task Manager claiming and queueing more tasks than it has capacity to run. You can enable / set this feature by using the following kibana.yml setting `xpack.task_manager.max_queued_tasks`. It defaults to `0` (disabled).